### PR TITLE
Add Cython to Windows CI jobs on Azure

### DIFF
--- a/ci/run.ps1
+++ b/ci/run.ps1
@@ -91,6 +91,9 @@ python --version
 echo ""
 python -m pip --disable-pip-version-check install --upgrade pefile pytest-xdist pytest-subtests jsonschema coverage
 
+# Needed for running the Cython tests
+python -m pip --disable-pip-version-check install cython
+
 echo ""
 echo "=== Start running tests ==="
 # Starting from VS2019 Powershell(?) will fail the test run

--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
-import functools, json, os
+import functools, json, os, textwrap
 from pathlib import Path
 import typing as T
 
@@ -271,6 +271,29 @@ class PythonSystemDependency(SystemDependency, _PythonDependencyBase):
                         libpath = Path(f'python{vernum}.dll')
                 else:
                     libpath = Path('libs') / f'python{vernum}.lib'
+                    # For a debug build, pyconfig.h may force linking with
+                    # pythonX_d.lib (see meson#10776). This cannot be avoided
+                    # and won't work unless we also have a debug build of
+                    # Python itself (except with pybind11, which has an ugly
+                    # hack to work around this) - so emit a warning to explain
+                    # the cause of the expected link error.
+                    buildtype = self.env.coredata.get_option(mesonlib.OptionKey('buildtype'))
+                    assert isinstance(buildtype, str)
+                    debug = self.env.coredata.get_option(mesonlib.OptionKey('debug'))
+                    # `debugoptimized` buildtype may not set debug=True currently, see gh-11645
+                    is_debug_build = debug or buildtype == 'debug'
+                    vscrt_debug = False
+                    if mesonlib.OptionKey('b_vscrt') in self.env.coredata.options:
+                        vscrt = self.env.coredata.options[mesonlib.OptionKey('b_vscrt')].value
+                        if vscrt in {'mdd', 'mtd', 'from_buildtype', 'static_from_buildtype'}:
+                            vscrt_debug = True
+                    if is_debug_build and vscrt_debug and not self.variables.get('Py_DEBUG'):
+                        mlog.warning(textwrap.dedent('''\
+                            Using a debug build type with MSVC or an MSVC-compatible compiler
+                            when the Python interpreter is not also a debug build will almost
+                            certainly result in a failed build. Prefer using a release build
+                            type or a debug Python interpreter.
+                            '''))
             # base_prefix to allow for virtualenvs.
             lib = Path(self.variables.get('base_prefix')) / libpath
         elif self.platform == 'mingw':

--- a/test cases/cython/1 basic/meson.build
+++ b/test cases/cython/1 basic/meson.build
@@ -1,11 +1,14 @@
 project(
   'basic cython project',
   ['cython', 'c'],
-  default_options : ['warning_level=3']
+  default_options : ['warning_level=3', 'buildtype=release'],
 )
 
-py_mod = import('python')
-py3 = py_mod.find_installation()
+if meson.backend() != 'ninja'
+  error('MESON_SKIP_TEST: Ninja backend required')
+endif
+
+py3 = import('python').find_installation()
 py3_dep = py3.dependency(required : false)
 if not py3_dep.found()
   error('MESON_SKIP_TEST: Python library not found.')

--- a/test cases/cython/2 generated sources/meson.build
+++ b/test cases/cython/2 generated sources/meson.build
@@ -1,6 +1,6 @@
 project(
   'generated cython sources',
-  ['cython'],
+  ['cython', 'c'],
   default_options : ['buildtype=release'],
 )
 

--- a/test cases/cython/2 generated sources/meson.build
+++ b/test cases/cython/2 generated sources/meson.build
@@ -1,12 +1,16 @@
 project(
   'generated cython sources',
   ['cython'],
+  default_options : ['buildtype=release'],
 )
 
-py_mod = import('python')
-py3 = py_mod.find_installation('python3')
-py3_dep = py3.dependency(required : false)
+if meson.backend() != 'ninja'
+  error('MESON_SKIP_TEST: Ninja backend required')
+endif
+
 fs = import('fs')
+py3 = import('python').find_installation('python3')
+py3_dep = py3.dependency(required : false)
 if not py3_dep.found()
   error('MESON_SKIP_TEST: Python library not found.')
 endif
@@ -18,7 +22,7 @@ ct = custom_target(
   command : [py3, '@INPUT@', '@OUTPUT@'],
 )
 
