### PR TITLE
Improvements to logging commands during compiler detection

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -417,7 +417,12 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
 
         cmd = compiler + [arg]
         try:
+            mlog.debug('-----')
+            mlog.debug(f'Detecting compiler via: {join_args(cmd)}')
             p, out, err = Popen_safe(cmd)
+            mlog.debug(f'compiler returned {p}')
+            mlog.debug(f'compiler stdout:\n{out}')
+            mlog.debug(f'compiler stderr:\n{err}')
         except OSError as e:
             popen_exceptions[join_args(cmd)] = e
             continue

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -1230,9 +1230,12 @@ def _get_gnu_compiler_defines(compiler: T.List[str]) -> T.Dict[str, str]:
     # Arguments to output compiler pre-processor defines to stdout
     # gcc, g++, and gfortran all support these arguments
     args = compiler + ['-E', '-dM', '-']
+    mlog.debug(f'Running command: {join_args(args)}')
     p, output, error = Popen_safe(args, write='', stdin=subprocess.PIPE)
     if p.returncode != 0:
-        raise EnvironmentException('Unable to detect GNU compiler type:\n' + output + error)
+        raise EnvironmentException('Unable to detect GNU compiler type:\n'
+                                   f'Compiler stdout:\n{output}\n-----\n'
+                                   f'Compiler stderr:\n{error}\n-----\n')
     # Parse several lines of the type:
     # `#define ___SOME_DEF some_value`
     # and extract `___SOME_DEF`
