### PR TITLE
mconf: hide deprecated options that have no description

### DIFF
--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -198,7 +198,8 @@ class Conf:
             root = k.as_root()
             if o.yielding and k.subproject and root in self.coredata.options:
                 printable_value = '<inherited from main project>'
-            self.add_option(str(root), o.description, printable_value, o.choices)
+            if o.description or not isinstance(o.deprecated, str):
+                self.add_option(str(root), o.description, printable_value, o.choices)
 
     def print_conf(self, pager: bool):
         if pager:

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -169,7 +169,10 @@ class OptionInterpreter:
         parser = self.option_types.get(opt_type)
         if not parser:
             raise OptionException(f'Unknown type {opt_type}.')
-        description = kwargs['description'] or opt_name
+        description = kwargs['description']
+
+        if not description and not isinstance(kwargs['deprecated'], str):
+            description = opt_name
 
         # Only keep in kwargs arguments that are used by option type's parser
         # because they use @permittedKwargs().


### PR DESCRIPTION
Sometimes after renaming an option you don't want the old name to keep cluttering the option list, while still maintaining backwards compatibility. It's not immediately obvious which options are obsolete when they are intermingled with the proper ones, especially when there's a lot of them.

This patch hides deprecated options from the `meson configure` output if their description has been omitted.

If this is not acceptable, an alternative solution could be to move the deprecated options into a separate sub-section, and perhaps auto-generate descriptions (e.g. `DEPRECATED: use new_opt instead`) if they are omitted.