### PR TITLE
ar linker: detect the "osx ld" case (thin archives not OK) based on the host OS

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2862,7 +2862,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             if target.import_filename:
                 commands += linker.gen_import_library_args(self.get_import_filename(target))
         elif isinstance(target, build.StaticLibrary):
-            commands += linker.get_std_link_args(not target.should_install())
+            commands += linker.get_std_link_args(self.environment, not target.should_install())
         else:
             raise RuntimeError('Unknown build target type.')
         return commands

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -341,13 +341,13 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
         if out.startswith('The CompCert'):
             return CompCertLinker(linker)
         if p.returncode == 0:
-            return ArLinker(linker)
+            return ArLinker(compiler.for_machine, linker)
         if p.returncode == 1 and err.startswith('usage'): # OSX
-            return ArLinker(linker)
+            return ArLinker(compiler.for_machine, linker)
         if p.returncode == 1 and err.startswith('Usage'): # AIX
             return AIXArLinker(linker)
         if p.returncode == 1 and err.startswith('ar: bad option: --'): # Solaris
-            return ArLinker(linker)
+            return ArLinker(compiler.for_machine, linker)
     _handle_exceptions(popen_exceptions, linkers, 'linker')
 
 

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1450,7 +1450,7 @@ class AllPlatformTests(BasePlatformTests):
             extra_args = []
         link_cmd = linker.get_exelist()
         link_cmd += linker.get_always_args()
-        link_cmd += linker.get_std_link_args(False)
+        link_cmd += linker.get_std_link_args(get_fake_env(), False)
         link_cmd += linker.get_output_args(outfile)
         link_cmd += [objectfile]
         self.pbcompile(compiler, source, objectfile, extra_args=extra_args)


### PR DESCRIPTION
Hi! I just got to the bottom of a regression cross-compiling a project for macOS (using the Linux-based "osxcross" toolchain).
It bisected to 0a3a9fa0c3ebf45c94d9009a59cead571cbecf7b.
The Meson behavior change that killed us (in case of LTO builds) was invoking llvm-ar with the options "csrDT" instead of "csrD"... which had been thoughtfully prevented already, but based on a condition that unfortunately doesn't work for cross builds.

Please feel free to rewrite the patch if it's an awkward fit.
The heart of the matter is replacing a `mesonlib.is_osx()` check in linkers.py.
My real-life test case is pretty horrible in terms of download size and time to test, but I can provide details if helpful.
I've tried it with the below patch successfully, and I can retest if further changes are needed.

Thanks for your time.