### PR TITLE
Fix find_program pkg-config when defined in machine file

### DIFF
--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -385,6 +385,8 @@ class BinaryTable:
                     raise mesonlib.MesonException(
                         f'Invalid type {command!r} for entry {name!r} in cross file')
                 self.binaries[name] = mesonlib.listify(command)
+                if name == 'pkgconfig':
+                    self.binaries['pkg-config'] = self.binaries[name]
 
     @staticmethod
     def detect_ccache() -> T.List[str]:

--- a/test cases/unit/45 native dep pkgconfig var/meson.build
+++ b/test cases/unit/45 native dep pkgconfig var/meson.build
@@ -13,3 +13,7 @@ assert(dep_type == 'native', 'Expected native')
 
 dep_type = dep_cross.get_pkgconfig_variable('dep_type')
 assert(dep_type == 'cross', 'Expected cross')
+
+pkgconfig = find_program('pkgconfig', native: false)
+pkg_config = find_program('pkg-config', native: false)
+assert(pkgconfig.full_path() == pkg_config.full_path())


### PR DESCRIPTION
When `pkg-config` or `pkgconf` are defined in the `[binaries]` section of a machine file, the entry is called `pkgconfig`, so we should match that when the user does `find_program('pkg-config')` or `find_program('pkgconf')`.

This is usually not needed because the dependency handler takes care of it, but sometimes the user wants to access pkg-config directly; for example, to pass to external build systems like cargo.