### PR TITLE
envconfig: Add VALADOC

### DIFF
--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -134,6 +134,7 @@ ENV_VAR_TOOL_MAP: T.Mapping[str, str] = {
     'pkgconfig': 'PKG_CONFIG',
     'pkg-config': 'PKG_CONFIG',
     'make': 'MAKE',
+    'valadoc': 'VALADOC',
     'vapigen': 'VAPIGEN',
     'llvm-config': 'LLVM_CONFIG',
 }


### PR DESCRIPTION
Similar to commit ba85c7175041 ("modules/gnome: use envconfig for VAPIGEN"). This is useful for ensuring that a particular version of valadoc is used.

cc: @dcbaker 