### PR TITLE
Add `declare_dependency(objects: ...)`

### DIFF
--- a/docs/markdown/snippets/dep_objects.md
+++ b/docs/markdown/snippets/dep_objects.md
@@ -1,0 +1,5 @@
+## New `declare_dependency(objects: )` argument
+
+A new argument to `declare_dependency` makes it possible to add objects
+directly to executables that use an internal dependency, without going
+for example through `link_whole`.

--- a/docs/markdown/snippets/gen_objects.md
+++ b/docs/markdown/snippets/gen_objects.md
@@ -1,0 +1,6 @@
+## Generated objects can be passed in the `objects:` keyword argument
+
+In previous versions of Meson, generated objects could only be
+passed as sources of a build target.  This was confusing, therefore
+generated objects can now be passed in the `objects:` keyword
+argument as well.

--- a/docs/yaml/functions/_build_target_base.yaml
+++ b/docs/yaml/functions/_build_target_base.yaml
@@ -194,8 +194,11 @@ kwargs:
     type: list[extracted_obj | file | str]
     description: |
       List of object files that should be linked in this target.
-      These can include third party products you don't have source to,
-      or object files produced by other build targets.
+
+      **Since 1.1.0** this can include generated files in addition to
+      object files that you don't have source to or that object files
+      produced by other build targets.  In earlier release, generated
+      object files had to be placed in `sources`.
 
   name_prefix:
     type: str | list[void]

--- a/docs/yaml/functions/declare_dependency.yaml
+++ b/docs/yaml/functions/declare_dependency.yaml
@@ -71,3 +71,10 @@ kwargs:
     description: |
       the directories to add to the string search path (i.e. `-J` switch for DMD).
       Must be [[@inc]] objects or plain strings.
+
+  objects:
+    type: list[extracted_obj]
+    since: 1.1.0
+    description: |
+      a list of object files, to be linked directly into the targets that use the
+      dependency.

--- a/docs/yaml/objects/build_tgt.yaml
+++ b/docs/yaml/objects/build_tgt.yaml
@@ -13,8 +13,8 @@ methods:
     source files. This is typically used to take single object files and link
     them to unit tests or to compile some source files with custom flags. To
     use the object file(s) in another build target, use the
-    `objects:` keyword argument to a [[build_target]] or include them in the command
-    line of a [[custom_target]].
+    `objects:` keyword argument to a [[build_target]] or [[declare_dependency]],
+    or include them in the command line of a [[custom_target]].
   varargs:
     name: source
     type: str | file

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -774,12 +774,11 @@ class BuildTarget(Target):
         for s in objects:
             if isinstance(s, (str, File, ExtractedObjects)):
                 self.objects.append(s)
-            elif isinstance(s, (GeneratedList, CustomTarget)):
-                msg = 'Generated files are not allowed in the \'objects\' kwarg ' + \
-                    f'for target {self.name!r}.\nIt is meant only for ' + \
-                    'pre-built object files that are shipped with the\nsource ' + \
-                    'tree. Try adding it in the list of sources.'
-                raise InvalidArguments(msg)
+            elif isinstance(s, (CustomTarget, CustomTargetIndex, GeneratedList)):
+                non_objects = [o for o in s.get_outputs() if not is_object(o)]
+                if non_objects:
+                    raise InvalidArguments(f'Generated file {non_objects[0]} in the \'objects\' kwarg is not an object.')
+                self.generated.append(s)
             else:
                 raise InvalidArguments(f'Bad object of type {type(s).__name__!r} in target {self.name!r}.')
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1291,6 +1291,7 @@ class BuildTarget(Target):
                 # Those parts that are internal.
                 self.process_sourcelist(dep.sources)
                 self.add_include_dirs(dep.include_directories, dep.get_include_type())
+                self.objects.extend(dep.objects)
                 for l in dep.libraries:
                     self.link(l)
                 for l in dep.whole_libraries:
@@ -1301,7 +1302,7 @@ class BuildTarget(Target):
                                                               [],
                                                               dep.get_compile_args(),
                                                               dep.get_link_args(),
-                                                              [], [], [], [], {}, [], [])
+                                                              [], [], [], [], {}, [], [], [])
                     self.external_deps.append(extpart)
                 # Deps of deps.
                 self.add_deps(dep.ext_deps)

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -31,13 +31,12 @@ from ..mesonlib import version_compare_many
 
 if T.TYPE_CHECKING:
     from .._typing import ImmutableListProtocol
