### PR TITLE
doc: Recommend tags for libraries utilities

### DIFF
--- a/docs/markdown/Installing.md
+++ b/docs/markdown/Installing.md
@@ -176,6 +176,12 @@ time, please help extending the list of well known categories.
   * Files installed into `localedir`.
 - `typelib`:
   * `gnome.generate_gir()` - `.typelib` file.
+- `bin`:
+  * Scripts and executables bundled with a library meant to be used by end
+    users.
+- `bin-devel`:
+  * Scripts and executables bundled with a library meant to be used by
+    developers (i.e. build tools).
 
 Custom installation tag can be set using the `install_tag` keyword argument
 on various functions such as [[custom_target]], [[configure_file]],


### PR DESCRIPTION
GLib installs a few executables that are not needed by applications that use the glib libraries, but are used either by build systems or by user scripts. Debian splits them into libglib2.0-dev-bin and libglib2.0-bin packages. Another example is GStreamer tools (e.g. gst-launch-1.0) that Debian packages separately in gstreamer1.0-tools.

It is common enough that Meson documentation should recommend a tag for consistency across projects.