### PR TITLE
Add warning_level=everything

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -85,7 +85,7 @@ machine](#specifying-options-per-machine) section for details.
 | strip                                  | false         | Strip targets on install                                       | no             | no                |
 | unity {on, off, subprojects}           | off           | Unity build                                                    | no             | no                |
 | unity_size {>=2}                       | 4             | Unity file block size                                          | no             | no                |
-| warning_level {0, 1, 2, 3}             | 1             | Set the warning level. From 0 = none to 3 = highest            | no             | yes               |
+| warning_level {0, 1, 2, 3, everything} | 1             | Set the warning level. From 0 = none to everything = highest   | no             | yes               |
 | werror                                 | false         | Treat warnings as errors                                       | no             | yes               |
 | wrap_mode {default, nofallback,<br>nodownload, forcefallback, nopromote} | default | Wrap mode to use                 | no             | no                |
 | force_fallback_for                     | []            | Force fallback for those dependencies                          | no             | no                |

--- a/docs/markdown/Configuring-a-build-directory.md
+++ b/docs/markdown/Configuring-a-build-directory.md
@@ -34,7 +34,7 @@ a sample output for a simple project.
       prefer_static   false         [true, false]                                              Whether to try static linking before shared linking
       strip           false         [true, false]                                              Strip targets on install
       unity           off           [on, off, subprojects]                                     Unity build
-      warning_level   1             [0, 1, 2, 3]                                               Compiler warning level to use
+      warning_level   1             [0, 1, 2, 3, everything]                                   Compiler warning level to use
       werror          false         [true, false]                                              Treat warnings as errors
 
     Backend options:

--- a/docs/markdown/snippets/warning_level_everything.md
+++ b/docs/markdown/snippets/warning_level_everything.md
@@ -1,0 +1,5 @@
+## `warning-level=everything` option
+
+The new `everything` value for the built-in `warning_level` enables roughly all applicable compiler warnings.
+For clang and MSVC, this simply enables `-Weverything` or `/Wall`, respectively.
+For GCC, meson enables warnings approximately equivalent to `-Weverything` from clang.

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -28,6 +28,7 @@ from .mixins.ti import TICompiler
 from .mixins.arm import ArmCompiler, ArmclangCompiler
 from .mixins.visualstudio import MSVCCompiler, ClangClCompiler
 from .mixins.gnu import GnuCompiler
+from .mixins.gnu import gnu_common_warning_args, gnu_c_warning_args
 from .mixins.intel import IntelGnuLikeCompiler, IntelVisualStudioLikeCompiler
 from .mixins.clang import ClangCompiler
 from .mixins.elbrus import ElbrusCompiler
@@ -152,7 +153,8 @@ class ClangCCompiler(_ClangCStds, ClangCompiler, CCompiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
-                          '3': default_warn_args + ['-Wextra', '-Wpedantic']}
+                          '3': default_warn_args + ['-Wextra', '-Wpedantic'],
+                          'everything': ['-Weverything']}
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
@@ -233,7 +235,8 @@ class ArmclangCCompiler(ArmclangCompiler, CCompiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
-                          '3': default_warn_args + ['-Wextra', '-Wpedantic']}
+                          '3': default_warn_args + ['-Wextra', '-Wpedantic'],
+                          'everything': ['-Weverything']}
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = CCompiler.get_options(self)
@@ -271,7 +274,10 @@ class GnuCCompiler(GnuCompiler, CCompiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
-                          '3': default_warn_args + ['-Wextra', '-Wpedantic']}
+                          '3': default_warn_args + ['-Wextra', '-Wpedantic'],
+                          'everything': (default_warn_args + ['-Wextra', '-Wpedantic'] +
+                                         self.supported_warn_args(gnu_common_warning_args) +
+                                         self.supported_warn_args(gnu_c_warning_args))}
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = CCompiler.get_options(self)
@@ -385,11 +391,12 @@ class IntelCCompiler(IntelGnuLikeCompiler, CCompiler):
                            info, exe_wrapper, linker=linker, full_version=full_version)
         IntelGnuLikeCompiler.__init__(self)
         self.lang_header = 'c-header'
