### PR TITLE
Add keyword for setting the mode of a file copied by fs.copyfile in the build directory

### DIFF
--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -235,6 +235,7 @@ Has the following keyword arguments:
    - install_dir `str`: Where to install the file to
    - install_tag: `str`: the install tag to assign to this target
    - install_mode `array[str | int]`: the mode to install the file with
+   - build_mode `array[str | int]`: the mode of the file in the build directory
 
 returns:
    - a [[custom_target]] object

--- a/docs/markdown/snippets/fs_copyfile.md
+++ b/docs/markdown/snippets/fs_copyfile.md
@@ -15,3 +15,6 @@ Will create a file in the current build directory called `file.txt`
 fs.copyfile('file.txt', 'outfile.txt')
 ```
 Will create a copy renamed to `outfile.txt`
+
+Additionally, `fs.copyfile` allows setting the mode of the file in the build directory,
+which may be useful when copying scripts.

--- a/mesonbuild/scripts/copy.py
+++ b/mesonbuild/scripts/copy.py
@@ -9,6 +9,7 @@ This is easier than trying to detect whether to use copy, cp, or something else.
 from __future__ import annotations
 
 import argparse
+import os
 import shutil
 import typing as T
 
@@ -18,16 +19,20 @@ if T.TYPE_CHECKING:
     class Args(Protocol):
         source: str
         dest: str
+        file_mode: int
 
 
 def run(raw_args: T.List[str]) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('source')
     parser.add_argument('dest')
+    parser.add_argument('--file-mode', action='store', help='permission bits as suitable to pass to `os.chmod`', type=int)
     args: Args = parser.parse_args(raw_args)
 
     try:
         shutil.copy2(args.source, args.dest)
+        if args.file_mode:
+            os.chmod(args.dest, args.file_mode)
     except Exception:
         return 1
     return 0

--- a/mesonbuild/scripts/copy.py
+++ b/mesonbuild/scripts/copy.py
@@ -6,13 +6,28 @@
 This is easier than trying to detect whether to use copy, cp, or something else.
 """
 
+from __future__ import annotations
+
+import argparse
 import shutil
 import typing as T
 
+if T.TYPE_CHECKING:
+    from typing_extensions import Protocol
 
-def run(args: T.List[str]) -> int:
+    class Args(Protocol):
+        source: str
+        dest: str
+
+
+def run(raw_args: T.List[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('source')
+    parser.add_argument('dest')
+    args: Args = parser.parse_args(raw_args)
+
     try:
-        shutil.copy2(args[0], args[1])
+        shutil.copy2(args.source, args.dest)
     except Exception:
         return 1
     return 0

--- a/test cases/common/14 configure file/check_file.py
+++ b/test cases/common/14 configure file/check_file.py
@@ -1,9 +1,21 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+import argparse
 import os
-import sys
+import stat
+import typing as T
 
-def permit_osx_workaround(m1,  m2):
+if T.TYPE_CHECKING:
+    from typing_extensions import Protocol
+
+    class Args(Protocol):
+        source: str
+        dest: T.Optional[str]
+        build_mode: T.Optional[str]
+
+
+def permit_osx_workaround(m1: int,  m2: int) -> bool:
     import platform
     if platform.system().lower() != 'darwin':
         return False
@@ -13,22 +25,35 @@ def permit_osx_workaround(m1,  m2):
         return False
     return True
 
-if len(sys.argv) == 2:
-    assert os.path.exists(sys.argv[1])
-elif len(sys.argv) == 3:
-    f1 = sys.argv[1]
-    f2 = sys.argv[2]
-    m1 = os.stat(f1).st_mtime_ns
-    m2 = os.stat(f2).st_mtime_ns
-    # Compare only os.stat()
-    if m1 != m2:
-        # Under macOS the lower four digits sometimes get assigned
-        # zero, even though shutil.copy2 should preserve metadata.
-        # Just have to accept it, I guess.
-        if not permit_osx_workaround(m1, m2):
-            raise RuntimeError(f'mtime of {f1!r} ({m1!r}) != mtime of {f2!r} ({m2!r})')
-    import filecmp
-    if not filecmp.cmp(f1, f2):
-        raise RuntimeError(f'{f1!r} != {f2!r}')
-else:
-    raise AssertionError
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('source')
+    parser.add_argument('dest', nargs='?', default=None)
+    parser.add_argument('--build-mode', action='store', default=None)
+    args: Args = parser.parse_args()
+
+    if not args.dest:
+        assert os.path.exists(args.source)
+        check = args.source
+    else:
+        m1 = os.stat(args.source).st_mtime_ns
+        m2 = os.stat(args.dest).st_mtime_ns
+        # Compare only os.stat()
+        if m1 != m2:
+            # Under macOS the lower four digits sometimes get assigned
+            # zero, even though shutil.copy2 should preserve metadata.
+            # Just have to accept it, I guess.
+            if not permit_osx_workaround(m1, m2):
+                raise RuntimeError(f'mtime of {args.source!r} ({m1!r}) != mtime of {args.dest!r} ({m2!r})')
+        import filecmp
+        if not filecmp.cmp(args.source, args.dest):
+            raise RuntimeError(f'{args.source!r} != {args.dest!r}')
+        check = args.dest
+
+    if args.build_mode:
+        mode = oct(os.stat(check).st_mode)[-3:]
+        assert mode == args.build_mode, f'{mode} == {args.build_mode}'
+
+
+if __name__ == "__main__":
+    main()

--- a/test cases/common/14 configure file/meson.build
+++ b/test cases/common/14 configure file/meson.build
@@ -210,8 +210,8 @@ endif
 # Test the fs replacement
 # Test copying of an empty configuration data object
 inf = 'invalid-utf8.bin.in'
-outf = fs.copyfile(inf, 'invalid-utf8-1.bin')
-test('fs.copyfile string', check_file, args: [files(inf), outf])
+outf = fs.copyfile(inf, 'invalid-utf8-1.bin', build_mode : 'r--rw--wx')
+test('fs.copyfile string', check_file, args: [files(inf), outf, '--build-mode', '463'])
 
 # Test with default outname of string
 outf = fs.copyfile(inf)


### PR DESCRIPTION
There are cases where users need to set the mode of a copied file in the build directory. This is actually rather painful to do in a cross platform way, so it would be nice if meson just provided this functionality. Since we already have everything in place to do this for install_mode, it's rather trivial to add support.

See https://gitea.treehouse.systems/ariadne/pkgconf/pulls/246, for an example of where this is useful.