### PR TITLE
fix custom_target crash if boolean true is specified in install_dir

### DIFF
--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -183,7 +183,7 @@ class CustomTarget(TypedDict):
     input: T.List[T.Union[str, build.BuildTarget, build.CustomTarget, build.CustomTargetIndex,
                           build.ExtractedObjects, build.GeneratedList, ExternalProgram, File]]
     install: bool
-    install_dir: T.List[T.Union[str, bool]]
+    install_dir: T.List[T.Union[str, T.Literal[False]]]
     install_mode: FileMode
     install_tag: T.List[T.Optional[str]]
     output: T.List[str]

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -297,11 +297,12 @@ INSTALL_TAG_KW: KwargInfo[T.Optional[str]] = KwargInfo('install_tag', (str, None
 
 INSTALL_KW = KwargInfo('install', bool, default=False)
 
-CT_INSTALL_DIR_KW: KwargInfo[T.List[T.Union[str, bool]]] = KwargInfo(
+CT_INSTALL_DIR_KW: KwargInfo[T.List[T.Union[str, Literal[False]]]] = KwargInfo(
     'install_dir',
     ContainerTypeInfo(list, (str, bool)),
     listify=True,
     default=[],
+    validator=lambda x: 'must be `false` if boolean' if True in x else None,
 )
 
 CT_BUILD_BY_DEFAULT: KwargInfo[T.Optional[bool]] = KwargInfo('build_by_default', (bool, type(None)), since='0.40.0')


### PR DESCRIPTION
We accept boolean false to indicate "do not install this one particular output", but the type checking simply checked if it is a bool. We do this correctly for configure_file, so copy the same validator from there.