### PR TITLE
Revert "CI: Add a temporary workaround for broken MSYS2 Python path s…

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -106,7 +106,6 @@ jobs:
             # Make sure it is on the PATH
             pypy3 -c "import sys; print(sys.version)"
           fi
-          export BOOST_ROOT=
           export PATHEXT="$PATHEXT;.py"
 
           if [[ '${{ matrix.COMPILER }}' == 'clang' ]]; then

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -51,9 +51,6 @@ jobs:
             TOOLCHAIN: clang
     env:
       MESON_CI_JOBNAME: msys2-${{ matrix.NAME }}
-      # XXX: Otherwise unsetting MSYSTEM doesn't work
-      # https://github.com/msys2/msys2-runtime/pull/101#issuecomment-1255195675
-      MSYS: noemptyenvvalues
 
     defaults:
       run:


### PR DESCRIPTION
…eparator behaviour"

This reverts commit 3fd2459a748cc9eed4be73132b002400da81cb0a.

The underlying issue has been fixed and deployed:
https://github.com/msys2-contrib/cpython-mingw/pull/107