### PR TITLE
Fix that VS backend respects "console" keyword in custom_target

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -651,7 +651,8 @@ class Vs2010Backend(backends.Backend):
                                                    capture=ofilenames[0] if target.capture else None,
                                                    feed=srcs[0] if target.feed else None,
                                                    force_serialize=True,
-                                                   env=target.env)
+                                                   env=target.env,
+                                                   verbose=target.console)
         if target.build_always_stale:
             # Use a nonexistent file to always consider the target out-of-date.
             ofilenames += [self.nonexistent_file(os.path.join(self.environment.get_scratch_dir(),


### PR DESCRIPTION
Previously the output of the custom target was always captured
and it was not possible to see the output unless build failed.