### PR TITLE
tests: remove compiler requirement in various unneeded cases

### DIFF
--- a/test cases/common/10 man install/meson.build
+++ b/test cases/common/10 man install/meson.build
@@ -1,4 +1,4 @@
-project('man install', 'c')
+project('man install')
 m1 = install_man('foo.1')
 m2 = install_man('bar.2')
 m3 = install_man('foo.fr.1', locale: 'fr')

--- a/test cases/common/101 testframework options/meson.build
+++ b/test cases/common/101 testframework options/meson.build
@@ -1,7 +1,7 @@
 # normally run only from run_tests.py or run_project_tests.py
 # else do like
 # meson build '-Dtestoption=A string with spaces' -Dother_one=true -Dcombo_opt=one -Dprefix=/usr -Dlibdir=lib -Dbackend=ninja -Dwerror=True
-project('options', 'c')
+project('options')
 
 assert(get_option('testoption') == 'A string with spaces', 'Incorrect value for testoption option.')
 assert(get_option('other_one') == true, 'Incorrect value for other_one option.')

--- a/test cases/common/106 multiple dir configure file/meson.build
+++ b/test cases/common/106 multiple dir configure file/meson.build
@@ -1,4 +1,4 @@
-project('multiple dir configure file', 'c')
+project('multiple dir configure file')
 
 subdir('subdir')
 

--- a/test cases/common/108 ternary/meson.build
+++ b/test cases/common/108 ternary/meson.build
@@ -1,4 +1,4 @@
-project('ternary operator', 'c')
+project('ternary operator')
 
 x = true
 one = true ? 1 : error('False branch should not be evaluated')

--- a/test cases/common/109 custom target capture/meson.build
+++ b/test cases/common/109 custom target capture/meson.build
@@ -1,4 +1,4 @@
-project('custom target', 'c')
+project('custom target')
 
 python3 = import('python3').find_python()
 

--- a/test cases/common/111 pathjoin/meson.build
+++ b/test cases/common/111 pathjoin/meson.build
@@ -1,4 +1,4 @@
-project('pathjoin', 'c')
+project('pathjoin')
 
 # Test string-args form since that is the canonical way
 assert(join_paths('foo')               == 'foo', 'Single argument join is broken')

--- a/test cases/common/113 interpreter copy mutable var on assignment/meson.build
+++ b/test cases/common/113 interpreter copy mutable var on assignment/meson.build
@@ -1,4 +1,4 @@
-project('foo', 'c')
+project('foo')
 
 a = configuration_data()
 a.set('HELLO', 1)

--- a/test cases/common/114 skip/meson.build
+++ b/test cases/common/114 skip/meson.build
@@ -1,3 +1,3 @@
-project('skip', 'c')
+project('skip')
 
 error('MESON_SKIP_TEST this test is always skipped.')

