### PR TITLE
pkgconfig: do not add valgrind as requirement

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -116,6 +116,8 @@ class DependenciesHelper:
             if hasattr(obj, 'generated_pc'):
                 self._check_generated_pc_deprecation(obj)
                 processed_reqs.append(obj.generated_pc)
+            elif isinstance(obj, dependencies.ValgrindDependency):
+                pass
             elif isinstance(obj, dependencies.PkgConfigDependency):
                 if obj.found():
                     processed_reqs.append(obj.name)


### PR DESCRIPTION
For the same reasons commit 7aa28456d ("Add dependency type for
Valgrind") removed linking with valgrind, pkgconfig shouldn't generate
"Requirements" for it, in general.

This solves dbus meson port question/issue from:
https://gitlab.freedesktop.org/dbus/dbus/-/merge_requests/303#note_1444819

