### PR TITLE
devenv: Add support for PowerShell 7 on Windows

### DIFF
--- a/mesonbuild/mdevenv.py
+++ b/mesonbuild/mdevenv.py
@@ -185,9 +185,8 @@ def run(options: argparse.Namespace) -> int:
             args = [shell_env]
         elif is_windows():
             shell = get_windows_shell()
-            if shell == 'powershell.exe':
-                args = ['powershell.exe']
-                args += ['-NoLogo', '-NoExit']
+            if shell in ['powershell.exe', 'pwsh.exe']:
+                args = [shell, '-NoLogo', '-NoExit']
                 prompt = f'function global:prompt {{  "{prompt_prefix} PS " + $PWD + "> "}}'
                 args += ['-Command', prompt]
             else:

--- a/mesonbuild/scripts/cmd_or_ps.ps1
+++ b/mesonbuild/scripts/cmd_or_ps.ps1
@@ -5,7 +5,7 @@ $i=1
 $ppid=(gwmi win32_process -Filter "processid='$pid'").parentprocessid
 $pname=(Get-Process -id $ppid).Name
 While($true) {
-  if($pname -eq "cmd" -Or $pname -eq "powershell") {
+  if($pname -eq "cmd" -Or $pname -eq "powershell" -Or $pname -eq "pwsh") {
     Write-Host ("{0}.exe" -f $pname)
     Break
   }


### PR DESCRIPTION
Checks "pwsh.exe" in addition to "powershell.exe" and "cmd.exe"
to support PowerShell 7 on Windows. The Powershell 7 support was added
in GStreamer (which is the origin of this script) already via
https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/2545