### PR TITLE
Use os.path.samefile for default include paths testing in -isystem.

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -100,6 +100,7 @@ class CLikeCompilerArgs(arglist.CompilerArgs):
         # Remove system/default include paths added with -isystem
         default_dirs = self.compiler.get_default_include_dirs()
         if default_dirs:
+            real_default_dirs = [os.path.realpath(i) for i in default_dirs]
             bad_idx_list = []  # type: T.List[int]
             for i, each in enumerate(new):
                 if not each.startswith('-isystem'):
@@ -108,11 +109,11 @@ class CLikeCompilerArgs(arglist.CompilerArgs):
                 # Remove the -isystem and the path if the path is a default path
                 if (each == '-isystem' and
                         i < (len(new) - 1) and
-                        new[i + 1] in default_dirs):
+                        os.path.realpath(new[i + 1]) in real_default_dirs):
                     bad_idx_list += [i, i + 1]
-                elif each.startswith('-isystem=') and each[9:] in default_dirs:
+                elif each.startswith('-isystem=') and os.path.realpath(each[9:]) in real_default_dirs:
                     bad_idx_list += [i]
-                elif each[8:] in default_dirs:
+                elif os.path.realpath(each[8:]) in real_default_dirs:
                     bad_idx_list += [i]
             for i in reversed(bad_idx_list):
                 new.pop(i)

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -1793,3 +1793,15 @@ class LinuxlikeTests(BasePlatformTests):
         self._run(install_cmd + ['--strip'], workdir=self.builddir)
         stdout = self._run(['file', '-b', lib])
         self.assertNotIn('not stripped', stdout)
+
+    def test_isystem_default_removal_with_symlink(self):
+        env = get_fake_env()
+        cpp = detect_cpp_compiler(env, MachineChoice.HOST)
+        default_dirs = cpp.get_default_include_dirs()
+        default_symlinks = []
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for i in range(len(default_dirs)):
+                symlink = f'{tmpdir}/default_dir{i}'
+                default_symlinks.append(symlink)
+                os.symlink(default_dirs[i], symlink)
+            self.assertFalse(cpp.compiler_args([f'-isystem{symlink}' for symlink in default_symlinks]).to_native())


### PR DESCRIPTION
This ensures correct removal of default include paths in -isystem options when symbolic links are involved.