### PR TITLE
Update the Debian Python path detection for setuptools >= 60

### DIFF
--- a/mesonbuild/modules/python3.py
+++ b/mesonbuild/modules/python3.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import sysconfig
 from .. import mesonlib
 
@@ -76,8 +77,16 @@ class Python3Module(ExtensionModule):
         if path_name not in valid_names:
             raise mesonlib.MesonException(f'{path_name} is not a valid path name {valid_names}.')
 
+        if 'deb_system' in sysconfig.get_scheme_names():
+            # Use Debian's custom deb_system scheme (with our prefix)
+            scheme = 'deb_system'
+        elif sys.version_info >= (3, 10):
+            scheme = sysconfig.get_default_scheme()
+        else:
+            scheme = sysconfig._get_default_scheme()
+
         # Get a relative path without a prefix, e.g. lib/python3.6/site-packages
-        return sysconfig.get_path(path_name, vars={'base': '', 'platbase': '', 'installed_base': ''})[1:]
+        return sysconfig.get_path(path_name, vars={'base': '', 'platbase': '', 'installed_base': ''}, scheme=scheme)[1:]
 
 
 def initialize(*args, **kwargs):


### PR DESCRIPTION
Debian now (since Python 3.10.2-6, in Debian 12 "bookworm") adds the `deb_system` scheme to `sysconfig`. Sorry it took so long to get that to happen.

Newer distutils (such as bundled with setuptools >= 60) adds fetch schemes from `sysconfig`, rather than duplicating the `sysconfig` schemes statically in `distutils.command.install`. This change broke meson's `deb_system` check.

This patch replaces that mechanism (for newer Debian releases) with explicit scheme selection, which is far simpler.
But it also retains the old mechanism, for older Debian releases that require it (Debian <= 11).

Fixes: https://github.com/mesonbuild/meson/issues/8739 (for python module, and makes similar minimal changes to the python3 module)

Fixes: https://bugs.debian.org/1026312