### PR TITLE
add implementation of get_dependency_gen_args() for cuda compiler

### DIFF
--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -732,6 +732,9 @@ class CudaCompiler(Compiler):
     def get_output_args(self, target: str) -> T.List[str]:
         return ['-o', target]
 
+    def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
+        return ['-MD', '-MT', outtarget, '-MF', outfile]
+
     def get_std_exe_link_args(self) -> T.List[str]:
         return self._to_host_flags(self.host_compiler.get_std_exe_link_args(), _Phase.LINKER)
 


### PR DESCRIPTION
Without `get_dependency_gen_args()` depfiles are not generated for cuda sources and can result in partial target rebuilds when source dependency changes occur in the project.

The `nvcc` preprocessor now supports `-MD`, `-MDD`, `-MF`, but still lacks implementation support for `-MQ`, instead providing only `-MT`. Supporting `-MD` and `-MF` overcomes previous limitations where `nvcc` required depfile generation in two commands and this was not possible with ninja. Using `-MT` is not great, but may be better than nothing for the moment. https://github.com/mesonbuild/meson/issues/1003#issuecomment-259103463 https://github.com/mesonbuild/meson/discussions/11227#discussioncomment-4553800