### PR TITLE
fix incorrect FeatureNew for separator kwarg in environment object methods

### DIFF
--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -336,4 +336,4 @@ DEFAULT_OPTIONS: KwargInfo[T.List[str]] = KwargInfo(
 ENV_METHOD_KW = KwargInfo('method', str, default='set', since='0.62.0',
     validator=in_set_validator({'set', 'prepend', 'append'}))
 
-ENV_SEPARATOR_KW = KwargInfo('separator', str, default=os.pathsep, since='0.62.0')
+ENV_SEPARATOR_KW = KwargInfo('separator', str, default=os.pathsep)


### PR DESCRIPTION
In commit 6acfe48f32110671a0adf80ad3497a35105b265d, the kwarg was added to environment() in addition to the env object methods. As part of the associated refactor, a shared KwargInfo was used, and evolved to be new since 0.62.0 in the two cases where it is in fact new.

However, it *also* set the base KwargInfo for the exact same newness, which is wrong as it was present ever since the initial introduction in 0.34.0

As usual for anything that predates 0.37.0 we simply don't tag FeatureNew. Revert this back to the same KwargInfo definition from before the refactoring commit.

Fixes #10402