### PR TITLE
BUG: Fix generated sources not being included as dependencies in cython transpilation

### DIFF
--- a/test cases/cython/2 generated sources/includestuff.pyx
+++ b/test cases/cython/2 generated sources/includestuff.pyx
@@ -1,0 +1,1 @@
+include "stuff.pxi"

--- a/test cases/cython/2 generated sources/meson.build
+++ b/test cases/cython/2 generated sources/meson.build
@@ -6,6 +6,7 @@ project(
 py_mod = import('python')
 py3 = py_mod.find_installation('python3')
 py3_dep = py3.dependency(required : false)
+fs = import('fs')
 if not py3_dep.found()
   error('MESON_SKIP_TEST: Python library not found.')
 endif
@@ -68,6 +69,25 @@ test(
   py3,
   args : [files('test.py'), 'g'],
   env : ['PYTHONPATH=' + meson.current_build_dir()]
+)
+
+stuff_pxi = fs.copyfile(
+  'stuff.pxi.in',
+  'stuff.pxi'
+)
+
+# Need to copy the cython source to the build directory
+# since meson can only generate the .pxi there
+includestuff_pyx = fs.copyfile(
+  'includestuff.pyx'
+)
+
+stuff_pxi_dep = declare_dependency(sources: stuff_pxi)
+
+includestuff_ext = py3.extension_module(
+  'includestuff',
+  includestuff_pyx,
+  dependencies: stuff_pxi_dep
 )
 
 subdir('libdir')

--- a/test cases/cython/2 generated sources/stuff.pxi.in
+++ b/test cases/cython/2 generated sources/stuff.pxi.in
@@ -1,0 +1,2 @@
+def func():
+    print("Hello world")


### PR DESCRIPTION
Generated graph looks correct.
xref #8961.
(Note: This is for the .pyx-> c phase for a target for pandas)

![image](https://user-images.githubusercontent.com/47963215/200083372-14e27211-770d-4f29-8c92-d1a8809941ea.png)

In pandas, we are including the generated .pxi as sources, but I also tested using them as dependencies, and it still works.

I'm not sure how to test this, though.

Ideas could be write test cases and compare against a golden ninja.build file, or running ninja directly against the pyx target to make sure the deps work correctly (not sure how to hook into the build system to invoke ninja directly)

cc @rgommers @eli-schwartz @xclaesse (Sorry for pinging so close to the weekend).