### PR TITLE
fixes and cleanups to mesonmain entrypoint's error handler

### DIFF
--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -49,7 +49,9 @@ def errorhandler(e, command):
             raise e
         traceback.print_exc()
 
-        if isinstance(e, OSError):
+        if command == 'runpython':
+            return 2
+        elif isinstance(e, OSError):
             error_msg = os.linesep.join([
                 "Unhandled python exception",
                 f"{e.strerror} - {e.args}",
@@ -58,13 +60,12 @@ def errorhandler(e, command):
             mlog.exception(error_msg)
             return e.errno
         else: # Exception
-            if command != 'runpython':
-                msg = 'Unhandled python exception'
-                if all(getattr(e, a, None) is not None for a in ['file', 'lineno', 'colno']):
-                    e = MesonBugException(msg, e.file, e.lineno, e.colno) # type: ignore
-                else:
-                    e = MesonBugException(msg)
-                mlog.exception(e)
+            msg = 'Unhandled python exception'
+            if all(getattr(e, a, None) is not None for a in ['file', 'lineno', 'colno']):
+                e = MesonBugException(msg, e.file, e.lineno, e.colno) # type: ignore
+            else:
+                e = MesonBugException(msg)
+            mlog.exception(e)
         return 2
 
 # Note: when adding arguments, please also add them to the completion

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -38,35 +38,33 @@ def errorhandler(e, command):
         if os.environ.get('MESON_FORCE_BACKTRACE'):
             raise e
         return 1
-    elif isinstance(e, OSError):
-        if os.environ.get('MESON_FORCE_BACKTRACE'):
-            raise e
-        traceback.print_exc()
-        error_msg = os.linesep.join([
-            "Unhandled python exception",
-            f"{e.strerror} - {e.args}",
-            "this is probably not a Meson bug."])
-
-        mlog.exception(error_msg)
-        return e.errno
-
-    else: # Exception
-        if os.environ.get('MESON_FORCE_BACKTRACE'):
-            raise e
-        traceback.print_exc()
+    else:
         # We assume many types of traceback are Meson logic bugs, but most
         # particularly anything coming from the interpreter during `setup`.
         # Some things definitely aren't:
         # - PermissionError is always a problem in the user environment
         # - runpython doesn't run Meson's own code, even though it is
         #   dispatched by our run()
-        if command != 'runpython':
-            msg = 'Unhandled python exception'
-            if all(getattr(e, a, None) is not None for a in ['file', 'lineno', 'colno']):
-                e = MesonBugException(msg, e.file, e.lineno, e.colno) # type: ignore
-            else:
-                e = MesonBugException(msg)
-            mlog.exception(e)
+        if os.environ.get('MESON_FORCE_BACKTRACE'):
+            raise e
+        traceback.print_exc()
+
+        if isinstance(e, OSError):
+            error_msg = os.linesep.join([
+                "Unhandled python exception",
+                f"{e.strerror} - {e.args}",
+                "this is probably not a Meson bug."])
+
+            mlog.exception(error_msg)
+            return e.errno
+        else: # Exception
+            if command != 'runpython':
+                msg = 'Unhandled python exception'
+                if all(getattr(e, a, None) is not None for a in ['file', 'lineno', 'colno']):
+                    e = MesonBugException(msg, e.file, e.lineno, e.colno) # type: ignore
+                else:
+                    e = MesonBugException(msg)
+                mlog.exception(e)
         return 2
 
 # Note: when adding arguments, please also add them to the completion

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -52,12 +52,8 @@ def errorhandler(e, command):
         if command == 'runpython':
             return 2
         elif isinstance(e, OSError):
-            error_msg = os.linesep.join([
-                "Unhandled python exception",
-                f"{e.strerror} - {e.args}",
-                "this is probably not a Meson bug."])
-
-            mlog.exception(error_msg)
+            mlog.exception("Unhandled python OSError. This is probably not a Meson bug, "
+                           "but an issue with your build environment.")
             return e.errno
         else: # Exception
             msg = 'Unhandled python exception'


### PR DESCRIPTION
- address https://github.com/mesonbuild/meson/pull/10810#issuecomment-1255369694: `meson --internal regenerate` no longer handles exceptions and formats them as `ERROR: XXX`, so you just get pythonic tracebacks
- runpython shouldn't interject Meson's own suggestions about OSError
- make the error message for OSError a bit nicer