### PR TITLE
mdist: fix error when running tests with a cross file

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1035,9 +1035,9 @@ def update_cmd_line_file(build_dir: str, options: argparse.Namespace):
 def format_cmd_line_options(options: argparse.Namespace) -> str:
     cmdline = ['-D{}={}'.format(str(k), v) for k, v in options.cmd_line_options.items()]
     if options.cross_file:
-        cmdline += [f'--cross-file {f}' for f in options.cross_file]
+        cmdline += [f'--cross-file={f}' for f in options.cross_file]
     if options.native_file:
-        cmdline += [f'--native-file {f}' for f in options.native_file]
+        cmdline += [f'--native-file={f}' for f in options.native_file]
     return ' '.join([shlex.quote(x) for x in cmdline])
 
 def major_versions_differ(v1: str, v2: str) -> bool:


### PR DESCRIPTION
Since commit 1420d0daceb10cafb52a7405f157032a5cc811a5 we use coredata's cmd_line.txt handler to get the right setup arguments. But there's a bug in that -- it mishandles cross/native files, producing invalid descriptions of the command line. The only other place this was used, though, is when generating meson-log.txt.

Fix it to produce correctly formatted arguments.

Fixes #10980