### PR TITLE
Flake8 errors

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1185,7 +1185,7 @@ class Backend:
         '''List of all files whose alteration means that the build
         definition needs to be regenerated.'''
         deps = OrderedSet([str(Path(self.build_to_src) / df)
-                for df in self.interpreter.get_build_def_files()])
+                           for df in self.interpreter.get_build_def_files()])
         if self.environment.is_cross_build():
             deps.update(self.environment.coredata.cross_files)
         deps.update(self.environment.coredata.config_files)

--- a/mesonbuild/cmake/common.py
+++ b/mesonbuild/cmake/common.py
@@ -161,7 +161,7 @@ def check_cmake_args(args: T.List[str]) -> T.List[str]:
 
 class CMakeInclude:
     def __init__(self, path: Path, isSystem: bool = False):
-        self.path     = path
+        self.path = path
         self.isSystem = isSystem
 
     def __repr__(self) -> str:
@@ -169,11 +169,11 @@ class CMakeInclude:
 
 class CMakeFileGroup:
     def __init__(self, data: T.Dict[str, T.Any]) -> None:
-        self.defines      = data.get('defines', '')                       # type: str
-        self.flags        = _flags_to_list(data.get('compileFlags', ''))  # type: T.List[str]
+        self.defines = data.get('defines', '')                       # type: str
+        self.flags = _flags_to_list(data.get('compileFlags', ''))  # type: T.List[str]
         self.is_generated = data.get('isGenerated', False)                # type: bool
-        self.language     = data.get('language', 'C')                     # type: str
-        self.sources      = [Path(x) for x in data.get('sources', [])]    # type: T.List[Path]
+        self.language = data.get('language', 'C')                     # type: str
+        self.sources = [Path(x) for x in data.get('sources', [])]    # type: T.List[Path]
 
         # Fix the include directories
         self.includes = []  # type: T.List[CMakeInclude]
@@ -199,21 +199,21 @@ class CMakeFileGroup:
 
 class CMakeTarget:
     def __init__(self, data: T.Dict[str, T.Any]) -> None:
-        self.artifacts               = [Path(x) for x in data.get('artifacts', [])]         # type: T.List[Path]
-        self.src_dir                 = Path(data.get('sourceDirectory', ''))                # type: Path
-        self.build_dir               = Path(data.get('buildDirectory', ''))                 # type: Path
-        self.name                    = data.get('name', '')                                 # type: str
-        self.full_name               = data.get('fullName', '')                             # type: str
-        self.install                 = data.get('hasInstallRule', False)                    # type: bool
-        self.install_paths           = [Path(x) for x in set(data.get('installPaths', []))] # type: T.List[Path]
-        self.link_lang               = data.get('linkerLanguage', '')                       # type: str
-        self.link_libraries          = _flags_to_list(data.get('linkLibraries', ''))        # type: T.List[str]
-        self.link_flags              = _flags_to_list(data.get('linkFlags', ''))            # type: T.List[str]
-        self.link_lang_flags         = _flags_to_list(data.get('linkLanguageFlags', ''))    # type: T.List[str]
-        # self.link_path             = Path(data.get('linkPath', ''))                       # type: Path
-        self.type                    = data.get('type', 'EXECUTABLE')                       # type: str
-        # self.is_generator_provided = data.get('isGeneratorProvided', False)               # type: bool
-        self.files                   = []                                                   # type: T.List[CMakeFileGroup]
+        self.artifacts = [Path(x) for x in data.get('artifacts', [])]               # type: T.List[Path]
+        self.src_dir = Path(data.get('sourceDirectory', ''))                        # type: Path
+        self.build_dir = Path(data.get('buildDirectory', ''))                       # type: Path
+        self.name = data.get('name', '')                                            # type: str
+        self.full_name = data.get('fullName', '')                                   # type: str
+        self.install = data.get('hasInstallRule', False)                            # type: bool
+        self.install_paths = [Path(x) for x in set(data.get('installPaths', []))]   # type: T.List[Path]
+        self.link_lang = data.get('linkerLanguage', '')                             # type: str
+        self.link_libraries = _flags_to_list(data.get('linkLibraries', ''))         # type: T.List[str]
+        self.link_flags = _flags_to_list(data.get('linkFlags', ''))                 # type: T.List[str]
+        self.link_lang_flags = _flags_to_list(data.get('linkLanguageFlags', ''))    # type: T.List[str]
+        # self.link_path = Path(data.get('linkPath', ''))                             # type: Path
+        self.type = data.get('type', 'EXECUTABLE')                                  # type: str
+        # self.is_generator_provided = data.get('isGeneratorProvided', False)         # type: bool
+        self.files = []                                                             # type: T.List[CMakeFileGroup]
 
         for i in data.get('fileGroups', []):
             self.files += [CMakeFileGroup(i)]
@@ -240,10 +240,10 @@ class CMakeTarget:
 
 class CMakeProject:
     def __init__(self, data: T.Dict[str, T.Any]) -> None:
-        self.src_dir   = Path(data.get('sourceDirectory', ''))   # type: Path
-        self.build_dir = Path(data.get('buildDirectory', ''))    # type: Path
-        self.name      = data.get('name', '')                    # type: str
-        self.targets   = []                                      # type: T.List[CMakeTarget]
+        self.src_dir = Path(data.get('sourceDirectory', ''))    # type: Path
+        self.build_dir = Path(data.get('buildDirectory', ''))   # type: Path
+        self.name = data.get('name', '')                        # type: str
+        self.targets = []                                       # type: T.List[CMakeTarget]
 
         for i in data.get('targets', []):
             self.targets += [CMakeTarget(i)]
@@ -259,8 +259,8 @@ class CMakeProject:
 
 class CMakeConfiguration:
     def __init__(self, data: T.Dict[str, T.Any]) -> None:
-        self.name     = data.get('name', '')   # type: str
-        self.projects = []                     # type: T.List[CMakeProject]
+        self.name = data.get('name', '')        # type: str
+        self.projects = []                      # type: T.List[CMakeProject]
         for i in data.get('projects', []):
             self.projects += [CMakeProject(i)]
 

--- a/mesonbuild/cmake/executor.py
+++ b/mesonbuild/cmake/executor.py
@@ -33,7 +33,7 @@ if T.TYPE_CHECKING:
     from ..mesonlib import MachineChoice
     from ..programs import ExternalProgram
 