-        default_warn_args = ['-Wall', '-w3', '-diag-disable:remark']
+        default_warn_args = ['-Wall', '-w3']
         self.warn_args = {'0': [],
-                          '1': default_warn_args,
-                          '2': default_warn_args + ['-Wextra'],
-                          '3': default_warn_args + ['-Wextra']}
+                          '1': default_warn_args + ['-diag-disable:remark'],
+                          '2': default_warn_args + ['-Wextra', '-diag-disable:remark'],
+                          '3': default_warn_args + ['-Wextra', '-diag-disable:remark'],
+                          'everything': default_warn_args + ['-Wextra']}
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = CCompiler.get_options(self)

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -33,7 +33,7 @@ from .mixins.ccrx import CcrxCompiler
 from .mixins.ti import TICompiler
 from .mixins.arm import ArmCompiler, ArmclangCompiler
 from .mixins.visualstudio import MSVCCompiler, ClangClCompiler
-from .mixins.gnu import GnuCompiler
+from .mixins.gnu import GnuCompiler, gnu_common_warning_args, gnu_cpp_warning_args
 from .mixins.intel import IntelGnuLikeCompiler, IntelVisualStudioLikeCompiler
 from .mixins.clang import ClangCompiler
 from .mixins.elbrus import ElbrusCompiler
@@ -194,7 +194,8 @@ class ClangCPPCompiler(ClangCompiler, CPPCompiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
-                          '3': default_warn_args + ['-Wextra', '-Wpedantic']}
+                          '3': default_warn_args + ['-Wextra', '-Wpedantic'],
+                          'everything': ['-Weverything']}
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = CPPCompiler.get_options(self)
@@ -314,7 +315,8 @@ class ArmclangCPPCompiler(ArmclangCompiler, CPPCompiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
-                          '3': default_warn_args + ['-Wextra', '-Wpedantic']}
+                          '3': default_warn_args + ['-Wextra', '-Wpedantic'],
+                          'everything': ['-Weverything']}
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = CPPCompiler.get_options(self)
@@ -360,7 +362,10 @@ class GnuCPPCompiler(GnuCompiler, CPPCompiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
-                          '3': default_warn_args + ['-Wextra', '-Wpedantic']}
+                          '3': default_warn_args + ['-Wextra', '-Wpedantic'],
+                          'everything': (default_warn_args + ['-Wextra', '-Wpedantic'] +
+                                         self.supported_warn_args(gnu_common_warning_args) +
+                                         self.supported_warn_args(gnu_cpp_warning_args))}
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         key = OptionKey('std', machine=self.for_machine, lang=self.language)
@@ -535,12 +540,12 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
                              info, exe_wrapper, linker=linker, full_version=full_version)
         IntelGnuLikeCompiler.__init__(self)
         self.lang_header = 'c++-header'
-        default_warn_args = ['-Wall', '-w3', '-diag-disable:remark',
-                             '-Wpch-messages']
+        default_warn_args = ['-Wall', '-w3', '-Wpch-messages']
         self.warn_args = {'0': [],
-                          '1': default_warn_args,
-                          '2': default_warn_args + ['-Wextra'],
-                          '3': default_warn_args + ['-Wextra']}
+                          '1': default_warn_args + ['-diag-disable:remark'],
+                          '2': default_warn_args + ['-Wextra', '-diag-disable:remark'],
+                          '3': default_warn_args + ['-Wextra', '-diag-disable:remark'],
+                          'everything': default_warn_args + ['-Wextra']}
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = CPPCompiler.get_options(self)

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -36,6 +36,7 @@ from .compilers import (
     CompileCheckMode,
 )
 from .mixins.gnu import GnuCompiler
+from .mixins.gnu import gnu_common_warning_args
 
 if T.TYPE_CHECKING:
     from ..dependencies import Dependency
