### PR TITLE
envconfig: add more binutils variables

### DIFF
--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -112,8 +112,17 @@ ENV_VAR_PROG_MAP: T.Mapping[str, str] = {
     'rust_ld': 'RUSTC_LD',
 
     # Binutils
-    'strip': 'STRIP',
     'ar': 'AR',
+    'as': 'AS',
+    'ld': 'LD',
+    'nm': 'NM',
+    'objcopy': 'OBJCOPY',
+    'objdump': 'OBJDUMP',
+    'ranlib': 'RANLIB',
+    'readelf': 'READELF',
+    'size': 'SIZE',
+    'strings': 'STRINGS',
+    'strip': 'STRIP',
     'windres': 'WINDRES',
 
     # Other tools


### PR DESCRIPTION
follow standard variables and allow distributions to remove some entries from their cross-files

ex:
https://github.com/void-linux/void-packages/blob/f23acdd24bfade3a4e14809fafaffe09b3c3c318/common/build-style/meson.sh#L50-L54

variables chosen from the variables nixos sets
https://github.com/NixOS/nixpkgs/blob/ea0f14a502c60223c96066de3ed548cb3be8ca47/pkgs/build-support/bintools-wrapper/setup-hook.sh#L58

sorted alphabetically

cc @Ericson2314 