### PR TITLE
cuda compiler: add get_dependency_gen_args

### DIFF
--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -776,3 +776,6 @@ class CudaCompiler(Compiler):
 
     def get_disable_assert_args(self) -> T.List[str]:
         return self.host_compiler.get_disable_assert_args()
+
+    def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
+        return ['-MD', '-MT', outtarget, '-MF', outfile]


### PR DESCRIPTION
The -MD -MT and -MF arguments according to https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#file-and-path-specifications-dependency-output are not passed to the nvcc compiler. This results in wrong partial rebuilds because dependencies are not tracked correctly, especially for header files.

https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#file-and-path-specifications-dependency-output