@@ -805,7 +806,10 @@ class GnuDCompiler(GnuCompiler, DCompiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
-                          '3': default_warn_args + ['-Wextra', '-Wpedantic']}
+                          '3': default_warn_args + ['-Wextra', '-Wpedantic'],
+                          'everything': (default_warn_args + ['-Wextra', '-Wpedantic'] +
+                                         self.supported_warn_args(gnu_common_warning_args))}
+
         self.base_options = {
             OptionKey(o) for o in [
              'b_colorout', 'b_sanitize', 'b_staticpic', 'b_vscrt',

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -23,7 +23,7 @@ from .compilers import (
 )
 from .mixins.clike import CLikeCompiler
 from .mixins.gnu import (
-    GnuCompiler, gnulike_buildtype_args, gnu_optimization_args,
+    GnuCompiler, gnulike_buildtype_args, gnu_optimization_args
 )
 from .mixins.intel import IntelGnuLikeCompiler, IntelVisualStudioLikeCompiler
 from .mixins.clang import ClangCompiler
@@ -155,7 +155,8 @@ class GnuFortranCompiler(GnuCompiler, FortranCompiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
-                          '3': default_warn_args + ['-Wextra', '-Wpedantic', '-fimplicit-none']}
+                          '3': default_warn_args + ['-Wextra', '-Wpedantic', '-fimplicit-none'],
+                          'everything': default_warn_args + ['-Wextra', '-Wpedantic', '-fimplicit-none']}
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = FortranCompiler.get_options(self)
@@ -246,7 +247,8 @@ class G95FortranCompiler(FortranCompiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
-                          '3': default_warn_args + ['-Wextra', '-pedantic']}
+                          '3': default_warn_args + ['-Wextra', '-pedantic'],
+                          'everything': default_warn_args + ['-Wextra', '-pedantic']}
 
     def get_module_outdir_args(self, path: str) -> T.List[str]:
         return ['-fmod=' + path]
@@ -299,7 +301,8 @@ class IntelFortranCompiler(IntelGnuLikeCompiler, FortranCompiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-warn', 'unused'],
-                          '3': ['-warn', 'all']}
+                          '3': ['-warn', 'all'],
+                          'everything': ['-warn', 'all']}
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = FortranCompiler.get_options(self)
@@ -351,7 +354,8 @@ class IntelClFortranCompiler(IntelVisualStudioLikeCompiler, FortranCompiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['/warn:unused'],
-                          '3': ['/warn:all']}
+                          '3': ['/warn:all'],
+                          'everything': ['/warn:all']}
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = FortranCompiler.get_options(self)
@@ -391,7 +395,8 @@ class PathScaleFortranCompiler(FortranCompiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args,
-                          '3': default_warn_args}
+                          '3': default_warn_args,
+                          'everything': default_warn_args}
 
     def openmp_flags(self) -> T.List[str]:
         return ['-mp']
@@ -412,7 +417,8 @@ class PGIFortranCompiler(PGICompiler, FortranCompiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args,
-                          '3': default_warn_args + ['-Mdclchk']}
+                          '3': default_warn_args + ['-Mdclchk'],
+                          'everything': default_warn_args + ['-Mdclchk']}
 
     def language_stdlib_only_link_flags(self, env: 'Environment') -> T.List[str]:
         # TODO: needs default search path added
@@ -437,7 +443,8 @@ class NvidiaHPC_FortranCompiler(PGICompiler, FortranCompiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args,
-                          '3': default_warn_args + ['-Mdclchk']}
+                          '3': default_warn_args + ['-Mdclchk'],
+                          'everything': default_warn_args + ['-Mdclchk']}
 
 
 class FlangFortranCompiler(ClangCompiler, FortranCompiler):
@@ -456,7 +463,8 @@ class FlangFortranCompiler(ClangCompiler, FortranCompiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args,
-                          '3': default_warn_args}
+                          '3': default_warn_args,
+                          'everything': default_warn_args}
 
     def language_stdlib_only_link_flags(self, env: 'Environment') -> T.List[str]:
         # We need to apply the search prefix here, as these link arguments may
@@ -488,7 +496,8 @@ class Open64FortranCompiler(FortranCompiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args,
-                          '3': default_warn_args}
+                          '3': default_warn_args,
+                          'everything': default_warn_args}
 
     def openmp_flags(self) -> T.List[str]:
         return ['-mp']
@@ -511,6 +520,7 @@ class NAGFortranCompiler(FortranCompiler):
             '1': [],
             '2': [],
             '3': [],
+            'everything': [],
         }
 
     def get_always_args(self) -> T.List[str]:

--- a/mesonbuild/compilers/mixins/arm.py
+++ b/mesonbuild/compilers/mixins/arm.py
@@ -85,7 +85,8 @@ class ArmCompiler(Compiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + [],
-                          '3': default_warn_args + []}  # type: T.Dict[str, T.List[str]]
+                          '3': default_warn_args + [],
+                          'everything': default_warn_args + []}  # type: T.Dict[str, T.List[str]]
         # Assembly
         self.can_compile_suffixes.add('s')
 

