### PR TITLE
interpreter: Don't say we're using -lfoo args when we're not

### DIFF
--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -190,7 +190,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
     def compiler(self) -> 'Compiler':
         return self.held_object
 
-    def _dep_msg(self, deps: T.List['dependencies.Dependency'], endl: str) -> str:
+    def _dep_msg(self, deps: T.List['dependencies.Dependency'], compile_only: bool, endl: str) -> str:
         msg_single = 'with dependency {}'
         msg_many = 'with dependencies {}'
         if not deps:
@@ -204,6 +204,8 @@ class CompilerHolder(ObjectHolder['Compiler']):
                                       location=self.current_node)
                 continue
             if isinstance(d, dependencies.ExternalLibrary):
+                if compile_only:
+                    continue
                 name = '-l' + d.name
             else:
                 name = d.name
@@ -239,9 +241,9 @@ class CompilerHolder(ObjectHolder['Compiler']):
         args.extend(extra_args)
         return args
 
-    def _determine_dependencies(self, deps: T.List['dependencies.Dependency'], endl: str = ':') -> T.Tuple[T.List['dependencies.Dependency'], str]:
+    def _determine_dependencies(self, deps: T.List['dependencies.Dependency'], compile_only: bool = False, endl: str = ':') -> T.Tuple[T.List['dependencies.Dependency'], str]:
         deps = dependencies.get_leaf_external_dependencies(deps)
-        return deps, self._dep_msg(deps, endl)
+        return deps, self._dep_msg(deps, compile_only, endl)
 
     @typed_pos_args('compiler.alignment', str)
     @typed_kwargs(
@@ -252,7 +254,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
     )
     def alignment_method(self, args: T.Tuple[str], kwargs: 'AlignmentKw') -> int:
         typename = args[0]
-        deps, msg = self._determine_dependencies(kwargs['dependencies'])
+        deps, msg = self._determine_dependencies(kwargs['dependencies'], compile_only=self.compiler.is_cross)
         result = self.compiler.alignment(typename, kwargs['prefix'], self.environment,
                                          extra_args=kwargs['args'],
                                          dependencies=deps)
@@ -269,7 +271,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
                 code.rel_to_builddir(self.environment.source_dir))
         testname = kwargs['name']
         extra_args = functools.partial(self._determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
-        deps, msg = self._determine_dependencies(kwargs['dependencies'], endl=None)
+        deps, msg = self._determine_dependencies(kwargs['dependencies'], compile_only=False, endl=None)
         result = self.compiler.run(code, self.environment, extra_args=extra_args,
                                    dependencies=deps)
         if testname:
@@ -346,7 +348,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
     def has_function_method(self, args: T.Tuple[str], kwargs: 'CommonKW') -> bool:
         funcname = args[0]
         extra_args = self._determine_args(kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
-        deps, msg = self._determine_dependencies(kwargs['dependencies'])
+        deps, msg = self._determine_dependencies(kwargs['dependencies'], compile_only=False)
         had, cached = self.compiler.has_function(funcname, kwargs['prefix'], self.environment,
                                                  extra_args=extra_args,
                                                  dependencies=deps)
@@ -386,7 +388,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
     def compute_int_method(self, args: T.Tuple[str], kwargs: 'CompupteIntKW') -> int:
         expression = args[0]
         extra_args = functools.partial(self._determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
-        deps, msg = self._determine_dependencies(kwargs['dependencies'])
+        deps, msg = self._determine_dependencies(kwargs['dependencies'], compile_only=self.compiler.is_cross)
         res = self.compiler.compute_int(expression, kwargs['low'], kwargs['high'],
                                         kwargs['guess'], kwargs['prefix'],
                                         self.environment, extra_args=extra_args,
@@ -399,7 +401,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
     def sizeof_method(self, args: T.Tuple[str], kwargs: 'CommonKW') -> int:
         element = args[0]
         extra_args = functools.partial(self._determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
-        deps, msg = self._determine_dependencies(kwargs['dependencies'])
+        deps, msg = self._determine_dependencies(kwargs['dependencies'], compile_only=self.compiler.is_cross)
         esize = self.compiler.sizeof(element, kwargs['prefix'], self.environment,
                                      extra_args=extra_args, dependencies=deps)
         mlog.log('Checking for size of', mlog.bold(element, True), msg, esize)
@@ -465,7 +467,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
 
         testname = kwargs['name']
         extra_args = functools.partial(self._determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
-        deps, msg = self._determine_dependencies(kwargs['dependencies'])
+        deps, msg = self._determine_dependencies(kwargs['dependencies'], compile_only=False)
         result, cached = self.compiler.links(code, self.environment,
                                              compiler=compiler,
                                              extra_args=extra_args,

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -193,10 +193,6 @@ class CompilerHolder(ObjectHolder['Compiler']):
     def _dep_msg(self, deps: T.List['dependencies.Dependency'], compile_only: bool, endl: str) -> str:
         msg_single = 'with dependency {}'
         msg_many = 'with dependencies {}'
-        if not deps:
-            return endl
-        if endl is None:
-            endl = ''
         names = []
         for d in deps:
             if isinstance(d, dependencies.InternalDependency):
@@ -211,8 +207,10 @@ class CompilerHolder(ObjectHolder['Compiler']):
                 name = d.name
             names.append(name)
         if not names:
-            return None
+            return endl
         tpl = msg_many if len(names) > 1 else msg_single
+        if endl is None:
+            endl = ''
         return tpl.format(', '.join(names)) + endl
 
     @noPosargs


### PR DESCRIPTION
`cc.compiles()`, and other compiler checks that use `cc.compiles()` under the hood, do not use link args at all when doing the compile check, so messages like this:

```
Checking if "have zlib" with dependency -lz compiles: YES
```

are very misleading. The compiler check command-line for that is:

```
cc [...]/testfile.c -o [...]/output.obj -c -D_FILE_OFFSET_BITS=64 -O0
```

Note the lack of linker args.