### PR TITLE
Improve WINEPATH reduction

### DIFF
--- a/mesonbuild/mdevenv.py
+++ b/mesonbuild/mdevenv.py
@@ -6,7 +6,7 @@ import itertools
 
 from pathlib import Path
 from . import build, minstall, dependencies
-from .mesonlib import MesonException, RealPathAction, is_windows, setup_vsenv, OptionKey, quote_arg
+from .mesonlib import MesonException, RealPathAction, is_windows, setup_vsenv, OptionKey, quote_arg, get_wine_shortpath
 from . import mlog
 
 import typing as T
@@ -28,43 +28,6 @@ def get_windows_shell() -> str:
     result = subprocess.check_output(command)
     return result.decode().strip()
 
-def get_wine_shortpath(build_dir: str, winecmd: str, wine_paths: T.List[str]) -> T.List[str]:
-    '''
-    WINEPATH size is limited to 1024 bytes which can easily be exceeded when
-    adding the path to every dll inside build directory. See
-    https://bugs.winehq.org/show_bug.cgi?id=45810.
-
-    To shorthen it as much as possible we use path relative to builddir
-    where possible and convert absolute paths to Windows shortpath (e.g.
-    "/usr/x86_64-w64-mingw32/lib" to "Z:\\usr\\X86_~FWL\\lib").
-    '''
-    rel_paths = []
-    abs_paths = []
-    builddir = Path(build_dir)
-    for p in wine_paths:
-        try:
-            rel = Path(p).relative_to(builddir)
-            rel_paths.append(str(rel))
-        except ValueError:
-            abs_paths.append(p)
-    if not abs_paths:
-        return rel_paths
-    with tempfile.NamedTemporaryFile('w', suffix='.bat', encoding='utf-8', delete=False) as bat_file:
-        bat_file.write('''
-        @ECHO OFF
-        for %%x in (%*) do (
-            echo|set /p=;%~sx
-        )
-        ''')
-    try:
-        stdout = subprocess.check_output([winecmd, 'cmd', '/C', bat_file.name] + abs_paths,
-                                         encoding='utf-8', stderr=subprocess.DEVNULL)
-        return rel_paths + [p for p in set(stdout.split(';')) if p]
-    except subprocess.CalledProcessError:
-        return rel_paths + abs_paths
-    finally:
-        os.unlink(bat_file.name)
-
 def reduce_winepath(build_dir: str, env: T.Dict[str, str]) -> None:
     winepath = env.get('WINEPATH')
     if not winepath:
@@ -72,10 +35,7 @@ def reduce_winepath(build_dir: str, env: T.Dict[str, str]) -> None:
     winecmd = shutil.which('wine64') or shutil.which('wine')
     if not winecmd:
         return
-    winepath = ';'.join(get_wine_shortpath(build_dir, winecmd, winepath.split(';')))
-    if len(winepath) > 1024:
-        mlog.warning(f'WINEPATH exceeds 1024 characters which could cause issues:\n{winepath}')
-    env['WINEPATH'] = winepath
+    env['WINEPATH'] = get_wine_shortpath([winecmd], winepath.split(';'), build_dir)
     mlog.log('Meson detected wine and has set WINEPATH accordingly')
 
 def get_env(b: build.Build, build_dir: str) -> T.Tuple[T.Dict[str, str], T.Set[str]]:

--- a/mesonbuild/mdevenv.py
+++ b/mesonbuild/mdevenv.py
@@ -28,17 +28,17 @@ def get_windows_shell() -> str:
     result = subprocess.check_output(command)
     return result.decode().strip()
 
-def reduce_winepath(build_dir: str, env: T.Dict[str, str]) -> None:
+def reduce_winepath(env: T.Dict[str, str]) -> None:
     winepath = env.get('WINEPATH')
     if not winepath:
         return
     winecmd = shutil.which('wine64') or shutil.which('wine')
     if not winecmd:
         return
-    env['WINEPATH'] = get_wine_shortpath([winecmd], winepath.split(';'), build_dir)
+    env['WINEPATH'] = get_wine_shortpath([winecmd], winepath.split(';'))
     mlog.log('Meson detected wine and has set WINEPATH accordingly')
 
-def get_env(b: build.Build, build_dir: str) -> T.Tuple[T.Dict[str, str], T.Set[str]]:
+def get_env(b: build.Build) -> T.Tuple[T.Dict[str, str], T.Set[str]]:
     extra_env = build.EnvironmentVariables()
     extra_env.set('MESON_DEVENV', ['1'])
     extra_env.set('MESON_PROJECT_NAME', [b.project_name])
@@ -49,7 +49,7 @@ def get_env(b: build.Build, build_dir: str) -> T.Tuple[T.Dict[str, str], T.Set[s
         env = i.get_env(env)
         varnames |= i.get_names()
 
-    reduce_winepath(build_dir, env)
+    reduce_winepath(env)
 
     return env, varnames
 
@@ -122,7 +122,7 @@ def run(options: argparse.Namespace) -> int:
         raise MesonException(f'Directory {options.wd!r} does not seem to be a Meson build directory.')
     b = build.load(options.wd)
 
-    devenv, varnames = get_env(b, options.wd)
+    devenv, varnames = get_env(b)
     if options.dump:
         if options.command:
             raise MesonException('--dump option does not allow running other command.')

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1338,7 +1338,8 @@ class SingleTestRunner:
                 if os.path.basename(c).startswith('wine'):
                     env['WINEPATH'] = get_wine_shortpath(
                         winecmd,
-                        ['Z:' + p for p in self.test.extra_paths] + env.get('WINEPATH', '').split(';')
+                        ['Z:' + p for p in self.test.extra_paths] + env.get('WINEPATH', '').split(';'),
+                        self.test.workdir
                     )
                     break
 

--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -51,7 +51,8 @@ def run_exe(exe: ExecutableSerialisation, extra_env: T.Optional[T.Dict[str, str]
         if exe.exe_wrapper and mesonlib.substring_is_in_list('wine', exe.exe_wrapper.get_command()):
             child_env['WINEPATH'] = mesonlib.get_wine_shortpath(
                 exe.exe_wrapper.get_command(),
-                ['Z:' + p for p in exe.extra_paths] + child_env.get('WINEPATH', '').split(';')
+                ['Z:' + p for p in exe.extra_paths] + child_env.get('WINEPATH', '').split(';'),
+                exe.workdir
             )
 
     stdin = None


### PR DESCRIPTION
- Remove duplicated code in mdevenv.py
- Change the limit to 1024 instead of 2048 which is what has been
  tested.
- Skip shortening if it is already short enough.
- Skip shortening with wine >= 6.4 which does not seems to have that
  limitation any more.
- Downgrade exception to warning in the case WINEPATH cannot be
  shortened under 1024 chars, it is possible that it will still work.