--- a/mesonbuild/compilers/mixins/ccrx.py
+++ b/mesonbuild/compilers/mixins/ccrx.py
@@ -72,7 +72,8 @@ class CcrxCompiler(Compiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + [],
-                          '3': default_warn_args + []}  # type: T.Dict[str, T.List[str]]
+                          '3': default_warn_args + [],
+                          'everything': default_warn_args + []}  # type: T.Dict[str, T.List[str]]
 
     def get_pic_args(self) -> T.List[str]:
         # PIC support is not enabled by default for CCRX,

--- a/mesonbuild/compilers/mixins/compcert.py
+++ b/mesonbuild/compilers/mixins/compcert.py
@@ -72,7 +72,8 @@ class CompCertCompiler(Compiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + [],
-                          '3': default_warn_args + []}  # type: T.Dict[str, T.List[str]]
+                          '3': default_warn_args + [],
+                          'everything': default_warn_args + []}  # type: T.Dict[str, T.List[str]]
 
     def get_always_args(self) -> T.List[str]:
         return []

--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -41,7 +41,8 @@ class ElbrusCompiler(GnuLikeCompiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
-                          '3': default_warn_args + ['-Wextra', '-Wpedantic']}
+                          '3': default_warn_args + ['-Wextra', '-Wpedantic'],
+                          'everything': default_warn_args + ['-Wextra', '-Wpedantic']}
 
     # FIXME: use _build_wrapper to call this so that linker flags from the env
     # get applied

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -92,6 +92,238 @@ gnu_color_args = {
     'never': ['-fdiagnostics-color=never'],
 }  # type: T.Dict[str, T.List[str]]
 
