### PR TITLE
tests: fix test that has source code incompatible with modern C

### DIFF
--- a/test cases/common/94 threads/meson.build
+++ b/test cases/common/94 threads/meson.build
@@ -1,6 +1,11 @@
 project('threads', 'cpp', 'c',
   default_options : ['cpp_std=c++11'])
 
+cc = meson.get_compiler('c')
+if cc.has_function_attribute('unused')
+  add_project_arguments('-DHAVE_UNUSED', language: 'c')
+endif
+
 threaddep = dependency('threads')
 
 test('cppthreadtest',

--- a/test cases/common/94 threads/threadprog.c
+++ b/test cases/common/94 threads/threadprog.c
@@ -22,7 +22,13 @@ int main(void) {
 #include<pthread.h>
 #include<stdio.h>
 
-void* main_func(void) {
+#ifdef HAVE_UNUSED
+    #define UNUSED_ATTR __attribute__((unused))
+#else
+    #define UNUSED_ATTR
+#endif
+
+void* main_func(void UNUSED_ATTR *arg) {
     printf("Printing from a thread.\n");
     return NULL;
 }


### PR DESCRIPTION
Delayed until clang 16, -Werror=incompatible-function-pointer-types is the default. GCC 14 is "likely to do the same".

See https://wiki.gentoo.org/wiki/Modern_C_porting