### PR TITLE
mtest: stop disrespecting the gdb config file

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1806,7 +1806,7 @@ class TestHarness:
     def get_wrapper(options: argparse.Namespace) -> T.List[str]:
         wrap = []  # type: T.List[str]
         if options.gdb:
-            wrap = [options.gdb_path, '--quiet', '--nh']
+            wrap = [options.gdb_path, '--quiet']
             if options.repeat > 1:
                 wrap += ['-ex', 'run', '-ex', 'quit']
             # Signal the end of arguments to gdb


### PR DESCRIPTION
This was added in commit 01be50fdd90851f17de5499537f10b5b62c9fb49 with zero explanation as a side effect of moving code around. It seems like a really bad idea and it causes people to view debugging Meson projects on e.g. debuginfod systems as "painful".

/cc @tristan957