### PR TITLE
Make more uses of `mlog.warning` non-fatal

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -284,7 +284,7 @@ class Backend:
         if isinstance(t, build.CustomTarget):
             if warn_multi_output and len(t.get_outputs()) != 1:
                 mlog.warning(f'custom_target {t.name!r} has more than one output! '
-                             'Using the first one.')
+                             f'Using the first one. Consider using `{t.name}[0]`.')
             filename = t.get_outputs()[0]
         elif isinstance(t, build.CustomTargetIndex):
             filename = t.get_outputs()[0]

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -58,7 +58,7 @@ def non_msvc_eh_options(eh: str, args: T.List[str]) -> None:
     if eh == 'none':
         args.append('-fno-exceptions')
     elif eh in {'s', 'c'}:
-        mlog.warning('non-MSVC compilers do not support ' + eh + ' exception handling.' +
+        mlog.warning(f'non-MSVC compilers do not support {eh} exception handling. '
                      'You may want to set eh to \'default\'.')
 
 class CPPCompiler(CLikeCompiler, Compiler):

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -59,7 +59,7 @@ def non_msvc_eh_options(eh: str, args: T.List[str]) -> None:
         args.append('-fno-exceptions')
     elif eh in {'s', 'c'}:
         mlog.warning(f'non-MSVC compilers do not support {eh} exception handling. '
-                     'You may want to set eh to \'default\'.')
+                     'You may want to set eh to \'default\'.', fatal=False)
 
 class CPPCompiler(CLikeCompiler, Compiler):
     def attribute_check_func(self, name: str) -> str:
@@ -692,7 +692,8 @@ class CPP11AsCPP14Mixin(CompilerMixinBase):
         key = OptionKey('std', machine=self.for_machine, lang=self.language)
         if options[key].value in {'vc++11', 'c++11'}:
             mlog.warning(self.id, 'does not support C++11;',
-                         'attempting best effort; setting the standard to C++14', once=True)
+                         'attempting best effort; setting the standard to C++14',
+                         once=True, fatal=False)
             # Don't mutate anything we're going to change, we need to use
             # deepcopy since we're messing with members, and we can't simply
             # copy the members because the option proxy doesn't support it.
