### PR TITLE
fixes for auto-generated clang-format rule (and friends)

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -236,7 +236,6 @@ class Build:
         self.environment = environment
         self.projects = {}
         self.targets: 'T.OrderedDict[str, T.Union[CustomTarget, BuildTarget]]' = OrderedDict()
-        self.run_target_names: T.Set[T.Tuple[str, str]] = set()
         self.global_args: PerMachine[T.Dict[str, T.List[str]]] = PerMachine({}, {})
         self.global_link_args: PerMachine[T.Dict[str, T.List[str]]] = PerMachine({}, {})
         self.projects_args: PerMachine[T.Dict[str, T.Dict[str, T.List[str]]]] = PerMachine({}, {})

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2009,9 +2009,6 @@ class Interpreter(InterpreterBase, HoldableObject):
         tg = build.RunTarget(name, all_args, kwargs['depends'], self.subdir, self.subproject, self.environment,
                              kwargs['env'])
         self.add_target(name, tg)
-        full_name = (self.subproject, name)
-        assert full_name not in self.build.run_target_names
-        self.build.run_target_names.add(full_name)
         return tg
 
     @FeatureNew('alias_target', '0.52.0')

--- a/test cases/common/51 run target/.clang-format
+++ b/test cases/common/51 run target/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: LLVM

--- a/test cases/common/51 run target/meson.build
+++ b/test cases/common/51 run target/meson.build
@@ -78,8 +78,13 @@ custom_target('configure_script_ct',
 run_target('ctags',
   command : converter)
 
-run_target('clang-format',
-  command : converter)
+clangf = run_target('clang-format',
+  command : [converter, files('.clang-format'), meson.current_build_dir() / 'clang-format'])
+custom_target('clang-tidy',
+  input: '.clang-tidy',
+  output: 'clang-tidy',
+  command : [converter, '@INPUT@', '@OUTPUT@'])
+alias_target('clang-format-check', clangf)
 
 # Check we can pass env to the program. Also check some string substitutions
 # that were added in 0.57.0 but not documented. This is documented behaviour


### PR DESCRIPTION
There are two problems which this PR solves:
- `clang-format-check` will rewrite files, then rewrite them back. clang-format has an option now, which can avoid doing that and also provides better UX
- I can create a valid meson.build which produces `clang-format` rules, that the documentation *claims* will override the builtin rules, but instead Meson errors out claiming there are multiple targets named `clang-format`