### PR TITLE
mesonbuild: fix ppc64 case for 10.5 and bring ppc/ppc64 trials to consistency

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -316,9 +316,12 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
         trial = 'aarch64'
     elif trial.startswith('arm') or trial.startswith('earm'):
         trial = 'arm'
-    elif trial.startswith(('powerpc64', 'ppc64')):
-        trial = 'ppc64'
-    elif trial.startswith(('powerpc', 'ppc')) or trial in {'macppc', 'power macintosh'}:
+    elif trial.startswith(('powerpc', 'ppc')):
+        if '64' not in trial:
+            trial = 'ppc'
+        else:
+            trial = 'ppc64'
+    elif trial in {'macppc', 'power macintosh'}:
         trial = 'ppc'
     elif trial in ('amd64', 'x64', 'i86pc'):
         trial = 'x86_64'
@@ -382,6 +385,13 @@ def detect_cpu(compilers: CompilersDict) -> str:
             trial = 'aarch64'
     elif trial.startswith('earm'):
         trial = 'arm'
+    elif trial.startswith(('powerpc', 'ppc')):
+        if '64' not in trial:
+            trial = 'ppc'
+        else:
+            trial = 'ppc64'
+    elif trial in {'macppc', 'power macintosh'}:
+        trial = 'ppc'
     elif trial == 'e2k':
         # Make more precise CPU detection for Elbrus platform.
         trial = platform.processor().lower()

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -423,6 +423,7 @@ def detect_machine_info(compilers: T.Optional[CompilersDict] = None) -> MachineI
 
 # TODO make this compare two `MachineInfo`s purely. How important is the
 # `detect_cpu_family({})` distinction? It is the one impediment to that.
+# The ppc case is for MacOS: Power Macintosh is identified as ppc, but 10.5 supports ppc64
 def machine_info_can_run(machine_info: MachineInfo):
     """Whether we can run binaries for this machine on the current machine.
 
@@ -437,7 +438,8 @@ def machine_info_can_run(machine_info: MachineInfo):
     return \
         (machine_info.cpu_family == true_build_cpu_family) or \
         ((true_build_cpu_family == 'x86_64') and (machine_info.cpu_family == 'x86')) or \
-        ((true_build_cpu_family == 'aarch64') and (machine_info.cpu_family == 'arm'))
+        ((true_build_cpu_family == 'aarch64') and (machine_info.cpu_family == 'arm')) or \
+        (mesonlib.is_osx() and (true_build_cpu_family == 'ppc') and (machine_info.cpu_family == 'ppc64'))
 
 class Environment:
     private_dir = 'meson-private'


### PR DESCRIPTION
This PR:

1. Fixes a build error on Leopard for `ppc64`. An example, where `gobject-introspection` fails to build for `ppc`+`ppc64` due to `mesonbuild` error: https://github.com/macports/macports-ports/pull/14909#issuecomment-1134971290
2. Brings trials for `ppc` and `ppc64` into consistency, so that we don’t get “power macintosh” as a cpu value.

Tested with the case of `gobject-introspection` build cited above: with these changes `meson` works as it should.