### PR TITLE
fix: `add_dep` function accessing `dep` attrs before checking if it's a valid dependency

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1373,6 +1373,9 @@ You probably should put it in link_with instead.''')
                 # This is a bit of a hack. We do not want Build to know anything
                 # about the interpreter so we can't import it and use isinstance.
                 # This should be reliable enough.
+                if hasattr(dep, 'held_object'):
+                    # FIXME: subproject is not a real ObjectHolder so we have to do this by hand
+                    dep = dep.held_object
                 if hasattr(dep, 'project_args_frozen') or hasattr(dep, 'global_args_frozen'):
                     raise InvalidArguments('Tried to use subproject object as a dependency.\n'
                                            'You probably wanted to use a dependency declared in it instead.\n'

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1343,12 +1343,6 @@ class BuildTarget(Target):
             if dep in self.added_deps:
                 continue
 
-            dep_d_features = dep.d_features
-
-            for feature in ('versions', 'import_dirs'):
-                if feature in dep_d_features:
-                    self.d_features[feature].extend(dep_d_features[feature])
-
             if isinstance(dep, dependencies.InternalDependency):
                 # Those parts that are internal.
                 self.process_sourcelist(dep.sources)
@@ -1387,6 +1381,13 @@ You probably should put it in link_with instead.''')
                                        'either an external dependency (returned by find_library() or '
                                        'dependency()) or an internal dependency (returned by '
                                        'declare_dependency()).')
+
+            dep_d_features = dep.d_features
+
+            for feature in ('versions', 'import_dirs'):
+                if feature in dep_d_features:
+                    self.d_features[feature].extend(dep_d_features[feature])
+
             self.added_deps.add(dep)
 
     def get_external_deps(self) -> T.List[dependencies.Dependency]:

--- a/test cases/failing/127 subproject object as a dependency/main.c
+++ b/test cases/failing/127 subproject object as a dependency/main.c
@@ -1,0 +1,1 @@
+int main(void) { return 0; }

--- a/test cases/failing/127 subproject object as a dependency/meson.build
+++ b/test cases/failing/127 subproject object as a dependency/meson.build
@@ -1,0 +1,4 @@
+project('test', 'c')
+
+executable(
+  'main', 'main.c', dependencies: subproject('sub'))

--- a/test cases/failing/127 subproject object as a dependency/subprojects/sub/meson.build
+++ b/test cases/failing/127 subproject object as a dependency/subprojects/sub/meson.build
@@ -1,0 +1,1 @@
+project('sub')

--- a/test cases/failing/127 subproject object as a dependency/test.json
+++ b/test cases/failing/127 subproject object as a dependency/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/127 subproject object as a dependency/meson.build:3:0: ERROR: Argument is of an unacceptable type 'SubprojectHolder'."
+    }
+  ]
+}

--- a/test cases/failing/127 subproject object as a dependency/test.json
+++ b/test cases/failing/127 subproject object as a dependency/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "test cases/failing/127 subproject object as a dependency/meson.build:3:0: ERROR: Argument is of an unacceptable type 'SubprojectHolder'."
+      "line": "test cases/failing/127 subproject object as a dependency/meson.build:3:0: ERROR: Tried to use subproject object as a dependency."
     }
   ]
 }


### PR DESCRIPTION
```python
[...]
            dep_d_features = dep.d_features

            for feature in ('versions', 'import_dirs'):
                if feature in dep_d_features:
                    self.d_features[feature].extend(dep_d_features[feature])
[...]
 ```
Code in this snippet tries to access the `d_features` attribute on `dep` before the if-else chain can ensure that `dep` is valid.

I wasn't quite sure if this has to be executed where it currently is, so I just moved it to the end of the for loop. If that's not the case, this snippet can be made into its own function to avoid an extra call to `isinstance` and get called in the first two branches of the if-else statement.

![current-output](https://i.imgur.com/kX4xzJl.png)

Fixes #10468