### PR TITLE
fix: prevent `meson configure` from exiting abnormally when the terminal width (or $COLUMNS) is equal or less than 60

### DIFF
--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -112,7 +112,8 @@ class Conf:
         """
         total_width = shutil.get_terminal_size(fallback=(160, 0))[0]
         _col = max(total_width // 5, 20)
-        four_column = (_col, _col, _col, total_width - (3 * _col))
+        last_column = total_width - (3 * _col)
+        four_column = (_col, _col, _col, last_column if last_column > 1 else _col)
         # In this case we don't have the choices field, so we can redistribute
         # the extra 40 characters to val and desc
         three_column = (_col, _col * 2, total_width // 2)


### PR DESCRIPTION
```python
        total_width = shutil.get_terminal_size(fallback=(160, 0))[0]
        _col = max(total_width // 5, 20)
        four_column = (_col, _col, _col, total_width - (3 * _col))
```
In the case where `total_width <=60` is true, `textwrap.wrap(line[3], four_column[3])` raises a `ValueError` which in turn causes meson to error out and exit.

I see that this has been brought up on #10211 and believe that instead of leaving it as-is, falling back to `_col` seems to be the right thing to do.