### PR TITLE
dependencies: log the real reason for a dependency lookup failing

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -406,7 +406,7 @@ class ExternalDependency(Dependency, HasNativeKwarg):
                 mlog.log(*found_msg)
 
                 if self.required:
-                    m = f'Unknown version of dependency {self.name!r}, but need {self.version_reqs!r}.'
+                    m = f'Unknown version, but need {self.version_reqs!r}.'
                     raise DependencyException(m)
 
             else:
@@ -423,7 +423,7 @@ class ExternalDependency(Dependency, HasNativeKwarg):
                     mlog.log(*found_msg)
 
                     if self.required:
-                        m = 'Invalid version of dependency, need {!r} {!r} found {!r}.'
+                        m = 'Invalid version, need {!r} {!r} found {!r}.'
                         raise DependencyException(m.format(self.name, not_found, self.version))
                     return
 

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -387,7 +387,8 @@ class ExternalDependency(Dependency, HasNativeKwarg):
     def log_info(self) -> str:
         return ''
 
-    def log_tried(self) -> str:
+    @staticmethod
+    def log_tried() -> str:
         return ''
 
     # Check if dependency version meets the requirements
@@ -602,7 +603,8 @@ class SystemDependency(ExternalDependency):
         super().__init__(DependencyTypeName('system'), env, kwargs, language=language)
         self.name = name
 
-    def log_tried(self) -> str:
+    @staticmethod
+    def log_tried() -> str:
         return 'system'
 
 
@@ -615,5 +617,6 @@ class BuiltinDependency(ExternalDependency):
         super().__init__(DependencyTypeName('builtin'), env, kwargs, language=language)
         self.name = name
 
-    def log_tried(self) -> str:
+    @staticmethod
+    def log_tried() -> str:
         return 'builtin'

--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -617,8 +617,9 @@ class CMakeDependency(ExternalDependency):
         build_dir = self._setup_cmake_dir(cmake_file)
         return self.cmakebin.call(args, build_dir, env=env)
 
-    def log_tried(self) -> str:
-        return self.type_name
+    @staticmethod
+    def log_tried() -> str:
+        return 'cmake'
 
     def log_details(self) -> str:
         modules = [self._original_module_name(x) for x in self.found_modules]

--- a/mesonbuild/dependencies/configtool.py
+++ b/mesonbuild/dependencies/configtool.py
@@ -149,8 +149,9 @@ class ConfigToolDependency(ExternalDependency):
         mlog.debug(f'Got config-tool variable {variable_name} : {variable}')
         return variable
 