+# Warnings collected from the GCC source and documentation.  This is an
+# objective set of all the warnings flags that apply to general projects: the
+# only ones omitted are those that require a project-specific value, or are
+# related to non-standard or legacy language support.  This behaves roughly
+# like -Weverything in clang.  Warnings implied by -Wall, -Wextra, or
+# higher-level warnings already enabled here are not included in these lists to
+# keep them as short as possible.  History goes back to GCC 3.0.0, everything
+# earlier is considered historical and listed under version 0.0.0.
+
+# GCC warnings for all C-family languages
+# Omitted non-general warnings:
+#   -Wabi=
+#   -Waggregate-return
+#   -Walloc-size-larger-than=BYTES
+#   -Walloca-larger-than=BYTES
+#   -Wframe-larger-than=BYTES
+#   -Wlarger-than=BYTES
+#   -Wstack-usage=BYTES
+#   -Wsystem-headers
+#   -Wtrampolines
+#   -Wvla-larger-than=BYTES
+#
+# Omitted warnings enabled elsewhere in meson:
+#   -Winvalid-pch (GCC 3.4.0)
+gnu_common_warning_args = {
+    "0.0.0": [
+        "-Wcast-qual",
+        "-Wconversion",
+        "-Wfloat-equal",
+        "-Wformat=2",
+        "-Winline",
+        "-Wmissing-declarations",
+        "-Wredundant-decls",
+        "-Wshadow",
+        "-Wundef",
+        "-Wuninitialized",
+        "-Wwrite-strings",
+    ],
+    "3.0.0": [
+        "-Wdisabled-optimization",
+        "-Wpacked",
+        "-Wpadded",
+    ],
+    "3.3.0": [
+        "-Wmultichar",
+        "-Wswitch-default",
+        "-Wswitch-enum",
+        "-Wunused-macros",
+    ],
+    "4.0.0": [
+        "-Wmissing-include-dirs",
+    ],
+    "4.1.0": [
+        "-Wunsafe-loop-optimizations",
+        "-Wstack-protector",
+    ],
+    "4.2.0": [
+        "-Wstrict-overflow=5",
+    ],
+    "4.3.0": [
+        "-Warray-bounds=2",
+        "-Wlogical-op",
+        "-Wstrict-aliasing=3",
+        "-Wvla",
+    ],
+    "4.6.0": [
+        "-Wdouble-promotion",
+        "-Wsuggest-attribute=const",
+        "-Wsuggest-attribute=noreturn",
+        "-Wsuggest-attribute=pure",
+        "-Wtrampolines",
+    ],
+    "4.7.0": [
+        "-Wvector-operation-performance",
+    ],
+    "4.8.0": [
+        "-Wsuggest-attribute=format",
+    ],
+    "4.9.0": [
+        "-Wdate-time",
+    ],
+    "5.1.0": [
+        "-Wformat-signedness",
+        "-Wnormalized=nfc",
+    ],
+    "6.1.0": [
+        "-Wduplicated-cond",
+        "-Wnull-dereference",
+        "-Wshift-negative-value",
+        "-Wshift-overflow=2",
+        "-Wunused-const-variable=2",
+    ],
+    "7.1.0": [
+        "-Walloca",
+        "-Walloc-zero",
+        "-Wformat-overflow=2",
+        "-Wformat-truncation=2",
+        "-Wstringop-overflow=3",
+    ],
+    "7.2.0": [
+        "-Wduplicated-branches",
+    ],
+    "8.1.0": [
+        "-Wattribute-alias=2",
+        "-Wcast-align=strict",
+        "-Wsuggest-attribute=cold",
+        "-Wsuggest-attribute=malloc",
+    ],
+    "10.1.0": [
+        "-Wanalyzer-too-complex",
+        "-Warith-conversion",
+    ],
+    "12.1.0": [
+        "-Wbidi-chars=ucn",
+        "-Wopenacc-parallelism",
+        "-Wtrivial-auto-var-init",
+    ],
+}  # type: T.Dict[str, T.List[str]]
+
+# GCC warnings for C
+# Omitted non-general or legacy warnings:
+#   -Wc11-c2x-compat
+#   -Wc90-c99-compat
+#   -Wc99-c11-compat
+#   -Wdeclaration-after-statement
+#   -Wtraditional
+#   -Wtraditional-conversion
+gnu_c_warning_args = {
+    "0.0.0": [
+        "-Wbad-function-cast",
+        "-Wmissing-prototypes",
+        "-Wnested-externs",
+        "-Wstrict-prototypes",
+    ],
+    "3.4.0": [
+        "-Wold-style-definition",
+        "-Winit-self",
+    ],
+    "4.1.0": [
+        "-Wc++-compat",
+    ],
+    "4.5.0": [
+        "-Wunsuffixed-float-constants",
+    ],
+}  # type: T.Dict[str, T.List[str]]
+
+# GCC warnings for C++
+# Omitted non-general or legacy warnings:
+#   -Wc++0x-compat
+#   -Wc++1z-compat
+#   -Wc++2a-compat
+#   -Wctad-maybe-unsupported
+#   -Wnamespaces
+#   -Wtemplates
+gnu_cpp_warning_args = {
+    "0.0.0": [
+        "-Wctor-dtor-privacy",
+        "-Weffc++",
+        "-Wnon-virtual-dtor",
+        "-Wold-style-cast",
+        "-Woverloaded-virtual",
+        "-Wsign-promo",
+    ],
+    "4.0.1": [
+        "-Wstrict-null-sentinel",
+    ],
+    "4.6.0": [
+        "-Wnoexcept",
+    ],
+    "4.7.0": [
+        "-Wzero-as-null-pointer-constant",
+    ],
+    "4.8.0": [
+        "-Wabi-tag",
+        "-Wuseless-cast",
+    ],
+    "4.9.0": [
+        "-Wconditionally-supported",
+    ],
+    "5.1.0": [
+        "-Wsuggest-final-methods",
+        "-Wsuggest-final-types",
+        "-Wsuggest-override",
+    ],
+    "6.1.0": [
+        "-Wmultiple-inheritance",
+        "-Wplacement-new=2",
+        "-Wvirtual-inheritance",
+    ],
+    "7.1.0": [
+        "-Waligned-new=all",
+        "-Wnoexcept-type",
+        "-Wregister",
+    ],
+    "8.1.0": [
+        "-Wcatch-value=3",
+        "-Wextra-semi",
+    ],
+    "9.1.0": [
+        "-Wdeprecated-copy-dtor",
+        "-Wredundant-move",
+    ],
+    "10.1.0": [
+        "-Wcomma-subscript",
+        "-Wmismatched-tags",
+        "-Wredundant-tags",
+        "-Wvolatile",
+    ],
+    "11.1.0": [
+        "-Wdeprecated-enum-enum-conversion",
+        "-Wdeprecated-enum-float-conversion",
+        "-Winvalid-imported-macros",
+    ],
+}  # type: T.Dict[str, T.List[str]]
+
+# GCC warnings for Objective C and Objective C++
+# Omitted non-general or legacy warnings:
+#   -Wtraditional
+#   -Wtraditional-conversion
+gnu_objc_warning_args = {
+    "0.0.0": [
+        "-Wselector",
+    ],
+    "3.3": [
+        "-Wundeclared-selector",
+    ],
+    "4.1.0": [
+        "-Wassign-intercept",
+        "-Wstrict-selector-match",
+    ],
+}  # type: T.Dict[str, T.List[str]]
+
 
 @functools.lru_cache(maxsize=None)
 def gnulike_default_include_dirs(compiler: T.Tuple[str, ...], lang: str) -> 'ImmutableListProtocol[str]':
