### PR TITLE
interpreter: `not_found_message` was being printed twice

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1706,7 +1706,6 @@ class Interpreter(InterpreterBase, HoldableObject):
         assert isinstance(d, Dependency)
         if not d.found() and not_found_message:
             self.message_impl([not_found_message])
-            self.message_impl([not_found_message])
         # Ensure the correct include type
         if 'include_type' in kwargs:
             wanted = kwargs['include_type']


### PR DESCRIPTION
when using `dependency(...)` and the `not_found_message` parameter is specified, the message gets logged twice instead of once.

fixes https://github.com/mesonbuild/meson/issues/8150