### PR TITLE
coredata: refactor options to remember their names

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -99,13 +99,13 @@ class CCompiler(CLikeCompiler, Compiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
-        opts.update({
-            OptionKey('std', machine=self.for_machine, lang=self.language): coredata.UserComboOption(
-                'C language standard to use',
-                ['none'],
-                'none',
-            )
-        })
+        opts.update(coredata.key_option_dict([
+            OptionKey('std', machine=self.for_machine, lang=self.language),
+            coredata.UserComboOption,
+            'C language standard to use',
+            ['none'],
+            'none',
+        ]))
         return opts
 
 
@@ -159,12 +159,11 @@ class ClangCCompiler(_ClangCStds, ClangCompiler, CCompiler):
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
         if self.info.is_windows() or self.info.is_cygwin():
-            opts.update({
-                OptionKey('winlibs', machine=self.for_machine, lang=self.language): coredata.UserArrayOption(
-                    'Standard Win libraries to link against',
-                    gnu_winlibs,
-                ),
-            })
+            opts.update(coredata.key_option_dict([
+                OptionKey('winlibs', machine=self.for_machine, lang=self.language), coredata.UserArrayOption,
+                'Standard Win libraries to link against',
+                gnu_winlibs,
+            ]))
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
@@ -292,12 +291,12 @@ class GnuCCompiler(GnuCompiler, CCompiler):
         key = OptionKey('std', machine=self.for_machine, lang=self.language)
         opts[key].choices = ['none'] + c_stds + g_stds
         if self.info.is_windows() or self.info.is_cygwin():
-            opts.update({
-                key.evolve('winlibs'): coredata.UserArrayOption(
-                    'Standard Win libraries to link against',
-                    gnu_winlibs,
-                ),
-            })
+            opts.update(coredata.key_option_dict([
+                key.evolve('winlibs'),
+                coredata.UserArrayOption,
+                'Standard Win libraries to link against',
+                gnu_winlibs,
+            ]))
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
@@ -426,12 +425,11 @@ class VisualStudioLikeCCompilerMixin(CompilerMixinBase):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
-        opts.update({
-            OptionKey('winlibs', machine=self.for_machine, lang=self.language): coredata.UserArrayOption(
-                'Windows libs to link against.',
-                msvc_winlibs,
-            ),
-        })
+        opts.update(coredata.key_option_dict([
+            OptionKey('winlibs', machine=self.for_machine, lang=self.language), coredata.UserArrayOption,
+            'Windows libs to link against.',
+            msvc_winlibs,
+        ]))
         return opts
 
     def get_option_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -170,14 +170,13 @@ class CPPCompiler(CLikeCompiler, Compiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
-        key = OptionKey('std', machine=self.for_machine, lang=self.language)
-        opts.update({
-            key: coredata.UserComboOption(
-                'C++ language standard to use',
-                ['none'],
-                'none',
-            ),
-        })
+        opts.update(coredata.key_option_dict([
+            OptionKey('std', machine=self.for_machine, lang=self.language),
+            coredata.UserComboOption,
+            'C++ language standard to use',
+            ['none'],
+            'none',
+        ]))
         return opts
 
 
@@ -200,26 +199,28 @@ class ClangCPPCompiler(ClangCompiler, CPPCompiler):
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = CPPCompiler.get_options(self)
         key = OptionKey('key', machine=self.for_machine, lang=self.language)
-        opts.update({
-            key.evolve('eh'): coredata.UserComboOption(
+        opts.update(coredata.key_option_dict(
+            (
+                key.evolve('eh'),
+                coredata.UserComboOption,
                 'C++ exception handling type.',
                 ['none', 'default', 'a', 's', 'sc'],
                 'default',
             ),
-            key.evolve('rtti'): coredata.UserBooleanOption('Enable RTTI', True),
-        })
+            (key.evolve('rtti'), coredata.UserBooleanOption, 'Enable RTTI', True),
+        ))
         opts[key.evolve('std')].choices = [
             'none', 'c++98', 'c++03', 'c++11', 'c++14', 'c++17', 'c++1z',
             'c++2a', 'c++20', 'gnu++11', 'gnu++14', 'gnu++17', 'gnu++1z',
             'gnu++2a', 'gnu++20',
         ]
         if self.info.is_windows() or self.info.is_cygwin():
-            opts.update({
-                key.evolve('winlibs'): coredata.UserArrayOption(
-                    'Standard Win libraries to link against',
-                    gnu_winlibs,
-                ),
-            })
+            opts.update(coredata.key_option_dict([
+                key.evolve('winlibs'),
+                coredata.UserArrayOption,
+                'Standard Win libraries to link against',
+                gnu_winlibs,
+            ]))
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
@@ -321,13 +322,13 @@ class ArmclangCPPCompiler(ArmclangCompiler, CPPCompiler):
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = CPPCompiler.get_options(self)
         key = OptionKey('std', machine=self.for_machine, lang=self.language)
-        opts.update({
-            key.evolve('eh'): coredata.UserComboOption(
-                'C++ exception handling type.',
-                ['none', 'default', 'a', 's', 'sc'],
-                'default',
-            ),
-        })
+        opts.update(coredata.key_option_dict([
+            key.evolve('eh'),
+            coredata.UserComboOption,
+            'C++ exception handling type.',
+            ['none', 'default', 'a', 's', 'sc'],
+            'default',
+        ]))
         opts[key].choices = [
             'none', 'c++98', 'c++03', 'c++11', 'c++14', 'c++17', 'gnu++98',
             'gnu++03', 'gnu++11', 'gnu++14', 'gnu++17',
@@ -370,30 +371,29 @@ class GnuCPPCompiler(GnuCompiler, CPPCompiler):
     def get_options(self) -> 'MutableKeyedOptionDictType':
         key = OptionKey('std', machine=self.for_machine, lang=self.language)
         opts = CPPCompiler.get_options(self)
-        opts.update({
-            key.evolve('eh'): coredata.UserComboOption(
+        opts.update(coredata.key_option_dict(
+            (
+                key.evolve('eh'),
+                coredata.UserComboOption,
                 'C++ exception handling type.',
                 ['none', 'default', 'a', 's', 'sc'],
                 'default',
             ),
-            key.evolve('rtti'): coredata.UserBooleanOption('Enable RTTI', True),
-            key.evolve('debugstl'): coredata.UserBooleanOption(
-                'STL debug mode',
-                False,
-            )
-        })
+            (key.evolve('rtti'), coredata.UserBooleanOption, 'Enable RTTI', True),
+            (key.evolve('debugstl'), coredata.UserBooleanOption, 'STL debug mode', False),
+        ))
         opts[key].choices = [
             'none', 'c++98', 'c++03', 'c++11', 'c++14', 'c++17', 'c++1z',
             'c++2a', 'c++20', 'gnu++03', 'gnu++11', 'gnu++14', 'gnu++17',
             'gnu++1z', 'gnu++2a', 'gnu++20',
         ]
         if self.info.is_windows() or self.info.is_cygwin():
-            opts.update({
-                key.evolve('winlibs'): coredata.UserArrayOption(
-                    'Standard Win libraries to link against',
-                    gnu_winlibs,
-                ),
-            })
+            opts.update(coredata.key_option_dict([
+                key.evolve('winlibs'),
+                coredata.UserArrayOption,
+                'Standard Win libraries to link against',
+                gnu_winlibs,
+            ]))
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
@@ -490,17 +490,16 @@ class ElbrusCPPCompiler(ElbrusCompiler, CPPCompiler):
             cpp_stds += ['c++20', 'gnu++20']
 
         key = OptionKey('std', machine=self.for_machine, lang=self.language)
-        opts.update({
-            key.evolve('eh'): coredata.UserComboOption(
+        opts.update(coredata.key_option_dict(
+            (
+                key.evolve('eh'),
+                coredata.UserComboOption,
                 'C++ exception handling type.',
                 ['none', 'default', 'a', 's', 'sc'],
                 'default',
             ),
-            key.evolve('debugstl'): coredata.UserBooleanOption(
-                'STL debug mode',
-                False,
-            ),
-        })
+            (key.evolve('debugstl'), coredata.UserBooleanOption, 'STL debug mode', False),
+        ))
         opts[key].choices = cpp_stds
         return opts
 
@@ -566,15 +565,17 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
             g_stds += ['gnu++2a']
 
         key = OptionKey('std', machine=self.for_machine, lang=self.language)
-        opts.update({
-            key.evolve('eh'): coredata.UserComboOption(
+        opts.update(coredata.key_option_dict(
+            (
+                key.evolve('eh'),
+                coredata.UserComboOption,
                 'C++ exception handling type.',
                 ['none', 'default', 'a', 's', 'sc'],
                 'default',
             ),
-            key.evolve('rtti'): coredata.UserBooleanOption('Enable RTTI', True),
-            key.evolve('debugstl'): coredata.UserBooleanOption('STL debug mode', False),
-        })
+            (key.evolve('rtti'), coredata.UserBooleanOption, 'Enable RTTI', True),
+            (key.evolve('debugstl'), coredata.UserBooleanOption, 'STL debug mode', False),
+        ))
         opts[key].choices = ['none'] + c_stds + g_stds
         return opts
 
@@ -630,18 +631,22 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
 
     def _get_options_impl(self, opts: 'MutableKeyedOptionDictType', cpp_stds: T.List[str]) -> 'MutableKeyedOptionDictType':
         key = OptionKey('std', machine=self.for_machine, lang=self.language)
-        opts.update({
-            key.evolve('eh'): coredata.UserComboOption(
+        opts.update(coredata.key_option_dict(
+            (
+                key.evolve('eh'),
+                coredata.UserComboOption,
                 'C++ exception handling type.',
                 ['none', 'default', 'a', 's', 'sc'],
                 'default',
             ),
-            key.evolve('rtti'): coredata.UserBooleanOption('Enable RTTI', True),
-            key.evolve('winlibs'): coredata.UserArrayOption(
+            (key.evolve('rtti'), coredata.UserBooleanOption, 'Enable RTTI', True),
+            (
+                key.evolve('winlibs'),
+                coredata.UserArrayOption,
                 'Windows libs to link against.',
                 msvc_winlibs,
             ),
-        })
+        ))
         opts[key.evolve('std')].choices = cpp_stds
         return opts
 

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -617,14 +617,21 @@ class CudaCompiler(Compiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
-        std_key = OptionKey('std', machine=self.for_machine, lang=self.language)
-        ccbindir_key = OptionKey('ccbindir', machine=self.for_machine, lang=self.language)
-        opts.update({
-            std_key:      coredata.UserComboOption('C++ language standard to use with CUDA',
-                                                   ['none', 'c++03', 'c++11', 'c++14', 'c++17'], 'none'),
-            ccbindir_key: coredata.UserStringOption('CUDA non-default toolchain directory to use (-ccbin)',
-                                                    ''),
-        })
+        opts.update(coredata.key_option_dict(
+            (
+                OptionKey('std', machine=self.for_machine, lang=self.language),
+                coredata.UserComboOption,
+                'C++ language standard to use with CUDA',
+                ['none', 'c++03', 'c++11', 'c++14', 'c++17'],
+                'none',
+            ),
+            (
+                OptionKey('ccbindir', machine=self.for_machine, lang=self.language),
+                coredata.UserStringOption,
+                'CUDA non-default toolchain directory to use (-ccbin)',
+                '',
+            )
+        ))
         return opts
 
     def _to_host_compiler_options(self, options: 'KeyedOptionDictType') -> 'KeyedOptionDictType':

--- a/mesonbuild/compilers/cython.py
+++ b/mesonbuild/compilers/cython.py
@@ -63,18 +63,20 @@ class CythonCompiler(Compiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
-        opts.update({
-            OptionKey('version', machine=self.for_machine, lang=self.language): coredata.UserComboOption(
+        opts.update(coredata.key_option_dict(
+            (
+                OptionKey('version', machine=self.for_machine, lang=self.language), coredata.UserComboOption,
                 'Python version to target',
                 ['2', '3'],
                 '3',
             ),
-            OptionKey('language', machine=self.for_machine, lang=self.language): coredata.UserComboOption(
+            (
+                OptionKey('language', machine=self.for_machine, lang=self.language), coredata.UserComboOption,
                 'Output C or C++ files',
                 ['c', 'cpp'],
                 'c',
             )
-        })
+        ))
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -129,14 +129,13 @@ class FortranCompiler(CLikeCompiler, Compiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
-        key = OptionKey('std', machine=self.for_machine, lang=self.language)
-        opts.update({
-            key: coredata.UserComboOption(
-                'Fortran language standard to use',
-                ['none'],
-                'none',
-            ),
-        })
+        opts.update(coredata.key_option_dict([
+            OptionKey('std', machine=self.for_machine, lang=self.language),
+            coredata.UserComboOption,
+            'Fortran language standard to use',
+            ['none'],
+            'none',
+        ]))
         return opts
 
 

--- a/mesonbuild/compilers/mixins/emscripten.py
+++ b/mesonbuild/compilers/mixins/emscripten.py
@@ -70,13 +70,12 @@ class EmscriptenMixin(Compiler):
 
     def get_options(self) -> 'coredata.MutableKeyedOptionDictType':
         opts = super().get_options()
-        key = OptionKey('thread_count', machine=self.for_machine, lang=self.language)
-        opts.update({
-            key: coredata.UserIntegerOption(
-                'Number of threads to use in web assembly, set to 0 to disable',
-                (0, None, 4),  # Default was picked at random
-            ),
-        })
+        opts.update(coredata.key_option_dict([
+            OptionKey('thread_count', machine=self.for_machine, lang=self.language),
+            coredata.UserIntegerOption,
+            'Number of threads to use in web assembly, set to 0 to disable',
+            (0, None, 4),  # Default was picked at random
+        ]))
 
         return opts
 

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -93,13 +93,13 @@ class ClangObjCCompiler(ClangCompiler, ObjCCompiler):
 
     def get_options(self) -> 'coredata.MutableKeyedOptionDictType':
         opts = super().get_options()
-        opts.update({
-            OptionKey('std', machine=self.for_machine, lang='c'): coredata.UserComboOption(
-                'C language standard to use',
-                ['none', 'c89', 'c99', 'c11', 'c17', 'gnu89', 'gnu99', 'gnu11', 'gnu17'],
-                'none',
-            )
-        })
+        opts.update(coredata.key_option_dict([
+            OptionKey('std', machine=self.for_machine, lang='c'),
+            coredata.UserComboOption,
+            'C language standard to use',
+            ['none', 'c89', 'c99', 'c11', 'c17', 'gnu89', 'gnu99', 'gnu11', 'gnu17'],
+            'none',
+        ]))
         return opts
 
     def get_option_compile_args(self, options: 'coredata.KeyedOptionDictType') -> T.List[str]:

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -93,13 +93,13 @@ class ClangObjCPPCompiler(ClangCompiler, ObjCPPCompiler):
 
     def get_options(self) -> 'coredata.MutableKeyedOptionDictType':
         opts = super().get_options()
-        opts.update({
-            OptionKey('std', machine=self.for_machine, lang='cpp'): coredata.UserComboOption(
-                'C++ language standard to use',
-                ['none', 'c++98', 'c++11', 'c++14', 'c++17', 'gnu++98', 'gnu++11', 'gnu++14', 'gnu++17'],
-                'none',
-            )
-        })
+        opts.update(coredata.key_option_dict([
+            OptionKey('std', machine=self.for_machine, lang='cpp'),
+            coredata.UserComboOption,
+            'C++ language standard to use',
+            ['none', 'c++98', 'c++11', 'c++14', 'c++17', 'gnu++98', 'gnu++11', 'gnu++14', 'gnu++17'],
+            'none',
+        ]))
         return opts
 
     def get_option_compile_args(self, options: 'coredata.KeyedOptionDictType') -> T.List[str]:

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -144,14 +144,13 @@ class RustCompiler(Compiler):
     # use_linker_args method instead.
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        key = OptionKey('std', machine=self.for_machine, lang=self.language)
-        return {
-            key: coredata.UserComboOption(
-                'Rust edition to use',
-                ['none', '2015', '2018', '2021'],
-                'none',
-            ),
-        }
+        return coredata.key_option_dict([
+            OptionKey('std', machine=self.for_machine, lang=self.language),
+            coredata.UserComboOption,
+            'Rust edition to use',
+            ['none', '2015', '2018', '2021'],
+            'none',
+        ])
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args = []

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -35,7 +35,7 @@ if T.TYPE_CHECKING:
     import argparse
 
 def array_arg(value: str) -> T.List[str]:
-    return UserArrayOption(None, value, allow_dups=True, user_input=True).value
+    return UserArrayOption('array', None, value, allow_dups=True, user_input=True).value
 
 def validate_builddir(builddir: Path) -> None:
     if not (builddir / 'meson-private' / 'coredata.dat').is_file():

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -175,7 +175,7 @@ class OptionInterpreter:
         # because they use @permittedKwargs().
         known_parser_kwargs = {'value', 'choices', 'yield', 'min', 'max'}
         parser_kwargs = {k: v for k, v in kwargs.items() if k in known_parser_kwargs and v is not None}
-        opt = parser(description, T.cast('ParserArgs', parser_kwargs))
+        opt = parser(opt_name, description, T.cast('ParserArgs', parser_kwargs))
         opt.deprecated = kwargs['deprecated']
         if isinstance(opt.deprecated, str):
             FeatureNew.single_use('String value to "deprecated" keyword argument', '0.63.0', self.subproject)
@@ -184,42 +184,42 @@ class OptionInterpreter:
         self.options[key] = opt
 
     @permittedKwargs({'value', 'yield'})
-    def string_parser(self, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
+    def string_parser(self, name: str, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
         value = kwargs.get('value', '')
-        return coredata.UserStringOption(description, value, kwargs['yield'])
+        return coredata.UserStringOption(name, description, value, kwargs['yield'])
 
     @permittedKwargs({'value', 'yield'})
-    def boolean_parser(self, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
+    def boolean_parser(self, name: str, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
         value = kwargs.get('value', True)
-        return coredata.UserBooleanOption(description, value, kwargs['yield'])
+        return coredata.UserBooleanOption(name, description, value, kwargs['yield'])
 
     @permittedKwargs({'value', 'yield', 'choices'})
-    def combo_parser(self, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
+    def combo_parser(self, name: str, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
         choices = kwargs.get('choices')
         if not choices:
             raise OptionException('Combo option missing "choices" keyword.')
         value = kwargs.get('value', choices[0])
-        return coredata.UserComboOption(description, choices, value, kwargs['yield'])
+        return coredata.UserComboOption(name, description, choices, value, kwargs['yield'])
 
     @permittedKwargs({'value', 'min', 'max', 'yield'})
-    def integer_parser(self, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
+    def integer_parser(self, name: str, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
         value = kwargs.get('value')
         if value is None:
             raise OptionException('Integer option must contain value argument.')
         inttuple = (kwargs.get('min'), kwargs.get('max'), value)
-        return coredata.UserIntegerOption(description, inttuple, kwargs['yield'])
+        return coredata.UserIntegerOption(name, description, inttuple, kwargs['yield'])
 
     @permittedKwargs({'value', 'yield', 'choices'})
-    def string_array_parser(self, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
+    def string_array_parser(self, name: str, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
         choices = kwargs.get('choices', [])
         value = kwargs.get('value', choices)
         if not isinstance(value, list):
             raise OptionException('Array choices must be passed as an array.')
-        return coredata.UserArrayOption(description, value,
+        return coredata.UserArrayOption(name, description, value,
                                         choices=choices,
                                         yielding=kwargs['yield'])
 
     @permittedKwargs({'value', 'yield'})
-    def feature_parser(self, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
+    def feature_parser(self, name: str, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
         value = kwargs.get('value', 'auto')
-        return coredata.UserFeatureOption(description, value, kwargs['yield'])
+        return coredata.UserFeatureOption(name, description, value, kwargs['yield'])

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -2289,6 +2289,7 @@ class OptionKey:
         """Convenience method to check if this is a base option."""
         return self.type is OptionType.BASE
 
+
 def pickle_load(filename: str, object_name: str, object_type: T.Type) -> T.Any:
     load_fail_msg = f'{object_name} file {filename!r} is corrupted. Try with a fresh build tree.'
     try:

--- a/test cases/failing/101 number in combo/test.json
+++ b/test cases/failing/101 number in combo/test.json
@@ -1,5 +1,5 @@
 {
   "stdout": [
-    { "line": "test cases/failing/101 number in combo/meson.build:1:0: ERROR: Value \"1\" (of type \"number\") for combo option \"Optimization level\" is not one of the choices. Possible choices are (as string): \"plain\", \"0\", \"g\", \"1\", \"2\", \"3\", \"s\"." }
+    { "line": "test cases/failing/101 number in combo/meson.build:1:0: ERROR: Value \"1\" (of type \"number\") for combo option \"optimization\" is not one of the choices. Possible choices are (as string): \"plain\", \"0\", \"g\", \"1\", \"2\", \"3\", \"s\"." }
   ]
 }


### PR DESCRIPTION
All UserOption initializers now take a string name as the first argument.

Options are usually stored in `OptionKey: UserOption` dictionaries. For this reason, two helper functions were added to make instantiating such dictionaries easier and less error-prone.

`coredata.key_option_pair()` takes a string name or OptionKey instance, a UserOption-derived class, and a variable number of arguments. It returns a tuple of `(OptionKey, UserOption instance)`, where the OptionKey is the first argument (passed as-is or converted from the string), and the UserOption is instantiated with the name derived from the OptionKey, and the rest of the arguments passed through.

Example:
```python
p = coredata.key_option_pair('foo', coredata.UserStringOption,
                             'foo description', '')
# Equivalent to:
key = OptionKey('foo')
opt = coredata.UserStringOption(str(key), 'foo description', '')
p = (key, opt)
```

`coredata.key_option_dict` takes a variable number of tuples or list, each representing an option. It returns a `MutableKeyedOptionDictType`.

Example:
```python
opts = coredata.key_option_dict(
        (
                'foo', coredata.UserStringOption,
                'foo description', '',
        ),
        (
                'bar', coredata.UserStringOption,
                'bar description', '',
        ),
)
# Equivalent to:
opts = OrderedDict(
        coredata.key_option_pair(
                'foo', coredata.UserStringOption,
                'foo description', '',
        ),
        coredata.key_option_pair(
                'bar', coredata.UserStringOption,
                'bar description', '',
        ),
)
```