-TYPE_result    = T.Tuple[int, T.Optional[str], T.Optional[str]]
+TYPE_result = T.Tuple[int, T.Optional[str], T.Optional[str]]
 TYPE_cache_key = T.Tuple[str, T.Tuple[str, ...], str, T.FrozenSet[T.Tuple[str, str]]]
 
 class CMakeExecutor:

--- a/mesonbuild/cmake/fileapi.py
+++ b/mesonbuild/cmake/fileapi.py
@@ -23,13 +23,13 @@ STRIP_KEYS = ['cmake', 'reply', 'backtrace', 'backtraceGraph', 'version']
 
 class CMakeFileAPI:
     def __init__(self, build_dir: Path):
-        self.build_dir            = build_dir
-        self.api_base_dir         = self.build_dir / '.cmake' / 'api' / 'v1'
-        self.request_dir          = self.api_base_dir / 'query' / 'client-meson'
-        self.reply_dir            = self.api_base_dir / 'reply'
-        self.cmake_sources        = []   # type: T.List[CMakeBuildFile]
+        self.build_dir = build_dir
+        self.api_base_dir = self.build_dir / '.cmake' / 'api' / 'v1'
+        self.request_dir = self.api_base_dir / 'query' / 'client-meson'
+        self.reply_dir = self.api_base_dir / 'reply'
+        self.cmake_sources = []   # type: T.List[CMakeBuildFile]
         self.cmake_configurations = []   # type: T.List[CMakeConfiguration]
-        self.kind_resolver_map    = {
+        self.kind_resolver_map = {
             'codemodel': self._parse_codemodel,
             'cmakeFiles': self._parse_cmakeFiles,
         }
@@ -103,7 +103,7 @@ class CMakeFileAPI:
             src_dir = Path(dir_entry.get('source', '.'))
             bld_dir = Path(dir_entry.get('build', '.'))
             src_dir = src_dir if src_dir.is_absolute() else source_dir / src_dir
-            bld_dir = bld_dir if bld_dir.is_absolute() else build_dir  / bld_dir
+            bld_dir = bld_dir if bld_dir.is_absolute() else build_dir / bld_dir
             src_dir = src_dir.resolve()
             bld_dir = bld_dir.resolve()
 

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -59,8 +59,8 @@ if T.TYPE_CHECKING:
     from ..backend.backends import Backend
     from ..environment import Environment
 
-TYPE_mixed        = T.Union[str, int, bool, Path, BaseNode]
-TYPE_mixed_list   = T.Union[TYPE_mixed, T.Sequence[TYPE_mixed]]
+TYPE_mixed = T.Union[str, int, bool, Path, BaseNode]
+TYPE_mixed_list = T.Union[TYPE_mixed, T.Sequence[TYPE_mixed]]
 TYPE_mixed_kwargs = T.Dict[str, TYPE_mixed_list]
 
 # Disable all warnings automatically enabled with --trace and friends
@@ -131,7 +131,7 @@ class OutputTargetMap:
     rm_so_version = re.compile(r'(\.[0-9]+)+$')
 
     def __init__(self, build_dir: Path):
-        self.tgt_map   = {}          # type: T.Dict[str, T.Union['ConverterTarget', 'ConverterCustomTarget']]
+        self.tgt_map = {}          # type: T.Dict[str, T.Union['ConverterTarget', 'ConverterCustomTarget']]
         self.build_dir = build_dir
 
     def add(self, tgt: T.Union['ConverterTarget', 'ConverterCustomTarget']) -> None:
@@ -210,36 +210,36 @@ class OutputTargetMap:
 
 class ConverterTarget:
     def __init__(self, target: CMakeTarget, env: 'Environment', for_machine: MachineChoice) -> None:
-        self.env            = env
-        self.for_machine    = for_machine
-        self.artifacts      = target.artifacts
-        self.src_dir        = target.src_dir
-        self.build_dir      = target.build_dir
-        self.name           = target.name
-        self.cmake_name     = target.name
-        self.full_name      = target.full_name
-        self.type           = target.type
-        self.install        = target.install
-        self.install_dir    = None  # type: T.Optional[Path]
+        self.env = env
+        self.for_machine = for_machine
+        self.artifacts = target.artifacts
+        self.src_dir = target.src_dir
+        self.build_dir = target.build_dir
+        self.name = target.name
+        self.cmake_name = target.name
+        self.full_name = target.full_name
+        self.type = target.type
+        self.install = target.install
+        self.install_dir = None  # type: T.Optional[Path]
         self.link_libraries = target.link_libraries
-        self.link_flags     = target.link_flags + target.link_lang_flags
-        self.depends_raw    = []  # type: T.List[str]
-        self.depends        = []  # type: T.List[T.Union[ConverterTarget, ConverterCustomTarget]]
+        self.link_flags = target.link_flags + target.link_lang_flags
+        self.depends_raw = []   # type: T.List[str]
+        self.depends = []       # type: T.List[T.Union[ConverterTarget, ConverterCustomTarget]]
 
         if target.install_paths:
             self.install_dir = target.install_paths[0]
 
-        self.languages           = set() # type: T.Set[str]
-        self.sources             = []  # type: T.List[Path]
-        self.generated           = []  # type: T.List[Path]
-        self.generated_ctgt      = []  # type: T.List[CustomTargetReference]
-        self.includes            = []  # type: T.List[Path]
-        self.sys_includes        = []  # type: T.List[Path]
-        self.link_with           = []  # type: T.List[T.Union[ConverterTarget, ConverterCustomTarget]]
-        self.object_libs         = []  # type: T.List[ConverterTarget]
-        self.compile_opts        = {}  # type: T.Dict[str, T.List[str]]
-        self.public_compile_opts = []  # type: T.List[str]
-        self.pie                 = False
+        self.languages = set()          # type: T.Set[str]
+        self.sources = []               # type: T.List[Path]
+        self.generated = []             # type: T.List[Path]
+        self.generated_ctgt = []        # type: T.List[CustomTargetReference]
+        self.includes = []              # type: T.List[Path]
+        self.sys_includes = []          # type: T.List[Path]
+        self.link_with = []             # type: T.List[T.Union[ConverterTarget, ConverterCustomTarget]]
+        self.object_libs = []           # type: T.List[ConverterTarget]
+        self.compile_opts = {}          # type: T.Dict[str, T.List[str]]
+        self.public_compile_opts = []   # type: T.List[str]
+        self.pie = False
 
         # Project default override options (c_std, cpp_std, etc.)
         self.override_options = []  # type: T.List[str]
@@ -247,11 +247,11 @@ class ConverterTarget:
         # Convert the target name to a valid meson target name
         self.name = _sanitize_cmake_name(self.name)
 
-        self.generated_raw = []  # type: T.List[Path]
+        self.generated_raw = []     # type: T.List[Path]
 
         for i in target.files:
-            languages    = set()  #  type: T.Set[str]
-            src_suffixes = set()  #  type: T.Set[str]
+            languages = set()       # type: T.Set[str]
+            src_suffixes = set()    # type: T.Set[str]
 
             # Insert suffixes
             for j in i.sources:
@@ -345,10 +345,10 @@ class ConverterTarget:
             self.depends_raw = trace.targets[self.cmake_name].depends
 
             rtgt = resolve_cmake_trace_targets(self.cmake_name, trace, self.env)
-            self.includes            += [Path(x) for x in rtgt.include_directories]
-            self.link_flags          += rtgt.link_flags
+            self.includes += [Path(x) for x in rtgt.include_directories]
+            self.link_flags += rtgt.link_flags
             self.public_compile_opts += rtgt.public_compile_opts
-            self.link_libraries      += rtgt.libraries
+            self.link_libraries += rtgt.libraries
 
         elif self.type.upper() not in ['EXECUTABLE', 'OBJECT_LIBRARY']:
             mlog.warning('CMake: Target', mlog.bold(self.cmake_name), 'not found in CMake trace. This can lead to build errors')
@@ -372,7 +372,7 @@ class ConverterTarget:
         for i in self.languages:
             supported += list(lang_suffixes[i])
         supported = [f'.{x}' for x in supported]
-        self.sources       = [x for x in self.sources       if any([x.name.endswith(y) for y in supported])]
+        self.sources = [x for x in self.sources if any([x.name.endswith(y) for y in supported])]
         self.generated_raw = [x for x in self.generated_raw if any([x.name.endswith(y) for y in supported])]
 
         # Make paths relative
@@ -397,7 +397,7 @@ class ConverterTarget:
                         path_is_in_root(x, root_src_dir) or
                         path_is_in_root(x, Path(self.env.get_build_dir()))
                     )