@@ -732,7 +733,7 @@ class VisualStudioCPPCompiler(CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixi
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         key = OptionKey('std', machine=self.for_machine, lang=self.language)
         if options[key].value != 'none' and version_compare(self.version, '<19.00.24210'):
-            mlog.warning('This version of MSVC does not support cpp_std arguments')
+            mlog.warning('This version of MSVC does not support cpp_std arguments', fatal=False)
             options = copy.copy(options)
             options[key].value = 'none'
 

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -782,7 +782,8 @@ class CoreData:
                 try:
                     value.set_value(oldval.value)
                 except MesonException:
-                    mlog.warning(f'Old value(s) of {key} are no longer valid, resetting to default ({value.value}).')
+                    mlog.warning(f'Old value(s) of {key} are no longer valid, resetting to default ({value.value}).',
+                                 fatal=False)
 
     def is_cross_build(self, when_building_for: MachineChoice = MachineChoice.HOST) -> bool:
         if when_building_for == MachineChoice.BUILD:

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -534,8 +534,11 @@ class JNISystemDependency(SystemDependency):
         modules: T.List[str] = mesonlib.listify(kwargs.get('modules', []))
         for module in modules:
             if module not in {'jvm', 'awt'}:
-                log = mlog.error if self.required else mlog.debug
-                log(f'Unknown JNI module ({module})')
+                msg = f'Unknown JNI module ({module})'
+                if self.required:
+                    mlog.error(msg)
+                else:
+                    mlog.debug(msg)
                 self.is_found = False
                 return
 
@@ -553,8 +556,11 @@ class JNISystemDependency(SystemDependency):
                     res = subprocess.run(['/usr/libexec/java_home', '--failfast', '--arch', m.cpu_family],
                                          stdout=subprocess.PIPE)
                     if res.returncode != 0:
-                        log = mlog.error if self.required else mlog.debug
-                        log('JAVA_HOME could not be discovered on the system. Please set it explicitly.')
+                        msg = 'JAVA_HOME could not be discovered on the system. Please set it explicitly.'
+                        if self.required:
+                            mlog.error(msg)
+                        else:
+                            mlog.debug(msg)
                         self.is_found = False
                         return
                     self.java_home = pathlib.Path(res.stdout.decode().strip())

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -422,7 +422,7 @@ class LLVMDependencyCMake(CMakeDependency):
         # cmake if dynamic is required
         if not self.static:
             self.is_found = False
-            mlog.warning('Ignoring LLVM CMake dependency because dynamic was requested')
+            mlog.warning('Ignoring LLVM CMake dependency because dynamic was requested', fatal=False)
             return
 
         if self.traceparser is None:
@@ -455,7 +455,7 @@ class LLVMDependencyCMake(CMakeDependency):
                 if required:
                     raise self._gen_exception(f'LLVM module {mod} was not found')
                 else:
-                    mlog.warning('Optional LLVM module', mlog.bold(mod), 'was not found')
+                    mlog.warning('Optional LLVM module', mlog.bold(mod), 'was not found', fatal=False)
                     continue
             for i in cm_targets:
                 res += [(i, required)]

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -455,7 +455,7 @@ class Environment:
                 # If we stored previous command line options, we can recover from
                 # a broken/outdated coredata.
                 if os.path.isfile(coredata.get_cmd_line_file(self.build_dir)):
-                    mlog.warning('Regenerating configuration from scratch.')
+                    mlog.warning('Regenerating configuration from scratch.', fatal=False)
                     mlog.log('Reason:', mlog.red(str(e)))
                     coredata.read_cmd_line_file(self.build_dir, options)
                     self.create_new_coredata(options)
@@ -551,7 +551,8 @@ class Environment:
         if bt in self.options and (db in self.options or op in self.options):
             mlog.warning('Recommend using either -Dbuildtype or -Doptimization + -Ddebug. '
                          'Using both is redundant since they override each other. '
-                         'See: https://mesonbuild.com/Builtin-options.html#build-type-options')
+                         'See: https://mesonbuild.com/Builtin-options.html#build-type-options',
+                         fatal=False)
 
         exe_wrapper = self.lookup_binary_entry(MachineChoice.HOST, 'exe_wrapper')
         if exe_wrapper is not None:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2905,10 +2905,12 @@ class Interpreter(InterpreterBase, HoldableObject):
             return
         if (self.coredata.options[OptionKey('b_lundef')].value and
                 self.coredata.options[OptionKey('b_sanitize')].value != 'none'):
-            mlog.warning('''Trying to use {} sanitizer on Clang with b_lundef.
-This will probably not work.
-Try setting b_lundef to false instead.'''.format(self.coredata.options[OptionKey('b_sanitize')].value),
-                         location=self.current_node)
+            value = self.coredata.options[OptionKey('b_sanitize')].value
+            mlog.warning(textwrap.dedent(f'''\
+                    Trying to use {value} sanitizer on Clang with b_lundef.
+                    This will probably not work.
+                    Try setting b_lundef to false instead.'''),
+                location=self.current_node)  # noqa: E128
 
     # Check that the indicated file is within the same subproject
     # as we currently are. This is to stop people doing

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -495,3 +495,14 @@ def stop_pager() -> None:
             pass
         log_pager.wait()
         log_pager = None
+
+
+def code_line(text: str, line: str, colno: int) -> str:
+    """Print a line with a caret pointing to the colno
+
+    :param text: A message to display before the line
+    :param line: The line of code to be pointed to
+    :param colno: The column number to point at
+    :return: A formatted string of the text, line, and a caret
+    """
+    return f'{text}\n{line}\n{" " * colno}^'

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import annotations
+import enum
 import os
 import io
 import sys
