### PR TITLE
minstall: do not trample install_mode by rpath fixer

### DIFF
--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -693,7 +693,6 @@ class Installer:
                 raise MesonException(f'File {fname!r} could not be found')
             elif os.path.isfile(fname):
                 file_copied = self.do_copyfile(fname, outname, makedirs=(dm, outdir))
-                self.set_mode(outname, install_mode, d.install_umask)
                 if should_strip and d.strip_bin is not None:
                     if fname.endswith('.jar'):
                         self.log('Not stripping jar target: {}'.format(os.path.basename(fname)))
@@ -723,6 +722,8 @@ class Installer:
                         pass
                     else:
                         raise
+                # file mode needs to be set last, after strip/depfixer editing
+                self.set_mode(outname, install_mode, d.install_umask)
 
 def rebuild_all(wd: str) -> bool:
     if not (Path(wd) / 'build.ninja').is_file():

--- a/test cases/common/190 install_mode/meson.build
+++ b/test cases/common/190 install_mode/meson.build
@@ -51,6 +51,7 @@ install_man('foo.1',
 executable('trivialprog',
   sources : 'trivial.c',
   install : true,
+  build_rpath: meson.current_build_dir(),
   install_mode : ['rwxr-sr-x', 'root', 'root'])
 
 # test install_mode in static_library


### PR DESCRIPTION
install_mode can include the setuid bit, which has the special property (mentioned in the set_mode logic for minstall itself) of needing to come last, because it "will get wiped by chmod" (or at least chown).

In fact, it's not just chown that wipes setuid, but other changes as well, such as the file contents. This is not an issue for install_data / custom_target, but for compiled outputs, we run depfixer to handle rpaths. This may or may not cause edits to the binary, depending on whether we have a build rpath to wipe, or an install rpath to add. (We also may run `strip`, but that external program already has its own mode restoration logic.)

Fix this by switching the order of operations around, so that setting the permissions happens last.

Fixes https://github.com/void-linux/void-packages/issues/38682