### PR TITLE
CMake: TraceTargets: Don't assume valid library list

### DIFF
--- a/mesonbuild/cmake/tracetargets.py
+++ b/mesonbuild/cmake/tracetargets.py
@@ -54,7 +54,9 @@ def resolve_cmake_trace_targets(target_name: str,
                 # CMake brute-forces a combination of prefix/suffix combinations to find the
                 # right library. Assume any bare argument passed which is not also a CMake
                 # target must be a system library we should try to link against.
-                res.libraries += clib_compiler.find_library(curr, env, [])
+                temp_libs = clib_compiler.find_library(curr, env, [])
+                if temp_libs is not None:
+                    res.libraries += temp_libs
             else:
                 not_found_warning(curr)
             continue


### PR DESCRIPTION
[11154 fix](https://github.com/mesonbuild/meson/issues/11154)