### PR TITLE
devenv should import env vars from vsenv

### DIFF
--- a/mesonbuild/mdevenv.py
+++ b/mesonbuild/mdevenv.py
@@ -157,6 +157,7 @@ def run(options: argparse.Namespace) -> int:
     b = build.load(options.builddir)
     workdir = options.workdir or options.builddir
 
+    setup_vsenv(b.need_vsenv)  # Call it before get_env to get vsenv vars as well
     dump_fmt = options.dump_format if options.dump else None
     devenv, varnames = get_env(b, dump_fmt)
     if options.dump:
@@ -179,8 +180,6 @@ def run(options: argparse.Namespace) -> int:
 
     install_data = minstall.load_install_data(str(privatedir / 'install.dat'))
     write_gdb_script(privatedir, install_data, workdir)
-
-    setup_vsenv(b.need_vsenv)
 
     args = options.devcmd
     if not args:


### PR DESCRIPTION
On Windows, `meson devenv` calls vsenv, but this is useless since env vars are not transfered to the subprocess.

This fixes that by importing env vars from vsenv, and updating the PATH accordingly. 

It allows to call scripts and executables from Visual Studio when activating the devenv shell.

For instance, before this fix, calling `meson devenv msbuild` was working, but calling `meson devenv` then `msbuild` was not.