### PR TITLE
Small rust fixes

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1878,8 +1878,8 @@ class NinjaBackend(backends.Backend):
             args.extend(rustc.get_linker_always_args())
 
         args += self.generate_basic_compiler_args(target, rustc, False)
-        # This matches rustc's default behavior.
-        args += ['--crate-name', target.name.replace('-', '_')]
+        # Rustc replaces - with _. spaces are not allowed, so we replace them with underscores
+        args += ['--crate-name', target.name.replace('-', '_').replace(' ', '_')]
         depfile = os.path.join(target.subdir, target.name + '.d')
         args += ['--emit', f'dep-info={depfile}', '--emit', 'link']
         args += target.get_extra_args('rust')

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1784,7 +1784,7 @@ class Executable(BuildTarget):
     typename = 'executable'
 
     def __init__(self, name: str, subdir: str, subproject: str, for_machine: MachineChoice,
-                 sources: T.List[File], structured_sources: T.Optional['StructuredSources'],
+                 sources: T.List[SourceOutputs], structured_sources: T.Optional['StructuredSources'],
                  objects, environment: environment.Environment, compilers: T.Dict[str, 'Compiler'],
                  kwargs):
         key = OptionKey('b_pie')
@@ -1913,7 +1913,7 @@ class StaticLibrary(BuildTarget):
     typename = 'static library'
 
     def __init__(self, name: str, subdir: str, subproject: str, for_machine: MachineChoice,
-                 sources: T.List[File], structured_sources: T.Optional['StructuredSources'],
+                 sources: T.List[SourceOutputs], structured_sources: T.Optional['StructuredSources'],
                  objects, environment: environment.Environment, compilers: T.Dict[str, 'Compiler'],
                  kwargs):
         self.prelink = kwargs.get('prelink', False)
@@ -1985,7 +1985,7 @@ class SharedLibrary(BuildTarget):
     typename = 'shared library'
 
     def __init__(self, name: str, subdir: str, subproject: str, for_machine: MachineChoice,
-                 sources: T.List[File], structured_sources: T.Optional['StructuredSources'],
+                 sources: T.List[SourceOutputs], structured_sources: T.Optional['StructuredSources'],
                  objects, environment: environment.Environment, compilers: T.Dict[str, 'Compiler'],
                  kwargs):
         self.soversion = None
@@ -2324,7 +2324,7 @@ class SharedModule(SharedLibrary):
     typename = 'shared module'
 
     def __init__(self, name: str, subdir: str, subproject: str, for_machine: MachineChoice,
-                 sources: T.List[File], structured_sources: T.Optional['StructuredSources'],
+                 sources: T.List[SourceOutputs], structured_sources: T.Optional['StructuredSources'],
                  objects, environment: environment.Environment,
                  compilers: T.Dict[str, 'Compiler'], kwargs):
         if 'version' in kwargs:
@@ -2694,7 +2694,7 @@ class Jar(BuildTarget):
     typename = 'jar'
 
     def __init__(self, name: str, subdir: str, subproject: str, for_machine: MachineChoice,
-                 sources: T.List[File], structured_sources: T.Optional['StructuredSources'],
+                 sources: T.List[SourceOutputs], structured_sources: T.Optional['StructuredSources'],
                  objects, environment: environment.Environment, compilers: T.Dict[str, 'Compiler'],
                  kwargs):
         super().__init__(name, subdir, subproject, for_machine, sources, structured_sources, objects,

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -1,4 +1,4 @@
-# Copyright © 2020 Intel Corporation
+# Copyright © 2020-2022 Intel Corporation
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -147,9 +147,12 @@ class RustModule(ExtensionModule):
         new_target_kwargs['install'] = False
         new_target_kwargs['dependencies'] = new_target_kwargs.get('dependencies', []) + kwargs['dependencies']
 
+        sources = T.cast('T.List[SourceOutputs]', base_target.sources.copy())
+        sources.extend(base_target.generated)
+
         new_target = Executable(
             name, base_target.subdir, state.subproject, base_target.for_machine,
-            base_target.sources, base_target.structured_sources,
+            sources, base_target.structured_sources,
             base_target.objects, base_target.environment, base_target.compilers,
             new_target_kwargs
         )


### PR DESCRIPTION
There are two fixes here, that came out of other work, but these deserve to be backported to I've split them out

1. rust crates cannot have spaces ` ` in their name, so replace them with `_`
2. When we build an automatic test from a `static_library` we need to copy the generated sources as well as the static ones