### PR TITLE
emit a FeatureNew when using include_directories as a string

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2634,6 +2634,13 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     def extract_incdirs(self, kwargs, key: str = 'include_directories'):
         prospectives = extract_as_list(kwargs, key)
+        if key == 'include_directories':
+            for i in prospectives:
+                if isinstance(i, str):
+                    FeatureNew.single_use('include_directories kwarg of type string', '0.50.0', self.subproject,
+                                          f'Use include_directories({i!r}) instead', location=self.current_node)
+                    break
+
         result = []
         for p in prospectives:
             if isinstance(p, build.IncludeDirs):


### PR DESCRIPTION
This was introduced in commit 3a6e2aeed9737f1082571e868ba50e72957f27c7 as part of 0.50.0, but did not contain a FeatureNew. As a result, people would use it without realizing that they broke support for versions of Meson included in their minimum requirements.