### PR TITLE
Support CUDA Toolkit 11.8

### DIFF
--- a/mesonbuild/modules/cuda.py
+++ b/mesonbuild/modules/cuda.py
@@ -246,11 +246,20 @@ class CudaModule(NewExtensionModule):
                 cuda_hi_limit_gpu_architecture = '8.6'        # noqa: E221
 
         if version_compare(cuda_version, '>=11.1'):
-            cuda_common_gpu_architectures += ['8.6', '8.6+PTX']  # noqa: E221
+            cuda_common_gpu_architectures += ['8.6']             # noqa: E221
             cuda_all_gpu_architectures    += ['8.6']             # noqa: E221
 
-            if version_compare(cuda_version, '<12.0'):
-                cuda_hi_limit_gpu_architecture = '9.0'        # noqa: E221
+            if version_compare(cuda_version, '<11.8'):
+                cuda_common_gpu_architectures += ['8.6+PTX']  # noqa: E221
+                cuda_hi_limit_gpu_architecture = '8.7'        # noqa: E221
+
+        if version_compare(cuda_version, '>=11.8'):
+            cuda_known_gpu_architectures  += ['Orin', 'Lovelace', 'Hopper']  # noqa: E221
+            cuda_common_gpu_architectures += ['8.9', '9.0', '9.0+PTX']       # noqa: E221
+            cuda_all_gpu_architectures    += ['8.7', '8.9', '9.0']           # noqa: E221
+
+            if version_compare(cuda_version, '<12'):
+                cuda_hi_limit_gpu_architecture = '9.1'        # noqa: E221
 
         if not cuda_arch_list:
             cuda_arch_list = 'Auto'
@@ -301,6 +310,9 @@ class CudaModule(NewExtensionModule):
                     'Xavier':        (['7.2'],             []),
                     'Turing':        (['7.5'],             ['7.5']),
                     'Ampere':        (['8.0'],             ['8.0']),
+                    'Orin':          (['8.7'],             []),
+                    'Lovelace':      (['8.9'],             ['8.9']),
+                    'Hopper':        (['9.0'],             ['9.0']),
                 }.get(arch_name, (None, None))
 
             if arch_bin is None:

--- a/mesonbuild/modules/cuda.py
+++ b/mesonbuild/modules/cuda.py
@@ -56,6 +56,8 @@ class CudaModule(NewExtensionModule):
 
         cuda_version = args[0]
         driver_version_table = [
+            {'cuda_version': '>=11.8.0',   'windows': '522.06', 'linux': '520.61.05'},
+            {'cuda_version': '>=11.7.1',   'windows': '516.31', 'linux': '515.48.07'},
             {'cuda_version': '>=11.7.0',   'windows': '516.01', 'linux': '515.43.04'},
             {'cuda_version': '>=11.6.1',   'windows': '511.65', 'linux': '510.47.03'},
             {'cuda_version': '>=11.6.0',   'windows': '511.23', 'linux': '510.39.01'},

--- a/mesonbuild/modules/cuda.py
+++ b/mesonbuild/modules/cuda.py
@@ -337,7 +337,7 @@ class CudaModule(NewExtensionModule):
 
             if version_compare(arch, '<' + cuda_lo_limit_gpu_architecture):
                 continue
-            if version_compare(arch, '>=' + cuda_hi_limit_gpu_architecture):
+            if cuda_hi_limit_gpu_architecture and version_compare(arch, '>=' + cuda_hi_limit_gpu_architecture):
                 continue
 
             if codev:
@@ -359,7 +359,7 @@ class CudaModule(NewExtensionModule):
 
             if version_compare(arch, '<' + cuda_lo_limit_gpu_architecture):
                 continue
-            if version_compare(arch, '>=' + cuda_hi_limit_gpu_architecture):
+            if cuda_hi_limit_gpu_architecture and version_compare(arch, '>=' + cuda_hi_limit_gpu_architecture):
                 continue
 
             arch = arch.replace('.', '')


### PR DESCRIPTION
Adds support for CUDA Toolkit 11.8 in the Meson CUDA module. Based on #11114 but modified.

Normally, the Meson `cuda.nvcc_arch_*()` functions are supposed to be a reflection of CMake's own [`select_compute_arch.cmake`](https://github.com/Kitware/CMake/blob/master/Modules/FindCUDA/select_compute_arch.cmake). However, they have not added CUDA 11.8 support yet and so we are obliged to improvise by ourselves, generalizing from what already exists. This PR constitutes an attempt at it.

I have chosen to deviate from #11114 in a few significant ways, most notably:

- I selected _Lovelace_ over _Ada_. All other architecture names (e.g. _Ampere_, _Turing_) are last names, not first names. Ada breaks that pattern. Lovelace isn't a last name, it's more of a title (_"Ada, Countess of Lovelace"_) but as the Internet and NVIDIA themselves commonly elide "Countess of" to yield "Ada Lovelace", and this is the name by which she is best known, it is arguably the quasi-last name we need.
- I have added the name _Orin_ to the list, mapped it to Compute Capability 8.7 without automatic PTX generation, and excluded it from the `Common` architectures list. This is like all other Tegra platforms, and defensible on the basis that code targeting one NVIDIA SoC is very unlikely to be copied and run as-is for another SoC later requiring dynamic compilation from PTX.
- As previously, I only generate PTX by default for the last generation supported by the CUDA Toolkit, in this occurrence, _Hopper_ 9.0+PTX.

Lastly, I update the minimum driver version table for CUDA 11.8, again following Table 3 in the [documentation](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html).

Closes #11114