### PR TITLE
docs: simplify SimpleStart apt commands

### DIFF
--- a/docs/markdown/SimpleStart.md
+++ b/docs/markdown/SimpleStart.md
@@ -28,7 +28,7 @@ All Linux distributions provide easy access to development tools.
 Typically you need to open a terminal and execute one command, which
 depends on your distro.
 
- - Debian, Ubuntu and derivatives: `sudo apt install build-essential`
+ - Debian, Ubuntu and derivatives: `sudo apt install g++`
  - Fedora, Centos, RHEL and derivatives: `sudo dnf install gcc-c++`
  - Arch: `sudo pacman -S gcc`
 
@@ -66,7 +66,7 @@ install more files that are needed for compilation.
 
 Installing Meson is just as simple as installing the compiler toolchain.
 
- - Debian, Ubuntu and derivatives: `sudo apt install meson ninja-build`
+ - Debian, Ubuntu and derivatives: `sudo apt install meson`
  - Fedora, Centos, RHEL and derivatives: `sudo dnf install meson ninja-build`
  - Arch: `sudo pacman -S meson`
 


### PR DESCRIPTION
- Install `g++` instead of `build-essential`. Citing [`build-essential`](https://packages.debian.org/stable/build-essential)'s description: _"If you do not plan to build Debian packages, you don't need this package"_. `g++` pulls in everything that is required to build C and C++ programs, while `build-essential` installs unneeded stuff like `make` and `dpkg-dev`.

- Remove explicit `ninja-build` when installing `meson`. The `meson` package also installs `ninja-build`, so specifying it isn't needed (just like in the `pacman` command)