### PR TITLE
tests/7 gnome: Fix incorrect unref of GResource

### DIFF
--- a/test cases/frameworks/7 gnome/resources/generated-main.c
+++ b/test cases/frameworks/7 gnome/resources/generated-main.c
@@ -6,7 +6,7 @@
 #define EXPECTED "This is a generated resource.\n"
 
 int main(int argc, char **argv) {
-    GResource *res = generated_resources_get_resource();
+    generated_resources_get_resource();
     GError *err = NULL;
     GBytes *data = g_resources_lookup_data("/com/example/myprog/res3.txt",
             G_RESOURCE_LOOKUP_FLAGS_NONE, &err);
@@ -22,6 +22,5 @@ int main(int argc, char **argv) {
     }
     fprintf(stdout, "All ok.\n");
     g_bytes_unref(data);
-    g_resource_unref(res);
     return 0;
 }

--- a/test cases/frameworks/7 gnome/resources/simple-main.c
+++ b/test cases/frameworks/7 gnome/resources/simple-main.c
@@ -6,7 +6,8 @@
 #define EXPECTED "This is a resource.\n"
 
 int main(int argc, char **argv) {
-    GResource *res = simple_resources_get_resource();
+    simple_resources_get_resource();
+
     GError *err = NULL;
     GBytes *data = g_resources_lookup_data("/com/example/myprog/res1.txt",
             G_RESOURCE_LOOKUP_FLAGS_NONE, &err);
@@ -22,6 +23,5 @@ int main(int argc, char **argv) {
     }
     fprintf(stdout, "All ok.\n");
     g_bytes_unref(data);
-    g_resource_unref(res);
     return 0;
 }


### PR DESCRIPTION
The returned GResource is transfer-none, since the generated function
basically calls g_static_resource_get_resource(). It should not be
unreffed. Causes an abort on Debian:

`GLib-GIO:ERROR:../../../gio/gresource.c:1451:g_static_resource_fini: assertion failed: (g_atomic_int_get (&resource->ref_count) >= 2)`