### PR TITLE
Revert "openbsd: execinfo is not a compiler lib"

### DIFF
--- a/mesonbuild/arglist.py
+++ b/mesonbuild/arglist.py
@@ -20,16 +20,12 @@ import os
 import re
 import typing as T
 
-from . import mesonlib
-
 if T.TYPE_CHECKING:
     from .linkers import StaticLinker
     from .compilers import Compiler
 
-UNIXY_COMPILER_INTERNAL_LIBS = ['m', 'c', 'pthread', 'dl', 'rt']  # type: T.List[str]
-# execinfo is a compiler lib on FreeBSD and NetBSD
-if mesonlib.is_freebsd() or mesonlib.is_netbsd():
-    UNIXY_COMPILER_INTERNAL_LIBS.append('execinfo')
+# execinfo is a compiler lib on BSD
+UNIXY_COMPILER_INTERNAL_LIBS = ['m', 'c', 'pthread', 'dl', 'rt', 'execinfo']  # type: T.List[str]
 
 
 class Dedup(enum.Enum):


### PR DESCRIPTION
OpenBSD now has execinfo as compiler lib. DragonFly has all along.

This reverts commit 0241948d8fa37f59eb93088a26e9b7ae642cc2d0.