### PR TITLE
Fix cmd_or_ps.ps1 script with pwsh7

### DIFF
--- a/mesonbuild/scripts/cmd_or_ps.ps1
+++ b/mesonbuild/scripts/cmd_or_ps.ps1
@@ -1,22 +1,17 @@
 # Copied from GStreamer project
 # Author: Seungha Yang <seungha.yang@navercorp.com>
+#         Xavier Claessens <xclaesse@gmail.com>
 
 $i=1
-$ppid=(gwmi win32_process -Filter "processid='$pid'").parentprocessid
-$pname=(Get-Process -id $ppid).Name
-While($true) {
+$ppid=$PID
+do {
+  $ppid=(Get-CimInstance Win32_Process -Filter "ProcessId=$ppid").parentprocessid
+  $pname=(Get-Process -id $ppid).Name
   if($pname -eq "cmd" -Or $pname -eq "powershell" -Or $pname -eq "pwsh") {
     Write-Host ("{0}.exe" -f $pname)
     Break
   }
-
+  # not found yet, find grand parent
   # 10 times iteration seems to be sufficient
-  if($i -gt 10) {
-    Break
-  }
-
-  # not found yet, find grand parant
-  $ppid=(gwmi win32_process -Filter "processid='$ppid'").parentprocessid
-  $pname=(Get-Process -id $ppid).Name
   $i++
-}
+} while ($i -lt 10)


### PR DESCRIPTION
gwmi command does not exist any more and is replaced by Get-CimInstance. See https://github.com/PowerShell/PowerShell/issues/4766.

While at it, use a do..while loop to avoid duplicated lines.

Fixes: #10820