### PR TITLE
call ranlib -c after static linking on macos

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -42,7 +42,7 @@ from ..compilers import (
     PGICCompiler,
     VisualStudioLikeCompiler,
 )
-from ..linkers import ArLinker, RSPFileSyntax
+from ..linkers import ArLinker, AppleArLinker, RSPFileSyntax
 from ..mesonlib import (
     File, LibType, MachineChoice, MesonException, OrderedSet, PerMachine,
     ProgressBar, quote_arg
@@ -2026,7 +2026,7 @@ class NinjaBackend(backends.Backend):
             if static_linker is None:
                 continue
             rule = 'STATIC_LINKER{}'.format(self.get_rule_suffix(for_machine))
-            cmdlist = []
+            cmdlist: T.List[T.Union[str, NinjaCommandArg]] = []
             args = ['$in']
             # FIXME: Must normalize file names with pathlib.Path before writing
             #        them out to fix this properly on Windows. See:
@@ -2040,6 +2040,17 @@ class NinjaBackend(backends.Backend):
             cmdlist += static_linker.get_exelist()
             cmdlist += ['$LINK_ARGS']
             cmdlist += NinjaCommandArg.list(static_linker.get_output_args('$out'), Quoting.none)
+            # The default ar on MacOS (at least through version 12), does not
+            # add extern'd variables to the symbol table by default, and
+            # requires that apple's ranlib be called with a special flag
+            # instead after linking
+            if isinstance(static_linker, AppleArLinker):
+                # This is a bit of a hack, but we assume that that we won't need
+                # an rspfile on MacOS, otherwise the arguments are passed to
+                # ranlib, not to ar
+                cmdlist.extend(args)
+                args = []
+                cmdlist.extend(['&&', 'ranlib', '-c', '$out'])
             description = 'Linking static target $out'
             if num_pools > 0:
                 pool = 'pool = link_pool'

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -24,6 +24,7 @@ from ..linkers import (
     guess_win_linker,
     guess_nix_linker,
     AIXArLinker,
+    AppleArLinker,
     ArLinker,
     ArmarLinker,
     ArmClangDynamicLinker,
@@ -343,7 +344,7 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
         if p.returncode == 0:
             return ArLinker(compiler.for_machine, linker)
         if p.returncode == 1 and err.startswith('usage'): # OSX
-            return ArLinker(compiler.for_machine, linker)
+            return AppleArLinker(compiler.for_machine, linker)
         if p.returncode == 1 and err.startswith('Usage'): # AIX
             return AIXArLinker(linker)
         if p.returncode == 1 and err.startswith('ar: bad option: --'): # Solaris

--- a/mesonbuild/linkers/__init__.py
+++ b/mesonbuild/linkers/__init__.py
@@ -24,6 +24,7 @@ from .linkers import (
     VisualStudioLikeLinker,
     VisualStudioLinker,
     IntelVisualStudioLinker,
+    AppleArLinker,
     ArLinker,
     ArmarLinker,
     DLinker,
@@ -93,6 +94,7 @@ __all__ = [
     'C2000Linker',
     'TILinker',
     'AIXArLinker',
+    'AppleArLinker',
     'PGIStaticLinker',
     'NvidiaHPC_StaticLinker',
 

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -215,6 +215,13 @@ class ArLinker(ArLikeLinker):
             return self.std_args
 
 
+class AppleArLinker(ArLinker):
+
+    # mostly this is used to determine that we need to call ranlib
+
+    id = 'applear'
+
+
 class ArmarLinker(ArLikeLinker):
     id = 'armar'
 

--- a/test cases/osx/9 global variable ar/libfile.c
+++ b/test cases/osx/9 global variable ar/libfile.c
@@ -1,0 +1,9 @@
+// Source: https://lists.gnu.org/archive/html/libtool/2002-07/msg00025.html
+
+#include <stdio.h>
+
+extern int l2;
+void l1(void)
+{
+  printf("l1 %d\n", l2);
+}

--- a/test cases/osx/9 global variable ar/libfile2.c
+++ b/test cases/osx/9 global variable ar/libfile2.c
@@ -1,0 +1,7 @@
+// Source: https://lists.gnu.org/archive/html/libtool/2002-07/msg00025.html
+
+int l2;
+void l2_func(void)
+{
+  l2 = 77;
+}

--- a/test cases/osx/9 global variable ar/meson.build
+++ b/test cases/osx/9 global variable ar/meson.build
@@ -1,0 +1,6 @@
+# Source: https://lists.gnu.org/archive/html/libtool/2002-07/msg00025.html
+
+project('global variable test', 'c')
+
+lib = static_library('mylib', 'libfile.c', 'libfile2.c')
+test('global variable', executable('prog', 'prog.c', link_with: lib))

--- a/test cases/osx/9 global variable ar/nativefile.ini
+++ b/test cases/osx/9 global variable ar/nativefile.ini
@@ -1,0 +1,2 @@
+[binaries]
+ar = 'ar'

--- a/test cases/osx/9 global variable ar/prog.c
+++ b/test cases/osx/9 global variable ar/prog.c
@@ -1,0 +1,7 @@
+// Source: https://lists.gnu.org/archive/html/libtool/2002-07/msg00025.html
+
+extern void l1(void);
+int main(void)
+{
+  l1();
+}


### PR DESCRIPTION
Apple, for some reason, decided that ranlib should not, by default, include extern'd variables in the symbol table when running ar with the `-s` option (run ranlib). So we must additionally call `ranlib -c $out` when linking a static archive, so that behavior is consistant between the Apple archiver and every other archvier other (including llvm-ar).

Incidently we never caught this because we have code to specifically chose llvm-ar when using any variaty of clang if it's available, and apple's clang is a variety of clang, and we install llvm for running llvm tests. Because of that I've modifed a test for apple that forces the use of the `ar` archiver, even when `llvm-ar` or `gcc-ar` are installed, and don't have this behavior.