### PR TITLE
clang-cl supports /std:c++20 now.

### DIFF
--- a/docs/markdown/snippets/clang_cl_c++20.md
+++ b/docs/markdown/snippets/clang_cl_c++20.md
@@ -1,0 +1,3 @@
+## `clang-cl` now accepts `cpp_std=c++20`
+
+Requires `clang-cl` 13 or later.

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -770,7 +770,7 @@ class ClangClCPPCompiler(CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixin, Cl
         ClangClCompiler.__init__(self, target)
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        cpp_stds = ['none', 'c++11', 'vc++11', 'c++14', 'vc++14', 'c++17', 'vc++17', 'c++latest']
+        cpp_stds = ['none', 'c++11', 'vc++11', 'c++14', 'vc++14', 'c++17', 'vc++17', 'c++20', 'vc++20', 'c++latest']
         return self._get_options_impl(super().get_options(), cpp_stds)
 
 


### PR DESCRIPTION
clang-cl now supports `/std:c++20`. I'm not sure exactly when it was added, but given `ClangClCPPCompiler` does no version checking (at least from a cursory comparison with `VisualStudioCPPCompiler`), I guess that's not an issue. Anyway, it's certainly there in current (i.e. clang-cl 15.0.1 from VS 17.4.3).

Obviously preferable to use over `c++latest` as that enables a lot of C++23 stuff...

Here's a quick fix if you want it. Wasn't sure if it warrants a release snippet since it's not really a new feature, but happy to add it.

Thanks
