### PR TITLE
build: don't add targets to link_whole_targets if we took their objects

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -859,6 +859,16 @@ class NinjaBackend(backends.Backend):
         else:
             pch_objects = []
 
+        o, od = self.flatten_object_list(target)
+        obj_targets = [t for t in od if t.uses_fortran()]
+        obj_list.extend(o)
+
+        fortran_order_deps = [self.get_target_filename(t) for t in obj_targets]
+        fortran_inc_args: T.List[str] = []
+        if target.uses_fortran():
+            fortran_inc_args = mesonlib.listify([target.compilers['fortran'].get_include_args(
+                self.get_target_private_dir(t), is_system=False) for t in obj_targets])
+
         # Generate compilation targets for C sources generated from Vala
         # sources. This can be extended to other $LANG->C compilers later if
         # necessary. This needs to be separate for at least Vala
@@ -898,15 +908,17 @@ class NinjaBackend(backends.Backend):
                                            src.rel_to_builddir(self.build_to_src))
                     unity_src.append(abs_src)
                 else:
-                    o, s = self.generate_single_compile(target, src, False, [], header_deps + d_generated_deps)
+                    o, s = self.generate_single_compile(target, src, False, [],
+                                                        header_deps + d_generated_deps + fortran_order_deps,
+                                                        fortran_inc_args)
                     obj_list.append(o)
                     compiled_sources.append(s)
                     source2object[s] = o
 
-        obj_list += self.flatten_object_list(target)
         if is_unity:
             for src in self.generate_unity_files(target, unity_src):
-                o, s = self.generate_single_compile(target, src, True, unity_deps + header_deps + d_generated_deps)
+                o, s = self.generate_single_compile(target, src, True, unity_deps + header_deps + d_generated_deps,
+                                                    fortran_order_deps, fortran_inc_args)
                 obj_list.append(o)
                 compiled_sources.append(s)
                 source2object[s] = o
@@ -916,7 +928,7 @@ class NinjaBackend(backends.Backend):
         else:
             final_obj_list = obj_list
         elem = self.generate_link(target, outname, final_obj_list, linker, pch_objects, stdlib_args=stdlib_args)
-        self.generate_dependency_scan_target(target, compiled_sources, source2object, generated_source_files)
+        self.generate_dependency_scan_target(target, compiled_sources, source2object, generated_source_files, fortran_order_deps)
         self.add_build(elem)
 
     def should_use_dyndeps_for_target(self, target: 'build.BuildTarget') -> bool:
@@ -941,7 +953,8 @@ class NinjaBackend(backends.Backend):
             return False
         return True
 
-    def generate_dependency_scan_target(self, target, compiled_sources, source2object, generated_source_files: T.List[mesonlib.File]):
+    def generate_dependency_scan_target(self, target, compiled_sources, source2object, generated_source_files: T.List[mesonlib.File],
+                                        object_deps: T.List[str]) -> None:
         if not self.should_use_dyndeps_for_target(target):
             return
         depscan_file = self.get_dep_scan_file_for(target)
@@ -963,6 +976,7 @@ class NinjaBackend(backends.Backend):
         # that those sources are present
         for g in generated_source_files:
             elem.orderdeps.add(g.relative_name())
+        elem.orderdeps.update(object_deps)
         scaninfo = TargetDependencyScannerInfo(self.get_target_private_dir(target), source2object)
         with open(pickle_abs, 'wb') as p:
             pickle.dump(scaninfo, p)
@@ -2605,7 +2619,10 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         commands += compiler.get_include_args(self.get_target_private_dir(target), False)
         return commands
 
-    def generate_single_compile(self, target, src, is_generated=False, header_deps=None, order_deps=None):
+    def generate_single_compile(self, target: build.BuildTarget, src,
+                                is_generated=False, header_deps=None,
+                                order_deps: T.Optional[T.List[str]] = None,
+                                extra_args: T.Optional[T.List[str]] = None) -> None:
         """
         Compiles C/C++, ObjC/ObjC++, Fortran, and D sources
         """
@@ -2692,6 +2709,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                                                     rel_obj)
                         self.add_build(depelem)
             commands += compiler.get_module_outdir_args(self.get_target_private_dir(target))
