### PR TITLE
pylint: warn on global use

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -24,7 +24,6 @@ disable=
     exec-used,
     fixme,
     global-statement,
-    global-variable-not-assigned,
     implicit-str-concat,
     import-error,
     import-outside-toplevel,

--- a/.pylintrc
+++ b/.pylintrc
@@ -23,7 +23,6 @@ disable=
     duplicate-value,
     exec-used,
     fixme,
-    global-statement,
     implicit-str-concat,
     import-error,
     import-outside-toplevel,

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -229,7 +229,7 @@ def verbose_git(cmd: T.List[str], workingdir: T.Union[str, bytes, os.PathLike], 
     return p.returncode == 0
 
 def set_meson_command(mainfile: str) -> None:
-    global _meson_command
+    global _meson_command  # pylint: disable=global-statement
     # On UNIX-like systems `meson` is a Python script
     # On Windows `meson` and `meson.exe` are wrapper exes
     if not mainfile.endswith('.py'):

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -229,7 +229,6 @@ def verbose_git(cmd: T.List[str], workingdir: T.Union[str, bytes, os.PathLike], 
     return p.returncode == 0
 
 def set_meson_command(mainfile: str) -> None:
-    global python_command
     global _meson_command
     # On UNIX-like systems `meson` is a Python script
     # On Windows `meson` and `meson.exe` are wrapper exes

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -504,7 +504,6 @@ def run(options: argparse.Namespace) -> int:
 updated_introspection_files = []  # type: T.List[str]
 
 def write_intro_info(intro_info: T.Sequence[T.Tuple[str, T.Union[dict, T.List[T.Any]]]], info_dir: str) -> None:
-    global updated_introspection_files
     for kind, data in intro_info:
         out_file = os.path.join(info_dir, f'intro-{kind}.json')
         tmp_file = os.path.join(info_dir, 'tmp_dump.json')
@@ -512,7 +511,7 @@ def write_intro_info(intro_info: T.Sequence[T.Tuple[str, T.Union[dict, T.List[T.
             json.dump(data, fp)
             fp.flush() # Not sure if this is needed
         os.replace(tmp_file, out_file)
-        updated_introspection_files += [kind]
+        updated_introspection_files.append(kind)
 
 def generate_introspection_file(builddata: build.Build, backend: backends.Backend) -> None:
     coredata = builddata.environment.get_coredata()
@@ -543,7 +542,6 @@ def split_version_string(version: str) -> T.Dict[str, T.Union[str, int]]:
     }
 
 def write_meson_info_file(builddata: build.Build, errors: list, build_files_updated: bool = False) -> None:
-    global updated_introspection_files
     info_dir = builddata.environment.info_dir
     info_file = get_meson_info_file(info_dir)
     intro_types = get_meson_introspection_types()

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -82,33 +82,33 @@ _logged_once = set()         # type: T.Set[T.Tuple[str, ...]]
 log_warnings_counter = 0     # type: int
 
 def disable() -> None:
-    global log_disable_stdout
+    global log_disable_stdout  # pylint: disable=global-statement
     log_disable_stdout = True
 
 def enable() -> None:
-    global log_disable_stdout
+    global log_disable_stdout  # pylint: disable=global-statement
     log_disable_stdout = False
 
 def set_quiet() -> None:
-    global log_errors_only
+    global log_errors_only  # pylint: disable=global-statement
     log_errors_only = True
 
 def set_verbose() -> None:
-    global log_errors_only
+    global log_errors_only  # pylint: disable=global-statement
     log_errors_only = False
 
 def initialize(logdir: str, fatal_warnings: bool = False) -> None:
-    global log_dir, log_file, log_fatal_warnings
+    global log_dir, log_file, log_fatal_warnings  # pylint: disable=global-statement
     log_dir = logdir
     log_file = open(os.path.join(logdir, log_fname), 'w', encoding='utf-8')
     log_fatal_warnings = fatal_warnings
 
 def set_timestamp_start(start: float) -> None:
-    global log_timestamp_start
+    global log_timestamp_start  # pylint: disable=global-statement
     log_timestamp_start = start
 
 def shutdown() -> T.Optional[str]:
-    global log_file
+    global log_file  # pylint: disable=global-statement
     if log_file is not None:
         path = log_file.name
         exception_around_goer = log_file
@@ -328,7 +328,7 @@ def _log_error(severity: str, *rargs: TV_Loggable,
 
     log(*args, once=once, **kwargs)
 
-    global log_warnings_counter
+    global log_warnings_counter  # pylint: disable=global-statement
     log_warnings_counter += 1
 
     if log_fatal_warnings and fatal:

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -391,7 +391,6 @@ def format_list(input_list: T.List[str]) -> str:
 
 @contextmanager
 def nested(name: str = '') -> T.Generator[None, None, None]:
-    global log_depth
     log_depth.append(name)
     try:
         yield

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -269,8 +269,6 @@ class VapiTarget(build.CustomTarget):
 # https://bugzilla.gnome.org/show_bug.cgi?id=774368
 gresource_dep_needed_version = '>= 2.51.1'
 
-native_glib_version: T.Optional[str] = None
-
 class GnomeModule(ExtensionModule):
 
     INFO = ModuleInfo('gnome')
@@ -285,6 +283,7 @@ class GnomeModule(ExtensionModule):
         self.install_gtk_update_icon_cache = False
         self.install_update_desktop_database = False
         self.devenv: T.Optional[build.EnvironmentVariables] = None
+        self.native_glib_version: T.Optional[str] = None
         self.methods.update({
             'post_install': self.post_install,
             'compile_resources': self.compile_resources,
@@ -300,19 +299,17 @@ class GnomeModule(ExtensionModule):
             'generate_vapi': self.generate_vapi,
         })
 
-    @staticmethod
-    def _get_native_glib_version(state: 'ModuleState') -> str:
-        global native_glib_version
-        if native_glib_version is None:
+    def _get_native_glib_version(self, state: 'ModuleState') -> str:
+        if self.native_glib_version is None:
             glib_dep = PkgConfigDependency('glib-2.0', state.environment,
                                            {'native': True, 'required': False})
             if glib_dep.found():
-                native_glib_version = glib_dep.get_version()
+                self.native_glib_version = glib_dep.get_version()
             else:
                 mlog.warning('Could not detect glib version, assuming 2.54. '
                              'You may get build errors if your glib is older.')
-                native_glib_version = '2.54'
-        return native_glib_version
+                self.native_glib_version = '2.54'
+        return self.native_glib_version
 
     @mesonlib.run_once
     def __print_gresources_warning(self, state: 'ModuleState') -> None:

--- a/mesonbuild/scripts/depfixer.py
+++ b/mesonbuild/scripts/depfixer.py
@@ -470,7 +470,7 @@ def fix_jar(fname: str) -> None:
     subprocess.check_call(['jar', 'ufm', fname, 'META-INF/MANIFEST.MF'])
 
 def fix_rpath(fname: str, rpath_dirs_to_remove: T.Set[bytes], new_rpath: T.Union[str, bytes], final_path: str, install_name_mappings: T.Dict[str, str], verbose: bool = True) -> None:
-    global INSTALL_NAME_TOOL
+    global INSTALL_NAME_TOOL  # pylint: disable=global-statement
     # Static libraries, import libraries, debug information, headers, etc
     # never have rpaths
     # DLLs and EXE currently do not need runtime path fixing

--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -23,8 +23,6 @@ import locale
 from .. import mesonlib
 from ..backend.backends import ExecutableSerialisation
 
-options = None
-
 def buildparser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description='Custom executable wrapper for Meson. Do not run on your own, mmm\'kay?')
     parser.add_argument('--unpickle')
@@ -102,7 +100,6 @@ def run_exe(exe: ExecutableSerialisation, extra_env: T.Optional[T.Dict[str, str]
     return 0
 
 def run(args: T.List[str]) -> int:
-    global options
     parser = buildparser()
     options, cmd_args = parser.parse_known_args(args)
     # argparse supports double dash to separate options and positional arguments,

--- a/mesonbuild/scripts/symbolextractor.py
+++ b/mesonbuild/scripts/symbolextractor.py
@@ -315,7 +315,7 @@ def gen_symbols(libfilename: str, impfilename: str, outfilename: str, cross_host
         dummy_syms(outfilename)
 
 def run(args: T.List[str]) -> int:
-    global TOOL_WARNING_FILE
+    global TOOL_WARNING_FILE  # pylint: disable=global-statement
     options = parser.parse_args(args)
     if len(options.args) != 4:
         print('symbolextractor.py <shared library file> <import library> <output file>')

--- a/mesonbuild/scripts/symbolextractor.py
+++ b/mesonbuild/scripts/symbolextractor.py
@@ -53,7 +53,6 @@ def write_if_changed(text: str, outfilename: str) -> None:
         f.write(text)
 
 def print_tool_warning(tools: T.List[str], msg: str, stderr: T.Optional[str] = None) -> None:
-    global TOOL_WARNING_FILE
     if os.path.exists(TOOL_WARNING_FILE):
         return
     m = f'{tools!r} {msg}. {RELINKING_WARNING}'

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -93,7 +93,7 @@ def open_wrapdburl(urlstring: str, allow_insecure: bool = False, have_opt: bool 
         raise WrapException(f'SSL module not available in {sys.executable}: Cannot contact the WrapDB.{insecure_msg}')
     else:
         # following code is only for those without Python SSL
-        global SSL_WARNING_PRINTED
+        global SSL_WARNING_PRINTED  # pylint: disable=global-statement
         if not SSL_WARNING_PRINTED:
             mlog.warning(f'SSL module not available in {sys.executable}: WrapDB traffic not authenticated.')
             SSL_WARNING_PRINTED = True

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -1082,15 +1082,12 @@ class LinuxlikeTests(BasePlatformTests):
         also tested.
         '''
         testdir = os.path.join(self.framework_test_dir, '7 gnome')
-        mesonbuild.modules.gnome.native_glib_version = '2.20'
-        env = {'MESON_UNIT_TEST_PRETEND_GLIB_OLD': "1"}
-        try:
+        with mock.patch('mesonbuild.modules.gnome.GnomeModule._get_native_glib_version', mock.Mock(return_value='2.20')):
+            env = {'MESON_UNIT_TEST_PRETEND_GLIB_OLD': "1"}
             self.init(testdir,
                       inprocess=True,
                       override_envvars=env)
             self.build(override_envvars=env)
-        finally:
-            mesonbuild.modules.gnome.native_glib_version = None
 
     @skipIfNoPkgconfig
     def test_pkgconfig_usage(self):


### PR DESCRIPTION
python's `global` is a code smell, so even though this introduces a bunch of `pylint: disable` comments, I think that's a good thing. It forces you to really think about whether global is a great idea. It turns out, in fact, we don't need it nearly as much as we're using it anyway. non-assigning mutations don't need global, so you can replace
```python
global foo
foo += ['bar']
```
with
```python
foo.append('bar')
```
no `global` necessary.

You also don't need it to read a global.

And In one case we're using a global where we should be using a class var.