### PR TITLE
Change minstall and mtest use mcompile to fix rebuild for VS backend

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1468,7 +1468,7 @@ class Vs2010Backend(backends.Backend):
         ET.SubElement(midl, 'InterfaceIdentifierFilename').text = '%(Filename)_i.c'
         ET.SubElement(midl, 'ProxyFileName').text = '%(Filename)_p.c'
         # FIXME: No benchmarks?
-        test_command = self.environment.get_build_command() + ['test', '--no-rebuild']
+        test_command = self.environment.get_build_command() + ['test']
         if not self.environment.coredata.get_option(OptionKey('stdsplit')):
             test_command += ['--no-stdsplit']
         if self.environment.coredata.get_option(OptionKey('errorlogs')):
@@ -1495,7 +1495,7 @@ class Vs2010Backend(backends.Backend):
         ET.SubElement(midl, 'TypeLibraryName').text = '%(Filename).tlb'
         ET.SubElement(midl, 'InterfaceIdentifierFilename').text = '%(Filename)_i.c'
         ET.SubElement(midl, 'ProxyFileName').text = '%(Filename)_p.c'
-        install_command = self.environment.get_build_command() + ['install', '--no-rebuild']
+        install_command = self.environment.get_build_command() + ['install']
         self.add_custom_build(root, 'run_install', '"%s"' % ('" "'.join(install_command)))
         ET.SubElement(root, 'Import', Project=r'$(VCTargetsPath)\Microsoft.Cpp.targets')
         self.add_regen_dependency(root)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -283,6 +283,9 @@ class Vs2010Backend(backends.Backend):
                     # Get dependencies on non-targets, such as Files
                     if isinstance(d, build.Target):
                         all_deps[d.get_id()] = d
+                for d in target.sources:
+                    if isinstance(d, build.ExtractedObjects):
+                        all_deps[d.target.get_id()] = d.target
             elif isinstance(target, build.RunTarget):
                 for d in target.get_dependencies():
                     all_deps[d.get_id()] = d

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -376,6 +376,6 @@ def run(options: 'argparse.Namespace') -> int:
             f'Backend `{backend}` is not yet supported by `compile`. Use generated project files directly instead.')
 
     mlog.log(mlog.green('INFO:'), 'calculating backend command to run:', join_args(cmd))
