### PR TITLE
gnome module: Use --quiet to supress printing the link command line

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1149,6 +1149,7 @@ class GnomeModule(ExtensionModule):
         gir_inc_dirs: T.List[str] = []
 
         scan_command: T.List[T.Union[str, build.Executable, 'ExternalProgram', 'OverrideProgram']] = [giscanner]
+        scan_command += ['--quiet']
         scan_command += ['--no-libtool']
         scan_command += ['--namespace=' + ns, '--nsversion=' + nsversion]
         scan_command += ['--warn-all']


### PR DESCRIPTION
This removes one line of stderr output per GObject Introspection file
processed, e.g.

g-ir-scanner: link: gcc -o Fwupd-2.0 Fwupd-2.0.o -L. -Wl,-rpath...