### PR TITLE
wrap: If the directory exists in a sub-subproject, uses it inplace

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -124,7 +124,6 @@ class PackageDefinition:
         self.basename = os.path.basename(fname)
         self.has_wrap = self.basename.endswith('.wrap')
         self.name = self.basename[:-5] if self.has_wrap else self.basename
-        self.directory = self.name
         # must be lowercase for consistency with dep=variable assignment
         self.provided_deps[self.name.lower()] = None
         # What the original file name was before redirection
@@ -132,9 +131,9 @@ class PackageDefinition:
         self.redirected = False
         if self.has_wrap:
             self.parse_wrap()
-            self.directory = self.values.get('directory', self.name)
             with open(fname, 'r', encoding='utf-8') as file:
                 self.wrapfile_hash = hashlib.sha256(file.read().encode('utf-8')).hexdigest()
+        self.directory = self.values.get('directory', self.name)
         if os.path.dirname(self.directory):
             raise WrapException('Directory key must be a name and not a path')
         if self.type and self.type not in ALL_TYPES:

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -346,10 +346,13 @@ class Resolver:
         self.directory = self.wrap.directory
 
         if self.wrap.has_wrap:
-            # We have a .wrap file, source code will be placed into main
-            # project's subproject_dir even if the wrap file comes from another
-            # subproject.
-            self.dirname = os.path.join(self.subdir_root, self.directory)
+            # We have a .wrap file, use directory relative to the location of
+            # the wrap file if it exists, otherwise source code will be placed
+            # into main project's subproject_dir even if the wrap file comes
+            # from another subproject.
+            self.dirname = os.path.join(os.path.dirname(self.wrap.filename), self.wrap.directory)
+            if not os.path.exists(self.dirname):
+                self.dirname = os.path.join(self.subdir_root, self.directory)
             # Check if the wrap comes from the main project.
             main_fname = os.path.join(self.subdir_root, self.wrap.basename)
             if self.wrap.filename != main_fname:

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -368,17 +368,16 @@ class Resolver:
             self.dirname = self.wrap.filename
         rel_path = os.path.relpath(self.dirname, self.source_dir)
 
-        meson_file = os.path.join(self.dirname, 'meson.build')
-        cmake_file = os.path.join(self.dirname, 'CMakeLists.txt')
-
-        if method not in ['meson', 'cmake']:
+        if method == 'meson':
+            buildfile = os.path.join(self.dirname, 'meson.build')
+        elif method == 'cmake':
+            buildfile = os.path.join(self.dirname, 'CMakeLists.txt')
+        else:
             raise WrapException('Only the methods "meson" and "cmake" are supported')
 
         # The directory is there and has meson.build? Great, use it.
-        if method == 'meson' and os.path.exists(meson_file):
+        if os.path.exists(buildfile):
             self.validate()
-            return rel_path
-        if method == 'cmake' and os.path.exists(cmake_file):
             return rel_path
 
         # Check if the subproject is a git submodule
@@ -408,10 +407,8 @@ class Resolver:
                 raise
 
         # A meson.build or CMakeLists.txt file is required in the directory
-        if method == 'meson' and not os.path.exists(meson_file):
-            raise WrapException('Subproject exists but has no meson.build file')
-        if method == 'cmake' and not os.path.exists(cmake_file):
-            raise WrapException('Subproject exists but has no CMakeLists.txt file')
+        if not os.path.exists(buildfile):
+            raise WrapException(f'Subproject exists but has no {os.path.basename(buildfile)} file')
 
         # At this point, the subproject has been successfully resolved for the
         # first time so save off the hash of the entire wrap file for future

--- a/test cases/common/254 subsubproject inplace/meson.build
+++ b/test cases/common/254 subsubproject inplace/meson.build
@@ -1,0 +1,3 @@
+project('main')
+
+subproject('sub')

--- a/test cases/common/254 subsubproject inplace/subprojects/sub/meson.build
+++ b/test cases/common/254 subsubproject inplace/subprojects/sub/meson.build
@@ -1,0 +1,3 @@
+project('sub')
+
+subproject('subsub')

--- a/test cases/common/254 subsubproject inplace/subprojects/sub/subprojects/subsub-1.0/meson.build
+++ b/test cases/common/254 subsubproject inplace/subprojects/sub/subprojects/subsub-1.0/meson.build
@@ -1,0 +1,1 @@
+project('subsub')

--- a/test cases/common/254 subsubproject inplace/subprojects/sub/subprojects/subsub.wrap
+++ b/test cases/common/254 subsubproject inplace/subprojects/sub/subprojects/subsub.wrap
@@ -1,0 +1,2 @@
+[wrap-file]
+directory = subsub-1.0


### PR DESCRIPTION
    A subproject could have a sub-subproject as a git submodule, or part of
    the subproject's release tarball, and still have a wrap file for it
    (e.g. needed for [provide] section). In that case we need to use the
    source tree for the sub-subproject inplace instead of downloading a new
    copy into the main project.
    
    This is the case with GLib 2.74, it has a subproject "gvdb" as git
    submodule, and part of release tarball, it ships gvdb.wrap file as well.
