### PR TITLE
docs: update IDE integrations

### DIFF
--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -420,10 +420,8 @@ schema is defined by the class structure given in
 
 - [Gnome Builder](https://wiki.gnome.org/Apps/Builder)
 - [KDevelop](https://www.kdevelop.org)
-- [Eclipse CDT](https://www.eclipse.org/cdt/) (experimental)
-- [Meson Cmake Wrapper](https://github.com/prozum/meson-cmake-wrapper) (for cmake IDEs) (currently unmaintained !!)
-- [Meson-UI](https://github.com/michaelbadcrumble/meson-ui) (Meson build GUI)
+- [Eclipse CDT](https://www.eclipse.org/cdt/)
 - [Meson Syntax Highlighter](https://plugins.jetbrains.com/plugin/13269-meson-syntax-highlighter) plugin for JetBrains IDEs.
-- [asabil.meson](https://open-vsx.org/extension/asabil/meson) extension for VS Code/Codium
+- [vscode-meson](https://github.com/mesonbuild/vscode-meson) extension for VS Code/Codium
 - [Qt Creator](https://doc.qt.io/qtcreator/creator-project-meson.html)
 - [mmeson](https://github.com/stephanlachnit/mmeson) (ccmake clone for Meson)

--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -426,3 +426,4 @@ schema is defined by the class structure given in
 - [Meson Syntax Highlighter](https://plugins.jetbrains.com/plugin/13269-meson-syntax-highlighter) plugin for JetBrains IDEs.
 - [asabil.meson](https://open-vsx.org/extension/asabil/meson) extension for VS Code/Codium
 - [Qt Creator](https://doc.qt.io/qtcreator/creator-project-meson.html)
+- [mmeson](https://github.com/stephanlachnit/mmeson) (ccmake clone for Meson)


### PR DESCRIPTION
I've written a small utility called [`mmeson`](https://github.com/stephanlachnit/mmeson) which is essentially a ccmake clone for Meson projects. I think it fits well in the list.

I also noticed in there was still the old repo to the vscode plugin and fixed it. I also don't think Meson support is still experimental in Eclipse, at least I couldn't find a reference to it being experimental. Meson-UI and Meson Cmake Wrapper are still unmaintained (last commits over two years ago), so maybe it is time to remove them.