@@ -350,6 +582,13 @@ class GnuCompiler(GnuLikeCompiler):
             # https://gcc.gnu.org/gcc-4.8/changes.html
             args[args.index('-Wpedantic')] = '-pedantic'
         return args
+
+    def supported_warn_args(self, warn_args_by_version: T.Dict[str, T.List[str]]) -> T.List[str]:
+        result = []
+        for version, warn_args in warn_args_by_version.items():
+            if mesonlib.version_compare(self.version, '>=' + version):
+                result += warn_args
+        return result
 
     def has_builtin_define(self, define: str) -> bool:
         return define in self.defines

--- a/mesonbuild/compilers/mixins/pgi.py
+++ b/mesonbuild/compilers/mixins/pgi.py
@@ -53,7 +53,8 @@ class PGICompiler(Compiler):
             '0': [],
             '1': default_warn_args,
             '2': default_warn_args,
-            '3': default_warn_args
+            '3': default_warn_args,
+            'everything': default_warn_args
         }
 
     def get_module_incdir_args(self) -> T.Tuple[str]:

--- a/mesonbuild/compilers/mixins/ti.py
+++ b/mesonbuild/compilers/mixins/ti.py
@@ -71,7 +71,8 @@ class TICompiler(Compiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + [],
-                          '3': default_warn_args + []}  # type: T.Dict[str, T.List[str]]
+                          '3': default_warn_args + [],
+                          'everything': default_warn_args + []}  # type: T.Dict[str, T.List[str]]
 
     def get_pic_args(self) -> T.List[str]:
         # PIC support is not enabled by default for TI compilers,

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -110,6 +110,7 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
         '1': ['/W2'],
         '2': ['/W3'],
         '3': ['/W4'],
+        'everything': ['/Wall'],
     }  # type: T.Dict[str, T.List[str]]
 
     INVOKES_LINKER = False

--- a/mesonbuild/compilers/mixins/xc16.py
+++ b/mesonbuild/compilers/mixins/xc16.py
@@ -69,7 +69,8 @@ class Xc16Compiler(Compiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + [],
-                          '3': default_warn_args + []}  # type: T.Dict[str, T.List[str]]
+                          '3': default_warn_args + [],
+                          'everything': default_warn_args + []}  # type: T.Dict[str, T.List[str]]
 
     def get_always_args(self) -> T.List[str]:
         return []

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -20,7 +20,7 @@ from ..mesonlib import OptionKey
 
 from .compilers import Compiler
 from .mixins.clike import CLikeCompiler
-from .mixins.gnu import GnuCompiler
+from .mixins.gnu import GnuCompiler, gnu_common_warning_args, gnu_objc_warning_args
 from .mixins.clang import ClangCompiler
 
 if T.TYPE_CHECKING:
@@ -68,7 +68,10 @@ class GnuObjCCompiler(GnuCompiler, ObjCCompiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
-                          '3': default_warn_args + ['-Wextra', '-Wpedantic']}
+                          '3': default_warn_args + ['-Wextra', '-Wpedantic'],
+                          'everything': (default_warn_args + ['-Wextra', '-Wpedantic'] +
+                                         self.supported_warn_args(gnu_common_warning_args) +
+                                         self.supported_warn_args(gnu_objc_warning_args))}
 
 
 class ClangObjCCompiler(ClangCompiler, ObjCCompiler):
@@ -85,7 +88,8 @@ class ClangObjCCompiler(ClangCompiler, ObjCCompiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
-                          '3': default_warn_args + ['-Wextra', '-Wpedantic']}
+                          '3': default_warn_args + ['-Wextra', '-Wpedantic'],
+                          'everything': ['-Weverything']}
 
     def get_options(self) -> 'coredata.MutableKeyedOptionDictType':
         opts = super().get_options()

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -20,7 +20,7 @@ from ..mesonlib import OptionKey
 
 from .mixins.clike import CLikeCompiler
 from .compilers import Compiler
