### PR TITLE
Automaticall tag installed tests

### DIFF
--- a/docs/markdown/Installing.md
+++ b/docs/markdown/Installing.md
@@ -182,6 +182,8 @@ time, please help extending the list of well known categories.
 - `bin-devel`:
   * Scripts and executables bundled with a library meant to be used by
     developers (i.e. build tools).
+- `tests`:
+  * Files installed into `installed-tests` subdir (*Since 0.64.0*).
 
 Custom installation tag can be set using the `install_tag` keyword argument
 on various functions such as [[custom_target]], [[configure_file]],

--- a/docs/markdown/Installing.md
+++ b/docs/markdown/Installing.md
@@ -184,6 +184,8 @@ time, please help extending the list of well known categories.
     developers (i.e. build tools).
 - `tests`:
   * Files installed into `installed-tests` subdir (*Since 0.64.0*).
+- `systemtap`:
+  * Files installed into `systemtap` subdir (*Since 0.64.0*).
 
 Custom installation tag can be set using the `install_tag` keyword argument
 on various functions such as [[custom_target]], [[configure_file]],

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1540,6 +1540,8 @@ class Backend:
             return 'devel'
         elif localedir in dest_path.parents:
             return 'i18n'
+        elif 'installed-tests' in dest_path.parts:
+            return 'tests'
         mlog.debug('Failed to guess install tag for', dest_path)
         return None
 

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1542,6 +1542,8 @@ class Backend:
             return 'i18n'
         elif 'installed-tests' in dest_path.parts:
             return 'tests'
+        elif 'systemtap' in dest_path.parts:
+            return 'systemtap'
         mlog.debug('Failed to guess install tag for', dest_path)
         return None
 


### PR DESCRIPTION
It is common, at least in GNOME projects, to install tests. Files goes into various locations, including:
- /usr/lib/x86_64-linux-gnu/installed-tests
- /usr/share/installed-tests
- /usr/libexec/installed-tests

It is safe to assume that everything that goes into a "installed-tests" subdir should be tagged as "tests" by default.