### PR TITLE
docs/markdown/Users.md:add meson-vcpkg (example project)

### DIFF
--- a/docs/markdown/Users.md
+++ b/docs/markdown/Users.md
@@ -102,6 +102,7 @@ format files
  - [LXC](https://github.com/lxc/lxc), Linux container runtime
  - [Marker](https://github.com/fabiocolacio/Marker), a GTK-3 markdown editor
  - [Mesa](https://mesa3d.org/), an open source graphics driver project
+ - [meson-vcpkg](https://github.com/Neumann-A/meson-vcpkg), example project illustrating how to use meson with vcpkg
  - [Miniz](https://github.com/richgel999/miniz), a zlib replacement library
  - [MiracleCast](https://github.com/albfan/miraclecast), connect external monitors to your system via Wifi-Display specification aka Miracast
  - [mpv](https://github.com/mpv-player/mpv), a free, open source, and cross-platform media player


### PR DESCRIPTION
Related to #3500, projected hosted by @Neumann-A

I thought about linking to this project somewhere in the docs, but doing a search for 'vcpkg' yielded no results.