### PR TITLE
add intel oneAPI ifort compiler to azure and run fortran tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,17 @@
+# intel oneapi installation is based on the examples at
+# https://github.com/oneapi-src/oneapi-ci
+#
+# and are copyrighted:
+#
+# SPDX-FileCopyrightText: 2020 Intel Corporation
+# SPDX-License-Identifier: MIT
+#
+# The rest of this file contains the standard Meson project copyright:
+#
+# SPDX-License-Identifer: Apache-2.0
+# Copyright 2022 The Meson development team
+
+
 name: $(BuildID)
 
 trigger:
@@ -35,6 +49,8 @@ pr:
 variables:
   CI: 1
   SOURCE_VERSION: $(Build.SourceVersion)
+  WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18680/w_HPCKit_p_2022.2.0.173_offline.exe
+  WINDOWS_FORTRAN_COMPONENTS: intel.oneapi.win.ifort-compiler
 
 jobs:
 
@@ -50,21 +66,46 @@ jobs:
           compiler: msvc2017
           backend: ninja
           MESON_RSP_THRESHOLD: 0
+          # "Compiler ifort can not compile programs"
+          ifort: false
         vc2017x64vs:
           arch: x64
           compiler: msvc2017
           backend: vs2017
+          # this causes tons of C projects to error with:
+          # "The syntax of the command is incorrect"
+          ifort: false
         clangclx64ninja:
           arch: x64
           compiler: clang-cl
           backend: ninja
+          ifort: true
 
   steps:
+  - task: Cache@2
+    inputs:
+      path: C:\Program Files (x86)\Intel\oneAPI
+      key: '"install" | "$(WINDOWS_HPCKIT_URL)" | "$(WINDOWS_FORTRAN_COMPONENTS)" | "compiler" | ci/intel-scripts/cache_exclude_windows.sh'
+      cacheHitVar: CACHE_RESTORED
+    condition: eq(variables.ifort, 'true')
+  - script: ci/intel-scripts/install_windows.bat $(WINDOWS_HPCKIT_URL) $(WINDOWS_FORTRAN_COMPONENTS)
+    displayName: install ifort
+    condition: and(ne(variables.CACHE_RESTORED, 'true'), eq(variables.ifort, 'true'))
+  - bash: ci/intel-scripts/cache_exclude_windows.sh
+    displayName: exclude unused files from cache
+    condition: and(ne(variables.CACHE_RESTORED, 'true'), eq(variables.ifort, 'true'))
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '3.7'
       addToPath: true
       architecture: 'x64'
+  - task: BatchScript@1
+    displayName: insert ifort into environment
+    inputs:
+      filename: ci/intel-scripts/activate_windows.bat
+      arguments: vs2019
+      modifyEnvironment: True
+    condition: eq(variables.ifort, 'true')
   - task: PowerShell@2
     inputs:
       targetType: 'filePath'
@@ -83,22 +124,47 @@ jobs:
           arch: x64
           compiler: msvc2019
           backend: ninja
+          ifort: true
         vc2019x64vs:
           arch: x64
           compiler: msvc2019
           backend: vs2019
+          # mysteriously, several tests fail because vs cannot find
+          # executables such as cmd.exe ???
+          ifort: false
         vc2019arm64ninjacross:
           arch: arm64
           compiler: msvc2019
           backend: ninja
           extraargs: --cross arm64cl.txt --cross-only
+          # ifort doesn't support arm64
+          ifort: false
 
   steps:
+  - task: Cache@2
+    inputs:
+      path: C:\Program Files (x86)\Intel\oneAPI
+      key: '"install" | "$(WINDOWS_HPCKIT_URL)" | "$(WINDOWS_FORTRAN_COMPONENTS)" | "compiler" | ci/intel-scripts/cache_exclude_windows.sh'
+      cacheHitVar: CACHE_RESTORED
+    condition: eq(variables.ifort, 'true')
+  - script: ci/intel-scripts/install_windows.bat $(WINDOWS_HPCKIT_URL) $(WINDOWS_FORTRAN_COMPONENTS)
+    displayName: install ifort
+    condition: and(ne(variables.CACHE_RESTORED, 'true'), eq(variables.ifort, 'true'))
+  - bash: ci/intel-scripts/cache_exclude_windows.sh
+    displayName: exclude unused files from cache
+    condition: and(ne(variables.CACHE_RESTORED, 'true'), eq(variables.ifort, 'true'))
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '3.7'
       addToPath: true
       architecture: 'x64'
