### PR TITLE
wrap: Preserve case of dependency names

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -141,6 +141,8 @@ class PackageDefinition:
     def parse_wrap(self) -> None:
         try:
             config = configparser.ConfigParser(interpolation=None)
+            # Don't call str.lower() on keys
+            config.optionxform = str
             config.read(self.filename, encoding='utf-8')
         except configparser.Error as e:
             raise WrapException(f'Failed to parse {self.basename}: {e!s}')


### PR DESCRIPTION
configparser lower() all keys by default which breaks CMake dependency
names that often contains capitals. For example:
```
[provide]
ICU = icu_dep
```
