### PR TITLE
minstall: make do_strip run with -Sx for macOS targets

### DIFF
--- a/test cases/unit/103 strip/lib.c
+++ b/test cases/unit/103 strip/lib.c
@@ -1,1 +1,3 @@
-void func(void){}
+#include <stdio.h>
+
+void func(void){ fprintf(stderr, "Test 1 2 3\n"); }


### PR DESCRIPTION
👋 

This PR fixes #10943 by ensuring the `do_strip` step runs as prescribed by the macOS man pages. I've ported existing tests to check that `strip=true` keeps working in Linux-like platforms, and works in Darwin.