### PR TITLE
compilers: fix regression in logging cached compile commands

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -454,8 +454,7 @@ class CompileResult(HoldableObject):
 
     def __init__(self, stdo: T.Optional[str] = None, stde: T.Optional[str] = None,
                  command: T.Optional[T.List[str]] = None,
-                 returncode: int = 999, pid: int = -1,
-                 text_mode: bool = True,
+                 returncode: int = 999,
                  input_name: T.Optional[str] = None,
                  output_name: T.Optional[str] = None,
                  cached: bool = False):
@@ -466,8 +465,6 @@ class CompileResult(HoldableObject):
         self.command = command or []
         self.cached = cached
         self.returncode = returncode
-        self.pid = pid
-        self.text_mode = text_mode
 
 
 class Compiler(HoldableObject, metaclass=abc.ABCMeta):
@@ -811,7 +808,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
             mlog.debug('Compiler stdout:\n', stdo)
             mlog.debug('Compiler stderr:\n', stde)
 
-            result = CompileResult(stdo, stde, command_list, p.returncode, p.pid, input_name=srcname)
+            result = CompileResult(stdo, stde, command_list, p.returncode, input_name=srcname)
             if want_output:
                 result.output_name = output
             yield result

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -453,18 +453,17 @@ class CompileResult(HoldableObject):
     """The result of Compiler.compiles (and friends)."""
 
     def __init__(self, stdo: T.Optional[str] = None, stde: T.Optional[str] = None,
-                 args: T.Optional[T.List[str]] = None,
+                 command: T.Optional[T.List[str]] = None,
                  returncode: int = 999, pid: int = -1,
                  text_mode: bool = True,
                  input_name: T.Optional[str] = None,
                  output_name: T.Optional[str] = None,
-                 command: T.Optional[T.List[str]] = None, cached: bool = False):
+                 cached: bool = False):
         self.stdout = stdo
         self.stderr = stde
         self.input_name = input_name
         self.output_name = output_name
         self.command = command or []
-        self.args = args or []
         self.cached = cached
         self.returncode = returncode
         self.pid = pid
@@ -812,7 +811,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
             mlog.debug('Compiler stdout:\n', stdo)
             mlog.debug('Compiler stderr:\n', stde)
 
-            result = CompileResult(stdo, stde, list(commands), p.returncode, p.pid, input_name=srcname)
+            result = CompileResult(stdo, stde, command_list, p.returncode, p.pid, input_name=srcname)
             if want_output:
                 result.output_name = output
             yield result


### PR DESCRIPTION
In commit d326c87fe22507b8c25078a7cd7ed88499ba7dc1 we added a special holder object for cached compilation results, with some broken attributes:

- "command", that was never set, but used to print the log

- "args", that was set to some, but not all, of the information a fresh compilation would log, but never used

Remove the useless args attribute, call it command, and use it properly.