### PR TITLE
docs: Add ld64.lld to linker reference table

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -56,6 +56,7 @@ These are return values of the `get_linker_id` method in a compiler object.
 | ld.solaris | Solaris and illumos                         |
 | ld.wasm    | emscripten's wasm-ld linker                 |
 | ld64       | Apple ld64                                  |
+| ld64.lld   | The LLVM linker, with the ld64 interface    |
 | link       | MSVC linker                                 |
 | lld-link   | The LLVM linker, with the MSVC interface    |
 | xilink     | Used with Intel-cl only, MSVC like          |


### PR DESCRIPTION
I forgot to ask the original author to add this to the original MR (#11243)