### PR TITLE
gnome.mkenum_simple(): Fix include path when header is in subdir

### DIFF
--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -204,6 +204,13 @@ for a build target, you must add the generated header to the build
 target's list of sources to codify the dependency. This is true for
 all generated sources, not just `mkenums_simple`.
 
+The generated source file includes all headers passed to the sources keyword
+argument, using paths relative to current build or source directory. That means
+that targets that compile the generated source file must have the current
+directory in its `include_directories`. *Since 1.3.0* `sources` outside of
+current directory do not require adding those directories into
+`include_directories` anymore.
+
 * `body_prefix`: additional prefix at the top of the body file,
   e.g. for extra includes
 * `decorator`: optional decorator for the function declarations,

--- a/test cases/frameworks/7 gnome/mkenums/meson.build
+++ b/test cases/frameworks/7 gnome/mkenums/meson.build
@@ -162,3 +162,13 @@ main = configure_file(
 enumexe6 = executable('enumprog6', main, enums_c2, enums_h6,
 dependencies : gobj)
 test('enum test 4', enumexe6)
+
+# Test with headers coming from other directories
+# https://github.com/mesonbuild/meson/pull/10855
+subdir('subdir')
+enums7 = gnome.mkenums_simple('enums7', sources: ['meson-sample.h', h2, h3])
+main = configure_file(
+  input : 'main.c',
+  output : 'mai7.c',
+  configuration : {'ENUM_FILE': 'enums7.h'})
+test('enums7 test', executable('enumprog7', main, enums7, dependencies : gobj))

--- a/test cases/frameworks/7 gnome/mkenums/subdir/h2.h.in
+++ b/test cases/frameworks/7 gnome/mkenums/subdir/h2.h.in
@@ -1,0 +1,5 @@
+#pragma once
+
+typedef enum {
+  MESON_SUBDIR_FOO,
+} MesonSubdir;

--- a/test cases/frameworks/7 gnome/mkenums/subdir/h3.h
+++ b/test cases/frameworks/7 gnome/mkenums/subdir/h3.h
@@ -1,0 +1,5 @@
+#pragma once
+
+typedef enum {
+  MESON_SUBDIR2_FOO,
+} MesonSubdir2;

--- a/test cases/frameworks/7 gnome/mkenums/subdir/meson.build
+++ b/test cases/frameworks/7 gnome/mkenums/subdir/meson.build
@@ -1,0 +1,2 @@
+h2 = configure_file(input: 'h2.h.in', output: 'h2.h', copy: true)
+h3 = files('h3.h')


### PR DESCRIPTION
It was generating #include with the basename of every header file. That assumes that every directory where there are headers are also included into search path when compiling the .c file.

Change to use path relative to current subdir, which can be both in build or source directory. That means that we assume that when the .c file is compiled, the target has a include_directories pointing to the directory where gnome.mkenum_simple() has been called, which is generally '.' and added automatically.

Also fix type annotation to only allow str and File sources, other types have never been working, it would require to iterate over custom target outputs, etc.