### PR TITLE
Support for generating opaque directories of data

### DIFF
--- a/data/syntax-highlighting/vim/syntax/meson.vim
+++ b/data/syntax-highlighting/vim/syntax/meson.vim
@@ -109,6 +109,7 @@ syn keyword mesonBuiltin
   \ library
   \ meson
   \ message
+  \ opaque_target
   \ option
   \ project
   \ run_command

--- a/docs/markdown/Custom-build-targets.md
+++ b/docs/markdown/Custom-build-targets.md
@@ -44,3 +44,71 @@ When doing this you need to be mindful of the following issues:
   must be written to `build_dir/subdir/foo.dat`
 * if you need a subdirectory for temporary files, use
   `build_dir/subdir/target.dir`
+
+# Generating a full subdirectory of files (since 0.64.0)
+
+There are many cases where one needs to generate a bunch of files
+where the list of outputs is unknown. The most common case is
+documentation. Tools like Doxygen, Sphinx and the like typically
+generate a whole directory tree full of files that you would need to
+install.
+
+For this case Meson provides the `opaque_target` command. It is more
+complex than other targets and typically require the developer to
+write a small wrapper script that runs the actual tool. The syntax
+looks like this.
+
+```meson
+doc_target = opaque_target('docs',
+    command: find_program('adaptor_script.py'),
+    args: ['--some-flag'],
+    install: true,
+    install_dir: 'some_dir')
+```
+
+An `opaque_target` function behaves much like a `custom_target` with
+the exception that it takes the command and arguments separately. This
+is needed so that Meson can insert additional integration command line
+arguments to the command line. When the script is executed, the
+command line looks like this.
+
+```
+adaptor_script.py --stamp=<path> --dep=<path> --scrath=<dir> \
+  --out=<dir> -- --some-flag
+```
+
+The first arguments are as follows:
+
+**--stamp** is a _stamp file_. That is, the file whose existance and
+    time samp specify whether the target is up to date or not. Its
+    contents are ignored. When the script is run successfully it must
+    update the time stamp of this file, typically by opening it for
+    writing and closing it. If the script did not succeed then it must
+    delete this file if it exists. If a stamp file exists after an
+    unsuccessfull run, the resulting behaviour is undefined.
+
+**--dep** specifies the dependency file. That is, it should list all
+    the source files whose changes should cause the target to be
+    re-run. It should be in the same syntax (a subset of Make
+    dependencies) as produced by compilers like GCC and Clang. This
+    file __must__ be written. If there is no dependency information
+    available, then the contents should be just a single line
+    consisting of the stamp file name followed by a colon. There must
+    _not_ be a space between the two.
+
+**--scratch** points to a directory that can be used for temporary
+    processing. The contents of this file are persisted over
+    consecutive invocations but they are cleared on every `clean`
+    operation.
+
+**--out** points to a directory where the final output files should be
+    placed. They are copied as is on install (if the `install` kwarg
+    is `true`). If the script is invoked multiple times it is the
+    responsibility of the script to ensure that no stray files from
+    the first run remain in the dir after the second run.
+
+**--** signals the end of integration args. Additional scripts
+     specified in the target follow this one. Meson may add new
+     integration flags in the future, so the script must be able to
+     handle any unknown arguments before this marker (typically by
+     ignoring them).

--- a/docs/markdown/snippets/opaque_target.md
+++ b/docs/markdown/snippets/opaque_target.md
@@ -1,0 +1,5 @@
+## New `opaque_target` for generating directory trees
+
+To make integrating tools like Doxygen and Sphinx easier, Meson now
+has a custom command for running targets that produce a large number
+of files, whose names are not know beforehand.

