### PR TITLE
fix confusing azure pipelines status for coverage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,3 +112,8 @@ jobs:
       filePath: .\ci\run.ps1
     env:
       MESON_CI_JOBNAME: azure-$(System.JobName)
+  - task: PowerShell@2
+    displayName: Gathering coverage report
+    inputs:
+      targetType: 'filePath'
+      filePath: .\ci\coverage.ps1

--- a/ci/coverage.ps1
+++ b/ci/coverage.ps1
@@ -1,0 +1,14 @@
+echo ""
+echo ""
+echo "=== Gathering coverage report ==="
+echo ""
+
+python3 -m coverage combine
+python3 -m coverage xml
+python3 -m coverage report
+
+# Currently codecov.py does not handle Azure, use this fork of a fork to get it
+# working without requiring a token
+git clone https://github.com/mensinda/codecov-python
+python3 -m pip install --ignore-installed ./codecov-python
+python3 -m codecov -f .coverage/coverage.xml -n "VS$env:compiler $env:arch $env:backend" -c $env:SOURCE_VERSION

--- a/ci/run.ps1
+++ b/ci/run.ps1
@@ -98,21 +98,4 @@ echo "=== Start running tests ==="
 # does that by default so we need to forward it.
 cmd /c "python 2>&1 ./tools/run_with_cov.py  run_tests.py --backend $env:backend $env:extraargs"
 
-$result = $LastExitCode
-
-echo ""
-echo ""
-echo "=== Gathering coverage report ==="
-echo ""
-
-python3 -m coverage combine
-python3 -m coverage xml
-python3 -m coverage report
-
-# Currently codecov.py does not handle Azure, use this fork of a fork to get it
-# working without requiring a token
-git clone https://github.com/mensinda/codecov-python
-python3 -m pip install --ignore-installed ./codecov-python
-python3 -m codecov -f .coverage/coverage.xml -n "VS$env:compiler $env:arch $env:backend" -c $env:SOURCE_VERSION
-
-exit $result
+exit $LastExitCode


### PR DESCRIPTION
The coverage report was always the final section of the main test run. This made it hard to scroll around and find exactly what went wrong -- particularly as not everyone realizes that coverage isn't part of the test run, but also because the output from coverage is... excessively long.

This mirrors what we do in our other workflows.