### PR TITLE
fix parameter expansion in several error messages

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2354,7 +2354,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                         if modname in module_files:
                             raise InvalidArguments(
                                 f'Namespace collision: module {modname} defined in '
-                                'two files {module_files[modname]} and {s}.')
+                                f'two files {module_files[modname]} and {s}.')
                         module_files[modname] = s
                     else:
                         submodmatch = submodre.match(line)
@@ -2365,8 +2365,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
 
                             if submodname in submodule_files:
                                 raise InvalidArguments(
-                                    'Namespace collision: submodule {submodname} defined in '
-                                    'two files {submodule_files[submodname]} and {s}.')
+                                    f'Namespace collision: submodule {submodname} defined in '
+                                    f'two files {submodule_files[submodname]} and {s}.')
                             submodule_files[submodname] = s
 
         self.fortran_deps[target.get_basename()] = {**module_files, **submodule_files}

--- a/mesonbuild/interpreter/dependencyfallbacks.py
+++ b/mesonbuild/interpreter/dependencyfallbacks.py
@@ -41,7 +41,7 @@ class DependencyFallbacksHolder(MesonInterpreterObject):
                 raise InvalidArguments('Characters <, > and = are forbidden in dependency names. To specify'
                                        'version\n requirements use the \'version\' keyword argument instead.')
             if name in self.names:
-                raise InterpreterException('dependency_fallbacks name {name!r} is duplicated')
+                raise InterpreterException(f'dependency_fallbacks name {name!r} is duplicated')
             self.names.append(name)
         self._display_name = self.names[0] if self.names else '(anonymous)'
 

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -101,7 +101,7 @@ class DependenciesHelper:
             else:
                 raise mesonlib.MesonException('requires argument not a string, '
                                               'library with pkgconfig-generated file '
-                                              'or pkgconfig-dependency object, got {obj!r}')
+                                              f'or pkgconfig-dependency object, got {obj!r}')
         return processed_reqs
 
     def add_cflags(self, cflags):


### PR DESCRIPTION
At several points in the code base, f-strings are not correctly expanded due to missing 'f' string prefix. This fixes all the occurrences I could find.