### PR TITLE
backend/ninja: omit --backend when regenerating build dir

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1197,9 +1197,7 @@ class NinjaBackend(backends.Backend):
             ['--internal',
              'regenerate',
              self.environment.get_source_dir(),
-             self.environment.get_build_dir(),
-             '--backend',
-             'ninja']
+             self.environment.get_build_dir()]
         self.add_rule(NinjaRule('REGENERATE_BUILD',
                                 c, [],
                                 'Regenerating build files.',


### PR DESCRIPTION
Currently a cosmetic bug is present: once a build dir was regenerated,
meson would start showing:

```
  User defined options
    backend: ninja
```

This is not true as user have not defined the option, it is default.
Fix this by omitting the `--backend ninja` parameter from "regenerate"

In my tests this does not affect the situation when one specifies
`--backend ninja` explicitly, it still shows the backend as user-defined
after reconfiguration.

Fixes: https://github.com/mesonbuild/meson/issues/10632