### PR TITLE
Add optional compress

### DIFF
--- a/packaging/create_zipapp.py
+++ b/packaging/create_zipapp.py
@@ -11,6 +11,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument('source', nargs='?', default='.', help='Source directory')
 parser.add_argument('--outfile', default='meson.pyz', help='Output file for the zipapp')
 parser.add_argument('--interpreter', default='/usr/bin/env python3', help='The name of the Python interpreter to use')
+parser.add_argument('--compress', action='store_true', default=False, help='Compress files')
 
 options = parser.parse_args(sys.argv[1:])
 
@@ -19,4 +20,4 @@ source = Path(options.source).resolve()
 with tempfile.TemporaryDirectory() as d:
     shutil.copy2(source / 'meson.py', Path(d, '__main__.py'))
     shutil.copytree(source / 'mesonbuild', Path(d, 'mesonbuild'))
-    zipapp.create_archive(d, interpreter=options.interpreter, target=options.outfile)
+    zipapp.create_archive(d, interpreter=options.interpreter, target=options.outfile, compressed=options.compress)


### PR DESCRIPTION
Compress files under source directory using Deflate method.
By default, files are not compressed in the archive.
Compression is active only when this option is defined.

[--compress](https://docs.python.org/3/library/zipapp.html?highlight=zipapp#cmdoption-zipapp-c) has no effect when copying an archive.