### PR TITLE
ninja depscanner: handle C++ sources named capital C

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -975,7 +975,9 @@ class NinjaBackend(backends.Backend):
         all_suffixes = set(compilers.lang_suffixes['cpp']) | set(compilers.lang_suffixes['fortran'])
         selected_sources = []
         for source in compiled_sources:
-            ext = os.path.splitext(source)[1][1:].lower()
+            ext = os.path.splitext(source)[1][1:]
+            if ext != 'C':
+                ext = ext.lower()
             if ext in all_suffixes:
                 selected_sources.append(source)
         return selected_sources
@@ -2706,7 +2708,9 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         if not self.should_use_dyndeps_for_target(target):
             return
         extension = os.path.splitext(src.fname)[1][1:]
-        if not (extension.lower() in compilers.lang_suffixes['fortran'] or extension in compilers.lang_suffixes['cpp']):
+        if extension != 'C':
+            extension = extension.lower()
+        if not (extension in compilers.lang_suffixes['fortran'] or extension in compilers.lang_suffixes['cpp']):
             return
         dep_scan_file = self.get_dep_scan_file_for(target)
         element.add_item('dyndep', dep_scan_file)

--- a/mesonbuild/scripts/depscan.py
+++ b/mesonbuild/scripts/depscan.py
@@ -51,7 +51,9 @@ class DependencyScanner:
         self.sources_with_exports: T.List[str] = []
 
     def scan_file(self, fname: str) -> None:
-        suffix = os.path.splitext(fname)[1][1:].lower()
+        suffix = os.path.splitext(fname)[1][1:]
+        if suffix != 'C':
+            suffix = suffix.lower()
         if suffix in lang_suffixes['fortran']:
             self.scan_fortran_file(fname)
         elif suffix in lang_suffixes['cpp']:


### PR DESCRIPTION
In commit 4ca9a16288f51cce99624a2ef595d879acdc02d8 we added unreliable support (it warns you if you try it) for gcc-compatible treatment of uppercase-C files being C++ instead of C. In order to handle it correctly, we needed to evaluate can-compile by special-casing "C" to avoid lowercasing it for comparisons.

This didn't cover all cases where we check if "C" is a C++ language file. We also straight-up check the language of a file (rather than working backwards to see if a C++ compiler can compile it) when doing module scanning, and this needs to special-case "C" as well.

We also had one case where we only checked lowercase fortran extensions, but not lowercase C++ extensions. While we are at it, use lowercase for C++ as well, except the "C" special case.

Fixes #10629