@@ -1254,9 +1257,12 @@ def _get_clang_compiler_defines(compiler: T.List[str]) -> T.Dict[str, str]:
     Get the list of Clang pre-processor defines
     """
     args = compiler + ['-E', '-dM', '-']
+    mlog.debug(f'Running command: {join_args(args)}')
     p, output, error = Popen_safe(args, write='', stdin=subprocess.PIPE)
     if p.returncode != 0:
-        raise EnvironmentException('Unable to get clang pre-processor defines:\n' + output + error)
+        raise EnvironmentException('Unable to get clang pre-processor defines:\n'
+                                   f'Compiler stdout:\n{output}\n-----\n'
+                                   f'Compiler stderr:\n{error}\n-----\n')
     defines: T.Dict[str, str] = {}
     for line in output.split('\n'):
         if not line:

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 from ..mesonlib import (
-    MesonException, EnvironmentException, MachineChoice,
+    MesonException, EnvironmentException, MachineChoice, join_args,
     search_version, is_windows, Popen_safe, windows_proof_rm,
 )
 from ..envconfig import BinaryTable
@@ -261,7 +261,7 @@ def _handle_exceptions(
     if exceptions:
         errmsg += '\nThe following exception(s) were encountered:'
         for c, e in exceptions.items():
-            errmsg += f'\nRunning "{c}" gave "{e}"'
+            errmsg += f'\nRunning `{c}` gave "{e}"'
     raise EnvironmentException(errmsg)
 
 
@@ -310,7 +310,7 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
         try:
             p, out, err = Popen_safe(linker + [arg])
         except OSError as e:
-            popen_exceptions[' '.join(linker + [arg])] = e
+            popen_exceptions[join_args(linker + [arg])] = e
             continue
         if "xilib: executing 'lib'" in err:
             return IntelVisualStudioLinker(linker, getattr(compiler, 'machine', None))
@@ -415,10 +415,11 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
         else:
             arg = '--version'
 
+        cmd = compiler + [arg]
         try:
-            p, out, err = Popen_safe(compiler + [arg])
+            p, out, err = Popen_safe(cmd)
         except OSError as e:
-            popen_exceptions[' '.join(compiler + [arg])] = e
+            popen_exceptions[join_args(cmd)] = e
             continue
 
         if 'ccrx' in compiler_name:
@@ -439,7 +440,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
         if guess_gcc_or_lcc:
             defines = _get_gnu_compiler_defines(compiler)
             if not defines:
-                popen_exceptions[' '.join(compiler)] = 'no pre-processor defines'
+                popen_exceptions[join_args(compiler)] = 'no pre-processor defines'
                 continue
 
             if guess_gcc_or_lcc == 'lcc':
@@ -495,7 +496,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
             # output format in future versions
             arm_ver_match = re.search('.*Component.*', out)
             if arm_ver_match is None:
-                popen_exceptions[' '.join(compiler)] = 'version string not found'
+                popen_exceptions[join_args(compiler)] = 'version string not found'
                 continue
             arm_ver_str = arm_ver_match.group(0)
             # Override previous values
@@ -514,7 +515,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
             try:
                 p, out, err = Popen_safe(compiler + [arg])
             except OSError as e:
-                popen_exceptions[' '.join(compiler + [arg])] = e
+                popen_exceptions[join_args(compiler + [arg])] = e
             version = search_version(out)
             match = re.search('^Target: (.*?)-', out, re.MULTILINE)
             if match:
@@ -674,7 +675,7 @@ def detect_cuda_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
         try:
             p, out, err = Popen_safe(compiler + [arg])
         except OSError as e:
-            popen_exceptions[' '.join(compiler + [arg])] = e
+            popen_exceptions[join_args(compiler + [arg])] = e
             continue
         # Example nvcc printout:
         #
@@ -710,7 +711,7 @@ def detect_fortran_compiler(env: 'Environment', for_machine: MachineChoice) -> C
             try:
                 p, out, err = Popen_safe(compiler + [arg])
             except OSError as e:
-                popen_exceptions[' '.join(compiler + [arg])] = e
+                popen_exceptions[join_args(compiler + [arg])] = e
                 continue
 
             version = search_version(out)
@@ -725,7 +726,7 @@ def detect_fortran_compiler(env: 'Environment', for_machine: MachineChoice) -> C
             if guess_gcc_or_lcc:
                 defines = _get_gnu_compiler_defines(compiler)
                 if not defines:
-                    popen_exceptions[' '.join(compiler)] = 'no pre-processor defines'
+                    popen_exceptions[join_args(compiler)] = 'no pre-processor defines'
                     continue
                 if guess_gcc_or_lcc == 'lcc':
                     version = _get_lcc_version_from_defines(defines)
@@ -852,13 +853,13 @@ def _detect_objc_or_objcpp_compiler(env: 'Environment', for_machine: MachineChoi
         try:
             p, out, err = Popen_safe(compiler + arg)
         except OSError as e:
-            popen_exceptions[' '.join(compiler + arg)] = e
+            popen_exceptions[join_args(compiler + arg)] = e
             continue
         version = search_version(out)
         if 'Free Software Foundation' in out:
             defines = _get_gnu_compiler_defines(compiler)
             if not defines:
-                popen_exceptions[' '.join(compiler)] = 'no pre-processor defines'
+                popen_exceptions[join_args(compiler)] = 'no pre-processor defines'
                 continue
             version = _get_gnu_version_from_defines(defines)
             comp = GnuObjCCompiler if objc else GnuObjCPPCompiler
@@ -870,7 +871,7 @@ def _detect_objc_or_objcpp_compiler(env: 'Environment', for_machine: MachineChoi
             linker = None
             defines = _get_clang_compiler_defines(compiler)
             if not defines:
-                popen_exceptions[' '.join(compiler)] = 'no pre-processor defines'
+                popen_exceptions[join_args(compiler)] = 'no pre-processor defines'
                 continue
             if 'Apple' in out:
                 comp = AppleClangObjCCompiler if objc else AppleClangObjCPPCompiler
@@ -901,7 +902,7 @@ def detect_java_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
     try:
         p, out, err = Popen_safe(exelist + ['-version'])
     except OSError:
-        raise EnvironmentException('Could not execute Java compiler "{}"'.format(' '.join(exelist)))
+        raise EnvironmentException('Could not execute Java compiler: {}'.format(join_args(exelist)))
     if 'javac' in out or 'javac' in err:
         version = search_version(err if 'javac' in err else out)
         if not version or version == 'unknown version':
@@ -911,7 +912,7 @@ def detect_java_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
         comp_class = JavaCompiler
         env.coredata.add_lang_args(comp_class.language, comp_class, for_machine, env)
         return comp_class(exelist, version, for_machine, info)
-    raise EnvironmentException('Unknown compiler "' + ' '.join(exelist) + '"')
+    raise EnvironmentException('Unknown compiler: ' + join_args(exelist))
 
 def detect_cs_compiler(env: 'Environment', for_machine: MachineChoice) -> Compiler:
     compilers, ccache, exe_wrap = _get_compilers(env, 'cs', for_machine)
@@ -921,7 +922,7 @@ def detect_cs_compiler(env: 'Environment', for_machine: MachineChoice) -> Compil
         try:
             p, out, err = Popen_safe(comp + ['--version'])
         except OSError as e:
-            popen_exceptions[' '.join(comp + ['--version'])] = e
+            popen_exceptions[join_args(comp + ['--version'])] = e
             continue
 
         version = search_version(out)
@@ -949,7 +950,7 @@ def detect_cython_compiler(env: 'Environment', for_machine: MachineChoice) -> Co
         try:
             err = Popen_safe(comp + ['-V'])[2]
         except OSError as e:
-            popen_exceptions[' '.join(comp + ['-V'])] = e
+            popen_exceptions[join_args(comp + ['-V'])] = e
             continue
 
         version = search_version(err)
@@ -971,13 +972,13 @@ def detect_vala_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
     try:
         p, out = Popen_safe(exelist + ['--version'])[0:2]
     except OSError:
-        raise EnvironmentException('Could not execute Vala compiler "{}"'.format(' '.join(exelist)))
+        raise EnvironmentException('Could not execute Vala compiler: {}'.format(join_args(exelist)))
     version = search_version(out)
     if 'Vala' in out:
         comp_class = ValaCompiler
         env.coredata.add_lang_args(comp_class.language, comp_class, for_machine, env)
         return comp_class(exelist, version, for_machine, is_cross, info)
-    raise EnvironmentException('Unknown compiler "' + ' '.join(exelist) + '"')
+    raise EnvironmentException('Unknown compiler: ' + join_args(exelist))
 
 def detect_rust_compiler(env: 'Environment', for_machine: MachineChoice) -> RustCompiler:
     popen_exceptions = {}  # type: T.Dict[str, Exception]
@@ -994,7 +995,7 @@ def detect_rust_compiler(env: 'Environment', for_machine: MachineChoice) -> Rust
         try:
             out = Popen_safe(compiler + arg)[1]
         except OSError as e:
-            popen_exceptions[' '.join(compiler + arg)] = e
+            popen_exceptions[join_args(compiler + arg)] = e
             continue
 
         version = search_version(out)
@@ -1114,7 +1115,7 @@ def detect_d_compiler(env: 'Environment', for_machine: MachineChoice) -> Compile
         try:
             p, out = Popen_safe(exelist + ['--version'])[0:2]
         except OSError as e:
-            popen_exceptions[' '.join(exelist + ['--version'])] = e
+            popen_exceptions[join_args(exelist + ['--version'])] = e
             continue
         version = search_version(out)
         full_version = out.split('\n', 1)[0]
@@ -1184,7 +1185,7 @@ def detect_d_compiler(env: 'Environment', for_machine: MachineChoice) -> Compile
             return DmdDCompiler(
                 exelist, version, for_machine, info, arch,
                 full_version=full_version, linker=linker)
-        raise EnvironmentException('Unknown compiler "' + ' '.join(exelist) + '"')
+        raise EnvironmentException('Unknown compiler: ' + join_args(exelist))
 
     _handle_exceptions(popen_exceptions, compilers)
     raise EnvironmentException('Unreachable code (exception to make mypy happy)')
@@ -1200,7 +1201,7 @@ def detect_swift_compiler(env: 'Environment', for_machine: MachineChoice) -> Com
     try:
         p, _, err = Popen_safe(exelist + ['-v'])
     except OSError:
-        raise EnvironmentException('Could not execute Swift compiler "{}"'.format(' '.join(exelist)))
+        raise EnvironmentException('Could not execute Swift compiler: {}'.format(join_args(exelist)))
     version = search_version(err)
     if 'Swift' in err:
         # As for 5.0.1 swiftc *requires* a file to check the linker:
@@ -1211,7 +1212,7 @@ def detect_swift_compiler(env: 'Environment', for_machine: MachineChoice) -> Com
         return SwiftCompiler(
             exelist, version, for_machine, is_cross, info, linker=linker)
 
-    raise EnvironmentException('Unknown compiler "' + ' '.join(exelist) + '"')
+    raise EnvironmentException('Unknown compiler: ' + join_args(exelist))
 
 
 # GNU/Clang defines and version


### PR DESCRIPTION
meson-log.txt should contain information on what commands were run, exactly, to get some classes of error.

/cc @rgommers @mkoeppe As promised.

Inspired by https://github.com/scipy/scipy/issues/16536

The following error message:

```
C compiler for the host machine: ccache cc (clang 13.1.6 "Apple clang version 13.1.6 (clang-1316.0.21.2.5)")
C linker for the host machine: cc ld64 764

../../meson.build:1:0: ERROR: Unable to get clang pre-processor defines:
error: invalid argument '-std=gnu++11' not allowed with 'C'


A full log can be found at /Users/mkoeppe/s/sage/scipy/.mesonpy-029irg41/build/meson-logs/meson-log.txt
```

Now becomes:

```
C compiler for the host machine: clang (clang 13.0.1 "clang version 13.0.1")
C linker for the host machine: clang ld.bfd 2.36.1

meson.build:1:0: ERROR: Unable to get clang pre-processor defines:
Compiler stdout:

-----
Compiler stderr:
error: invalid argument '-std=c++11' not allowed with 'C'

-----


A full log can be found at /tmp/testproj/builddir/meson-logs/meson-log.txt
```

This is mostly the same thing we already printed to the console, but now we say that it's "Compiler stderr:".
The log file also records the actual command that was run, which is key (because we will tell people to go look in that file for more info).

We do the same thing for --version checks when trying to detect what vendor/version the compiler is, though that only logs to the logfile, not the console.