### PR TITLE
target python 3.10 as the mypy language version

### DIFF
--- a/run_mypy.py
+++ b/run_mypy.py
@@ -120,7 +120,7 @@ def main() -> int:
         if not opts.quiet:
             print('Running mypy (this can take some time) ...')
         p = subprocess.run(
-            [sys.executable, '-m', 'mypy'] + args + to_check,
+            [sys.executable, '-m', 'mypy', '--python-version', '3.10'] + args + to_check,
             cwd=root,
         )
         return p.returncode


### PR DESCRIPTION
mypy has a bug when running on/for 3.11 which results in incorrect analysis of the codebase, specifically due to enum.Enum's self.name

See:

https://github.com/python/typeshed/issues/7564
https://github.com/python/mypy/issues/12483