### PR TITLE
i18n: Fix source root in Gettext targets for subprojects

### DIFF
--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -49,6 +49,7 @@ class ModuleState:
                                     interpreter.environment.get_build_dir())
         self.subproject = interpreter.subproject
         self.subdir = interpreter.subdir
+        self.root_subdir = interpreter.root_subdir
         self.current_lineno = interpreter.current_lineno
         self.environment = interpreter.environment
         self.project_name = interpreter.build.project_name

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1185,8 +1185,8 @@ class GnomeModule(ExtensionModule):
         scan_command += list(scan_external_ldflags)
 
         if self._gir_has_option('--sources-top-dirs'):
-            scan_command += ['--sources-top-dirs', os.path.join(state.environment.get_source_dir(), self.interpreter.subproject_dir, state.subproject)]
-            scan_command += ['--sources-top-dirs', os.path.join(state.environment.get_build_dir(), self.interpreter.subproject_dir, state.subproject)]
+            scan_command += ['--sources-top-dirs', os.path.join(state.environment.get_source_dir(), state.root_subdir)]
+            scan_command += ['--sources-top-dirs', os.path.join(state.environment.get_build_dir(), state.root_subdir)]
 
         if '--warn-error' in scan_command:
             FeatureDeprecated.single_use('gnome.generate_gir argument --warn-error', '0.55.0',

--- a/mesonbuild/modules/hotdoc.py
+++ b/mesonbuild/modules/hotdoc.py
@@ -177,9 +177,8 @@ class HotdocTargetBuilder:
 
         value, _ = self.get_value([list, str], 'gi_c_source_roots', default=[], force_list=True)
         value.extend([
-            os.path.join(self.state.environment.get_source_dir(),
-                         self.interpreter.subproject_dir, self.state.subproject),
-            os.path.join(self.state.environment.get_build_dir(), self.interpreter.subproject_dir, self.state.subproject)
+            os.path.join(self.sourcedir, self.state.root_subdir),
+            os.path.join(self.builddir, self.state.root_subdir)
         ])
 
         self.cmd += ['--gi-c-source-roots'] + value

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -256,10 +256,13 @@ class I18nModule(ExtensionModule):
 
         extra_arg = '--extra-args=' + '@@'.join(extra_args) if extra_args else None
 
+        source_root = path.join(state.source_root, state.root_subdir)
+        subdir = path.relpath(state.subdir, start=state.root_subdir) if state.subdir else None
+
         potargs = state.environment.get_build_command() + ['--internal', 'gettext', 'pot', pkg_arg]
-        potargs.append(f'--source-root={state.source_root}')
-        if state.subdir:
-            potargs.append(f'--subdir={state.subdir}')
+        potargs.append(f'--source-root={source_root}')
+        if subdir:
+            potargs.append(f'--subdir={subdir}')
         if datadirs:
             potargs.append(datadirs)
         if extra_arg:
@@ -302,9 +305,9 @@ class I18nModule(ExtensionModule):
         targets.append(allgmotarget)
 
         updatepoargs = state.environment.get_build_command() + ['--internal', 'gettext', 'update_po', pkg_arg]
-        updatepoargs.append(f'--source-root={state.source_root}')
-        if state.subdir:
-            updatepoargs.append(f'--subdir={state.subdir}')
+        updatepoargs.append(f'--source-root={source_root}')
+        if subdir:
+            updatepoargs.append(f'--subdir={subdir}')
         if lang_arg:
             updatepoargs.append(lang_arg)
         if datadirs:


### PR DESCRIPTION
Gettext should search for input files relative to the (sub)project source root, not the global source root.