### PR TITLE
tests: Add a test for a target with no sources

### DIFF
--- a/test cases/warning/8 target with no sources/meson.build
+++ b/test cases/warning/8 target with no sources/meson.build
@@ -1,0 +1,3 @@
+project('no sources', 'c')
+
+static_library('no sources')

--- a/test cases/warning/8 target with no sources/test.json
+++ b/test cases/warning/8 target with no sources/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "WARNING: Build target no sources has no sources. This was never supposed to be allowed but did because of a bug, support will be removed in a future release of Meson"
+    }
+  ]
+}


### PR DESCRIPTION
Since this was broken for a long time, we should have a test for it, as pointed out by @jon-turney 