### PR TITLE
mtest: handle TAP tests with unknown version.

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1056,7 +1056,7 @@ class TestRunTAP(TestRun):
     async def parse(self, harness: 'TestHarness', lines: T.AsyncIterator[str]) -> None:
         res = None
         warnings = [] # type: T.List[TAPParser.UnknownLine]
-        version: int
+        version: T.Optional[int] = None
 
         async for i in TAPParser().parse_async(lines):
             if isinstance(i, TAPParser.Version):
@@ -1075,6 +1075,9 @@ class TestRunTAP(TestRun):
                 self.additional_error += 'TAP parsing error: ' + i.message
                 res = TestResult.ERROR
 
+        if version is None:
+            self.warnings.append('Unknown TAP version. The first line MUST be `TAP version <int>`. Assuming version 12.')
+            version = 12
         if warnings:
             unknown = str(mlog.yellow('UNKNOWN'))
             width = len(str(max(i.lineno for i in warnings)))


### PR DESCRIPTION
TAP 14 states:
> Harnesses may treat any TAP stream lacking a version as a failed test.

TAP 13 states:
> In the absence of any version line version 12 is assumed. It is an
> error to explicitly specify any version lower than 13.

So, modern TAP is saying that we should treat a missing version as a test definition bug, it's no longer okay to use a missing version as saying "let's use TAP 12". But, we can choose whether to treat it that way or error out.

Let's do a diagnostic, as we do elsewhere. But allow TAP streams that aren't well defined, if they used to be well defined (back in TAP 12).