### PR TITLE
gnome module: fix regression that broke using built xml files as gresources

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -371,7 +371,7 @@ class GnomeModule(ExtensionModule):
             rv.append(script)
         return ModuleReturnValue(None, rv)
 
-    @typed_pos_args('gnome.compile_resources', str, (str, mesonlib.File))
+    @typed_pos_args('gnome.compile_resources', str, (str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList))
     @typed_kwargs(
         'gnome.compile_resources',
         _BUILD_BY_DEFAULT,
@@ -426,6 +426,13 @@ class GnomeModule(ExtensionModule):
                     ifile = os.path.join(state.environment.get_build_dir(), input_file.subdir, input_file.fname)
                 else:
                     ifile = os.path.join(input_file.subdir, input_file.fname)
+
+            elif isinstance(input_file, (build.CustomTarget, build.CustomTargetIndex, build.GeneratedList)):
+                raise MesonException('Resource xml files generated at build-time cannot be used with '
+                                     'gnome.compile_resources() in the current version of glib-compile-resources '
+                                     'because we need to scan the xml for dependencies due to '
+                                     '<https://bugzilla.gnome.org/show_bug.cgi?id=774368>\nUse '
+                                     'configure_file() instead to generate it at configure-time.')
             else:
                 ifile = os.path.join(state.subdir, input_file)
 


### PR DESCRIPTION
In commit 3dcc7125833cae138987aa4535c88dbd4dbd960d we moved to typed_pos_args. In the process, we deleted some code to specifically raise an error if you use custom_target or generator outputs, instead leaving it out of the typed pos args.

However, that support was specifically supposed to be there. It was onlyan error in part of an if statement for handling old versions of glib-compile-resources. The specific error it calls out is that we need to manually parse the depfile at configure time, due to an external bug; obviously this is impossible if the gresource is only created at build time.

Reinstate the original error message check, and allow built outputs to be used as compile_resources() inputs.

Fixes #10367