### PR TITLE
gnome: include gtk3-update-icon-cache into the search

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -361,6 +361,8 @@ class GnomeModule(ExtensionModule):
             prog = state.find_program('gtk4-update-icon-cache', required=False)
             found = isinstance(prog, build.Executable) or prog.found()
             if not found:
+                prog = state.find_program('gtk3-update-icon-cache')
+            if not prog.found:
                 prog = state.find_program('gtk-update-icon-cache')
             icondir = os.path.join(datadir_abs, 'icons', 'hicolor')
             script = state.backend.get_executable_serialisation([prog, '-q', '-t', '-f', icondir])


### PR DESCRIPTION
Include gtk3-update-icon-cache in the search, as currently we have both gtk+2 and gtk+3 in the homebrew installations (and we are using [this](https://github.com/Homebrew/homebrew-core/blob/39bda302f558422e2f912c147515076d435723f0/Formula/gtk%2B3.rb#L72-L73) to avoid name clash).

followup of #8272
relates to https://github.com/Homebrew/homebrew-core/pull/111062
