### PR TITLE
deprecate running "meson builddir" without setup subcommand

### DIFF
--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -240,7 +240,9 @@ See [the Meson file rewriter documentation](Rewriter.md) for more info.
 
 Configures a build directory for the Meson project.
 
-This is the default Meson command (invoked if there was no COMMAND supplied).
+*Deprecated since 0.64.0*: This is the default Meson command (invoked if there
+was no COMMAND supplied). However, supplying the command is necessary to avoid
+clashes with future added commands, so "setup" should be used explicitly.
 
 {{ setup_arguments.inc }}
 

--- a/docs/markdown/Continuous-Integration.md
+++ b/docs/markdown/Continuous-Integration.md
@@ -36,8 +36,8 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then echo FROM YOUR/REPO:eoan > Dockerfile; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then echo ADD . /root >> Dockerfile; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker build -t withgit .; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker run withgit /bin/sh -c "cd /root && TRAVIS=true CC=$CC CXX=$CXX meson builddir && meson test -C builddir"; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then SDKROOT=$(xcodebuild -version -sdk macosx Path) meson builddir && meson test -C builddir; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker run withgit /bin/sh -c "cd /root && TRAVIS=true CC=$CC CXX=$CXX meson setup builddir && meson test -C builddir"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then SDKROOT=$(xcodebuild -version -sdk macosx Path) meson setup builddir && meson test -C builddir; fi
 ```
 
 ## CircleCi for Linux (with Docker)
@@ -192,7 +192,7 @@ install:
   - pip install meson ninja
 
 script:
-  - meson builddir
+  - meson setup builddir
   - meson compile -C builddir
   - meson test -C builddir
 ```

--- a/docs/markdown/Creating-releases.md
+++ b/docs/markdown/Creating-releases.md
@@ -82,7 +82,7 @@ For example:
 ```sh
 git clone https://github.com/myproject
 cd myproject/subprojects/mysubproject
-meson builddir
+meson setup builddir
 meson dist -C builddir
 ```
 This produces `builddir/meson-dist/mysubproject-1.0.tar.xz` tarball.

--- a/docs/markdown/Cross-compilation.md
+++ b/docs/markdown/Cross-compilation.md
@@ -371,5 +371,5 @@ file called x86-linux, then the following command would start a cross
 build using that cross files:
 
 ```sh
-meson builddir/ --cross-file x86-linux
+meson setup builddir/ --cross-file x86-linux
 ```

--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -261,7 +261,7 @@ to be using the same compiler. This can be achieved using Dub's
 variable when running Meson.
 ```
 dub build urld --compiler=dmd
-DC="dmd" meson builddir
+DC="dmd" meson setup builddir
 ```
 
 ## Config tool

--- a/docs/markdown/GuiTutorial.md
+++ b/docs/markdown/GuiTutorial.md
@@ -64,7 +64,7 @@ executable('sdlprog', 'sdlprog.c')
 
 With this done we can start the build with the following command:
 
-    meson builddir
+    meson setup builddir
 
 Here `builddir` is the _build directory_, everything that is generated
 during the build is put in that directory. When run, it should look

--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -20,7 +20,7 @@ that the source resides in an Eclipse-like directory called
 `workspace/project/build`. First, we initialize Meson by running the
 following command in the source directory.
 
-    meson builddir
+    meson setup builddir
 
 With this command Meson will configure the project and also generate
 introspection information that is stored in `intro-*.json` files in

--- a/docs/markdown/IndepthTutorial.md
+++ b/docs/markdown/IndepthTutorial.md
@@ -138,7 +138,7 @@ test suite, we just need to execute the following commands (starting
 at source tree root directory).
 
 ```console
-$ meson builddir && cd builddir
+$ meson setup builddir && cd builddir
 $ meson compile
 $ meson test
 ```

--- a/docs/markdown/Quick-guide.md
+++ b/docs/markdown/Quick-guide.md
@@ -75,7 +75,7 @@ Troubleshooting:
 --
 Common Issues:
 ```console
-$ meson builddir
+$ meson setup builddir
 $ bash: /usr/bin/meson: No such file or directory
 ```
 
@@ -102,7 +102,7 @@ are working on. The steps to take are very simple.
 
 ```console
 $ cd /path/to/source/root
-$ meson builddir && cd builddir
+$ meson setup builddir && cd builddir
 $ meson compile
 $ meson test
 ```

--- a/docs/markdown/Release-notes-for-0.51.0.md
+++ b/docs/markdown/Release-notes-for-0.51.0.md
@@ -136,7 +136,7 @@ If you have installed something to `/tmp/dep`, which has a layout like:
 /tmp/dep/bin
 ```
 
-then invoke Meson as `meson builddir/ -Dcmake_prefix_path=/tmp/dep`
+then invoke Meson as `meson setup builddir/ -Dcmake_prefix_path=/tmp/dep`
 
 ## Tests that should fail but did not are now errors
 

--- a/docs/markdown/Release-notes-for-0.54.0.md
+++ b/docs/markdown/Release-notes-for-0.54.0.md
@@ -120,12 +120,12 @@ value < 1 lets the backend decide how many threads to use. For msbuild
 this means `-m`, for ninja it means passing no arguments.
 
 ```console
-meson builddir --backend vs
+meson setup builddir --backend vs
 meson compile -C builddir -j0  # this is the same as `msbuild builddir/my.sln -m`
 ```
 
 ```console
-meson builddir
+meson setup builddir
 meson compile -C builddir -j3  # this is the same as `ninja -C builddir -j3`
 ```
 

--- a/docs/markdown/Release-notes-for-0.55.0.md
+++ b/docs/markdown/Release-notes-for-0.55.0.md
@@ -245,7 +245,7 @@ used to force fallback for specific subprojects.
 Example:
 
 ```
