### PR TITLE
mtest: reconfigure before loading tests

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1560,6 +1560,16 @@ class TestHarness:
         startdir = os.getcwd()
         try:
             os.chdir(self.options.wd)
+
+            # Before loading build / test data, make sure that the build
+            # configuration does not need to be regenerated. This needs to
+            # happen before rebuild_deps(), because we need the correct list of
+            # tests and their dependencies to compute
+            if not self.options.no_rebuild:
+                ret = subprocess.run(self.ninja + ['build.ninja']).returncode
+                if ret != 0:
+                    raise TestException(f'Could not configure {self.options.wd!r}')
+
             self.build_data = build.load(os.getcwd())
             if not self.options.setup:
                 self.options.setup = self.build_data.test_setup_default_name

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1523,6 +1523,19 @@ class TestHarness:
             if namebase:
                 self.logfile_base += '-' + namebase.replace(' ', '_')
 
+        self.load_metadata()
+
+        ss = set()
+        for t in self.tests:
+            for s in t.suite:
+                ss.add(s)
+        self.suites = list(ss)
+
+    def get_console_logger(self) -> 'ConsoleLogger':
+        assert self.console_logger
+        return self.console_logger
+
+    def load_metadata(self) -> None:
         startdir = os.getcwd()
         try:
             os.chdir(self.options.wd)
@@ -1535,16 +1548,6 @@ class TestHarness:
                 self.tests = self.load_tests('meson_test_setup.dat')
         finally:
             os.chdir(startdir)
-
-        ss = set()
-        for t in self.tests:
-            for s in t.suite:
-                ss.add(s)
-        self.suites = list(ss)
-
-    def get_console_logger(self) -> 'ConsoleLogger':
-        assert self.console_logger
-        return self.console_logger
 
     def load_tests(self, file_name: str) -> T.List[TestSerialisation]:
         datafile = Path('meson-private') / file_name


### PR DESCRIPTION
Contains a few preparatory commits, and then the fix for the referenced commit.

Two things to call out, from the commit messages:

1) mtest: pull detection of ninja into TestHarness

    This changes the exit code in case ninja isn't found from 125 to 127, which
    seems more appropriate given the justification for returning 125 (to make git
    bisect run skip that commit). If we can't find ninja we'll not succeed in
    other commits either.

2) mtest: Run ninja build.ninja before loading tests

    One issue with this is that that we will now output more useless ninja output
    when nothing needs to be done (the "Entering directory" part is not repeated,
    as we happen to be in the build directory already). It likely is worth
    removing that output, perhaps by testing if anything needs to be done with
    ninja -n, but that seems better addressed separately.

Fixes: #9852