### PR TITLE
is_dragonflybsd() returns 'dragonflybsd'

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -136,7 +136,7 @@ These are provided by the `.system()` method call.
 | android             | By convention only, subject to change |
 | cygwin              | The Cygwin environment for Windows |
 | darwin              | Either OSX or iOS |
-| dragonfly           | DragonFly BSD |
+| dragonflybsd        | DragonFly BSD |
 | emscripten          | Emscripten's Javascript environment |
 | freebsd             | FreeBSD and its derivatives |
 | gnu                 | GNU Hurd |

--- a/docs/markdown/howtox.md
+++ b/docs/markdown/howtox.md
@@ -311,7 +311,7 @@ later.
 ```meson
 # Not needed on Windows!
 my_dep = dependency('', required : false)
-if host_machine.system() in ['freebsd', 'netbsd', 'openbsd', 'dragonfly']
+if host_machine.system() in ['freebsd', 'netbsd', 'openbsd', 'dragonflybsd']
   my_dep = dependency('some dep', required : false)
 elif host_machine.system() == 'linux'
   my_dep = dependency('some other dep', required : false)

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -318,7 +318,7 @@ class MachineInfo(HoldableObject):
 
     def is_dragonflybsd(self) -> bool:
         """Machine is DragonflyBSD?"""
-        return self.system == 'dragonfly'
+        return self.system == 'dragonflybsd'
 
     def is_freebsd(self) -> bool:
         """Machine is FreeBSD?"""

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -664,7 +664,7 @@ def is_debianlike() -> bool:
 
 
 def is_dragonflybsd() -> bool:
-    return platform.system().lower() == 'dragonfly'
+    return platform.system().lower() == 'dragonflybsd'
 
 
 def is_netbsd() -> bool:

--- a/test cases/common/132 get define/meson.build
+++ b/test cases/common/132 get define/meson.build
@@ -26,7 +26,7 @@ foreach lang : ['c', 'cpp']
     # set.
     d = cc.get_define('__FreeBSD__')
     assert(d != '', '__FreeBSD__ value is unset')
-  elif host_system == 'dragonfly'
+  elif host_system == 'dragonflybsd'
     d = cc.get_define('__DragonFly__')
     assert(d == '1', '__DragonFly__ value is @0@ instead of 1'.format(d))
   elif host_system == 'netbsd'

--- a/test cases/common/221 zlib/meson.build
+++ b/test cases/common/221 zlib/meson.build
@@ -1,6 +1,6 @@
 project('zlib system dependency', 'c')
 
-if not ['darwin', 'freebsd', 'dragonfly', 'windows', 'android'].contains(host_machine.system())
+if not ['darwin', 'freebsd', 'dragonflybsd', 'windows', 'android'].contains(host_machine.system())
   error('MESON_SKIP_TEST only applicable on macOS, FreeBSD, DragonflyBSD, Windows, and Android.')
 endif
 


### PR DESCRIPTION
A small change that makes it easier to sort out BSD operating systems; as it stands currently, DragonFlyBSD is the only outlier on the reference table.