### PR TITLE
linkers: detection should invoke the linker with lang_link_args only

### DIFF
--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from .. import mlog
 from ..mesonlib import (
-    EnvironmentException, OptionKey,
+    EnvironmentException,
     Popen_safe, join_args, search_version
 )
 from .linkers import (
@@ -71,7 +71,7 @@ def guess_win_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
     elif isinstance(comp_class.LINKER_PREFIX, list):
         check_args = comp_class.LINKER_PREFIX + ['/logo'] + comp_class.LINKER_PREFIX + ['--version']
 
-    check_args += env.coredata.options[OptionKey('args', lang=comp_class.language, machine=for_machine)].value
+    check_args += env.coredata.get_external_link_args(for_machine, comp_class.language)
 
     override = []  # type: T.List[str]
     value = env.lookup_binary_entry(for_machine, comp_class.language + '_ld')
@@ -140,7 +140,7 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
     """
     env.coredata.add_lang_args(comp_class.language, comp_class, for_machine, env)
     extra_args = extra_args or []
-    extra_args += env.coredata.options[OptionKey('args', lang=comp_class.language, machine=for_machine)].value
+    extra_args += env.coredata.get_external_link_args(for_machine, comp_class.language)
 
     if isinstance(comp_class.LINKER_PREFIX, str):
         check_args = [comp_class.LINKER_PREFIX + '--version'] + extra_args


### PR DESCRIPTION
Currently we invoke it with lang_args only, which is wrong and probably useless.

Fixes misdetecting the linker when overridden as -fuse-ld, which led to Meson trying to pass incompatible flags, outright failing if CFLAGS contained flags that only work with a non-default linker, or in the most benevolent case, having the status log report the wrong linker.

/cc @unhappy-ending @thesamesam