### PR TITLE
Improve logging of issues during linker detection

### DIFF
--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from ..mesonlib import (
     EnvironmentException, OptionKey,
-    Popen_safe, search_version
+    Popen_safe, join_args, search_version
 )
 from .linkers import (
     AppleDynamicLinker,
@@ -51,8 +51,8 @@ defaults['gcc_static_linker'] = ['gcc-ar']
 defaults['clang_static_linker'] = ['llvm-ar']
 
 def __failed_to_detect_linker(compiler: T.List[str], args: T.List[str], stdout: str, stderr: str) -> 'T.NoReturn':
-    msg = 'Unable to detect linker for compiler "{} {}"\nstdout: {}\nstderr: {}'.format(
-        ' '.join(compiler), ' '.join(args), stdout, stderr)
+    msg = 'Unable to detect linker for compiler `{}`\nstdout: {}\nstderr: {}'.format(
+        join_args(compiler + args), stdout, stderr)
     raise EnvironmentException(msg)
 
 

--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from .. import mlog
 from ..mesonlib import (
     EnvironmentException, OptionKey,
     Popen_safe, join_args, search_version
@@ -152,7 +153,13 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
         override = comp_class.use_linker_args(value[0], comp_version)
         check_args += override
 
-    _, o, e = Popen_safe(compiler + check_args)
+    mlog.debug('-----')
+    mlog.debug(f'Detecting linker via: {join_args(compiler + check_args)}')
+    p, o, e = Popen_safe(compiler + check_args)
+    mlog.debug(f'linker returned {p}')
+    mlog.debug(f'linker stdout:\n{o}')
+    mlog.debug(f'linker stderr:\n{e}')
+
     v = search_version(o + e)
     linker: DynamicLinker
     if 'LLD' in o.split('\n')[0]:


### PR DESCRIPTION
Also, when the linker is borked and we try to detect it as Apple ld, we should not do so, so don't.