### PR TITLE
cmake: Add rule relaxations for CMake subprojects (fixes #10613)

### DIFF
--- a/test cases/cmake/2 advanced/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/2 advanced/subprojects/cmMod/CMakeLists.txt
@@ -17,7 +17,7 @@ generate_export_header(cmModLib)
 
 set_target_properties(cmModLib PROPERTIES VERSION 1.0.1)
 
-add_executable(testEXE main.cpp)
+add_executable(testEXE main.cpp "${CMAKE_CURRENT_BINARY_DIR}/config.h")
 
 target_link_libraries(cmModLib       ZLIB::ZLIB)
 target_link_libraries(cmModLibStatic ;ZLIB::ZLIB;)


### PR DESCRIPTION
It ended up being more intrusive than I would have liked, but this was the only way to implement exceptions, without allowing projects to access files in the build directory.

This still won't address the issue of being able to address files in the build directory in general if the build directory is not located anywhere inside the meson project.