### PR TITLE
don't tell documentation contributors to skip CI

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,11 +30,3 @@ You can simply run:
 ```
 $ ninja -C built_docs/ upload
 ```
-
-## Contributing to the documentation
-
-Commits that only change documentation should have `[skip ci]` in their commit message, so CI is not run (it is quite slow).
-For example:
-```
-A commit message [skip ci]
-```

--- a/docs/markdown/Contributing.md
+++ b/docs/markdown/Contributing.md
@@ -462,11 +462,6 @@ notes. These features should be written in standalone files in the
 `docs/markdown/snippets` directory. The release manager will combine
 them into one page when doing the release.
 
-[Integration tests should be disabled](#skipping-integration-tests) for
-documentation-only commits by putting `[skip ci]` into commit title.
-Reviewers should ask contributors to put `[skip ci]` into the title because
-tests are run again after merge for `master`.
-
 ## Python Coding style
 
 Meson follows the basic Python coding style. Additional rules are the

--- a/skip_ci.py
+++ b/skip_ci.py
@@ -61,8 +61,7 @@ def main():
         if args.base_branch_origin:
             base = 'origin/' + base
         if all(is_documentation(f) for f in get_git_files(base)):
-            print("Don't run CI for documentation-only changes, add '[skip ci]' to commit title.")
-            print('See http://mesonbuild.com/Contributing.html#skipping-integration-tests')
+            print("Documentation change, CI skipped.")
             sys.exit(1)
     except Exception:
         # If this script fails we want build to proceed.


### PR DESCRIPTION
The CI correctly handles documentation changes automatically, it's no longer necessary to do it by hand.

Relevant: https://github.com/mesonbuild/meson/pull/10433