### PR TITLE
Improve error handling for gcc directory search

### DIFF
--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -22,6 +22,7 @@ import pathlib
 import re
 import subprocess
 import typing as T
+import warnings
 
 from ... import mesonlib
 from ... import mlog
@@ -489,8 +490,13 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
             # paths under /lib would be considered not a "system path",
             # which is wrong and breaks things. Store everything, just to be sure.
             pobj = pathlib.Path(p)
-            unresolved = pobj.as_posix()
-            if pobj.exists():
+            unresolved = pobj.as_posix()           
+            try:
+                p_exists = pobj.exists()
+            except OSError as e:
+                warnings.warn("Error processing directory " + str(e))
+                p_exists = False
+            if p_exists:
                 if unresolved not in result:
                     result.append(unresolved)
                 try:


### PR DESCRIPTION
This fixes a bug where meson fails to build on windows due to msys2 containing incorrect build paths. Most of the time Windows simply says that the directory doesn't exist, but in special cases (such as with BitLocker), an exception is thrown that blocks the build.

This catches the exception and converts it to a warning.

How these warnings look like in practice:

> C:\envs\venv\Lib\site-packages\mesonbuild\compilers\mixins\gnu.py:497: UserWarning: Error processing directory [WinError -2144272384] This drive is locked by BitLocker Drive Encryption. You must unlock this drive from Control Panel: 'D:\\a\\_temp\\msys64\\ucrt64\\x86_64-w64-mingw32\\lib\\x86_64-w64-mingw32\\10.3.0'