### PR TITLE
build: CustomTargetIndex.is_linkable_target misses '.dylib'

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2772,7 +2772,7 @@ class CustomTargetIndex(HoldableObject):
 
     def is_linkable_target(self) -> bool:
         suf = os.path.splitext(self.output)[-1]
-        return suf in {'.a', '.dll', '.lib', '.so'}
+        return suf in {'.a', '.dll', '.lib', '.so', '.dylib'}
 
     def links_dynamically(self) -> bool:
         """Whether this target links dynamically or statically


### PR DESCRIPTION
CustomTarget.is_linkable_target has '.dylib'.

See also 93b1d31af9d90f306aa104eee1e9be8e1ebbacad that added '.dylib'
to CustomTarget.is_linkable_target but didn't add '.dylib' to
CustomTargetIndex.is_linkable_target.