### PR TITLE
Add page listing Meson usage in proprietary projects.

### DIFF
--- a/docs/markdown/Corporate-users.md
+++ b/docs/markdown/Corporate-users.md
@@ -1,0 +1,41 @@
+---
+title: Corporate users
+...
+
+# List of companies using Meson.
+
+In addition to [open source projects](Users.md) Meson is also used in
+by many corporations for their private projects. This page lists some
+of them that we are aware of.
+
+If you'd like to have your company project shown on this page, see the
+instructions at the bottom of this page.
+
+Open source projects are listed on [their own page](Users.md).
+
+## Projects with public info
+
+Company X wrote a blog post about their usage of Meson on [this page
+here](https://not.a.real.url).
+
+## Projects with comments
+
+"We use Meson for our X project and it has made us Y% more
+productive." -Developer McDeveloperface, Foo corp
+
+## Companies using Meson
+
+- Bob incorporated uses Meson to build the firmware of their
+  flibbertigibbet device.
+
+# Adding new entries
+
+We welcome new entries to this page. The procedure is quite simple:
+get approval from the PR department of your company (if needed) and
+then file a merge request with the necessary information.
+
+As you can probably guess, the more information your entry is, the
+higher up on the page it gets.
+
+The boring legalese: we reserve the right to reorder and/or remove
+entries on this page as we see fit.

--- a/docs/markdown/Users.md
+++ b/docs/markdown/Users.md
@@ -2,15 +2,17 @@
 title: Users
 ...
 
-# List of projects using Meson
+# List of open source projects using Meson
 
 If you have a project that uses Meson that you want to add to this
 list, please [file a
 pull-request](https://github.com/mesonbuild/meson/edit/master/docs/markdown/Users.md)
 for it. All the software on this list is tested for regressions before
-release, so it's highly recommended that projects add themselves
-here. Some additional projects are listed in the [`meson` GitHub
+release, so it's highly recommended that projects add themselves here.
+Some additional projects are listed in the [`meson` GitHub
 topic](https://github.com/topics/meson).
+
+Closed source projects are listed [on their own page](Corporate-Users.md).
 
  - [2048.cpp](https://github.com/plibither8/2048.cpp), a fully featured terminal version of the game "2048" written in C++
  - [Adwaita Manager](https://github.com/AdwCustomizerTeam/AdwCustomizer), change the look of Adwaita, with ease

--- a/docs/sitemap.txt
+++ b/docs/sitemap.txt
@@ -133,6 +133,7 @@ index.md
 		Porting-from-autotools.md
 		Use-of-Python.md
 		Users.md
+		Corporate-users.md
 		Using-multiple-build-directories.md
 		Vs-External.md
 	Contributing.md


### PR DESCRIPTION
We'd need to get at least some sort of a list of entries before merging this.