### PR TITLE
dependencies: Always force PKG_CONFIG_ALLOW_SYSTEM_CFLAGS

### DIFF
--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -204,12 +204,12 @@ class PkgConfigDependency(ExternalDependency):
         return shlex.split(cmd)
 
     def _set_cargs(self) -> None:
-        env = None
-        if self.language == 'fortran':
-            # gfortran doesn't appear to look in system paths for INCLUDE files,
-            # so don't allow pkg-config to suppress -I flags for system paths
-            env = os.environ.copy()
-            env['PKG_CONFIG_ALLOW_SYSTEM_CFLAGS'] = '1'
+        # gfortran doesn't appear to look in system paths for INCLUDE files,
+        # so don't allow pkg-config to suppress -I flags for system paths
+        # Also pkgconf suppresses the prefix it was installed to
+        # when built with Meson
+        env = os.environ.copy()
+        env['PKG_CONFIG_ALLOW_SYSTEM_CFLAGS'] = '1'
         ret, out, err = self._call_pkgbin(['--cflags', self.name], env=env)
         if ret != 0:
             raise DependencyException(f'Could not generate cargs for {self.name}:\n{err}\n')


### PR DESCRIPTION
This is needed too for pkgconf because it strips them by default when built with Meson. The autotools alternatives provides an option to skip that behaviour, but it would be best not to rely on build semantics.

Fixes #11088