--- a/docs/yaml/functions/opaque_target.yaml
+++ b/docs/yaml/functions/opaque_target.yaml
@@ -1,0 +1,41 @@
+name: opaque_target
+returns: custom_tgt
+description: |
+  *Since 0.64.0* Create a custom build target that generates a bunch of files (possibly
+  in subdirectories) whose names and paths can't be known beforehand. This function
+  is typically used for generating documentation.
+  ```meson
+  opaque_target('foo',
+    command: some_exe,
+    install: true
+    install_dir: datadir)
+  ```
+
+  This function takes all the same keyword arguments as `custom_target` with the
+  exception that the `command` kwarg takes only the program to execute, all
+  arguments must be specified with the `args` kwargh.
+
+  The return value is a custom target object.
+
+notes:
+  - |
+    Meson adds extra integration flags to the process invocation. See the
+    [documentation](Custom-build-targets.md) for details.
+
+optargs:
+  name:
+    type: str
+    description: |
+      The *unique* id of the custom target
+
+      This posarg is optional and defaults to the basename of the stampfile.
+
+kwargs:
+  args:
+    type: list[str | file | build_tgt]
+    description: |
+      Additional command line arguments to pass to the script.
+
+  command:
+    type: external_program
+    description: The script to run.

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -162,6 +162,7 @@ class AstInterpreter(InterpreterBase):
                            'range': self.func_do_nothing,
                            'structured_sources': self.func_do_nothing,
                            'debug': self.func_do_nothing,
+                           'opaque_target': self.func_do_nothing,
                            })
 
     def _unholder_args(self, args: _T, kwargs: _V) -> T.Tuple[_T, _V]:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3445,15 +3445,17 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         # empty. https://github.com/mesonbuild/meson/issues/1220
         ctlist = []
         for t in self.build.get_targets().values():
-            if isinstance(t, build.CustomTarget):
+            if isinstance(t, build.CustomTarget) and not t.is_opaque:
                 # Create a list of all custom target outputs
                 for o in t.get_outputs():
                     ctlist.append(os.path.join(self.get_target_dir(t), o))
         # As above, but restore the top level directory after deletion.
+        gendir_list = []
         for t in self.build.get_targets().values():
-            if isinstance(t, build.CustomTarget):
-                if False:
-                    gendir_list.append('fake')
+            if isinstance(t, build.CustomTarget) and t.is_opaque:
+                opdata = mesonlib.get_opaque_data(t.subproject, t.name)
+                gendir_list.append(opdata.scratch)
+                gendir_list.append(opdata.out)
 
         if ctlist or gendir_list:
             elem.add_dep(self.generate_custom_target_clean(ctlist, gendir_list))

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2443,6 +2443,7 @@ class CustomTarget(Target, CommandBase):
         self.install_mode = install_mode
         self.install_tag = _process_install_tag(install_tag, len(self.outputs))
         self.name = name if name else self.outputs[0]
+        self.is_opaque = False
 
         # Whether to use absolute paths for all files on the commandline
         self.absolute_paths = absolute_paths

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -408,6 +408,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                            'join_paths': self.func_join_paths,
                            'library': self.func_library,
                            'message': self.func_message,
+                           'opaque_target': self.func_opaque_target,
                            'option': self.func_option,
                            'project': self.func_project,
                            'range': self.func_range,
@@ -1983,6 +1984,40 @@ class Interpreter(InterpreterBase, HoldableObject):
             backend=self.backend)
         self.add_target(tg.name, tg)
         return tg
