### PR TITLE
hotdoc module: fix broken include paths

### DIFF
--- a/mesonbuild/modules/hotdoc.py
+++ b/mesonbuild/modules/hotdoc.py
@@ -283,8 +283,7 @@ class HotdocTargetBuilder:
         self.process_known_arg("--project-version")
         self.process_known_arg("--sitemap", value_processor=self.ensure_file)
         self.process_known_arg("--html-extra-theme", value_processor=self.ensure_dir)
-        self.process_known_arg(None, "include_paths",
-                               value_processor=lambda x: [self.include_paths.add(self.ensure_dir(v)) for v in x])
+        self.include_paths.update(self.ensure_dir(v) for v in self.kwargs.pop('include_paths'))
         self.process_known_arg('--c-include-directories', argname="dependencies", value_processor=self.process_dependencies)
         self.process_gi_c_source_roots()
         self.process_extra_assets()


### PR DESCRIPTION
Since commit 32b14b1bb533e10c7344c2e04125a226553c9b9f, hotdoc is run during configure as an external program. It turns out though, that in some cases we passed NoneType in the cmd array, previously to hotdoc.run_hotdoc.run() and now via subprocesses. The former "worked" due to ignoring unknown arguments (?) but the latter was broken because command line interfaces don't accept python NoneType objects, naturally.

End result: when for example building Meson's own documentation, this fails with a python traceback.

The reason this happens to begin with turns out to be, once again, because of the legacy debt of homebrewed kwargs parsing. We have a function for `process_known_args` that handles args and ignores them if they are NoneType, and then include_paths is handled via a custom processor that internally adds them, then returns a *list* of NoneType which then gets appended to the global cmd, because the logic ends up as `[None, None] is None` which is a failed check, so we go ahead and add it.

It's odd that we ever attempted to process it twice to begin with, so let's simply not do that.