### PR TITLE
vs: Fix and simplify CustomBuild command

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1510,15 +1510,15 @@ class Vs2010Backend(backends.Backend):
             message.text = msg
         if not verify_files:
             ET.SubElement(custombuild, 'VerifyInputsAndOutputsExist').text = 'false'
-        ET.SubElement(custombuild, 'Command').text = f'''setlocal
-{command}
-if %%errorlevel%% neq 0 goto :cmEnd
-:cmEnd
-endlocal & call :cmErrorLevel %%errorlevel%% & goto :cmDone
-:cmErrorLevel
-exit /b %%1
-:cmDone
-if %%errorlevel%% neq 0 goto :VCEnd'''
+
+        # If a command ever were to change the current directory or set local
+        # variables this would need to be more complicated, as msbuild by
+        # default executes all CustomBuilds in a project using the same
+        # shell. Right now such tasks are all done inside the meson_exe
+        # wrapper. The trailing newline appears to be necessary to allow
+        # parallel custom builds to work.
+        ET.SubElement(custombuild, 'Command').text = f"{command}\n"
+
         if not outputs:
             # Use a nonexistent file to always consider the target out-of-date.
             outputs = [self.nonexistent_file(os.path.join(self.environment.get_scratch_dir(),


### PR DESCRIPTION
%% survived into the output since 038b31e72bc02f0a9b. That failed to fail, at least in the common cases, because the whole command sequence is unnecessary / redundant - it appears to come from cmake, which executes multiple commands within a single CustomBuild element. So this PR just removes all of the batch scripting.

We'd need the setlocal back if meson ever were to set the working directory and/or environment variable from within the custom build - but that seems mighty unlikely?
