### PR TITLE
devenv: various improvements

### DIFF
--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -345,6 +345,8 @@ These variables are set in environment in addition to those set using [[meson.ad
   schemas is compiled. This is automatically set when using `gnome.compile_schemas()`.
   Note that this requires GLib >= 2.64 when `gnome.compile_schemas()` is used in
   more than one directory.
+- `QEMU_LD_PREFIX` *Since 1.0.0* is set to the `sys_root` value from cross file
+  when cross compiling and that property is defined.
 
 Since *Since 0.62.0* if bash-completion scripts are being installed and the
 shell is bash, they will be automatically sourced.

--- a/docs/markdown/snippets/devenv.md
+++ b/docs/markdown/snippets/devenv.md
@@ -1,0 +1,15 @@
+## Developer environment improvements
+
+When cross compiling, the developer environment now sets all environment
+variables for the HOST machine. It now also sets `QEMU_LD_PREFIX` to the
+`sys_root` value from cross file if property is defined. That means that cross
+compiled executables can often be run transparently on the build machine, for
+example when cross compiling for aarch64 linux from x86_64 linux.
+
+A new argument `--workdir` has been added, by default it is set to build
+directory. For example, `meson devenv -C builddir --workdir .` can be used to
+remain in the current dir (often source dir) instead.
+
+`--dump` now prints shell commands like `FOO="/prepend/path:$FOO:/append/path"`,
+using the litteral `$FOO` instead of current value of `FOO` from environment.
+This makes easier to evaluate those expressions in a different environment.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1854,10 +1854,8 @@ class Backend:
         host_machine = self.environment.machines[MachineChoice.HOST]
         need_wine = not build_machine.is_windows() and host_machine.is_windows()
         for t in self.build.get_targets().values():
-            cross_built = not self.environment.machines.matches_build_machine(t.for_machine)
-            can_run = not cross_built or not need_exe_wrapper or need_wine
             in_default_dir = t.should_install() and not t.get_install_dir()[2]
-            if not can_run or not in_default_dir:
+            if t.for_machine != MachineChoice.HOST or not in_default_dir:
                 continue
             tdir = os.path.join(self.environment.get_build_dir(), self.get_target_dir(t))
             if isinstance(t, build.Executable):

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1108,10 +1108,7 @@ class Backend:
                         break
 
             is_cross = self.environment.is_cross_build(test_for_machine)
-            if is_cross and self.environment.need_exe_wrapper():
-                exe_wrapper = self.environment.get_exe_wrapper()
-            else:
-                exe_wrapper = None
+            exe_wrapper = self.environment.get_exe_wrapper()
             machine = self.environment.machines[exe.for_machine]
             if machine.is_windows() or machine.is_cygwin():
                 extra_bdeps: T.List[T.Union[build.BuildTarget, build.CustomTarget]] = []

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -25,9 +25,7 @@ from .mesonlib import (
     search_version, MesonBugException
 )
 from . import mlog
-from .programs import (
-    ExternalProgram, EmptyExternalProgram
-)
+from .programs import ExternalProgram
 
 from .envconfig import (
     BinaryTable, MachineInfo, Properties, known_cpu_families, CMakeVariables,
@@ -852,7 +850,7 @@ class Environment:
             return value
         return not machine_info_can_run(self.machines[for_machine])
 
-    def get_exe_wrapper(self) -> ExternalProgram:
+    def get_exe_wrapper(self) -> T.Optional[ExternalProgram]:
         if not self.need_exe_wrapper():
-            return EmptyExternalProgram()
+            return None
         return self.exe_wrapper

--- a/mesonbuild/mdevenv.py
+++ b/mesonbuild/mdevenv.py
@@ -6,7 +6,8 @@ import itertools
 
 from pathlib import Path
 from . import build, minstall, dependencies
-from .mesonlib import MesonException, is_windows, setup_vsenv, OptionKey, get_wine_shortpath
+from .mesonlib import (MesonException, is_windows, setup_vsenv, OptionKey,
+                       get_wine_shortpath, MachineChoice)
 from . import mlog
 
 import typing as T
@@ -51,6 +52,10 @@ def get_env(b: build.Build, dump: bool) -> T.Tuple[T.Dict[str, str], T.Set[str]]
     extra_env = build.EnvironmentVariables()
     extra_env.set('MESON_DEVENV', ['1'])
     extra_env.set('MESON_PROJECT_NAME', [b.project_name])
+
+    sysroot = b.environment.properties[MachineChoice.HOST].get_sys_root()
+    if sysroot:
+        extra_env.set('QEMU_LD_PREFIX', [sysroot])
 
     env = {} if dump else os.environ.copy()
     varnames = set()

--- a/mesonbuild/mdevenv.py
+++ b/mesonbuild/mdevenv.py
@@ -150,6 +150,14 @@ def run(options: argparse.Namespace) -> int:
             print(f'export {name}')
         return 0
 
+    if b.environment.need_exe_wrapper():
+        m = 'An executable wrapper could be required'
+        exe_wrapper = b.environment.get_exe_wrapper()
+        if exe_wrapper:
+            cmd = ' '.join(exe_wrapper.get_command())
+            m += f': {cmd}'
+        mlog.log(m)
+
     install_data = minstall.load_install_data(str(privatedir / 'install.dat'))
     write_gdb_script(privatedir, install_data, workdir)
 

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -39,7 +39,7 @@ from ..interpreterbase.decorators import typed_pos_args
 from ..mesonlib import (
     MachineChoice, MesonException, OrderedSet, Popen_safe, join_args,
 )
-from ..programs import OverrideProgram, EmptyExternalProgram
+from ..programs import OverrideProgram
 from ..scripts.gettext import read_linguas
 
 if T.TYPE_CHECKING:
@@ -1464,9 +1464,8 @@ class GnomeModule(ExtensionModule):
             t_args.append(f'--{program_name}={path}')
         if namespace:
             t_args.append('--namespace=' + namespace)
-        # if not need_exe_wrapper, we get an EmptyExternalProgram. If none provided, we get NoneType
         exe_wrapper = state.environment.get_exe_wrapper()
-        if not isinstance(exe_wrapper, (NoneType, EmptyExternalProgram)):
+        if exe_wrapper:
             t_args.append('--run=' + ' '.join(exe_wrapper.get_command()))
         t_args.append(f'--htmlargs={"@@".join(kwargs["html_args"])}')
         t_args.append(f'--scanargs={"@@".join(kwargs["scan_args"])}')

--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -345,25 +345,6 @@ class NonExistingExternalProgram(ExternalProgram):  # lgtm [py/missing-call-to-i
         return False
 
 
-class EmptyExternalProgram(ExternalProgram):  # lgtm [py/missing-call-to-init]
-    '''
-    A program object that returns an empty list of commands. Used for cases
-    such as a cross file exe_wrapper to represent that it's not required.
-    '''
-
-    def __init__(self) -> None:
-        self.name = None
-        self.command = []
-        self.path = None
-
-    def __repr__(self) -> str:
-        r = '<{} {!r} -> {!r}>'
-        return r.format(self.__class__.__name__, self.name, self.command)
-
-    def found(self) -> bool:
-        return True
-
-
 class OverrideProgram(ExternalProgram):
 
     """A script overriding a program."""

--- a/mesonbuild/utils/core.py
+++ b/mesonbuild/utils/core.py
@@ -119,23 +119,24 @@ class EnvironmentVariables(HoldableObject):
         self.envvars.append((self._prepend, name, values, separator))
 
     @staticmethod
-    def _set(env: T.Dict[str, str], name: str, values: T.List[str], separator: str) -> str:
+    def _set(env: T.Dict[str, str], name: str, values: T.List[str], separator: str, default_value: T.Optional[str]) -> str:
         return separator.join(values)
 
     @staticmethod
-    def _append(env: T.Dict[str, str], name: str, values: T.List[str], separator: str) -> str:
-        curr = env.get(name)
+    def _append(env: T.Dict[str, str], name: str, values: T.List[str], separator: str, default_value: T.Optional[str]) -> str:
+        curr = env.get(name, default_value)
         return separator.join(values if curr is None else [curr] + values)
 
     @staticmethod
-    def _prepend(env: T.Dict[str, str], name: str, values: T.List[str], separator: str) -> str:
-        curr = env.get(name)
+    def _prepend(env: T.Dict[str, str], name: str, values: T.List[str], separator: str, default_value: T.Optional[str]) -> str:
+        curr = env.get(name, default_value)
         return separator.join(values if curr is None else values + [curr])
 
-    def get_env(self, full_env: T.MutableMapping[str, str]) -> T.Dict[str, str]:
+    def get_env(self, full_env: T.MutableMapping[str, str], dump: bool = False) -> T.Dict[str, str]:
         env = full_env.copy()
         for method, name, values, separator in self.envvars:
-            env[name] = method(env, name, values, separator)
+            default_value = f'${name}' if dump else None
+            env[name] = method(env, name, values, separator, default_value)
         return env
 
 


### PR DESCRIPTION
commit 9f7ce6aff2e17ba320015faffbb2f536f62cf458 (HEAD -> devenv)

    devenv: Always include env for HOST machine
    
    Cross compiled executables could still be run with an exe wrapper, or
    with proper binfmt installed.
    
    Fixes: #10999

commit 675baa28371f0c3b5106f7d6c952d47e88aa7fc8

    devenv: Add executables locations to both PATH and WINEPATH
    
    Handles the case when wine-binfmt is installed, which makes .exe files
    executable without without specifying an exe wrapper.

commit c7c7af30ac91c72086d7591ec295c044e5c58825

    devenv: Do not include system values in --dump
    
    This makes --dump print variables like `FOO=/path:$FOO:/another/path`.

commit a53d1640b3f68c51968067be300e10bc158b9699

    devenv: Add more info how to get gdb scripts working
    
    Now that top builddir is not the default workdir any more, the .gdbinit
    file we write there won't be loaded automatically unless user cd there,
    or use --init-command. There is also a global setting that user has to
    set to allow automatically loading .gdbinit file.

commit 8e20ba6ee46a2129d06c34d46672e0c000df8e18

    devenv: Add --workdir option
    
    Most of the time it is preferable to remain the the top source dir
    instead of going into the builddir. Add --workdir argument to be able to
    have a different workdir than builddir, but keep it default to builddir
    for backward compatibility, and also because it makes gdb integration
    better.
