### PR TITLE
Add support for storing options in meson.options

### DIFF
--- a/data/syntax-highlighting/vim/ftdetect/meson.vim
+++ b/data/syntax-highlighting/vim/ftdetect/meson.vim
@@ -1,3 +1,4 @@
 au BufNewFile,BufRead meson.build set filetype=meson
+au BufNewFile,BufRead meson.options set filetype=meson
 au BufNewFile,BufRead meson_options.txt set filetype=meson
 au BufNewFile,BufRead *.wrap set filetype=dosini

--- a/docs/markdown/Adding-new-projects-to-wrapdb.md
+++ b/docs/markdown/Adding-new-projects-to-wrapdb.md
@@ -106,7 +106,7 @@ Remember that all files go in the directory
 `subprojects/packagefiles/<project-name>`.
 
 ```
-${EDITOR} meson.build meson_options.txt
+${EDITOR} meson.build meson.options
 ```
 
 In order to apply the locally added build files to the upstream

--- a/docs/markdown/Build-options.md
+++ b/docs/markdown/Build-options.md
@@ -7,8 +7,9 @@ short-description: Build options to configure project properties
 Most non-trivial builds require user-settable options. As an example a
 program may have two different data backends that are selectable at
 build time. Meson provides for this by having a option definition
-file. Its name is `meson_options.txt` and it is placed at the root of
-your source tree.
+file. Its name is `meson.options` and it is placed at the root of
+your source tree. For versions of meson before 1.1, this file was called
+`meson_options.txt`.
 
 Here is a simple option file.
 

--- a/docs/markdown/Configuring-a-build-directory.md
+++ b/docs/markdown/Configuring-a-build-directory.md
@@ -7,7 +7,7 @@ short-description: Configuring a pre-generated build directory
 Often you want to change the settings of your build after it has been
 generated. For example you might want to change from a debug build
 into a release build, set custom compiler flags, change the build
-options provided in your `meson_options.txt` file and so on.
+options provided in your `meson.options` file and so on.
 
 The main tool for this is the `meson configure` command.
 

--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -16,7 +16,7 @@ If specified, a leading `~` is expanded to the user home directory.
 Environment variables are not available as is the rule throughout Meson.
 That is, $HOME, %USERPROFILE%, $MKLROOT, etc. have no meaning to the Meson
 filesystem module. If needed, pass such variables into Meson via command
-line options in `meson_options.txt`, native-file or cross-file.
+line options in `meson.options`, native-file or cross-file.
 
 Where possible, symlinks and parent directory notation are resolved to an
 absolute path.

--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -338,7 +338,7 @@ The output format is as follows:
 ```json
 [
     "/Path/to/the/targets/meson.build",
-    "/Path/to/the/targets/meson_options.txt",
+    "/Path/to/the/targets/meson.options",
     "/Path/to/the/targets/subdir/meson.build"
 ]
 ```

--- a/docs/markdown/Porting-from-autotools.md
+++ b/docs/markdown/Porting-from-autotools.md
@@ -150,7 +150,7 @@ else
 endif
 ```
 
-`meson_options.txt`:
+`meson.options`:
 
 ```meson
 option('enable-dep11', type : 'boolean', value : true, description : 'enable DEP-11')

--- a/docs/markdown/snippets/meson_options.md
+++ b/docs/markdown/snippets/meson_options.md
@@ -1,0 +1,7 @@
+## Support for reading options from meson.options
+
+Support has been added for reading options from `meson.options` instead of
+`meson_options.txt`. These are equivalent, but not using the `.txt` extension
+for a build file has a few advantages, chief among them many tools and text
+editors expect a file with the `.txt` extension to be plain text files, not
+build scripts.

--- a/docs/yaml/functions/dependency.yaml
+++ b/docs/yaml/functions/dependency.yaml
@@ -82,7 +82,7 @@ kwargs:
     since: 0.38.0
     description: |
       An array of default option values
-      that override those set in the subproject's `meson_options.txt`
+      that override those set in the subproject's `meson.options`
       (like `default_options` in [[project]], they only have
       effect when Meson is run for the first time, and command line
       arguments override any default options in build files)

--- a/docs/yaml/functions/subproject.yaml
+++ b/docs/yaml/functions/subproject.yaml
@@ -9,7 +9,7 @@ description: |
   `${MESON_SOURCE_ROOT}/subprojects/foo`.
 
   - `default_options` *(since 0.37.0)*: an array of default option values
