### PR TITLE
dependencies: handle one more case of subproject installed files

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -680,7 +680,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             else:
                 if not self.is_subproject() and srcdir / self.subproject_dir in p.parents:
                     continue
-                if p.is_absolute() and p.is_dir() and srcdir / self.root_subdir in p.resolve().parents:
+                if p.is_absolute() and p.is_dir() and srcdir / self.root_subdir in [p] + list(p.resolve().parents):
                     variables[k] = P_OBJ.DependencyVariableString(v)
         for d in deps:
             if not isinstance(d, dependencies.Dependency):

--- a/test cases/common/251 subproject dependency variables/meson.build
+++ b/test cases/common/251 subproject dependency variables/meson.build
@@ -11,3 +11,8 @@ executable(
     'foo2',
     subfiles_dep.get_variable('pkgdatadir2') / 'foo.c'
 )
+
+executable(
+    'foor32',
+    subfiles_dep.get_variable('pkgdatadir3') / 'foo.c'
+)

--- a/test cases/common/251 subproject dependency variables/subprojects/subfiles/foo.c
+++ b/test cases/common/251 subproject dependency variables/subprojects/subfiles/foo.c
@@ -1,0 +1,1 @@
+int main(void) { return 0; }

--- a/test cases/common/251 subproject dependency variables/subprojects/subfiles/meson.build
+++ b/test cases/common/251 subproject dependency variables/subprojects/subfiles/meson.build
@@ -4,11 +4,13 @@ files_dep = declare_dependency(
     variables: [
       'pkgdatadir=@0@/subdir'.format(meson.current_source_dir()),
       'pkgdatadir2=@0@/subdir2'.format(meson.current_source_dir()),
+      'pkgdatadir3=@0@'.format(meson.current_source_dir()),
     ]
 )
 
 install_data('subdir/foo.c', install_dir: get_option('datadir') / 'subdir')
 install_subdir('subdir2', install_dir: get_option('datadir'))
+install_data('foo.c', install_dir: get_option('datadir'))
 
 import('pkgconfig').generate(
     name: 'depvar_resource',
@@ -21,6 +23,7 @@ import('pkgconfig').generate(
     uninstalled_variables: [
       'pkgdatadir=@0@/subdir'.format(meson.current_source_dir()),
       'pkgdatadir2=@0@/subdir2'.format(meson.current_source_dir()),
+      'pkgdatadir3=@0@'.format(meson.current_source_dir()),
     ],
     dataonly: true,
 )

--- a/test cases/common/251 subproject dependency variables/test.json
+++ b/test cases/common/251 subproject dependency variables/test.json
@@ -1,6 +1,7 @@
 {
   "installed": [
     { "type": "file",  "file": "usr/share/pkgconfig/depvar_resource.pc" },
+    { "type": "file",  "file": "usr/share/foo.c" },
     { "type": "file",  "file": "usr/share/subdir/foo.c" },
     { "type": "file",  "file": "usr/share/subdir2/foo.c" }
   ]


### PR DESCRIPTION
Some projects treat meson.project_source_root() as the root of the dependency files, because the project itself merely wraps a bunch of datafiles. Our validation to make sure this doesn't point to another subproject, made use of pathlib.Path's generator for all component paths, which... did not include the path itself. So go ahead and explicitly check that too. Add a test case to verify it while we are at it.

Fixes https://github.com/mesonbuild/meson/pull/10103#issuecomment-1114901033