### PR TITLE
compilers: correct the MSVC version comparison for turning on __cplusplus

### DIFF
--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -740,7 +740,7 @@ class VisualStudioCPPCompiler(CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixi
         # By default, MSVC has a broken __cplusplus define that pretends to be c++98:
         # https://docs.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-160
         # Pass the flag to enable a truthful define, if possible.
-        if version_compare(self.version, '>= 15.7') and '/Zc:__cplusplus' not in args:
+        if version_compare(self.version, '>= 19.14.26428') and '/Zc:__cplusplus' not in args:
             return args + ['/Zc:__cplusplus']
         return args
 


### PR DESCRIPTION
We compared a Visual Studio (the IDE) version, but we wanted a MSVC (the compiler) version. This caused the option to be passed for a few too many versions of MSVC, and emit a "D9002 : ignoring unknown option" on those systems.

Compare the correct version using the version mapping from https://walbourn.github.io/vs-2017-15-7-update/

Fixes #10787

Co-authored-by: CorrodedCoder <38778644+CorrodedCoder@users.noreply.github.com>