### PR TITLE
mlog: set LESS environment variable for pager.

### DIFF
--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -436,6 +436,9 @@ def start_pager() -> None:
         env = os.environ.copy()
         if 'LESS' not in env:
             env['LESS'] = 'RXF'
+        # Set "-c" for lv to support color
+        if 'LV' not in env:
+            env['LV'] = '-c'
         log_pager = subprocess.Popen(pager_cmd, stdin=subprocess.PIPE,
                                      text=True, encoding='utf-8', env=env)
     except Exception as e:


### PR DESCRIPTION
See #11075 for details. This unbreaks pager output from e.g. `meson configure` when the user has `PAGER=less` set in their environment (without `-R`). This follows the behaviour of tools such as git and bat. If the old behaviour is *really* desired, users can still set e.g. `PAGER='less -+RXF'`.

The copy of `os.environ` is probably not required over just setting `os.environ['LESS']`, but better safe than sorry.

Also, this is only tested on current Arch Linux (and notably not Windows), as that's the only development system I have to hand right now.