### PR TITLE
Fix custom_target whose input is extract_objects of generated sources

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -836,7 +836,7 @@ class Backend:
         # With unity builds, sources don't map directly to objects,
         # we only support extracting all the objects in this mode,
         # so just return all object files.
-        if self.is_unity(extobj.target):
+        if extobj.target.is_unity:
             compsrcs = classify_unity_sources(extobj.target.compilers.values(), sources)
             sources = []
             unity_size = extobj.target.get_option(OptionKey('unity_size'))
@@ -1279,10 +1279,6 @@ class Backend:
                 continue
             libs.extend(self.get_custom_target_provided_by_generated_source(t))
         return libs
-
-    def is_unity(self, target: build.BuildTarget) -> bool:
-        optval = target.get_option(OptionKey('unity'))
-        return optval == 'on' or (optval == 'subprojects' and target.subproject != '')
 
     def get_custom_target_sources(self, target: build.CustomTarget) -> T.List[str]:
         '''

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -792,7 +792,7 @@ class NinjaBackend(backends.Backend):
         # Generate rules for building the remaining source files in this target
         outname = self.get_target_filename(target)
         obj_list = []
-        is_unity = self.is_unity(target)
+        is_unity = target.is_unity
         header_deps = []
         unity_src = []
         unity_deps = [] # Generated sources that must be built before compiling a Unity target.
@@ -1527,7 +1527,7 @@ class NinjaBackend(backends.Backend):
             # Outputted header
             hname = os.path.join(self.get_target_dir(target), target.vala_header)
             args += ['--header', hname]
-            if self.is_unity(target):
+            if target.is_unity:
                 # Without this the declarations will get duplicated in the .c
                 # files and cause a build failure when all of them are
                 # #include-d in one .c file.

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -878,7 +878,7 @@ class Vs2010Backend(backends.Backend):
         # Prefix to use to access the source tree's subdir from the vcxproj dir
         proj_to_src_dir = os.path.join(proj_to_src_root, self.get_target_dir(target))
         (sources, headers, objects, languages) = self.split_sources(target.sources)
-        if self.is_unity(target):
+        if target.is_unity:
             sources = self.generate_unity_files(target, sources)
         compiler = self._get_cl_compiler(target)
         build_args = compiler.get_buildtype_args(self.buildtype)

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -259,9 +259,6 @@ class XCodeBackend(backends.Backend):
         obj_path = f'{project}.build/{buildtype}/{tname}.build/Objects-normal/{arch}/{stem}.o'
         return obj_path
 
-    def get_extracted_obj_paths(self, target: build.BuildTarget, outputs: T.List[str]) -> T.List[str]:
-        return outputs
-
     def generate(self):
         self.serialize_tests()
         # Cache the result as the method rebuilds the array every time it is called.
@@ -1469,7 +1466,7 @@ class XCodeBackend(backends.Backend):
                 # Add extracted objects to the link line by hand.
                 if isinstance(o, build.ExtractedObjects):
                     added_objs = set()
-                    for objname_rel in o.get_outputs(self):
+                    for objname_rel in self.determine_ext_objs(o):
                         objname_abs = os.path.join(self.environment.get_build_dir(), o.target.subdir, objname_rel)
                         if objname_abs not in added_objs:
                             added_objs.add(objname_abs)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -753,8 +753,6 @@ class BuildTarget(Target):
                  sources: T.List['SourceOutputs'], structured_sources: T.Optional[StructuredSources],
                  objects, environment: environment.Environment, compilers: T.Dict[str, 'Compiler'], kwargs):
         super().__init__(name, subdir, subproject, True, for_machine, environment)
-        unity_opt = environment.coredata.get_option(OptionKey('unity'))
-        self.is_unity = unity_opt == 'on' or (unity_opt == 'subprojects' and subproject != '')
         self.all_compilers = compilers
         self.compilers = OrderedDict() # type: OrderedDict[str, Compiler]
         self.objects: T.List[T.Union[str, 'File', 'ExtractedObjects']] = []
@@ -809,6 +807,11 @@ class BuildTarget(Target):
 
     def __str__(self):
         return f"{self.name}"
+
+    @property
+    def is_unity(self) -> bool:
+        unity_opt = self.get_option(OptionKey('unity'))
+        return unity_opt == 'on' or (unity_opt == 'subprojects' and self.subproject != '')
 
     def validate_install(self):
         if self.for_machine is MachineChoice.BUILD and self.need_install:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -447,12 +447,6 @@ class ExtractedObjects(HoldableObject):
                                      'in Unity builds. You can only extract all '
                                      'the object files for each compiler at once.')
 
-    def get_outputs(self, backend: 'Backend') -> T.List[str]:
-        return [
-            backend.object_filename_from_source(self.target, source)
-            for source in self.get_sources(self.srclist, self.genlist)
-        ]
-
 
 @dataclass(eq=False, order=False)
 class StructuredSources(HoldableObject):
@@ -2878,7 +2872,7 @@ def get_sources_string_names(sources, backend):
         elif isinstance(s, (BuildTarget, CustomTarget, CustomTargetIndex, GeneratedList)):
             names += s.get_outputs()
         elif isinstance(s, ExtractedObjects):
-            names += s.get_outputs(backend)
+            names += backend.determine_ext_objs(s)
         elif isinstance(s, File):
             names.append(s.fname)
         else:

--- a/test cases/common/216 custom target input extracted objects/check_object.py
+++ b/test cases/common/216 custom target input extracted objects/check_object.py
@@ -3,11 +3,15 @@
 import sys, os
 
 if __name__ == '__main__':
-    if len(sys.argv) != 3:
-        print(sys.argv[0], 'object', 'output')
+    if len(sys.argv) < 4:
+        print(sys.argv[0], 'n output objects...')
         sys.exit(1)
-    elif os.path.exists(sys.argv[1]):
-        with open(sys.argv[2], 'wb') as out:
-            pass
-    else:
+    if len(sys.argv) != int(sys.argv[1]) + 3:
+        print(f'expected {sys.argv[1]} objects, got {len(sys.argv) - 3}')
         sys.exit(1)
+    for i in sys.argv[3:]:
+        print('testing', i)
+        if not os.path.exists(i):
+            sys.exit(1)
+    with open(sys.argv[2], 'wb') as out:
+        pass

--- a/test cases/common/216 custom target input extracted objects/libdir/gen.py
+++ b/test cases/common/216 custom target input extracted objects/libdir/gen.py
@@ -1,0 +1,6 @@
+#! /usr/bin/env python3
+import sys
+with open(sys.argv[1], 'r') as f:
+    for l in f:
+        l = l.rstrip()
+        print(l.replace(sys.argv[2], sys.argv[3]))

--- a/test cases/common/216 custom target input extracted objects/libdir/meson.build
+++ b/test cases/common/216 custom target input extracted objects/libdir/meson.build
@@ -1,1 +1,21 @@
-objlib = static_library('object', 'source.c', override_options : ['unity=off'])
+gen_py = find_program('gen.py')
+ctsrc = custom_target('custom_target sources',
+                       output: 'ct-source.c',
+                       input: 'source.c',
+                       command: [ gen_py, '@INPUT@', 'func1', 'func2' ], capture: true)
+
+gen = generator(gen_py, arguments: ['@INPUT@', 'func1', 'func3'],
+                output: 'gen-@PLAINNAME@',
+                capture: true)
+gensrc = gen.process('source.c')
+
+
+gen = generator(gen_py, arguments: ['@INPUT@', 'func1', 'func4'],
+                output: 'gen-@PLAINNAME@',
+                capture: true)
+sublibsrc = gen.process('source.c')
+subobjlib = static_library('subobject', sublibsrc)
+
+objlib = static_library('object', 'source.c', ctsrc, gensrc,
+                        objects: subobjlib.extract_all_objects(recursive: false),
+                        override_options : ['unity=off'])

--- a/test cases/common/216 custom target input extracted objects/meson.build
+++ b/test cases/common/216 custom target input extracted objects/meson.build
@@ -14,5 +14,35 @@ subdir('libdir')
 custom_target('check',
   input: objlib.extract_objects('source.c'),
   output: 'objcheck',
-  command: [checker, '@INPUT@', '@OUTPUT@'],
+  command: [checker, '1', '@OUTPUT@', '@INPUT@'],
+  build_by_default: true)
+
+custom_target('checkct',
+  input: objlib.extract_objects(ctsrc),
+  output: 'objcheck-ct',
+  command: [checker, '1', '@OUTPUT@', '@INPUT@'],
+  build_by_default: true)
+
+custom_target('checkcti',
+  input: objlib.extract_objects(ctsrc[0]),
+  output: 'objcheck-cti',
+  command: [checker, '1', '@OUTPUT@', '@INPUT@'],
+  build_by_default: true)
+
+custom_target('checkgen',
+  input: objlib.extract_objects(gensrc),
+  output: 'objcheck-gen',
+  command: [checker, '1', '@OUTPUT@', '@INPUT@'],
+  build_by_default: true)
+
+custom_target('checkall',
+  input: objlib.extract_all_objects(recursive: false),
+  output: 'objcheck-all',
+  command: [checker, '3', '@OUTPUT@', '@INPUT@'],
+  build_by_default: true)
+
+custom_target('checkall-recursive',
+  input: objlib.extract_all_objects(recursive: true),
+  output: 'objcheck-all-recursive',
+  command: [checker, '4', '@OUTPUT@', '@INPUT@'],
   build_by_default: true)

--- a/test cases/failing/126 extract from unity/meson.build
+++ b/test cases/failing/126 extract from unity/meson.build
@@ -1,0 +1,4 @@
+project('extract nonexisting gen', 'c')
+
+lib1 = library('lib1', 'src1.c', 'src2.c', override_options: ['unity=on'])
+lib2 = library('lib2', objects: lib1.extract_objects('src1.c'))

--- a/test cases/failing/126 extract from unity/src1.c
+++ b/test cases/failing/126 extract from unity/src1.c
@@ -1,0 +1,3 @@
+int sub_lib_method1() {
+    return 1337;
+}

--- a/test cases/failing/126 extract from unity/src2.c
+++ b/test cases/failing/126 extract from unity/src2.c
@@ -1,0 +1,3 @@
+int sub_lib_method2() {
+    return 1337;
+}

--- a/test cases/failing/126 extract from unity/test.json
+++ b/test cases/failing/126 extract from unity/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/126 extract from unity/meson.build:4:0: ERROR: Single object files can not be extracted in Unity builds. You can only extract all the object files for each compiler at once."
+    }
+  ]
+}


### PR DESCRIPTION
Fix yet another extract_objects corner case.  This time however the fix is generic and removes some ugly hooking from build.py to the backend. Crossing fingers that it works on Xcode and VS...