### PR TITLE
python module: don't overwrite and destroy the .pc dependency name

### DIFF
--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -91,7 +91,6 @@ mod_kwargs -= {'name_prefix', 'name_suffix'}
 class _PythonDependencyBase(_Base):
 
     def __init__(self, python_holder: 'PythonInstallation', embed: bool):
-        self.name = 'python'  # override the name from the "real" dependency lookup
         self.embed = embed
         self.version: str = python_holder.version
         self.platform = python_holder.platform


### PR DESCRIPTION
When finding a py.dependency() we try to use pkg-config. We then apply our own custom base class, which replaces self.name with the informative comment "override the name from the "real" dependency lookup", to which I can only say "uhhh why". Why do we want to do that???

It turns out we don't, it was just a really old legacy design because we had a SystemDependency with a .pkgdep attribute hiding the real dependency bizarro-land style. We cleaned that up in commit 4d67dd19e5b7dcec6716840d30984fa41eef55c6 and as part of that, we *shifted over* the self.name assignment to preserve the visible effects, sort of. We didn't have a *reason* to override the name, we just did it because... we weren't sure whether it mattered.

Unfortunately it very much does matter the other way -- we don't want it. We can pass this dependency to the pkgconfig module, which uses the name attribute to fill out the `Requires: ` field. Also, the name should name what we have. :p

Get rid of this bizarre historic quirk. Since we have proper dependencies here, we should go all in.

Fixes https://github.com/ufo-kit/ufo-core/pull/185#issuecomment-1328224996