### PR TITLE
interpreter: fix a subproject check with symlinks

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -684,7 +684,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             else:
                 if not self.is_subproject() and srcdir / self.subproject_dir in p.parents:
                     continue
-                if p.is_absolute() and p.is_dir() and srcdir / self.root_subdir in [p] + list(p.resolve().parents):
+                if p.is_absolute() and p.is_dir() and srcdir / self.root_subdir in [p] + list(Path(os.path.abspath(p)).parents):
                     variables[k] = P_OBJ.DependencyVariableString(v)
         for d in deps:
             if not isinstance(d, dependencies.Dependency):

--- a/test cases/unit/106 subproject symlink/cp.py
+++ b/test cases/unit/106 subproject symlink/cp.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+from sys import argv
+from shutil import copy
+
+copy(argv[1], argv[2])

--- a/test cases/unit/106 subproject symlink/meson.build
+++ b/test cases/unit/106 subproject symlink/meson.build
@@ -1,8 +1,15 @@
 project('foo', 'c')
 
-symlinked_subproject = subproject('symlinked_subproject')
+symlinked_subproject = subproject('symlinked_subproject').get_variable('dep')
 
 executable('foo',
     sources : 'main.c',
-    dependencies : symlinked_subproject.get_variable('dep')
+    dependencies : symlinked_subproject
+)
+
+custom_target(
+    input : symlinked_subproject.get_variable('datadir') / 'datafile',
+    output : 'datafile_copy',
+    command : [find_program('cp.py'), '@INPUT@', '@OUTPUT@'],
+    build_always : true
 )

--- a/test cases/unit/106 subproject symlink/symlinked_subproject/datadir/datafile
+++ b/test cases/unit/106 subproject symlink/symlinked_subproject/datadir/datafile
@@ -1,0 +1,1 @@
+hello meson

--- a/test cases/unit/106 subproject symlink/symlinked_subproject/datadir/meson.build
+++ b/test cases/unit/106 subproject symlink/symlinked_subproject/datadir/meson.build
@@ -1,0 +1,1 @@
+install_data('datafile')

--- a/test cases/unit/106 subproject symlink/symlinked_subproject/meson.build
+++ b/test cases/unit/106 subproject symlink/symlinked_subproject/meson.build
@@ -1,3 +1,10 @@
 project('symlinked_subproject', 'c', version : '1.0.0')
 
-dep = declare_dependency(sources : 'src.c')
+dep = declare_dependency(
+    sources : 'src.c',
+    variables : {
+        'datadir': meson.current_source_dir() / 'datadir'
+    }
+)
+
+subdir('datadir')


### PR DESCRIPTION
As discussed with @eli-schwartz in #10449  I ran into some problems with subprojects and symlinks earlier. Couldn't get it to work without the attached change. I think the current behavior is unintended but perhaps @eli-schwartz could verify I haven't misunderstood something here.