### PR TITLE
Fix 2 typos in a single string which can be shown in error messages.

### DIFF
--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -111,7 +111,7 @@ class WindowsModule(ExtensionModule):
 
     @typed_pos_args('windows.compile_resources', varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex), min_varargs=1)
     @typed_kwargs(
-        'winddows.compile_resoures',
+        'windows.compile_resources',
         DEPEND_FILES_KW.evolve(since='0.47.0'),
         DEPENDS_KW.evolve(since='0.47.0'),
         INCLUDE_DIRECTORIES,


### PR DESCRIPTION
We had someone reporting a bug in our software build with this ugly typo (2 in one actually even! Double `d` and missing `c`) showing in the error message. I just thought I'd fix it. :-D