### PR TITLE
RFC: meson: Add .get_subprojects() method

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -305,6 +305,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         self.project_args_frozen = False
         self.global_args_frozen = False  # implies self.project_args_frozen
         self.subprojects: T.Dict[str, SubprojectHolder] = {}
+        self.my_subprojects: T.Dict[str, SubprojectHolder] = {}
         self.subproject_stack: T.List[str] = []
         self.configure_file_outputs: T.Dict[str, int] = {}
         # Passed from the outside, only used in subprojects.
@@ -889,6 +890,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                 wanted = kwargs['version']
                 if pv == 'undefined' or not mesonlib.version_compare_many(pv, wanted)[0]:
                     raise InterpreterException(f'Subproject {subp_name} version is {pv} but {wanted} required.')
+            self.my_subprojects[subp_name] = subproject;
             return subproject
 
         r = self.environment.wrap_resolver
@@ -971,6 +973,8 @@ class Interpreter(InterpreterBase, HoldableObject):
         self.active_projectname = current_active
         self.subprojects.update(subi.subprojects)
         self.subprojects[subp_name] = SubprojectHolder(subi, subdir, warnings=subi_warnings)
+        self.my_subprojects.update(subi.my_subprojects)
+        self.my_subprojects[subp_name] = self.subprojects[subp_name];
         # Duplicates are possible when subproject uses files from project root
         if build_def_files:
             self.build_def_files.update(build_def_files)

--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -16,6 +16,7 @@ from ..interpreter.type_checking import ENV_KW, ENV_METHOD_KW, ENV_SEPARATOR_KW,
 from ..interpreterbase import (MesonInterpreterObject, FeatureNew, FeatureDeprecated,
                                typed_pos_args,  noArgsFlattening, noPosargs, noKwargs,
                                typed_kwargs, KwargInfo, InterpreterException)
+from .interpreterobjects import (SubprojectHolder)
 from .primitives import MesonVersionString
 from .type_checking import NATIVE_KW, NoneType
 
@@ -81,6 +82,7 @@ class MesonMain(MesonInterpreterObject):
                              'has_external_property': self.has_external_property_method,
                              'backend': self.backend_method,
                              'add_devenv': self.add_devenv_method,
+                             'get_subprojects': self.get_subprojects_method,
                              })
 
     def _find_source_script(
@@ -454,3 +456,8 @@ class MesonMain(MesonInterpreterObject):
         converted = env_convertor_with_method(env, kwargs['method'], kwargs['separator'])
         assert isinstance(converted, build.EnvironmentVariables)
         self.build.devenv.append(converted)
+
+    @noPosargs
+    @noKwargs
+    def get_subprojects_method(self, args: T.List['TYPE_var'], kwargs: 'TYPE_kwargs') -> T.Dict[str, SubprojectHolder]:
+        return self.interpreter.my_subprojects


### PR DESCRIPTION
Useful to automatically extract variables from all subprojects previously
registered inside the active one, including those of their children.

**TBD:** 
If you think this is usefull, I'am willing to add test case, feature check and documentation.

**Example:**
```
    subs = meson.get_subprojects()
    all_test_deps = []
    foreach name, sub: subs
        all_test_deps += sub.get_variable('test_deps', [])
    endforeach
```

**Behavior:**
```
    meson.build:
        project('example')
        subproject('sub1')
        meson.get_subprojects()
        # returns sub1, sub2.1, sub2.2.1, sub2.2, sub2
        subproject('sub2')
        subprojects/sub1/meson.build
        meson.get_subprojects()
        # returns sub1, sub2.1, sub2.2.1, sub2.2, sub2

    subprojects/sub1/meson.build:
        project('sub1')
        meson.get_subprojects()
        # returns []

    subprojects/sub2/meson.build:
        project('sub2')
        subproject('sub2.1')
        subproject('sub2.2')
        meson.get_subprojects()
        # returns sub2.1, sub2.2.1, sub2.2

    subprojects/sub2.1/meson.build:
        project('sub2.1')

    subprojects/sub2.2/meson.build:
        project('sub2.2')
        subproject('sub2.2.1')
        meson.get_subprojects()
        # returns sub2.2.1

    subprojects/sub2.2.1/meson.build:
        project('sub2.2.1')
```
