### PR TITLE
fix regression in reporting errors for invalid gnu_symbol_visibility

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1255,7 +1255,7 @@ class BuildTarget(Target):
         if self.gnu_symbol_visibility != '':
             permitted = ['default', 'internal', 'hidden', 'protected', 'inlineshidden']
             if self.gnu_symbol_visibility not in permitted:
-                raise InvalidArguments('GNU symbol visibility arg {} not one of: {}'.format(self.symbol_visibility, ', '.join(permitted)))
+                raise InvalidArguments('GNU symbol visibility arg {} not one of: {}'.format(self.gnu_symbol_visibility, ', '.join(permitted)))
 
     def validate_win_subsystem(self, value: str) -> str:
         value = value.lower()


### PR DESCRIPTION
In commit fb2cdd0fe2797b30e1fd4c118407302402739a3b the internal property was renamed, but one use case of it in raising a MesonException was not changed to go with it.

This meant that instead of erroring out with:

```
ERROR: GNU symbol visibility arg XXXX not one of: default, internal, hidden, protected, inlineshidden
```

we instead errored out with:
```
AttributeError: 'SharedLibrary' object has no attribute 'symbol_visibility'
```

Fixes #9659