### PR TITLE
Add @BASENAMES@ and @PLAINNAMES@ to custom_target

### DIFF
--- a/docs/markdown/Generating-sources.md
+++ b/docs/markdown/Generating-sources.md
@@ -106,6 +106,22 @@ executable('myexe', ['main.c', foo_ch[1]], link_with : libfoo)
 In this case `libfoo` depends on both `foo.c` and `foo.h` but `myexe`
 only depends on `foo.h`, the second output.
 
+Since 0.63, if a generate creates multiple files using a `@BASENAME@` or
+`@PLAINNAME@` scheme, the `@BASENAMES@` and `@PLAINNAMES@` value may be used:
+
+```meson
+
+procd = custom_target(
+    'processed sources',
+    output : @BASENAMES@,
+    input : ['foo.c.in', 'bar.c.in']
+    command : [find_program('processor'), '@INPUT@', '@OUTPUT@'],
+)
+
+executable('myexe', ['main.c', procd])
+```
+Which has an `output` field equivalent to: `['foo.c', 'bar.c']`
+
 ### Using dependencies to manage generated resources
 
 In some cases it might be easier to use `declare_dependency` to

--- a/docs/markdown/snippets/add_custom_targeT_output_templates_for_many_files.md
+++ b/docs/markdown/snippets/add_custom_targeT_output_templates_for_many_files.md
@@ -1,0 +1,16 @@
+## `custom_target` gains `output` templates for multiple files
+
+Currently, if you have a target with multiple outputs, you have to manually list
+them all, even if they are using a `@PLAINNAME@` or `@BASENAME@` scheme. Now,
+Meson will handle that scheme for multiple files as well with the `@PLAINNAMES@`
+and `@BASENAMES@` value, like so:
+
+```meson
+custom_target(
+  output : '@PLAINNAMES@.out',
+  input : ['a.in', 'b.in', 'c.in'],
+  command : [find_program('input-compiler), '@OUTDIR@', '@INPUT@'],
+)
+```
+
+Meson will convert this to `output : ['a.out', 'b.out', 'c.out']` automatically.

--- a/docs/yaml/functions/custom_target.yaml
+++ b/docs/yaml/functions/custom_target.yaml
@@ -31,7 +31,9 @@ description: |
   - `@OUTDIR@`: the full path to the directory where the output(s) must be written
   - `@DEPFILE@`: the full path to the dependency file passed to `depfile`
   - `@PLAINNAME@`: the input filename, without a path
