### PR TITLE
Fix test_rust_clippy for rust 1.65

### DIFF
--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -4352,7 +4352,8 @@ class AllPlatformTests(BasePlatformTests):
         self.init(testdir, extra_args=['--werror'], override_envvars={'RUSTC': 'clippy-driver'})
         with self.assertRaises(subprocess.CalledProcessError) as cm:
             self.build()
-        self.assertIn('error: use of a blacklisted/placeholder name `foo`', cm.exception.stdout)
+        self.assertTrue('error: use of a blacklisted/placeholder name `foo`' in cm.exception.stdout or
+                        'error: use of a disallowed/placeholder name `foo`' in cm.exception.stdout)
 
     @skip_if_not_language('rust')
     def test_rust_rlib_linkage(self) -> None:


### PR DESCRIPTION
clippy changed output message.
If we need to check rust version instead of the arbitrary `or` clause, please tell me.
fix #11004