+
+    @typed_pos_args('opaque_target', optargs=[str])
+    @typed_kwargs(
+        'opaque_target',
+        COMMAND_KW,
+        KwargInfo('args', ContainerTypeInfo(list, (str, mesonlib.File), allow_empty=True), required=True, listify=True),
+        CT_BUILD_ALWAYS,
+        CT_BUILD_ALWAYS_STALE,
+        CT_BUILD_BY_DEFAULT,
+        CT_INPUT_KW,
+        CT_INSTALL_DIR_KW,
+        CT_INSTALL_TAG_KW,
+        DEPENDS_KW,
+        DEPEND_FILES_KW,
+        DEPFILE_KW,
+        INSTALL_KW,
+    )
+    def func_opaque_target(self, node: mparser.FunctionNode, args: T.Tuple[str],
+                           kwargs: 'kwtypes.OpaqueTarget') -> build.CustomTarget:
+        if len(args) != 1:
+            raise InterpreterException('Opaque_target takes exactly one positional argument.')
+        opaque_data = mesonlib.get_opaque_data(self.subproject, args[0])
+        kwargs['output'] = opaque_data.stamp
+        kwargs['depfile'] = opaque_data.dep
+        integration_args = ['--stamp=@OUTPUT@',
+                            '--dep=@DEPFILE@',
+                            '--scratch=' + opaque_data.scratch,
+                            '--out=' + opaque_data.out,
+                            '--']
+        kwargs['command'] = listify(kwargs['command']) + integration_args + kwargs['args']
+        del kwargs['args']
+        ct = self.func_custom_target(node, args, kwargs)
+        ct.is_opaque = True
+        return ct
 
     @typed_pos_args('run_target', str)
     @typed_kwargs(

--- a/mesonbuild/scripts/cleantrees.py
+++ b/mesonbuild/scripts/cleantrees.py
@@ -18,7 +18,7 @@ import shutil
 import pickle
 import typing as T
 
-def rmtrees(build_dir: str, trees: T.List[str]) -> None:
+def rmtrees(build_dir: str, trees: T.List[str], restore_dir: bool) -> None:
     for t in trees:
         # Never delete trees outside of the builddir
         if os.path.isabs(t):
@@ -28,6 +28,8 @@ def rmtrees(build_dir: str, trees: T.List[str]) -> None:
         # Skip if it doesn't exist, or if it is not a directory
         if os.path.isdir(bt):
             shutil.rmtree(bt, ignore_errors=True)
+        if restore_dir:
+            os.makedirs(bt)
 
 def run(args: T.List[str]) -> int:
     if len(args) != 1:
@@ -35,8 +37,9 @@ def run(args: T.List[str]) -> int:
         print('cleantrees.py <data-file>')
         return 1
     with open(args[0], 'rb') as f:
-        data = pickle.load(f)
-    rmtrees(data.build_dir, data.trees)
+        (del_trees, del_and_restore_trees) = pickle.load(f)
+    rmtrees(del_trees.build_dir, del_trees.trees, False)
+    rmtrees(del_and_restore_trees.build_dir, del_and_restore_trees.trees, True)
     # Never fail cleaning
     return 0
 

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2020 The Meson development team
+# Copyright 2012-2022 The Meson development team
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -94,6 +94,7 @@ __all__ = [
     'get_compiler_for_source',
     'get_filenames_templates_dict',
     'get_library_dirs',
+    'get_opaque_data',
     'get_variable_regex',
     'get_wine_shortpath',
     'git',
@@ -141,6 +142,7 @@ __all__ = [
     'version_compare_condition_with_min',
     'version_compare_many',
     'search_version',
+    'OpaqueData',
     'windows_proof_rm',
     'windows_proof_rmtree',
 ]
@@ -2277,3 +2279,21 @@ def first(iter: T.Iterable[_T], predicate: T.Callable[[_T], bool]) -> T.Optional
         if predicate(i):
             return i
     return None
+
+class OpaqueData:
+    def __init__(self, scratch: str, out: str, stamp: str, dep: str):
+        self.scratch = scratch
+        self.out = out
+        self.stamp = stamp
+        self.dep = dep
+
+def get_opaque_data(subproject: str, target_name: str) -> OpaqueData:
+    if subproject:
+        sub_str = subproject + '_'
+    else:
+        sub_str = ''
+    gendir = 'meson-gen'
+    return OpaqueData(os.path.join(gendir, sub_str, target_name + '_s'),
+                      os.path.join(gendir, sub_str, target_name),
+                      target_name + '.stamp',
+                      target_name + '.d')

--- a/test cases/common/260 opaque/ersatz_doctool.py
+++ b/test cases/common/260 opaque/ersatz_doctool.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import sys, os, subprocess, shutil
+import pathlib
+
+from argparse import ArgumentParser
+
+# Argparse does not permit ignoring unknown args.
+# Do it by hand.
+
+known_args = ['--out',
+              '--scratch',
+              '--stamp',
+              '--dep']
+
+def is_known(arg):
+    for a in known_args:
+        if arg.startswith(a):
+            return True
+    return False
+
+parser = ArgumentParser(description='Helper tool to test opaque generation')
+
+parser.add_argument('--out',
+                    required=True, help='Directory where to write final output.')
+parser.add_argument('--scratch',
+                    required=True,
+                    help='Directory to use for temporary files.')
+parser.add_argument('--stamp', required=True,
+                    help='Path to stamp file.')
+parser.add_argument('--dep', required=True,
+                    help='Path to dependency file.')
+
+def run_doxygen(meson_args, extra_args):
+    if len(extra_args) != 1:
+        sys.exit('Incorrect number of input arguments.')
+    if extra_args[0] != '--foobar':
+        sys.exit(f'Input arg is incorrect: {extra_args[0]}')
+    known_args = [x for x in meson_args if is_known(x)]
+    meson_opts = parser.parse_args(known_args)
+    outdir = pathlib.Path(meson_opts.out)
+    outsub = outdir / 'subdir'
+    scratchdir = pathlib.Path(meson_opts.scratch)
+    if os.path.exists(meson_opts.stamp):
+        os.unlink(meson_opts.stamp)
+    if not scratchdir.is_dir():
+        sys.exit('Meson did not create scratch dir.')
+    if not outdir.is_dir():
+        sys.exit('Meson did not create out dir.')
+    with open(scratchdir / 'dummy_file', 'wb'):
+        pass
+    with open(outdir / 'out_top.txt', 'wb'):
+        pass
+    outsub.mkdir(exist_ok=True)
+    with open(outsub / 'out_subdir.txt', 'wb'):
+        pass
+    # Always touch the stamp file last after every other step has succeeded.
+    with open(meson_opts.stamp, 'w'):
+        pass
+
+if __name__ == '__main__':
+    for i in range(len(sys.argv)):
+        if sys.argv[i] == '--':
+            run_doxygen(sys.argv[1:i], sys.argv[i+1:])
+            sys.exit(0)
+    sys.exit('Mandatory separator argument "--" missing.')

--- a/test cases/common/260 opaque/meson.build
+++ b/test cases/common/260 opaque/meson.build
@@ -1,0 +1,8 @@
+project('opaque_gen', 'c')
+
+opaque_target('datagen',
+    command: [find_program('ersatz_doctool.py')],
+    args: ['--foobar'],
+    install: true,
+    install_dir: get_option('datadir') / 'doc'
+)

--- a/test cases/common/260 opaque/test.json
+++ b/test cases/common/260 opaque/test.json
@@ -1,0 +1,6 @@
+{
+  "installed": [
+    { "type": "file", "file": "usr/share/doc/out_top.txt" },
+    { "type": "file", "file": "usr/share/doc/subdir/out_subdir.txt"}
+  ]
+}

--- a/test cases/frameworks/14 doxygen/doc/doxyrunner.py
+++ b/test cases/frameworks/14 doxygen/doc/doxyrunner.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import sys, os, subprocess, shutil
+import pathlib
+
+from argparse import ArgumentParser
+
+parser = ArgumentParser(description='Helper tool to integrate Doxygen with Meson')
+
+parser.add_argument('--out', 
+                    required=True, help='Directory where to write final output.')
+parser.add_argument('--scratch', 
+                    required=True, 
+                    help='Directory to use for temporary files.')
+parser.add_argument('--stamp', required=True, 
+                    help='Path to stamp file.')
+parser.add_argument('--dep', required=True,
+                    help='Path to dependency file.')
+
+def run_doxygen(meson_opts, extra_args):
+    # This simulates a program that does not support a -o argument
+    # but instead writes its output to cwd with a path segment
+    # we need to get rid of.
+    #
+    # You can tell Doxygen where to output its sources, but only
+    # in Doxyfile, not via the command line.
+    doxyfile = pathlib.Path(extra_args[0])
+    outdir = pathlib.Path(meson_opts.out)
+    scratchdir = pathlib.Path(meson_opts.scratch)
+    if scratchdir.exists():
+        shutil.rmtree(scratchdir)
+    scratchdir.mkdir(parents=True)
+    if outdir.exists():
+        shutil.rmtree(outdir)
+    shutil.copy(doxyfile, scratchdir)
+    doxyrc = subprocess.call(['doxygen', doxyfile.name], cwd=scratchdir)
+    docdir = scratchdir / 'doc'
+    html = docdir / 'html'
+    shutil.copytree(html, outdir / 'html')
+    if doxyrc != 0:
+        sys.exit(doxyrc)
+    with open(meson_opts.dep, 'w') as stampfile:
+        stampfile.write(f'"{meson_opts.stamp}": \n')
+    # Always touch the stamp file last after every other step has succeeded.
+    with open(meson_opts.stamp, 'w'):
+        pass
+
+if __name__ == '__main__':
+    for i in range(len(sys.argv)):
+        if sys.argv[i] == '--':
+            run_doxygen(parser.parse_args(sys.argv[1:i]), sys.argv[i+1:])
+            sys.exit(0)
+    sys.exit('Mandatory separator argument "--" missing.')

--- a/test cases/frameworks/14 doxygen/doc/doxyrunner.py
+++ b/test cases/frameworks/14 doxygen/doc/doxyrunner.py
@@ -7,12 +7,12 @@ from argparse import ArgumentParser
 
 parser = ArgumentParser(description='Helper tool to integrate Doxygen with Meson')
 
-parser.add_argument('--out', 
+parser.add_argument('--out',
                     required=True, help='Directory where to write final output.')
-parser.add_argument('--scratch', 
-                    required=True, 
+parser.add_argument('--scratch',
+                    required=True,
                     help='Directory to use for temporary files.')
-parser.add_argument('--stamp', required=True, 
+parser.add_argument('--stamp', required=True,
                     help='Path to stamp file.')
 parser.add_argument('--dep', required=True,
                     help='Path to dependency file.')
@@ -39,8 +39,8 @@ def run_doxygen(meson_opts, extra_args):
     shutil.copytree(html, outdir / 'html')
     if doxyrc != 0:
         sys.exit(doxyrc)
-    with open(meson_opts.dep, 'w') as stampfile:
-        stampfile.write(f'"{meson_opts.stamp}": \n')
+    with open(meson_opts.dep, 'w') as depfile:
+        depfile.write(f'"{meson_opts.stamp}": \n')
     # Always touch the stamp file last after every other step has succeeded.
     with open(meson_opts.stamp, 'w'):
         pass

--- a/test cases/frameworks/14 doxygen/doc/meson.build
+++ b/test cases/frameworks/14 doxygen/doc/meson.build
@@ -1,6 +1,8 @@
 cdata.set('TOP_SRCDIR', meson.source_root())
 cdata.set('TOP_BUILDDIR', meson.build_root())
 
+wrapper_script = find_program('doxyrunner.py')
+
 doxyfile = configure_file(input: 'Doxyfile.in',
                           output: 'Doxyfile',
                           configuration: cdata,
@@ -8,9 +10,8 @@ doxyfile = configure_file(input: 'Doxyfile.in',
 
 datadir = join_paths(get_option('datadir'), 'doc', 'spede')
 
-html_target = custom_target('spede-docs',
-                            input: doxyfile,
-                            output: 'html',
-                            command: [doxygen, doxyfile],
-                            install: true,
-                            install_dir: datadir)
+opaque_target('spede-docs',
+              command: wrapper_script,
+              args: [doxyfile],
+              install: true,
+              install_dir: datadir)


### PR DESCRIPTION
This is designed to support arbitrary document generators (Doxygen, hdoc, Sphinx, what have you) in a straightforward way without needing to add custom code for every one of them in Meson core.

Basically the end user writes a custom script that is given specific arguments to tell where it should put its things.

This MR is not final by any means, documentation, a proper unit test and the like are missing, just posting this here to get feedback before committing too deeply. Also missing are the docs, this needs a page of its own explaining the integration interface.