### PR TITLE
qt module: correctly compare program name for lrelease version

### DIFF
--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -154,7 +154,7 @@ class QtBaseModule(ExtensionModule):
             # Ensure that the version of qt and each tool are the same
             def get_version(p: ExternalProgram) -> str:
                 _, out, err = Popen_safe(p.get_command() + arg)
-                if b.startswith('lrelease') or not qt_dep.version.startswith('4'):
+                if name == 'lrelease' or not qt_dep.version.startswith('4'):
                     care = out
                 else:
                     care = err


### PR DESCRIPTION
(b, name) will always have the canonical tool name, not just a potentially weird bin path. We need to check stderr for qt4 tools other than lrelease, but we keyed off of the tool bin path, so matches were by no means guaranteed, and specifically, would fail if the tool is looked up via bindir.

This really should always have checked the canonical name, which is guaranteed to be correct.

Partial fix for #10443