-    that override those set in the subproject's `meson_options.txt`
+    that override those set in the subproject's `meson.options`
     (like `default_options` in `project`, they only have effect when
     Meson is run for the first time, and command line arguments override
     any default options in build files). *(since 0.54.0)*: `default_library`
@@ -45,7 +45,7 @@ kwargs:
     since: 0.37.0
     description: |
       An array of default option values
-      that override those set in the subproject's `meson_options.txt`
+      that override those set in the subproject's `meson.options`
       (like `default_options` in [[project]], they only have effect when
       Meson is run for the first time, and command line arguments override
       any default options in build files). *(since 0.54.0)*: `default_library`

--- a/man/meson.1
+++ b/man/meson.1
@@ -105,7 +105,7 @@ print all top level targets (executables, libraries, etc)
 print the source files of the given target
 .TP
 \fB\-\-buildsystem\-files\fR
-print all files that make up the build system (meson.build, meson_options.txt etc)
+print all files that make up the build system (meson.build, meson.options, meson_options.txt etc)
 .TP
 \fB\-\-tests\fR
 print all unit tests

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -76,7 +76,6 @@ class IntrospectionInterpreter(AstInterpreter):
             self.environment = env
         self.subproject_dir = subproject_dir
         self.coredata = self.environment.get_coredata()
-        self.option_file = os.path.join(self.source_root, self.subdir, 'meson_options.txt')
         self.backend = backend
         self.default_options = {OptionKey('backend'): self.backend}
         self.project_data = {}    # type: T.Dict[str, T.Any]
@@ -113,9 +112,12 @@ class IntrospectionInterpreter(AstInterpreter):
             proj_vers = 'undefined'
         self.project_data = {'descriptive_name': proj_name, 'version': proj_vers}
 
-        if os.path.exists(self.option_file):
+        optfile = os.path.join(self.source_root, self.subdir, 'meson.options')
+        if not os.path.exists(optfile):
+            optfile = os.path.join(self.source_root, self.subdir, 'meson_options.txt')
+        if os.path.exists(optfile):
             oi = optinterpreter.OptionInterpreter(self.subproject)
-            oi.process(self.option_file)
+            oi.process(optfile)
             self.coredata.update_project_options(oi.options)
 
         def_opts = self.flatten_args(kwargs.get('default_options', []))

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -1023,6 +1023,7 @@ class XCodeBackend(backends.Backend):
             group_id = self.write_group_target_entry(objects_dict, target)
             children_array.add_item(group_id)
         potentials = [os.path.join(current_subdir, 'meson.build'),
+                      os.path.join(current_subdir, 'meson.options'),
                       os.path.join(current_subdir, 'meson_options.txt')]
         for bf in potentials:
             i = self.fileref_ids.get(bf, None)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -23,8 +23,9 @@ from .. import compilers
 from .. import envconfig
 from ..wrap import wrap, WrapMode
 from .. import mesonlib
-from ..mesonlib import (MesonBugException, HoldableObject, FileMode, MachineChoice, OptionKey,
-                        listify, extract_as_list, has_path_sep, PerMachine)
+from ..mesonlib import (MesonBugException, MesonException, HoldableObject,
+                        FileMode, MachineChoice, OptionKey, listify,
+                        extract_as_list, has_path_sep, PerMachine)
 from ..programs import ExternalProgram, NonExistingExternalProgram
 from ..dependencies import Dependency
 from ..depfile import DepFile
@@ -288,7 +289,6 @@ class Interpreter(InterpreterBase, HoldableObject):
         # be different for dependencies provided by wrap files.
         self.subproject_directory_name = subdir.split(os.path.sep)[-1]
         self.subproject_dir = subproject_dir
-        self.option_file = os.path.join(self.source_root, self.subdir, 'meson_options.txt')
         self.relaxations = relaxations or set()
         if not mock and ast is None:
             self.load_root_meson_file()
@@ -1150,11 +1150,27 @@ class Interpreter(InterpreterBase, HoldableObject):
                 raise InterpreterException(f'Meson version is {cv} but project requires {pv}')
             mesonlib.project_meson_versions[self.subproject] = kwargs['meson_version']
 
