### PR TITLE
unittests: Skip prelinking test with gcc 8 or older

### DIFF
--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -1726,10 +1726,8 @@ class LinuxlikeTests(BasePlatformTests):
         testdir = os.path.join(self.unit_test_dir, '86 prelinking')
         env = get_fake_env(testdir, self.builddir, self.prefix)
         cc = detect_c_compiler(env, MachineChoice.HOST)
-        if cc.id == "gcc":
-            gccver = subprocess.check_output(['gcc', '--version'])
-            if b'7.5.0' in gccver:
-                raise SkipTest('GCC on Bionic is too old to be supported.')
+        if cc.id == "gcc" and not version_compare(cc.version, '>=9'):
+            raise SkipTest('Prelinking not supported with gcc 8 or older.')
         self.init(testdir)
         self.build()
         outlib = os.path.join(self.builddir, 'libprelinked.a')


### PR DESCRIPTION
This was already skipped when running on the Ubuntu 18.04 version of gcc,
but it also fails with gcc 8.3.0 on Debian 10. Instead of hard-coding
specific versions to look for, do a version comparison.