### PR TITLE
MVSC: Allow path separator to be also forward slash after drive letter

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -499,7 +499,7 @@ class NinjaBackend(backends.Backend):
         # use backslashes, but without the leading drive name, so
         # allow the path to start with any path separator, i.e.
         # \MyDir\include\stdio.h.
-        matchre = re.compile(rb"^(.*\s)([a-zA-Z]:\\|[\\\/]).*stdio.h$")
+        matchre = re.compile(rb"^(.*\s)([a-zA-Z]:[\\/]|[\\\/]).*stdio.h$")
 
         def detect_prefix(out):
             for line in re.split(rb'\r?\n', out):


### PR DESCRIPTION
Ccache normalizes the include paths from compiler stdout to use
forward slashes and rewrites the paths to relative if they are within
CCACHE_BASEDIR because ninja uses this information to detect
changes.

Arguably this should be changed in ccache that
the rewritten include paths use backwards slashes but allowing
either seems quite harmless.