### PR TITLE
Use meson setup [options] in meson RPM macro

### DIFF
--- a/data/macros.meson
+++ b/data/macros.meson
@@ -4,7 +4,7 @@
 
 %meson \
     %set_build_flags \
-    %{shrink:%{__meson} \
+    %{shrink:%{__meson} setup \
         --buildtype=plain \
         --prefix=%{_prefix} \
         --libdir=%{_libdir} \


### PR DESCRIPTION
Fixes the following warning when building a rpm pkg using %meson macro:
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.