### PR TITLE
Fix a few testsuite failures I encountered locally

### DIFF
--- a/run_meson_command_tests.py
+++ b/run_meson_command_tests.py
@@ -132,13 +132,17 @@ class CommandTests(unittest.TestCase):
         bindir = (self.tmpdir / 'bin')
         bindir.mkdir()
         (bindir / 'meson').symlink_to(self.src_root / 'meson.py')
+        (bindir / 'python3').symlink_to(python_command[0])
         os.environ['PATH'] = str(bindir) + os.pathsep + os.environ['PATH']
+        # use our overridden PATH-compatible python
+        path_resolved_meson_command = resolved_meson_command.copy()
+        path_resolved_meson_command[0] = str(bindir / 'python3')
         # See if it works!
         meson_py = 'meson'
         meson_setup = [meson_py, 'setup']
         meson_command = meson_setup + self.meson_args
         stdo = self._run(meson_command + [self.testdir, builddir])
-        self.assertMesonCommandIs(stdo.split('\n')[0], resolved_meson_command)
+        self.assertMesonCommandIs(stdo.split('\n')[0], path_resolved_meson_command)
 
     def test_meson_installed(self):
         # Install meson

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -1407,7 +1407,7 @@ def check_meson_commands_work(use_tmpdir: bool, extra_args: T.List[str]) -> None
     meson_commands = mesonlib.python_command + [get_meson_script()]
     with TemporaryDirectoryWinProof(prefix='b ', dir=None if use_tmpdir else '.') as build_dir:
         print('Checking that configuring works...')
-        gen_cmd = meson_commands + [testdir, build_dir] + backend_flags + extra_args
+        gen_cmd = meson_commands + ['setup' , testdir, build_dir] + backend_flags + extra_args
         pc, o, e = Popen_safe(gen_cmd)
         if pc.returncode != 0:
             raise RuntimeError(f'Failed to configure {testdir!r}:\n{e}\n{o}')

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -83,7 +83,7 @@ foreach qt : ['qt4', 'qt5', 'qt6']
 
     translations_cpp = qtmodule.compile_translations(qresource: qt+'_lang.qrc')
     # unity builds suck and definitely cannot handle two qrc embeds in one compilation unit
-    unityproof_translations = static_library(qt+'unityproof_translations', translations_cpp)
+    unityproof_translations = static_library(qt+'unityproof_translations', translations_cpp, dependencies: qtdep)
 
     extra_cpp_args += '-DQT="@0@"'.format(qt)
     qexe = executable(qt + 'app',

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -182,7 +182,7 @@ class LinuxlikeTests(BasePlatformTests):
             for name in {'ct', 'ct0'}:
                 ct_dep = PkgConfigDependency(name, env, kwargs)
                 self.assertTrue(ct_dep.found())
-                self.assertIn('-lct', ct_dep.get_link_args())
+                self.assertIn('-lct', ct_dep.get_link_args(raw=True))
 
     def test_pkgconfig_gen_deps(self):
         '''


### PR DESCRIPTION
- we don't test Qt4 in CI
- we don't test whether the tests succeed if some random obscure system dep is installed
- we don't test non-default pythons

The latter two are just bugs in our test definitions. Then first one is actually a bug in the project definition.

...

Also throw in a free deprecation warning fix.