### PR TITLE
linkers: Don't build thin archives on illumos or Solaris

### DIFF
--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -208,8 +208,12 @@ class ArLinker(ArLikeLinker):
         return self.can_rsp
 
     def get_std_link_args(self, env: 'Environment', is_thin: bool) -> T.List[str]:
-        # FIXME: osx ld rejects this: "file built for unknown-unsupported file format"
-        if is_thin and not env.machines[self.for_machine].is_darwin():
+        # Thin archives are a GNU extension not supported by the system linkers
+        # on Mac OS X, Solaris, or illumos, so don't build them on those OSes.
+        # OS X ld rejects with: "file built for unknown-unsupported file format"
+        # illumos/Solaris ld rejects with: "unknown file type"
+        if is_thin and not env.machines[self.for_machine].is_darwin() \
+          and not env.machines[self.for_machine].is_sunos():
             return self.std_thin_args
         else:
             return self.std_args


### PR DESCRIPTION
The system linkers don't support this particular GNU extension on these OS'es, so don't build them there.

Based on an OpenIndiana patch created by @AndWac. Closes #9882.