### PR TITLE
test cases: Don't fall off the end of main() without an exit status

### DIFF
--- a/test cases/common/141 special characters/arg-char-test.c
+++ b/test cases/common/141 special characters/arg-char-test.c
@@ -7,4 +7,5 @@ int main(int argc, char **argv) {
   if (c != argv[1][0])
     fprintf(stderr, "Expected %x, got %x\n", (unsigned int) c, (unsigned int) argv[1][0]);
   assert(c == argv[1][0]);
+  return 0;
 }

--- a/test cases/common/141 special characters/arg-string-test.c
+++ b/test cases/common/141 special characters/arg-string-test.c
@@ -9,4 +9,5 @@ int main(int argc, char **argv) {
   if (s[0] != argv[1][0])
     fprintf(stderr, "Expected %x, got %x\n", (unsigned int) s[0], (unsigned int) argv[1][0]);
   assert(s[0] == argv[1][0]);
+  return 0;
 }

--- a/test cases/common/141 special characters/arg-unquoted-test.c
+++ b/test cases/common/141 special characters/arg-unquoted-test.c
@@ -14,4 +14,5 @@ int main(int argc, char **argv) {
   assert(s[0] == argv[1][0]);
   // There is no way to convert a macro argument into a character constant.
   // Otherwise we'd test that as well
+  return 0;
 }


### PR DESCRIPTION
This is undefined behaviour, and seems to have caused test failures
when backporting Meson to an older toolchain in the Steam Runtime.