### PR TITLE
mtest: fix xml chars discouraged to use

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -72,6 +72,26 @@ GNU_ERROR_RETURNCODE = 99
 # Exit if 3 Ctrl-C's are received within one second
 MAX_CTRLC = 3
 
+# Define unencodable xml characters' regex for replacing
+# them with their printable representation
+UNENCODABLE_UNICHRS = [(0x00, 0x08), (0x0B, 0x0C), (0x0E, 0x1F), (0x7F, 0x84),
+                       (0x86, 0x9F), (0xFDD0, 0xFDEF), (0xFFFE, 0xFFFF)]
+# Not narrow build
+if sys.maxunicode >= 0x10000:
+    UNENCODABLE_UNICHRS.extend([(0x1FFFE, 0x1FFFF), (0x2FFFE, 0x2FFFF),
+                                (0x3FFFE, 0x3FFFF), (0x4FFFE, 0x4FFFF),
+                                (0x5FFFE, 0x5FFFF), (0x6FFFE, 0x6FFFF),
+                                (0x7FFFE, 0x7FFFF), (0x8FFFE, 0x8FFFF),
+                                (0x9FFFE, 0x9FFFF), (0xAFFFE, 0xAFFFF),
+                                (0xBFFFE, 0xBFFFF), (0xCFFFE, 0xCFFFF),
+                                (0xDFFFE, 0xDFFFF), (0xEFFFE, 0xEFFFF),
+                                (0xFFFFE, 0xFFFFF), (0x10FFFE, 0x10FFFF)])
+UNENCODABLE_RANGES = [fr'{chr(low)}-{chr(high)}' for (low, high)
+                      in UNENCODABLE_UNICHRS]
+UNENCODABLE_XML_CHARS_RE = re.compile(
+    '([' + ''.join(UNENCODABLE_RANGES) + '])')
+
+
 def is_windows() -> bool:
     platname = platform.system().lower()
     return platname == 'windows'
@@ -1148,14 +1168,21 @@ class TestRunRust(TestRun):
 
 TestRun.PROTOCOL_TO_CLASS[TestProtocol.RUST] = TestRunRust
 
+# Check unencodable characters in xml output and replace them with
+# their printable representation
+def replace_unencodable_xml_chars(original_str: str) -> str:
+    # [1:-1] is needed for removing `'` characters from both start and end
+    # of the string
+    replacement_lambda = lambda illegal_chr: repr(illegal_chr.group())[1:-1]
+    return UNENCODABLE_XML_CHARS_RE.sub(replacement_lambda, original_str)
 
 def decode(stream: T.Union[None, bytes]) -> str:
     if stream is None:
         return ''
     try:
-        return stream.decode('utf-8')
+        return replace_unencodable_xml_chars(stream.decode('utf-8'))
     except UnicodeDecodeError:
-        return stream.decode('iso-8859-1', errors='ignore')
+        return replace_unencodable_xml_chars(stream.decode('iso-8859-1', errors='ignore'))
 
 async def read_decode(reader: asyncio.StreamReader,
                       queue: T.Optional['asyncio.Queue[T.Optional[str]]'],

--- a/test cases/unit/110 replace unencodable xml chars/meson.build
+++ b/test cases/unit/110 replace unencodable xml chars/meson.build
@@ -1,0 +1,7 @@
+project(
+    'replace unencodable xml chars',
+    version : '>= 0.55'
+)
+
+test_script = find_program('script.py')
+test('main', test_script)

--- a/test cases/unit/110 replace unencodable xml chars/script.py
+++ b/test cases/unit/110 replace unencodable xml chars/script.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import sys
+
+# Create base string(\nHello Meson\n) to see valid chars are not replaced
+base_string_invalid = '\n\x48\x65\x6c\x6c\x6f\x20\x4d\x65\x73\x6f\x6e\n'
+# Create invalid input from all known unencodable chars
+invalid_string = (
+    '\x00\x01\x02\x03\x04\x05\x06\x07\x08\x0b\x0c\x0e\x0f\x10\x11'
+    '\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\x7f'
+    '\x80\x81\x82\x83\x84\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f'
+    '\x90\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9a\x9b\x9c\x9d\x9e'
+    '\x9f\ufdd0\ufdd1\ufdd2\ufdd3\ufdd4\ufdd5\ufdd6\ufdd7\ufdd8'
+    '\ufdd9\ufdda\ufddb\ufddc\ufddd\ufdde\ufddf\ufde0\ufde1'
+    '\ufde2\ufde3\ufde4\ufde5\ufde6\ufde7\ufde8\ufde9\ufdea'
+    '\ufdeb\ufdec\ufded\ufdee\ufdef\ufffe\uffff')
+if sys.maxunicode >= 0x10000:
+    invalid_string = invalid_string + (
+        '\U0001fffe\U0001ffff\U0002fffe\U0002ffff'
+        '\U0003fffe\U0003ffff\U0004fffe\U0004ffff'
+        '\U0005fffe\U0005ffff\U0006fffe\U0006ffff'
+        '\U0007fffe\U0007ffff\U0008fffe\U0008ffff'
+        '\U0009fffe\U0009ffff\U000afffe\U000affff'
+        '\U000bfffe\U000bffff\U000cfffe\U000cffff'
+        '\U000dfffe\U000dffff\U000efffe\U000effff'
+        '\U000ffffe\U000fffff\U0010fffe\U0010ffff')
+
+print(invalid_string)


### PR DESCRIPTION
Fixes #9894.

I copied most of the implementation from [there](https://stackoverflow.com/a/22273639). Instead of filtering them, I replaced such characters with their printable representation.

**For example:**
```meson
project('tutorial', 'c')
test('mytest',find_program('python'), args: ['-c','print(u"Test\x07")'])
```

**was failing with:**
```
builddir/meson-logs/testlog.junit.xml:2: parser error : PCDATA invalid Char value 7
e name="mytest" classname="tutorial" time="0.06694579124450684"><system-out>Test
```

**now it doesn't fail, instead it produces:**
```xml
<?xml version="1.0" encoding="utf-8"?>
<testsuites tests="1" errors="0" failures="0"><testsuite name="tutorial" tests="1" errors="0" failures="0" skipped="0" time="0.008198976516723633"><testcase name="mytest" classname="tutorial" time="0.008198976516723633"><system-out>Test\x07</system-out></testcase></testsuite></testsuites>
```


**TBD:**
I am not sure if this solution is suitable. If you think it is okay and tests are necessary I can add test cases.

