### PR TITLE
Only reconfigure if configure options actually changed

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -97,8 +97,11 @@ class UserOption(T.Generic[_T], HoldableObject):
     def validate_value(self, value: T.Any) -> _T:
         raise RuntimeError('Derived option class did not override validate_value.')
 
-    def set_value(self, newvalue: T.Any) -> None:
-        self.value = self.validate_value(newvalue)
+    def set_value(self, newvalue: T.Any) -> bool:
+        newvalue = self.validate_value(newvalue)
+        dirty = not hasattr(self, "value") or self.value != newvalue
+        self.value = newvalue
+        return dirty
 
 class UserStringOption(UserOption[str]):
     def __init__(self, description: str, value: T.Any, yielding: T.Optional[bool] = None):
@@ -633,7 +636,8 @@ class CoreData:
 
         raise MesonException(f'Tried to get unknown builtin option {str(key)}')
 
-    def set_option(self, key: OptionKey, value) -> None:
+    def set_option(self, key: OptionKey, value) -> bool:
+        dirty = False
         if key.is_builtin():
             if key.name == 'prefix':
                 value = self.sanitize_prefix(value)
@@ -673,17 +677,20 @@ class CoreData:
             newname = opt.deprecated
             newkey = OptionKey.from_string(newname).evolve(subproject=key.subproject)
             mlog.deprecation(f'Option {key.name!r} is replaced by {newname!r}')
-            self.set_option(newkey, value)
+            dirty = self.set_option(newkey, value) or dirty
 
-        opt.set_value(value)
+        dirty = opt.set_value(value) or dirty
 
         if key.name == 'buildtype':
-            self._set_others_from_buildtype(value)
+            dirty = self._set_others_from_buildtype(value) or dirty
         elif key.name in {'wrap_mode', 'force_fallback_for'}:
             # We could have the system dependency cached for a dependency that
             # is now forced to use subproject fallback. We probably could have
             # more fine grained cache invalidation, but better be safe.
             self.clear_deps_cache()
+            dirty = True
+
+        return dirty
 
     def clear_deps_cache(self):
         self.deps.host.clear()
@@ -718,7 +725,9 @@ class CoreData:
             result.append(('debug', actual_debug, debug))
         return result
 
-    def _set_others_from_buildtype(self, value: str) -> None:
+    def _set_others_from_buildtype(self, value: str) -> bool:
+        dirty = False
+
         if value == 'plain':
             opt = '0'
             debug = False
@@ -736,9 +745,12 @@ class CoreData:
             debug = True
         else:
             assert value == 'custom'
-            return
-        self.options[OptionKey('optimization')].set_value(opt)
-        self.options[OptionKey('debug')].set_value(debug)
+            return False
+
+        dirty = self.options[OptionKey('optimization')].set_value(opt) or dirty
+        dirty = self.options[OptionKey('debug')].set_value(debug) or dirty
+
+        return dirty
 
     @staticmethod
     def is_per_machine_option(optname: OptionKey) -> bool:
@@ -789,21 +801,25 @@ class CoreData:
             return False
         return len(self.cross_files) > 0
 
-    def copy_build_options_from_regular_ones(self) -> None:
+    def copy_build_options_from_regular_ones(self) -> bool:
+        dirty = False
         assert not self.is_cross_build()
         for k in BUILTIN_OPTIONS_PER_MACHINE:
             o = self.options[k]
-            self.options[k.as_build()].set_value(o.value)
+            dirty = self.options[k.as_build()].set_value(o.value) or dirty
         for bk, bv in self.options.items():
             if bk.machine is MachineChoice.BUILD:
                 hk = bk.as_host()
                 try:
                     hv = self.options[hk]
-                    bv.set_value(hv.value)
+                    dirty = bv.set_value(hv.value) or dirty
                 except KeyError:
                     continue
 
-    def set_options(self, options: T.Dict[OptionKey, T.Any], subproject: str = '') -> None:
+        return dirty
+
+    def set_options(self, options: T.Dict[OptionKey, T.Any], subproject: str = '') -> bool:
+        dirty = False
         if not self.is_cross_build():
             options = {k: v for k, v in options.items() if k.machine is not MachineChoice.BUILD}
         # Set prefix first because it's needed to sanitize other options
@@ -820,7 +836,7 @@ class CoreData:
             if k == pfk:
                 continue
             elif k in self.options:
-                self.set_option(k, v)
+                dirty = self.set_option(k, v) or dirty
             elif k.machine != MachineChoice.BUILD:
                 unknown_options.append(k)
         if unknown_options:
@@ -829,7 +845,9 @@ class CoreData:
             raise MesonException(f'{sub}Unknown options: "{unknown_options_str}"')
 
         if not self.is_cross_build():
-            self.copy_build_options_from_regular_ones()
+            dirty = self.copy_build_options_from_regular_ones() or dirty
+
+        return dirty
 
     def set_default_options(self, default_options: T.MutableMapping[OptionKey, str], subproject: str, env: 'Environment') -> None:
         # Main project can set default options on subprojects, but subprojects

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -86,8 +86,8 @@ class Conf:
     def clear_cache(self):
         self.coredata.clear_deps_cache()
 
-    def set_options(self, options):
-        self.coredata.set_options(options)
+    def set_options(self, options) -> bool:
+        return self.coredata.set_options(options)
 
     def save(self):
         # Do nothing when using introspection
@@ -320,9 +320,8 @@ def run(options):
 
         save = False
         if options.cmd_line_options:
-            c.set_options(options.cmd_line_options)
+            save = c.set_options(options.cmd_line_options)
             coredata.update_cmd_line_file(builddir, options)
-            save = True
         elif options.clearcache:
             c.clear_cache()
             save = True

--- a/test cases/unit/109 configure same noop/meson.build
+++ b/test cases/unit/109 configure same noop/meson.build
@@ -1,0 +1,1 @@
+project('configure same noop test')

--- a/test cases/unit/109 configure same noop/meson_options.txt
+++ b/test cases/unit/109 configure same noop/meson_options.txt
@@ -1,0 +1,5 @@
+option(
+  'opt',
+  type : 'string',
+  value: '',
+)

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -4290,3 +4290,13 @@ class AllPlatformTests(BasePlatformTests):
 
         self.init(testdir)
         self.build()
+
+    def test_configure_same_noop(self):
+        testdir = os.path.join(self.unit_test_dir, '109 configure same noop')
+        self.init(testdir, extra_args=['-Dopt=val'])
+
+        filename = os.path.join(self.privatedir, 'coredata.dat')
+        oldmtime = os.path.getmtime(filename)
+        self.setconf(["-Dopt=val"])
+        newmtime = os.path.getmtime(filename)
+        self.assertEqual(oldmtime, newmtime)


### PR DESCRIPTION
Currently, if we run "meson configure -Doption=value", meson will
do a reconfigure when running "ninja build" afterwards, even if
the new value is the same one that was already configured previously.

To avoid this unnecessary reconfigure, we can keep track of whether
any option values actually changed when running configure, and only
save the conf file if any options actually changed. If none changed,
we don't save the file.