### PR TITLE
implement rustc controlled whole-archive linking

### DIFF
--- a/test cases/rust/2 sharedlib/meson.build
+++ b/test cases/rust/2 sharedlib/meson.build
@@ -1,10 +1,11 @@
-project('rust shared library', 'rust')
+project('rust shared library', 'rust', 'c')
 
 if host_machine.system() == 'darwin'
   error('MESON_SKIP_TEST: does not work right on macos, please fix!')
 endif
 
-l = shared_library('stuff', 'stuff.rs', install : true)
+s = static_library('static', 'value.c')
+l = shared_library('stuff', 'stuff.rs', link_whole : s, install : true)
 e = executable('prog', 'prog.rs', link_with : l, install : true)
 
 if build_machine.system() == 'windows'

--- a/test cases/rust/2 sharedlib/stuff.rs
+++ b/test cases/rust/2 sharedlib/stuff.rs
@@ -1,3 +1,11 @@
 #![crate_name = "stuff"]
 
-pub fn explore() -> &'static str { "librarystring" }
+extern "C" {
+        fn c_value() -> i32;
+}
+
+pub fn explore() -> String {
+    unsafe {
+        format!("library{}string", c_value())
+    }
+}

--- a/test cases/rust/2 sharedlib/value.c
+++ b/test cases/rust/2 sharedlib/value.c
@@ -1,0 +1,3 @@
+int c_value(void) {
+    return 7;
+}

--- a/test cases/rust/3 staticlib/meson.build
+++ b/test cases/rust/3 staticlib/meson.build
@@ -1,5 +1,7 @@
-project('rust static library', 'rust')
+project('rust static library', 'rust', 'c')
 
-l = static_library('stuff', 'stuff.rs', install : true)
+o = static_library('other', 'other.rs')
+v = static_library('value', 'value.c')
+l = static_library('stuff', 'stuff.rs', link_whole : [o, v], install : true)
 e = executable('prog', 'prog.rs', link_with : l, install : true)
 test('linktest', e)

--- a/test cases/rust/3 staticlib/other.rs
+++ b/test cases/rust/3 staticlib/other.rs
@@ -1,0 +1,5 @@
+pub fn explore(
+    value: i32,
+) -> String {
+    format!("library{}string", value)
+}

--- a/test cases/rust/3 staticlib/prog.rs
+++ b/test cases/rust/3 staticlib/prog.rs
@@ -1,3 +1,5 @@
 extern crate stuff;
 
-fn main() { println!("printing: {}", stuff::explore()); }
+fn main() {
+    println!("printing: {}", stuff::explore());
+}

--- a/test cases/rust/3 staticlib/stuff.rs
+++ b/test cases/rust/3 staticlib/stuff.rs
@@ -1,3 +1,14 @@
 #![crate_name = "stuff"]
 
-pub fn explore() -> &'static str { "librarystring" }
+extern crate other;
+
+extern "C" {
+    fn c_explore_value() -> i32;
+}
+
+pub fn explore(
+) -> String {
+    unsafe {
+        other::explore(c_explore_value())
+    }
+}

--- a/test cases/rust/3 staticlib/value.c
+++ b/test cases/rust/3 staticlib/value.c
@@ -1,0 +1,5 @@
+int
+c_explore_value (void)
+{
+    return 42;
+}

--- a/test cases/rust/5 polyglot static/clib.c
+++ b/test cases/rust/5 polyglot static/clib.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+void hello_from_rust(void);
+
+static void hello_from_c(void) {
+    printf("Hello from C!\n");
+}
+
+void hello_from_both(void) {
+    hello_from_c();
+    hello_from_rust();
+}

--- a/test cases/rust/5 polyglot static/meson.build
+++ b/test cases/rust/5 polyglot static/meson.build
@@ -8,7 +8,8 @@ deps = [
 
 extra_winlibs = meson.get_compiler('c').get_id() in ['msvc', 'clang-cl'] ? ['userenv.lib', 'ws2_32.lib', 'bcrypt.lib'] : []
 
-l = static_library('stuff', 'stuff.rs', rust_crate_type : 'staticlib', install : true)
+r = static_library('stuff', 'stuff.rs', rust_crate_type : 'staticlib')
+l = static_library('clib', 'clib.c', link_with : r, install : true)
 e = executable('prog', 'prog.c',
                dependencies: deps,
                link_with : l,

--- a/test cases/rust/5 polyglot static/prog.c
+++ b/test cases/rust/5 polyglot static/prog.c
@@ -1,8 +1,7 @@
 #include <stdio.h>
 
-void f();
+void hello_from_both();
 
 int main(void) {
-    printf("Hello from C!\n");
-    f();
+    hello_from_both();
 }

--- a/test cases/rust/5 polyglot static/stuff.rs
+++ b/test cases/rust/5 polyglot static/stuff.rs
@@ -1,6 +1,6 @@
 #![crate_name = "stuff"]
 
 #[no_mangle]
-pub extern fn f() {
+pub extern "C" fn hello_from_rust() {
     println!("Hello from Rust!");
 }

--- a/test cases/rust/5 polyglot static/test.json
+++ b/test cases/rust/5 polyglot static/test.json
@@ -2,6 +2,6 @@
   "installed": [
     {"type": "exe", "file": "usr/bin/prog"},
     {"type": "pdb", "file": "usr/bin/prog"},
-    {"type": "file", "file": "usr/lib/libstuff.a"}
+    {"type": "file", "file": "usr/lib/libclib.a"}
   ]
 }


### PR DESCRIPTION
Rustc as of version 1.61.0 has support for controlling when whole-archive linking takes place, previous to this it tried to make a good guess about what you wanted, which worked most of the time. This is now implemented. Additionally, because meson breaks some rustc assumption about library naming on windows, we have to manually pass whole-archive libraries, bypassing rustc's interface and talking directly to the linker for MSVC (and those imitating it), which we were doing incorrectly. This has been fixed.

Fixes: #10723
Fixes: #11247