### PR TITLE
documentation: extend custom_target install

### DIFF
--- a/docs/yaml/functions/custom_target.yaml
+++ b/docs/yaml/functions/custom_target.yaml
@@ -161,10 +161,11 @@ kwargs:
 
   install:
     type: bool
-    description: When true, this target is installed during the install step.
+    description: When true, one or more files of this target are installed during
+      the install step (see `install_dir` for details).
 
   install_dir:
-    type: str | list[str]
+    type: str | list[str | bool]
     description: |
       If only one install_dir is provided, all outputs are installed there.
       *Since 0.40.0* Allows you to specify the installation directory for each


### PR DESCRIPTION
This is a follow up of the mentioned bug report:

custom_target allows selective installation if it outputs more than one
file. Mention this explicitly in install.
Additionally, fix the types for install_dir.

see: https://github.com/mesonbuild/meson/issues/505