### PR TITLE
Fix destdir_join

### DIFF
--- a/mesonbuild/scripts/__init__.py
+++ b/mesonbuild/scripts/__init__.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import PurePath
+
 def destdir_join(d1: str, d2: str) -> str:
     if not d1:
         return d2
     # c:\destdir + c:\prefix must produce c:\destdir\prefix
-    if len(d2) > 1 and d2[1] == ':':
-        return d1 + d2[2:]
-    return d1 + d2
+    return str(PurePath(d1, *PurePath(d2).parts[1:]))


### PR DESCRIPTION
The old implementation assumed a path is of Windows iff the second character is a colon. However, that is not always true. First, a colon can be included in a non-Windows path. For example, it is totally fine to have a directory named `:` on Linux 5.17.0 tmpfs. Second, a Windows path may start with `\\` for UNC or extended length.

Use pathlib to handle all of these cases.

The problem was found during QEMU development:
https://github.com/patchew-project/qemu/commit/a923ba2db1bd396ecf98cc74d7ed6e2398f77fe1#diff-cb6cd6656e23b30f170ce2692ea2f8582de1cb46c92c3b659b34dcbd2ee83b19R10-R18