### PR TITLE
cross: move multilib options to [binaries] section

### DIFF
--- a/cross/armclang-linux.txt
+++ b/cross/armclang-linux.txt
@@ -17,15 +17,12 @@
 [binaries]
 # we could set exe_wrapper = qemu-arm-static but to test the case
 # when cross compiled binaries can't be run we don't do that
-c = '/opt/arm/developmentstudio-2019.0/sw/ARMCompiler6.12/bin/armclang'
+c = ['/opt/arm/developmentstudio-2019.0/sw/ARMCompiler6.12/bin/armclang', '--target=aarch64-arm-none-eabi']
 #c = '/opt/arm/developmentstudio-2019.0/sw/ARMCompiler5.06u6/bin/armcc'
 #cpp = '/usr/bin/arm-linux-gnueabihf-g++'
 ar = '/opt/arm/developmentstudio-2019.0/sw/ARMCompiler6.12/bin/armar'
 #strip = '/usr/arm-linux-gnueabihf/bin/strip'
 #pkgconfig = '/usr/bin/arm-linux-gnueabihf-pkg-config'
-
-[built-in options]
-c_args = ['--target=aarch64-arm-none-eabi']
 
 [host_machine]
 system = 'baremetal'

--- a/cross/armclang.txt
+++ b/cross/armclang.txt
@@ -2,16 +2,16 @@
 # to the environment(PATH) variable, so that Meson can find
 # the armclang, armlink and armar while building.
 [binaries]
-c = 'armclang'
-cpp = 'armclang'
+c = ['armclang', '--target=arm-arm-none-eabi']
+cpp = ['armclang', '--target=arm-arm-none-eabi']
 ar = 'armar'
 strip = 'armar'
 
 [built-in options]
 # The '--target', '-mcpu' options with the appropriate values should be mentioned
 # to cross compile c/c++ code with armclang.
-c_args      = ['--target=arm-arm-none-eabi', '-mcpu=cortex-m0plus']
-cpp_args    = ['--target=arm-arm-none-eabi', '-mcpu=cortex-m0plus']
+c_args      = ['-mcpu=cortex-m0plus']
+cpp_args    = ['-mcpu=cortex-m0plus']
 
 [host_machine]
 system = 'bare metal'      # Update with your system name - bare metal/OS.

--- a/cross/ccomp-armv7a.txt
+++ b/cross/ccomp-armv7a.txt
@@ -1,10 +1,10 @@
 [binaries]
-c = 'ccomp'
+c = ['ccomp', '-target', 'armv7a-eabi']
 ar = 'ccomp'
 strip = 'strip'
 
 [built-in options]
-c_args      = ['-target', 'armv7a-eabi', '-fall']
+c_args      = ['-fall']
 
 [host_machine]
 system = 'bare metal'      # Update with your system name - bare metal/OS.

--- a/cross/iphone.txt
+++ b/cross/iphone.txt
@@ -3,20 +3,20 @@
 # these might not work for you. Use the googels and xcrun.
 
 [binaries]
-c = 'clang'
-cpp = 'clang++'
-objc = 'clang'
-objcpp = 'clang++'
+c = ['clang', '-arch', 'arm64', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk']
+cpp = ['clang++', '-arch', 'arm64', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk']
+objc = ['clang', '-arch', 'arm64', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk']
+objcpp = ['clang++', '-arch', 'arm64', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk']
 ar = 'ar'
 strip = 'strip'
 
 [built-in options]
-c_args = ['-arch', 'arm64', '-miphoneos-version-min=11.0', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk']
-cpp_args = ['-arch', 'arm64', '-miphoneos-version-min=11.0', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk']
-c_link_args = ['-arch', 'arm64', '-miphoneos-version-min=11.0', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk']
-cpp_link_args = ['-arch', 'arm64', '-miphoneos-version-min=11.0', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk']
-objc_args = ['-arch', 'arm64', '-miphoneos-version-min=11.0', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk']
-objcpp_args = ['-arch', 'arm64', '-miphoneos-version-min=11.0', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk']
+c_args = ['-miphoneos-version-min=11.0']
+cpp_args = ['-miphoneos-version-min=11.0']
+c_link_args = ['-miphoneos-version-min=11.0']
+cpp_link_args = ['-miphoneos-version-min=11.0']
+objc_args = ['-miphoneos-version-min=11.0']
+objcpp_args = ['-miphoneos-version-min=11.0']
 
 [properties]
 root = '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer'

--- a/cross/tvos.txt
+++ b/cross/tvos.txt
@@ -3,16 +3,16 @@
 # these might not work for you. Use the googels and xcrun.
 
 [binaries]
-c = 'clang'
-cpp = 'clang++'
+c = ['clang', '-arch', 'arm64', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk']
+cpp = ['clang++', '-arch', 'arm64', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk']
 ar = 'ar'
 strip = 'strip'
 
 [built-in options]
-c_args = ['-arch', 'arm64', '-mtvos-version-min=12.0', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk']
-cpp_args = ['-arch', 'arm64', '-mtvos-version-min=12.0', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk']
-c_link_args = ['-arch', 'arm64', '-mtvos-version-min=12.0', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk']
-cpp_link_args = ['-arch', 'arm64', '-mtvos-version-min=12.0', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk']
+c_args = ['-mtvos-version-min=12.0']
+cpp_args = ['-mtvos-version-min=12.0']
+c_link_args = ['-mtvos-version-min=12.0']
+cpp_link_args = ['-mtvos-version-min=12.0']
 
 [properties]
 root = '/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer'

--- a/cross/ubuntu-armhf.txt
+++ b/cross/ubuntu-armhf.txt
@@ -1,8 +1,8 @@
 [binaries]
 # we could set exe_wrapper = qemu-arm-static but to test the case
 # when cross compiled binaries can't be run we don't do that
-c = '/usr/bin/arm-linux-gnueabihf-gcc'
-cpp = '/usr/bin/arm-linux-gnueabihf-g++'
+c = ['/usr/bin/arm-linux-gnueabihf-gcc', '--target', 'arm-unknown-linux-gnueabihf']
+cpp = ['/usr/bin/arm-linux-gnueabihf-g++', '--target', 'arm-unknown-linux-gnueabihf']
 rust = ['rustc', '--target', 'arm-unknown-linux-gnueabihf', '-C', 'linker=/usr/bin/arm-linux-gnueabihf-gcc-7']
 ar = '/usr/arm-linux-gnueabihf/bin/ar'
 strip = '/usr/arm-linux-gnueabihf/bin/strip'


### PR DESCRIPTION
c_args are meant to be overridden by the user if needed (even via the environment CFLAGS variables + -Doptimization=plain, for example), so they should not contain any option that affect the multilib search path.  For example, a hypothetical native file like this:

 ```
[binaries]
c = gcc

[built-in options]
c_args = ['-m32']
```

would *not* build 32-bit binaries if -Dc_args is passed to meson. Such options, instead should be in the [binaries] section.  Adjust the sample cross files included with meson.

(That said, I am not sure who is using these cross files and I wonder if it would be better to just delete them).