### PR TITLE
Add LLVM_CONFIG support

### DIFF
--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -132,6 +132,7 @@ ENV_VAR_PROG_MAP: T.Mapping[str, str] = {
     'pkg-config': 'PKG_CONFIG',
     'make': 'MAKE',
     'vapigen': 'VAPIGEN',
+    'llvm-config': 'LLVM_CONFIG',
 }
 
 # Deprecated environment variables mapped from the new variable to the old one


### PR DESCRIPTION
Allow meson to use the llvm-config specified by the LLVM_CONFIG environment variable if it is defined. This was discussed in https://github.com/anarazel/postgres/pull/60#discussion_r952040174