+  - task: BatchScript@1
+    displayName: insert ifort into environment
+    inputs:
+      filename: ci/intel-scripts/activate_windows.bat
+      arguments: vs2019
+      modifyEnvironment: True
+    condition: eq(variables.ifort, 'true')
   - task: PowerShell@2
     inputs:
       targetType: 'filePath'

--- a/ci/intel-scripts/activate_windows.bat
+++ b/ci/intel-scripts/activate_windows.bat
@@ -1,0 +1,16 @@
+REM SPDX-FileCopyrightText: 2020 Intel Corporation
+REM
+REM SPDX-License-Identifier: MIT
+
+set VS_VER=%1
+
+@call "C:\Program Files (x86)\Intel\oneAPI\setvars-vcvarsall.bat" %VS_VER%
+
+for /f "tokens=* usebackq" %%f in (`dir /b "C:\Program Files (x86)\Intel\oneAPI\compiler\" ^| findstr /V latest ^| sort`) do @set "LATEST_VERSION=%%f"
+@call "C:\Program Files (x86)\Intel\oneAPI\compiler\%LATEST_VERSION%\env\vars.bat"
+
+echo "Visual Studio Version: %VS_VER%"
+echo "OneAPI version: %LATEST_VERSION%"
+echo "C:\Program Files (x86)\Intel\oneAPI\compiler\%LATEST_VERSION%\env\vars.bat"
+echo "OneAPI root directory: %ONEAPI_ROOT%"
+where ifort.exe

--- a/ci/intel-scripts/cache_exclude_windows.sh
+++ b/ci/intel-scripts/cache_exclude_windows.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2020 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+#shellcheck disable=SC2010
+LATEST_VERSION=$(ls -1 "C:\Program Files (x86)\Intel\oneAPI\compiler" | grep -v latest | sort | tail -1)
+
+rm -rf "C:\Program Files (x86)\Intel\oneAPI\compiler\'$LATEST_VERSION'\windows\compiler\lib\ia32_win"
+rm -rf "C:\Program Files (x86)\Intel\oneAPI\compiler\'$LATEST_VERSION'\windows\bin\intel64_ia32"
+rm -rf "C:\Program Files (x86)\Intel\oneAPI\compiler\'$LATEST_VERSION'\windows\lib\emu"
+rm -rf "C:\Program Files (x86)\Intel\oneAPI\compiler\'$LATEST_VERSION'\windows\lib\oclfpga"
+rm -rf "C:\Program Files (x86)\Intel\oneAPI\compiler\'$LATEST_VERSION'\windows\lib\ocloc"
+rm -rf "C:\Program Files (x86)\Intel\oneAPI\compiler\'$LATEST_VERSION'\windows\lib\x86"

--- a/ci/intel-scripts/install_windows.bat
+++ b/ci/intel-scripts/install_windows.bat
@@ -1,0 +1,16 @@
+REM SPDX-FileCopyrightText: 2022 Intel Corporation
+REM
+REM SPDX-License-Identifier: MIT
+
+set URL=%1
+set COMPONENTS=%2
+
+curl.exe --output %TEMP%\webimage.exe --url %URL% --retry 5 --retry-delay 5
+start /b /wait %TEMP%\webimage.exe -s -x -f webimage_extracted --log extract.log
+del %TEMP%\webimage.exe
+if "%COMPONENTS%"=="" (
+  webimage_extracted\bootstrapper.exe -s --action install --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 -p=NEED_VS2022_INTEGRATION=0 --log-dir=.
+) else (
+  webimage_extracted\bootstrapper.exe -s --action install --components=%COMPONENTS% --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 -p=NEED_VS2022_INTEGRATION=0 --log-dir=.
+)
+rd /s/q "webimage_extracted"

--- a/ci/run.ps1
+++ b/ci/run.ps1
@@ -67,7 +67,7 @@ echo ($env:Path).Replace(';',"`n")
 echo "=== PATH END ==="
 echo ""
 
