### PR TITLE
Revert some commits that broke PCH on MSVC, and others

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1403,13 +1403,11 @@ You probably should put it in link_with instead.''')
                     raise InvalidArguments(msg + ' This is not possible in a cross build.')
                 else:
                     mlog.warning(msg + ' This will fail in cross build.')
-            # When we're a static library and we link_whole: to another static
-            # library, we need to add that target's objects to ourselves.
-            # Otherwise add it to the link_whole_targets, but not both.
             if isinstance(self, StaticLibrary):
+                # When we're a static library and we link_whole: to another static
+                # library, we need to add that target's objects to ourselves.
                 self.objects += t.extract_all_objects_recurse()
-            else:
-                self.link_whole_targets.append(t)
+            self.link_whole_targets.append(t)
 
     def extract_all_objects_recurse(self) -> T.List[T.Union[str, 'ExtractedObjects']]:
         objs = [self.extract_all_objects()]

--- a/test cases/osx/9 global variable ar/libfile.c
+++ b/test cases/osx/9 global variable ar/libfile.c
@@ -1,9 +1,0 @@
-// Source: https://lists.gnu.org/archive/html/libtool/2002-07/msg00025.html
-
-#include <stdio.h>
-
-extern int l2;
-void l1(void)
-{
-  printf("l1 %d\n", l2);
-}

--- a/test cases/osx/9 global variable ar/libfile2.c
+++ b/test cases/osx/9 global variable ar/libfile2.c
@@ -1,7 +1,0 @@
-// Source: https://lists.gnu.org/archive/html/libtool/2002-07/msg00025.html
-
-int l2;
-void l2_func(void)
-{
-  l2 = 77;
-}

--- a/test cases/osx/9 global variable ar/meson.build
+++ b/test cases/osx/9 global variable ar/meson.build
@@ -1,6 +1,0 @@
-# Source: https://lists.gnu.org/archive/html/libtool/2002-07/msg00025.html
-
-project('global variable test', 'c')
-
-lib = static_library('mylib', 'libfile.c', 'libfile2.c')
-test('global variable', executable('prog', 'prog.c', link_with: lib))

--- a/test cases/osx/9 global variable ar/nativefile.ini
+++ b/test cases/osx/9 global variable ar/nativefile.ini
@@ -1,2 +1,0 @@
-[binaries]
-ar = 'ar'

--- a/test cases/osx/9 global variable ar/prog.c
+++ b/test cases/osx/9 global variable ar/prog.c
@@ -1,7 +1,0 @@
-// Source: https://lists.gnu.org/archive/html/libtool/2002-07/msg00025.html
-
-extern void l1(void);
-int main(void)
-{
-  l1();
-}


### PR DESCRIPTION
This reverts commit c94c492089e7fecb56b7cc11ea76712a770f1e34.

This broke propagated deps as well as PCH in MSVC, and has not been fixed in time for the final release of 0.64.0, so it needs to be reverted and then brought back later.

Fixes #10745
Fixes #10975

Also reverts the following commits that were broken and fixed by c94c492089e7fecb56b7cc11ea76712a770f1e34 and therefore need to be reverted by it:
- Revert "tests: Test extern'd globals on MacOS with the Apple Archiver"
  This reverts commit d285be763f193606b078f218fdedc58679dfe037.
- Revert "backends/ninja: run `ranlib -c $out` when using the apple ar"
  This reverts commit bdc6f243e9f95246b5801d2c0ccf64173fb280f3.