### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -18,6 +18,9 @@ on:
       - ".github/workflows/cygwin.yml"
       - "run*tests.py"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: windows-latest

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -23,6 +23,9 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     # do not run the weekly scheduled job in a fork

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -19,6 +19,9 @@ on:
     types:
       - published
 
+permissions:
+  contents: write # for release creation (svenstaro/upload-release-action)
+
 # This job is copy/paster into wrapdb CI, please update it there when doing any
 # change here.
 jobs:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.