### PR TITLE
tests: fix edge case where non-default python is used, by skipping it

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -69,9 +69,15 @@ jobs:
     - uses: actions/checkout@v2
     # Avoid picking up an older version of LLVM that does not work.
     - run: brew update
+    # github actions overwrites brew's python. Force it to reassert itself, by running in a separate step.
+    - name: unbreak python in github actions
+      run: |
+        find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
+        sudo rm -rf /Library/Frameworks/Python.framework/
+        brew install --force python3 && brew unlink python3 && brew unlink python3 && brew link --overwrite python3
     # use python3 from homebrew because it is a valid framework, unlike the actions one:
     # https://github.com/actions/setup-python/issues/58
-    - run: brew install pkg-config ninja llvm qt@5 boost ldc hdf5 openmpi lapack scalapack sdl2 python3 boost-python3 gtk-doc
+    - run: brew install pkg-config ninja llvm qt@5 boost ldc hdf5 openmpi lapack scalapack sdl2 boost-python3 gtk-doc
     - run: |
         python3 -m pip install --upgrade setuptools
         python3 -m pip install --upgrade pip

--- a/test cases/python/2 extmodule/meson.build
+++ b/test cases/python/2 extmodule/meson.build
@@ -34,10 +34,17 @@ py.install_sources(blaster, subdir: 'pure')
 
 py3_pkg_dep = dependency('python3', method: 'pkg-config', required : false)
 if py3_pkg_dep.found()
-  python_lib_dir = py3_pkg_dep.get_pkgconfig_variable('libdir')
+  py3_dep_majver = py3_pkg_dep.version().split('.')
+  py3_dep_majver = py3_dep_majver[0] + '.' + py3_dep_majver[1]
+  message(f'got two pythons: pkg-config is @py3_dep_majver@, and module is', py.language_version())
+  if py3_dep_majver != py.language_version()
+    message('skipped python3 pkg-config test because the default python3 is different from Meson\'s')
+  else
+    python_lib_dir = py3_pkg_dep.get_pkgconfig_variable('libdir')
 
-  # Check we can apply a version constraint
-  dependency('python3', version: '>=@0@'.format(py_dep.version()))
+    # Check we can apply a version constraint
+    dependency('python3', version: '>=@0@'.format(py_dep.version()))
+  endif
 else
-  message('Skipped python3 pkg-config test')
+  message('Skipped python3 pkg-config test because it was not found')
 endif

--- a/test cases/python3/3 cython/meson.build
+++ b/test cases/python3/3 cython/meson.build
@@ -6,8 +6,14 @@ py3_dep = dependency('python3', required : false)
 
 if cython.found() and py3_dep.found()
   py3_dep = dependency('python3')
+  py3_dep_majver = py3_dep.version().split('.')
+  py3_dep_majver = py3_dep_majver[0] + '.' + py3_dep_majver[1]
   py3_mod = import('python3')
   py3 = py3_mod.find_python()
+  if py3_dep_majver != py3_mod.language_version()
+      v = py3_mod.language_version()
+      error('MESON_SKIP_TEST: deprecated python3 module is non-functional when default python3 is different from Meson\'s', v)
+  endif
   subdir('libdir')
 
   test('cython tester',


### PR DESCRIPTION
In a couple of python module tests, we try to test things that rely on the default python being the same one we look up in the python module. This is unsolvable for the deprecated python3 module, as it actually uses the in-process version of python for everything. For the python module, we could actually look up the default system python instead of the one we are running with, but then we wouldn't be testing the functionality of that alternative python... and also the install manifest tests would see files installed for the wrong version of python, and report a combination of missing+extra files...

Solve both tests by just skipping the parts we cannot check.