### PR TITLE
fix incorrectly allowed kwarg for custom_target

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2424,7 +2424,6 @@ class CustomTarget(Target, CommandBase):
                  install_dir: T.Optional[T.Sequence[T.Union[str, bool]]] = None,
                  install_mode: T.Optional[FileMode] = None,
                  install_tag: T.Optional[T.Sequence[T.Optional[str]]] = None,
-                 override_options: T.Optional[T.Dict[OptionKey, str]] = None,
                  absolute_paths: bool = False,
                  backend: T.Optional['Backend'] = None,
                  ):
@@ -2455,8 +2454,6 @@ class CustomTarget(Target, CommandBase):
             _install_tag = list(_install_tag) * len(self.outputs)
         self.install_tag = _install_tag
         self.name = name if name else self.outputs[0]
-
-        self.set_option_overrides(override_options or {})
 
         # Whether to use absolute paths for all files on the commandline
         self.absolute_paths = absolute_paths

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -71,7 +71,7 @@ from .type_checking import (
     CT_INSTALL_TAG_KW,
     INSTALL_TAG_KW,
     LANGUAGE_KW,
-    NATIVE_KW, OVERRIDE_OPTIONS_KW,
+    NATIVE_KW,
     REQUIRED_KW,
     NoneType,
     in_set_validator,
@@ -1857,7 +1857,6 @@ class Interpreter(InterpreterBase, HoldableObject):
         ENV_KW.evolve(since='0.57.0'),
         INSTALL_KW,
         INSTALL_MODE_KW.evolve(since='0.47.0'),
-        OVERRIDE_OPTIONS_KW,
         KwargInfo('feed', bool, default=False, since='0.59.0'),
         KwargInfo('capture', bool, default=False),
         KwargInfo('console', bool, default=False, since='0.48.0'),
@@ -1948,7 +1947,6 @@ class Interpreter(InterpreterBase, HoldableObject):
             install_dir=kwargs['install_dir'],
             install_mode=kwargs['install_mode'],
             install_tag=kwargs['install_tag'],
-            override_options=kwargs['override_options'],
             backend=self.backend)
         self.add_target(tg.name, tg)
         return tg

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -11,7 +11,7 @@ from typing_extensions import TypedDict, Literal, Protocol
 from .. import build
 from .. import coredata
 from ..compilers import Compiler
-from ..mesonlib import MachineChoice, File, FileMode, FileOrString, OptionKey
+from ..mesonlib import MachineChoice, File, FileMode, FileOrString
 from ..modules.cmake import CMakeSubprojectOptions
 from ..programs import ExternalProgram
 
@@ -187,7 +187,6 @@ class CustomTarget(TypedDict):
     install_mode: FileMode
     install_tag: T.List[T.Optional[str]]
     output: T.List[str]
-    override_options: T.Dict[OptionKey, str]
 
 class AddTestSetup(TypedDict):
 

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -328,7 +328,7 @@ INCLUDE_DIRECTORIES: KwargInfo[T.List[T.Union[str, IncludeDirs]]] = KwargInfo(
 # for cases like default_options and override_options
 DEFAULT_OPTIONS: KwargInfo[T.List[str]] = KwargInfo(
     'default_options',
-    ContainerTypeInfo(list, (str, IncludeDirs)),
+    ContainerTypeInfo(list, str),
     listify=True,
     default=[],
     validator=_options_validator,


### PR DESCRIPTION
override_options makes no sense for custom_target as we don't use it for anything. Also, this was added in commit c3c30d4b060239654c9b848092692ab346ebed9d despite not being allowed in permittedKwargsc3c30d4b0.

For inexplicable reasons, we had a known_kwargs for custom_target that looped over kwargs and issued a warning, not an error, for unknown kwargs. It was impossible to ever hit that check to begin with, though, ever since commit e08d73510552fa4a3a087af1a9e5fded8f5749fd which added permittedKwargs and obsoleted those manual checks with real errors.

So at one point override_options was specially permitted to be used without emitting a warning, and then for about half a decade it was an error, and then based on some dead code it was allowed again for a bit. But through all this it doesn't do anything and isn't documented.