### PR TITLE
compilers: Add support for stand-alone leak sanitizer

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -142,7 +142,7 @@ available on all platforms or with all compilers:
 | b_vscrt       | from_buildtype | none, md, mdd, mt, mtd, from_buildtype, static_from_buildtype    | VS runtime library to use (since 0.48.0) (static_from_buildtype since 0.56.0) |
 
 The value of `b_sanitize` can be one of: `none`, `address`, `thread`,
-`undefined`, `memory`, `address,undefined`, but note that some
+`undefined`, `memory`, `leak`, `address,undefined`, but note that some
 compilers might not support all of them. For example Visual Studio
 only supports the address sanitizer.
 

--- a/docs/markdown/Configuring-a-build-directory.md
+++ b/docs/markdown/Configuring-a-build-directory.md
@@ -53,7 +53,7 @@ a sample output for a simple project.
       b_ndebug    false         [true, false, if-release]                                     Disable asserts
       b_pch       true          [true, false]                                                 Use precompiled headers
       b_pgo       off           [off, generate, use]                                          Use profile guided optimization
-      b_sanitize  none          [none, address, thread, undefined, memory, address,undefined] Code sanitizer to use
+      b_sanitize  none          [none, address, thread, undefined, leak, memory, address,undefined] Code sanitizer to use
       b_staticpic true          [true, false]                                                 Build static libraries as position independent
 
     Compiler options:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -278,7 +278,7 @@ base_options: 'KeyedOptionDictType' = {
                                                       ['default', 'thin'],
                                                       'default'),
     OptionKey('b_sanitize'): coredata.UserComboOption('Code sanitizer to use',
-                                                      ['none', 'address', 'thread', 'undefined', 'memory', 'address,undefined'],
+                                                      ['none', 'address', 'thread', 'undefined', 'memory', 'leak', 'address,undefined'],
                                                       'none'),
     OptionKey('b_lundef'): coredata.UserBooleanOption('Use -Wl,--no-undefined when linking', True),
     OptionKey('b_asneeded'): coredata.UserBooleanOption('Use -Wl,--as-needed when linking', True),


### PR DESCRIPTION
Leak sanitizer can be enabled without the whole AddressSanitizer, this
can be done by passing -fsanitize=leak as documented at [1].

Meson doesn't support this, so add support for it.

[1] https://clang.llvm.org/docs/LeakSanitizer.html