### PR TITLE
compilers: Add optimization=plain option

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -67,28 +67,28 @@ Options that are labeled "per machine" in the table are set per
 machine. See the [specifying options per
 machine](#specifying-options-per-machine) section for details.
 
-| Option                               | Default value | Description                                                    | Is per machine | Is per subproject |
-| ------                               | ------------- | -----------                                                    | -------------- | ----------------- |
+| Option                                 | Default value | Description                                                    | Is per machine | Is per subproject |
+| -------------------------------------- | ------------- | -----------                                                    | -------------- | ----------------- |
 | auto_features {enabled, disabled, auto} | auto       | Override value of all 'auto' features                          | no             | no                |
 | backend {ninja, vs,<br>vs2010, vs2012, vs2013, vs2015, vs2017, vs2019, vs2022, xcode} | ninja | Backend to use        | no             | no                |
 | buildtype {plain, debug,<br>debugoptimized, release, minsize, custom} | debug |  Build type to use                    | no             | no                |
-| debug                                | true          | Enable debug symbols and other information                     | no             | no                |
+| debug                                  | true          | Enable debug symbols and other information                     | no             | no                |
 | default_library {shared, static, both} | shared      | Default library type                                           | no             | yes               |
-| errorlogs                            | true          | Whether to print the logs from failing tests.                  | no             | no                |
-| install_umask {preserve, 0000-0777}  | 022           | Default umask to apply on permissions of installed files       | no             | no                |
-| layout {mirror,flat}                 | mirror        | Build directory layout                                         | no             | no                |
-| optimization {0, g, 1, 2, 3, s}      | 0             | Optimization level                                             | no             | no                |
-| pkg_config_path {OS separated path}  | ''            | Additional paths for pkg-config to search before builtin paths | yes            | no                |
-| prefer_static                        | false         | Whether to try static linking before shared linking            | no             | no                |
-| cmake_prefix_path                    | []            | Additional prefixes for cmake to search before builtin paths   | yes            | no                |
-| stdsplit                             | true          | Split stdout and stderr in test logs                           | no             | no                |
-| strip                                | false         | Strip targets on install                                       | no             | no                |
-| unity {on, off, subprojects}         | off           | Unity build                                                    | no             | no                |
-| unity_size {>=2}                     | 4             | Unity file block size                                          | no             | no                |
-| warning_level {0, 1, 2, 3}           | 1             | Set the warning level. From 0 = none to 3 = highest            | no             | yes               |
-| werror                               | false         | Treat warnings as errors                                       | no             | yes               |
+| errorlogs                              | true          | Whether to print the logs from failing tests.                  | no             | no                |
+| install_umask {preserve, 0000-0777}    | 022           | Default umask to apply on permissions of installed files       | no             | no                |
+| layout {mirror,flat}                   | mirror        | Build directory layout                                         | no             | no                |
+| optimization {plain, 0, g, 1, 2, 3, s} | 0             | Optimization level                                             | no             | no                |
+| pkg_config_path {OS separated path}    | ''            | Additional paths for pkg-config to search before builtin paths | yes            | no                |
+| prefer_static                          | false         | Whether to try static linking before shared linking            | no             | no                |
+| cmake_prefix_path                      | []            | Additional prefixes for cmake to search before builtin paths   | yes            | no                |
+| stdsplit                               | true          | Split stdout and stderr in test logs                           | no             | no                |
+| strip                                  | false         | Strip targets on install                                       | no             | no                |
+| unity {on, off, subprojects}           | off           | Unity build                                                    | no             | no                |
+| unity_size {>=2}                       | 4             | Unity file block size                                          | no             | no                |
+| warning_level {0, 1, 2, 3}             | 1             | Set the warning level. From 0 = none to 3 = highest            | no             | yes               |
+| werror                                 | false         | Treat warnings as errors                                       | no             | yes               |
 | wrap_mode {default, nofallback,<br>nodownload, forcefallback, nopromote} | default | Wrap mode to use                 | no             | no                |
-| force_fallback_for                   | []            | Force fallback for those dependencies                          | no             | no                |
+| force_fallback_for                     | []            | Force fallback for those dependencies                          | no             | no                |
 
 <a name="build-type-options"></a> For setting optimization levels and
 toggling debug, you can either set the `buildtype` option, or you can
@@ -100,7 +100,7 @@ the two-way mapping:
 
 | buildtype      | debug | optimization |
 | ---------      | ----- | ------------ |
-| plain          | false | 0            |
+| plain          | false | plain        |
 | debug          | true  | 0            |
 | debugoptimized | true  | 2            |
 | release        | false | 3            |

--- a/docs/markdown/Configuring-a-build-directory.md
+++ b/docs/markdown/Configuring-a-build-directory.md
@@ -30,7 +30,7 @@ a sample output for a simple project.
       default_library shared        [shared, static, both]                                     Default library type
       install_umask   0022          [preserve, 0000-0777]                                      Default umask to apply on permissions of installed files
       layout          mirror        [mirror, flat]                                             Build directory layout
-      optimization    3             [0, g, 1, 2, 3, s]                                         Optimization level
+      optimization    3             [plain, 0, g, 1, 2, 3, s]                                  Optimization level
       prefer_static   false         [true, false]                                              Whether to try static linking before shared linking
       strip           false         [true, false]                                              Strip targets on install
       unity           off           [on, off, subprojects]                                     Unity build

--- a/docs/markdown/snippets/add_optimization_plain_option.md
+++ b/docs/markdown/snippets/add_optimization_plain_option.md
@@ -1,0 +1,10 @@
+## Add `optimization` `plain` option
+
+The `optimization` built-in option now accepts `plain` value,
+which will not set any optimization flags. This is now the default
+value of the flag for `buildtype=plain`, which is useful for distros,
+that set the optimization and hardening flags by other means.
+
+If you are using the value of `get_option('optimization')` in your
+Meson scripts, make sure you are not making assumptions about it,
+such as that the value can be passed to a compiler in `-O` flag.

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -52,7 +52,8 @@ LANGNAMEMAP = {'c': 'C',
                'objcpp': 'OBJCPLUSPLUS',
                'swift': 'SWIFT_'
                }
-OPT2XCODEOPT = {'0': '0',
+OPT2XCODEOPT = {'plain': None,
+                '0': '0',
                 'g': '0',
                 '1': '1',
                 '2': '2',
@@ -1561,7 +1562,9 @@ class XCodeBackend(backends.Backend):
                 settings_dict.add_item('EXECUTABLE_SUFFIX', suffix)
             settings_dict.add_item('GCC_GENERATE_DEBUGGING_SYMBOLS', BOOL2XCODEBOOL[target.get_option(OptionKey('debug'))])
             settings_dict.add_item('GCC_INLINES_ARE_PRIVATE_EXTERN', 'NO')
-            settings_dict.add_item('GCC_OPTIMIZATION_LEVEL', OPT2XCODEOPT[target.get_option(OptionKey('optimization'))])
+            opt_flag = OPT2XCODEOPT[target.get_option(OptionKey('optimization'))]
+            if opt_flag is not None:
+                settings_dict.add_item('GCC_OPTIMIZATION_LEVEL', opt_flag)
             if target.has_pch:
                 # Xcode uses GCC_PREFIX_HEADER which only allows one file per target/executable. Precompiling various header files and
                 # applying a particular pch to each source file will require custom scripts (as a build phase) and build flags per each

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -249,7 +249,8 @@ msvc_winlibs = ['kernel32.lib', 'user32.lib', 'gdi32.lib',
                 'winspool.lib', 'shell32.lib', 'ole32.lib', 'oleaut32.lib',
                 'uuid.lib', 'comdlg32.lib', 'advapi32.lib']  # type: T.List[str]
 
-clike_optimization_args = {'0': [],
+clike_optimization_args = {'plain': [],
+                           '0': [],
                            'g': [],
                            '1': ['-O1'],
                            '2': ['-O2'],
@@ -257,7 +258,8 @@ clike_optimization_args = {'0': [],
                            's': ['-Os'],
                            }  # type: T.Dict[str, T.List[str]]
 
-cuda_optimization_args = {'0': [],
+cuda_optimization_args = {'plain': [],
+                          '0': [],
                           'g': ['-O0'],
                           '1': ['-O1'],
                           '2': ['-O2'],

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -28,7 +28,9 @@ if T.TYPE_CHECKING:
     from ..environment import Environment
     from ..mesonlib import MachineChoice
 
-cs_optimization_args = {'0': [],
+cs_optimization_args = {
+                        'plain': [],
+                        '0': [],
                         'g': [],
                         '1': ['-optimize+'],
                         '2': ['-optimize+'],

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -66,7 +66,8 @@ d_feature_args = {'gcc':  {'unittest': '-funittest',
                            }
                   }  # type: T.Dict[str, T.Dict[str, str]]
 
-ldc_optimization_args = {'0': [],
+ldc_optimization_args = {'plain': [],
+                         '0': [],
                          'g': [],
                          '1': ['-O1'],
                          '2': ['-O2'],
@@ -74,7 +75,8 @@ ldc_optimization_args = {'0': [],
                          's': ['-Oz'],
                          }  # type: T.Dict[str, T.List[str]]
 
-dmd_optimization_args = {'0': [],
+dmd_optimization_args = {'plain': [],
+                         '0': [],
                          'g': [],
                          '1': ['-O'],
                          '2': ['-O'],

--- a/mesonbuild/compilers/mixins/arm.py
+++ b/mesonbuild/compilers/mixins/arm.py
@@ -43,6 +43,7 @@ arm_buildtype_args = {
 }  # type: T.Dict[str, T.List[str]]
 
 arm_optimization_args = {
+    'plain': [],
     '0': ['-O0'],
     'g': ['-g'],
     '1': ['-O1'],
@@ -61,6 +62,7 @@ armclang_buildtype_args = {
 }  # type: T.Dict[str, T.List[str]]
 
 armclang_optimization_args = {
+    'plain': [],
     '0': [], # Compiler defaults to -O0
     'g': ['-g'],
     '1': ['-O1'],

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -35,6 +35,7 @@ clang_color_args = {
 }  # type: T.Dict[str, T.List[str]]
 
 clang_optimization_args = {
+    'plain': [],
     '0': ['-O0'],
     'g': ['-Og'],
     '1': ['-O1'],

--- a/mesonbuild/compilers/mixins/compcert.py
+++ b/mesonbuild/compilers/mixins/compcert.py
@@ -38,6 +38,7 @@ ccomp_buildtype_args = {
 }  # type: T.Dict[str, T.List[str]]
 
 ccomp_optimization_args = {
+    'plain': [],
     '0': ['-O0'],
     'g': ['-O0'],
     '1': ['-O1'],

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -55,6 +55,7 @@ gnulike_buildtype_args = {
 }  # type: T.Dict[str, T.List[str]]
 
 gnu_optimization_args = {
+    'plain': [],
     '0': ['-O0'],
     'g': ['-Og'],
     '1': ['-O1'],

--- a/mesonbuild/compilers/mixins/intel.py
+++ b/mesonbuild/compilers/mixins/intel.py
@@ -58,7 +58,8 @@ class IntelGnuLikeCompiler(GnuLikeCompiler):
         'custom': [],
     }  # type: T.Dict[str, T.List[str]]
 
-    OPTIM_ARGS = {
+    OPTIM_ARGS: T.Dict[str, T.List[str]] = {
+        'plain': [],
         '0': ['-O0'],
         'g': ['-O0'],
         '1': ['-O1'],
@@ -136,7 +137,8 @@ class IntelVisualStudioLikeCompiler(VisualStudioLikeCompiler):
         'custom': [],
     }  # type: T.Dict[str, T.List[str]]
 
-    OPTIM_ARGS = {
+    OPTIM_ARGS: T.Dict[str, T.List[str]] = {
+        'plain': [],
         '0': ['/Od'],
         'g': ['/Od'],
         '1': ['/O1'],

--- a/mesonbuild/compilers/mixins/ti.py
+++ b/mesonbuild/compilers/mixins/ti.py
@@ -39,6 +39,7 @@ ti_buildtype_args = {
 }  # type: T.Dict[str, T.List[str]]
 
 ti_optimization_args = {
+    'plain': [],
     '0': ['-O0'],
     'g': ['-Ooff'],
     '1': ['-O1'],

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -62,6 +62,7 @@ vs64_instruction_set_args = {
 }  # T.Dicst[str, T.Optional[T.List[str]]]
 
 msvc_optimization_args = {
+    'plain': [],
     '0': ['/Od'],
     'g': [], # No specific flag to optimize debugging, /Zi or /ZI will create debug information
     '1': ['/O1'],

--- a/mesonbuild/compilers/mixins/xc16.py
+++ b/mesonbuild/compilers/mixins/xc16.py
@@ -39,6 +39,7 @@ xc16_buildtype_args = {
 }  # type: T.Dict[str, T.List[str]]
 
 xc16_optimization_args = {
+    'plain': [],
     '0': ['-O0'],
     'g': ['-O0'],
     '1': ['-O1'],

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -31,6 +31,7 @@ if T.TYPE_CHECKING:
 
 
 rust_optimization_args = {
+    'plain': [],
     '0': [],
     'g': ['-C', 'opt-level=0'],
     '1': ['-C', 'opt-level=1'],

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -27,6 +27,7 @@ if T.TYPE_CHECKING:
     from ..mesonlib import MachineChoice
 
 swift_optimization_args = {
+    'plain': [],
     '0': [],
     'g': [],
     '1': ['-O'],

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -693,7 +693,7 @@ class CoreData:
         result = []
         value = self.options[OptionKey('buildtype')].value
         if value == 'plain':
-            opt = '0'
+            opt = 'plain'
             debug = False
         elif value == 'debug':
             opt = '0'
@@ -720,7 +720,7 @@ class CoreData:
 
     def _set_others_from_buildtype(self, value: str) -> None:
         if value == 'plain':
-            opt = '0'
+            opt = 'plain'
             debug = False
         elif value == 'debug':
             opt = '0'
@@ -1217,7 +1217,7 @@ BUILTIN_CORE_OPTIONS: 'MutableKeyedOptionDictType' = OrderedDict([
     (OptionKey('errorlogs'),       BuiltinOption(UserBooleanOption, "Whether to print the logs from failing tests", True)),
     (OptionKey('install_umask'),   BuiltinOption(UserUmaskOption, 'Default umask to apply on permissions of installed files', '022')),
     (OptionKey('layout'),          BuiltinOption(UserComboOption, 'Build directory layout', 'mirror', choices=['mirror', 'flat'])),
-    (OptionKey('optimization'),    BuiltinOption(UserComboOption, 'Optimization level', '0', choices=['0', 'g', '1', '2', '3', 's'])),
+    (OptionKey('optimization'),    BuiltinOption(UserComboOption, 'Optimization level', '0', choices=['plain', '0', 'g', '1', '2', '3', 's'])),
     (OptionKey('prefer_static'),   BuiltinOption(UserBooleanOption, 'Whether to try static linking before shared linking', False)),
     (OptionKey('stdsplit'),        BuiltinOption(UserBooleanOption, 'Split stdout and stderr in test logs', True)),
     (OptionKey('strip'),           BuiltinOption(UserBooleanOption, 'Strip targets on install', False)),

--- a/test cases/failing/101 number in combo/test.json
+++ b/test cases/failing/101 number in combo/test.json
@@ -1,5 +1,5 @@
 {
   "stdout": [
-    { "line": "test cases/failing/101 number in combo/meson.build:1:0: ERROR: Value \"1\" (of type \"number\") for combo option \"Optimization level\" is not one of the choices. Possible choices are (as string): \"0\", \"g\", \"1\", \"2\", \"3\", \"s\"." }
+    { "line": "test cases/failing/101 number in combo/meson.build:1:0: ERROR: Value \"1\" (of type \"number\") for combo option \"Optimization level\" is not one of the choices. Possible choices are (as string): \"plain\", \"0\", \"g\", \"1\", \"2\", \"3\", \"s\"." }
   ]
 }


### PR DESCRIPTION
https://github.com/mesonbuild/meson/pull/9287 changed the `optimization=0` to pass `-O0` to the compiler. This change is reasonable by itself but unfortunately, it breaks `buildtype=plain`, which promises that “no extra build flags are used”.

`buildtype=plain` is important for distros like NixOS, which manage compiler flags for optimization and hardening themselves.

Let’s introduce a new optimization level that does nothing and set it as the default for `buildtype=plain`.
