### PR TITLE
backends: Try guessing install tag for all installed files

### DIFF
--- a/test cases/unit/98 install all targets/meson.build
+++ b/test cases/unit/98 install all targets/meson.build
@@ -31,6 +31,22 @@ configure_file(input: 'foo.in', output: 'foo2-devel.h',
 static_library('static', 'lib.c',
   install: true,
 )
+custom_target('ct-header1',
+  output: ['ct-header1.h'],
+  command: ['script.py', '@OUTPUT@'],
+  install_dir: get_option('includedir'),
+  install: true,
+)
+custom_target('ct-header2',
+  output: ['ct-header2.h', 'ct-header3.h'],
+  command: ['script.py', '@OUTPUT@'],
+  install_dir: [false, get_option('includedir')],
+  install: true,
+)
+install_emptydir(get_option('includedir') / 'subdir-devel')
+install_subdir('custom_files',
+  install_dir: get_option('includedir'),
+)
 
 # Those files should have 'runtime' tag
 executable('app', 'main.c',

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -4054,6 +4054,11 @@ class AllPlatformTests(BasePlatformTests):
             Path(installpath, 'usr/lib/libstatic.a'),
             Path(installpath, 'usr/lib/libboth.a'),
             Path(installpath, 'usr/lib/libboth2.a'),
+            Path(installpath, 'usr/include/ct-header1.h'),
+            Path(installpath, 'usr/include/ct-header3.h'),
+            Path(installpath, 'usr/include/subdir-devel'),
+            Path(installpath, 'usr/include/custom_files'),
+            Path(installpath, 'usr/include/custom_files/data.txt'),
         }
 
         if cc.get_id() in {'msvc', 'clang-cl'}:


### PR DESCRIPTION
It was only trying to guess install tag, and log missing tags, for files installed by install_data(). Do it also for all other files, especially custom_taget() that commonly installs generated headers.