### PR TITLE
compilers: remove opinionated c++ warning flag

### DIFF
--- a/docs/markdown/snippets/cxx_warn_args_dtor.md
+++ b/docs/markdown/snippets/cxx_warn_args_dtor.md
@@ -1,0 +1,3 @@
+## Flags removed from cpp/objcpp warning level 1
+
+`-Wnon-virtual-dtor` is no longer implied by `meson setup -Dwarning_level=1`.

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -190,7 +190,7 @@ class ClangCPPCompiler(ClangCompiler, CPPCompiler):
         CPPCompiler.__init__(self, ccache, exelist, version, for_machine, is_cross,
                              info, exe_wrapper, linker=linker, full_version=full_version)
         ClangCompiler.__init__(self, defines)
-        default_warn_args = ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor']
+        default_warn_args = ['-Wall', '-Winvalid-pch']
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
@@ -310,7 +310,7 @@ class ArmclangCPPCompiler(ArmclangCompiler, CPPCompiler):
         CPPCompiler.__init__(self, ccache, exelist, version, for_machine, is_cross,
                              info, exe_wrapper, linker=linker, full_version=full_version)
         ArmclangCompiler.__init__(self)
-        default_warn_args = ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor']
+        default_warn_args = ['-Wall', '-Winvalid-pch']
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
@@ -356,7 +356,7 @@ class GnuCPPCompiler(GnuCompiler, CPPCompiler):
         CPPCompiler.__init__(self, ccache, exelist, version, for_machine, is_cross,
                              info, exe_wrapper, linker=linker, full_version=full_version)
         GnuCompiler.__init__(self, defines)
-        default_warn_args = ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor']
+        default_warn_args = ['-Wall', '-Winvalid-pch']
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
@@ -536,7 +536,7 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
         IntelGnuLikeCompiler.__init__(self)
         self.lang_header = 'c++-header'
         default_warn_args = ['-Wall', '-w3', '-diag-disable:remark',
-                             '-Wpch-messages', '-Wnon-virtual-dtor']
+                             '-Wpch-messages']
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -63,7 +63,7 @@ class GnuObjCPPCompiler(GnuCompiler, ObjCPPCompiler):
         ObjCPPCompiler.__init__(self, ccache, exelist, version, for_machine, is_cross,
                                 info, exe_wrapper, linker=linker, full_version=full_version)
         GnuCompiler.__init__(self, defines)
-        default_warn_args = ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor']
+        default_warn_args = ['-Wall', '-Winvalid-pch']
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
@@ -81,7 +81,7 @@ class ClangObjCPPCompiler(ClangCompiler, ObjCPPCompiler):
         ObjCPPCompiler.__init__(self, ccache, exelist, version, for_machine, is_cross,
                                 info, exe_wrapper, linker=linker, full_version=full_version)
         ClangCompiler.__init__(self, defines)
-        default_warn_args = ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor']
+        default_warn_args = ['-Wall', '-Winvalid-pch']
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],


### PR DESCRIPTION
-Wnon-virtual-dtor is not what people think of as a standard warning flag. It was previously removed from -Wall in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=16190 on the grounds that people didn't like it and were refusing to use -Wall at all because it forced this warning. Instead, it is enabled by -Weffc++ which is typically not enabled and even comes with GCC documentation warnings stating that the standard library doesn't obey it, and you might need to `grep -v` and filter out warnings. (!!!)

It doesn't fit into the typical semantics of Meson's warning_level option, which usually aligns with compiler standard warning levelsrather than a niche ideological warning level.

It was originally added in commit 22af56e05aa9cba4740d2ff303d876bb0c3cfb2b, but without any specific rationale included, and has gone unquestioned since then -- except by the Meson users who see it, assume there is a finely crafted design behind it, and quietly opt out by rolling their own warning options with `add_project_arguments('-Wall', ...)`.

/cc @kjellahl