### PR TITLE
emscripten: prefer to specify options as single arguments

### DIFF
--- a/cross/wasm.txt
+++ b/cross/wasm.txt
@@ -5,9 +5,9 @@ ar = '/home/jpakkane/src/emsdk/upstream/emscripten/emar'
 
 [built-in options]
 c_args = []
-c_link_args = ['-s','EXPORT_ALL=1']
+c_link_args = ['-sEXPORT_ALL=1']
 cpp_args = []
-cpp_link_args = ['-s', 'EXPORT_ALL=1']
+cpp_link_args = ['-sEXPORT_ALL=1']
 
 [host_machine]
 

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -212,6 +212,8 @@ class EmscriptenCCompiler(EmscriptenMixin, ClangCCompiler):
                  full_version: T.Optional[str] = None):
         if not is_cross:
             raise MesonException('Emscripten compiler can only be used for cross compilation.')
+        if not version_compare(version, '>=1.39.19'):
+            raise MesonException('Meson requires Emscripten >= 1.39.19')
         ClangCCompiler.__init__(self, ccache, exelist, version, for_machine, is_cross,
                                 info, exe_wrapper=exe_wrapper, linker=linker,
                                 defines=defines, full_version=full_version)

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -285,6 +285,8 @@ class EmscriptenCPPCompiler(EmscriptenMixin, ClangCPPCompiler):
                  full_version: T.Optional[str] = None):
         if not is_cross:
             raise MesonException('Emscripten compiler can only be used for cross compilation.')
+        if not version_compare(version, '>=1.39.19'):
+            raise MesonException('Meson requires Emscripten >= 1.39.19')
         ClangCPPCompiler.__init__(self, ccache, exelist, version, for_machine, is_cross,
                                   info, exe_wrapper=exe_wrapper, linker=linker,
                                   defines=defines, full_version=full_version)

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -365,8 +365,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
 
             # emcc requires a file input in order to pass arguments to the
             # linker. It'll exit with an error code, but still print the
-            # linker version. Old emcc versions ignore -Wl,--version completely,
-            # however. We'll report "unknown version" in that case.
+            # linker version.
             with tempfile.NamedTemporaryFile(suffix='.c') as f:
                 cmd = compiler + [cls.LINKER_PREFIX + "--version", f.name]
                 _, o, _ = Popen_safe(cmd)

--- a/mesonbuild/compilers/mixins/emscripten.py
+++ b/mesonbuild/compilers/mixins/emscripten.py
@@ -65,7 +65,7 @@ class EmscriptenMixin(Compiler):
         args = ['-pthread']
         count: int = env.coredata.options[OptionKey('thread_count', lang=self.language, machine=self.for_machine)].value
         if count:
-            args.extend(['-s', f'PTHREAD_POOL_SIZE={count}'])
+            args.append(f'-sPTHREAD_POOL_SIZE={count}')
         return args
 
     def get_options(self) -> 'coredata.MutableKeyedOptionDictType':

--- a/mesonbuild/compilers/mixins/emscripten.py
+++ b/mesonbuild/compilers/mixins/emscripten.py
@@ -59,10 +59,10 @@ class EmscriptenMixin(Compiler):
         return os.path.join(dirname, 'output.' + suffix)
 
     def thread_flags(self, env: 'Environment') -> T.List[str]:
-        return ['-s', 'USE_PTHREADS=1']
+        return ['-pthread']
 
     def thread_link_flags(self, env: 'Environment') -> T.List[str]:
-        args = ['-s', 'USE_PTHREADS=1']
+        args = ['-pthread']
         count: int = env.coredata.options[OptionKey('thread_count', lang=self.language, machine=self.for_machine)].value
         if count:
             args.extend(['-s', f'PTHREAD_POOL_SIZE={count}'])

--- a/mesonbuild/compilers/mixins/emscripten.py
+++ b/mesonbuild/compilers/mixins/emscripten.py
@@ -58,9 +58,6 @@ class EmscriptenMixin(Compiler):
             suffix = 'o'
         return os.path.join(dirname, 'output.' + suffix)
 
-    def thread_flags(self, env: 'Environment') -> T.List[str]:
-        return ['-pthread']
-
     def thread_link_flags(self, env: 'Environment') -> T.List[str]:
         args = ['-pthread']
         count: int = env.coredata.options[OptionKey('thread_count', lang=self.language, machine=self.for_machine)].value

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -885,10 +885,10 @@ class WASMDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, Dyna
     id = 'ld.wasm'
 
     def get_allow_undefined_args(self) -> T.List[str]:
-        return ['-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0']
+        return ['-sERROR_ON_UNDEFINED_SYMBOLS=0']
 
     def no_undefined_args(self) -> T.List[str]:
-        return ['-s', 'ERROR_ON_UNDEFINED_SYMBOLS=1']
+        return ['-sERROR_ON_UNDEFINED_SYMBOLS=1']
 
     def get_soname_args(self, env: 'Environment', prefix: str, shlib_name: str,
                         suffix: str, soversion: str, darwin_versions: T.Tuple[str, str]) -> T.List[str]:


### PR DESCRIPTION
See the individual commits for more details. 

In short, this PR ensures that Emscripten settings are specified without a space between the `-s` and option name. This would fix the generation of pkg-config files that CMake cannot link against, see for example this diff:
<details>
    <summary>Details</summary>

```diff
--- a/vips.pc
+++ b/vips.pc
@@ -6,5 +6,5 @@ Name: vips
 Description: Image processing library
 Version: 8.13.2
 Requires: glib-2.0 >= 2.40, gio-2.0, gobject-2.0, gmodule-no-export-2.0, expat, imagequant, cgif >= 0.2.0, libexif >= 0.6, libjpeg, spng >= 0.7, libwebp >= 0.6, libwebpmux >= 0.6, libwebpdemux >= 0.6, libtiff-4, lcms2
-Libs: -L${libdir} -lvips -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=4 -lm -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=4 -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=4 -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=4 -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=4 -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=4 -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=4 -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=4 -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=4 -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=4 -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=4 -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=4 -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=4 -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=4 /src/build/target/lib/vips-modules-8.13/vips-jxl.wasm
-Cflags: -I${includedir} -s USE_PTHREADS=1 -DHAVE_CONFIG_H=1
+Libs: -L${libdir} -lvips -pthread -sPTHREAD_POOL_SIZE=4 -lm /src/build/target/lib/vips-modules-8.13/vips-jxl.wasm
+Cflags: -I${includedir} -pthread -DHAVE_CONFIG_H=1
```
</details>

I could not find the minimum Emscripten version that Meson supports, but this PR would imply that 1.39.19 is the minimum. This is an acceptable minimum, as the old fastcomp backend has been removed and is no longer supported since Emscripten 2.0.0.
https://github.com/emscripten-core/emscripten/blob/main/ChangeLog.md#200-08102020