### PR TITLE
Fix a typo in the CUDA template

### DIFF
--- a/mesonbuild/templates/cudatemplates.py
+++ b/mesonbuild/templates/cudatemplates.py
@@ -21,7 +21,7 @@ hello_cuda_template = '''#include <iostream>
 
 int main(int argc, char **argv) {{
     if(argc != 1) {{
-        std::cout << argv[0] <<  "takes no arguments.\\n";
+        std::cout << argv[0] << " takes no arguments.\\n";
         return 1;
     }}
     std::cout << "This is project " << PROJECT_NAME << ".\\n";


### PR DESCRIPTION
The original version will output something like `xtakes no arguments`, and the modified version will correctly output `x takes no arguments`.