### PR TITLE
Do not call wine if the WINEPATH is already short enough

### DIFF
--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -1893,6 +1893,11 @@ def get_wine_shortpath(winecmd: T.List[str], wine_paths: T.Sequence[str]) -> str
 
     wine_paths = list(OrderedSet(wine_paths))
 
+    # do we even need to bother shortening the path?
+    wine_path = ';'.join(wine_paths)
+    if len(wine_path) < 2048:
+        return wine_path
+
     getShortPathScript = '%s.bat' % str(uuid.uuid4()).lower()[:5]
     with open(getShortPathScript, mode='w', encoding='utf-8') as f:
         f.write("@ECHO OFF\nfor %%x in (%*) do (\n echo|set /p=;%~sx\n)\n")

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -1913,9 +1913,9 @@ def get_wine_shortpath(winecmd: T.List[str], wine_paths: T.Sequence[str]) -> str
         wine_path = ';'.join(wine_paths)
     finally:
         os.remove(getShortPathScript)
-    if len(wine_path) > 2048:
+    if len(wine_path) >= 2048:
         raise MesonException(
-            'WINEPATH size {} > 2048'
+            'WINEPATH size {} >= 2048'
             ' this will cause random failure.'.format(
                 len(wine_path)))
 


### PR DESCRIPTION
We call 'wine cmd' to shorten the wine paths so that we do not exceed
the 2048-char limit for the WINEPATH environment variable.

In the most common case where the path is well below this limit, just
use the unadulterated paths.
This speeds up generating exe_wrapper outputs, and also seems to work
correctly in more cases.

Fixes https://github.com/mesonbuild/meson/issues/10401