### PR TITLE
declare_dependency: fix regression in printing the correct error

### DIFF
--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -409,7 +409,7 @@ LINK_WITH_KW: KwargInfo[T.List[T.Union[BothLibraries, SharedLibrary, StaticLibra
     ContainerTypeInfo(list, (BothLibraries, SharedLibrary, StaticLibrary, CustomTarget, CustomTargetIndex, Jar, Executable, Dependency)),
     listify=True,
     default=[],
-    validator=lambda x: _link_with_error if isinstance(x, Dependency) else None,
+    validator=lambda x: _link_with_error if any(isinstance(i, Dependency) for i in x) else None,
 )
 
 def link_whole_validator(values: T.List[T.Union[StaticLibrary, CustomTarget, CustomTargetIndex, Dependency]]) -> T.Optional[str]:


### PR DESCRIPTION
In commit 47426f3663f795ae9af59075297bf8215ae81f40 we migrated to typed_kwargs, but the validator accepted a list and checked to see if it was a single Dependency object.

Fixes #10813