### PR TITLE
fix build_target(objects: ...) documentation

### DIFF
--- a/docs/yaml/functions/_build_target_base.yaml
+++ b/docs/yaml/functions/_build_target_base.yaml
@@ -191,11 +191,11 @@ kwargs:
       (but *not* before that). On Windows, this argument has no effect.
 
   objects:
-    type: list[extracted_obj]
+    type: list[extracted_obj | file | str]
     description: |
-      List of prebuilt object files (usually for third party
-      products you don't have source to) that should be linked in this
-      target, **never** use this for object files that you build yourself.
+      List of object files that should be linked in this target.
+      These can include third party products you don't have source to,
+      or object files produced by other build targets.
 
   name_prefix:
     type: str | list[void]

--- a/test cases/unit/15 prebuilt object/cp.py
+++ b/test cases/unit/15 prebuilt object/cp.py
@@ -1,0 +1,5 @@
+#! /usr/bin/env python3
+
+import sys
+from shutil import copyfile
+copyfile(*sys.argv[1:])

--- a/test cases/unit/15 prebuilt object/meson.build
+++ b/test cases/unit/15 prebuilt object/meson.build
@@ -19,7 +19,22 @@ endif
 # declaration. run_tests.py generates the
 # prebuilt object before running this test.
 
-e = executable('prog', 'main.c',
-objects : prebuilt)
+e = []
 
-test('objtest', e)
+e += executable('exe1', sources: 'main.c', objects: prebuilt)
+e += executable('exe2', sources: 'main.c', objects: files(prebuilt))
+
+sl1 = static_library('lib3', objects: prebuilt)
+e += executable('exe3', sources: 'main.c', objects: sl1.extract_all_objects(recursive: true))
+
+ct = custom_target(output: 'copy-' + prebuilt, input: prebuilt,
+                   command: [find_program('cp.py'), '@INPUT@', '@OUTPUT@'])
+e += executable('exe4', 'main.c', ct)
+e += executable('exe5', 'main.c', ct[0])
+
+sl2 = static_library('lib6', sources: ct)
+e += executable('exe6', sources: 'main.c', objects: sl2.extract_all_objects(recursive: true))
+
+foreach i : e
+  test(i.name(), i)
+endforeach


### PR DESCRIPTION
The documentation for build_target(...) does not list file or str as the possible types for the "objects" keyword argument, even though in theory the argument is meant for prebuild object files that are part of the sources.
    
Of course that is only the theory, because an ExtractedObjects object is probably used a lot more than a file in the source tree.  But at least make the reference manual's typing information accurate.