-from .mixins.gnu import GnuCompiler
+from .mixins.gnu import GnuCompiler, gnu_common_warning_args, gnu_objc_warning_args
 from .mixins.clang import ClangCompiler
 
 if T.TYPE_CHECKING:
@@ -67,7 +67,10 @@ class GnuObjCPPCompiler(GnuCompiler, ObjCPPCompiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
-                          '3': default_warn_args + ['-Wextra', '-Wpedantic']}
+                          '3': default_warn_args + ['-Wextra', '-Wpedantic'],
+                          'everything': (default_warn_args + ['-Wextra', '-Wpedantic'] +
+                                         self.supported_warn_args(gnu_common_warning_args) +
+                                         self.supported_warn_args(gnu_objc_warning_args))}
 
 
 class ClangObjCPPCompiler(ClangCompiler, ObjCPPCompiler):
@@ -85,7 +88,8 @@ class ClangObjCPPCompiler(ClangCompiler, ObjCPPCompiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
-                          '3': default_warn_args + ['-Wextra', '-Wpedantic']}
+                          '3': default_warn_args + ['-Wextra', '-Wpedantic'],
+                          'everything': ['-Weverything']}
 
     def get_options(self) -> 'coredata.MutableKeyedOptionDictType':
         opts = super().get_options()

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1223,7 +1223,7 @@ BUILTIN_CORE_OPTIONS: 'MutableKeyedOptionDictType' = OrderedDict([
     (OptionKey('strip'),           BuiltinOption(UserBooleanOption, 'Strip targets on install', False)),
     (OptionKey('unity'),           BuiltinOption(UserComboOption, 'Unity build', 'off', choices=['on', 'off', 'subprojects'])),
     (OptionKey('unity_size'),      BuiltinOption(UserIntegerOption, 'Unity block size', (2, None, 4))),
-    (OptionKey('warning_level'),   BuiltinOption(UserComboOption, 'Compiler warning level to use', '1', choices=['0', '1', '2', '3'], yielding=False)),
+    (OptionKey('warning_level'),   BuiltinOption(UserComboOption, 'Compiler warning level to use', '1', choices=['0', '1', '2', '3', 'everything'], yielding=False)),
     (OptionKey('werror'),          BuiltinOption(UserBooleanOption, 'Treat warnings as errors', False, yielding=False)),
     (OptionKey('wrap_mode'),       BuiltinOption(UserComboOption, 'Wrap mode', 'default', choices=['default', 'nofallback', 'nodownload', 'forcefallback', 'nopromote'])),
     (OptionKey('force_fallback_for'), BuiltinOption(UserArrayOption, 'Force fallback for those subprojects', [])),

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -2279,6 +2279,9 @@ class AllPlatformTests(BasePlatformTests):
         self.setconf('--warnlevel=3')
         obj = mesonbuild.coredata.load(self.builddir)
         self.assertEqual(obj.options[OptionKey('warning_level')].value, '3')
+        self.setconf('--warnlevel=everything')
+        obj = mesonbuild.coredata.load(self.builddir)
+        self.assertEqual(obj.options[OptionKey('warning_level')].value, 'everything')
         self.wipe()
 
         # But when using -D syntax, it should be 'warning_level'
@@ -2288,6 +2291,9 @@ class AllPlatformTests(BasePlatformTests):
         self.setconf('-Dwarning_level=3')
         obj = mesonbuild.coredata.load(self.builddir)
         self.assertEqual(obj.options[OptionKey('warning_level')].value, '3')
+        self.setconf('-Dwarning_level=everything')
+        obj = mesonbuild.coredata.load(self.builddir)
+        self.assertEqual(obj.options[OptionKey('warning_level')].value, 'everything')
         self.wipe()
 
         # Mixing --option and -Doption is forbidden


### PR DESCRIPTION
Adds a new highest warning level that is roughly equivalent to "all warnings".
This adds a way to use `/Wall` with MSVC (without the previous broken warning),
`-Weverything` with clang, and almost all general warnings in GCC with
strictness roughly equivalent to clang's `-Weverything`.

For objectivity, all warnings are included except those that require specific
values or are related to language level compatibility.  This warning level is
mainly intended for new code, and it is expected that projects will need to add
some suppressions.

Since the warnings enabled at this level are inherently unstable with respect
to compiler versions, it is intended for use by developers and not to be set as
the default.