### PR TITLE
basic oneapi compiler support for linux

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -20,6 +20,8 @@ These are return values of the `get_id` (Compiler family) and
 | gcc       | The GNU Compiler Collection      | gcc             |
 | intel     | Intel compiler (Linux and Mac)   | gcc             |
 | intel-cl  | Intel compiler (Windows)         | msvc            |
+| intel-llvm    | Intel oneAPI LLVM-based compiler            |                 |
+| intel-llvm-cl | Intel oneAPI LLVM-based compiler (Windows)  | msvc            |
 | lcc       | Elbrus C/C++/Fortran Compiler    |                 |
 | llvm      | LLVM-based compiler (Swift, D)   |                 |
 | mono      | Xamarin C# compiler              |                 |

--- a/docs/markdown/snippets/oneapi_compilers.md
+++ b/docs/markdown/snippets/oneapi_compilers.md
@@ -1,0 +1,8 @@
+## Basic support for oneAPI compilers on Linux and Windows
+
+To use on Linux:
+
+```
+source /opt/intel/oneapi/setvars.sh
+CC=icx CXX=icpx FC=ifx meson setup builddir
+```

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -408,6 +408,11 @@ class IntelCCompiler(IntelGnuLikeCompiler, CCompiler):
         return args
 
 
+class IntelLLVMCCompiler(ClangCCompiler):
+
+    id = 'intel-llvm'
+
+
 class VisualStudioLikeCCompilerMixin(CompilerMixinBase):
 
     """Shared methods that apply to MSVC-like C compilers."""
@@ -528,6 +533,11 @@ class IntelClCCompiler(IntelVisualStudioLikeCompiler, VisualStudioLikeCCompilerM
         elif std.value != 'none':
             args.append('/Qstd:' + std.value)
         return args
+
+
+class IntelLLVMClCCompiler(IntelClCCompiler):
+
+    id = 'intel-llvm-cl'
 
 
 class ArmCCompiler(ArmCompiler, CCompiler):

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -155,7 +155,7 @@ class CPPCompiler(CLikeCompiler, Compiler):
         }
 
         # Currently, remapping is only supported for Clang, Elbrus and GCC
-        assert self.id in frozenset(['clang', 'lcc', 'gcc', 'emscripten', 'armltdclang'])
+        assert self.id in frozenset(['clang', 'lcc', 'gcc', 'emscripten', 'armltdclang', 'intel-llvm'])
 
         if cpp_std not in CPP_FALLBACKS:
             # 'c++03' and 'c++98' don't have fallback types
@@ -595,6 +595,11 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
         return []
 
 
+class IntelLLVMCPPCompiler(ClangCPPCompiler):
+
+    id = 'intel-llvm'
+
+
 class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
 
     """Mixin for C++ specific method overrides in MSVC-like compilers."""
@@ -781,6 +786,11 @@ class IntelClCPPCompiler(VisualStudioLikeCPPCompilerMixin, IntelVisualStudioLike
     def get_compiler_check_args(self, mode: CompileCheckMode) -> T.List[str]:
         # XXX: this is a hack because so much GnuLike stuff is in the base CPPCompiler class.
         return IntelVisualStudioLikeCompiler.get_compiler_check_args(self, mode)
+
+
+class IntelLLVMClCPPCompiler(IntelClCPPCompiler):
+
+    id = 'intel-llvm-cl'
 
 
 class ArmCPPCompiler(ArmCompiler, CPPCompiler):

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -327,6 +327,11 @@ class IntelFortranCompiler(IntelGnuLikeCompiler, FortranCompiler):
         return ['-gen-dep=' + outtarget, '-gen-depformat=make']
 
 
+class IntelLLVMFortranCompiler(IntelFortranCompiler):
+
+    id = 'intel-llvm'
+
+
 class IntelClFortranCompiler(IntelVisualStudioLikeCompiler, FortranCompiler):
 
     file_suffixes = ('f90', 'f', 'for', 'ftn', 'fpp', )
@@ -366,6 +371,10 @@ class IntelClFortranCompiler(IntelVisualStudioLikeCompiler, FortranCompiler):
     def get_module_outdir_args(self, path: str) -> T.List[str]:
         return ['/module:' + path]
 
+
+class IntelLLVMClFortranCompiler(IntelClFortranCompiler):
+
+    id = 'intel-llvm-cl'
 
 class PathScaleFortranCompiler(FortranCompiler):
 

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -1059,7 +1059,8 @@ def detect_tests_to_run(only: T.Dict[str, T.List[str]], use_tmp: bool) -> T.List
                        shutil.which('flang') or
                        shutil.which('pgfortran') or
                        shutil.which('nagfor') or
-                       shutil.which('ifort'))
+                       shutil.which('ifort') or
+                       shutil.which('ifx'))
 
     skip_cmake = ((os.environ.get('compiler') == 'msvc2015' and under_ci) or
                   'cmake' not in tool_vers_map or


### PR DESCRIPTION
Linux-only support for oneapi compilers. I have not used meson before, but know how to use the intel compilers. My only test was to build c, cpp, and fortran hello world programs.

I introduced new classes because I expect we will want some differences (e.g. compiler id) relative to base class compiler.

Trying to unblock https://github.com/spack/spack/pull/31810#issuecomment-1272448547.