-    def log_tried(self) -> str:
-        return self.type_name
+    @staticmethod
+    def log_tried() -> str:
+        return 'config-tool'
 
     def get_variable(self, *, cmake: T.Optional[str] = None, pkgconfig: T.Optional[str] = None,
                      configtool: T.Optional[str] = None, internal: T.Optional[str] = None,

--- a/mesonbuild/dependencies/detect.py
+++ b/mesonbuild/dependencies/detect.py
@@ -113,8 +113,11 @@ def find_external_dependency(name: str, env: 'Environment', kwargs: T.Dict[str, 
             d._check_version()
             pkgdep.append(d)
         except DependencyException as e:
+            assert isinstance(c, functools.partial), 'for mypy'
+            bettermsg = f'Dependency lookup for {name} with method {c.func.log_tried()!r} failed: {e}'
+            mlog.debug(bettermsg)
+            e.args = (bettermsg,)
             pkg_exc.append(e)
-            mlog.debug(str(e))
         else:
             pkg_exc.append(None)
             details = d.log_details()

--- a/mesonbuild/dependencies/detect.py
+++ b/mesonbuild/dependencies/detect.py
@@ -178,8 +178,7 @@ def _build_external_dependency_list(name: str, env: 'Environment', for_machine: 
         if isinstance(packages[lname], type):
             entry1 = T.cast('T.Type[ExternalDependency]', packages[lname])  # mypy doesn't understand isinstance(..., type)
             if issubclass(entry1, ExternalDependency):
-                # TODO: somehow make mypy understand that entry1(env, kwargs) is OK...
-                func: T.Callable[[], 'ExternalDependency'] = lambda: entry1(env, kwargs)  # type: ignore
+                func: T.Callable[[], 'ExternalDependency'] = functools.partial(entry1, env, kwargs)
                 dep = [func]
         else:
             entry2 = T.cast('T.Union[DependencyFactory, WrappedFactoryFunc]', packages[lname])

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -115,9 +115,6 @@ class GTestDependencySystem(SystemDependency):
         else:
             return 'building self'
 
-    def log_tried(self) -> str:
-        return 'system'
-
 
 class GTestDependencyPC(PkgConfigDependency):
 
@@ -185,9 +182,6 @@ class GMockDependencySystem(SystemDependency):
             return 'prebuilt'
         else:
             return 'building self'
-
-    def log_tried(self) -> str:
-        return 'system'
 
 
 class GMockDependencyPC(PkgConfigDependency):

--- a/mesonbuild/dependencies/factory.py
+++ b/mesonbuild/dependencies/factory.py
@@ -100,15 +100,15 @@ class DependencyFactory:
         ] = {
             # Just attach the correct name right now, either the generic name
             # or the method specific name.
-            DependencyMethods.EXTRAFRAMEWORK: lambda env, kwargs: framework_class(framework_name or name, env, kwargs),
-            DependencyMethods.PKGCONFIG: lambda env, kwargs: pkgconfig_class(pkgconfig_name or name, env, kwargs),
-            DependencyMethods.CMAKE: lambda env, kwargs: cmake_class(cmake_name or name, env, kwargs),
-            DependencyMethods.SYSTEM: lambda env, kwargs: system_class(name, env, kwargs),
-            DependencyMethods.BUILTIN: lambda env, kwargs: builtin_class(name, env, kwargs),
+            DependencyMethods.EXTRAFRAMEWORK: functools.partial(framework_class, framework_name or name),
+            DependencyMethods.PKGCONFIG: functools.partial(pkgconfig_class, pkgconfig_name or name),
+            DependencyMethods.CMAKE: functools.partial(cmake_class, cmake_name or name),
+            DependencyMethods.SYSTEM: functools.partial(system_class, name),
+            DependencyMethods.BUILTIN: functools.partial(builtin_class, name),
             DependencyMethods.CONFIG_TOOL: None,
         }
         if configtool_class is not None:
-            self.classes[DependencyMethods.CONFIG_TOOL] = lambda env, kwargs: configtool_class(name, env, kwargs)
+            self.classes[DependencyMethods.CONFIG_TOOL] = functools.partial(configtool_class, name)
 
     @staticmethod
     def _process_method(method: DependencyMethods, env: 'Environment', for_machine: MachineChoice) -> bool:

--- a/mesonbuild/dependencies/framework.py
+++ b/mesonbuild/dependencies/framework.py
@@ -115,5 +115,6 @@ class ExtraFrameworkDependency(ExternalDependency):
     def log_info(self) -> str:
         return self.framework_path or ''
 
-    def log_tried(self) -> str:
+    @staticmethod
+    def log_tried() -> str:
         return 'framework'

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -393,9 +393,6 @@ class ShadercDependency(SystemDependency):
 
                 break
 
-    def log_tried(self) -> str:
-        return 'system'
-
 
 class CursesConfigToolDependency(ConfigToolDependency):
 

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -284,7 +284,8 @@ class Python3DependencySystem(SystemDependency):
         self.version = sysconfig.get_config_var('py_version')
         self.is_found = True
 
-    def log_tried(self) -> str:
+    @staticmethod
+    def log_tried() -> str:
         return 'sysconfig'
 
 class PcapDependencyConfigTool(ConfigToolDependency):

--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -479,8 +479,9 @@ class PkgConfigDependency(ExternalDependency):
         # a path rather than the raw dlname
         return os.path.basename(dlname)
 
-    def log_tried(self) -> str:
-        return self.type_name
+    @staticmethod
+    def log_tried() -> str:
+        return 'pkgconfig'
 
     def get_variable(self, *, cmake: T.Optional[str] = None, pkgconfig: T.Optional[str] = None,
                      configtool: T.Optional[str] = None, internal: T.Optional[str] = None,

--- a/mesonbuild/dependencies/platform.py
+++ b/mesonbuild/dependencies/platform.py
@@ -54,5 +54,6 @@ class AppleFrameworks(ExternalDependency):
     def log_info(self) -> str:
         return ', '.join(self.frameworks)
 
-    def log_tried(self) -> str:
+    @staticmethod
+    def log_tried() -> str:
         return 'framework'

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -50,9 +50,6 @@ class GLDependencySystem(SystemDependency):
             # FIXME: Detect version using self.clib_compiler
             return
 
-    def log_tried(self) -> str:
-        return 'system'
-
 class GnuStepDependency(ConfigToolDependency):
 
     tools = ['gnustep-config']
@@ -236,9 +233,6 @@ class VulkanDependencySystem(SystemDependency):
                 for lib in libs:
                     self.link_args.append(lib)
                 return
-
-    def log_tried(self) -> str:
-        return 'system'
 
 gl_factory = DependencyFactory(
     'gl',

--- a/test cases/failing/78 framework dependency with version/test.json
+++ b/test cases/failing/78 framework dependency with version/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "test cases/failing/78 framework dependency with version/meson.build:8:0: ERROR: Unknown version of dependency 'appleframeworks', but need ['>0']."
+      "line": "test cases/failing/78 framework dependency with version/meson.build:8:0: ERROR: Dependency lookup for appleframeworks with method 'framework' failed: Unknown version, but need ['>0']."
     }
   ]
 }

--- a/test cases/failing/80 gl dependency with version/test.json
+++ b/test cases/failing/80 gl dependency with version/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "test cases/failing/80 gl dependency with version/meson.build:9:0: ERROR: Unknown version of dependency 'gl', but need ['>0']."
+      "line": "test cases/failing/80 gl dependency with version/meson.build:9:0: ERROR: Dependency lookup for gl with method 'system' failed: Unknown version, but need ['>0']."
     }
   ]
 }

--- a/test cases/failing/81 threads dependency with version/test.json
+++ b/test cases/failing/81 threads dependency with version/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "test cases/failing/81 threads dependency with version/meson.build:3:0: ERROR: Unknown version of dependency 'threads', but need ['>0']."
+      "line": "test cases/failing/81 threads dependency with version/meson.build:3:0: ERROR: Dependency lookup for threads with method 'system' failed: Unknown version, but need ['>0']."
     }
   ]
 }


### PR DESCRIPTION
In the debug logs, always log if a dependency lookup raises a DependencyException. In the `required: false` case, this information  would otherwise disappear forever, and we would just not even log that we tried it -- it doesn't appear in "(tried x, y and z)".

In the `required: true` case, we would re-raise the first exception if it failed to be detected. Update the raise message with the same information we print to the debug logs, indicating which dependency and which method was used in the failing attempt.
