### PR TITLE
wayland: Lookup for wayland-scanner using pkgconfig

### DIFF
--- a/mesonbuild/modules/unstable_wayland.py
+++ b/mesonbuild/modules/unstable_wayland.py
@@ -18,7 +18,7 @@ from . import ExtensionModule, ModuleReturnValue
 from ..build import CustomTarget
 from ..interpreter.type_checking import NoneType, in_set_validator
 from ..interpreterbase import FeatureNew, typed_pos_args, typed_kwargs, KwargInfo
-from ..mesonlib import File, MesonException, MachineChoice
+from ..mesonlib import File, MesonException
 
 
 class WaylandModule(ExtensionModule):
@@ -47,10 +47,9 @@ class WaylandModule(ExtensionModule):
         if self.scanner_bin is None:
             # wayland-scanner from BUILD machine must have same version as wayland
             # libraries from HOST machine.
-            dep = self.interpreter.func_dependency(state.current_node, ['wayland-client'], {})
-            self.scanner_bin = state.find_program('wayland-scanner',
-                                                  for_machine=MachineChoice.BUILD,
-                                                  wanted=dep.version)
+            dep = state.dependency('wayland-client')
+            self.scanner_bin = state.find_tool('wayland-scanner', 'wayland-scanner', 'wayland_scanner',
+                                               wanted=dep.version)
 
         scope = 'public' if kwargs['public'] else 'private'
         sides = [i for i in ['client', 'server'] if kwargs[i]]
@@ -107,7 +106,7 @@ class WaylandModule(ExtensionModule):
             raise MesonException('stable protocols do not require a version number.')
 
         if self.protocols_dep is None:
-            self.protocols_dep = self.interpreter.func_dependency(state.current_node, ['wayland-protocols'], {})
+            self.protocols_dep = state.dependency('wayland-protocols')
 
         if self.pkgdatadir is None:
             self.pkgdatadir = self.protocols_dep.get_variable(pkgconfig='pkgdatadir', internal='pkgdatadir')


### PR DESCRIPTION
Just like some of glib tools, wayland-scanner can be defined in the
pkgconfig dependency variables. Share code between gnome and wayland
modules into ModuleState.