### PR TITLE
macos: map arm64e to aarch64, map "whole" architecture strings

### DIFF
--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -708,16 +708,25 @@ def darwin_get_object_archs(objpath: str) -> 'ImmutableListProtocol[str]':
         mlog.debug(f'lipo {objpath}: {stderr}')
         return None
     stdo = stdo.rsplit(': ', 1)[1]
+
     # Convert from lipo-style archs to meson-style CPUs
-    stdo = stdo.replace('i386', 'x86')
-    stdo = stdo.replace('arm64', 'aarch64')
-    stdo = stdo.replace('ppc7400', 'ppc')
-    stdo = stdo.replace('ppc970', 'ppc')
+    map_arch = {
+        'i386' : 'x86',
+        'arm64' : 'aarch64',
+        'arm64e' : 'aarch64',
+        'ppc7400' : 'ppc',
+        'ppc970' : 'ppc',
+    }
+    lipo_archs = stdo.split()
+    meson_archs = []
+    for lipo_arch in lipo_archs:
+        meson_archs.append(map_arch.get(lipo_arch, lipo_arch))
+
     # Add generic name for armv7 and armv7s
     if 'armv7' in stdo:
-        stdo += ' arm'
-    return stdo.split()
+        meson_archs.append('arm')
 
+    return meson_archs
 
 def detect_vcs(source_dir: T.Union[str, Path]) -> T.Optional[T.Dict[str, str]]:
     vcs_systems = [


### PR DESCRIPTION
Some macos libraries use arm64e instead of arm64 as architecture. Due to the
string replace approach taken so far, we'd end up with aarch64e as
architecture, which the rest of meson doesn't know.

Move architecture mapping to map whole architecture names and add arm64e ->
aarch64 mapping.

This change doesn't touch the case for armv7[s], where we add arm, rather than
replace armv7[s], but it's certainly not in line with the other mappings.

Fixes: #9493