### PR TITLE
Add typing annotations to the wayland module

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1652,7 +1652,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     @disablerIfNotFound
     @permittedKwargs(permitted_dependency_kwargs)
     @typed_pos_args('dependency', varargs=str, min_varargs=1)
-    def func_dependency(self, node, args, kwargs):
+    def func_dependency(self, node, args, kwargs) -> Dependency:
         # Replace '' by empty list of names
         names = [n for n in args[0] if n]
         if len(names) > 1:

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -51,6 +51,7 @@ modules = [
     'mesonbuild/modules/unstable_external_project.py',
     'mesonbuild/modules/unstable_icestorm.py',
     'mesonbuild/modules/unstable_rust.py',
+    'mesonbuild/modules/unstable_wayland.py',
     'mesonbuild/modules/windows.py',
     'mesonbuild/mparser.py',
     'mesonbuild/msetup.py',


### PR DESCRIPTION
This ends up being pretty small since they're already using the typed_*args helpers.