### PR TITLE
CI: skip libgcrypt test on msys2

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -289,6 +289,7 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
         trial = platform.processor().lower()
     else:
         trial = platform.machine().lower()
+    mlog.debug(f'detecting CPU family based on trial={trial!r}')
     if trial.startswith('i') and trial.endswith('86'):
         trial = 'x86'
     elif trial == 'bepc':

--- a/test cases/frameworks/24 libgcrypt/test.json
+++ b/test cases/frameworks/24 libgcrypt/test.json
@@ -1,3 +1,3 @@
 {
-  "skip_on_jobname": ["azure"]
+  "skip_on_jobname": ["azure", "msys2"]
 }


### PR DESCRIPTION
This is no longer implicitly installed due to libxslt. Actually though, we don't need to test this in order to ensure that the custom dependency works -- we have other jobs that test it, and the config-tool handling itself won't suddenly fail on msys2 specifically.