@@ -315,7 +316,16 @@ def log_once(*args: TV_Loggable, is_error: bool = False,
 def get_error_location_string(fname: str, lineno: int) -> str:
     return f'{fname}:{lineno}:'
 
-def _log_error(severity: str, *rargs: TV_Loggable,
+
+class _Severity(enum.Enum):
+
+    NOTICE = enum.auto()
+    WARNING = enum.auto()
+    ERROR = enum.auto()
+    DEPRECATION = enum.auto()
+
+
+def _log_error(severity: _Severity, *rargs: TV_Loggable,
                once: bool = False, fatal: bool = True,
                location: T.Optional[BaseNode] = None,
                nested: bool = True, sep: T.Optional[str] = None,
@@ -325,16 +335,14 @@ def _log_error(severity: str, *rargs: TV_Loggable,
 
     # The typing requirements here are non-obvious. Lists are invariant,
     # therefore T.List[A] and T.List[T.Union[A, B]] are not able to be joined
-    if severity == 'notice':
+    if severity is _Severity.NOTICE:
         label = [bold('NOTICE:')]  # type: TV_LoggableList
-    elif severity == 'warning':
+    elif severity is _Severity.WARNING:
         label = [yellow('WARNING:')]
-    elif severity == 'error':
+    elif severity is _Severity.ERROR:
         label = [red('ERROR:')]
-    elif severity == 'deprecation':
+    elif severity is _Severity.DEPRECATION:
         label = [red('DEPRECATION:')]
-    else:
-        raise MesonException('Invalid severity ' + severity)
     # rargs is a tuple, not a list
     args = label + list(rargs)
 
@@ -359,7 +367,7 @@ def error(*args: TV_Loggable,
           location: T.Optional[BaseNode] = None,
           nested: bool = True, sep: T.Optional[str] = None,
           end: T.Optional[str] = None) -> None:
-    return _log_error('error', *args, once=once, fatal=fatal, location=location,
+    return _log_error(_Severity.ERROR, *args, once=once, fatal=fatal, location=location,
                       nested=nested, sep=sep, end=end, is_error=True)
 
 def warning(*args: TV_Loggable,
@@ -367,7 +375,7 @@ def warning(*args: TV_Loggable,
             location: T.Optional[BaseNode] = None,
             nested: bool = True, sep: T.Optional[str] = None,
             end: T.Optional[str] = None) -> None:
-    return _log_error('warning', *args, once=once, fatal=fatal, location=location,
+    return _log_error(_Severity.WARNING, *args, once=once, fatal=fatal, location=location,
                       nested=nested, sep=sep, end=end, is_error=True)
 
 def deprecation(*args: TV_Loggable,
@@ -375,7 +383,7 @@ def deprecation(*args: TV_Loggable,
                 location: T.Optional[BaseNode] = None,
                 nested: bool = True, sep: T.Optional[str] = None,
                 end: T.Optional[str] = None) -> None:
-    return _log_error('deprecation', *args, once=once, fatal=fatal, location=location,
+    return _log_error(_Severity.DEPRECATION, *args, once=once, fatal=fatal, location=location,
                       nested=nested, sep=sep, end=end, is_error=True)
 
 def notice(*args: TV_Loggable,
@@ -383,7 +391,7 @@ def notice(*args: TV_Loggable,
            location: T.Optional[BaseNode] = None,
            nested: bool = True, sep: T.Optional[str] = None,
            end: T.Optional[str] = None) -> None:
-    return _log_error('notice', *args, once=once, fatal=fatal, location=location,
+    return _log_error(_Severity.NOTICE, *args, once=once, fatal=fatal, location=location,
                       nested=nested, sep=sep, end=end, is_error=False)
 
 def get_relative_path(target: Path, current: Path) -> Path:

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 import os
 import io
 import sys
@@ -26,6 +27,9 @@ from pathlib import Path
 
 if T.TYPE_CHECKING:
     from ._typing import StringProtocol, SizedStringProtocol
+
+    from .mparser import BaseNode
+
 
 """This is (mostly) a standalone module used to write logging
 information about Meson runs. Some output goes to screen,
@@ -218,12 +222,12 @@ def process_markup(args: T.Sequence[TV_Loggable], keep: bool) -> T.List[str]:
             arr.append(str(arg))
     return arr
 
-def force_print(*args: str, nested: bool, **kwargs: T.Any) -> None:
+def force_print(*args: str, nested: bool, sep: T.Optional[str] = None,
+                end: T.Optional[str] = None) -> None:
     if log_disable_stdout:
         return
     iostr = io.StringIO()
-    kwargs['file'] = iostr
-    print(*args, **kwargs)
+    print(*args, sep=sep, end=end, file=iostr)
 
     raw = iostr.getvalue()
     if log_depth:
@@ -242,11 +246,11 @@ def force_print(*args: str, nested: bool, **kwargs: T.Any) -> None:
         cleaned = raw.encode('ascii', 'replace').decode('ascii')
         print(cleaned, end='')
 
-# We really want a heterogeneous dict for this, but that's in typing_extensions
-def debug(*args: TV_Loggable, **kwargs: T.Any) -> None:
+def debug(*args: TV_Loggable, sep: T.Optional[str] = None,
+          end: T.Optional[str] = None) -> None:
     arr = process_markup(args, False)
     if log_file is not None:
-        print(*arr, file=log_file, **kwargs)
+        print(*arr, file=log_file, sep=sep, end=end)
         log_file.flush()
 
 def _debug_log_cmd(cmd: str, args: T.List[str]) -> None:
@@ -260,27 +264,30 @@ def cmd_ci_include(file: str) -> None:
 
 
 def log(*args: TV_Loggable, is_error: bool = False,
-        once: bool = False, **kwargs: T.Any) -> None:
+        once: bool = False, nested: bool = True,
+        sep: T.Optional[str] = None,
+        end: T.Optional[str] = None) -> None:
     if once:
-        log_once(*args, is_error=is_error, **kwargs)
+        log_once(*args, is_error=is_error, nested=nested, sep=sep, end=end)
     else:
-        _log(*args, is_error=is_error, **kwargs)
+        _log(*args, is_error=is_error, nested=nested, sep=sep, end=end)
 
 
 def _log(*args: TV_Loggable, is_error: bool = False,
-         **kwargs: T.Any) -> None:
-    nested = kwargs.pop('nested', True)
+         nested: bool = True, sep: T.Optional[str] = None,
+         end: T.Optional[str] = None) -> None:
     arr = process_markup(args, False)
     if log_file is not None:
-        print(*arr, file=log_file, **kwargs)
+        print(*arr, file=log_file, sep=sep, end=end)
         log_file.flush()
     if colorize_console():
         arr = process_markup(args, True)
     if not log_errors_only or is_error:
-        force_print(*arr, nested=nested, **kwargs)
+        force_print(*arr, nested=nested, sep=sep, end=end)
 
 def log_once(*args: TV_Loggable, is_error: bool = False,
-             **kwargs: T.Any) -> None:
+             nested: bool = True, sep: T.Optional[str] = None,
+             end: T.Optional[str] = None) -> None:
     """Log variant that only prints a given message one time per meson invocation.
 
     This considers ansi decorated values by the values they wrap without
@@ -296,7 +303,7 @@ def log_once(*args: TV_Loggable, is_error: bool = False,
     if t in _logged_once:
         return
     _logged_once.add(t)
-    _log(*args, is_error=is_error, **kwargs)
+    _log(*args, is_error=is_error, nested=nested, sep=sep, end=end)
 
 # This isn't strictly correct. What we really want here is something like:
 # class StringProtocol(typing_extensions.Protocol):
@@ -309,7 +316,11 @@ def get_error_location_string(fname: str, lineno: int) -> str:
     return f'{fname}:{lineno}:'
 
 def _log_error(severity: str, *rargs: TV_Loggable,
-               once: bool = False, fatal: bool = True, **kwargs: T.Any) -> None:
+               once: bool = False, fatal: bool = True,
+               location: T.Optional[BaseNode] = None,
+               nested: bool = True, sep: T.Optional[str] = None,
+               end: T.Optional[str] = None,
+               is_error: bool = True) -> None:
     from .mesonlib import MesonException, relpath
 
     # The typing requirements here are non-obvious. Lists are invariant,
@@ -327,7 +338,6 @@ def _log_error(severity: str, *rargs: TV_Loggable,
     # rargs is a tuple, not a list
     args = label + list(rargs)
 
-    location = kwargs.pop('location', None)
     if location is not None:
         location_file = relpath(location.filename, os.getcwd())
         location_str = get_error_location_string(location_file, location.lineno)
@@ -336,7 +346,7 @@ def _log_error(severity: str, *rargs: TV_Loggable,
         location_list = T.cast('TV_LoggableList', [location_str])
         args = location_list + args
 
-    log(*args, once=once, **kwargs)
+    log(*args, once=once, nested=nested, sep=sep, end=end, is_error=is_error)
 
     global log_warnings_counter  # pylint: disable=global-statement
     log_warnings_counter += 1
@@ -344,17 +354,37 @@ def _log_error(severity: str, *rargs: TV_Loggable,
     if log_fatal_warnings and fatal:
         raise MesonException("Fatal warnings enabled, aborting")
 
-def error(*args: TV_Loggable, **kwargs: T.Any) -> None:
-    return _log_error('error', *args, **kwargs, is_error=True)
+def error(*args: TV_Loggable,
+          once: bool = False, fatal: bool = True,
+          location: T.Optional[BaseNode] = None,
+          nested: bool = True, sep: T.Optional[str] = None,
+          end: T.Optional[str] = None) -> None:
+    return _log_error('error', *args, once=once, fatal=fatal, location=location,
+                      nested=nested, sep=sep, end=end, is_error=True)
 
-def warning(*args: TV_Loggable, **kwargs: T.Any) -> None:
-    return _log_error('warning', *args, **kwargs, is_error=True)
+def warning(*args: TV_Loggable,
+            once: bool = False, fatal: bool = True,
+            location: T.Optional[BaseNode] = None,
+            nested: bool = True, sep: T.Optional[str] = None,
+            end: T.Optional[str] = None) -> None:
+    return _log_error('warning', *args, once=once, fatal=fatal, location=location,
+                      nested=nested, sep=sep, end=end, is_error=True)
 
-def deprecation(*args: TV_Loggable, **kwargs: T.Any) -> None:
-    return _log_error('deprecation', *args, **kwargs, is_error=True)
+def deprecation(*args: TV_Loggable,
+                once: bool = False, fatal: bool = True,
+                location: T.Optional[BaseNode] = None,
+                nested: bool = True, sep: T.Optional[str] = None,
+                end: T.Optional[str] = None) -> None:
+    return _log_error('deprecation', *args, once=once, fatal=fatal, location=location,
+                      nested=nested, sep=sep, end=end, is_error=True)
 
-def notice(*args: TV_Loggable, **kwargs: T.Any) -> None:
-    return _log_error('notice', *args, **kwargs, is_error=False)
+def notice(*args: TV_Loggable,
+           once: bool = False, fatal: bool = True,
+           location: T.Optional[BaseNode] = None,
+           nested: bool = True, sep: T.Optional[str] = None,
+           end: T.Optional[str] = None) -> None:
+    return _log_error('notice', *args, once=once, fatal=fatal, location=location,
+                      nested=nested, sep=sep, end=end, is_error=False)
 
 def get_relative_path(target: Path, current: Path) -> Path:
     """Get the path to target from current"""

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -319,14 +319,15 @@ class GnomeModule(ExtensionModule):
                                         gresource_dep_needed_version):
             mlog.warning('GLib compiled dependencies do not work reliably with \n'
                          'the current version of GLib. See the following upstream issue:',
-                         mlog.bold('https://bugzilla.gnome.org/show_bug.cgi?id=774368'))
+                         mlog.bold('https://bugzilla.gnome.org/show_bug.cgi?id=774368'),
+                         fatal=False)
 
     @staticmethod
     def _print_gdbus_warning() -> None:
         mlog.warning('Code generated with gdbus_codegen() requires the root directory be added to\n'
                      '  include_directories of targets with GLib < 2.51.3:',
                      mlog.bold('https://github.com/mesonbuild/meson/issues/1387'),
-                     once=True)
+                     once=True, fatal=False)
 
     @typed_kwargs(
         'gnome.post_install',
@@ -1966,7 +1967,8 @@ class GnomeModule(ExtensionModule):
             else:
                 mlog.warning('The current version of GLib does not support extra arguments \n'
                              'for glib-genmarshal. You need at least GLib 2.53.3. See ',
-                             mlog.bold('https://github.com/mesonbuild/meson/pull/2049'))
+                             mlog.bold('https://github.com/mesonbuild/meson/pull/2049'),
+                             fatal=False)
         for k in ['internal', 'nostdinc', 'skip_source', 'stdinc', 'valist_marshallers']:
             # Mypy can't figure out that this is correct
             if kwargs[k]:                                            # type: ignore

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -320,7 +320,7 @@ class GnomeModule(ExtensionModule):
             mlog.warning('GLib compiled dependencies do not work reliably with \n'
                          'the current version of GLib. See the following upstream issue:',
                          mlog.bold('https://bugzilla.gnome.org/show_bug.cgi?id=774368'),
-                         fatal=False)
+                         once=True, fatal=False)
 
     @staticmethod
     def _print_gdbus_warning() -> None:
@@ -1968,7 +1968,7 @@ class GnomeModule(ExtensionModule):
                 mlog.warning('The current version of GLib does not support extra arguments \n'
                              'for glib-genmarshal. You need at least GLib 2.53.3. See ',
                              mlog.bold('https://github.com/mesonbuild/meson/pull/2049'),
-                             fatal=False)
+                             once=True, fatal=False)
         for k in ['internal', 'nostdinc', 'skip_source', 'stdinc', 'valist_marshallers']:
             # Mypy can't figure out that this is correct
             if kwargs[k]:                                            # type: ignore

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -47,7 +47,7 @@ def decode_match(match: T.Match[str]) -> str:
 class ParseException(MesonException):
     def __init__(self, text: str, line: str, lineno: int, colno: int) -> None:
         # Format as error message, followed by the line with the error, followed by a caret to show the error column.
-        super().__init__("{}\n{}\n{}".format(text, line, '{}^'.format(' ' * colno)))
+        super().__init__(mlog.code_line(text, line, colno))
         self.lineno = lineno
         self.colno = colno
 

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -193,11 +193,10 @@ class Lexer:
                     elif tid in {'string', 'fstring'}:
                         # Handle here and not on the regexp to give a better error message.
                         if match_text.find("\n") != -1:
-                            msg = ParseException("Newline character in a string detected, use ''' (three single quotes) "
-                                                 "for multiline strings instead.\n"
-                                                 "This will become a hard error in a future Meson release.",
-                                                 self.getline(line_start), lineno, col)
-                            mlog.warning(msg, location=BaseNode(lineno, col, filename))
+                            msg = ("Newline character in a string detected, use ''' (three single quotes) "
+                                   "for multiline strings instead.\n"
+                                   "This will become a hard error in a future Meson release.")
+                            mlog.warning(mlog.code_line(msg, self.getline(line_start), col), location=BaseNode(lineno, col, filename))
                         value = match_text[2 if tid == 'fstring' else 1:-1]
                         try:
                             value = ESCAPE_SEQUENCE_SINGLE_RE.sub(decode_match, value)

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -15,7 +15,6 @@
 from dataclasses import dataclass
 import re
 import codecs
-import types
 import typing as T
 from .mesonlib import MesonException
 from . import mlog
@@ -236,7 +235,7 @@ class Lexer:
                         else:
                             if match_text in self.future_keywords:
                                 mlog.warning(f"Identifier '{match_text}' will become a reserved keyword in a future release. Please rename it.",
-                                             location=types.SimpleNamespace(filename=filename, lineno=lineno))
+                                             location=BaseNode(lineno, col, filename))
                             value = match_text
                     yield Token(tid, filename, curline_start, curline, col, bytespan, value)
                     break

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -206,10 +206,11 @@ class MesonApp:
         b = build.Build(env)
 
         intr = interpreter.Interpreter(b, user_defined_options=user_defined_options)
-        if env.is_cross_build():
-            logger_fun = mlog.log
-        else:
-            logger_fun = mlog.debug
+        # Super hack because mlog.log and mlog.debug have different signatures,
+        # and there is currently no way to annotate them correctly, unionize them, or
+        # even to write `T.Callable[[*mlog.TV_Loggable], None]`
+        logger_fun = T.cast('T.Callable[[mlog.TV_Loggable, mlog.TV_Loggable], None]',
+                            (mlog.log if env.is_cross_build() else mlog.debug))
         build_machine = intr.builtin['build_machine']
         host_machine = intr.builtin['host_machine']
         target_machine = intr.builtin['target_machine']

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -249,7 +249,7 @@ def check_direntry_issues(direntry_array: T.Union[T.Iterable[T.Union[str, bytes]
                 You are using {e!r} which is not a Unicode-compatible
                 locale but you are trying to access a file system entry called {de!r} which is
                 not pure ASCII. This may cause problems.
-                '''), file=sys.stderr)
+                '''))
 
 class SecondLevelHolder(HoldableObject, metaclass=abc.ABCMeta):
     ''' A second level object holder. The primary purpose

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -54,7 +54,6 @@ except ImportError:
     has_ssl = False
 
 REQ_TIMEOUT = 600.0
-SSL_WARNING_PRINTED = False
 WHITELIST_SUBDOMAIN = 'wrapdb.mesonbuild.com'
 
 ALL_TYPES = ['file', 'git', 'hg', 'svn']
@@ -95,10 +94,7 @@ def open_wrapdburl(urlstring: str, allow_insecure: bool = False, have_opt: bool 
         raise WrapException(f'SSL module not available in {sys.executable}: Cannot contact the WrapDB.{insecure_msg}')
     else:
         # following code is only for those without Python SSL
-        global SSL_WARNING_PRINTED  # pylint: disable=global-statement
-        if not SSL_WARNING_PRINTED:
-            mlog.warning(f'SSL module not available in {sys.executable}: WrapDB traffic not authenticated.')
-            SSL_WARNING_PRINTED = True
+        mlog.warning(f'SSL module not available in {sys.executable}: WrapDB traffic not authenticated.', once=True)
 
     # If we got this far, allow_insecure was manually passed
     nossl_url = url._replace(scheme='http')


### PR DESCRIPTION
At least, that's how it started. Then I noticed that I wasn't get completions, and realized that I was lazy when I annotated the mlog module, and used lots of `**kwargs: T.Any`, which is less than ideal. In cleaning tha tup I found some annoying mypy issues, as well as a few actual bugs or shortcomings in the exiting code. Finally we get to adding `fatal=False` in a bunch of places where the end user cannot reasonably be expected to fix the warning (old versions of software, the need to support old versions of meson, etc). I noticed this when there was a suggestion to bump the required c++ version of a wrap to c++14 because of a warning that MSVC doesn't support c++11, and we just set it to c++14 instead.