-    from ..build import StructuredSources
     from ..compilers.compilers import Compiler
     from ..environment import Environment
     from ..interpreterbase import FeatureCheckBase
     from ..build import (
         CustomTarget, IncludeDirs, CustomTargetIndex, LibTypes,
-        StaticLibrary
+        StaticLibrary, StructuredSources, ExtractedObjects
     )
     from ..mesonlib import FileOrString
 
@@ -252,7 +251,8 @@ class InternalDependency(Dependency):
                  whole_libraries: T.List[T.Union[StaticLibrary, CustomTarget, CustomTargetIndex]],
                  sources: T.Sequence[T.Union[FileOrString, CustomTarget, StructuredSources]],
                  ext_deps: T.List[Dependency], variables: T.Dict[str, str],
-                 d_module_versions: T.List[T.Union[str, int]], d_import_dirs: T.List['IncludeDirs']):
+                 d_module_versions: T.List[T.Union[str, int]], d_import_dirs: T.List['IncludeDirs'],
+                 objects: T.List['ExtractedObjects']):
         super().__init__(DependencyTypeName('internal'), {})
         self.version = version
         self.is_found = True
@@ -264,6 +264,7 @@ class InternalDependency(Dependency):
         self.sources = list(sources)
         self.ext_deps = ext_deps
         self.variables = variables
+        self.objects = objects
         if d_module_versions:
             self.d_features['versions'] = d_module_versions
         if d_import_dirs:
@@ -315,7 +316,7 @@ class InternalDependency(Dependency):
         return InternalDependency(
             self.version, final_includes, final_compile_args,
             final_link_args, final_libraries, final_whole_libraries,
-            final_sources, final_deps, self.variables, [], [])
+            final_sources, final_deps, self.variables, [], [], [])
 
     def get_include_dirs(self) -> T.List['IncludeDirs']:
         return self.include_directories

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -670,12 +670,14 @@ class Interpreter(InterpreterBase, HoldableObject):
         SOURCES_KW,
         VARIABLES_KW.evolve(since='0.54.0', since_values={list: '0.56.0'}),
         KwargInfo('version', (str, NoneType)),
+        KwargInfo('objects', ContainerTypeInfo(list, build.ExtractedObjects), listify=True, default=[], since='1.1.0'),
     )
     def func_declare_dependency(self, node, args, kwargs):
         deps = kwargs['dependencies']
         incs = self.extract_incdirs(kwargs)
         libs = kwargs['link_with']
         libs_whole = kwargs['link_whole']
+        objects = kwargs['objects']
         sources = self.source_strings_to_files(kwargs['sources'])
         compile_args = kwargs['compile_args']
         link_args = kwargs['link_args']
@@ -703,7 +705,8 @@ class Interpreter(InterpreterBase, HoldableObject):
 
         dep = dependencies.InternalDependency(version, incs, compile_args,
                                               link_args, libs, libs_whole, sources, deps,
-                                              variables, d_module_versions, d_import_dirs)
+                                              variables, d_module_versions, d_import_dirs,
+                                              objects)
         return dep
 
     @typed_pos_args('assert', bool, optargs=[str])

--- a/mesonbuild/modules/external_project.py
+++ b/mesonbuild/modules/external_project.py
@@ -269,7 +269,7 @@ class ExternalProject(NewExtensionModule):
         link_args = [f'-L{abs_libdir}', f'-l{libname}']
         sources = self.target
         dep = InternalDependency(version, [], compile_args, link_args, [],
-                                 [], [sources], [], {}, [], [])
+                                 [], [sources], [], {}, [], [], [])
         return dep
 
 

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -2151,7 +2151,7 @@ class GnomeModule(ExtensionModule):
         # - add relevant directories to include dirs
         incs = [build.IncludeDirs(state.subdir, ['.'] + vapi_includes, False)]
         sources = [vapi_target] + vapi_depends
-        rv = InternalDependency(None, incs, [], [], link_with, [], sources, [], {}, [], [])
+        rv = InternalDependency(None, incs, [], [], link_with, [], sources, [], {}, [], [], [])
         created_values.append(rv)
         return ModuleReturnValue(rv, created_values)
 

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -193,6 +193,8 @@ class DependenciesHelper:
                     self.add_version_reqs(obj.name, obj.version_reqs)
             elif isinstance(obj, dependencies.InternalDependency):
                 if obj.found():
