### PR TITLE
Revert "mtest: handle TAP tests with unknown version."

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1056,7 +1056,7 @@ class TestRunTAP(TestRun):
     async def parse(self, harness: 'TestHarness', lines: T.AsyncIterator[str]) -> None:
         res = None
         warnings = [] # type: T.List[TAPParser.UnknownLine]
-        version: T.Optional[int] = None
+        version: int
 
         async for i in TAPParser().parse_async(lines):
             if isinstance(i, TAPParser.Version):
@@ -1075,9 +1075,6 @@ class TestRunTAP(TestRun):
                 self.additional_error += 'TAP parsing error: ' + i.message
                 res = TestResult.ERROR
 
-        if version is None:
-            self.warnings.append('Unknown TAP version. The first line MUST be `TAP version <int>`. Assuming version 12.')
-            version = 12
         if warnings:
             unknown = str(mlog.yellow('UNKNOWN'))
             width = len(str(max(i.lineno for i in warnings)))


### PR DESCRIPTION
This reverts commit b7a5c384a1f1ba80c09904e7ef4f5160bdae3345.

The added warning triggers widely, is not actually required by the TAP spec, even version 14. Even if it were required as of TAP 14, it'd amount to suddenly requiring TAP 14, given that the version number previously was not required.

The warning causes trouble for e.g. PostgreSQL due to its verbosity.