### PR TITLE
gnome/yelp: fix `xml:lang` attributes

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1357,7 +1357,7 @@ class GnomeModule(ExtensionModule):
                 l_subdir,
                 state.subproject,
                 state.environment,
-                [itstool, '-m', os.path.join(l_subdir, gmo_file), '-o', '@OUTDIR@', '@INPUT@'],
+                [itstool, '-m', os.path.join(l_subdir, gmo_file), '--lang', l, '-o', '@OUTDIR@', '@INPUT@'],
                 sources_files,
                 sources,
                 extra_depends=[gmotarget],


### PR DESCRIPTION
itstool detects a language code from the mo file’s basename, so when https://github.com/mesonbuild/meson/commit/26c1869a142a952ffa23fe566a255b259304a39b changed the file name to be prefixed with project name, values like “my-project-xx” ended up in the `xml:lang` attribute of the generated page files, instead of the expected IETF BCP 47 language tag.

Let’s fix it by passing a locale code to itstool explicitly.

----

I noticed this in gnome-nettool’s help files (click _Download from mirror_ on https://archlinux.org/packages/extra/x86_64/gnome-nettool/). For example, look at `/usr/share/help/ca/gnome-nettool/index.page`:

```xml
<?xml version="1.0" encoding="utf-8"?>
<page xmlns="http://projectmallard.org/1.0/" type="guide" style="task" id="index" xml:lang="gnome-nettool-ca">
```

Verified that this patch fixes the issue.