### PR TITLE
fix type checking for declare_dependency to allow linking to executable

### DIFF
--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -10,7 +10,7 @@ import typing as T
 from .. import compilers
 from ..build import (EnvironmentVariables, EnvInitValueType, CustomTarget, BuildTarget,
                      CustomTargetIndex, ExtractedObjects, GeneratedList, IncludeDirs,
-                     BothLibraries, SharedLibrary, StaticLibrary, Jar)
+                     BothLibraries, SharedLibrary, StaticLibrary, Jar, Executable)
 from ..coredata import UserFeatureOption
 from ..dependencies import Dependency, InternalDependency
 from ..interpreterbase.decorators import KwargInfo, ContainerTypeInfo
@@ -400,9 +400,9 @@ D_MODULE_VERSIONS_KW: KwargInfo[T.List[T.Union[str, int]]] = KwargInfo(
 _link_with_error = '''can only be self-built targets, external dependencies (including libraries) must go in "dependencies".'''
 
 # Allow Dependency for the better error message? But then in other cases it will list this as one of the allowed types!
-LINK_WITH_KW: KwargInfo[T.List[T.Union[BothLibraries, SharedLibrary, StaticLibrary, CustomTarget, CustomTargetIndex, Jar]]] = KwargInfo(
+LINK_WITH_KW: KwargInfo[T.List[T.Union[BothLibraries, SharedLibrary, StaticLibrary, CustomTarget, CustomTargetIndex, Jar, Executable]]] = KwargInfo(
     'link_with',
-    ContainerTypeInfo(list, (BothLibraries, SharedLibrary, StaticLibrary, CustomTarget, CustomTargetIndex, Jar, Dependency)),
+    ContainerTypeInfo(list, (BothLibraries, SharedLibrary, StaticLibrary, CustomTarget, CustomTargetIndex, Jar, Executable, Dependency)),
     listify=True,
     default=[],
     validator=lambda x: _link_with_error if isinstance(x, Dependency) else None,

--- a/test cases/common/148 shared module resolving symbol in executable/meson.build
+++ b/test cases/common/148 shared module resolving symbol in executable/meson.build
@@ -16,5 +16,10 @@ endif
 
 dl = meson.get_compiler('c').find_library('dl', required: false)
 e = executable('prog', 'prog.c', dependencies: dl, export_dynamic: true)
+e_dep = declare_dependency(link_with: e)
+
 m = shared_module('module', 'module.c', link_with: e)
+m2 = shared_module('module2', 'module.c', dependencies: e_dep)
+
 test('test', e, args: m.full_path())
+test('test2', e, args: m2.full_path())


### PR DESCRIPTION
We have to handle this, because Windows needs to link to the implib of the executable (???) in order to create a shared module. This is explicitly checked for and handled in the backend, and creating a build target with `link_with: some_exe` still works, even. But updating declare_dependency to typed_kwargs neglected to take that into account, so creating a convenience interface for those same arguments failed.

Discovered by @paper42 from Void Linux during rc1 testing.