### PR TITLE
Fix bug where tildes aren't considered correctly in find_program

### DIFF
--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -235,7 +235,7 @@ class ExternalProgram(mesonlib.HoldableObject):
     def _search_dir(self, name: str, search_dir: T.Optional[str]) -> T.Optional[list]:
         if search_dir is None:
             return None
-        trial = os.path.join(search_dir, name)
+        trial = os.path.join(search_dir, os.path.expanduser(name))
         if os.path.exists(trial):
             if self._is_executable(trial):
                 return [trial]
@@ -309,6 +309,12 @@ class ExternalProgram(mesonlib.HoldableObject):
         path = os.environ.get('PATH', None)
         if mesonlib.is_windows() and path:
             path = self._windows_sanitize_path(path)
+        elif path:
+            # Expand "~" into full paths.
+            path2 = []
+            for p in path.split(":"):
+                path2.append(os.path.expanduser(p))
+            path = ":".join(path2)
         command = shutil.which(name, path=path)
         if mesonlib.is_windows():
             return self._search_windows_special_cases(name, command)


### PR DESCRIPTION
I ran into an issue today where I tried to use `rust.bindgen` and it didn't work because the bindgen was hidden `PATH=~/.cargo/bin/`. Apparently, `shutil.which` and `os.path.join` don't properly consider the `~` operator when trying to resolve applications and paths. 

> Unlike a Unix shell, Python does not do any automatic path expansions. Functions such as [expanduser()](https://docs.python.org/3/library/os.path.html#os.path.expanduser) and [expandvars()](https://docs.python.org/3/library/os.path.html#os.path.expandvars) can be invoked explicitly when an application desires shell-like path expansion. (See also the [glob](https://docs.python.org/3/library/glob.html#module-glob) module.)

https://docs.python.org/3/library/os.path.html#os.path.expanduser

This PR fixes that by wrapping everything in `expanduser`. I am sure there are other places where this is an issue too.