### PR TITLE
delay importing ctypes unless it is actually used

### DIFF
--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 from pathlib import Path
 import argparse
-import ctypes
 import enum
 import sys
 import stat
@@ -699,6 +698,7 @@ def windows_detect_native_arch() -> str:
     if sys.platform != 'win32':
         return ''
     try:
+        import ctypes
         process_arch = ctypes.c_ushort()
         native_arch = ctypes.c_ushort()
         kernel32 = ctypes.windll.kernel32


### PR DESCRIPTION
ctypes uses FFI, and surprisingly often people's Python installations will be broken because ctypes is broken (e.g. the system libffi has been updated and Python needs to be recompiled). That is not our fault, but it does manifest as Meson failing to run. It turns out we aren't even using it though. At least, pretty often.

We have two uses of ctypes, and both of them are for Windows. One of them is already conditionally imported in the function that uses it, but the other is imported at startup. Move this down into the invoking function.

On non-Windows systems, it is now impossible for Meson to fail to run when ctypes is broken, because we don't use it. Anecdotally, this issue tends to come up on Linux systems primarily.

Fixes #11111
Closes #11112