-                ):
+                    ):
                 mlog.warning('CMake: path', mlog.bold(x.as_posix()), 'is inside the root project but', mlog.bold('not'), 'inside the subproject.')
                 mlog.warning(' --> Ignoring. This can lead to build errors.')
                 return None
@@ -425,9 +425,9 @@ class ConverterTarget:
                 self.generated += [gen_file]
 
         # Remove delete entries
-        self.includes     = [x for x in self.includes     if x is not None]
+        self.includes = [x for x in self.includes if x is not None]
         self.sys_includes = [x for x in self.sys_includes if x is not None]
-        self.sources      = [x for x in self.sources      if x is not None]
+        self.sources = [x for x in self.sources if x is not None]
 
         # Make sure '.' is always in the include directories
         if Path('.') not in self.includes:
@@ -461,7 +461,7 @@ class ConverterTarget:
             return res
 
         self.link_libraries = handle_frameworks(self.link_libraries)
-        self.link_flags     = handle_frameworks(self.link_flags)
+        self.link_flags = handle_frameworks(self.link_flags)
 
         # Handle explicit CMake add_dependency() calls
         for i in self.depends_raw:
@@ -500,14 +500,14 @@ class ConverterTarget:
         self.generated = [x for x in self.generated if not any([x.name.endswith('.' + y) for y in obj_suffixes])]
 
     def _append_objlib_sources(self, tgt: 'ConverterTarget') -> None:
-        self.includes       += tgt.includes
-        self.sources        += tgt.sources
-        self.generated      += tgt.generated
+        self.includes += tgt.includes
+        self.sources += tgt.sources
+        self.generated += tgt.generated
         self.generated_ctgt += tgt.generated_ctgt
-        self.includes        = list(OrderedSet(self.includes))
-        self.sources         = list(OrderedSet(self.sources))
-        self.generated       = list(OrderedSet(self.generated))
-        self.generated_ctgt  = list(OrderedSet(self.generated_ctgt))
+        self.includes = list(OrderedSet(self.includes))
+        self.sources = list(OrderedSet(self.sources))
+        self.generated = list(OrderedSet(self.generated))
+        self.generated_ctgt = list(OrderedSet(self.generated_ctgt))
 
         # Inherit compiler arguments since they may be required for building
         for lang, opts in tgt.compile_opts.items():
@@ -609,20 +609,20 @@ class ConverterCustomTarget:
         if not self.name:
             self.name = f'custom_tgt_{ConverterCustomTarget.tgt_counter}'
             ConverterCustomTarget.tgt_counter += 1
-        self.cmake_name       = str(self.name)
+        self.cmake_name = str(self.name)
         self.original_outputs = list(target.outputs)
-        self.outputs          = [x.name for x in self.original_outputs]
-        self.conflict_map     = {}                      # type: T.Dict[str, str]
-        self.command          = []                      # type: T.List[T.List[T.Union[str, ConverterTarget]]]
-        self.working_dir      = target.working_dir
-        self.depends_raw      = target.depends
-        self.inputs           = []                      # type: T.List[T.Union[str, CustomTargetReference]]
-        self.depends          = []                      # type: T.List[T.Union[ConverterTarget, ConverterCustomTarget]]
-        self.current_bin_dir  = target.current_bin_dir  # type: Path
-        self.current_src_dir  = target.current_src_dir  # type: Path
-        self.env              = env
-        self.for_machine      = for_machine
-        self._raw_target      = target
+        self.outputs = [x.name for x in self.original_outputs]
+        self.conflict_map = {}                          # type: T.Dict[str, str]
+        self.command = []                               # type: T.List[T.List[T.Union[str, ConverterTarget]]]
+        self.working_dir = target.working_dir
+        self.depends_raw = target.depends
+        self.inputs = []                                # type: T.List[T.Union[str, CustomTargetReference]]
+        self.depends = []                               # type: T.List[T.Union[ConverterTarget, ConverterCustomTarget]]
+        self.current_bin_dir = target.current_bin_dir   # type: Path
+        self.current_src_dir = target.current_src_dir   # type: Path
+        self.env = env
+        self.for_machine = for_machine
+        self._raw_target = target
 
         # Convert the target name to a valid meson target name
         self.name = _sanitize_cmake_name(self.name)
