### PR TITLE
Better error message when custom_targets has duplicates in the output kwarg

### DIFF
--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -295,6 +295,13 @@ OVERRIDE_OPTIONS_KW: KwargInfo[T.List[str]] = KwargInfo(
 
 
 def _output_validator(outputs: T.List[str]) -> T.Optional[str]:
+    output_set = set(outputs)
+    if len(output_set) != len(outputs):
+        seen = set()
+        for el in outputs:
+            if el in seen:
+                return f"contains {el!r} multiple times, but no duplicates are allowed."
+            seen.add(el)
     for i in outputs:
         if i == '':
             return 'Output must not be empty.'


### PR DESCRIPTION
This patch changes 

```
ERROR: Multiple producers for Ninja target "file.c". Please rename your targets.
```
to 
```
meson.build:4:0: ERROR: custom_target: "output" keyword argument contains "file.c" multiple times
```