### PR TITLE
test cases: use best practices method to find the python3 program

### DIFF
--- a/docs/markdown/Generating-sources.md
+++ b/docs/markdown/Generating-sources.md
@@ -53,7 +53,7 @@ is generated and that the proper include paths are created for the
 target:
 
 ```meson
-prog_python = import('python').find_installation('python3')
+prog_python = [[#find_program]]('python3')
 
 foo_c = custom_target(
     'foo.c',
@@ -89,7 +89,7 @@ get each output file separately. The order is the same as the order of
 the output argument to `custom_target`
 
 ```meson
-prog_python = import('python').find_installation('python3')
+prog_python = [[#find_program]]('python3')
 
 foo_ch = custom_target(
     'foo.[ch]',

--- a/mesonbuild/scripts/python_info.py
+++ b/mesonbuild/scripts/python_info.py
@@ -5,10 +5,14 @@
 # type: ignore
 # pylint: disable=deprecated-module
 
-import os.path
-import sysconfig
-import json
 import sys
+
+# do not inject mesonbuild.scripts
+# python -P would work too, but is exclusive to >=3.11
+if sys.path[0].endswith('scripts'):
+    del sys.path[0]
+
+import json, os, sysconfig
 import distutils.command.install
 
 def get_distutils_paths(scheme=None, prefix=None):

--- a/test cases/common/257 generated header dep/meson.build
+++ b/test cases/common/257 generated header dep/meson.build
@@ -8,7 +8,7 @@ project('generated header dep', 'c')
 # dependency on the header file. This happened in GLib:
 # https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2917.
 
-python = import('python').find_installation()
+python = find_program('python3')
 header = custom_target(
   output: 'foo.h',
   capture: true,

--- a/test cases/common/44 pkgconfig-gen/meson.build
+++ b/test cases/common/44 pkgconfig-gen/meson.build
@@ -18,7 +18,7 @@ if v.version_compare('<0.29')
   error('MESON_SKIP_TEST: pkg-config version \'' + v + '\' too old')
 endif
 
-python = import('python').find_installation()
+python = find_program('python3')
 fs = import('fs')
 pkgg = import('pkgconfig')
 

--- a/test cases/failing/115 run_target in test/meson.build
+++ b/test cases/failing/115 run_target in test/meson.build
@@ -1,7 +1,7 @@
 project('trivial test', 'c')
 
-py_inst = import('python').find_installation()
+python = find_program('python3')
 
 exe = executable('trivialprog', 'trivial.c')
-runt = run_target('invalid', command: [py_inst, '--version'])
+runt = run_target('invalid', command: [python, '--version'])
 test('runtest', exe, args: runt)

--- a/test cases/failing/116 run_target in add_install_script/meson.build
+++ b/test cases/failing/116 run_target in add_install_script/meson.build
@@ -1,7 +1,7 @@
 project('trivial test', 'c')
 
-py_inst = import('python').find_installation()
+python = find_program('python3')
 
 exe = executable('trivialprog', 'trivial.c')
-runt = run_target('invalid', command: [py_inst, '--version'])
+runt = run_target('invalid', command: [python, '--version'])
 meson.add_install_script(exe, runt)

--- a/test cases/java/8 codegen custom target/com/mesonbuild/meson.build
+++ b/test cases/java/8 codegen custom target/com/mesonbuild/meson.build
@@ -1,4 +1,4 @@
-python = import('python').find_installation('python3')
+python = find_program('python3')
 
 config_file = custom_target('confgen',
                             input : 'Config.java.in',

--- a/test cases/unit/64 alias target/meson.build
+++ b/test cases/unit/64 alias target/meson.build
@@ -1,6 +1,6 @@
 project('alias target', 'c')
 
-python3 = import('python').find_installation()
+python3 = find_program('python3')
 
 exe_target = executable('prog', 'main.c',
   build_by_default : false)

--- a/test cases/unit/70 cross test passed/meson.build
+++ b/test cases/unit/70 cross test passed/meson.build
@@ -6,7 +6,7 @@ project(
 
 e = executable('exec', 'src/main.c')
 
-py = import('python').find_installation()
+py = find_program('python3')
 
 test('root', e)
 test('main', py, args : [meson.current_source_dir() / 'script.py', e])

--- a/test cases/unit/71 summary/meson.build
+++ b/test cases/unit/71 summary/meson.build
@@ -11,7 +11,7 @@ summary({'Some boolean': false,
          'enabled_opt': get_option('enabled_opt'),
         }, section: 'Configuration')
 summary({'missing prog': find_program('xyzzy', required: false),
-         'existing prog': import('python').find_installation(),
+         'existing prog': find_program(get_option('python')).full_path(),
          'missing dep': dependency('', required: false),
          'external dep': dependency('zlib', required: false),
          'internal dep': declare_dependency(),

--- a/test cases/unit/71 summary/meson_options.txt
+++ b/test cases/unit/71 summary/meson_options.txt
@@ -1,1 +1,2 @@
 option('enabled_opt', type: 'feature', value: 'auto')
+option('python', type: 'string')

--- a/test cases/unit/73 dep files/meson.build
+++ b/test cases/unit/73 dep files/meson.build
@@ -1,6 +1,6 @@
 project('test', 'c')
 
-python = import('python').find_installation()
+python = find_program('python3')
 
 lib = library('foo', 'foo.c')
 

--- a/test cases/unit/99 custom target name/meson.build
+++ b/test cases/unit/99 custom target name/meson.build
@@ -1,6 +1,6 @@
 project('custom target name', 'c')
 
-python = import('python').find_installation()
+python = find_program('python3')
 
 # Name argument is optional and should default to 'file.txt'
 custom_target(

--- a/test cases/windows/13 test argument extra paths/test/meson.build
+++ b/test cases/windows/13 test argument extra paths/test/meson.build
@@ -1,3 +1,3 @@
-python3 = import('python').find_installation('')
+python3 = find_program('python3')
 
 test('run_exe', python3, args: [files('test_run_exe.py')[0], barexe])

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -44,6 +44,7 @@ from mesonbuild.mesonlib import (
     MesonException, EnvironmentException, OptionKey, ExecutableSerialisation, EnvironmentVariables,
     windows_proof_rm
 )
+from mesonbuild.programs import ExternalProgram
 
 from mesonbuild.compilers.mixins.clang import ClangCompiler
 from mesonbuild.compilers.mixins.gnu import GnuCompiler
@@ -3371,7 +3372,7 @@ class AllPlatformTests(BasePlatformTests):
 
     def test_summary(self):
         testdir = os.path.join(self.unit_test_dir, '71 summary')
-        out = self.init(testdir, extra_args=['-Denabled_opt=enabled'])
+        out = self.init(testdir, extra_args=['-Denabled_opt=enabled', f'-Dpython={sys.executable}'])
         expected = textwrap.dedent(r'''
             Some Subproject 2.0
 
@@ -3401,7 +3402,7 @@ class AllPlatformTests(BasePlatformTests):
 
               Stuff
                 missing prog   : NO
-                existing prog  : ''' + sys.executable + '''
+                existing prog  : ''' + ExternalProgram('python3', [sys.executable], silent=True).path + '''
                 missing dep    : NO
                 external dep   : YES 1.2.3
                 internal dep   : YES
@@ -3421,6 +3422,7 @@ class AllPlatformTests(BasePlatformTests):
                 libdir         : lib
                 prefix         : /usr
                 enabled_opt    : enabled
+                python         : ''' + sys.executable + '''
             ''')
         expected_lines = expected.split('\n')[1:]
         out_start = out.find(expected_lines[0])


### PR DESCRIPTION
We do not need the python module's find_installation() for this, as this does various things to set up building and installing python modules (pure python and C-API). This functionality is already tested in the python tests.

Elsewhere, when we just need an interpreter capable of running python scripts in order to guarantee a useful scripting language for custom commands, it suffices to use find_program(), which does not run an introspection script or do module imports, and is thus faster and a bit cleaner.

Either way, both methods are guaranteed to find the python3 interpreter, deferring to mesonlib.python_command for that guarantee.