### PR TITLE
typing: simplify type annotations for libraries

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -57,6 +57,7 @@ if T.TYPE_CHECKING:
     from .mparser import BaseNode
 
     GeneratedTypes = T.Union['CustomTarget', 'CustomTargetIndex', 'GeneratedList']
+    LibTypes = T.Union['SharedLibrary', 'StaticLibrary', 'CustomTarget', 'CustomTargetIndex']
 
 pch_kwargs = {'c_pch', 'cpp_pch'}
 
@@ -755,7 +756,7 @@ class BuildTarget(Target):
         self.external_deps: T.List[dependencies.Dependency] = []
         self.include_dirs: T.List['IncludeDirs'] = []
         self.link_language = kwargs.get('link_language')
-        self.link_targets: T.List[T.Union[SharedLibrary, StaticLibrary, 'CustomTarget', 'CustomTargetIndex']] = []
+        self.link_targets: T.List[LibTypes] = []
         self.link_whole_targets: T.List[T.Union[StaticLibrary, CustomTarget, CustomTargetIndex]] = []
         self.link_depends = []
         self.added_deps = set()

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -36,7 +36,7 @@ if T.TYPE_CHECKING:
     from ..environment import Environment
     from ..interpreterbase import FeatureCheckBase
     from ..build import (
-        CustomTarget, IncludeDirs, CustomTargetIndex, SharedLibrary,
+        CustomTarget, IncludeDirs, CustomTargetIndex, LibTypes,
         StaticLibrary
     )
     from ..mesonlib import FileOrString
@@ -235,7 +235,7 @@ class Dependency(HoldableObject):
 class InternalDependency(Dependency):
     def __init__(self, version: str, incdirs: T.List['IncludeDirs'], compile_args: T.List[str],
                  link_args: T.List[str],
-                 libraries: T.List[T.Union[SharedLibrary, StaticLibrary, CustomTarget, CustomTargetIndex]],
+                 libraries: T.List[LibTypes],
                  whole_libraries: T.List[T.Union[StaticLibrary, CustomTarget, CustomTargetIndex]],
                  sources: T.Sequence[T.Union[FileOrString, CustomTarget, StructuredSources]],
                  ext_deps: T.List[Dependency], variables: T.Dict[str, str],

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -2056,8 +2056,8 @@ class GnomeModule(ExtensionModule):
                 ofile.write(package + '\n')
         return build.Data([mesonlib.File(True, outdir, fname)], install_dir, install_dir, mesonlib.FileMode(), state.subproject)
 
-    def _get_vapi_link_with(self, target: build.CustomTarget) -> T.List[T.Union[build.CustomTarget, build.CustomTargetIndex, build.SharedLibrary, build.StaticLibrary]]:
-        link_with: T.List[T.Union[build.StaticLibrary, build.SharedLibrary, build.CustomTarget, build.CustomTargetIndex]] = []
+    def _get_vapi_link_with(self, target: build.CustomTarget) -> T.List[build.LibTypes]:
+        link_with: T.List[build.LibTypes] = []
         for dep in target.get_target_dependencies():
             if isinstance(dep, build.SharedLibrary):
                 link_with.append(dep)
@@ -2097,7 +2097,7 @@ class GnomeModule(ExtensionModule):
 
         inputs = kwargs['sources']
 
-        link_with: T.List[T.Union[build.SharedLibrary, build.StaticLibrary, build.CustomTarget, build.CustomTargetIndex]] = []
+        link_with: T.List[build.LibTypes] = []
         for i in inputs:
             if isinstance(i, str):
                 cmd.append(os.path.join(source_dir, i))


### PR DESCRIPTION
In a bunch of places we need to list various types of libraries including custom_target outputs, and it gets very long. Use a common T.Union for this.