### PR TITLE
fix traceback when run_command has a find_program as the inline arg

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -759,7 +759,12 @@ external dependencies (including libraries) must go to "dependencies".''')
                           'configuration')
         expanded_args: T.List[str] = []
         if isinstance(cmd, build.Executable):
-            progname = node.args.arguments[0].value
+            for name, exe in self.build.find_overrides.items():
+                if cmd == exe:
+                    progname = name
+                    break
+            else:
+                raise MesonBugException('cmd was a built executable but not found in overrides table')
             raise InterpreterException(overridden_msg.format(progname, cmd.description()))
         if isinstance(cmd, ExternalProgram):
             if not cmd.found():


### PR DESCRIPTION
We were poking directly at the node, so if it was a FunctionNode then this broke. Instead, just do a reverse lookup in the overrides table to get the original find_program name.