### PR TITLE
mesonbuild/mtest.py: filter more invalid googletest JUnit4 attributes

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -774,6 +774,10 @@ class JunitBuilder(TestLogger):
                     del case.attrib['result']
                 for case in suite.findall('.//testcase[@timestamp]'):
                     del case.attrib['timestamp']
+                for case in suite.findall('.//testcase[@file]'):
+                    del case.attrib['file']
+                for case in suite.findall('.//testcase[@line]'):
+                    del case.attrib['line']
                 self.root.append(suite)
             return
 


### PR DESCRIPTION
googletest 1.12.1 generates new JUnit4 invalid attributes file and line.

Maybe all gtest "invalid" attributes are actually valid JUnit5 attributes, and maybe schema should be upgraded to JUni5.