-  - `@BASENAME@`: the input filename, with extension removed
+  - `@PLAINNAMES@`: each intput filename, with the extension removed (since 0.63.0)
+  - `@BASENAME@`: the input filename, without a path with extension removed
+  - `@BASENAMES@`: each input filename, without a path, with the extension removed (since 0.63.0)
   - `@PRIVATE_DIR@` *(since 0.50.1)*: path to a directory where the custom target must store all its intermediate files.
   - `@SOURCE_ROOT@`: the path to the root of the source tree. Depending on the backend,
     this may be an absolute or a relative to current workdir path.

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1838,16 +1838,26 @@ class Interpreter(InterpreterBase, HoldableObject):
         This cannot be done with typed_kwargs because it requires the number of
         inputs.
         """
+        outputs = list(outputs)
         for out in outputs:
             if has_multi_in and ('@PLAINNAME@' in out or '@BASENAME@' in out):
                 raise InvalidArguments(f'{name}: output cannot containe "@PLAINNAME@" or "@BASENAME@" '
-                                       'when there is more than one input (we can\'t know which to use)')
-        if '.' in outputs:
-            FeatureDeprecated.single_use(
-                'using "." as an output for custom_target', '0.63.0',
-                subproject,
-                'This is unreliable, instead list each output.',
-                node)
+                                       'when there is more than one input (we can\'t know which to use) '
+                                       'Did you mean @PLAINNAMES@ or @BASENAMES@')
+            elif '@BASENAMES@' in out or '@PLAINNAMES@' in out:
+                FeatureNew.single_use(
+                    f'custom_target output {out}', '0.63.0',
+                    subproject,
+                    'This is unreliable, list each output, or use @PLAINNAMES@ or @BASENAMES@',
+                    node)
+                if len(outputs) != 1:
+                    raise InvalidArguments(f'{name}: @BASENAMES@ and @PLAINAMES@ must be the only output when used')
+            if out == '.':
+                FeatureDeprecated.single_use(
+                    'using "." as an output for custom_target', '0.63.0',
+                    subproject,
+                    'This is unreliable, list each output, or use @PLAINNAMES@ or @BASENAMES@',
+                    node)
 
     @typed_pos_args('custom_target', optargs=[str])
     @typed_kwargs(

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -1522,9 +1522,9 @@ def substitute_values(command: T.List[str], values: T.Dict[str, T.Union[str, T.L
 
     # Substitution
     outcmd = []  # type: T.List[str]
-    rx_keys = [re.escape(key) for key in values if key not in ('@INPUT@', '@OUTPUT@')]
+    rx_keys = [re.escape(key) for key in values if key not in {'@INPUT@', '@OUTPUT@', '@PLAINNAMES@', '@BASENAMES@'}]
     value_rx = re.compile('|'.join(rx_keys)) if rx_keys else None
-    for vv in command:
+    for i, vv in enumerate(command):
         more: T.Optional[str] = None
         if not isinstance(vv, str):
             outcmd.append(vv)
@@ -1546,6 +1546,18 @@ def substitute_values(command: T.List[str], values: T.Dict[str, T.Union[str, T.L
             else:
                 raise MesonException("Command has '@OUTPUT@' as part of a "
                                      "string and more than one output file")
+
+        elif '@BASENAMES@' in vv:
+            if vv == '@BASENAMES@':
+                outcmd.extend(values['@BASENAMES@'])
+            else:
+                outcmd.append(vv.replace('@BASENAMES@', values['@BASENAMES@'][i]))
+
+        elif '@PLAINNAMES@' in vv:
+            if vv == '@PLAINNAMES@':
+                outcmd.extend(values['@PLAINNAMES@'])
+            else:
+                outcmd.append(vv.replace('@PLAINNAMES@', values['@PLAINNAMES@'][i]))
 
         # Append values that are exactly a template string.
         # This is faster than a string replace.

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -1581,11 +1581,11 @@ def get_filenames_templates_dict(inputs: T.List[str], outputs: T.List[str]) -> T
     @PLAINNAME@ - the filename of the input file
     @BASENAME@ - the filename of the input file with the extension removed
 
-    If there is more than one input file, the following keys are also created:
+    If there input files, the following keys are also created:
 
     @INPUT0@, @INPUT1@, ... one for each input file
 
-    If there is more than one output file, the following keys are also created:
+    If there are output files, the following keys are also created:
 
     @OUTPUT0@, @OUTPUT1@, ... one for each output file
     '''

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -1570,9 +1570,11 @@ def get_filenames_templates_dict(inputs: T.List[str], outputs: T.List[str]) -> T
     Create a dictionary with template strings as keys and values as values for
     the following templates:
 
-    @INPUT@  - the full path to one or more input files, from @inputs
-    @OUTPUT@ - the full path to one or more output files, from @outputs
-    @OUTDIR@ - the full path to the directory containing the output files
+    @INPUT@      - the full path to one or more input files, from @inputs
+    @OUTPUT@     - the full path to one or more output files, from @outputs
+    @OUTDIR@     - the full path to the directory containing the output files
+    @PLAINNAMES@ - the filename of each input file
+    @BASENAMES@  - the filename of each input file, with the extension removed
 
     If there is only one input file, the following keys are also created:
 
@@ -1595,10 +1597,12 @@ def get_filenames_templates_dict(inputs: T.List[str], outputs: T.List[str]) -> T
         for (ii, vv) in enumerate(inputs):
             # Write out @INPUT0@, @INPUT1@, ...
             values[f'@INPUT{ii}@'] = vv
+        values['@PLAINNAMES@'] = [os.path.basename(i) for i in inputs]
+        values['@BASENAMES@'] = [os.path.splitext(i)[0] for i in values['@PLAINNAMES@']]
         if len(inputs) == 1:
             # Just one value, substitute @PLAINNAME@ and @BASENAME@
-            values['@PLAINNAME@'] = plain = os.path.basename(inputs[0])
-            values['@BASENAME@'] = os.path.splitext(plain)[0]
+            values['@PLAINNAME@'] = values['@PLAINNAMES@'][0]
+            values['@BASENAME@'] = values['@BASENAMES@'][0]
     if outputs:
         # Gather values derived from the outputs, similar to above.
         values['@OUTPUT@'] = outputs


### PR DESCRIPTION
There are currently projects in the wild (I don't want to shame them), who are recommending this:
```meson
custom_target(
  ...
  input : ['a.in', 'b.in', 'c.in'],
  output : '.'
  command : [find_program('cmd'), '@OUTPUT@', '@INPUT@'],
)
```
of course, this isn't what they actually want, they just don't want to have to list `['a.out', 'b.out', 'c.out']` in their output lines. So lets make it easy to do the right thing:
```meson
custom_target(
  ...
  input : ['a.in', 'b.in', 'c.in'],
  output : '@PLAINNAMES@.out',
  command : [find_program('cmd'), 'batch', '@OUTDIR@', '@INPUT@'],
)
```

With the plural form passed (it is allowed only to be passed as an exclusve output argument), meson will replace that with the @PLAINNAME@ applied to *each* output, making it simple to handle a custom_target with multiple outputs that follow the @BASENAME@ or @PLAINNAME@ scheme.

still needs tests, but I figure we're going to bikeshed about the naming for a while, so...