@@ -766,28 +766,28 @@ class ConverterCustomTarget:
 
 class CMakeInterpreter:
     def __init__(self, build: 'Build', subdir: Path, src_dir: Path, install_prefix: Path, env: 'Environment', backend: 'Backend'):
-        self.build          = build
-        self.subdir         = subdir
-        self.src_dir        = src_dir
-        self.build_dir_rel  = subdir / '__CMake_build'
-        self.build_dir      = Path(env.get_build_dir()) / self.build_dir_rel
+        self.build = build
+        self.subdir = subdir
+        self.src_dir = src_dir
+        self.build_dir_rel = subdir / '__CMake_build'
+        self.build_dir = Path(env.get_build_dir()) / self.build_dir_rel
         self.install_prefix = install_prefix
-        self.env            = env
-        self.for_machine    = MachineChoice.HOST # TODO make parameter
-        self.backend_name   = backend.name
-        self.linkers        = set()  # type: T.Set[str]
-        self.fileapi        = CMakeFileAPI(self.build_dir)
+        self.env = env
+        self.for_machine = MachineChoice.HOST # TODO make parameter
+        self.backend_name = backend.name
+        self.linkers = set()  # type: T.Set[str]
+        self.fileapi = CMakeFileAPI(self.build_dir)
 
         # Raw CMake results
-        self.bs_files          = []    # type: T.List[Path]
+        self.bs_files = []    # type: T.List[Path]
         self.codemodel_configs = None  # type: T.Optional[T.List[CMakeConfiguration]]
-        self.cmake_stderr      = None  # type: T.Optional[str]
+        self.cmake_stderr = None  # type: T.Optional[str]
 
         # Analysed data
-        self.project_name      = ''
-        self.languages         = []  # type: T.List[str]
-        self.targets           = []  # type: T.List[ConverterTarget]
-        self.custom_targets    = []  # type: T.List[ConverterCustomTarget]
+        self.project_name = ''
+        self.languages = []  # type: T.List[str]
+        self.targets = []  # type: T.List[ConverterTarget]
+        self.custom_targets = []  # type: T.List[ConverterCustomTarget]
         self.trace: CMakeTraceParser
         self.output_target_map = OutputTargetMap(self.build_dir)
 
@@ -1027,8 +1027,8 @@ class CMakeInterpreter:
 
         # Add the targets
         processing = []   # type: T.List[str]
-        processed  = {}   # type: T.Dict[str, T.Dict[str, T.Optional[str]]]
-        name_map   = {}   # type: T.Dict[str, str]
+        processed = {}   # type: T.Dict[str, T.Dict[str, T.Optional[str]]]
+        name_map = {}   # type: T.Dict[str, str]
 
         def extract_tgt(tgt: T.Union[ConverterTarget, ConverterCustomTarget, CustomTargetReference]) -> IdNode:
             tgt_name = None
@@ -1056,13 +1056,13 @@ class CMakeInterpreter:
             detect_cycle(tgt)
 
             # First handle inter target dependencies
-            link_with           = []  # type: T.List[IdNode]
-            objec_libs          = []  # type: T.List[IdNode]
-            sources             = []  # type: T.List[Path]
-            generated           = []  # type: T.List[T.Union[IdNode, IndexNode]]
-            generated_filenames = []  # type: T.List[str]
-            custom_targets      = []  # type: T.List[ConverterCustomTarget]
-            dependencies        = []  # type: T.List[IdNode]
+            link_with = []              # type: T.List[IdNode]
+            objec_libs = []             # type: T.List[IdNode]
+            sources = []                # type: T.List[Path]
+            generated = []              # type: T.List[T.Union[IdNode, IndexNode]]
+            generated_filenames = []    # type: T.List[str]
+            custom_targets = []         # type: T.List[ConverterCustomTarget]
+            dependencies = []           # type: T.List[IdNode]
             for i in tgt.link_with:
                 assert isinstance(i, ConverterTarget)
                 if i.name not in processed:

--- a/mesonbuild/cmake/toolchain.py
+++ b/mesonbuild/cmake/toolchain.py
@@ -37,20 +37,20 @@ class CMakeExecScope(Enum):
 
 class CMakeToolchain:
     def __init__(self, cmakebin: 'CMakeExecutor', env: 'Environment', for_machine: MachineChoice, exec_scope: CMakeExecScope, build_dir: Path, preload_file: T.Optional[Path] = None) -> None:
-        self.env            = env
-        self.cmakebin       = cmakebin
-        self.for_machine    = for_machine
-        self.exec_scope     = exec_scope
-        self.preload_file   = preload_file
-        self.build_dir      = build_dir
-        self.build_dir      = self.build_dir.resolve()
+        self.env = env
+        self.cmakebin = cmakebin
+        self.for_machine = for_machine
+        self.exec_scope = exec_scope
+        self.preload_file = preload_file
+        self.build_dir = build_dir
+        self.build_dir = self.build_dir.resolve()
         self.toolchain_file = build_dir / 'CMakeMesonToolchainFile.cmake'
-        self.cmcache_file   = build_dir / 'CMakeCache.txt'
-        self.minfo          = self.env.machines[self.for_machine]
-        self.properties     = self.env.properties[self.for_machine]
-        self.compilers      = self.env.coredata.compilers[self.for_machine]
-        self.cmakevars      = self.env.cmakevars[self.for_machine]
-        self.cmakestate     = self.env.coredata.cmake_cache[self.for_machine]
+        self.cmcache_file = build_dir / 'CMakeCache.txt'
+        self.minfo = self.env.machines[self.for_machine]
+        self.properties = self.env.properties[self.for_machine]
+        self.compilers = self.env.coredata.compilers[self.for_machine]
+        self.cmakevars = self.env.cmakevars[self.for_machine]
+        self.cmakestate = self.env.coredata.cmake_cache[self.for_machine]
 
         self.variables = self.get_defaults()
         self.variables.update(self.cmakevars.get_variables())
