### PR TITLE
Add github's CodeQL scanner to CI.

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,5 @@
+queries:
+  - uses: ./.github/codeql/lgtm.qls
+
+paths-ignore:
+  - 'test cases'

--- a/.github/codeql/lgtm.qls
+++ b/.github/codeql/lgtm.qls
@@ -1,0 +1,4 @@
+# for some reason this doesn't work by default any way I can see
+
+- import: codeql-suites/python-lgtm.qls
+  from: codeql/python-queries

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,31 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  analyze:
+    # lgtm.com does not run in forks, for good reason
+    if: github.repository == 'mesonbuild/meson'
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        config-file: .github/codeql/codeql-config.yml
+        languages: python
+        # we have none
+        setup-python-dependencies: false
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
lgtm.com was acquired by github. It is deprecated and on its way out, because they've integrated the functionality itself into github. Take a look at what its official replacement can do.

This does run as yet another Actions slot, which is already fairly excessive, but the average runtime seems about 5 minutes so that's not too bad...