### PR TITLE
ci: Fix usage of concurrency in branches other than master

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -1,7 +1,7 @@
 name: cygwin
 
 concurrency:
-  group: cygwin-${{ github.head_ref }}
+  group: cygwin-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/file_format.yml
+++ b/.github/workflows/file_format.yml
@@ -3,7 +3,7 @@ name: File format check
 on: [push, pull_request]
 
 concurrency:
-  group: file_fmt-${{ github.head_ref }}
+  group: file_fmt-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,7 +1,7 @@
 name: CI image builder
 
 concurrency:
-  group: img_builder-${{ github.head_ref }}
+  group: img_builder-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 name: Lint
 
 concurrency:
-  group: lint-${{ github.head_ref }}
+  group: lint-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,7 +1,7 @@
 name: macos
 
 concurrency:
-  group: macos-${{ github.head_ref }}
+  group: macos-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -1,7 +1,7 @@
 name: msys2
 
 concurrency:
-  group: msys2-${{ github.head_ref }}
+  group: msys2-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/nonative.yml
+++ b/.github/workflows/nonative.yml
@@ -1,7 +1,7 @@
 name: Cross-only compilation environment
 
 concurrency:
-  group: nonative-${{ github.head_ref }}
+  group: nonative-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/os_comp.yml
+++ b/.github/workflows/os_comp.yml
@@ -1,7 +1,7 @@
 name: linux
 
 concurrency:
-  group: linux-${{ github.head_ref }}
+  group: linux-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/unusedargs_missingreturn.yml
+++ b/.github/workflows/unusedargs_missingreturn.yml
@@ -10,7 +10,7 @@ env:
   FFLAGS: "-fimplicit-none"
 
 concurrency:
-  group: unusedargs-${{ github.head_ref }}
+  group: unusedargs-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
👋 

During the testing of #10966, I noticed that in my fork every newly pushed commit cancelled CI for all branches, not just the one that was pushed. This is because, according to the [documentation](https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value), `github.head_ref` is a variable that is only defined for pull requests and not for individual push events.

This PR fixes the issue by adding the official suggested fallback value to all affected jobs.