### PR TITLE
properly type utils/core.py and add it to mypy

### DIFF
--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -28,6 +28,7 @@ import typing as T
 if T.TYPE_CHECKING:
     from ..environment import Environment
     from ..mesonlib import MachineChoice
+    from ..utils.core import EnvironOrDict
     from .._typing import ImmutableListProtocol
     from ..build import EnvironmentVariables
 
@@ -152,7 +153,7 @@ class PkgConfigDependency(ExternalDependency):
         return env
 
     @staticmethod
-    def setup_env(env: T.MutableMapping[str, str], environment: 'Environment', for_machine: MachineChoice,
+    def setup_env(env: EnvironOrDict, environment: 'Environment', for_machine: MachineChoice,
                   uninstalled: bool = False) -> T.Dict[str, str]:
         envvars = PkgConfigDependency.get_env(environment, for_machine, uninstalled)
         env = envvars.get_env(env)
@@ -162,7 +163,7 @@ class PkgConfigDependency(ExternalDependency):
                 mlog.debug(f'env[{key}]: {value}')
         return env
 
-    def _call_pkgbin(self, args: T.List[str], env: T.Optional[T.MutableMapping[str, str]] = None) -> T.Tuple[int, str, str]:
+    def _call_pkgbin(self, args: T.List[str], env: T.Optional[EnvironOrDict] = None) -> T.Tuple[int, str, str]:
         assert isinstance(self.pkgbin, ExternalProgram)
         env = env or os.environ
         env = PkgConfigDependency.setup_env(env, self.env, self.for_machine)

--- a/mesonbuild/utils/core.py
+++ b/mesonbuild/utils/core.py
@@ -27,9 +27,12 @@ import abc
 import typing as T
 
 if T.TYPE_CHECKING:
+    from hashlib import _Hash
     from typing_extensions import Literal
     from ..mparser import BaseNode
-    from . import programs
+    from .. import programs
+
+    EnvironOrDict = T.Union[T.Dict[str, str], os._Environ[str]]
 
 
 __all__ = [
@@ -78,7 +81,7 @@ EnvInitValueType = T.Dict[str, T.Union[str, T.List[str]]]
 class EnvironmentVariables(HoldableObject):
     def __init__(self, values: T.Optional[EnvInitValueType] = None,
                  init_method: Literal['set', 'prepend', 'append'] = 'set', separator: str = os.pathsep) -> None:
-        self.envvars: T.List[T.Tuple[T.Callable[[T.Dict[str, str], str, T.List[str], str], str], str, T.List[str], str]] = []
+        self.envvars: T.List[T.Tuple[T.Callable[[T.Dict[str, str], str, T.List[str], str, T.Optional[str]], str], str, T.List[str], str]] = []
         # The set of all env vars we have operations for. Only used for self.has_name()
         self.varnames: T.Set[str] = set()
 
@@ -92,7 +95,7 @@ class EnvironmentVariables(HoldableObject):
         repr_str = "<{0}: {1}>"
         return repr_str.format(self.__class__.__name__, self.envvars)
 
-    def hash(self, hasher: T.Any):
+    def hash(self, hasher: _Hash) -> None:
         myenv = self.get_env({})
         for key in sorted(myenv.keys()):
             hasher.update(bytes(key, encoding='utf-8'))
@@ -132,7 +135,7 @@ class EnvironmentVariables(HoldableObject):
         curr = env.get(name, default_value)
         return separator.join(values if curr is None else values + [curr])
 
-    def get_env(self, full_env: T.MutableMapping[str, str], dump: bool = False) -> T.Dict[str, str]:
+    def get_env(self, full_env: EnvironOrDict, dump: bool = False) -> T.Dict[str, str]:
         env = full_env.copy()
         for method, name, values, separator in self.envvars:
             default_value = f'${name}' if dump else None

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -33,6 +33,7 @@ modules = [
     'mesonbuild/interpreter/type_checking.py',
     'mesonbuild/mcompile.py',
     'mesonbuild/mdevenv.py',
+    'mesonbuild/utils/core.py',
     'mesonbuild/utils/platform.py',
     'mesonbuild/utils/universal.py',
     'mesonbuild/minit.py',


### PR DESCRIPTION
EnvironmentVariables was always broken, it used MutableMapping because everyone <3 abstract interfaces, especially when they are broken and don't actually do what you want.

This needs a dict interface, exposing `.copy()`. We either use a dict or os._Environ, and the latter also supports that.