### PR TITLE
Change `unstable_external_project` to `unstable-external_project`

### DIFF
--- a/docs/markdown/External-Project-module.md
+++ b/docs/markdown/External-Project-module.md
@@ -114,7 +114,7 @@ project('My Autotools Project', 'c',
   meson_version : '>=0.56.0',
 )
 
-mod = import('unstable_external_project')
+mod = import('unstable-external_project')
 
 p = mod.add_project('configure',
   configure_options : ['--prefix=@PREFIX@',

--- a/docs/markdown/Release-notes-for-0.56.0.md
+++ b/docs/markdown/Release-notes-for-0.56.0.md
@@ -281,7 +281,7 @@ the default compiler.
 
 ## External projects
 
-A new experimental module `unstable_external_project` has been added
+A new experimental module `unstable-external_project` has been added
 to build code using other build systems than Meson. Currently only
 supporting projects with a configure script that generates Makefiles.
 
@@ -290,7 +290,7 @@ project('My Autotools Project', 'c',
   meson_version : '>=0.56.0',
 )
 
-mod = import('unstable_external_project')
+mod = import('unstable-external_project')
 
 p = mod.add_project('configure',
   configure_options : ['--prefix=@PREFIX@',

--- a/docs/markdown/Release-notes-for-0.57.0.md
+++ b/docs/markdown/Release-notes-for-0.57.0.md
@@ -128,7 +128,7 @@ can be passed dependencies returned by `declare_dependency`, as long as they
 only specify compiler/linker arguments or other dependencies that satisfy
 the same requirements.
 
-## `unstable_external_project` improvements
+## `unstable-external_project` improvements
 
 - Default arguments are added to `add_project()` in case some tags are not found
   in `configure_options`: `'--prefix=@PREFIX@'`, `'--libdir=@PREFIX@/@LIBDIR@'`,


### PR DESCRIPTION
Apparently this is a misspelling even though it has been in the docs since the creation of the module.