### PR TITLE
python module: implicitly add python dep to extensions

### DIFF
--- a/docs/markdown/Python-module.md
+++ b/docs/markdown/Python-module.md
@@ -99,9 +99,9 @@ Additionally, the following diverge from [[shared_module]]'s default behavior:
   of Python that support this (the python headers define `PyMODINIT_FUNC` has
   default visibility).
 
-`extension_module` does not add any dependencies to the library so
-user may need to add `dependencies : py_installation.dependency()`,
-see [[dependency]].
+*since 0.63.0* `extension_module` automatically adds a dependency to the library
+if one is not explicitly provided. To support older versions, the user may need to
+add `dependencies : py_installation.dependency()`, see [[dependency]].
 
 **Returns**: a [[@build_tgt]] object
 

--- a/docs/markdown/snippets/python-extension-module-implicit-dependency.md
+++ b/docs/markdown/snippets/python-extension-module-implicit-dependency.md
@@ -1,0 +1,13 @@
+## Python extension modules now depend on the python library by default
+
+Python extension modules are usually expected to link to the python library
+and/or its headers in order to build correctly (via the default `embed: false`,
+which may not actually link to the library itself). This means that every
+single use of `.extension_module()` needed to include the `dependencies:
+py_installation.dependency()` kwarg explicitly.
+
+In the interest of doing the right thing out of the box, this is now the
+default for extension modules that don't already include a dependency on
+python. This is not expected to break anything, because it should always be
+needed. Nevertheless, `py_installation.dependency().partial_dependency()` will
+be detected as already included while providing no compile/link args.

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 from pathlib import Path
 import functools
@@ -26,6 +27,7 @@ from ..coredata import UserFeatureOption
 from ..build import known_shmod_kwargs
 from ..dependencies import DependencyMethods, PkgConfigDependency, NotFoundDependency, SystemDependency, ExtraFrameworkDependency
 from ..dependencies.base import process_method_kw
+from ..dependencies.detect import get_dep_identifier
 from ..environment import detect_cpu_family
 from ..interpreter import ExternalProgramHolder, extract_required_kwarg, permitted_dependency_kwargs
 from ..interpreter.type_checking import NoneType
@@ -539,31 +541,41 @@ class PythonInstallation(ExternalProgramHolder):
 
         return self.interpreter.func_shared_module(None, args, kwargs)
 
+    def _dependency_method_impl(self, kwargs: TYPE_kwargs) -> Dependency:
+        for_machine = self.interpreter.machine_from_native_kwarg(kwargs)
+        identifier = get_dep_identifier(self._full_path(), kwargs)
+
+        dep = self.interpreter.coredata.deps[for_machine].get(identifier)
+        if dep is not None:
+            return dep
+
+        new_kwargs = kwargs.copy()
+        new_kwargs['required'] = False
+        methods = process_method_kw({DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM}, kwargs)
+        # it's theoretically (though not practically) possible to not bind dep, let's ensure it is.
+        dep: Dependency = NotFoundDependency('python', self.interpreter.environment)
+        for d in python_factory(self.interpreter.environment, for_machine, new_kwargs, methods, self):
+            dep = d()
+            if dep.found():
+                break
+
+        self.interpreter.coredata.deps[for_machine].put(identifier, dep)
+        return dep
+
     @disablerIfNotFound
     @permittedKwargs(permitted_dependency_kwargs | {'embed'})
     @FeatureNewKwargs('python_installation.dependency', '0.53.0', ['embed'])
     @noPosargs
     def dependency_method(self, args: T.List['TYPE_var'], kwargs: 'TYPE_kwargs') -> 'Dependency':
         disabled, required, feature = extract_required_kwarg(kwargs, self.subproject)
-        # it's theoretically (though not practically) possible for the else clse
-        # to not bind dep, let's ensure it is.
-        dep: 'Dependency' = NotFoundDependency('python', self.interpreter.environment)
         if disabled:
             mlog.log('Dependency', mlog.bold('python'), 'skipped: feature', mlog.bold(feature), 'disabled')
+            return NotFoundDependency('python', self.interpreter.environment)
         else:
-            new_kwargs = kwargs.copy()
-            new_kwargs['required'] = False
-            methods = process_method_kw({DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM}, kwargs)
-            for d in python_factory(self.interpreter.environment,
-                                    MachineChoice.BUILD if kwargs.get('native', False) else MachineChoice.HOST,
-                                    new_kwargs, methods, self):
-                dep = d()
-                if dep.found():
-                    break
+            dep = self._dependency_method_impl(kwargs)
             if required and not dep.found():
                 raise mesonlib.MesonException('Python dependency not found')
-
-        return dep
+            return dep
 
     @typed_pos_args('install_data', varargs=(str, mesonlib.File))
     @typed_kwargs('python_installation.install_sources', _PURE_KW, _SUBDIR_KW,

--- a/test cases/python/2 extmodule/ext/meson.build
+++ b/test cases/python/2 extmodule/ext/meson.build
@@ -1,6 +1,5 @@
 pylib = py.extension_module('tachyon',
   'tachyon_module.c',
-  dependencies : py_dep,
   c_args: '-DMESON_MODULENAME="tachyon"',
   install: true,
 )

--- a/test cases/python/2 extmodule/ext/nested/meson.build
+++ b/test cases/python/2 extmodule/ext/nested/meson.build
@@ -1,6 +1,5 @@
 py.extension_module('tachyon',
   '../tachyon_module.c',
-  dependencies : py_dep,
   c_args: '-DMESON_MODULENAME="nested.tachyon"',
   install: true,
   subdir: 'nested'

--- a/test cases/python/2 extmodule/ext/wrongdir/meson.build
+++ b/test cases/python/2 extmodule/ext/wrongdir/meson.build
@@ -1,6 +1,5 @@
 py.extension_module('tachyon',
   '../tachyon_module.c',
-  dependencies : py_dep,
   c_args: '-DMESON_MODULENAME="tachyon"',
   install: true,
   install_dir: get_option('libdir')


### PR DESCRIPTION
If there isn't a preexisting dependency on python, append one. It's almost assuredly needed, so just do the right thing out of the box.

/cc @rgommers

See modified unittest. After removing the passed-around dep from `dependencies: ...` it still builds. Quickly tested with SciPy as well -- seems to build, does NOT build if you use `py3_dep.partial_dependency()` as the loophole in the release notes indicates.

As discussed elsewhere, I don't know why one would ever *not* want to have this dep, but... if you really really don't, then the partial_dependency lets you skip out on it. :shrug: