### PR TITLE
DOCS: Rust-module: Remove note about unstable API

### DIFF
--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -11,8 +11,6 @@ authors:
 *(new in 0.57.0)*
 *(Stable since 1.0.0)*
 
-**Note** Unstable modules make no backwards compatible API guarantees.
-
 The rust module provides helper to integrate rust code into Meson. The
 goal is to make using rust in Meson more pleasant, while still
 remaining mesonic, this means that it attempts to make Rust work more


### PR DESCRIPTION
Small follow-up on #11072. This PR removes the note about the unstable API of the Rust module, since it's no longer unstable as of Meson 1.0.0.