### PR TITLE
CI: add potential workaround for python crashes in MSYS2

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -51,6 +51,9 @@ jobs:
             TOOLCHAIN: clang
     env:
       MESON_CI_JOBNAME: msys2-${{ matrix.NAME }}
+      # XXX: For some reason enabling jit debugging "fixes" random python crashes
+      # see https://github.com/msys2/MINGW-packages/issues/11864
+      MSYS: "winjitdebug"
 
     defaults:
       run:


### PR DESCRIPTION
There hasn't been any progress on this upstream lately, so try what we use in MSYS2 CI right now

@eli-schwartz 