### PR TITLE
compilers: Detect Vala compiler for the requested machine

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -949,7 +949,7 @@ def detect_cython_compiler(env: 'Environment', for_machine: MachineChoice) -> Co
 
 def detect_vala_compiler(env: 'Environment', for_machine: MachineChoice) -> Compiler:
     from .vala import ValaCompiler
-    exelist = env.lookup_binary_entry(MachineChoice.BUILD, 'vala')
+    exelist = env.lookup_binary_entry(for_machine, 'vala')
     is_cross = env.is_cross_build(for_machine)
     info = env.machines[for_machine]
     if exelist is None:


### PR DESCRIPTION
Instead of unconditionally detecting it for the build machine.
The rationale for making this use the build machine was wrong.
The valac transpiler needs search paths for the host machine
(specifically, the `--vapidir` default paths).

This reverts part of af846a109f70b0b063b9d3c7a30225a22949bb48.