### PR TITLE
Fix crash when a reconfigure adds a new subproject

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -855,7 +855,6 @@ class Interpreter(InterpreterBase, HoldableObject):
         sub = SubprojectHolder(NullSubprojectInterpreter(), os.path.join(self.subproject_dir, subp_name),
                                disabled_feature=disabled_feature, exception=exception)
         self.subprojects[subp_name] = sub
-        self.coredata.initialized_subprojects.add(subp_name)
         return sub
 
     def do_subproject(self, subp_name: str, method: Literal['meson', 'cmake'], kwargs: kwargs.DoSubproject) -> SubprojectHolder:
@@ -979,7 +978,6 @@ class Interpreter(InterpreterBase, HoldableObject):
         self.build_def_files.update(subi.build_def_files)
         self.build.merge(subi.build)
         self.build.subprojects[subp_name] = subi.project_version
-        self.coredata.initialized_subprojects.add(subp_name)
         return self.subprojects[subp_name]
 
     def _do_subproject_cmake(self, subp_name: str, subdir: str, subdir_abs: str,
@@ -1160,6 +1158,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             default_options = self.project_default_options.copy()
             default_options.update(self.default_project_options)
             self.coredata.init_builtins(self.subproject)
+            self.coredata.initialized_subprojects.add(self.subproject)
         else:
             default_options = {}
         self.coredata.set_default_options(default_options, self.subproject, self.environment)

--- a/test cases/unit/107 new subproject on reconfigure/meson.build
+++ b/test cases/unit/107 new subproject on reconfigure/meson.build
@@ -1,0 +1,3 @@
+project('New subproject on reconfigure')
+
+subproject('foo', required: get_option('foo'))

--- a/test cases/unit/107 new subproject on reconfigure/meson_options.txt
+++ b/test cases/unit/107 new subproject on reconfigure/meson_options.txt
@@ -1,0 +1,1 @@
+option('foo', type: 'feature', value: 'disabled')

--- a/test cases/unit/107 new subproject on reconfigure/subprojects/foo/foo.c
+++ b/test cases/unit/107 new subproject on reconfigure/subprojects/foo/foo.c
@@ -1,0 +1,2 @@
+void foo(void);
+void foo(void) {}

--- a/test cases/unit/107 new subproject on reconfigure/subprojects/foo/meson.build
+++ b/test cases/unit/107 new subproject on reconfigure/subprojects/foo/meson.build
@@ -1,0 +1,8 @@
+project('foo', 'c')
+
+# Ensure that builtin options have been initialised.
+assert(get_option('default_library') == 'shared')
+
+# This uses default_library option internally and used to cause a crash:
+# https://github.com/mesonbuild/meson/issues/10225.
+library('foo', 'foo.c')

--- a/unittests/platformagnostictests.py
+++ b/unittests/platformagnostictests.py
@@ -83,3 +83,14 @@ class PlatformAgnosticTests(BasePlatformTests):
         mesonlog = os.path.join(self.builddir, 'meson-logs/meson-log.txt')
         with open(mesonlog, mode='r', encoding='utf-8') as file:
             self.assertIn(log_msg, file.read())
+
+    def test_new_subproject_reconfigure(self):
+        testdir = os.path.join(self.unit_test_dir, '107 new subproject on reconfigure')
+        self.init(testdir)
+        self.build()
+
+        # Enable the subproject "foo" and reconfigure, this is used to fail
+        # because per-subproject builtin options were not initialized:
+        # https://github.com/mesonbuild/meson/issues/10225.
+        self.setconf('-Dfoo=enabled')
+        self.build('reconfigure')


### PR DESCRIPTION
When a subproject is disabled on the initial configuration we should not
add it into self.coredata.initialized_subprojects because that will
prevent calling self.coredata.init_builtins() on a reconfigure if the
subproject gets enabled.

Fixes: #10225.