### PR TITLE
CI: fix error when mixing clang 14 with released valgrind versions

### DIFF
--- a/mesonbuild/mesonlib/__init__.py
+++ b/mesonbuild/mesonlib/__init__.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 """Helper functions and classes."""
 
 import os

--- a/test cases/unit/2 testsetups/meson.build
+++ b/test cases/unit/2 testsetups/meson.build
@@ -2,6 +2,13 @@ project('testsetups', 'c')
 
 vg = find_program('valgrind')
 
+cc = meson.get_compiler('c')
+# clang 14 uses dwarf 5, and valgrind 3.19 GIT does not support this
+if cc.get_id() == 'clang' and cc.version().version_compare('>=14') and \
+    vg.version().version_compare('<3.20')
+  add_project_arguments('-gdwarf-4', language: 'c')
+endif
+
 # This is only set when running under Valgrind test setup.
 env = environment()
 env.set('TEST_ENV', '1')


### PR DESCRIPTION
Because clang now defaults to a dwarf version that valgrind does not yet support. There's support in valgrind git master, though.