### PR TITLE
nasm: Fixes for using under MSVC standalone

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,6 +94,8 @@ jobs:
   - bash: ci/intel-scripts/cache_exclude_windows.sh
     displayName: exclude unused files from cache
     condition: and(ne(variables.CACHE_RESTORED, 'true'), eq(variables.ifort, 'true'))
+  - script: choco install -y nasm
+    displayName: install NASM
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '3.7'

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1549,6 +1549,7 @@ You probably should put it in link_with instead.''')
         MASK_LANGS = frozenset([
             # (language, linker)
             ('cpp', 'cuda'),
+            ('nasm', 'c'),
         ])
         # Pick a compiler based on the language priority-order
         for l in clink_langs:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -84,7 +84,7 @@ source_suffixes = all_suffixes - header_suffixes
 # List of languages that by default consume and output libraries following the
 # C ABI; these can generally be used interchangeably
 # This must be sorted, see sort_clink().
-clib_langs = ('objcpp', 'cpp', 'objc', 'c', 'fortran')
+clib_langs = ('objcpp', 'cpp', 'objc', 'c', 'nasm', 'fortran')
 # List of languages that can be linked with C code directly by the linker
 # used in build.py:process_compilers() and build.py:get_dynamic_linker()
 # This must be sorted, see sort_clink().

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -189,6 +189,9 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
             trials = [['xilib']]
         elif is_windows() and compiler.id == 'pgi': # this handles cpp / nvidia HPC, in addition to just c/fortran
             trials = [['ar']]  # For PGI on Windows, "ar" is just a wrapper calling link/lib.
+        elif is_windows() and compiler.id == 'nasm':
+            # This may well be LINK.EXE if it's under a MSVC environment
+            trials = [defaults['vs_static_linker'], defaults['clang_cl_static_linker']] + default_linkers
         else:
             trials = default_linkers
     popen_exceptions = {}

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -1198,11 +1198,11 @@ def detect_nasm_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
         if 'NASM' in output:
             comp_class = NasmCompiler
             env.coredata.add_lang_args(comp_class.language, comp_class, for_machine, env)
-            return comp_class([], comp, version, for_machine, info, cc.linker, is_cross=is_cross)
+            return comp_class([], comp, version, for_machine, info, cc, is_cross=is_cross)
         elif 'yasm' in output:
             comp_class = YasmCompiler
             env.coredata.add_lang_args(comp_class.language, comp_class, for_machine, env)
-            return comp_class([], comp, version, for_machine, info, cc.linker, is_cross=is_cross)
+            return comp_class([], comp, version, for_machine, info, cc, is_cross=is_cross)
     _handle_exceptions(popen_exceptions, compilers)
     raise EnvironmentException('Unreachable code (exception to make mypy happy)')
 

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -457,6 +457,24 @@ class MSVCCompiler(VisualStudioLikeCompiler):
     def get_pch_base_name(self, header: str) -> str:
         return os.path.basename(header)
 
+    # Linking ASM-only objects into an executable or DLL
+    # require this, otherwise it'll fail to find
+    # _WinMain or _DllMainCRTStartup.
+    def get_crt_link_args(self, crt_val: str, buildtype: str) -> T.List[str]:
+        host_crt_compile_args = self.get_crt_compile_args(crt_val, buildtype)
+        for arg in host_crt_compile_args:
+            if arg == '/MTd':
+                return ['/DEFAULTLIB:libucrtd.lib', '/DEFAULTLIB:libvcruntimed.lib', '/DEFAULTLIB:libcmtd.lib']
+            elif arg == '/MT':
+                return ['/DEFAULTLIB:libucrt.lib', '/DEFAULTLIB:libvcruntime.lib', '/DEFAULTLIB:libcmt.lib']
+            elif arg == '/MDd':
+                return ['/DEFAULTLIB:ucrtd.lib', '/DEFAULTLIB:vcruntimed.lib', '/DEFAULTLIB:msvcrtd.lib']
+            elif arg == '/MD':
+                return ['/DEFAULTLIB:ucrt.lib', '/DEFAULTLIB:vcruntime.lib', '/DEFAULTLIB:msvcrt.lib']
+            else:
+                continue
+        return []
+
 
 class ClangClCompiler(VisualStudioLikeCompiler):
 

--- a/test cases/nasm/1 configure file/hello_win.asm
+++ b/test cases/nasm/1 configure file/hello_win.asm
@@ -1,0 +1,43 @@
+; ---------------------------------------------
+; Hello World for Win64 Intel x64 Assembly
+;
+; by fruel (https://github.com/fruel)
+; 13 June 2016
+; Modified by Amyspark for NASM
+; 8 December 2022
+; ---------------------------------------------
+
+default rel
+
+%include "config.asm"
+
+extern GetStdHandle
+extern WriteConsoleA
+extern ExitProcess
+
+    SECTION .rdata
+msg:    db "Hello World",10     ; the string to print, 10=cr
+len:    equ $-msg               ; "$" means "here"
+                                ; len is a value, not an address
+
+    SECTION .bss
+bytesWritten: resd 1
+
+SECTION .text                   ; code section
+        global main             ; make label available to linker
+main:
+    sub rsp, 5 * 8              ; reserve shadow space
+
+    mov rcx, -11                ; nStdHandle (STD_OUTPUT_HANDLE)
+    call GetStdHandle
+
+    mov  rcx, rax               ; hConsoleOutput
+    lea  rdx, msg               ; *lpBuffer
+    mov  r8, len - 1            ; nNumberOfCharsToWrite
+    lea  r9, bytesWritten       ; lpNumberOfCharsWritten
+    push DWORD 0h               ; lpReserved
+    push DWORD 0h               ; lpReserved
+    call WriteConsoleA
+
+    mov rcx, HELLO              ; uExitCode
+    call ExitProcess

--- a/test cases/nasm/1 configure file/meson.build
+++ b/test cases/nasm/1 configure file/meson.build
@@ -42,7 +42,13 @@ config_file = configure_file(
 cc = meson.get_compiler('c')
 link_args = cc.get_supported_link_arguments(['-no-pie'])
 
-exe = executable('hello', asm_gen.process('hello.asm'),
+if host_machine.system() == 'windows'
+  sources = asm_gen.process('hello_win.asm')
+else
+  sources = asm_gen.process('hello.asm')
+endif
+
+exe = executable('hello', sources,
   link_args: link_args,
 )
 

--- a/test cases/nasm/2 asm language/hello_win.asm
+++ b/test cases/nasm/2 asm language/hello_win.asm
@@ -1,0 +1,43 @@
+; ---------------------------------------------
+; Hello World for Win64 Intel x64 Assembly
+;
+; by fruel (https://github.com/fruel)
+; 13 June 2016
+; Modified by Amyspark for NASM
+; 8 December 2022
+; ---------------------------------------------
+
+default rel
+
+%include "config.asm"
+
+extern GetStdHandle
+extern WriteConsoleA
+extern ExitProcess
+
+    SECTION .rdata
+msg:    db "Hello World",10     ; the string to print, 10=cr
+len:    equ $-msg               ; "$" means "here"
+                                ; len is a value, not an address
+
+    SECTION .bss
+bytesWritten: resd 1
+
+SECTION .text                   ; code section
+        global main             ; make label available to linker
+main:
+    sub rsp, 5 * 8              ; reserve shadow space
+
+    mov rcx, -11                ; nStdHandle (STD_OUTPUT_HANDLE)
+    call GetStdHandle
+
+    mov  rcx, rax               ; hConsoleOutput
+    lea  rdx, msg               ; *lpBuffer
+    mov  r8, len - 1            ; nNumberOfCharsToWrite
+    lea  r9, bytesWritten       ; lpNumberOfCharsWritten
+    push DWORD 0h               ; lpReserved
+    push DWORD 0h               ; lpReserved
+    call WriteConsoleA
+
+    mov rcx, HELLO              ; uExitCode
+    call ExitProcess

--- a/test cases/nasm/2 asm language/meson.build
+++ b/test cases/nasm/2 asm language/meson.build
@@ -1,8 +1,19 @@
 project('test', 'c')
 
-if not host_machine.cpu_family().startswith('x86')
-  assert(not add_languages('nasm', required: false))
-  error('MESON_SKIP_TEST: nasm only supported for x86 and x86_64')
+if host_machine.cpu_family() == 'x86' and host_machine.system() == 'windows'
+  asm_format = 'win32'
+elif host_machine.cpu_family() == 'x86_64' and host_machine.system() == 'windows'
+  asm_format = 'win64'
+elif host_machine.cpu_family() == 'x86' and host_machine.system() == 'linux'
+  asm_format = 'elf32'
+elif host_machine.cpu_family() == 'x86_64' and host_machine.system() == 'linux'
+  asm_format = 'elf64'
+else
+  error('MESON_SKIP_TEST: skipping test on this platform')
+endif
+
+if meson.backend().startswith('vs')
+  error('MESON_SKIP_TEST: VS backend does not recognise NASM yet')
 endif
 
 if not add_languages('nasm', required: false)
@@ -38,7 +49,13 @@ config_file = configure_file(
 cc = meson.get_compiler('c')
 link_args = cc.get_supported_link_arguments(['-no-pie'])
 
-exe = executable('hello', 'hello.asm',
+if host_machine.system() == 'windows'
+  sources = files('hello_win.asm')
+else
+  sources = files('hello.asm')
+endif
+
+exe = executable('hello', sources,
   nasm_args: '-DFOO',
   link_args: link_args,
 )

--- a/test cases/nasm/3 nasm only/dummy.asm
+++ b/test cases/nasm/3 nasm only/dummy.asm
@@ -1,0 +1,4 @@
+global dummy
+section .rdata align=16
+dummy:
+  dd 0x00010203

--- a/test cases/nasm/3 nasm only/dummy.def
+++ b/test cases/nasm/3 nasm only/dummy.def
@@ -1,0 +1,2 @@
+EXPORTS
+	dummy

--- a/test cases/nasm/3 nasm only/meson.build
+++ b/test cases/nasm/3 nasm only/meson.build
@@ -1,0 +1,13 @@
+project('nasm only')
+
+if not add_languages('nasm', required: false)
+  error('MESON_SKIP_TEST: nasm not found')
+endif
+
+sources = files('dummy.asm')
+
+dummy = library(
+    'dummy',
+    sources,
+    vs_module_defs: 'dummy.def',
+)

--- a/test cases/nasm/4 nasm and c together/dummy.asm
+++ b/test cases/nasm/4 nasm and c together/dummy.asm
@@ -1,0 +1,4 @@
+global dummy
+section .rdata align=16
+dummy:
+  dd 0x00010203

--- a/test cases/nasm/4 nasm and c together/hello.c
+++ b/test cases/nasm/4 nasm and c together/hello.c
@@ -1,0 +1,15 @@
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+
+extern uint32_t dummy[]; 
+
+int main()
+{
+    if (*dummy != 0x00010203u) {
+        fprintf(stderr, "Dummy value was: %" PRIu32 "\n", *dummy);
+        return 1;
+    }
+
+    return 0;
+}

--- a/test cases/nasm/4 nasm and c together/meson.build
+++ b/test cases/nasm/4 nasm and c together/meson.build
@@ -1,4 +1,4 @@
-project('nasm only')
+project('nasm and c together', 'c')
 
 if not add_languages('nasm', required: false)
   error('MESON_SKIP_TEST: nasm not found')
@@ -8,10 +8,11 @@ if meson.backend().startswith('vs')
   error('MESON_SKIP_TEST: VS backend does not recognise NASM yet')
 endif
 
-sources = files('dummy.asm')
+sources = files('dummy.asm', 'hello.c')
 
-dummy = library(
-    'dummy',
-    sources,
-    vs_module_defs: 'dummy.def',
+hello = executable(
+  'hello',
+  sources,
 )
+
+test('hello', hello)

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -76,6 +76,7 @@ class BasePlatformTests(TestCase):
         self.unit_test_dir = os.path.join(src_root, 'test cases/unit')
         self.rewrite_test_dir = os.path.join(src_root, 'test cases/rewrite')
         self.linuxlike_test_dir = os.path.join(src_root, 'test cases/linuxlike')
+        self.nasm_test_dir = os.path.join(src_root, 'test cases/nasm')
         self.objc_test_dir = os.path.join(src_root, 'test cases/objc')
         self.objcpp_test_dir = os.path.join(src_root, 'test cases/objcpp')
 

--- a/unittests/windowstests.py
+++ b/unittests/windowstests.py
@@ -398,3 +398,35 @@ class WindowsTests(BasePlatformTests):
         with mock.patch.object(self, 'install_command', self.meson_command + ['install']):
             out = self.install(override_envvars=env)
             self.assertIn('Activating VS', out)
+
+    @skip_if_not_language('nasm')
+    def test_nasm_alone_uses_nasm_linker(self):
+        # TODO: there should be some way to query how we're linking things
+        # without resorting to reading the ninja.build file
+        if self.backend is not Backend.ninja:
+            raise SkipTest('This test reads the ninja file')
+
+        testdir = os.path.join(self.nasm_test_dir, '3 nasm only')
+        self.init(testdir)
+
+        build_ninja = os.path.join(self.builddir, 'build.ninja')
+        with open(build_ninja, encoding='utf-8') as f:
+            contents = f.read()
+
+        self.assertRegex(contents, r'build dummy(\.dll)?.*: nasm_LINKER')
+
+    @skip_if_not_language('nasm')
+    def test_nasm_with_c_use_c_linker(self):
+        # TODO: there should be some way to query how we're linking things
+        # without resorting to reading the ninja.build file
+        if self.backend is not Backend.ninja:
+            raise SkipTest('This test reads the ninja file')
+
+        testdir = os.path.join(self.nasm_test_dir, '4 nasm and c together')
+        self.init(testdir)
+
+        build_ninja = os.path.join(self.builddir, 'build.ninja')
+        with open(build_ninja, encoding='utf-8') as f:
+            contents = f.read()
+
+        self.assertRegex(contents, r'build hello(\.exe)?.*: c_LINKER')


### PR DESCRIPTION
:wave:

This PR fixes the issues I found when trying to use NASM to build a library under MSVC.  The associated issues need to be fixed in tandem in order for the test to pass. 

First, I override `get_crt_link_args` in the MSVS mixin to ensure all linkage always get a full set of default libraries as per [the Microsoft docs](https://learn.microsoft.com/en-us/cpp/c-runtime-library/crt-library-features?view=msvc-170); then, I added the  MSVC linkers to the corresponding trial list for NASM.

TODO: check if the default library set is needed for Clang/CL as well.

Fixes #11082 
Fixes #11083