### PR TITLE
devenv: do not fatally error if pkg-config or bash-completion is not available

### DIFF
--- a/mesonbuild/mdevenv.py
+++ b/mesonbuild/mdevenv.py
@@ -96,7 +96,7 @@ def get_env(b: build.Build, build_dir: str) -> T.Tuple[T.Dict[str, str], T.Set[s
 def bash_completion_files(b: build.Build, install_data: 'InstallData') -> T.List[str]:
     result = []
     dep = dependencies.PkgConfigDependency('bash-completion', b.environment,
-                                           {'silent': True, 'version': '>=2.10'})
+                                           {'required': False, 'silent': True, 'version': '>=2.10'})
     if dep.found():
         prefix = b.environment.coredata.get_option(OptionKey('prefix'))
         assert isinstance(prefix, str), 'for mypy'


### PR DESCRIPTION
We might be using all fallbacks, or be super weird and not use bash-completion, or simply have a different PKG_CONFIG_LIBDIR set. And devenv already checks whether the dependency is found, but defaults to required anyway, which is wrong.