--- a/test cases/common/12 data/meson.build
+++ b/test cases/common/12 data/meson.build
@@ -1,4 +1,4 @@
-project('data install test', 'c',
+project('data install test',
   default_options : ['install_umask=preserve'])
 install_data(sources : 'datafile.dat', install_dir : 'share/progname')
 # Some file in /etc that is only read-write by root; add a sticky bit for testing

--- a/test cases/common/123 custom target directory install/meson.build
+++ b/test cases/common/123 custom target directory install/meson.build
@@ -1,4 +1,4 @@
-project('custom-target-dir-install', 'c')
+project('custom-target-dir-install')
 
 docgen = find_program('docgen.py')
 

--- a/test cases/common/136 empty build file/meson.build
+++ b/test cases/common/136 empty build file/meson.build
@@ -1,2 +1,2 @@
-project('subdir with empty meson.build test', 'c')
+project('subdir with empty meson.build test')
 subdir('subdir')

--- a/test cases/common/139 mesonintrospect from scripts/meson.build
+++ b/test cases/common/139 mesonintrospect from scripts/meson.build
@@ -1,4 +1,4 @@
-project('mesonintrospect from scripts', 'c')
+project('mesonintrospect from scripts')
 
 python = import('python3').find_python()
 

--- a/test cases/common/140 custom target multiple outputs/meson.build
+++ b/test cases/common/140 custom target multiple outputs/meson.build
@@ -1,4 +1,4 @@
-project('multiple outputs install', 'c')
+project('multiple outputs install')
 
 gen = find_program('generator.py')
 

--- a/test cases/common/143 list of file sources/meson.build
+++ b/test cases/common/143 list of file sources/meson.build
@@ -1,4 +1,4 @@
-project('test', 'c')
+project('test')
 
 mod_py = import('python3')
 python = mod_py.find_python()

--- a/test cases/common/162 subdir if_found/meson.build
+++ b/test cases/common/162 subdir if_found/meson.build
@@ -1,4 +1,4 @@
-project('subdir if found', 'c')
+project('subdir if found')
 
 found_dep = declare_dependency()
 not_found_dep = dependency('nonexisting', required : false)

--- a/test cases/common/163 default options prefix dependent defaults/meson.build
+++ b/test cases/common/163 default options prefix dependent defaults/meson.build
@@ -1,1 +1,1 @@
-project('default options prefix dependent defaults ', 'c', default_options : ['sharedstatedir=/sharedstate', 'prefix=/usr'])
+project('default options prefix dependent defaults ', default_options : ['sharedstatedir=/sharedstate', 'prefix=/usr'])

--- a/test cases/common/166 yield/meson.build
+++ b/test cases/common/166 yield/meson.build
@@ -1,4 +1,4 @@
-project('yield_options', 'c')
+project('yield_options')
 
 subproject('sub')
 

--- a/test cases/common/166 yield/subprojects/sub/meson.build
+++ b/test cases/common/166 yield/subprojects/sub/meson.build
@@ -1,4 +1,4 @@
-project('subbie', 'c')
+project('subbie')
 
 assert(get_option('unshared_option') == 'three', 'Unshared option has wrong value in subproject.')
 assert(get_option('shared_option') == 'two', 'Shared option has wrong value in subproject.')

--- a/test cases/common/176 subproject version/meson.build
+++ b/test cases/common/176 subproject version/meson.build
@@ -1,4 +1,4 @@
-project('subproject version', 'c',
+project('subproject version',
   version : '2.3.4',
   license: 'mylicense')
 

--- a/test cases/common/176 subproject version/subprojects/a/meson.build
+++ b/test cases/common/176 subproject version/subprojects/a/meson.build
@@ -1,4 +1,4 @@
-project('mysubproject', 'c',
+project('mysubproject',
   version : '1.0.0',
   license : 'sublicense')
 

--- a/test cases/common/177 subdir_done/meson.build
+++ b/test cases/common/177 subdir_done/meson.build
@@ -1,7 +1,7 @@
 # Should run, even though main.cpp does not exist and we call error in the last line.
 # subdir_done jumps to end, so both lines are not executed.
 
-project('example exit', 'cpp')
+project('example exit')
 
 if true
   subdir_done()

--- a/test cases/common/191 subproject array version/meson.build
+++ b/test cases/common/191 subproject array version/meson.build
@@ -1,3 +1,3 @@
-project('master', 'c')
+project('master')
 
 x = subproject('foo', version : ['>=1.0.0', '<2.0'])

--- a/test cases/common/191 subproject array version/subprojects/foo/meson.build
+++ b/test cases/common/191 subproject array version/subprojects/foo/meson.build
@@ -1,1 +1,1 @@
-project('foo', 'c', version : '1.0.0')
+project('foo', version : '1.0.0')

--- a/test cases/common/193 feature option disabled/meson.build
+++ b/test cases/common/193 feature option disabled/meson.build
@@ -1,4 +1,4 @@
-project('feature user option', 'c',
+project('feature user option',
   default_options : ['auto_features=disabled'])
 
 feature_opts = get_option('auto_features')

--- a/test cases/common/202 custom target build by default/meson.build
+++ b/test cases/common/202 custom target build by default/meson.build
@@ -1,4 +1,4 @@
-project('custom-target-dir-install', 'c')
+project('custom-target-dir-install')
 
 docgen = find_program('docgen.py')
 

--- a/test cases/common/217 test priorities/meson.build
+++ b/test cases/common/217 test priorities/meson.build
@@ -1,4 +1,4 @@
-project('test priorities', 'c')
+project('test priorities')
 
 test_prog = find_program('testprog.py')
 

--- a/test cases/common/232 dependency allow_fallback/meson.build
+++ b/test cases/common/232 dependency allow_fallback/meson.build
@@ -1,4 +1,4 @@
-project('subproject fallback', 'c')
+project('subproject fallback')
 
 foob_dep = dependency('foob', allow_fallback: true, required: false)
 assert(foob_dep.found())

--- a/test cases/common/237 fstrings/meson.build
+++ b/test cases/common/237 fstrings/meson.build
@@ -1,4 +1,4 @@
-project('meson-test', 'c')
+project('meson-test')
 
 n = 10
 m = 'bar'

--- a/test cases/common/238 dependency include_type inconsistency/meson.build
+++ b/test cases/common/238 dependency include_type inconsistency/meson.build
@@ -1,4 +1,4 @@
-project('test', 'c', 'cpp')
+project('test')
 
 foo_dep = subproject('foo').get_variable('foo_dep')
 

--- a/test cases/common/238 dependency include_type inconsistency/subprojects/baz/meson.build
+++ b/test cases/common/238 dependency include_type inconsistency/subprojects/baz/meson.build
@@ -1,3 +1,3 @@
-project('baz', 'cpp')
+project('baz')
 
 baz_dep = declare_dependency()

--- a/test cases/common/238 dependency include_type inconsistency/subprojects/foo/meson.build
+++ b/test cases/common/238 dependency include_type inconsistency/subprojects/foo/meson.build
@@ -1,4 +1,4 @@
-project('foo', 'c', 'cpp')
+project('foo')
 
 baz_dep = dependency('baz',
     fallback: ['baz', 'baz_dep'],

--- a/test cases/common/239 includedir violation/meson.build
+++ b/test cases/common/239 includedir violation/meson.build
@@ -1,4 +1,4 @@
-project('foo', 'c')
+project('foo')
 
 # It is fine to include the root source dir
 include_directories('.')

--- a/test cases/common/239 includedir violation/subprojects/sub/meson.build
+++ b/test cases/common/239 includedir violation/subprojects/sub/meson.build
@@ -1,3 +1,3 @@
-project('subproj', 'c')
+project('subproj')
 
 include_directories('.')

--- a/test cases/common/240 dependency native host == build/meson.build
+++ b/test cases/common/240 dependency native host == build/meson.build
@@ -1,4 +1,4 @@
-project('foo', 'c')
+project('foo')
 
 if meson.is_cross_build()
   error('MESON_SKIP_TEST Test does not make sense for cross builds')

--- a/test cases/common/242 custom target feed/meson.build
+++ b/test cases/common/242 custom target feed/meson.build
@@ -1,4 +1,4 @@
-project('custom target feed', 'c')
+project('custom target feed')
 
 python3 = import('python3').find_python()
 

--- a/test cases/common/246 dependency fallbacks/meson.build
+++ b/test cases/common/246 dependency fallbacks/meson.build
@@ -1,4 +1,4 @@
-project('dependency fallbacks', 'c')
+project('dependency fallbacks')
 
 # pkg-config has 'libpng' but cmake has 'png' and we have a 'png' subproject
 # for platforms that have neither.

--- a/test cases/common/26 find program/meson.build
+++ b/test cases/common/26 find program/meson.build
@@ -1,4 +1,4 @@
-project('find program', 'c')
+project('find program')
 
 if build_machine.system() == 'windows'
   # Things Windows does not provide:
@@ -15,6 +15,7 @@ else
    arguments : ['@INPUT@', '@OUTPUT@'])
 
   generated = gen.process('source.in')
+  add_languages('c', required: true)
   e = executable('prog', generated)
   test('external exe', e)
 endif

--- a/test cases/common/34 logic ops/meson.build
+++ b/test cases/common/34 logic ops/meson.build
@@ -1,4 +1,4 @@
-project('logicopts', 'c')
+project('logicopts')
 
 t = true
 f = false

--- a/test cases/common/35 string operations/meson.build
+++ b/test cases/common/35 string operations/meson.build
@@ -1,4 +1,4 @@
-project('string formatting', 'c')
+project('string formatting')
 
 templ = '@0@bar@1@'
 

--- a/test cases/common/43 subproject options/meson.build
+++ b/test cases/common/43 subproject options/meson.build
@@ -1,4 +1,4 @@
-project('suboptions', 'c')
+project('suboptions')
 
 subproject('subproject')
 

--- a/test cases/common/43 subproject options/subprojects/subproject/meson.build
+++ b/test cases/common/43 subproject options/subprojects/subproject/meson.build
@@ -1,4 +1,4 @@
-project('subproject', 'c')
+project('subproject')
 
 if get_option('opt')
   error('option set when it should be unset.')

--- a/test cases/common/49 custom target/meson.build
+++ b/test cases/common/49 custom target/meson.build
@@ -1,4 +1,4 @@
-project('custom target', 'c')
+project('custom target')
 
 python = find_program('python3', required : false)
 if not python.found()

--- a/test cases/common/56 array methods/meson.build
+++ b/test cases/common/56 array methods/meson.build
@@ -1,4 +1,4 @@
-project('array methods', 'c')
+project('array methods')
 
 empty = []
 one = ['abc']

--- a/test cases/common/59 install subdir/meson.build
+++ b/test cases/common/59 install subdir/meson.build
@@ -1,4 +1,4 @@
-project('install a whole subdir', 'c',
+project('install a whole subdir',
   default_options : ['install_umask=preserve'])
 
 # A subdir with an exclusion:

--- a/test cases/common/61 number arithmetic/meson.build
+++ b/test cases/common/61 number arithmetic/meson.build
@@ -1,4 +1,4 @@
-project('number arithmetic', 'c')
+project('number arithmetic')
 
 if 6 + 4 != 10
   error('Number addition is broken')

--- a/test cases/common/62 string arithmetic/meson.build
+++ b/test cases/common/62 string arithmetic/meson.build
@@ -1,4 +1,4 @@
-project('string arithmetic', 'c', meson_version: '>=0.62.0')
+project('string arithmetic', meson_version: '>=0.62.0')
 
 assert('foo' + 'bar' == 'foobar')
 assert('foo' + 'bar' + 'baz' == 'foobarbaz')

--- a/test cases/common/63 array arithmetic/meson.build
+++ b/test cases/common/63 array arithmetic/meson.build
@@ -1,4 +1,4 @@
-project('array arithmetic', 'c')
+project('array arithmetic')
 
 array1 = ['foo', 'bar']
 array2 = ['qux', 'baz']

--- a/test cases/common/64 arithmetic bidmas/meson.build
+++ b/test cases/common/64 arithmetic bidmas/meson.build
@@ -1,4 +1,4 @@
-project('arithmetic bidmas', 'c')
+project('arithmetic bidmas')
 
 if 5 * 3 - 6 / 2 + 1 != 13
   error('Arithmetic bidmas broken')

--- a/test cases/common/67 modules/meson.build
+++ b/test cases/common/67 modules/meson.build
@@ -1,4 +1,4 @@
-project('module test', 'c')
+project('module test')
 
 modtest = import('modtest')
 modtest.print_hello()

--- a/test cases/common/69 configure file in custom target/meson.build
+++ b/test cases/common/69 configure file in custom target/meson.build
@@ -1,4 +1,4 @@
-project('conf file in custom target', 'c')
+project('conf file in custom target')
 
 subdir('inc')
 subdir('src')

--- a/test cases/common/70 external test program/meson.build
+++ b/test cases/common/70 external test program/meson.build
@@ -1,3 +1,3 @@
-project('test is external', 'c')
+project('test is external')
 
 test('external', find_program('mytest.py'), args : ['correct'])

--- a/test cases/common/71 ctarget dependency/meson.build
+++ b/test cases/common/71 ctarget dependency/meson.build
@@ -1,4 +1,4 @@
-project('custom target dependency', 'c')
+project('custom target dependency')
 
 # Sometimes custom targets do not take input files
 # but instead do globbing or some similar wackiness.

--- a/test cases/common/84 plusassign/meson.build
+++ b/test cases/common/84 plusassign/meson.build
@@ -1,4 +1,4 @@
-project('plusassign', 'c')
+project('plusassign')
 
 x = []
 

--- a/test cases/common/85 skip subdir/meson.build
+++ b/test cases/common/85 skip subdir/meson.build
@@ -1,3 +1,3 @@
-project('foo', 'c')
+project('foo')
 
 subdir('subdir1/subdir2')

--- a/test cases/common/97 find program path/meson.build
+++ b/test cases/common/97 find program path/meson.build
@@ -1,4 +1,4 @@
-project('find program', 'c')
+project('find program')
 
 python = import('python3').find_python()
 

--- a/test cases/failing/10 out of bounds/meson.build
+++ b/test cases/failing/10 out of bounds/meson.build
@@ -1,4 +1,4 @@
-project('out of bounds', 'c')
+project('out of bounds')
 
 x = []
 y = x[0]

--- a/test cases/failing/104 no fallback/meson.build
+++ b/test cases/failing/104 no fallback/meson.build
@@ -1,2 +1,2 @@
-project('no fallback', 'c')
+project('no fallback')
 foob_dep = dependency('foob', allow_fallback: false, required: true)

--- a/test cases/failing/105 feature require/meson.build
+++ b/test cases/failing/105 feature require/meson.build
@@ -1,2 +1,2 @@
-project('no fallback', 'c')
+project('no fallback')
 foo = get_option('reqfeature').require(false, error_message: 'frobnicator not available')

--- a/test cases/failing/106 feature require.bis/meson.build
+++ b/test cases/failing/106 feature require.bis/meson.build
@@ -1,2 +1,2 @@
-project('no fallback', 'c')
+project('no fallback')
 foo = get_option('reqfeature').require(false)

--- a/test cases/failing/108 enter subdir twice/meson.build
+++ b/test cases/failing/108 enter subdir twice/meson.build
@@ -1,3 +1,3 @@
-project('subdir2', 'c')
+project('subdir2')
 subdir('sub')
 subdir('sub')

--- a/test cases/failing/109 invalid fstring/meson.build
+++ b/test cases/failing/109 invalid fstring/meson.build
@@ -1,3 +1,3 @@
-project('invalid-fstring', 'c')
+project('invalid-fstring')
 
 z = f'invalid fstring: @foo@'

--- a/test cases/failing/11 object arithmetic/meson.build
+++ b/test cases/failing/11 object arithmetic/meson.build
@@ -1,3 +1,3 @@
-project('object arithmetic', 'c')
+project('object arithmetic')
 
 foo = '5' + meson

--- a/test cases/failing/112 cmake executable dependency/meson.build
+++ b/test cases/failing/112 cmake executable dependency/meson.build
@@ -1,4 +1,4 @@
-project('cmake-executable-dependency', ['c', 'cpp'])
+project('cmake-executable-dependency', 'c')
 
 if not find_program('cmake', required: false).found()
   error('MESON_SKIP_TEST CMake is not installed')

--- a/test cases/failing/12 string arithmetic/meson.build
+++ b/test cases/failing/12 string arithmetic/meson.build
@@ -1,3 +1,3 @@
-project('string arithmetic', 'c')
+project('string arithmetic')
 
 foo = 'a' + 3

--- a/test cases/failing/122 cmake subproject error/meson.build
+++ b/test cases/failing/122 cmake subproject error/meson.build
@@ -1,4 +1,4 @@
-project('cmake-executable-dependency', ['c', 'cpp'])
+project('cmake-executable-dependency')
 
 if not find_program('cmake', required: false).found()
   error('MESON_SKIP_TEST CMake is not installed')

--- a/test cases/failing/13 array arithmetic/meson.build
+++ b/test cases/failing/13 array arithmetic/meson.build
@@ -1,3 +1,3 @@
-project('array arithmetic', 'c')
+project('array arithmetic')
 
 foo = ['a', 'b'] * 3

--- a/test cases/failing/14 invalid option name/meson.build
+++ b/test cases/failing/14 invalid option name/meson.build
@@ -1,1 +1,1 @@
-project('foo', 'c')
+project('foo')

--- a/test cases/failing/18 wrong plusassign/meson.build
+++ b/test cases/failing/18 wrong plusassign/meson.build
@@ -1,3 +1,3 @@
-project('false plusassign', 'c')
+project('false plusassign')
 
 3 += 4

--- a/test cases/failing/20 version/meson.build
+++ b/test cases/failing/20 version/meson.build
@@ -1,1 +1,1 @@
-project('version mismatch', 'c', meson_version : '>100.0.0')
+project('version mismatch', meson_version : '>100.0.0')

--- a/test cases/failing/21 subver/meson.build
+++ b/test cases/failing/21 subver/meson.build
@@ -1,3 +1,3 @@
-project('master', 'c')
+project('master')
 
 x = subproject('foo', version : '>1.0.0')

--- a/test cases/failing/21 subver/subprojects/foo/meson.build
+++ b/test cases/failing/21 subver/subprojects/foo/meson.build
@@ -1,1 +1,1 @@
-project('foo', 'c', version : '1.0.0')
+project('foo', version : '1.0.0')

--- a/test cases/failing/22 assert/meson.build
+++ b/test cases/failing/22 assert/meson.build
@@ -1,3 +1,3 @@
-project('failing assert', 'c')
+project('failing assert')
 
 assert(false, 'I am fail.')

--- a/test cases/failing/24 int conversion/meson.build
+++ b/test cases/failing/24 int conversion/meson.build
@@ -1,3 +1,3 @@
-project('int conversion', 'c')
+project('int conversion')
 
 'notanumber'.to_int()

--- a/test cases/failing/25 badlang/meson.build
+++ b/test cases/failing/25 badlang/meson.build
@@ -1,3 +1,3 @@
-project('badlang', 'c')
+project('badlang')
 
 add_languages('nonexisting')

--- a/test cases/failing/26 output subdir/meson.build
+++ b/test cases/failing/26 output subdir/meson.build
@@ -1,4 +1,4 @@
-project('outdir path', 'c')
+project('outdir path')
 
 configure_file(input : 'foo.in',
   output : 'subdir/foo',

--- a/test cases/failing/27 noprog use/meson.build
+++ b/test cases/failing/27 noprog use/meson.build
@@ -1,4 +1,4 @@
-project('using not found exe', 'c')
+project('using not found exe')
 
 nope = find_program('nonexisting', required : false)
 

--- a/test cases/failing/28 no crossprop/meson.build
+++ b/test cases/failing/28 no crossprop/meson.build
@@ -1,3 +1,3 @@
-project('no crossprop', 'c')
+project('no crossprop')
 
 message(meson.get_cross_property('nonexisting'))

--- a/test cases/failing/29 nested ternary/meson.build
+++ b/test cases/failing/29 nested ternary/meson.build
@@ -1,3 +1,3 @@
-project('nested ternary', 'c')
+project('nested ternary')
 
 x = true ? (false ? 1 : 0) : 2

--- a/test cases/failing/3 missing subdir/meson.build
+++ b/test cases/failing/3 missing subdir/meson.build
@@ -1,3 +1,3 @@
-project('subdir', 'c')
+project('subdir')
 
 subdir('missing')

--- a/test cases/failing/30 invalid man extension/meson.build
+++ b/test cases/failing/30 invalid man extension/meson.build
@@ -1,2 +1,2 @@
-project('man install', 'c')
+project('man install')
 m1 = install_man('foo.a1')

--- a/test cases/failing/31 no man extension/meson.build
+++ b/test cases/failing/31 no man extension/meson.build
@@ -1,2 +1,2 @@
-project('man install', 'c')
+project('man install')
 m1 = install_man('foo')

--- a/test cases/failing/33 non-root subproject/meson.build
+++ b/test cases/failing/33 non-root subproject/meson.build
@@ -1,3 +1,3 @@
-project('non-root subproject', 'c')
+project('non-root subproject')
 
 subdir('some')

--- a/test cases/failing/34 dependency not-required then required/meson.build
+++ b/test cases/failing/34 dependency not-required then required/meson.build
@@ -1,4 +1,4 @@
-project('dep-test', 'c', version : '1.0')
+project('dep-test', version : '1.0')
 
 foo_dep = dependency('foo-bar-xyz-12.3', required : false)
 bar_dep = dependency('foo-bar-xyz-12.3')

--- a/test cases/failing/38 prefix absolute/meson.build
+++ b/test cases/failing/38 prefix absolute/meson.build
@@ -1,2 +1,2 @@
-project('prefix-abs', 'c',
+project('prefix-abs',
   default_options : ['prefix=some/path/notabs'])

--- a/test cases/failing/4 missing meson.build/meson.build
+++ b/test cases/failing/4 missing meson.build/meson.build
@@ -1,3 +1,3 @@
-project('missing meson.build', 'c')
+project('missing meson.build')
 
 subdir('subdir')

--- a/test cases/failing/40 custom target plainname many inputs/meson.build
+++ b/test cases/failing/40 custom target plainname many inputs/meson.build
@@ -1,4 +1,4 @@
-project('plain name many inputs', 'c')
+project('plain name many inputs')
 
 catfiles = find_program('catfiles.py')
 

--- a/test cases/failing/41 custom target outputs not matching install_dirs/meson.build
+++ b/test cases/failing/41 custom target outputs not matching install_dirs/meson.build
@@ -1,4 +1,4 @@
-project('outputs not matching install_dirs', 'c')
+project('outputs not matching install_dirs')
 
 gen = find_program('generator.py')
 

--- a/test cases/failing/43 abs subdir/meson.build
+++ b/test cases/failing/43 abs subdir/meson.build
@@ -1,4 +1,4 @@
-project('abs subdir', 'c')
+project('abs subdir')
 
 # For some reason people insist on doing this, probably
 # because Make has taught them to never rely on anything.

--- a/test cases/failing/44 abspath to srcdir/meson.build
+++ b/test cases/failing/44 abspath to srcdir/meson.build
@@ -1,3 +1,3 @@
-project('meson', 'c')
+project('meson')
 
 include_directories(meson.current_source_dir())

--- a/test cases/failing/5 misplaced option/meson.build
+++ b/test cases/failing/5 misplaced option/meson.build
@@ -1,3 +1,3 @@
-project('misplaced option', 'c')
+project('misplaced option')
 
 option('dummy', type : 'string')

--- a/test cases/failing/50 inconsistent comparison/meson.build
+++ b/test cases/failing/50 inconsistent comparison/meson.build
@@ -1,4 +1,4 @@
-project('kwarg before arg', 'c')
+project('kwarg before arg')
 
 # All of these should fail, though only the first one will error out if
 # everything's working correctly.

--- a/test cases/failing/55 or on new line/meson.build
+++ b/test cases/failing/55 or on new line/meson.build
@@ -1,4 +1,4 @@
-project('silent_or', 'c')
+project('silent_or')
 
 if get_option('foo') == 'true'
         or get_option('foo') == 'auto'

--- a/test cases/failing/6 missing incdir/meson.build
+++ b/test cases/failing/6 missing incdir/meson.build
@@ -1,3 +1,3 @@
-project('missing incdir', 'c')
+project('missing incdir')
 
 inc = include_directories('nosuchdir')

--- a/test cases/failing/60 subproj filegrab/meson.build
+++ b/test cases/failing/60 subproj filegrab/meson.build
@@ -1,4 +1,4 @@
-project('mainproj', 'c')
+project('mainproj')
 
 # Try to grab a file from a parent project.
 

--- a/test cases/failing/62 grab sibling/meson.build
+++ b/test cases/failing/62 grab sibling/meson.build
@@ -1,3 +1,3 @@
-project('master', 'c')
+project('master')
 
 subproject('a')

--- a/test cases/failing/62 grab sibling/subprojects/b/meson.build
+++ b/test cases/failing/62 grab sibling/subprojects/b/meson.build
@@ -1,3 +1,3 @@
-projecT('b', 'c')
+projecT('b')
 
 message('I do nothing.')

--- a/test cases/failing/67 install_data rename bad size/meson.build
+++ b/test cases/failing/67 install_data rename bad size/meson.build
@@ -1,3 +1,3 @@
-project('data install test', 'c')
+project('data install test')
 
 install_data(['file1.txt', 'file2.txt'], rename : 'just one name')

--- a/test cases/failing/69 dual override/meson.build
+++ b/test cases/failing/69 dual override/meson.build
@@ -1,4 +1,4 @@
-project('yo dawg', 'c')
+project('yo dawg')
 
 p = find_program('overrides.py')
 meson.override_find_program('override', p)

--- a/test cases/failing/7 go to subproject/meson.build
+++ b/test cases/failing/7 go to subproject/meson.build
@@ -1,3 +1,3 @@
-project('fff', 'c')
+project('fff')
 
 subdir('subprojects')

--- a/test cases/failing/70 override used/meson.build
+++ b/test cases/failing/70 override used/meson.build
@@ -1,4 +1,4 @@
-project('overridde an already found exe', 'c')
+project('overridde an already found exe')
 
 old = find_program('something.py')
 replacement = find_program('other.py')

--- a/test cases/failing/71 run_command unclean exit/meson.build
+++ b/test cases/failing/71 run_command unclean exit/meson.build
@@ -1,4 +1,4 @@
-project('run_command unclean exit', 'c')
+project('run_command unclean exit')
 
 rcprog = find_program('./returncode.py')
 run_command(rcprog, '1', check : true)

--- a/test cases/failing/75 non ascii in ascii encoded configure file/meson.build
+++ b/test cases/failing/75 non ascii in ascii encoded configure file/meson.build
@@ -1,4 +1,4 @@
-project('non acsii to ascii encoding', 'c')
+project('non acsii to ascii encoding')
 # Writing a non ASCII character with a ASCII encoding should fail
 conf9 = configuration_data()
 conf9.set('var', 'д')

--- a/test cases/failing/8 recursive/meson.build
+++ b/test cases/failing/8 recursive/meson.build
@@ -1,3 +1,3 @@
-project('recursive', 'c')
+project('recursive')
 
 a = subproject('a')

--- a/test cases/failing/8 recursive/subprojects/a/meson.build
+++ b/test cases/failing/8 recursive/subprojects/a/meson.build
@@ -1,3 +1,3 @@
-project('a', 'c')
+project('a')
 
 b = subproject('b')

--- a/test cases/failing/8 recursive/subprojects/b/meson.build
+++ b/test cases/failing/8 recursive/subprojects/b/meson.build
@@ -1,3 +1,3 @@
-project('b', 'c')
+project('b')
 
 a = subproject('a')

--- a/test cases/failing/82 gtest dependency with version/meson.build
+++ b/test cases/failing/82 gtest dependency with version/meson.build
@@ -1,4 +1,4 @@
-project('gtest dependency with version', ['c', 'cpp'])
+project('gtest dependency with version', 'cpp')
 
 if not dependency('gtest', method: 'system', required: false).found()
    error('MESON_SKIP_TEST test requires gtest')

--- a/test cases/failing/97 subdir parse error/meson.build
+++ b/test cases/failing/97 subdir parse error/meson.build
@@ -1,2 +1,2 @@
-project('subdir false plusassign', 'c')
+project('subdir false plusassign')
 subdir('subdir')


### PR DESCRIPTION
Compiled languages are Meson's bread and butter, but hardly required. This is convenient, because many test caases specifically, do not care about testing the compiler interactions.

In such cases, we can skip doing compiler lookups which aren't used, as they only slow down test setup.