### PR TITLE
CI: Add a temporary workaround for broken MSYS2 Python path separator behaviour

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -51,6 +51,9 @@ jobs:
             TOOLCHAIN: clang
     env:
       MESON_CI_JOBNAME: msys2-${{ matrix.NAME }}
+      # XXX: Otherwise unsetting MSYSTEM doesn't work
+      # https://github.com/msys2/msys2-runtime/pull/101#issuecomment-1255195675
+      MSYS: noemptyenvvalues
 
     defaults:
       run:


### PR DESCRIPTION
"MSYSTEM= python ..." no longer works because of some changes in the MSYS2 runtime

Until this is fixed in either MinGW Python or the MSYS2 runtime this should revert things to the previous behaviour to get the CI green again.

See https://github.com/msys2/msys2-runtime/pull/101#issuecomment-1255195675