### PR TITLE
Try to clarify what modules are found/missing

### DIFF
--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -755,13 +755,18 @@ class PythonModule(ExtensionModule):
         msg: T.List['mlog.TV_Loggable'] = ['Program', python.name]
         if want_modules:
             msg.append('({})'.format(', '.join(want_modules)))
-        msg.append('found:')
+        msg.append('required:')
+        if required:
+            msg.append(mlog.green('YES'))
+        else:
+            msg.append(mlog.red('NO'))
+        msg.append('configured:')
         if python.found() and not missing_modules:
             msg.extend([mlog.green('YES'), '({})'.format(' '.join(python.command))])
         else:
-            msg.append(mlog.red('NO'))
+            msg.extend([mlog.red('NO'), 'missing: {}'.format(', '.join(missing_modules))])
         if found_modules:
-            msg.append('modules:')
+            msg.append('found:')
             msg.append(', '.join(found_modules))
 
         mlog.log(*msg)

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -755,18 +755,13 @@ class PythonModule(ExtensionModule):
         msg: T.List['mlog.TV_Loggable'] = ['Program', python.name]
         if want_modules:
             msg.append('({})'.format(', '.join(want_modules)))
-        msg.append('required:')
-        if required:
-            msg.append(mlog.green('YES'))
-        else:
-            msg.append(mlog.red('NO'))
-        msg.append('configured:')
+        msg.append('found:')
         if python.found() and not missing_modules:
             msg.extend([mlog.green('YES'), '({})'.format(' '.join(python.command))])
         else:
             msg.extend([mlog.red('NO'), 'missing: {}'.format(', '.join(missing_modules))])
         if found_modules:
-            msg.append('found:')
+            msg.append('modules:')
             msg.append(', '.join(found_modules))
 
         mlog.log(*msg)

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -752,17 +752,22 @@ class PythonModule(ExtensionModule):
                 else:
                     found_modules.append(mod)
 
-        msg: T.List['mlog.TV_Loggable'] = ['Program', python.name]
-        if want_modules:
-            msg.append('({})'.format(', '.join(want_modules)))
+        msg: T.List['mlog.TV_Loggable'] = ['Runtime dependency', display_name]
+
+        found_modules_msg = ', '.join(found_modules)
+        missing_modules_msg = ', '.join(missing_modules)
+        if found_modules_msg and missing_modules_msg:
+            msg.append("(found: {} | missing: {})".format(found_modules_msg, missing_modules_msg))
+        elif found_modules_msg:
+            msg.append("(found: {})".format(found_modules_msg))
+        elif missing_modules_msg:
+            msg.append("(missing: {})".format(missing_modules_msg))
+
         msg.append('found:')
         if python.found() and not missing_modules:
             msg.extend([mlog.green('YES'), '({})'.format(' '.join(python.command))])
         else:
-            msg.extend([mlog.red('NO'), 'missing: {}'.format(', '.join(missing_modules))])
-        if found_modules:
-            msg.append('modules:')
-            msg.append(', '.join(found_modules))
+            msg.append(mlog.red('NO'))
 
         mlog.log(*msg)
 


### PR DESCRIPTION
I recently used the meson build system in a relatively simple project that used python optionally. I received the following output and found it confusing. Here is the relevant section of `meson.build`

```
testing_py = py.find_installation('python3',
  modules: ['cffi', 'hypothesis', 'numpy', 'pandas', 'pytest_benchmark'],
  required: false
  )
```

I am missing `hypothesis` and `pytest_benchmark`, running `meson build` I get the following:

```
...
Program python3 (cffi, hypothesis, numpy, pandas, pytest_benchmark) found: NO modules: cffi, numpy, pandas
...
```

I interpreted this as `cffi, numpy, pandas` were not found. I then installed them and found they were already installed and eventually realized that I was actually missing `hypothesis`/`pytest_benchmark`.

@eli-schwartz in another repository suggested that I make a PR. So, I modified the output a bit to try to clarify missing/found and whether or not the installation is even required.

## Output Examples

These outputs are generating with a section like the following,

```python
testing_py = py.find_installation('python3.9',    
  modules: ['cffi', 'hypothesis', 'numpy', 'pandas', 'pytest_benchmark'],     
  # modules: [],  
  required: false,    
  )    
```

- `python3.9` does **not** exist on my system, `python3.10` does exist
- I ask for no dependencies or install/remove modules for various outputs

### python3.9/no modules

```
Runtime dependency python3.9 found: NO
```

### python3.9/with modules

```
Runtime dependency python3.9 found: NO
```

### python3.10/no modules

```
Runtime dependency python3.10 found: YES (/usr/bin/python3.10)
```

### python3/no modules (this will be 3.10 on my system)

```
Runtime dependency python3 found: YES (/usr/bin/python3)
```

### python3.10/some modules missing

```
Runtime dependency python3.10 (found: cffi, numpy, pandas | missing: hypothesis, pytest_benchmark) found: NO
```

### python3.10/all modules found

```
Runtime dependency python3.10 (found: cffi, hypothesis, numpy, pandas, pytest_benchmark) found: YES (/usr/bin/python3.10)
```