### PR TITLE
Fix issue where the -j flag would sometimes not be added to certain external projects

### DIFF
--- a/mesonbuild/scripts/externalproject.py
+++ b/mesonbuild/scripts/externalproject.py
@@ -65,10 +65,7 @@ class ExternalProject:
 
         install_cmd = self.make.copy()
         install_env = {}
-        if is_make:
-            install_cmd.append(f'DESTDIR={self.install_dir}')
-        else:
-            install_env['DESTDIR'] = self.install_dir
+        install_env['DESTDIR'] = self.install_dir
         install_cmd.append('install')
         rc = self._run('install', install_cmd, install_env)
         if rc != 0:

--- a/mesonbuild/scripts/externalproject.py
+++ b/mesonbuild/scripts/externalproject.py
@@ -48,16 +48,15 @@ class ExternalProject:
         with open(self.stampfile, 'w', encoding='utf-8'):
             pass
 
-    def gnu_make(self) -> bool:
+    def supports_jobs_flag(self) -> bool:
         p, o, e = Popen_safe(self.make + ['--version'])
-        if p.returncode == 0 and 'GNU Make' in o:
+        if p.returncode == 0 and ('GNU Make' in o or 'waf' in o):
             return True
         return False
 
     def build(self) -> int:
-        is_make = self.make[0] == 'make'
         make_cmd = self.make.copy()
-        if is_make and self.gnu_make():
+        if self.supports_jobs_flag():
             make_cmd.append(f'-j{multiprocessing.cpu_count()}')
         rc = self._run('build', make_cmd)
         if rc != 0:


### PR DESCRIPTION
Sometimes the make command will be `/usr/bin/make` instead of just `make`, which will prevent the multi-threading flag from being added. This PR addresses that by removing the test entirely, as it seems to me that `self.gnu_make()` is sufficient.

Thanks to @xclaesse for finding the issue!