### PR TITLE
fix broken zlib dependency lookup for MSVC

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -20,7 +20,6 @@ disable=
     duplicate-value,
     exec-used,
     fixme,
-    implicit-str-concat,
     import-error,
     import-outside-toplevel,
     inconsistent-mro,

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -500,7 +500,7 @@ class ZlibSystemDependency(SystemDependency):
             self.link_args = ['-lz']
         else:
             if self.clib_compiler.get_argument_syntax() == 'msvc':
-                libs = ['zlib1' 'zlib']
+                libs = ['zlib1', 'zlib']
             else:
                 libs = ['z']
             for lib in libs:


### PR DESCRIPTION
a.k.a. pylint: enable implicit-str-concat

Which catches a very real bug. The zlib system dependency failed to work on MSVC since initial implementation in commit
c1a3b37ab7e4ccf3a946ee4ba6da81a4c230ecc4 -- it looked for the wrong name.

Cherry-picked from #10767 because this one needs to be backported.