### PR TITLE
Change the warning generated by importing an unstable module to non-fatal

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -664,7 +664,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                     raise InvalidArguments(f'Module "{ext_module.INFO.name}" has not been stabilized, and must be imported as unstable-{ext_module.INFO.name}')
                 ext_module = NotFoundExtensionModule(real_modname)
             else:
-                mlog.warning(f'Module {ext_module.INFO.name} has no backwards or forwards compatibility and might not exist in future releases.', location=node)
+                mlog.warning(f'Module {ext_module.INFO.name} has no backwards or forwards compatibility and might not exist in future releases.', location=node, fatal=False)
 
         self.modules[real_modname] = ext_module
         return ext_module


### PR DESCRIPTION
Penalizing users for helping to test unstable modules really makes no sense. As a fatal warning, users can no longer use `--fatal-meson-warnings`.