### PR TITLE
mtest: ignore invalid input

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -426,11 +426,6 @@ class TAPParser:
                 else:
                     yield self.Version(version=self.version)
                 return
-
-            if not line:
-                return
-
-            yield self.Error(f'unexpected input at line {self.lineno}')
         else:
             # end of file
             if self.state == self._YAML:

--- a/unittests/taptests.py
+++ b/unittests/taptests.py
@@ -255,7 +255,6 @@ class TAPParserTests(unittest.TestCase):
     def test_unexpected(self):
         events = self.parse_tap('1..1\ninvalid\nok 1')
         self.assert_plan(events, num_tests=1, late=False)
-        self.assert_error(events)
         self.assert_test(events, number=1, name='', result=TestResult.OK)
         self.assert_last(events)
 


### PR DESCRIPTION
TAP version 14 introduced subtests, that are supposedly backward compatible because "TAP13 specifies that non-TAP output should be ignored".  Meson reported TAP syntax errors based on behavior of "prove" at the time, but it seems that now "prove" has become a lot more lenient; it even accepts the following completely bogus input just fine:

```
ok 1
    ok 2
x
1..1
```

So do the same and make Meson's parser accept invalid TAP input silently.

Fixes: #10032