### PR TITLE
find_library with argument beginning in "lib" is a bad idea, warn about it

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -1158,6 +1158,8 @@ class CLikeCompiler(Compiler):
                 trial = self._get_file_from_list(env, trials)
                 if not trial:
                     continue
+                if libname.startswith('lib') and trial.name.startswith(libname):
+                    mlog.warning(f'find_library({libname!r}) starting in "lib" only works by accident and is not portable')
                 return [trial.as_posix()]
         return None
 


### PR DESCRIPTION
We need to support cases where the library might be called "foo.so" and therefore we check for exact matches too. But this also allows `cc.find_library('libfoo')` to find libfoo.so, which is strange and won't work in many cases. Emit a warning when this happens.

Fixes #10838