### PR TITLE
Git subproject revision checking

### DIFF
--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -394,19 +394,22 @@ class Runner:
 
     def update(self) -> bool:
         self.log(f'Updating {self.wrap.name}...')
+        success = False
         if self.wrap.type == 'file':
-            return self.update_file()
+            success = self.update_file()
         elif self.wrap.type == 'git':
-            return self.update_git()
+            success = self.update_git()
         elif self.wrap.type == 'hg':
-            return self.update_hg()
+            success = self.update_hg()
         elif self.wrap.type == 'svn':
-            return self.update_svn()
+            success = self.update_svn()
         elif self.wrap.type is None:
             self.log('  -> Cannot update subproject with no wrap file')
         else:
             self.log('  -> Cannot update', self.wrap.type, 'subproject')
-        return True
+        if success:
+            self.wrap.update_hash_cache(self.wrap_resolver.dirname)
+        return success
 
     def checkout(self) -> bool:
         options = T.cast('CheckoutArguments', self.options)

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -132,7 +132,9 @@ class PackageDefinition:
         self.redirected = False
         if self.has_wrap:
             self.parse_wrap()
-        self.directory = self.values.get('directory', self.name)
+            self.directory = self.values.get('directory', self.name)
+            with open(fname, 'r', encoding='utf-8') as file:
+                self.wrapfile_hash = hashlib.sha256(file.read().encode('utf-8')).hexdigest()
         if os.path.dirname(self.directory):
             raise WrapException('Directory key must be a name and not a path')
         if self.type and self.type not in ALL_TYPES:
@@ -220,6 +222,14 @@ class PackageDefinition:
             return self.values[key]
         except KeyError:
             raise WrapException(f'Missing key {key!r} in {self.basename}')
+
+    def get_hashfile(self, subproject_directory: str) -> str:
+        return os.path.join(subproject_directory, '.meson-subproject-wrap-hash.txt')
+
+    def update_hash_cache(self, subproject_directory: str) -> None:
+        if self.has_wrap:
+            with open(self.get_hashfile(subproject_directory), 'w', encoding='utf-8') as file:
+                file.write(self.wrapfile_hash + '\n')
 
 def get_directory(subdir_root: str, packagename: str) -> str:
     fname = os.path.join(subdir_root, packagename + '.wrap')
@@ -367,6 +377,7 @@ class Resolver:
 
         # The directory is there and has meson.build? Great, use it.
         if method == 'meson' and os.path.exists(meson_file):
+            self.validate()
             return rel_path
         if method == 'cmake' and os.path.exists(cmake_file):
             return rel_path
@@ -402,6 +413,11 @@ class Resolver:
             raise WrapException('Subproject exists but has no meson.build file')
         if method == 'cmake' and not os.path.exists(cmake_file):
             raise WrapException('Subproject exists but has no CMakeLists.txt file')
+
+        # At this point, the subproject has been successfully resolved for the
+        # first time so save off the hash of the entire wrap file for future
+        # reference.
+        self.wrap.update_hash_cache(self.dirname)
 
         return rel_path
 
@@ -503,6 +519,26 @@ class Resolver:
             push_url = self.wrap.values.get('push-url')
             if push_url:
                 verbose_git(['remote', 'set-url', '--push', 'origin', push_url], self.dirname, check=True)
+
+    def validate(self) -> None:
+        # This check is only for subprojects with wraps.
+        if not self.wrap.has_wrap:
+            return
+
+        # Retrieve original hash, if it exists.
+        hashfile = self.wrap.get_hashfile(self.dirname)
+        if os.path.isfile(hashfile):
+            with open(hashfile, 'r', encoding='utf-8') as file:
+                expected_hash = file.read().strip()
+        else:
+            # If stored hash doesn't exist then don't warn.
+            return
+
+        actual_hash = self.wrap.wrapfile_hash
+
+        # Compare hashes and warn the user if they don't match.
+        if expected_hash != actual_hash:
+            mlog.warning(f'Subproject {self.wrap.name}\'s revision may be out of date; its wrap file has changed since it was first configured')
 
     def is_git_full_commit_id(self, revno: str) -> bool:
         result = False

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -127,6 +127,7 @@ class PackageDefinition:
         self.directory = self.name
         # must be lowercase for consistency with dep=variable assignment
         self.provided_deps[self.name.lower()] = None
+        # What the original file name was before redirection
         self.original_filename = fname
         self.redirected = False
         if self.has_wrap:
@@ -137,7 +138,6 @@ class PackageDefinition:
         if self.type and self.type not in ALL_TYPES:
             raise WrapException(f'Unknown wrap type {self.type!r}')
         self.filesdir = os.path.join(os.path.dirname(self.filename), 'packagefiles')
-        # What the original file name was before redirection
 
     def parse_wrap(self) -> None:
         try:

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -3733,9 +3733,25 @@ class AllPlatformTests(BasePlatformTests):
                   patch_directory = wrap_git_builddef
                   revision = master
                 '''.format(upstream_uri)))
-            self.init(srcdir)
+            out = self.init(srcdir)
             self.build()
             self.run_tests()
+
+            # Make sure the warning does not occur on the first init.
+            out_of_date_warning = 'revision may be out of date'
+            self.assertNotIn(out_of_date_warning, out)
+
+            # Change the wrap's revisions, reconfigure, and make sure it does
+            # warn on the reconfigure.
+            with open(os.path.join(srcdir, 'subprojects', 'wrap_git.wrap'), 'w', encoding='utf-8') as f:
+                f.write(textwrap.dedent('''
+                  [wrap-git]
+                  url = {}
+                  patch_directory = wrap_git_builddef
+                  revision = not-master
+                '''.format(upstream_uri)))
+            out = self.init(srcdir, extra_args='--reconfigure')
+            self.assertIn(out_of_date_warning, out)
 
     def test_extract_objects_custom_target_no_warning(self):
         testdir = os.path.join(self.common_test_dir, '22 object extraction')


### PR DESCRIPTION
Motivated by [this comment](https://github.com/mesonbuild/meson/issues/10348#issuecomment-1135107044) on #10348. This PR resolves #10348.

55624565adaba206aad79c5536e4bb04b2221c27 adds a cache file for subprojects with a wrap file. It saves off a the hash of the wrap file when it first executes the subproject. Then when configuring the subproject, it checks the current hash against the saved hash. If they differ, then it warns the user that the subproject may be out-of-date.

73e95a0c82e83d99d3d898ea9d6d029bdda4c672 is not really related, just a bit of housekeeping I came across while working on this.