### PR TITLE
Accept disablers in summary values

### DIFF
--- a/docs/markdown/snippets/summary-disabler.md
+++ b/docs/markdown/snippets/summary-disabler.md
@@ -1,0 +1,3 @@
+## `summary()` accepts disablers
+
+Disabler options can be passed to `summary()` as the value to be printed.

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -166,11 +166,14 @@ class Summary:
                 elif isinstance(i, (ExternalProgram, Dependency)):
                     FeatureNew.single_use('dependency or external program in summary', '0.57.0', subproject)
                     formatted_values.append(i.summary_value())
+                elif isinstance(i, Disabler):
+                    FeatureNew.single_use('disabler in summary', '0.64.0', subproject)
+                    formatted_values.append(mlog.red('NO'))
                 elif isinstance(i, coredata.UserOption):
                     FeatureNew.single_use('feature option in summary', '0.58.0', subproject)
                     formatted_values.append(i.printable_value())
                 else:
-                    m = 'Summary value in section {!r}, key {!r}, must be string, integer, boolean, dependency or external program'
+                    m = 'Summary value in section {!r}, key {!r}, must be string, integer, boolean, dependency, disabler, or external program'
                     raise InterpreterException(m.format(section, k))
             self.sections[section][k] = (formatted_values, list_sep)
             self.max_key_len = max(self.max_key_len, len(k))

--- a/test cases/unit/71 summary/meson.build
+++ b/test cases/unit/71 summary/meson.build
@@ -15,9 +15,10 @@ summary({'missing prog': find_program('xyzzy', required: false),
          'missing dep': dependency('', required: false),
          'external dep': dependency('zlib', required: false),
          'internal dep': declare_dependency(),
+         'disabler': disabler(),
         }, section: 'Stuff')
 summary('A number', 1, section: 'Configuration')
 summary('yes', true, bool_yn : true, section: 'Configuration')
 summary('no', false, bool_yn : true, section: 'Configuration')
-summary('coma list', ['a', 'b', 'c'], list_sep: ', ', section: 'Configuration')
-summary('long coma list', ['alpha', 'alphacolor', 'apetag', 'audiofx', 'audioparsers', 'auparse', 'autodetect', 'avi'], list_sep: ', ', section: 'Plugins')
+summary('comma list', ['a', 'b', 'c'], list_sep: ', ', section: 'Configuration')
+summary('long comma list', ['alpha', 'alphacolor', 'apetag', 'audiofx', 'audioparsers', 'auparse', 'autodetect', 'avi'], list_sep: ', ', section: 'Plugins')

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -3317,7 +3317,7 @@ class AllPlatformTests(BasePlatformTests):
                 A number       : 1
                 yes            : YES
                 no             : NO
-                coma list      : a, b, c
+                comma list     : a, b, c
 
               Stuff
                 missing prog   : NO
@@ -3325,9 +3325,10 @@ class AllPlatformTests(BasePlatformTests):
                 missing dep    : NO
                 external dep   : YES 1.2.3
                 internal dep   : YES
+                disabler       : NO
 
               Plugins
-                long coma list : alpha, alphacolor, apetag, audiofx, audioparsers, auparse,
+                long comma list: alpha, alphacolor, apetag, audiofx, audioparsers, auparse,
                                  autodetect, avi
 
               Subprojects


### PR DESCRIPTION
They are commonly used as a replacement for a `dependency`, and not accepting them in `summary` breaks the last example in [1] when used as a value.

Also fix a typo in the `summary` test case.

[1] https://mesonbuild.com/Disabler.html#disabling-parts-of-the-build