### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/file_format.yml
+++ b/.github/workflows/file_format.yml
@@ -6,6 +6,9 @@ concurrency:
   group: file_fmt-${{ github.head_ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,9 @@ on:
     - "**.py"
     - ".github/workflows/lint.yml"
 
+permissions:
+  contents: read
+
 jobs:
 
   pylint:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,6 +20,9 @@ on:
       - ".github/workflows/macos.yml"
       - "run_unittests.py"
 
+permissions:
+  contents: read
+
 jobs:
   unittests-appleclang:
     runs-on: macos-latest

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -20,6 +20,9 @@ on:
       - ".github/workflows/msys2.yml"
       - "run_unittests.py"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: windows-2019

--- a/.github/workflows/nonative.yml
+++ b/.github/workflows/nonative.yml
@@ -22,6 +22,9 @@ on:
       - ".github/workflows/nonative.yml"
       - "run*tests.py"
 
+permissions:
+  contents: read
+
 jobs:
   cross-only-armhf:
     runs-on: ubuntu-latest

--- a/.github/workflows/os_comp.yml
+++ b/.github/workflows/os_comp.yml
@@ -26,6 +26,9 @@ on:
       - ".github/workflows/os_comp.yml"
       - "run_unittests.py"
 
+permissions:
+  contents: read
+
 jobs:
   arch:
     name: ${{ matrix.cfg.name }}

--- a/.github/workflows/unusedargs_missingreturn.yml
+++ b/.github/workflows/unusedargs_missingreturn.yml
@@ -36,6 +36,9 @@ on:
     - "test cases/objcpp/**"
     - "test caes/windows/**"
 
+permissions:
+  contents: read
+
 jobs:
 
   linux:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