-meson builddir/ --force-fallback-for=foo,bar
+meson setup builddir/ --force-fallback-for=foo,bar
 ```
 
 ## Implicit dependency fallback

--- a/docs/markdown/Release-notes-for-0.56.0.md
+++ b/docs/markdown/Release-notes-for-0.56.0.md
@@ -154,13 +154,13 @@ foo = 'other val'
 ```
 
 ```console
-meson builddir/ --native-file my.ini
+meson setup builddir/ --native-file my.ini
 ```
 
 Will result in the option foo having the value `other val`,
 
 ```console
-meson builddir/ --native-file my.ini -Dfoo='different val'
+meson setup builddir/ --native-file my.ini -Dfoo='different val'
 ```
 
 Will result in the option foo having the value `different val`,

--- a/docs/markdown/Release-notes-for-0.57.0.md
+++ b/docs/markdown/Release-notes-for-0.57.0.md
@@ -187,7 +187,7 @@ For example:
 ```sh
 git clone https://github.com/myproject
 cd myproject/subprojects/mysubproject
-meson builddir
+meson setup builddir
 meson dist -C builddir
 ```
 

--- a/docs/markdown/Using-multiple-build-directories.md
+++ b/docs/markdown/Using-multiple-build-directories.md
@@ -39,7 +39,7 @@ builds as fast as possible. This is the default project type for
 Meson, so setting it up is simple.
 
     mkdir builddir
-    meson builddir
+    meson setup builddir
 
 Another common setup is to build with debug and optimizations to, for
 example, run performance tests. Setting this up is just as simple.
@@ -51,7 +51,7 @@ For systems where the default compiler is GCC, we would like to
 compile with Clang, too. So let's do that.
 
     mkdir buildclang
-    CC=clang CXX=clang++ meson buildclang
+    CC=clang CXX=clang++ meson setup buildclang
 
 You can add cross builds, too. As an example, let's set up a Linux ->
 Windows cross compilation build using MinGW.
@@ -84,7 +84,7 @@ The steps to run it with Meson are very simple.
 
     rm -rf buildscan
     mkdir buildscan
-    scan-build meson buildscan
+    scan-build meson setup buildscan
     cd buildscan
     scan-build ninja
 

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -121,11 +121,13 @@ class CommandLineParser:
         return 0
 
     def run(self, args):
+        implicit_setup_command_notice = False
         pending_python_deprecation_notice = False
         # If first arg is not a known command, assume user wants to run the setup
         # command.
         known_commands = list(self.commands.keys()) + ['-h', '--help']
         if not args or args[0] not in known_commands:
+            implicit_setup_command_notice = True
             args = ['setup'] + args
 
         # Hidden commands have their own parser instead of using the global one
@@ -190,6 +192,9 @@ class CommandLineParser:
                 mlog.exception(e)
             return 2
         finally:
+            if implicit_setup_command_notice:
+                mlog.warning('Running the setup command as `meson [options]` instead of '
+                             '`meson setup [options]` is ambiguous and deprecated.', fatal=False)
             if pending_python_deprecation_notice:
                 mlog.notice('You are using Python 3.6 which is EOL. Starting with v0.62.0, '
                             'Meson will require Python 3.7 or newer', fatal=False)

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -635,7 +635,7 @@ def _run_test(test: TestDef,
               should_fail: str) -> TestResult:
     gen_start = time.time()
     # Configure in-process
-    gen_args = []  # type: T.List[str]
+    gen_args = ['setup']
     if 'prefix' not in test.do_not_set_opts:
         gen_args += ['--prefix', 'x:/usr'] if mesonlib.is_windows() else ['--prefix', '/usr']
     if 'libdir' not in test.do_not_set_opts:

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -59,7 +59,7 @@ class BasePlatformTests(TestCase):
         self.meson_native_files = []
         self.meson_cross_files = []
         self.meson_command = python_command + [get_meson_script()]
-        self.setup_command = self.meson_command + self.meson_args
+        self.setup_command = self.meson_command + ['setup'] + self.meson_args
         self.mconf_command = self.meson_command + ['configure']
         self.mintro_command = self.meson_command + ['introspect']
         self.wrap_command = self.meson_command + ['wrap']
@@ -205,7 +205,7 @@ class BasePlatformTests(TestCase):
         self.privatedir = os.path.join(self.builddir, 'meson-private')
         if inprocess:
             try:
-                returncode, out, err = run_configure_inprocess(self.meson_args + args + extra_args, override_envvars)
+                returncode, out, err = run_configure_inprocess(['setup'] + self.meson_args + args + extra_args, override_envvars)
             except Exception as e:
                 if not allow_fail:
                     self._print_meson_log()


### PR DESCRIPTION
This is ambiguous, if the build directory has the same name as a subcommand then we end up running the subcommand. It also means we have a hard time adding *new* subcommands, because if it is a popular name of a build directory then suddenly scripts that try to set up a build directory end up running a subcommand instead.

The fact that we support this at all is a legacy design. Back in the day, the "meson" program was for setting up a build directory and all other tools were their own entry points, e.g. `mesontest` or `mesonconf`. Then in commit fa278f351fe3d6924b4d1961f77b5b4a36e133f8 we migrated to the subcommand mechanism. So, for backwards compatibility, we made those tools print a warning and then invoke `meson <tool>`. We also made the `meson` tool default to setup.

However, we only warned for the other tools whose entry points were eventually deleted. We never warned for setup itself, we just continued to silently default to setup if no tool was provided.

`meson setup` has worked since 0.42, which is 5 years old this week. It's available essentially everywhere. No one needs to use the old backwards-compatible invocation method, but it continues to drag down our ability to innovate. Let's finally do what we should have done a long time ago, and sunset it.