### PR TITLE
Add a `dependencies` keyword argument to bindgen

### DIFF
--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -35,7 +35,7 @@ that automatically.
 Additional, test only dependencies may be passed via the dependencies
 argument.
 
-### bindgen(*, input: string | BuildTarget | [](string | BuildTarget), output: string, include_directories: [](include_directories | string), c_args: []string, args: []string)
+### bindgen(*, input: string | BuildTarget | [](string | BuildTarget), output: string, include_directories: [](include_directories | string), c_args: []string, args: []string, dependencies: []Dependency)
 
 This function wraps bindgen to simplify creating rust bindings around C
 libraries. This has two advantages over hand-rolling ones own with a
@@ -54,6 +54,7 @@ It takes the following keyword arguments
   these are passed to clang as `-I` arguments *(string since 1.0.0)*
 - c_args — A list of string arguments to pass to clang untouched
 - args — A list of string arguments to pass to `bindgen` untouched.
+- dependencies — A list of `Dependency` objects to pass to the underlying clang call (*since 1.0.0*)
 
 ```meson
 rust = import('unstable-rust')

--- a/docs/markdown/snippets/rust_bindgen_deps.md
+++ b/docs/markdown/snippets/rust_bindgen_deps.md
@@ -1,0 +1,5 @@
+## rust.bindgen accepts a dependency argument
+
+The `bindgen` method of the `rust` module now accepts a dependencies argument.
+Any include paths in these dependencies will be passed to the underlying call to
+`clang`, and the call to `bindgen` will correctly depend on any generatd sources.

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -19,7 +19,7 @@ from . import ExtensionModule, ModuleReturnValue, ModuleInfo
 from .. import mlog
 from ..build import BothLibraries, BuildTarget, CustomTargetIndex, Executable, ExtractedObjects, GeneratedList, IncludeDirs, CustomTarget, StructuredSources
 from ..dependencies import Dependency, ExternalLibrary
-from ..interpreter.type_checking import TEST_KWS, OUTPUT_KW, INCLUDE_DIRECTORIES, include_dir_string_new
+from ..interpreter.type_checking import DEPENDENCIES_KW, TEST_KWS, OUTPUT_KW, INCLUDE_DIRECTORIES, include_dir_string_new
 from ..interpreterbase import ContainerTypeInfo, InterpreterException, KwargInfo, typed_kwargs, typed_pos_args, noPosargs
 from ..mesonlib import File
 
@@ -64,12 +64,8 @@ class RustModule(ExtensionModule):
     @typed_kwargs(
         'rust.test',
         *TEST_KWS,
+        DEPENDENCIES_KW,
         KwargInfo('is_parallel', bool, default=False),
-        KwargInfo(
-            'dependencies',
-            ContainerTypeInfo(list, (Dependency, ExternalLibrary)),
-            listify=True,
-            default=[]),
     )
     def test(self, state: 'ModuleState', args: T.Tuple[str, BuildTarget], kwargs: 'FuncTest') -> ModuleReturnValue:
         """Generate a rust test target from a given rust target.

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 import os
 import typing as T
 
@@ -52,9 +53,9 @@ class RustModule(ExtensionModule):
 
     INFO = ModuleInfo('rust', '0.57.0', stabilized='1.0.0')
 
-    def __init__(self, interpreter: 'Interpreter') -> None:
+    def __init__(self, interpreter: Interpreter) -> None:
         super().__init__(interpreter)
-        self._bindgen_bin: T.Optional['ExternalProgram'] = None
+        self._bindgen_bin: T.Optional[ExternalProgram] = None
         self.methods.update({
             'test': self.test,
             'bindgen': self.bindgen,
@@ -67,7 +68,7 @@ class RustModule(ExtensionModule):
         DEPENDENCIES_KW,
         KwargInfo('is_parallel', bool, default=False),
     )
-    def test(self, state: 'ModuleState', args: T.Tuple[str, BuildTarget], kwargs: 'FuncTest') -> ModuleReturnValue:
+    def test(self, state: ModuleState, args: T.Tuple[str, BuildTarget], kwargs: FuncTest) -> ModuleReturnValue:
         """Generate a rust test target from a given rust target.
 
         Rust puts it's unitests inside it's main source files, unlike most
@@ -173,7 +174,7 @@ class RustModule(ExtensionModule):
         INCLUDE_DIRECTORIES.evolve(feature_validator=include_dir_string_new),
         OUTPUT_KW,
     )
-    def bindgen(self, state: 'ModuleState', args: T.List, kwargs: 'FuncBindgen') -> ModuleReturnValue:
+    def bindgen(self, state: ModuleState, args: T.List, kwargs: FuncBindgen) -> ModuleReturnValue:
         """Wrapper around bindgen to simplify it's use.
 
         The main thing this simplifies is the use of `include_directory`
@@ -182,7 +183,7 @@ class RustModule(ExtensionModule):
         header, *_deps = self.interpreter.source_strings_to_files(kwargs['input'])
 
         # Split File and Target dependencies to add pass to CustomTarget
-        depends: T.List['SourceOutputs'] = []
+        depends: T.List[SourceOutputs] = []
         depend_files: T.List[File] = []
         for d in _deps:
             if isinstance(d, File):
@@ -232,5 +233,5 @@ class RustModule(ExtensionModule):
         return ModuleReturnValue([target], [target])
 
 
-def initialize(interp: 'Interpreter') -> RustModule:
+def initialize(interp: Interpreter) -> RustModule:
     return RustModule(interp)

--- a/test cases/rust/12 bindgen/dependencies/clib2.c
+++ b/test cases/rust/12 bindgen/dependencies/clib2.c
@@ -1,0 +1,5 @@
+#include "internal_dep.h"
+
+int64_t add64(const int64_t first, const int64_t second) {
+    return first + second;
+}

--- a/test cases/rust/12 bindgen/dependencies/external_dep.h
+++ b/test cases/rust/12 bindgen/dependencies/external_dep.h
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifer: Apache-2.0 */
+/* Copyright © 2022 Intel Corporation */
+
+#include <zlib.h>
+
+struct External {
+    z_stream * stream;
+};

--- a/test cases/rust/12 bindgen/dependencies/internal_dep.h
+++ b/test cases/rust/12 bindgen/dependencies/internal_dep.h
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2022 Intel Corporation
+
+#include "gen.h"
+
+int64_t add64(const int64_t, const int64_t);

--- a/test cases/rust/12 bindgen/dependencies/internal_main.rs
+++ b/test cases/rust/12 bindgen/dependencies/internal_main.rs
@@ -1,0 +1,16 @@
+// SPDX-license-identifer: Apache-2.0
+// Copyright © 2021 Intel Corporation
+
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+include!("internal_dep.rs");
+
+use std::convert::TryInto;
+
+fn main() {
+    unsafe {
+        std::process::exit(add64(0, 0).try_into().unwrap_or(5));
+    };
+}

--- a/test cases/rust/12 bindgen/dependencies/meson.build
+++ b/test cases/rust/12 bindgen/dependencies/meson.build
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2022 Intel Corporation
+
+dep_zlib = dependency('zlib', required : false, disabler : true)
+
+external_dep_rs = rust.bindgen(
+  input : 'external_dep.h',
+  output : 'external_dep.rs',
+  dependencies : dep_zlib
+)
+
+external_dep = static_library(
+  'external_dep',
+  [external_dep_rs],
+  dependencies : dep_zlib.partial_dependency(links : true),
+)
+
+rust.test('external dep', external_dep)
+
+int_dep = declare_dependency(
+  sources : [gen_h, gen2_h],
+  include_directories : include_directories('..'),
+)
+
+internal_dep_rs = rust.bindgen(
+  input : 'internal_dep.h',
+  output : 'internal_dep.rs',
+  dependencies : int_dep,
+)
+
+c_lib2 = static_library(
+  'clib2',
+  'clib2.c',
+  dependencies : int_dep,
+)
+
+rust_bin_int_dep = executable(
+  'rust_bin_int_dep',
+  structured_sources(['internal_main.rs', internal_dep_rs]),
+  link_with : [c_lib, c_lib2],
+)
+
+test('generated header dependency', rust_bin_int_dep)

--- a/test cases/rust/12 bindgen/meson.build
+++ b/test cases/rust/12 bindgen/meson.build
@@ -1,5 +1,5 @@
 # SPDX-license-identifer: Apache-2.0
-# Copyright © 2021 Intel Corporation
+# Copyright © 2021-2022 Intel Corporation
 
 project('rustmod bindgen', ['c', 'rust'], meson_version : '>= 0.63')
 
@@ -80,3 +80,4 @@ rust_bin2 = executable(
 test('generated header', rust_bin2)
 
 subdir('sub')
+subdir('dependencies')


### PR DESCRIPTION
Allows passing `dependency` objects to the `rust.bindgen` method. This is useful when the header you're generating bindings for includes system headers, and needs to pass include flags to clang from said dependencies. In addition we can create correct ordering for generated sources in an `internal_dependency` for the bindgen call

This includes https://github.com/mesonbuild/meson/pull/11062, but that PR should be merged first because it needs backport, while the rest of this doesn't.