@@ -165,7 +165,7 @@ class CMakeToolchain:
         # Only set these in a cross build. Otherwise CMake will trip up in native
         # builds and thing they are cross (which causes TRY_RUN() to break)
         if self.env.is_cross_build(when_building_for=self.for_machine):
-            defaults['CMAKE_SYSTEM_NAME']      = [SYSTEM_MAP.get(self.minfo.system, self.minfo.system)]
+            defaults['CMAKE_SYSTEM_NAME'] = [SYSTEM_MAP.get(self.minfo.system, self.minfo.system)]
             defaults['CMAKE_SYSTEM_PROCESSOR'] = [self.minfo.cpu_family]
 
         defaults['CMAKE_SIZEOF_VOID_P'] = ['8' if self.minfo.is_64_bit else '4']
@@ -216,8 +216,8 @@ class CMakeToolchain:
 
         # Generate the CMakeLists.txt
         mlog.debug('CMake Toolchain: Calling CMake once to generate the compiler state')
-        languages     = list(self.compilers.keys())
-        lang_ids      = [language_map.get(x, x.upper()) for x in languages]
+        languages = list(self.compilers.keys())
+        lang_ids = [language_map.get(x, x.upper()) for x in languages]
         cmake_content = dedent(f'''
             cmake_minimum_required(VERSION 3.7)
             project(CompInfo {' '.join(lang_ids)})
@@ -253,7 +253,7 @@ class CMakeToolchain:
 
         for lang in languages:
             lang_cmake = language_map.get(lang, lang.upper())
-            file_name  = f'CMake{lang_cmake}Compiler.cmake'
+            file_name = f'CMake{lang_cmake}Compiler.cmake'
             vars = vars_by_file.setdefault(file_name, {})
             vars[f'CMAKE_{lang_cmake}_COMPILER_FORCED'] = ['1']
             self.cmakestate.update(lang, vars)

--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -56,17 +56,17 @@ class CMakeTarget:
                 name:        str,
                 target_type: str,
                 properties:  T.Optional[T.Dict[str, T.List[str]]] = None,
-                imported:    bool                                 = False,
-                tline:       T.Optional[CMakeTraceLine]           = None
+                imported:    bool = False,
+                tline:       T.Optional[CMakeTraceLine] = None
             ):
         if properties is None:
             properties = {}
-        self.name            = name
-        self.type            = target_type
-        self.properties      = properties
-        self.imported        = imported
-        self.tline           = tline
-        self.depends         = []      # type: T.List[str]
+        self.name = name
+        self.type = target_type
+        self.properties = properties
+        self.imported = imported
+        self.tline = tline
+        self.depends = []      # type: T.List[str]
         self.current_bin_dir = None    # type: T.Optional[Path]
         self.current_src_dir = None    # type: T.Optional[Path]
 
@@ -95,9 +95,9 @@ class CMakeGeneratorTarget(CMakeTarget):
 
 class CMakeTraceParser:
     def __init__(self, cmake_version: str, build_dir: Path, env: 'Environment', permissive: bool = True) -> None:
-        self.vars:                      T.Dict[str, T.List[str]]     = {}
-        self.vars_by_file: T.Dict[Path, T.Dict[str, T.List[str]]]    = {}
-        self.targets:                   T.Dict[str, CMakeTarget]     = {}
+        self.vars:                      T.Dict[str, T.List[str]] = {}
+        self.vars_by_file: T.Dict[Path, T.Dict[str, T.List[str]]] = {}
+        self.targets:                   T.Dict[str, CMakeTarget] = {}
         self.cache:                     T.Dict[str, CMakeCacheEntry] = {}
 
         self.explicit_headers = set()  # type: T.Set[Path]
@@ -203,7 +203,7 @@ class CMakeTraceParser:
                 fn(l)
 
         # Evaluate generator expressions
-        strlist_gen:  T.Callable[[T.List[str]], T.List[str]]  = lambda strlist: parse_generator_expressions(';'.join(strlist), self).split(';') if strlist else []
+        strlist_gen:  T.Callable[[T.List[str]], T.List[str]] = lambda strlist: parse_generator_expressions(';'.join(strlist), self).split(';') if strlist else []
         pathlist_gen: T.Callable[[T.List[str]], T.List[Path]] = lambda strlist: [Path(x) for x in parse_generator_expressions(';'.join(strlist), self).split(';')] if strlist else []
 
         self.vars = {k: strlist_gen(v) for k, v in self.vars.items()}
@@ -303,10 +303,10 @@ class CMakeTraceParser:
         """
         # DOC: https://cmake.org/cmake/help/latest/command/set.html
 
-        cache_type  = None
+        cache_type = None
         cache_force = 'FORCE' in tline.args
         try:
-            cache_idx  = tline.args.index('CACHE')
+            cache_idx = tline.args.index('CACHE')
             cache_type = tline.args[cache_idx + 1]
         except (ValueError, IndexError):
             pass
@@ -466,7 +466,7 @@ class CMakeTraceParser:
         cbinary_dir = self.var_to_str('MESON_PS_CMAKE_CURRENT_BINARY_DIR')
         csource_dir = self.var_to_str('MESON_PS_CMAKE_CURRENT_SOURCE_DIR')
 
-        target.working_dir     = Path(working_dir) if working_dir else None
+        target.working_dir = Path(working_dir) if working_dir else None
         target.current_bin_dir = Path(cbinary_dir) if cbinary_dir else None
         target.current_src_dir = Path(csource_dir) if csource_dir else None
         target._outputs_str = self._guess_files(target._outputs_str)

--- a/mesonbuild/cmake/tracetargets.py
+++ b/mesonbuild/cmake/tracetargets.py
@@ -110,8 +110,8 @@ def resolve_cmake_trace_targets(target_name: str,
         processed_targets += [curr]
 
     res.include_directories = sorted(set(res.include_directories))
-    res.link_flags          = sorted(set(res.link_flags))
+    res.link_flags = sorted(set(res.link_flags))
     res.public_compile_opts = sorted(set(res.public_compile_opts))
-    res.libraries           = sorted(set(res.libraries))
+    res.libraries = sorted(set(res.libraries))
 
     return res

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -230,7 +230,7 @@ class CudaCompiler(Compiler):
             instring = False
             argit = iter(arg)
             for c in argit:
-                if   c == CM and not instring:
+                if c == CM and not instring:
                     l.append('')
                 elif c == DQ:
                     l[-1] += c
@@ -364,7 +364,7 @@ class CudaCompiler(Compiler):
                 continue
 
             # Handle breakup of flag-values into a flag-part and value-part.
-            if   flag[:1] not in '-/':
+            if flag[:1] not in '-/':
                 # This is not a flag. It's probably a file input. Pass it through.
                 xflags.append(flag)
                 continue
@@ -379,7 +379,7 @@ class CudaCompiler(Compiler):
                 # This is a single-letter short option. These options (with the
                 # exception of -o) are allowed to receive their argument with neither
                 # space nor = sign before them. Detect and separate them in that event.
-                if   flag[2:3] == '':            # -I something
+                if flag[2:3] == '':            # -I something
                     try:
                         val = next(flagit)
                     except StopIteration:
@@ -390,7 +390,7 @@ class CudaCompiler(Compiler):
                     val = flag[2:]
                 flag = flag[:2]                  # -I
             elif flag in self._FLAG_LONG2SHORT_WITHARGS or \
-                 flag in self._FLAG_SHORT2LONG_WITHARGS:
+                    flag in self._FLAG_SHORT2LONG_WITHARGS:
                 # This is either -o or a multi-letter flag, and it is receiving its
                 # value isolated.
                 try:
@@ -398,7 +398,7 @@ class CudaCompiler(Compiler):
                 except StopIteration:
                     pass
             elif flag.split('=', 1)[0] in self._FLAG_LONG2SHORT_WITHARGS or \
-                 flag.split('=', 1)[0] in self._FLAG_SHORT2LONG_WITHARGS:
+                    flag.split('=', 1)[0] in self._FLAG_SHORT2LONG_WITHARGS:
                 # This is either -o or a multi-letter flag, and it is receiving its
                 # value after an = sign.
                 flag, val = flag.split('=', 1)    # -o=something
@@ -412,7 +412,7 @@ class CudaCompiler(Compiler):
                 # We do not know whether this GCC-speak flag takes an isolated
                 # argument. Assuming it does not (the vast majority indeed don't),
                 # wrap this argument in an -Xcompiler flag and send it down to NVCC.
-                if   flag == '-ffast-math':
+                if flag == '-ffast-math':
                     xflags.append('-use_fast_math')
                     xflags.append('-Xcompiler='+flag)
                 elif flag == '-fno-fast-math':
@@ -436,7 +436,7 @@ class CudaCompiler(Compiler):
             # Take care of the various NVCC-supported flags that need special handling.
             flag = self._FLAG_LONG2SHORT_WITHARGS.get(flag, flag)
 
-            if   flag in {'-include', '-isystem', '-I', '-L', '-l'}:
+            if flag in {'-include', '-isystem', '-I', '-L', '-l'}:
                 # These flags are known to GCC, but list-valued in NVCC. They potentially
                 # require double-quoting to prevent NVCC interpreting the flags as lists
                 # when GCC would not have done so.
@@ -456,7 +456,7 @@ class CudaCompiler(Compiler):
                     xflags.append(self._shield_nvcc_list_arg(val))
             elif flag == '-O':
                 # Handle optimization levels GCC knows about that NVCC does not.
-                if   val == 'fast':
+                if val == 'fast':
                     xflags.append('-O3')
                     xflags.append('-use_fast_math')
                     xflags.append('-Xcompiler')
@@ -617,7 +617,7 @@ class CudaCompiler(Compiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
-        std_key      = OptionKey('std',      machine=self.for_machine, lang=self.language)
+        std_key = OptionKey('std', machine=self.for_machine, lang=self.language)
         ccbindir_key = OptionKey('ccbindir', machine=self.for_machine, lang=self.language)
         opts.update({
             std_key:      coredata.UserComboOption('C++ language standard to use with CUDA',

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -979,7 +979,6 @@ class CLikeCompiler(Compiler):
             return m.cpu_family == 'x86'
         return None
 
-
     def symbols_have_underscore_prefix(self, env: 'Environment') -> bool:
         '''
         Check if the compiler prefixes an underscore to global C symbols
@@ -998,7 +997,6 @@ class CLikeCompiler(Compiler):
         # As a last resort, try search in a compiled binary, which is the
         # most unreliable way of checking this, see #5482
         return self._symbols_have_underscore_prefix_searchbin(env)
-
 
     def _get_patterns(self, env: 'Environment', prefixes: T.List[str], suffixes: T.List[str], shared: bool = False) -> T.List[str]:
         patterns = []  # type: T.List[str]

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -299,7 +299,7 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
         with self._build_wrapper(code, env, extra_args=args, mode=mode) as p:
             if p.returncode != 0:
                 return False, p.cached
-            return not(warning_text in p.stderr or warning_text in p.stdout), p.cached
+            return not (warning_text in p.stderr or warning_text in p.stdout), p.cached
 
     def get_compile_debugfile_args(self, rel_obj: str, pch: bool = False) -> T.List[str]:
         pdbarr = rel_obj.split('.')[:-1]

--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -106,7 +106,7 @@ class CMakeDependency(ExternalDependency):
         # Store a copy of the CMake path on the object itself so it is
         # stored in the pickled coredata and recovered.
         self.cmakebin:  T.Optional[CMakeExecutor] = None
-        self.cmakeinfo: T.Optional[CMakeInfo]     = None
+        self.cmakeinfo: T.Optional[CMakeInfo] = None
 
         # Where all CMake "build dirs" are located
         self.cmake_root_dir = environment.scratch_dir
@@ -553,7 +553,7 @@ class CMakeDependency(ExternalDependency):
             )
             incDirs        += rtgt.include_directories
             compileOptions += rtgt.public_compile_opts