+        if extra_args is not None:
+            commands.extend(extra_args)
 
         element = NinjaBuildElement(self.all_outputs, rel_obj, compiler_name, rel_src)
         self.add_header_deps(target, element, header_deps)
@@ -2910,7 +2929,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             for dep in target.link_whole_targets:
                 l = dep.extract_all_objects(False)
                 objects_from_static_libs += self.determine_ext_objs(l, '')
-                objects_from_static_libs.extend(self.flatten_object_list(dep))
+                objects_from_static_libs.extend(self.flatten_object_list(dep)[0])
 
             return objects_from_static_libs
         else:

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1279,7 +1279,7 @@ class Vs2010Backend(backends.Backend):
         for lib in self.get_custom_target_provided_libraries(target):
             additional_links.append(self.relpath(lib, self.get_target_dir(target)))
         additional_objects = []
-        for o in self.flatten_object_list(target, down):
+        for o in self.flatten_object_list(target, down)[0]:
             assert isinstance(o, str)
             additional_objects.append(o)
         for o in custom_objs:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1466,11 +1466,13 @@ You probably should put it in link_with instead.''')
                     raise InvalidArguments(msg + ' This is not possible in a cross build.')
                 else:
                     mlog.warning(msg + ' This will fail in cross build.')
+            # When we're a static library and we link_whole: to another static
+            # library, we need to add that target's objects to ourselves.
+            # Otherwise add it to the link_whole_targets, but not both.
             if isinstance(self, StaticLibrary):
-                # When we're a static library and we link_whole: to another static
-                # library, we need to add that target's objects to ourselves.
                 self.objects += t.extract_all_objects_recurse()
-            self.link_whole_targets.append(t)
+            else:
+                self.link_whole_targets.append(t)
 
     def extract_all_objects_recurse(self) -> T.List[T.Union[str, 'ExtractedObjects']]:
         objs = [self.extract_all_objects()]

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1416,9 +1416,17 @@ You probably should put it in link_with instead.''')
                         mlog.warning(f'Try to link an installed static library target {self.name} with a'
                                      'custom target that is not installed, this might cause problems'
                                      'when you try to use this static library')
-                elif t.is_internal():
+                elif t.is_internal() and not t.uses_rust():
                     # When we're a static library and we link_with to an
                     # internal/convenience library, promote to link_whole.
+                    #
+                    # There are cases we cannot do this, however. In Rust, for
+                    # example, this can't be done with Rust ABI libraries, though
+                    # it could be done with C ABI libraries, though there are
+                    # several meson issues that need to be fixed:
+                    # https://github.com/mesonbuild/meson/issues/10722
+                    # https://github.com/mesonbuild/meson/issues/10723
+                    # https://github.com/mesonbuild/meson/issues/10724
                     return self.link_whole(t)
             if not isinstance(t, (Target, CustomTargetIndex)):
                 raise InvalidArguments(f'{t!r} is not a target.')

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1634,6 +1634,9 @@ You probably should put it in link_with instead.''')
     def uses_rust(self) -> bool:
         return 'rust' in self.compilers
 
+    def uses_fortran(self) -> bool:
+        return 'fortran' in self.compilers
+
     def get_using_msvc(self) -> bool:
         '''
         Check if the dynamic linker is MSVC. Used by Executable, StaticLibrary,


### PR DESCRIPTION
What happens is this:
 - liba is a convenience static library
 - libb is an installed static library
 - libb links in liba with --link-whole
 - libc links to libb
 - we generate a link line with libb *and* liba, even though libb is a
   strict superset of liba

This is a bug that has existed since the optimization was added to avoid
calling link-whole on convenience libraries, and to instead propagate
their dependencies up. For most linkers this is harmless, if
inefficient. However, for apple's ld64 with the addition calling `ranlib
-c`, this ends up causing multiple copies of symbols to clash (I think
that other linkers recognize that these symbols are the same and combine
them), and linking to fail.

The fix is to stop adding libraries to a target's `link_whole_targets`
when we take its objects instead. This is an all around win since it
fixes this bug, shortens linker command lines, and avoids opening
archives that no new symbols will be found in anyway.