### PR TITLE
pkgconfig: Variables can be a single string

### DIFF
--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -109,7 +109,9 @@ def _lower_strlist(input: T.List[str]) -> T.List[str]:
     return [i.lower() for i in input]
 
 
-def variables_validator(contents: T.Union[T.List[str], T.Dict[str, str]]) -> T.Optional[str]:
+def variables_validator(contents: T.Union[str, T.List[str], T.Dict[str, str]]) -> T.Optional[str]:
+    if isinstance(contents, str):
+        contents = [contents]
     if isinstance(contents, dict):
         variables = contents
     else:
@@ -130,7 +132,9 @@ def variables_validator(contents: T.Union[T.List[str], T.Dict[str, str]]) -> T.O
     return None
 
 
-def variables_convertor(contents: T.Union[T.List[str], T.Dict[str, str]]) -> T.Dict[str, str]:
+def variables_convertor(contents: T.Union[str, T.List[str], T.Dict[str, str]]) -> T.Dict[str, str]:
+    if isinstance(contents, str):
+        contents = [contents]
     if isinstance(contents, dict):
         return contents
     variables = {}
@@ -433,7 +437,9 @@ SOURCES_KW: KwargInfo[T.List[T.Union[str, File, CustomTarget, CustomTargetIndex,
 
 VARIABLES_KW: KwargInfo[T.Dict[str, str]] = KwargInfo(
     'variables',
-    (ContainerTypeInfo(list, str), ContainerTypeInfo(dict, str)),
+    # str is listified by validator/convertor, cannot use listify=True here because
+    # that would listify dict too.
+    (str, ContainerTypeInfo(list, str), ContainerTypeInfo(dict, str)), # type: ignore
     validator=variables_validator,
     convertor=variables_convertor,
     default={},

--- a/test cases/common/44 pkgconfig-gen/meson.build
+++ b/test cases/common/44 pkgconfig-gen/meson.build
@@ -169,3 +169,10 @@ pkgg.generate(
   version : libver,
   variables: ['bar=${libdir}/bar']
 )
+
+# Regression test: variables kwarg should listify single string value
+pkgg.generate(
+  name : 'libvartest3',
+  description : 'Check that variables can be single string',
+  variables: 'foo=bar',
+)

--- a/test cases/common/44 pkgconfig-gen/test.json
+++ b/test cases/common/44 pkgconfig-gen/test.json
@@ -8,6 +8,7 @@
     {"type": "file", "file": "usr/lib/pkgconfig/libhello.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/libvartest.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/libvartest2.pc"},
+    {"type": "file", "file": "usr/lib/pkgconfig/libvartest3.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/simple2.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/simple3.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/simple5.pc"},


### PR DESCRIPTION
It used to be listified and libxml2 wrap relies on that.