### PR TITLE
rust: Generate a rust-project.json file when rust targets are present

### DIFF
--- a/docs/markdown/Rust.md
+++ b/docs/markdown/Rust.md
@@ -54,3 +54,14 @@ executable(
     )
 )
 ```
+
+## Use with rust-analyzer
+
+*Since 0.64.0.*
+
+Meson will generate a `rust-project.json` file in the root of the build
+directory if there are any rust targets in the project. Most IDEs will need to
+be configured to use the file as it's not in the source root (Meson does not
+write files into the source directory). [See the upstream
+docs](https://rust-analyzer.github.io/manual.html#non-cargo-based-projects) for
+more information on how to configure that.

--- a/docs/markdown/snippets/rust_project_json.md
+++ b/docs/markdown/snippets/rust_project_json.md
@@ -1,0 +1,5 @@
+## Generates rust-project.json when there are Rust targets
+
+This is a format similar to compile_commands.json, but specifically used by the
+official rust LSP, rust-analyzer. It is generated automatically if there are
+Rust targets, and is placed in the build directory.

--- a/mesonbuild/arglist.py
+++ b/mesonbuild/arglist.py
@@ -53,7 +53,7 @@ class Dedup(enum.Enum):
     OVERRIDDEN = 2
 
 
-class CompilerArgs(collections.abc.MutableSequence):
+class CompilerArgs(T.MutableSequence[str]):
     '''
     List-like class that manages a list of compiler arguments. Should be used
     while constructing compiler arguments from various sources. Can be

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -92,6 +92,7 @@ __all__ = [
     'exe_exists',
     'expand_arguments',
     'extract_as_list',
+    'first',
     'generate_list',
     'get_compiler_for_source',
     'get_filenames_templates_dict',
@@ -2292,3 +2293,17 @@ def pickle_load(filename: str, object_name: str, object_type: T.Type) -> T.Any:
     if major_versions_differ(obj.version, coredata_version):
         raise MesonVersionMismatchException(obj.version, coredata_version)
     return obj
+
+
+def first(iter: T.Iterable[_T], predicate: T.Callable[[_T], bool]) -> T.Optional[_T]:
+    """Find the first entry in an iterable where the given predicate is true
+
+    :param iter: The iterable to search
+    :param predicate: A finding function that takes an element from the iterable
+        and returns True if found, otherwise False
+    :return: The first found element, or None if it is not found
+    """
+    for i in iter:
+        if predicate(i):
+            return i
+    return None


### PR DESCRIPTION
When at least one Rust target is present, we now generate a
rust-project.json file, which can be consumed by rust-analyzer. This is
placed in the build directory, and the editor must be configured to look
for this (as it is not a default search path).

Fixes: #10678