-        if os.path.exists(self.option_file):
+        # Load "meson.options" before "meson_options.txt", and produce a warning if
+        # it is being used with an old version. I have added check that if both
+        # exist the warning isn't raised
+        option_file = os.path.join(self.source_root, self.subdir, 'meson.options')
+        old_option_file = os.path.join(self.source_root, self.subdir, 'meson_options.txt')
+
+        if os.path.exists(option_file):
+            if os.path.exists(old_option_file):
+                if os.path.samefile(option_file, old_option_file):
+                    mlog.debug("Not warning about meson.options with version minimum < 1.1 because meson_options.txt also exists")
+                else:
+                    raise MesonException("meson.options and meson_options.txt both exist, but are not the same file.")
+            else:
+                FeatureNew.single_use('meson.options file', '1.1', self.subproject, 'Use meson_options.txt instead')
+        else:
+            option_file = old_option_file
+        if os.path.exists(option_file):
             oi = optinterpreter.OptionInterpreter(self.subproject)
-            oi.process(self.option_file)
+            oi.process(option_file)
             self.coredata.update_project_options(oi.options)
-            self.add_build_def_file(self.option_file)
+            self.add_build_def_file(option_file)
 
         # Do not set default_options on reconfigure otherwise it would override
         # values previously set from command line. That means that changing

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -319,12 +319,12 @@ def list_buildoptions(coredata: cdata.CoreData, subprojects: T.Optional[T.List[s
     return optlist
 
 def find_buildsystem_files_list(src_dir: str) -> T.List[str]:
+    build_files = frozenset({'meson.build', 'meson.options', 'meson_options.txt'})
     # I feel dirty about this. But only slightly.
-    filelist = []  # type: T.List[str]
+    filelist: T.List[str] = []
     for root, _, files in os.walk(src_dir):
-        for f in files:
-            if f in {'meson.build', 'meson_options.txt'}:
-                filelist.append(os.path.relpath(os.path.join(root, f), src_dir))
+        filelist.extend(os.path.relpath(os.path.join(root, f), src_dir)
+                        for f in build_files.intersection(files))
     return filelist
 
 def list_buildsystem_files(builddata: build.Build, interpreter: Interpreter) -> T.List[str]:

--- a/test cases/warning/9 meson.options/meson.build
+++ b/test cases/warning/9 meson.options/meson.build
@@ -1,0 +1,3 @@
+project('options too old', meson_version : '>= 0.63')
+
+subproject('no-warn')

--- a/test cases/warning/9 meson.options/meson.options
+++ b/test cases/warning/9 meson.options/meson.options
@@ -1,0 +1,1 @@
+option('foo', type : 'string')

--- a/test cases/warning/9 meson.options/subprojects/no-warn/meson.build
+++ b/test cases/warning/9 meson.options/subprojects/no-warn/meson.build
@@ -1,0 +1,1 @@
+project('has both no warn', meson_version : '>= 0.63')

--- a/test cases/warning/9 meson.options/subprojects/no-warn/meson.options
+++ b/test cases/warning/9 meson.options/subprojects/no-warn/meson.options
@@ -1,0 +1,1 @@
+option('foo', type : 'string')

--- a/test cases/warning/9 meson.options/subprojects/no-warn/meson_options.txt
+++ b/test cases/warning/9 meson.options/subprojects/no-warn/meson_options.txt
@@ -1,0 +1,1 @@
+meson.options

--- a/test cases/warning/9 meson.options/test.json
+++ b/test cases/warning/9 meson.options/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "WARNING: Project targets '>= 0.63' but uses feature introduced in '1.1': meson.options file. Use meson_options.txt instead"
+    }
+  ]
+}

--- a/unittests/failuretests.py
+++ b/unittests/failuretests.py
@@ -78,7 +78,9 @@ class FailureTests(BasePlatformTests):
         super().setUp()
         self.srcdir = os.path.realpath(tempfile.mkdtemp())
         self.mbuild = os.path.join(self.srcdir, 'meson.build')
-        self.moptions = os.path.join(self.srcdir, 'meson_options.txt')
+        self.moptions = os.path.join(self.srcdir, 'meson.options')
+        if not os.path.exists(self.moptions):
+            self.moptions = os.path.join(self.srcdir, 'meson_options.txt')
 
     def tearDown(self):
         super().tearDown()


### PR DESCRIPTION
This provides support for using `meson.options` instead of `meson_options.txt`.

This makes sense for a couple of reasons:
1. text editors (and other tools) expect `.txt` files to be plain text files, not build scripts
2. meson.options is more consist with meson.build

The goal has been to design this in such a way that if a project uses a `meson.options` file with a minimum below 1.1, then meson will warn, but if a `meson_options.txt` exist, and both point to the same file, then the error is reduced to a debug message.

Fixes: #11176
Fixes: #6951
Fixes: #5288