### PR TITLE
backends: add a new "null" backend

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -75,7 +75,7 @@ machine](#specifying-options-per-machine) section for details.
 | Option                                 | Default value | Description                                                    | Is per machine | Is per subproject |
 | -------------------------------------- | ------------- | -----------                                                    | -------------- | ----------------- |
 | auto_features {enabled, disabled, auto} | auto       | Override value of all 'auto' features                          | no             | no                |
-| backend {ninja, vs,<br>vs2010, vs2012, vs2013, vs2015, vs2017, vs2019, vs2022, xcode} | ninja | Backend to use        | no             | no                |
+| backend {ninja, vs,<br>vs2010, vs2012, vs2013, vs2015, vs2017, vs2019, vs2022, xcode, none} | ninja | Backend to use  | no             | no                |
 | buildtype {plain, debug,<br>debugoptimized, release, minsize, custom} | debug |  Build type to use                    | no             | no                |
 | debug                                  | true          | Enable debug symbols and other information                     | no             | no                |
 | default_library {shared, static, both} | shared      | Default library type                                           | no             | yes               |
@@ -94,6 +94,16 @@ machine](#specifying-options-per-machine) section for details.
 | werror                                 | false         | Treat warnings as errors                                       | no             | yes               |
 | wrap_mode {default, nofallback,<br>nodownload, forcefallback, nopromote} | default | Wrap mode to use                 | no             | no                |
 | force_fallback_for                     | []            | Force fallback for those dependencies                          | no             | no                |
+
+#### Details for `backend`
+
+Several build file formats are supported as command runners to build the
+configured project. Meson prefers ninja by default, but platform-specific
+backends are also available for better IDE integration with native tooling:
+Visual Studio for Windows, and xcode for macOS. It is also possible to
+configure with no backend at all, which is an error if you have targets to
+build, but for projects that need configuration + testing + installation allows
+for a lighter automated build pipeline.
 
 #### Details for `buildtype`
 

--- a/docs/markdown/snippets/none-backend.md
+++ b/docs/markdown/snippets/none-backend.md
@@ -1,0 +1,4 @@
+## New "none" backend
+
+The `--backend=none` option has been added, to configure a project that has no
+build rules, only install rules. This avoids depending on ninja.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -258,6 +258,7 @@ def get_backend_from_name(backend: str, build: T.Optional[build.Build] = None, i
 class Backend:
 
     environment: T.Optional['Environment']
+    name = '<UNKNOWN>'
 
     def __init__(self, build: T.Optional[build.Build], interpreter: T.Optional['Interpreter']):
         # Make it possible to construct a dummy backend
@@ -269,7 +270,6 @@ class Backend:
         self.interpreter = interpreter
         self.environment = build.environment
         self.processed_targets: T.Set[str] = set()
-        self.name = '<UNKNOWN>'
         self.build_dir = self.environment.get_build_dir()
         self.source_dir = self.environment.get_source_dir()
         self.build_to_src = mesonlib.relpath(self.environment.get_source_dir(),

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -251,6 +251,9 @@ def get_backend_from_name(backend: str, build: T.Optional[build.Build] = None, i
     elif backend == 'xcode':
         from . import xcodebackend
         return xcodebackend.XCodeBackend(build, interpreter)
+    elif backend == 'none':
+        from . import nonebackend
+        return nonebackend.NoneBackend(build, interpreter)
     return None
 
 # This class contains the basic functionality that is needed by all backends.

--- a/mesonbuild/backend/nonebackend.py
+++ b/mesonbuild/backend/nonebackend.py
@@ -1,0 +1,31 @@
+# Copyright 2022 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from .backends import Backend
+from .. import mlog
+from ..mesonlib import MesonBugException
+
+
+class NoneBackend(Backend):
+
+    name = 'none'
+
+    def generate(self):
+        if self.build.get_targets():
+            raise MesonBugException('None backend cannot generate target rules, but should have failed earlier.')
+        mlog.log('Generating simple install-only backend')
+        self.serialize_tests()
+        self.create_install_data_files()

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -101,9 +101,11 @@ def detect_microsoft_gdk(platform: str) -> bool:
     return re.match(r'Gaming\.(Desktop|Xbox.XboxOne|Xbox.Scarlett)\.x64', platform, re.IGNORECASE)
 
 class Vs2010Backend(backends.Backend):
+
+    name = 'vs2010'
+
     def __init__(self, build: T.Optional[build.Build], interpreter: T.Optional[Interpreter]):
         super().__init__(build, interpreter)
-        self.name = 'vs2010'
         self.project_file_version = '10.0.30319.1'
         self.sln_file_version = '11.00'
         self.sln_version_comment = '2010'

--- a/mesonbuild/backend/vs2012backend.py
+++ b/mesonbuild/backend/vs2012backend.py
@@ -23,9 +23,11 @@ if T.TYPE_CHECKING:
     from ..interpreter import Interpreter
 
 class Vs2012Backend(Vs2010Backend):
+
+    name = 'vs2012'
+
     def __init__(self, build: T.Optional[Build], interpreter: T.Optional[Interpreter]):
         super().__init__(build, interpreter)
-        self.name = 'vs2012'
         self.vs_version = '2012'
         self.sln_file_version = '12.00'
         self.sln_version_comment = '2012'

--- a/mesonbuild/backend/vs2013backend.py
+++ b/mesonbuild/backend/vs2013backend.py
@@ -22,9 +22,11 @@ if T.TYPE_CHECKING:
     from ..interpreter import Interpreter
 
 class Vs2013Backend(Vs2010Backend):
+
+    name = 'vs2013'
+
     def __init__(self, build: T.Optional[Build], interpreter: T.Optional[Interpreter]):
         super().__init__(build, interpreter)
-        self.name = 'vs2013'
         self.vs_version = '2013'
         self.sln_file_version = '12.00'
         self.sln_version_comment = '2013'

--- a/mesonbuild/backend/vs2015backend.py
+++ b/mesonbuild/backend/vs2015backend.py
@@ -23,9 +23,11 @@ if T.TYPE_CHECKING:
     from ..interpreter import Interpreter
 
 class Vs2015Backend(Vs2010Backend):
+
+    name = 'vs2015'
+
     def __init__(self, build: T.Optional[Build], interpreter: T.Optional[Interpreter]):
         super().__init__(build, interpreter)
-        self.name = 'vs2015'
         self.vs_version = '2015'
         self.sln_file_version = '12.00'
         self.sln_version_comment = '14'

--- a/mesonbuild/backend/vs2017backend.py
+++ b/mesonbuild/backend/vs2017backend.py
@@ -26,9 +26,11 @@ if T.TYPE_CHECKING:
 
 
 class Vs2017Backend(Vs2010Backend):
+
+    name = 'vs2017'
+
     def __init__(self, build: T.Optional[Build], interpreter: T.Optional[Interpreter]):
         super().__init__(build, interpreter)
-        self.name = 'vs2017'
         self.vs_version = '2017'
         self.sln_file_version = '12.00'
         self.sln_version_comment = '15'

--- a/mesonbuild/backend/vs2019backend.py
+++ b/mesonbuild/backend/vs2019backend.py
@@ -25,9 +25,11 @@ if T.TYPE_CHECKING:
 
 
 class Vs2019Backend(Vs2010Backend):
+
+    name = 'vs2019'
+
     def __init__(self, build: T.Optional[Build], interpreter: T.Optional[Interpreter]):
         super().__init__(build, interpreter)
-        self.name = 'vs2019'
         self.sln_file_version = '12.00'
         self.sln_version_comment = 'Version 16'
         if self.environment is not None:

--- a/mesonbuild/backend/vs2022backend.py
+++ b/mesonbuild/backend/vs2022backend.py
@@ -25,9 +25,11 @@ if T.TYPE_CHECKING:
 
 
 class Vs2022Backend(Vs2010Backend):
+
+    name = 'vs2022'
+
     def __init__(self, build: T.Optional[Build], interpreter: T.Optional[Interpreter]):
         super().__init__(build, interpreter)
-        self.name = 'vs2022'
         self.sln_file_version = '12.00'
         self.sln_version_comment = 'Version 17'
         if self.environment is not None:

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -191,9 +191,11 @@ class PbxDict:
             ofile.write(';\n')
 
 class XCodeBackend(backends.Backend):
+
+    name = 'xcode'
+
     def __init__(self, build: T.Optional[build.Build], interpreter: T.Optional[Interpreter]):
         super().__init__(build, interpreter)
-        self.name = 'xcode'
         self.project_uid = self.environment.coredata.lang_guids['default'].replace('-', '')[:24]
         self.buildtype = self.environment.coredata.get_option(OptionKey('buildtype'))
         self.project_conflist = self.gen_id()

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -61,7 +61,7 @@ if T.TYPE_CHECKING:
 # But the corresponding Git tag needs to be '0.1.0rc1'
 version = '1.0.99'
 
-backendlist = ['ninja', 'vs', 'vs2010', 'vs2012', 'vs2013', 'vs2015', 'vs2017', 'vs2019', 'vs2022', 'xcode']
+backendlist = ['ninja', 'vs', 'vs2010', 'vs2012', 'vs2013', 'vs2015', 'vs2017', 'vs2019', 'vs2022', 'xcode', 'none']
 
 DEFAULT_YIELDING = False
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3090,6 +3090,8 @@ class Interpreter(InterpreterBase, HoldableObject):
                                    "internal use. Please rename.")
 
     def add_target(self, name: str, tobj: build.Target) -> None:
+        if self.backend.name == 'none':
+            raise InterpreterException('Install-only backend cannot generate target rules, try using `--backend=ninja`.')
         if name == '':
             raise InterpreterException('Target name must not be empty.')
         if name.strip() == '':

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -265,6 +265,7 @@ def check_dist(packagename, meson_command, extra_meson_args, bld_root, privdir):
     unpacked_files = glob(os.path.join(unpackdir, '*'))
     assert len(unpacked_files) == 1
     unpacked_src_dir = unpacked_files[0]
+    meson_command += ['setup']
     meson_command += create_cmdline_args(bld_root)
     meson_command += extra_meson_args
 

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -43,7 +43,7 @@ import xml.etree.ElementTree as et
 from . import build
 from . import environment
 from . import mlog
-from .coredata import major_versions_differ, MesonVersionMismatchException
+from .coredata import MesonVersionMismatchException, OptionKey, major_versions_differ
 from .coredata import version as coredata_version
 from .mesonlib import (MesonException, OrderedSet, RealPathAction,
                        get_wine_shortpath, join_args, split_args, setup_vsenv)
@@ -2099,7 +2099,11 @@ def run(options: argparse.Namespace) -> int:
     setup_vsenv(b.need_vsenv)
 
     if not options.no_rebuild:
-        if not (Path(options.wd) / 'build.ninja').is_file():
+        backend = b.environment.coredata.get_option(OptionKey('backend'))
+        if backend == 'none':
+            # nothing to build...
+            options.no_rebuild = True
+        elif backend != 'ninja':
             print('Only ninja backend is supported to rebuild tests before running them.')
             # Disable, no point in trying to build anything later
             options.no_rebuild = True

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1582,12 +1582,6 @@ class TestHarness:
         if self.options.no_rebuild:
             return
 
-        if not (Path(self.options.wd) / 'build.ninja').is_file():
-            print('Only ninja backend is supported to rebuild tests before running them.')
-            # Disable, no point in trying to build anything later
-            self.options.no_rebuild = True
-            return
-
         self.ninja = environment.detect_ninja()
         if not self.ninja:
             print("Can't find ninja, can't rebuild test.")
@@ -2103,6 +2097,12 @@ def run(options: argparse.Namespace) -> int:
 
     b = build.load(options.wd)
     setup_vsenv(b.need_vsenv)
+
+    if not options.no_rebuild:
+        if not (Path(options.wd) / 'build.ninja').is_file():
+            print('Only ninja backend is supported to rebuild tests before running them.')
+            # Disable, no point in trying to build anything later
+            options.no_rebuild = True
 
     with TestHarness(options) as th:
         try:

--- a/run_tests.py
+++ b/run_tests.py
@@ -327,11 +327,11 @@ def run_configure_external(full_command: T.List[str], env: T.Optional[T.Dict[str
     pc, o, e = mesonlib.Popen_safe(full_command, env=env)
     return pc.returncode, o, e
 
-def run_configure(commandlist: T.List[str], env: T.Optional[T.Dict[str, str]] = None, catch_exception: bool = False) -> T.Tuple[int, str, str]:
+def run_configure(commandlist: T.List[str], env: T.Optional[T.Dict[str, str]] = None, catch_exception: bool = False) -> T.Tuple[bool, T.Tuple[int, str, str]]:
     global meson_exe
     if meson_exe:
-        return run_configure_external(meson_exe + commandlist, env=env)
-    return run_configure_inprocess(commandlist, env=env, catch_exception=catch_exception)
+        return (False, run_configure_external(meson_exe + commandlist, env=env))
+    return (True, run_configure_inprocess(commandlist, env=env, catch_exception=catch_exception))
 
 def print_system_info():
     print(mlog.bold('System information.'))

--- a/run_tests.py
+++ b/run_tests.py
@@ -297,7 +297,7 @@ def run_mtest_inprocess(commandlist: T.List[str]) -> T.Tuple[int, str, str]:
     out = StringIO()
     with mock.patch.object(sys, 'stdout', out), mock.patch.object(sys, 'stderr', out):
         returncode = mtest.run_with_args(commandlist)
-    return returncode, stdout.getvalue()
+    return returncode, out.getvalue()
 
 def clear_meson_configure_class_caches() -> None:
     CCompiler.find_library_cache = {}

--- a/test cases/python/7 install path/meson.build
+++ b/test cases/python/7 install path/meson.build
@@ -17,4 +17,8 @@ py_plat.install_sources('test.py', pure: true, subdir: 'kwrevert')
 install_data('test.py', install_dir: py_plat.get_install_dir() / 'kw/data')
 install_data('test.py', install_dir: py_plat.get_install_dir(pure: true) / 'kwrevert/data')
 
+if get_option('backend') == 'none'
+    subdir('target')
+endif
+
 subdir('structured')

--- a/test cases/python/7 install path/target/meson.build
+++ b/test cases/python/7 install path/target/meson.build
@@ -1,0 +1,3 @@
+testcase expect_error('Install-only backend cannot generate target rules, try using `--backend=ninja`.')
+    import('fs').copyfile('../test.py')
+endtestcase

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -70,6 +70,7 @@ class BasePlatformTests(TestCase):
             self.uninstall_command = get_backend_commands(self.backend)
         # Test directories
         self.common_test_dir = os.path.join(src_root, 'test cases/common')
+        self.python_test_dir = os.path.join(src_root, 'test cases/python')
         self.rust_test_dir = os.path.join(src_root, 'test cases/rust')
         self.vala_test_dir = os.path.join(src_root, 'test cases/vala')
         self.framework_test_dir = os.path.join(src_root, 'test cases/frameworks')


### PR DESCRIPTION
It can only be used for projects that don't have any rules at all, i.e. they are purely using Meson to:

- configure files
- run (script?) tests
- install files that exist by the end of the setup stage

This can be useful e.g. for Meson itself, a pure python project.