### PR TITLE
ninja backend: generate additional meta-rules for test/benchmarks targets

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 from collections import OrderedDict
 from dataclasses import dataclass, InitVar
@@ -1244,10 +1245,12 @@ class Backend:
         for name, b in self.build.get_targets().items():
             if b.build_by_default:
                 result[name] = b
-        # Get all targets used as test executables and arguments. These must
-        # also be built by default. XXX: Sometime in the future these should be
-        # built only before running tests.
-        for t in self.build.get_tests():
+        return result
+
+    def get_testlike_targets(self, benchmark: bool = False) -> T.OrderedDict[str, T.Union[build.BuildTarget, build.CustomTarget]]:
+        result: T.OrderedDict[str, T.Union[build.BuildTarget, build.CustomTarget]] = OrderedDict()
+        targets = self.build.get_benchmarks() if benchmark else self.build.get_tests()
+        for t in targets:
             exe = t.exe
             if isinstance(exe, (build.CustomTarget, build.BuildTarget)):
                 result[exe.get_id()] = exe

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -358,6 +358,7 @@ class Vs2010Backend(backends.Backend):
 
     def generate_solution(self, sln_filename, projlist):
         default_projlist = self.get_build_by_default_targets()
+        default_projlist.update(self.get_testlike_targets())
         sln_filename_tmp = sln_filename + '~'
         # Note using the utf-8 BOM requires the blank line, otherwise Visual Studio Version Selector fails.
         # Without the BOM, VSVS fails if there is a blank line.

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -385,7 +385,7 @@ class BasePlatformTests(TestCase):
 
     def assertReconfiguredBuildIsNoop(self):
         'Assert that we reconfigured and then there was nothing to do'
-        ret = self.build()
+        ret = self.build(stderr=False)
         self.assertIn('The Meson build system', ret)
         if self.backend is Backend.ninja:
             for line in ret.split('\n'):
@@ -407,7 +407,7 @@ class BasePlatformTests(TestCase):
             raise RuntimeError(f'Invalid backend: {self.backend.name!r}')
 
     def assertBuildIsNoop(self):
-        ret = self.build()
+        ret = self.build(stderr=False)
         if self.backend is Backend.ninja:
             self.assertIn(ret.split('\n')[-2], self.no_rebuild_stdout)
         elif self.backend is Backend.vs:


### PR DESCRIPTION
'meson-test-prereq' now depends on any targets that were formerly added directly to 'all'. Behavior is not changed -- the all target still depends on this other meta-rule, and thus indirectly depends on all targets it used to depend on.

It is now possible to build just the targets needed for the testsuite and then e.g. run `meson test --no-rebuild`.