### PR TITLE
minstall: handle extra error for selinuxenabled

### DIFF
--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -235,7 +235,7 @@ def restore_selinux_contexts() -> None:
     '''
     try:
         subprocess.check_call(['selinuxenabled'])
-    except (FileNotFoundError, NotADirectoryError, PermissionError, subprocess.CalledProcessError):
+    except (FileNotFoundError, NotADirectoryError, OSError, PermissionError, subprocess.CalledProcessError):
         # If we don't have selinux or selinuxenabled returned 1, failure
         # is ignored quietly.
         return


### PR DESCRIPTION
Microsoft's WSL2 uses a Plan 9 filesystem, which returns IOError when file is missing.

Fixes: https://github.com/mesonbuild/meson/issues/10774