### PR TITLE
wrap: correctly override dependency names with capital letters

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -123,7 +123,8 @@ class PackageDefinition:
         self.has_wrap = self.basename.endswith('.wrap')
         self.name = self.basename[:-5] if self.has_wrap else self.basename
         self.directory = self.name
-        self.provided_deps[self.name] = None
+        # must be lowercase for consistency with dep=variable assignment
+        self.provided_deps[self.name.lower()] = None
         self.original_filename = fname
         self.redirected = False
         if self.has_wrap:
@@ -195,8 +196,9 @@ class PackageDefinition:
             for k, v in config['provide'].items():
                 if k == 'dependency_names':
                     # A comma separated list of dependency names that does not
-                    # need a variable name
-                    names_dict = {n.strip(): None for n in v.split(',')}
+                    # need a variable name; must be lowercase for consistency with
+                    # dep=variable assignment
+                    names_dict = {n.strip().lower(): None for n in v.split(',')}
                     self.provided_deps.update(names_dict)
                     continue
                 if k == 'program_names':


### PR DESCRIPTION
When we do wrap resolution, we do a case-insensitive lookup because keys, i.e. `dep_name = variable_name`, are case insensitive. In order to check whether we should process a subproject, we need to know if the lowercased dependency name matches.

We do this by looking up the lowercase name, and assuming that the stored name is also lowercase. But for dependency_names, this isn't "case insensitive and stored in lowercase" so we need to manually force it to be consistent.

Likewise, when looking up the wrap name (which works like dependency_names and doesn't need a provide section at all) the disk filename of the wrap file is case sensitive, but needs to be manually forced for consistency.