-            libraries      += rtgt.libraries + rtgt.link_flags
+            libraries += rtgt.libraries + rtgt.link_flags
 
         # Make sure all elements in the lists are unique and sorted
         incDirs = sorted(set(incDirs))

--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -548,10 +548,11 @@ class CMakeDependency(ExternalDependency):
                 self.found_modules += [i]
 
             rtgt = resolve_cmake_trace_targets(i, self.traceparser, self.env,
-                clib_compiler=self.clib_compiler,
-                not_found_warning=lambda x: mlog.warning('CMake: Dependency', mlog.bold(x), 'for', mlog.bold(name), 'was not found')
-            )
-            incDirs        += rtgt.include_directories
+                                               clib_compiler=self.clib_compiler,
+                                               not_found_warning=lambda x:
+                                                   mlog.warning('CMake: Dependency', mlog.bold(x), 'for', mlog.bold(name), 'was not found')
+                                               )
+            incDirs += rtgt.include_directories
             compileOptions += rtgt.public_compile_opts
             libraries += rtgt.libraries + rtgt.link_flags
 

--- a/mesonbuild/dependencies/detect.py
+++ b/mesonbuild/dependencies/detect.py
@@ -103,7 +103,7 @@ def find_external_dependency(name: str, env: 'Environment', kwargs: T.Dict[str, 
     candidates = _build_external_dependency_list(name, env, for_machine, kwargs)
 
     pkg_exc: T.List[DependencyException] = []
-    pkgdep:  T.List[ExternalDependency]  = []
+    pkgdep:  T.List[ExternalDependency] = []
     details = ''
 
     for c in candidates:

--- a/mesonbuild/dependencies/factory.py
+++ b/mesonbuild/dependencies/factory.py
@@ -101,11 +101,11 @@ class DependencyFactory:
             # Just attach the correct name right now, either the generic name
             # or the method specific name.
             DependencyMethods.EXTRAFRAMEWORK: lambda env, kwargs: framework_class(framework_name or name, env, kwargs),
-            DependencyMethods.PKGCONFIG:      lambda env, kwargs: pkgconfig_class(pkgconfig_name or name, env, kwargs),
-            DependencyMethods.CMAKE:          lambda env, kwargs: cmake_class(cmake_name or name, env, kwargs),
-            DependencyMethods.SYSTEM:         lambda env, kwargs: system_class(name, env, kwargs),
-            DependencyMethods.BUILTIN:        lambda env, kwargs: builtin_class(name, env, kwargs),
-            DependencyMethods.CONFIG_TOOL:    None,
+            DependencyMethods.PKGCONFIG: lambda env, kwargs: pkgconfig_class(pkgconfig_name or name, env, kwargs),
+            DependencyMethods.CMAKE: lambda env, kwargs: cmake_class(cmake_name or name, env, kwargs),
+            DependencyMethods.SYSTEM: lambda env, kwargs: system_class(name, env, kwargs),
+            DependencyMethods.BUILTIN: lambda env, kwargs: builtin_class(name, env, kwargs),
+            DependencyMethods.CONFIG_TOOL: None,
         }
         if configtool_class is not None:
             self.classes[DependencyMethods.CONFIG_TOOL] = lambda env, kwargs: configtool_class(name, env, kwargs)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1343,7 +1343,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             self.summary_impl('Subprojects', all_subprojects,
                               {'bool_yn': True,
                                'list_sep': ' ',
-                              })
+                               })
         # Add automatic section with all user defined options
         if self.user_defined_options:
             values = collections.OrderedDict()

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1829,20 +1829,22 @@ class Interpreter(InterpreterBase, HoldableObject):
 
         self._validate_custom_target_outputs(len(kwargs['input']) > 1, kwargs['output'], "vcs_tag")
 
