### PR TITLE
docs: Add missing import to the windows module example.

### DIFF
--- a/docs/markdown/Windows-module.md
+++ b/docs/markdown/Windows-module.md
@@ -8,6 +8,7 @@ Windows.
 ### compile_resources
 
 ```
+  windows = import('windows')
   windows.compile_resources(...(string | File | CustomTarget | CustomTargetIndex),
                             args: []string,
                             depend_files: [](string | File),


### PR DESCRIPTION
It personally took me a few minutes to figure out what to do with the error message:
```sh
ERROR: Unknown variable "windows".
```
Obviously it needs to be set, but how? Is it a default build option I'm missing? Should it be set by meson automagically?
Having the `import` directive within the example makes it complete and removes the guesswork.