### PR TITLE
depfixer: silence `fix_jar()` and make it do something

### DIFF
--- a/mesonbuild/scripts/depfixer.py
+++ b/mesonbuild/scripts/depfixer.py
@@ -465,7 +465,12 @@ def fix_jar(fname: str) -> None:
             if not line.startswith('Class-Path:'):
                 f.write(line)
         f.truncate()
-    subprocess.check_call(['jar', 'ufm', fname, 'META-INF/MANIFEST.MF'])
+    # jar -um doesn't allow removing existing attributes.  Use -uM instead,
+    # which a) removes the existing manifest from the jar and b) disables
+    # special-casing for the manifest file, so we can re-add it as a normal
+    # archive member.  This puts the manifest at the end of the jar rather
+    # than the beginning, but the spec doesn't forbid that.
+    subprocess.check_call(['jar', 'ufM', fname, 'META-INF/MANIFEST.MF'])
 
 def fix_rpath(fname: str, rpath_dirs_to_remove: T.Set[bytes], new_rpath: T.Union[str, bytes], final_path: str, install_name_mappings: T.Dict[str, str], verbose: bool = True) -> None:
     global INSTALL_NAME_TOOL  # pylint: disable=global-statement

--- a/mesonbuild/scripts/depfixer.py
+++ b/mesonbuild/scripts/depfixer.py
@@ -457,7 +457,7 @@ def fix_darwin(fname: str, new_rpath: str, final_path: str, install_name_mapping
         raise SystemExit(err)
 
 def fix_jar(fname: str) -> None:
-    subprocess.check_call(['jar', 'xfv', fname, 'META-INF/MANIFEST.MF'])
+    subprocess.check_call(['jar', 'xf', fname, 'META-INF/MANIFEST.MF'])
     with open('META-INF/MANIFEST.MF', 'r+', encoding='utf-8') as f:
         lines = f.readlines()
         f.seek(0)

--- a/test cases/unit/110 classpath/com/mesonbuild/Simple.java
+++ b/test cases/unit/110 classpath/com/mesonbuild/Simple.java
@@ -1,0 +1,7 @@
+package com.mesonbuild;
+
+class Simple {
+    public static void main(String [] args) {
+        System.out.println("Java is working.\n");
+    }
+}

--- a/test cases/unit/110 classpath/meson.build
+++ b/test cases/unit/110 classpath/meson.build
@@ -1,0 +1,14 @@
+project('simplejava', 'java')
+
+one = jar('one', 'com/mesonbuild/Simple.java',
+  main_class : 'com.mesonbuild.Simple',
+  install : true,
+  install_dir : get_option('bindir'),
+)
+
+two = jar('two', 'com/mesonbuild/Simple.java',
+  main_class : 'com.mesonbuild.Simple',
+  install : true,
+  install_dir : get_option('bindir'),
+  link_with : one,
+)

--- a/unittests/machinefiletests.py
+++ b/unittests/machinefiletests.py
@@ -42,6 +42,7 @@ import mesonbuild.modules.pkgconfig
 
 
 from run_tests import (
+    Backend,
     get_fake_env
 )
 
@@ -367,6 +368,23 @@ class NativeFileTests(BasePlatformTests):
     def test_java_compiler(self):
         self._single_implementation_compiler(
             'java', 'javac', 'javac 9.99.77', '9.99.77')
+
+    @skip_if_not_language('java')
+    def test_java_classpath(self):
+        if self.backend is not Backend.ninja:
+            raise SkipTest('Jar is only supported with Ninja')
+        testdir = os.path.join(self.unit_test_dir, '110 classpath')
+        self.init(testdir)
+        self.build()
+        one_build_path = get_classpath(os.path.join(self.builddir, 'one.jar'))
+        self.assertIsNone(one_build_path)
+        two_build_path = get_classpath(os.path.join(self.builddir, 'two.jar'))
+        self.assertEqual(two_build_path, 'one.jar')
+        self.install()
+        one_install_path = get_classpath(os.path.join(self.installdir, 'usr/bin/one.jar'))
+        self.assertIsNone(one_install_path)
+        two_install_path = get_classpath(os.path.join(self.installdir, 'usr/bin/two.jar'))
+        self.assertIsNone(two_install_path)
 
     @skip_if_not_language('swift')
     def test_swift_compiler(self):


### PR DESCRIPTION
`fix_jar()` tries to remove an existing `Class-Path` entry from the jar manifest by postprocessing the manifest and passing it to `jar -um`.  However, `jar -um` can only add/replace manifest entries, not remove them, and it also complains loudly when replacing an entry:

    Dec 13, 2022 7:11:19 PM java.util.jar.Attributes read
    WARNING: Duplicate name in Manifest: Manifest-Version.
    Ensure that the manifest does not have duplicate entries, and
    that blank lines separate individual sections in both your
    manifest and in the META-INF/MANIFEST.MF entry in the jar file.

Thus `fix_jar()` produces one such warning for each entry in the manifest and accomplishes nothing else.

Use `jar -uM` instead.  This completely removes the manifest from the jar and allows adding it back as a normal zip member, fixing `fix_jar()` and avoiding the warnings.

Also don't extract `MANIFEST.MF` verbosely to avoid non-actionable output when installing a jar:

    inflated: META-INF/MANIFEST.MF

Fixes #3763.  Fixes https://github.com/mesonbuild/meson/issues/10491.