### PR TITLE
docs: ensure stable order of release notes

### DIFF
--- a/docs/genrelnotes.py
+++ b/docs/genrelnotes.py
@@ -70,7 +70,7 @@ def generate(relnotes, to_version, source_dir, output_dir):
     output.parent.mkdir(exist_ok=True, parents=True)
     with output.open('w', encoding='utf-8') as ofile:
         ofile.write(RELNOTE_TEMPLATE.format(title, to_version, title_suffix))
-        for snippetfile in Path(source_dir, 'markdown/snippets').glob('*.md'):
+        for snippetfile in sorted(Path(source_dir, 'markdown/snippets').glob('*.md')):
             snippet = snippetfile.read_text(encoding='utf-8')
             ofile.write(snippet)
             if not snippet.endswith('\n'):


### PR DESCRIPTION
Merging snippets happens in arbitrary order -- whatever filesystem globbing results in. This didn't matter too much when we ran it once at release time and checked the resulting release notes into git. However, now that we generate a temporary version of the release notes for development versions, the order of the results will periodically change.

Sort the files before processing them in order to guarantee that whatever order they are in, they stay that way.

As a side effect, it's now technically possible to guarantee an ordering by judicious use of snippets naming.