+        cmd = self.environment.get_build_command() + \
+            ['--internal',
+             'vcstagger',
+             '@INPUT0@',
+             '@OUTPUT0@',
+             fallback,
+             source_dir,
+             replace_string,
+             regex_selector] + vcs_cmd
+
         tg = build.CustomTarget(
             kwargs['output'][0],
             self.subdir,
             self.subproject,
             self.environment,
-            self.environment.get_build_command() +
-                ['--internal',
-                'vcstagger',
-                '@INPUT0@',
-                '@OUTPUT0@',
-                fallback,
-                source_dir,
-                replace_string,
-                regex_selector] + vcs_cmd,
+            cmd,
             self.source_strings_to_files(kwargs['input']),
             kwargs['output'],
             build_by_default=True,

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -381,7 +381,7 @@ DEFAULT_OPTIONS: KwargInfo[T.List[str]] = KwargInfo(
 )
 
 ENV_METHOD_KW = KwargInfo('method', str, default='set', since='0.62.0',
-    validator=in_set_validator({'set', 'prepend', 'append'}))
+                          validator=in_set_validator({'set', 'prepend', 'append'}))
 
 ENV_SEPARATOR_KW = KwargInfo('separator', str, default=os.pathsep)
 

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -66,7 +66,7 @@ class StaticLinker:
         return []
 
     def get_output_args(self, target: str) -> T.List[str]:
-        return[]
+        return []
 
     def get_coverage_link_args(self) -> T.List[str]:
         return []

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -125,7 +125,7 @@ def get_target_from_intro_data(target: ParsedTargetName, builddir: Path, introsp
             t = i['type'].replace(' ', '_')
             suggestions.append(f'- ./{p}:{t}')
         suggestions_str = '\n'.join(suggestions)
-        raise MesonException(f'Can\'t invoke target `{target.full_name}`: ambiguous name.' \
+        raise MesonException(f'Can\'t invoke target `{target.full_name}`: ambiguous name.'
                              f'Add target type and/or path:\n{suggestions_str}')
 
     return found_targets[0]

--- a/mesonbuild/modules/cuda.py
+++ b/mesonbuild/modules/cuda.py
@@ -44,8 +44,8 @@ class CudaModule(NewExtensionModule):
 
     @noKwargs
     def min_driver_version(self, state: 'ModuleState',
-                                 args: T.Tuple[str],
-                                 kwargs: T.Dict[str, T.Any]) -> str:
+                           args: T.Tuple[str],
+                           kwargs: T.Dict[str, T.Any]) -> str:
         argerror = InvalidArguments('min_driver_version must have exactly one positional argument: ' +
                                     'a CUDA Toolkit version string. Beware that, since CUDA 11.0, ' +
                                     'the CUDA Toolkit\'s components (including NVCC) are versioned ' +
@@ -96,16 +96,16 @@ class CudaModule(NewExtensionModule):
 
     @permittedKwargs(['detected'])
     def nvcc_arch_flags(self, state: 'ModuleState',
-                              args: T.Tuple[T.Union[Compiler, CudaCompiler, str]],
-                              kwargs: T.Dict[str, T.Any]) -> T.List[str]:
+                        args: T.Tuple[T.Union[Compiler, CudaCompiler, str]],
+                        kwargs: T.Dict[str, T.Any]) -> T.List[str]:
         nvcc_arch_args = self._validate_nvcc_arch_args(args, kwargs)
         ret = self._nvcc_arch_flags(*nvcc_arch_args)[0]
         return ret
 
     @permittedKwargs(['detected'])
     def nvcc_arch_readable(self, state: 'ModuleState',
-                                 args: T.Tuple[T.Union[Compiler, CudaCompiler, str]],
-                                 kwargs: T.Dict[str, T.Any]) -> T.List[str]:
+                           args: T.Tuple[T.Union[Compiler, CudaCompiler, str]],
+                           kwargs: T.Dict[str, T.Any]) -> T.List[str]:
         nvcc_arch_args = self._validate_nvcc_arch_args(args, kwargs)
         ret = self._nvcc_arch_flags(*nvcc_arch_args)[1]
         return ret

