### PR TITLE
Fix the wrong detection of Win32 platform in MSVC backend

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1312,7 +1312,7 @@ class Vs2010Backend(backends.Backend):
             pdb.text = f'$(OutDir){target_name}.pdb'
         targetmachine = ET.SubElement(link, 'TargetMachine')
         if target.for_machine is MachineChoice.BUILD:
-            targetplatform = platform
+            targetplatform = platform.lower()
         else:
             targetplatform = self.platform.lower()
         if targetplatform == 'win32':


### PR DESCRIPTION
Add a missing `lower()` for MSVCbackend platform detection. This PR will fix #10539.  

I am not familiar with meson. So I hope someone who knows MSVC backend well can check my code. Hope my changes will not affect the build of any other architectures.