### PR TITLE
Ignore unused compiler options for "meson configure"

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -821,7 +821,7 @@ class CoreData:
                 continue
             elif k in self.options:
                 self.set_option(k, v)
-            elif k.machine != MachineChoice.BUILD:
+            elif k.machine != MachineChoice.BUILD and k.type != OptionType.COMPILER:
                 unknown_options.append(k)
         if unknown_options:
             unknown_options_str = ', '.join(sorted(str(s) for s in unknown_options))


### PR DESCRIPTION
"meson setup" ignores unused compiler options, like "cpp_args" on a project without C++.

"meson configure" doesn't have the filtering from "set_default_options", so it fails with : ERROR: Unknown options: "cpp_args"

So now unused compiler options (ie not in coredata.options) are no longer marked unknown.

Fixes: #11060