--- a/mesonbuild/modules/java.py
+++ b/mesonbuild/modules/java.py
@@ -89,14 +89,15 @@ class JavaModule(NewExtensionModule):
         return ModuleReturnValue(target, [target])
 
     @FeatureNew('java.generate_native_headers', '0.62.0')
-    @typed_pos_args('java.generate_native_headers',
+    @typed_pos_args(
+        'java.generate_native_headers',
         varargs=(str, mesonlib.File, Target, CustomTargetIndex, GeneratedList))
-    @typed_kwargs('java.generate_native_headers',
-        KwargInfo('classes', ContainerTypeInfo(list, str), default=[], listify=True,
-            required=True),
+    @typed_kwargs(
+        'java.generate_native_headers',
+        KwargInfo('classes', ContainerTypeInfo(list, str), default=[], listify=True, required=True),
         KwargInfo('package', str, default=None))
     def generate_native_headers(self, state: ModuleState, args: T.Tuple[T.List[mesonlib.FileOrString]],
-                               kwargs: T.Dict[str, T.Optional[str]]) -> ModuleReturnValue:
+                                kwargs: T.Dict[str, T.Optional[str]]) -> ModuleReturnValue:
         classes = T.cast('T.List[str]', kwargs.get('classes'))
         package = kwargs.get('package')
 

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -210,16 +210,20 @@ class RustModule(ExtensionModule):
         else:
             name = header.get_outputs()[0]
 
+        cmd = self._bindgen_bin.get_command() + \
+            [
+                '@INPUT@', '--output',
+                os.path.join(state.environment.build_dir, '@OUTPUT@')
+            ] + \
+            kwargs['args'] + ['--'] + kwargs['c_args'] + inc_strs + \
+            ['-MD', '-MQ', '@INPUT@', '-MF', '@DEPFILE@']
+
         target = CustomTarget(
             f'rustmod-bindgen-{name}'.replace('/', '_'),
             state.subdir,
             state.subproject,
             state.environment,
-            self._bindgen_bin.get_command() + [
-                '@INPUT@', '--output',
-                os.path.join(state.environment.build_dir, '@OUTPUT@')] +
-                kwargs['args'] + ['--'] + kwargs['c_args'] + inc_strs +
-                ['-MD', '-MQ', '@INPUT@', '-MF', '@DEPFILE@'],
+            cmd,
             [header],
             [kwargs['output']],
             depfile='@PLAINNAME@.d',

--- a/mesonbuild/modules/wayland.py
+++ b/mesonbuild/modules/wayland.py
@@ -23,7 +23,7 @@ from ..interpreterbase import typed_pos_args, typed_kwargs, KwargInfo
 from ..mesonlib import File, MesonException
 
 if T.TYPE_CHECKING:
-    from typing_extensions import Literal,TypedDict
+    from typing_extensions import Literal, TypedDict
 
     from . import ModuleState
     from ..build import Executable

--- a/mesonbuild/scripts/coverage.py
+++ b/mesonbuild/scripts/coverage.py
@@ -36,7 +36,6 @@ def coverage(outputs: T.List[str], source_root: str, subproject_root: str, build
 
     gcovr_config = ['-e', re.escape(subproject_root)]
 
-
     # gcovr >= 4.2 requires a different syntax for out of source builds
     if gcovr_exe and mesonlib.version_compare(gcovr_version, '>=4.2'):
         gcovr_base_cmd = [gcovr_exe, '-r', source_root, build_root]

--- a/mesonbuild/scripts/run_tool.py
+++ b/mesonbuild/scripts/run_tool.py
@@ -60,7 +60,7 @@ def run_tool(name: str, srcdir: Path, builddir: Path, fn: T.Callable[..., subpro
         for f in itertools.chain(*globs):
             strf = str(f)
             if f.is_dir() or f.suffix not in suffixes or \
-                any(fnmatch.fnmatch(strf, i) for i in ignore):
+                    any(fnmatch.fnmatch(strf, i) for i in ignore):
                 continue
             futures.append(e.submit(fn, f, *args))
         if futures:


### PR DESCRIPTION
This removes all but two issues reported by flake8 for `mesonbuild`. They are mostly dealing with white spaces (7148e1b6b3dad6001746c14f778e1410b37d6187 and 057b797a42044e750a0e1a0aa5c31ae7da6a75af), but a couple of them requires in my opinion some slight moving around of the code (dfa7cf168886b74fed628c82bcfe28dc86863225) in order to meet the PEP8 coding standard while also being readable. 

The remaining errors, that I've not dealt with are
```
mesonbuild/build.py:707:71: F821 undefined name 'WrapMode'
mesonbuild/build.py:712:23: F821 undefined name 'WrapMode'
```
As I'm not entirely sure why this definition isn't imported, I've let it be as-is. That said, I'd think this would do the trick
```python
from .wrap import WrapMode
```

If someone can confirm that would be a good fix, I can include it.

Fixes #10672