-ct_ext = py3.extension_module('ct', ct, dependencies : py3_dep)
+ct_ext = py3.extension_module('ct', ct)
 
 test(
   'custom target',
@@ -35,7 +39,7 @@ cti = custom_target(
   command : [py3, '@INPUT@', '@OUTPUT@'],
 )
 
-cti_ext = py3.extension_module('cti', cti[0], dependencies : py3_dep)
+cti_ext = py3.extension_module('cti', cti[0])
 
 cf = configure_file(
   input : 'configure.pyx.in',
@@ -43,7 +47,7 @@ cf = configure_file(
   copy : true,
 )
 
-cf_ext = py3.extension_module('cf', cf, dependencies : py3_dep)
+cf_ext = py3.extension_module('cf', cf)
 
 test(
   'configure file',
@@ -61,7 +65,6 @@ gen = generator(
 g_ext = py3.extension_module(
   'g',
   gen.process('g.in'),
-  dependencies : py3_dep,
 )
 
 test(

--- a/test cases/cython/3 cython_args/meson.build
+++ b/test cases/cython/3 cython_args/meson.build
@@ -1,7 +1,14 @@
-project('cython_args', ['cython', 'c'])
+project('cython_args', ['cython', 'c'],
+  # Needed because Windows Python builds are release-only and tend to be
+  # unhappy with a debug build type.
+  default_options : ['buildtype=release']
+)
 
-pymod = import('python')
-python = pymod.find_installation('python3')
+if meson.backend() != 'ninja'
+  error('MESON_SKIP_TEST: Ninja backend required')
+endif
+
+python = import('python').find_installation('python3')
 python_dep = python.dependency()
 if not python_dep.found()
   error('MESON_SKIP_TEST: Python library not found.')
@@ -12,9 +19,9 @@ mod = python.extension_module(
   files('cythonargs.pyx'),
   cython_args: [
     '--compile-time-env',
-    'VALUE=1'
+    'VALUE=1',
+    '-3',
   ],
-  dependencies: [python_dep]
 )
 
 test(

--- a/test cases/python/3 cython/libdir/meson.build
+++ b/test cases/python/3 cython/libdir/meson.build
@@ -1,11 +1,11 @@
 pyx_c = custom_target('storer_pyx',
   output : 'storer_pyx.c',
   input : 'storer.pyx',
-  command : [cython, '@INPUT@', '-o', '@OUTPUT@'],
+  command : [cython, '@INPUT@', '-o', '@OUTPUT@', '-3'],
 )
 
 slib = py3.extension_module('storer',
   'storer.c', pyx_c,
-  dependencies : py3_dep)
+)
 
 pydir = meson.current_build_dir()

--- a/test cases/python/3 cython/meson.build
+++ b/test cases/python/3 cython/meson.build
@@ -1,6 +1,6 @@
 project('cython', 'c',
-  default_options : ['warning_level=3'])
-
+  default_options : ['warning_level=3', 'buildtype=release']
+)
 if meson.backend() != 'ninja'
   error('MESON_SKIP_TEST: Ninja backend required')
 endif
@@ -10,8 +10,7 @@ if not cython.found()
   error('MESON_SKIP_TEST: Cython3 not found.')
 endif
 
-py_mod = import('python')
-py3 = py_mod.find_installation()
+py3 = import('python').find_installation(pure: false)
 py3_dep = py3.dependency(required: false)
 if not py3_dep.found()
   error('MESON_SKIP_TEST: Python library not found.')

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -856,9 +856,9 @@ class AllPlatformTests(BasePlatformTests):
                     if "includestuff.pyx.c" in generated_source:
                         name = generated_source
                         break
-        # Split the path (we only want the includestuff.cpython-blahblahblah)
-        name = os.path.normpath(name).split("/")[-2:]
-        name = "/".join(name)  # Glue list into a string
+        # Split the path (we only want the includestuff.cpython-blahblah.so.p/includestuff.pyx.c)
+        name = os.path.normpath(name).split(os.sep)[-2:]
+        name = os.sep.join(name)  # Glue list into a string
         self.build(target=name)
 
     def test_build_pyx_depfiles(self):
@@ -3272,7 +3272,7 @@ class AllPlatformTests(BasePlatformTests):
             for k in ('install_filename', 'dependencies', 'win_subsystem'):
                 if k in i:
                     del i[k]
-                    
+
             sources = []
             for j in i['target_sources']:
                 sources += j.get('sources', [])


### PR DESCRIPTION
In gh-10775 an issue with building a simple Cython extension with MSVC on Windows was reported. Right now the Cython tests are skipped on Azure - from [example CI log](https://dev.azure.com/jussi0947/jussi/_build/results?buildId=15089&view=logs&jobId=5015ea34-1c35-577b-b206-c8bea8465a58&j=5015ea34-1c35-577b-b206-c8bea8465a58&t=d96bae21-2af5-55ef-6693-add22ffd7f07):
```
Not running cython tests.

 [SKIPPED]   cython: 1 basic    (cython_language=c)
Reason: not run because preconditions were not met
 [SKIPPED]   cython: 1 basic    (cython_language=cpp)
Reason: not run because preconditions were not met
 [SKIPPED]   cython: 2 generated sources
Reason: not run because preconditions were not met
 [SKIPPED]   cython: 3 cython_args
Reason: not run because preconditions were not met
```

[skip actions]