### PR TITLE
env2mfile: reuse logical lists of interesting facts from meson itself

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -107,6 +107,7 @@ CFLAGS_MAPPING: T.Mapping[str, str] = {
     'vala': 'VALAFLAGS',
     'rust': 'RUSTFLAGS',
     'cython': 'CYTHONFLAGS',
+    'cs': 'CSFLAGS', # This one might not be standard.
 }
 
 # All these are only for C-linkable languages; see `clink_langs` above.

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -90,7 +90,7 @@ CPU_FAMILIES_64_BIT = [
 ]
 
 # Map from language identifiers to environment variables.
-ENV_VAR_PROG_MAP: T.Mapping[str, str] = {
+ENV_VAR_COMPILER_MAP: T.Mapping[str, str] = {
     # Compilers
     'c': 'CC',
     'cpp': 'CXX',
@@ -110,7 +110,10 @@ ENV_VAR_PROG_MAP: T.Mapping[str, str] = {
     'objc_ld': 'OBJC_LD',
     'objcpp_ld': 'OBJCXX_LD',
     'rust_ld': 'RUSTC_LD',
+}
 
+# Map from utility names to environment variables.
+ENV_VAR_TOOL_MAP: T.Mapping[str, str] = {
     # Binutils
     'ar': 'AR',
     'as': 'AS',
@@ -134,6 +137,8 @@ ENV_VAR_PROG_MAP: T.Mapping[str, str] = {
     'vapigen': 'VAPIGEN',
     'llvm-config': 'LLVM_CONFIG',
 }
+
+ENV_VAR_PROG_MAP = {**ENV_VAR_COMPILER_MAP, **ENV_VAR_TOOL_MAP}
 
 # Deprecated environment variables mapped from the new variable to the old one
 # Deprecated in 0.54.0


### PR DESCRIPTION
Meson internally knows about many languages and tools, and `*FLAGS` variables, and which languages to use them for. Instead of duplicating this logic, import it from `mesonbuild.*`

This logic was originally standalone, but now that it is merged into the Meson tree we can have a single source of truth.