### PR TITLE
docs: compiler.find_library: discourage lib prefix

### DIFF
--- a/docs/refman/generatormd.py
+++ b/docs/refman/generatormd.py
@@ -123,7 +123,7 @@ class GeneratorMD(GeneratorBase):
 
         self.generated_files[file_id] = self._gen_filename(file_id)
         out_file = self.out_dir / self.generated_files[file_id]
-        out_file.write_text(data, encoding='ascii')
+        out_file.write_text(data, encoding='utf-8')
         mlog.log('Generated', mlog.bold(out_file.name))
 
     def _write_template(self, data: T.Dict[str, T.Any], file_id: str, template_name: T.Optional[str] = None) -> None:

--- a/docs/yaml/objects/compiler.yaml
+++ b/docs/yaml/objects/compiler.yaml
@@ -355,7 +355,7 @@ methods:
   posargs:
     libname:
       type: str
-      description: The library to find.
+      description: The library to find, without “lib” prefix.
   kwargs:
     required:
       type: bool | feature


### PR DESCRIPTION
I continue seeing it in the wild.