### PR TITLE
linkers: detect ld64 as AppleDynamicLinker

### DIFF
--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -824,6 +824,11 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
         return ["-Wl,-cache_path_lto," + path]
 
 
+class LLVMLD64DynamicLinker(AppleDynamicLinker):
+
+    id = 'ld64.lld'
+
+
 class GnuDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, DynamicLinker):
 
     """Representation of GNU ld.bfd and ld.gold."""


### PR DESCRIPTION
Adjusted version of https://github.com/mesonbuild/meson/pull/10880.

ld64 is currently detected as LLVMDynamicLinker, causing incompatible arguments to be passed:
```
Detecting linker via: /opt/homebrew/opt/llvm/bin/clang -Wl,--version -fuse-ld=/opt/homebrew/opt/llvm/bin/ld64.lld
linker returned <Popen: returncode: 0 args: ['/opt/homebrew/opt/llvm/bin/clang', '-Wl,--vers...>
linker stdout:
Homebrew LLD 15.0.6

linker stderr:

```
```
ld64.lld: error: unknown argument '--as-needed'
ld64.lld: error: unknown argument '--no-undefined'
ld64.lld: error: unknown argument '--start-group'
ld64.lld: error: unknown argument '--end-group'
```

This commit detects `ld64` as an `AppleDynamicLinker` as described in [this comment](https://github.com/mesonbuild/meson/pull/10880#issuecomment-1264553781), by searching for `ld64.lld` in the output of `clang -Wl,-v -fuse-ld=lld`.

The original pull request seems stalled so I thought I'd quickly implement it, hope I'm not stepping on any toes!