### PR TITLE
python 3.11: suppress an incorrect EncodingWarning

### DIFF
--- a/mesonbuild/dependencies/hdf5.py
+++ b/mesonbuild/dependencies/hdf5.py
@@ -21,7 +21,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from ..mesonlib import OrderedSet, join_args
+from ..mesonlib import Popen_safe, OrderedSet, join_args
 from .base import DependencyException, DependencyMethods
 from .configtool import ConfigToolDependency
 from .pkgconfig import PkgConfigDependency
@@ -163,10 +163,9 @@ def hdf5_factory(env: 'Environment', for_machine: 'MachineChoice',
         PCEXE = shutil.which('pkg-config')
         if PCEXE:
             # some distros put hdf5-1.2.3.pc with version number in .pc filename.
-            ret = subprocess.run([PCEXE, '--list-all'], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
-                                 text=True)
+            ret, stdout, _ = Popen_safe([PCEXE, '--list-all'], stderr=subprocess.DEVNULL)
             if ret.returncode == 0:
-                for pkg in ret.stdout.split('\n'):
+                for pkg in stdout.split('\n'):
                     if pkg.startswith('hdf5'):
                         pkgconfig_files.add(pkg.split(' ', 1)[0])
 

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -240,6 +240,13 @@ def run(original_args, mainfile):
         # workaround for https://bugs.python.org/issue34624
         import warnings
         warnings.filterwarnings('error', category=EncodingWarning, module='mesonbuild')
+        # python 3.11 adds a warning that in 3.15, UTF-8 mode will be default.
+        # This is fantastic news, we'd love that. Less fantastic: this warning is silly,
+        # we *want* these checks to be affected. Plus, the recommended alternative API
+        # would (in addition to warning people when UTF-8 mode removed the problem) also
+        # require using a minimum python version of 3.11 (in which the warning was added)
+        # or add verbose if/else soup.
+        warnings.filterwarnings('ignore', message="UTF-8 Mode affects .*getpreferredencoding", category=EncodingWarning)
 
     # Meson gets confused if stdout can't output Unicode, if the
     # locale isn't Unicode, just force stdout to accept it. This tries

--- a/mesonbuild/scripts/depfixer.py
+++ b/mesonbuild/scripts/depfixer.py
@@ -21,7 +21,7 @@ import shutil
 import subprocess
 import typing as T
 
-from ..mesonlib import OrderedSet, generate_list
+from ..mesonlib import OrderedSet, generate_list, Popen_safe
 
 SHT_STRTAB = 3
 DT_NEEDED = 1
@@ -391,9 +391,9 @@ def fix_elf(fname: str, rpath_dirs_to_remove: T.Set[bytes], new_rpath: T.Optiona
             e.fix_rpath(fname, rpath_dirs_to_remove, new_rpath)
 
 def get_darwin_rpaths_to_remove(fname: str) -> T.List[str]:
-    out = subprocess.check_output(['otool', '-l', fname],
-                                  universal_newlines=True,
-                                  stderr=subprocess.DEVNULL)
+    p, out, _ = Popen_safe(['otool', '-l', fname], stderr=subprocess.DEVNULL)
+    if p.returncode != 0:
+        raise subprocess.CalledProcessError(p.returncode, p.args, out)
     result = []
     current_cmd = 'FOOBAR'
     for line in out.split('\n'):

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -1416,7 +1416,7 @@ def Popen_safe(args: T.List[str], write: T.Optional[str] = None,
     if not sys.stdout.encoding or encoding.upper() != 'UTF-8':
         p, o, e = Popen_safe_legacy(args, write=write, stdin=stdin, stdout=stdout, stderr=stderr, **kwargs)
     else:
-        p = subprocess.Popen(args, universal_newlines=True, close_fds=False,
+        p = subprocess.Popen(args, universal_newlines=True, encoding=encoding, close_fds=False,
                              stdin=stdin, stdout=stdout, stderr=stderr, **kwargs)
         o, e = p.communicate(write)
     # Sometimes the command that we run will call another command which will be

--- a/run_tests.py
+++ b/run_tests.py
@@ -76,6 +76,15 @@ else:
 os.environ['PYTHONWARNDEFAULTENCODING'] = '1'
 # work around https://bugs.python.org/issue34624
 os.environ['MESON_RUNNING_IN_PROJECT_TESTS'] = '1'
+# python 3.11 adds a warning that in 3.15, UTF-8 mode will be default.
+# This is fantastic news, we'd love that. Less fantastic: this warning is silly,
+# we *want* these checks to be affected. Plus, the recommended alternative API
+# would (in addition to warning people when UTF-8 mode removed the problem) also
+# require using a minimum python version of 3.11 (in which the warning was added)
+# or add verbose if/else soup.
+if sys.version_info >= (3, 10):
+    import warnings
+    warnings.filterwarnings('ignore', message="UTF-8 Mode affects .*getpreferredencoding", category=EncodingWarning)
 
 def guess_backend(backend_str: str, msbuild_exe: str) -> T.Tuple['Backend', T.List[str]]:
     # Auto-detect backend if unspecified


### PR DESCRIPTION
python 3.11 adds a warning that in 3.15, UTF-8 mode will be default. This is fantastic news, we'd love that. Less fantastic: this warning is silly, we *want* these checks to be affected. Plus, the recommended alternative API would (in addition to warning people when UTF-8 mode removed the problem) also require using a minimum python version of 3.11 (in which the warning was added) or add verbose if/else soup.

The simple, and obvious, approach is to add a warnings filter to hide it.