### PR TITLE
Only reconfigure if configure options actually changed

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -23,7 +23,7 @@ from .mesonlib import (
     MesonException, EnvironmentException, MachineChoice, PerMachine,
     PerMachineDefaultable, default_libdir, default_libexecdir,
     default_prefix, split_args, OptionKey, OptionType, stringlistify,
-    pickle_load
+    pickle_load, replace_if_different
 )
 from .wrap import WrapMode
 import ast
@@ -1066,7 +1066,7 @@ def save(obj: CoreData, build_dir: str) -> str:
         pickle.dump(obj, f)
         f.flush()
         os.fsync(f.fileno())
-    os.replace(tempfilename, filename)
+    replace_if_different(filename, tempfilename)
     return filename
 
 

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -93,7 +93,6 @@ class Conf:
         # Do nothing when using introspection
         if self.default_values_only:
             return
-        # Only called if something has changed so overwrite unconditionally.
         coredata.save(self.coredata, self.build_dir)
         # We don't write the build file because any changes to it
         # are erased when Meson is executed the next time, i.e. when

--- a/test cases/unit/109 configure same noop/meson.build
+++ b/test cases/unit/109 configure same noop/meson.build
@@ -1,0 +1,1 @@
+project('configure same noop test')

--- a/test cases/unit/109 configure same noop/meson_options.txt
+++ b/test cases/unit/109 configure same noop/meson_options.txt
@@ -1,0 +1,5 @@
+option(
+  'opt',
+  type : 'string',
+  value: '',
+)

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -4290,3 +4290,13 @@ class AllPlatformTests(BasePlatformTests):
 
         self.init(testdir)
         self.build()
+
+    def test_configure_same_noop(self):
+        testdir = os.path.join(self.unit_test_dir, '109 configure same noop')
+        self.init(testdir, extra_args=['-Dopt=val'])
+
+        filename = os.path.join(self.privatedir, 'coredata.dat')
+        oldmtime = os.path.getmtime(filename)
+        self.setconf(["-Dopt=val"])
+        newmtime = os.path.getmtime(filename)
+        self.assertEqual(oldmtime, newmtime)


### PR DESCRIPTION
Currently, if we run "meson configure -Doption=value", meson will
do a reconfigure when running "ninja build" afterwards, even if
the new value is the same one that was already configured previously.

To avoid this unnecessary reconfigure, let's use replace_if_different()
instead of unconditionally replacing the conf file in coredata's save()
function.