### PR TITLE
Fix optimization level 's' for the TI CL2000 compiler

### DIFF
--- a/mesonbuild/compilers/mixins/ti.py
+++ b/mesonbuild/compilers/mixins/ti.py
@@ -44,7 +44,7 @@ ti_optimization_args = {
     '1': ['-O1'],
     '2': ['-O2'],
     '3': ['-O3'],
-    's': ['-04']
+    's': ['-O4']
 }  # type: T.Dict[str, T.List[str]]
 
 ti_debug_args = {


### PR DESCRIPTION
A wrong command line option is passed to the TI CL2000 compiler if the optimization level is set to 's' (0 instead of O).