-$progs = @("python","ninja","pkg-config","cl","rc","link","pypy3")
+$progs = @("python","ninja","pkg-config","cl","rc","link","pypy3","ifort")
 foreach ($prog in $progs) {
   echo ""
   echo "Locating ${prog}:"

--- a/cross/arm64cl.txt
+++ b/cross/arm64cl.txt
@@ -1,6 +1,7 @@
 [binaries]
 c = 'cl'
 cpp = 'cl'
+fc = 'false'
 ar = 'lib'
 windres = 'rc'
 

--- a/cross/none.txt
+++ b/cross/none.txt
@@ -11,6 +11,7 @@ endian = 'little'
 [binaries]
 c = ['false']
 cpp = ['false']
+fc = ['false']
 objc = ['false']
 objcpp = ['false']
 ar = ['false']

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -101,7 +101,9 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
 
     # /showIncludes is needed for build dependency tracking in Ninja
     # See: https://ninja-build.org/manual.html#_deps
-    always_args = ['/nologo', '/showIncludes']  # type: T.List[str]
+    # Assume UTF-8 sources by default, but self.unix_args_to_native() removes it
+    # if `/source-charset` is set too.
+    always_args = ['/nologo', '/showIncludes', '/utf-8']
     warn_args = {
         '0': [],
         '1': ['/W2'],
@@ -115,10 +117,6 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
         self.base_options = {mesonlib.OptionKey(o) for o in ['b_pch', 'b_ndebug', 'b_vscrt']} # FIXME add lto, pgo and the like
         self.target = target
         self.is_64 = ('x64' in target) or ('x86_64' in target)
-        # Assume UTF-8 sources by default on Visual Studio 2015 or later, or clang,
-        # but self.unix_args_to_native() removes it if `/source-charset` is set too.
-        if isinstance(self, ClangClCompiler) or mesonlib.version_compare(self.version, '>=19.00'):
-            self.always_args = self.always_args + ['/utf-8']
         # do some canonicalization of target machine
         if 'x86_64' in target:
             self.machine = 'x64'

--- a/test cases/fortran/14 fortran links c/meson.build
+++ b/test cases/fortran/14 fortran links c/meson.build
@@ -3,7 +3,9 @@ project('Fortran calling C', 'fortran', 'c',
   default_options : ['default_library=static'])
 
 ccid = meson.get_compiler('c').get_id()
-if ccid == 'msvc' or ccid == 'clang-cl'
+fcid = meson.get_compiler('fortran').get_id()
+
+if fcid == 'gcc' and ccid in ['msvc', 'clang-cl']
   error('MESON_SKIP_TEST: MSVC and GCC do not interoperate like this.')
 endif
 

--- a/test cases/fortran/9 cpp/meson.build
+++ b/test cases/fortran/9 cpp/meson.build
@@ -3,7 +3,7 @@ project('C, C++ and Fortran', 'c', 'cpp', 'fortran')
 cpp = meson.get_compiler('cpp')
 fc = meson.get_compiler('fortran')
 
-if build_machine.system() == 'windows' and cpp.get_id() != fc.get_id()
+if build_machine.system() == 'windows' and fc.get_id() == 'gcc' and cpp.get_id() != 'gcc'
   error('MESON_SKIP_TEST mixing gfortran with non-GNU C++ does not work.')
 endif
 

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1945,6 +1945,12 @@ class AllPlatformTests(BasePlatformTests):
 
         for lang in langs:
             for target_type in ('executable', 'library'):
+                if is_windows() and lang == 'fortran' and target_type == 'library':
+                    # non-Gfortran Windows Fortran compilers do not do shared libraries in a Fortran standard way
+                    # see "test cases/fortran/6 dynamic"
+                    fc = detect_compiler_for(env, 'fortran', MachineChoice.HOST)
+                    if fc.get_id() in {'intel-cl', 'pgi'}:
+                        continue
                 # test empty directory
                 with tempfile.TemporaryDirectory() as tmpdir:
                     self._run(self.meson_command + ['init', '--language', lang, '--type', target_type],


### PR DESCRIPTION
And fix the regression that totally broke it.

@Hofer-Julian this should fix the issue we discussed.

@dcbaker thoughts?

...

Actually running this correctly is a bag of mixed results. I don't understand why the `vc2019x64vs` job has 13 failing tests in which, randomly, I get errors about how it cannot find some command (e.g. rc.exe, but also cmd.exe)