### PR TITLE
docs: add cross-file example

### DIFF
--- a/docs/markdown/Cross-compilation.md
+++ b/docs/markdown/Cross-compilation.md
@@ -4,7 +4,34 @@ short-description: Setting up cross-compilation
 
 # Cross compilation
 
-Meson has full support for cross compilation. Since cross compiling is
+Meson has full support for cross compilation through the use of
+a cross build definition file.  An minimal example of one such
+file `x86_64-w64-mingw32.txt` for a GCC/MinGW cross compiler
+targeting 64-bit Windows could be:
+
+```ini
+[binaries]
+c = 'x86_64-w64-mingw32-gcc'
+cpp = 'x86_64-w64-mingw32-g++'
+ar = 'x86_64-w64-mingw32-ar'
+strip = 'x86_64-w64-mingw32-strip'
+exe_wrapper = 'wine64'
+
+[host_machine]
+system = 'windows'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'
+```
+
+Which is then used during the `setup` phase.
+
+```sh
+meson setup --cross-file x86_64-w64-mingw32.txt build-mingw
+meson compile -C build-mingw
+```
+
+Since cross compiling is
 more complicated than native building, let's first go over some
 nomenclature. The three most important definitions are traditionally
 called *build*, *host* and *target*. This is confusing because those


### PR DESCRIPTION
When looking through the cross-compilation docs for the first time, I was slowed by the absence of minimal example.  From experiences with autotools and cmake, the compiler executable is the one thing I'm certain that I have to specify somewhere.  It wasn't unless I found [a fork](https://thiblahute.github.io/jpakkane.github.io/Cross-compilation.html) that I made the connection with the `[binaries]` section.

Even then, my first attempt omitted the `[host_machine]` section, which unfortunately worked.  I assumed that the lack of an error meant that this information had been extracted from the toolchain (eg. by looking at pre-defined macros).  Thankfully I noticed that Linux specific compiler arguments were being passed for a cross-mingw build, and looked further.

This PR adds what I think is a bare minimum working cross build definition file right at the top, where hopefully others with a low tldr threshold will see it.

Just to be extra clear.  I'm new to meson, so this example may well be incomplete or incorrect in some subtle way.  In particular, I'm uncertain about the `cpu = x86_64` line.  meson insists that `cpu` be set, but happily accepts `cpu = foo`, so clearly the value isn't be used in my case (a simple "hello" project).