### PR TITLE
Make sure to print transitive dependency name when pkg-config fails

### DIFF
--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -89,13 +89,13 @@ class PkgConfigDependency(ExternalDependency):
         assert isinstance(self.pkgbin, ExternalProgram)
         mlog.debug('Determining dependency {!r} with pkg-config executable '
                    '{!r}'.format(name, self.pkgbin.get_path()))
-        ret, self.version, _ = self._call_pkgbin(['--modversion', name])
-        if ret != 0:
-            return
-
-        self.is_found = True
-
         try:
+            ret, self.version, err = self._call_pkgbin(['--modversion', name])
+            if ret != 0:
+                raise DependencyException(f'Could not query version for {name}:\n{err}\n')
+
+            self.is_found = True
+
             # Fetch cargs to be used while using this dependency
             self._set_cargs()
             # Fetch the libraries and library paths needed for using this

--- a/test cases/failing/129 pkgconfig full error/meson.build
+++ b/test cases/failing/129 pkgconfig full error/meson.build
@@ -1,0 +1,3 @@
+project('test', 'c')
+
+foo_dep = dependency('libfoo', version: '>= 1.2.3', method: 'pkg-config')

--- a/test cases/failing/129 pkgconfig full error/test.json
+++ b/test cases/failing/129 pkgconfig full error/test.json
@@ -1,0 +1,26 @@
+{
+  "env": {
+    "PKG_CONFIG_PATH": "@ROOT@/testdata/libfoopath"
+  },
+  "stdout": [
+    {
+      "comment": "This is the error message due to libfoo failing pkg-config, there is an unwanted space char at the end of the actual error, so matching with 're' here",
+      "match": "re",
+      "line": "Run-time dependency libfoo found: NO"
+    },
+    {
+      "comment": [
+         "pkg-config --modversion used to not check dependencies and return version info, thus when a dependency does not exist",
+         "meson failure point will be diferent. If pkg-config is new, meson will fail at --modversion step, and if pkg-config is old",
+         "meson will fail at later --cflags step. Thus error messages will be different as below:",
+         "with pkg-config v0.29.1:",
+         "Package 'libbar', required by 'libfoo', not found",
+         "with v1.8.0:",
+         "pkg-config error with 'libfoo': Package libbar was not found in the pkg-config search path.",
+         "Thus below check just makes sure dependent package name appears somewhere in th eoutput"
+       ],
+      "match": "re",
+      "line": ".*libbar"
+    }
+  ]
+}

--- a/test cases/failing/129 pkgconfig full error/testdata/libfoopath/libfoo.pc
+++ b/test cases/failing/129 pkgconfig full error/testdata/libfoopath/libfoo.pc
@@ -1,0 +1,4 @@
+Name: libfoo
+Description: Does foo stuff
+Requires: libbar
+Version: 0.1.2


### PR DESCRIPTION
Fixes #11076 