### PR TITLE
Add missing since annotations in docs

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -233,15 +233,15 @@ Support for packages which require a specified version for CMake
 kwarg (*introduced in 0.57.0*). The specified `cmake_package_version`
 will be passed directly as the second parameter to `find_package`.
 
-It is also possible to reuse existing `Find<name>.cmake` files with
-the `cmake_module_path` property. Using this property is equivalent to
-setting the `CMAKE_MODULE_PATH` variable in CMake. The path(s) given
-to `cmake_module_path` should all be relative to the project source
-directory. Absolute paths should only be used if the CMake files are
-not stored in the project itself.
+It is also possible to reuse existing `Find<name>.cmake` files with the
+`cmake_module_path` property (*since 0.50.0*). Using this property is
+equivalent to setting the `CMAKE_MODULE_PATH` variable in CMake. The
+path(s) given to `cmake_module_path` should all be relative to the
+project source directory. Absolute paths should only be used if the
+CMake files are not stored in the project itself.
 
 Additional CMake parameters can be specified with the `cmake_args`
-property.
+property (*since 0.50.0*).
 
 ## Dub
 

--- a/docs/markdown/Python-module.md
+++ b/docs/markdown/Python-module.md
@@ -111,6 +111,8 @@ add `dependencies : py_installation.dependency()`, see [[dependency]].
 python_dependency py_installation.dependency(...)
 ```
 
+*since 0.53.0*
+
 This method accepts no positional arguments, and the same keyword
 arguments as the standard [[dependency]] function. It also supports the
 following keyword argument:

--- a/docs/markdown/_include_qt_base.md
+++ b/docs/markdown/_include_qt_base.md
@@ -106,6 +106,8 @@ build target.
 
 ## has_tools
 
+*since 0.54.0*
+
 This method returns `true` if all tools used by this module are found,
 `false` otherwise.
 
@@ -123,8 +125,6 @@ This method takes the following keyword arguments:
   `true` or an enabled [`feature`](Build-options.md#features) and some tools are
   missing Meson will abort.
 - `method` string: method used to find the Qt dependency (`auto` by default).
-
-*Since: 0.54.0*
 
 ## Dependencies
 

--- a/docs/yaml/builtins/meson.yaml
+++ b/docs/yaml/builtins/meson.yaml
@@ -403,6 +403,7 @@ methods:
 
   - name: project_license
     returns: list[str]
+    since: 0.45.0
     description: Returns the array of licenses specified in [[project]] function call.
 
   - name: project_name

--- a/docs/yaml/functions/_build_target_base.yaml
+++ b/docs/yaml/functions/_build_target_base.yaml
@@ -63,6 +63,7 @@ kwargs:
 
   build_rpath:
     type: str
+    since: 0.42.0
     description: |
       A string to add to target's rpath definition in the build dir,
       but which will be removed on install
@@ -281,7 +282,7 @@ kwargs:
 
   rust_crate_type:
     type: str
-    since: 0.41.0
+    since: 0.42.0
     description: |
       Set the specific type of rust crate to compile (when compiling rust).
 

--- a/docs/yaml/functions/dependency.yaml
+++ b/docs/yaml/functions/dependency.yaml
@@ -79,7 +79,7 @@ varargs:
 kwargs:
   default_options:
     type: list[str]
-    since: 0.37.0
+    since: 0.38.0
     description: |
       An array of default option values
       that override those set in the subproject's `meson_options.txt`
@@ -131,6 +131,7 @@ kwargs:
 
   method:
     type: str
+    since: 0.40.0
     default: "'auto'"
     description: |
       Defines the way the dependency is detected, the default is

--- a/docs/yaml/functions/subdir_done.yaml
+++ b/docs/yaml/functions/subdir_done.yaml
@@ -1,5 +1,6 @@
 name: subdir_done
 returns: void
+since: 0.46.0
 description: |
   Stops further interpretation of the Meson script file from the point
   of the invocation. All steps executed up to this point are valid and

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3098,7 +3098,7 @@ Try setting b_lundef to false instead.'''.format(self.coredata.options[OptionKey
     def build_target(self, node: mparser.BaseNode, args, kwargs, targetclass):
         @FeatureNewKwargs('build target', '0.42.0', ['rust_crate_type', 'build_rpath', 'implicit_include_directories'])
         @FeatureNewKwargs('build target', '0.41.0', ['rust_args'])
-        @FeatureNewKwargs('build target', '0.40.0', ['build_by_default'])
+        @FeatureNewKwargs('build target', '0.38.0', ['build_by_default'])
         @FeatureNewKwargs('build target', '0.48.0', ['gnu_symbol_visibility'])
         def build_target_decorator_caller(self, node, args, kwargs):
             return True


### PR DESCRIPTION
This is based on searching for `@FeatureNew*` decorators.

There is also one correction to a version in a decorators; `build_by_default` was added in #1303, which is 0.38.0, not 0.40.0.