### PR TITLE
modules/wayland: Change core_only to include_core_only

### DIFF
--- a/docs/markdown/Wayland-module.md
+++ b/docs/markdown/Wayland-module.md
@@ -50,7 +50,7 @@ generated = wl_mod.scan_xml(
   client : true,
   server : true,
   public : false,
-  core_only : false,
+  include_core_only : false,
 )
 ```
 This function accepts one or more arguments of either string or file type.
@@ -62,8 +62,9 @@ It takes the following keyword arguments:
   generated. The default is true.
 - `server` Optional arg that specifies if server side header file is
   generated. The default is false.
-- `core_only` Optional arg that specifies that generated headers only include
-  wayland-client-core.h instead of wayland-client.h. Since *0.64.0*
+- `include_core_only` Optional arg that specifies that generated headers only include
+  `wayland-<client|server>-core.h` instead of `wayland-<client|server>.h`. 
+  The default is true. Since *0.64.0*
 
 **Returns**: a list of [[@custom_tgt]] in the order source, client side header,
 server side header. Generated header files have the name

--- a/docs/markdown/Wayland-module.md
+++ b/docs/markdown/Wayland-module.md
@@ -50,7 +50,7 @@ generated = wl_mod.scan_xml(
   client : true,
   server : true,
   public : false,
-  include_core_only : false,
+  include_core_only : true,
 )
 ```
 This function accepts one or more arguments of either string or file type.

--- a/mesonbuild/modules/wayland.py
+++ b/mesonbuild/modules/wayland.py
@@ -37,7 +37,7 @@ if T.TYPE_CHECKING:
         public: bool
         client: bool
         server: bool
-        core_only: bool
+        include_core_only: bool
 
     class FindProtocol(TypedDict):
 
@@ -66,7 +66,7 @@ class WaylandModule(ExtensionModule):
         KwargInfo('public', bool, default=False),
         KwargInfo('client', bool, default=True),
         KwargInfo('server', bool, default=False),
-        KwargInfo('core_only', bool, default=False, since='0.64.0'),
+        KwargInfo('include_core_only', bool, default=False, since='0.64.0'),
     )
     def scan_xml(self, state: ModuleState, args: T.Tuple[T.List[FileOrString]], kwargs: ScanXML) -> ModuleReturnValue:
         if self.scanner_bin is None:
@@ -101,7 +101,7 @@ class WaylandModule(ExtensionModule):
 
             for side in sides:
                 command = [self.scanner_bin, f'{side}-header', '@INPUT@', '@OUTPUT@']
-                if kwargs['core_only']:
+                if kwargs['include_core_only']:
                     command.append('--include-core-only')
 
                 header = CustomTarget(

--- a/mesonbuild/modules/wayland.py
+++ b/mesonbuild/modules/wayland.py
@@ -66,7 +66,7 @@ class WaylandModule(ExtensionModule):
         KwargInfo('public', bool, default=False),
         KwargInfo('client', bool, default=True),
         KwargInfo('server', bool, default=False),
-        KwargInfo('include_core_only', bool, default=False, since='0.64.0'),
+        KwargInfo('include_core_only', bool, default=True, since='0.64.0'),
     )
     def scan_xml(self, state: ModuleState, args: T.Tuple[T.List[FileOrString]], kwargs: ScanXML) -> ModuleReturnValue:
         if self.scanner_bin is None:

--- a/test cases/wayland/2 core only/meson.build
+++ b/test cases/wayland/2 core only/meson.build
@@ -9,6 +9,6 @@ wl_mod = import('unstable-wayland')
 wl_client_dep = dependency('wayland-client')
 
 xdg_shell_xml = wl_mod.find_protocol('xdg-shell')
-xdg_shell = wl_mod.scan_xml(xdg_shell_xml, core_only : true)
+xdg_shell = wl_mod.scan_xml(xdg_shell_xml, include_core_only : true)
 exe = executable('core', 'core.c', xdg_shell, dependencies : wl_client_dep)
 test('core', exe)


### PR DESCRIPTION
Change the name of the core_only option to include_core_only to match the flag used by wayland-scanner.

Also the use of wayland-<client|server>.h is discouraged, therefore set the default value of include_core_only to true.