### PR TITLE
Add cc.preprocess() method

### DIFF
--- a/docs/markdown/snippets/preprocess.md
+++ b/docs/markdown/snippets/preprocess.md
@@ -1,0 +1,14 @@
+## New method to preprocess source files
+
+Compiler object has a new `preprocess()` method. It is supported by all C/C++
+compilers. It preprocess sources without compiling them.
+
+The preprocessor will receive the same arguments (include directories, defines,
+etc) as with normal compilation. That includes for example args added with
+`add_project_arguments()`, or on the command line with `-Dc_args=-DFOO`.
+
+```meson
+cc = meson.get_compiler('c')
+pp_files = cc.preprocess('foo.c', 'bar.c', output: '@PLAINNAME@')
+exe = executable('app', pp_files)
+```

--- a/docs/yaml/objects/compiler.yaml
+++ b/docs/yaml/objects/compiler.yaml
@@ -586,3 +586,25 @@ methods:
     gcc or msvc, but use the same argument syntax as one of those two compilers
     such as clang or icc, especially when they use different syntax on different
     operating systems.
+
+- name: preprocess
+  returns: list[custom_idx]
+  since: 0.64.0
+  description: |
+    Preprocess a list of source files but do not compile them. The preprocessor
+    will receive the same arguments (include directories, defines, etc) as with
+    normal compilation. That includes for example args added with
+    `add_project_arguments()`, or on the command line with `-Dc_args=-DFOO`.
+  varargs_inherit: _build_target_base
+  kwargs:
+    output:
+      type: str
+      description: |
+        Template for name of preprocessed files: `@PLAINNAME@` is replaced by
+        the source filename and `@BASENAME@` is replaced by the source filename
+        without its extension.
+    compile_args:
+      type: list[str]
+      description: |
+        Extra flags to pass to the preprocessor
+

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -792,6 +792,8 @@ class Backend:
 
     def object_filename_from_source(self, target: build.BuildTarget, source: 'FileOrString') -> str:
         assert isinstance(source, mesonlib.File)
+        if isinstance(target, build.CompileTarget):
+            return target.sources_map[source]
         build_dir = self.environment.get_build_dir()
         rel_src = source.rel_to_builddir(self.build_to_src)
 

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -50,6 +50,8 @@ if T.TYPE_CHECKING:
 
     from typing_extensions import TypedDict
 
+    _ALL_SOURCES_TYPE = T.List[T.Union[File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList]]
+
     class TargetIntrospectionData(TypedDict):
 
         language: str
@@ -1864,3 +1866,28 @@ class Backend:
             else:
                 env.prepend('PATH', list(extra_paths))
         return env
+
+    def compiler_to_generator(self, target: build.BuildTarget,
+                              compiler: 'Compiler',
+                              sources: _ALL_SOURCES_TYPE,
+                              output_templ: str) -> build.GeneratedList:
+        '''
+        Some backends don't support custom compilers. This is a convenience
+        method to convert a Compiler to a Generator.
+        '''
+        exelist = compiler.get_exelist()
+        exe = programs.ExternalProgram(exelist[0])
+        args = exelist[1:]
+        # FIXME: There are many other args missing
+        commands = self.generate_basic_compiler_args(target, compiler)
+        commands += compiler.get_dependency_gen_args('@OUTPUT@', '@DEPFILE@')
+        commands += compiler.get_output_args('@OUTPUT@')
+        commands += compiler.get_compile_only_args() + ['@INPUT@']
+        commands += self.get_source_dir_include_args(target, compiler)
+        commands += self.get_build_dir_include_args(target, compiler)
+        generator = build.Generator(exe, args + commands.to_native(), [output_templ], depfile='@PLAINNAME@.d')
+        return generator.process_files(sources, self.interpreter)
+
+    def compile_target_to_generator(self, target: build.CompileTarget) -> build.GeneratedList:
+        all_sources = T.cast('_ALL_SOURCES_TYPE', target.sources) + T.cast('_ALL_SOURCES_TYPE', target.generated)
+        return self.compiler_to_generator(target, target.compiler, all_sources, target.output_templ)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1983,7 +1983,7 @@ class NinjaBackend(backends.Backend):
 
     @classmethod
     def compiler_to_rule_name(cls, compiler: Compiler) -> str:
-        return cls.get_compiler_rule_name(compiler.get_language(), compiler.for_machine)
+        return cls.get_compiler_rule_name(compiler.get_language(), compiler.for_machine, compiler.mode)
 
     @classmethod
     def compiler_to_pch_rule_name(cls, compiler: Compiler) -> str:
@@ -2362,6 +2362,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                     self.generate_llvm_ir_compile_rule(compiler)
                 self.generate_compile_rule_for(langname, compiler)
                 self.generate_pch_rule_for(langname, compiler)
+                for mode in compiler.get_modes():
+                    self.generate_compile_rule_for(langname, mode)
 
     def generate_generator_list_rules(self, target):
         # CustomTargets have already written their rules and

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -986,6 +986,9 @@ class NinjaBackend(backends.Backend):
                 obj_list.append(o)
                 compiled_sources.append(s)
                 source2object[s] = o
+        if isinstance(target, build.CompileTarget):
+            # Skip the link stage for this special type of target
+            return
         linker, stdlib_args = self.determine_linker_and_stdlib_args(target)
         if isinstance(target, build.StaticLibrary) and target.prelink:
             final_obj_list = self.generate_prelink(target, obj_list)

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -494,6 +494,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
     language: str
     id: str
     warn_args: T.Dict[str, T.List[str]]