+                    if obj.objects:
+                        raise mesonlib.MesonException('.pc file cannot refer to individual object files.')
                     processed_libs += obj.get_link_args()
                     processed_cflags += obj.get_compile_args()
                     self._add_lib_dependencies(obj.libraries, obj.whole_libraries, obj.ext_deps, public, private_external_deps=True)

--- a/test cases/common/260 declare_dependency objects/bar.c
+++ b/test cases/common/260 declare_dependency objects/bar.c
@@ -1,0 +1,1 @@
+void bar(void) {}

--- a/test cases/common/260 declare_dependency objects/foo.c
+++ b/test cases/common/260 declare_dependency objects/foo.c
@@ -1,0 +1,3 @@
+extern void bar(void);
+
+void foo(void) { bar(); }

--- a/test cases/common/260 declare_dependency objects/meson.build
+++ b/test cases/common/260 declare_dependency objects/meson.build
@@ -1,0 +1,23 @@
+# Test that declare_dependency(objects: ...) fixes issues with duplicated
+# objects in the final link line, thanks to deduplication of dependencies.
+# The commented declare_dependency() invocation using link_whole instead
+# fails thusly:
+#
+#     ar csrDT libbar.a libfoo.a.p/foo.c.o libbar.a.p/bar.c.o
+#     ar csrDT libfoo.a libfoo.a.p/foo.c.o
+#     cc  -o prog prog.p/prog.c.o -Wl,--as-needed -Wl,--no-undefined -Wl,--whole-archive -Wl,--start-group libfoo.a libbar.a -Wl,--end-group -Wl,--no-whole-archive
+#     /usr/bin/ld: libfoo.a.p/foo.c.o: in function `foo':
+#     ../foo.c:3: multiple definition of `foo'; libfoo.a.p/foo.c.o:../foo.c:3: first defined here
+
+project('Transitive declare_dependency(objects)', 'c')
+
+libfoo = static_library('foo', 'foo.c')
+#foo = declare_dependency(link_whole: libfoo)
+foo = declare_dependency(objects: libfoo.extract_all_objects(recursive: true))
+
+libbar = static_library('bar', 'bar.c', dependencies: foo)
+
+#bar = declare_dependency(link_whole: libbar, dependencies: foo)
+bar = declare_dependency(objects: libbar.extract_all_objects(recursive: true), dependencies: foo)
+
+executable('prog', sources: files('prog.c'), dependencies: [foo, bar])

--- a/test cases/common/260 declare_dependency objects/prog.c
+++ b/test cases/common/260 declare_dependency objects/prog.c
@@ -1,0 +1,3 @@
+extern void foo(void);
+
+int main(void) { foo(); }

--- a/test cases/unit/15 prebuilt object/meson.build
+++ b/test cases/unit/15 prebuilt object/meson.build
@@ -35,6 +35,12 @@ e += executable('exe5', 'main.c', ct[0])
 sl2 = static_library('lib6', sources: ct)
 e += executable('exe6', sources: 'main.c', objects: sl2.extract_all_objects(recursive: true))
 
+e += executable('exe7', sources: 'main.c', objects: ct)
+e += executable('exe8', sources: 'main.c', objects: ct[0])
+
+sl3 = static_library('lib9', objects: ct)
+e += executable('exe9', sources: 'main.c', objects: sl2.extract_all_objects(recursive: true))
+
 foreach i : e
   test(i.name(), i)
 endforeach


### PR DESCRIPTION
In order to fix the issue documented in https://github.com/mesonbuild/meson/issues/8151#issuecomment-754796420, this pull request adds a new "objects" keyword argument to declare_dependency.

When a dependency is added to a static library and the static library is then used with `link_whole`, duplicate objects can occur at the time of the final link:

```
ar csrDT libbar.a libfoo.a.p/foo.c.o libbar.a.p/bar.c.o
ar csrDT libfoo.a libfoo.a.p/foo.c.o
cc  -o prog prog.p/prog.c.o -Wl,--as-needed -Wl,--no-undefined -Wl,--whole-archive -Wl,--start-group libfoo.a libbar.a -Wl,--end-group -Wl,--no-whole-archive
/usr/bin/ld: libfoo.a.p/foo.c.o: in function `foo':
../foo.c:3: multiple definition of `foo'; libfoo.a.p/foo.c.o:../foo.c:3: first defined here
```

To fix this, it is easiest to bypass the `.a` file completely and just link the object files directly in the final executable. This can be done more easily with the new `declare_dependency(objects: ...) construct I am introducing.

@roolebo 