### PR TITLE
Add ParenthesizedNode

### DIFF
--- a/mesonbuild/interpreterbase/interpreterbase.py
+++ b/mesonbuild/interpreterbase/interpreterbase.py
@@ -225,6 +225,8 @@ class InterpreterBase:
             raise ContinueRequest()
         elif isinstance(cur, mparser.BreakNode):
             raise BreakRequest()
+        elif isinstance(cur, mparser.ParenthesizedNode):
+            return self.evaluate_statement(cur.inner)
         else:
             raise InvalidCode("Unknown statement.")
         return None

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -475,6 +475,11 @@ class TernaryNode(BaseNode):
         self.trueblock = trueblock    # type: BaseNode
         self.falseblock = falseblock  # type: BaseNode
 
+class ParenthesizedNode(BaseNode):
+    def __init__(self, inner: BaseNode, lineno: int, colno: int, end_lineno: int, end_colno: int):
+        super().__init__(lineno, colno, inner.filename, end_lineno=end_lineno, end_colno=end_colno)
+        self.inner = inner              # type: BaseNode
+
 comparison_map = {'equal': '==',
                   'nequal': '!=',
                   'lt': '<',
@@ -668,7 +673,7 @@ class Parser:
         if self.accept('lparen'):
             e = self.statement()
             self.block_expect('rparen', block_start)
-            return e
+            return ParenthesizedNode(e, block_start.lineno, block_start.colno, self.current.lineno, self.current.colno)
         elif self.accept('lbracket'):
             args = self.args()
             self.block_expect('rbracket', block_start)

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -90,6 +90,8 @@ class OptionInterpreter:
     def reduce_single(self, arg: T.Union[str, mparser.BaseNode]) -> 'TYPE_var':
         if isinstance(arg, str):
             return arg
+        if isinstance(arg, mparser.ParenthesizedNode):
+            return self.reduce_single(arg.inner)
         elif isinstance(arg, (mparser.StringNode, mparser.BooleanNode,
                               mparser.NumberNode)):
             return arg.value


### PR DESCRIPTION
This is from #10971, will be removed from there as soon as this here is merged.

This adds a new node type in order to be able to distinguish
```
foo = bar ? 1 : 2
```
and
```
foo = (bar ? 1 : 2)
```

I sadly don't know, whether any tests are needed and if a release note snippet is needed, as this is internal. All tests pass locally