-    p, *_ = mesonlib.Popen_safe(cmd, stdout=sys.stdout.buffer, stderr=sys.stderr.buffer, env=env)
+    p, *_ = mesonlib.Popen_safe(cmd, cwd=bdir, stdout=sys.stdout.buffer, stderr=sys.stderr.buffer, env=env)
 
     return p.returncode

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -120,9 +120,9 @@ def get_target_from_intro_data(target: ParsedTargetName, builddir: Path, introsp
     elif len(found_targets) > 1:
         suggestions: T.List[str] = []
         for i in found_targets:
-            p = Path(i['filename'][0]).relative_to(resolved_bdir)
-            t = i['type'].replace(' ', '_')
-            suggestions.append(f'- ./{p}:{t}')
+            target_path = str(Path(i['filename'][0]).relative_to(resolved_bdir).parent)
+            target_type = i['type'].replace(' ', '_')
+            suggestions.append(f'- {target_path}/{i["name"]}:{target_type}')
         suggestions_str = '\n'.join(suggestions)
         raise MesonException(f'Can\'t invoke target `{target.full_name}`: ambiguous name.'
                              f'Add target type and/or path:\n{suggestions_str}')

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -119,11 +119,10 @@ def get_target_from_intro_data(target: ParsedTargetName, builddir: Path, introsp
         found_targets = intro_targets
     else:
         for intro_target in intro_targets:
-            if (intro_target['subproject'] or
-                    (target.type and target.type != intro_target['type'].replace(' ', '_')) or
-                    (target.path
-                        and intro_target['filename'] != 'no_name'
-                        and Path(target.path) != Path(intro_target['filename'][0]).relative_to(resolved_bdir).parent)):
+            if ((target.type and target.type != intro_target['type'].replace(' ', '_')) or
+                (target.path
+                    and intro_target['filename'] != 'no_name'
+                    and Path(target.path) != Path(intro_target['filename'][0]).relative_to(resolved_bdir).parent)):
                 continue
             found_targets += [intro_target]
 

--- a/mesonbuild/mesonlib/vsenv.py
+++ b/mesonbuild/mesonlib/vsenv.py
@@ -26,7 +26,13 @@ def _setup_vsenv(force: bool) -> bool:
         return False
     if os.environ.get('OSTYPE') == 'cygwin':
         return False
-    if 'MESON_FORCE_VSENV_FOR_UNITTEST' not in os.environ:
+    if 'MESON_FORCE_VSENV_FOR_UNITTEST' in os.environ:
+        # Calling vcvars.bat too many times can cause error
+        # "The input line is too long."
+        # so remove it after first forced activation so that any subprocess
+        # does not activate it again
+        del os.environ['MESON_FORCE_VSENV_FOR_UNITTEST']
+    else:
         # VSINSTALL is set when running setvars from a Visual Studio installation
         # Tested with Visual Studio 2012 and 2017
         if 'VSINSTALLDIR' in os.environ:

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -54,7 +54,7 @@ from mesonbuild.mlog import blue, bold, cyan, green, red, yellow, normal_green
 from mesonbuild.coredata import backendlist, version as meson_version
 from mesonbuild.modules.python import PythonExternalProgram
 from run_tests import get_fake_options, run_configure, get_meson_script
-from run_tests import get_backend_commands, get_backend_args_for_dir, Backend
+from run_tests import get_backend_commands, Backend
 from run_tests import ensure_backend_detects_changes
 from run_tests import guess_backend
 
@@ -676,12 +676,11 @@ def _run_test(test: TestDef,
         testresult.fail('Generating the build system failed.')
         return testresult
     builddata = build.load(test_build_dir)
-    dir_args = get_backend_args_for_dir(backend, test_build_dir)
 
     # Build with subprocess
     def build_step() -> None:
         build_start = time.time()
-        pc, o, e = Popen_safe(compile_commands + dir_args, cwd=test_build_dir)
+        pc, o, e = Popen_safe(compile_commands, cwd=test_build_dir)
         testresult.add_step(BuildStep.build, o, e, '', time.time() - build_start)
         if should_fail == 'build':
             if pc.returncode != 0:
@@ -734,7 +733,7 @@ def _run_test(test: TestDef,
 
     # Clean with subprocess
     env = test.env.copy()
-    pi, o, e = Popen_safe(clean_commands + dir_args, cwd=test_build_dir, env=env)
+    pi, o, e = Popen_safe(clean_commands, cwd=test_build_dir, env=env)
     testresult.add_step(BuildStep.clean, o, e)
     if pi.returncode != 0:
         testresult.fail('Running clean failed.')
@@ -1416,8 +1415,7 @@ def check_meson_commands_work(use_tmpdir: bool, extra_args: T.List[str]) -> None
         if pc.returncode != 0:
             raise RuntimeError(f'Failed to introspect --targets {testdir!r}:\n{e}\n{o}')
         print('Checking that building works...')
-        dir_args = get_backend_args_for_dir(backend, build_dir)
-        pc, o, e = Popen_safe(compile_commands + dir_args, cwd=build_dir)
+        pc, o, e = Popen_safe(compile_commands, cwd=build_dir)
         if pc.returncode != 0:
             raise RuntimeError(f'Failed to build {testdir!r}:\n{e}\n{o}')
         print('Checking that testing works...')

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -825,9 +825,13 @@ class AllPlatformTests(BasePlatformTests):
         self.assertPathExists(genfile2)
         self.assertPathDoesNotExist(exe1)
         self.assertPathDoesNotExist(exe2)
-        self.build(target=('fooprog' + exe_suffix))
+        if self.backend == Backend.ninja:
+            target_suffix = exe_suffix
+        else:
+            target_suffix = ''
+        self.build(target=('fooprog' + target_suffix))
         self.assertPathExists(exe1)
-        self.build(target=('barprog' + exe_suffix))
+        self.build(target=('barprog' + target_suffix))
         self.assertPathExists(exe2)
 
     def test_internal_include_order(self):

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -3427,6 +3427,11 @@ class AllPlatformTests(BasePlatformTests):
             self._run([*self.meson_command, 'compile', '-C', self.builddir, '--vs-args=-t:{}:Clean'.format(re.sub(r'[\%\$\@\;\.\(\)\']', '_', get_exe_name('trivialprog')))])
             self.assertPathDoesNotExist(os.path.join(self.builddir, get_exe_name('trivialprog')))
 
+        # Custom target with extracted objects
+        testdir = os.path.join(self.common_test_dir, '22 object extraction')
+        self.init(testdir, extra_args=['--wipe'])
+        self._run([*self.meson_command, 'compile', '-C', self.builddir, 'custom_target with object inputs'])
+
     def test_spurious_reconfigure_built_dep_file(self):
         testdir = os.path.join(self.unit_test_dir, '73 dep files')
 

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -3271,7 +3271,7 @@ class AllPlatformTests(BasePlatformTests):
 
     def test_alias_target(self):
         testdir = os.path.join(self.unit_test_dir, '64 alias target')
-        self.init(testdir)
+        self.init(testdir, extra_args=['-Dbuildtype=release'])
         self.build()
         self.assertPathDoesNotExist(os.path.join(self.builddir, 'prog' + exe_suffix))
         self.assertPathDoesNotExist(os.path.join(self.builddir, 'hello.txt'))

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -396,8 +396,8 @@ class BasePlatformTests(TestCase):
         elif self.backend is Backend.vs:
             # Ensure that some target said that no rebuild was done
             # XXX: Note CustomBuild did indeed rebuild, because of the regen checker!
-            self.assertIn('ClCompile:\n  All outputs are up-to-date.', ret)
-            self.assertIn('Link:\n  All outputs are up-to-date.', ret)
+            self.assertRegex(ret, re.compile('ClCompile:\s*All outputs are up-to-date\.', flags=re.IGNORECASE))
+            self.assertRegex(ret, re.compile('Link:\s*All outputs are up-to-date\.', flags=re.IGNORECASE))
             # Ensure that no targets were built
             self.assertNotRegex(ret, re.compile('ClCompile:\n [^\n]*cl', flags=re.IGNORECASE))
             self.assertNotRegex(ret, re.compile('Link:\n [^\n]*link', flags=re.IGNORECASE))
@@ -413,9 +413,9 @@ class BasePlatformTests(TestCase):
         elif self.backend is Backend.vs:
             # Ensure that some target of each type said that no rebuild was done
             # We always have at least one CustomBuild target for the regen checker
-            self.assertIn('CustomBuild:\n  All outputs are up-to-date.', ret)
-            self.assertIn('ClCompile:\n  All outputs are up-to-date.', ret)
-            self.assertIn('Link:\n  All outputs are up-to-date.', ret)
+            self.assertRegex(ret, re.compile('CustomBuild:\s*All outputs are up-to-date\.', flags=re.IGNORECASE), )
+            self.assertRegex(ret, re.compile('ClCompile:\s*All outputs are up-to-date\.', flags=re.IGNORECASE))
+            self.assertRegex(ret, re.compile('Link:\s*All outputs are up-to-date\.', flags=re.IGNORECASE))
             # Ensure that no targets were built
             self.assertNotRegex(ret, re.compile('CustomBuild:\n [^\n]*cl', flags=re.IGNORECASE))
             self.assertNotRegex(ret, re.compile('ClCompile:\n [^\n]*cl', flags=re.IGNORECASE))


### PR DESCRIPTION
- Change mtest and minstall to call mcompile for rebuild so that automatic
 rebuild works for VS backend as well.
- Explicitly call REGEN target first in msbuild compile because otherwise if
 build files have been changed, they are not properly regenerated before
 building other targets. This often lead to build errors if files were added
 to build because first build after changing used old VS projects.
 For some reason this worked without calling REGEN if the maxCpuCount
 argument is removed

- Change tests to build VS backend through 'meson compile' because this 
simplified the test scripts and improves test coverage for the command line functions.
Duplicating the build logic e.g. how to build single target with msbuild
for tests does not seem wise.

- Fix mcompile suggesting targets that do not work since correct format
is PATH/TARGET:TYPE and not PATH/FILENAME:TYPE
- Fix that run targets could not be built for any other buildtype than debug
- Fix that targets not built by default could not be built with 'meson compile' at all
- Fix custom target with object inputs on VS backend.

