### PR TITLE
Add preserve_path_from argument when running moc in `headers` mode.

### DIFF
--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -465,7 +465,7 @@ class QtBaseModule(ExtensionModule):
                 self.tools['moc'], arguments, ['moc_@BASENAME@.cpp'],
                 depfile='moc_@BASENAME@.cpp.d',
                 name=f'Qt{self.qt_version} moc header')
-            output.append(moc_gen.process_files(kwargs['headers'], state))
+            output.append(moc_gen.process_files(kwargs['headers'], state, preserve_path_from = state.environment.source_dir))
         if kwargs['sources']:
             moc_gen = build.Generator(
                 self.tools['moc'], arguments, ['@BASENAME@.moc'],

--- a/test cases/frameworks/4 qt/10955/main.cpp
+++ b/test cases/frameworks/4 qt/10955/main.cpp
@@ -1,0 +1,10 @@
+#include "one/value.h"
+#include "two/value.h"
+
+auto main(int argc, char * argv[]) -> int
+{
+    auto one = One::Value{};
+    auto two = Two::Value{};
+    
+    return 0;
+}

--- a/test cases/frameworks/4 qt/10955/meson.build
+++ b/test cases/frameworks/4 qt/10955/meson.build
@@ -1,0 +1,4 @@
+executable_10955_sources = files('main.cpp')
+subdir('one')
+subdir('two')
+executable('executable_10955', sources: executable_10955_sources, dependencies: qtcore)

--- a/test cases/frameworks/4 qt/10955/one/meson.build
+++ b/test cases/frameworks/4 qt/10955/one/meson.build
@@ -1,0 +1,1 @@
+executable_10955_sources += qtmodule.compile_moc(headers: ['value.h'])

--- a/test cases/frameworks/4 qt/10955/one/value.cpp
+++ b/test cases/frameworks/4 qt/10955/one/value.cpp
@@ -1,0 +1,1 @@
+#include "value.moc"

--- a/test cases/frameworks/4 qt/10955/one/value.h
+++ b/test cases/frameworks/4 qt/10955/one/value.h
@@ -1,0 +1,9 @@
+#include <QObject>
+
+namespace One {
+    class Value : public QObject {
+        Q_OBJECT
+    public:
+        Value() { };
+    };
+}

--- a/test cases/frameworks/4 qt/10955/two/meson.build
+++ b/test cases/frameworks/4 qt/10955/two/meson.build
@@ -1,0 +1,1 @@
+executable_10955_sources += qtmodule.compile_moc(headers: ['value.h'])

--- a/test cases/frameworks/4 qt/10955/two/value.cpp
+++ b/test cases/frameworks/4 qt/10955/two/value.cpp
@@ -1,0 +1,1 @@
+#include "value.moc"

--- a/test cases/frameworks/4 qt/10955/two/value.h
+++ b/test cases/frameworks/4 qt/10955/two/value.h
@@ -1,0 +1,9 @@
+#include <QObject>
+
+namespace Two {
+    class Value : public QObject {
+        Q_OBJECT
+    public:
+        Value() { };
+    };
+}

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -149,10 +149,11 @@ foreach qt : ['qt4', 'qt5', 'qt6']
 
     if qt == 'qt5'
       subdir('subfolder')
+    elif qt == 'qt6'
+      subdir('10955')
     endif
 
     # Check we can apply a version constraint
     dependency(qt, modules: qt_modules, version: '>=@0@'.format(qtdep.version()), method : get_option('method'))
-
   endif
 endforeach


### PR DESCRIPTION
This fixes #10955 partially.

When using the sources kwarg, the moc tool generates .moc files. Those are meant to be #included in a .cpp file, which makes it necessary to add the correct -Ibuild/dir flag to the correct .cpp file compiling command. I'm not sure whether this is wanted or even possible ...