+    mode: str = 'COMPILER'
 
     def __init__(self, exelist: T.List[str], version: str,
                  for_machine: MachineChoice, info: 'MachineInfo',
@@ -513,6 +514,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         self.linker = linker
         self.info = info
         self.is_cross = is_cross
+        self.modes: T.List[Compiler] = []
 
     def __repr__(self) -> str:
         repr_str = "<{0}: v{1} `{2}`>"
@@ -530,6 +532,9 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
 
     def get_id(self) -> str:
         return self.id
+
+    def get_modes(self) -> T.List[Compiler]:
+        return self.modes
 
     def get_linker_id(self) -> str:
         # There is not guarantee that we have a dynamic linker instance, as
@@ -1050,6 +1055,9 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
     def get_preprocess_only_args(self) -> T.List[str]:
         raise EnvironmentException('This compiler does not have a preprocessor')
 
+    def get_preprocess_to_file_args(self) -> T.List[str]:
+        return self.get_preprocess_only_args()
+
     def get_default_include_dirs(self) -> T.List[str]:
         # TODO: This is a candidate for returning an immutable list
         return []
@@ -1290,6 +1298,10 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
     def needs_static_linker(self) -> bool:
         raise NotImplementedError(f'There is no static linker for {self.language}')
 
+    def get_preprocessor(self) -> Compiler:
+        """Get compiler's preprocessor.
+        """
+        raise EnvironmentException(f'{self.get_id()} does not support preprocessor')
 
 def get_global_options(lang: str,
                        comp: T.Type[Compiler],

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -318,6 +318,12 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
     def get_coverage_args(self) -> T.List[str]:
         return ['--coverage']
 
+    def get_preprocess_to_file_args(self) -> T.List[str]:
+        # We want to allow preprocessing files with any extension, such as
+        # foo.c.in. In that case we need to tell GCC/CLANG to treat them as
+        # assembly file.
+        return self.get_preprocess_only_args() + ['-x', 'assembler-with-cpp']
+
 
 class GnuCompiler(GnuLikeCompiler):
     """

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -159,6 +159,9 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
     def get_preprocess_only_args(self) -> T.List[str]:
         return ['/EP']
 
+    def get_preprocess_to_file_args(self) -> T.List[str]:
+        return ['/EP', '/P']
+
     def get_compile_only_args(self) -> T.List[str]:
         return ['/c']
 
@@ -173,6 +176,8 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
         return ['/fsanitize=address']
 
     def get_output_args(self, target: str) -> T.List[str]:
+        if self.mode == 'PREPROCESSOR':
+            return ['/Fi' + target]
         if target.endswith('.exe'):
             return ['/Fe' + target]
         return ['/Fo' + target]

--- a/test cases/common/255 preprocess/bar.c
+++ b/test cases/common/255 preprocess/bar.c
@@ -1,0 +1,3 @@
+int bar(void) {
+    return BAR;
+}

--- a/test cases/common/255 preprocess/foo.c
+++ b/test cases/common/255 preprocess/foo.c
@@ -1,0 +1,1 @@
+#include <foo.h>

--- a/test cases/common/255 preprocess/foo.h
+++ b/test cases/common/255 preprocess/foo.h
@@ -1,0 +1,2 @@
+int bar(void);
+int main(void) { return FOO + bar(); }

--- a/test cases/common/255 preprocess/meson.build
+++ b/test cases/common/255 preprocess/meson.build
@@ -1,0 +1,15 @@
+project('preprocess', 'c')
+
+cc = meson.get_compiler('c')
+
+add_project_arguments(['-DFOO=0', '-DBAR=0'], language: 'c')
+
+pp_files = cc.preprocess('foo.c', 'bar.c', output: '@PLAINNAME@')
+
+foreach f : pp_files
+  message(f.full_path())
+endforeach
+
+subdir('src')
+
+test('test-foo', executable('app', pp_files, link_depends: file_map))

--- a/test cases/common/255 preprocess/src/file.map.in
+++ b/test cases/common/255 preprocess/src/file.map.in
@@ -1,0 +1,3 @@
+#if 1
+Hello World
+#endif

--- a/test cases/common/255 preprocess/src/meson.build
+++ b/test cases/common/255 preprocess/src/meson.build
@@ -1,4 +1,3 @@
 file_map = cc.preprocess('file.map.in',
   output: '@BASENAME@',
-  compile_args: ['-x', 'assembler-with-cpp'],
 )

--- a/test cases/common/255 preprocess/src/meson.build
+++ b/test cases/common/255 preprocess/src/meson.build
@@ -1,0 +1,4 @@
+file_map = cc.preprocess('file.map.in',
+  output: '@BASENAME@',
+  compile_args: ['-x', 'assembler-with-cpp'],
+)


### PR DESCRIPTION
This exposes any clike compiler's preprocessor. Many projects preprocess their files using a custom_target() or a generator() but that implies knowing the command line syntax of different compilers (especially MSVC) which is something Meson already knows. It's makes preprocessing unconsistent because they don't use the same CFLAGS as normal compilation because a custom target does not always have access to cflags added via `add_project_arguments()`, `-Dc_args`, etc.

The way it is implemented in the ninja backend ensures that the preprocessing uses exactly the same command line than normal compilation, there is almost no special casing for preprocessor. Howerver, things are more complicated for other backends, so it internally converts to a Generator to reuse existing infrastructure.

Lots of the infrastructure introduced in this PR could be used in the future to add support for assemblers and transpilers in vs/xcode backend.