### PR TITLE
Replace KwargInfo.since_values and .deprecated_values

### DIFF
--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -20,7 +20,7 @@ from ..interpreterbase import (ObjectHolder, noPosargs, noKwargs,
 from ..interpreterbase.decorators import ContainerTypeInfo, typed_kwargs, KwargInfo, typed_pos_args
 from ..mesonlib import OptionKey
 from .interpreterobjects import (extract_required_kwarg, extract_search_dirs)
-from .type_checking import REQUIRED_KW, in_set_validator, NoneType
+from .type_checking import REQUIRED_KW, in_set_validator, types_feature_validator, NoneType
 
 if T.TYPE_CHECKING:
     from ..interpreter import Interpreter
@@ -146,7 +146,7 @@ _PREFIX_KW: KwargInfo[str] = KwargInfo(
     'prefix',
     (str, ContainerTypeInfo(list, str)),
     default='',
-    since_values={list: '1.0.0'},
+    feature_validator=types_feature_validator({list: '1.0.0'}),
     convertor=lambda x: '\n'.join(x) if isinstance(x, list) else x)
 
 _NO_BUILTIN_ARGS_KW = KwargInfo('no_builtin_args', bool, default=False)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -86,7 +86,8 @@ from .type_checking import (
     TEST_KWS,
     NoneType,
     in_set_validator,
-    env_convertor_with_method
+    env_convertor_with_method,
+    types_feature_validator,
 )
 from . import primitives as P_OBJ
 
@@ -670,7 +671,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         LINK_WITH_KW,
         LINK_WHOLE_KW.evolve(since='0.46.0'),
         SOURCES_KW,
-        VARIABLES_KW.evolve(since='0.54.0', since_values={list: '0.56.0'}),
+        VARIABLES_KW.evolve(since='0.54.0', feature_validator=types_feature_validator({list: '0.56.0'})),
         KwargInfo('version', (str, NoneType)),
         KwargInfo('objects', ContainerTypeInfo(list, build.ExtractedObjects), listify=True, default=[], since='1.1.0'),
     )

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -375,11 +375,11 @@ INCLUDE_DIRECTORIES: KwargInfo[T.List[T.Union[str, IncludeDirs]]] = KwargInfo(
     default=[],
 )
 
-def include_dir_string_new(val: T.List[T.Union[str, IncludeDirs]]) -> T.Iterable[FeatureCheckBase]:
+def include_dir_string_new(val: T.List[T.Union[str, IncludeDirs]], message: str) -> T.Iterable[FeatureCheckBase]:
     strs = [v for v in val if isinstance(v, str)]
     if strs:
         str_msg = ", ".join(f"'{s}'" for s in strs)
-        yield FeatureNew('include_directories kwarg of type string', '1.0.0',
+        yield FeatureNew(f'{message} of type string', '1.0.0',
                          f'Use include_directories({str_msg}) instead')
 
 # for cases like default_options and override_options

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -567,7 +567,7 @@ TEST_KWS: T.List[KwargInfo] = [
     KwargInfo('protocol', str,
               default='exitcode',
               validator=in_set_validator({'exitcode', 'tap', 'gtest', 'rust'}),
-              since_values={'gtest': '0.55.0', 'rust': '0.57.0'}),
+              feature_validator=value_feature_validator({'gest': '0.55.0', 'rust': '0.57.0'})),
     KwargInfo('priority', int, default=0, since='0.52.0'),
     # TODO: env needs reworks of the way the environment variable holder itself works probably
     ENV_KW,

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -394,7 +394,7 @@ class KwargInfo(T.Generic[_T]):
                  deprecated: T.Optional[str] = None,
                  deprecated_message: T.Optional[str] = None,
                  deprecated_values: T.Optional[T.Dict[T.Union[_T, T.Type[T.List], T.Type[T.Dict]], T.Union[str, T.Tuple[str, str]]]] = None,
-                 feature_validator: T.Optional[T.Callable[[_T], T.Iterable[FeatureCheckBase]]] = None,
+                 feature_validator: T.Optional[T.Callable[[_T, str], T.Iterable[FeatureCheckBase]]] = None,
                  validator: T.Optional[T.Callable[[T.Any], T.Optional[str]]] = None,
                  convertor: T.Optional[T.Callable[[_T], object]] = None,
                  not_set_warning: T.Optional[str] = None):
@@ -425,7 +425,7 @@ class KwargInfo(T.Generic[_T]):
                deprecated: T.Union[str, None, _NULL_T] = _NULL,
                deprecated_message: T.Union[str, None, _NULL_T] = _NULL,
                deprecated_values: T.Union[T.Dict[T.Union[_T, T.Type[T.List], T.Type[T.Dict]], T.Union[str, T.Tuple[str, str]]], None, _NULL_T] = _NULL,
-               feature_validator: T.Union[T.Callable[[_T], T.Iterable[FeatureCheckBase]], None, _NULL_T] = _NULL,
+               feature_validator: T.Union[T.Callable[[_T, str], T.Iterable[FeatureCheckBase]], None, _NULL_T] = _NULL,
                validator: T.Union[T.Callable[[_T], T.Optional[str]], None, _NULL_T] = _NULL,
                convertor: T.Union[T.Callable[[_T], TYPE_var], None, _NULL_T] = _NULL) -> 'KwargInfo':
         """Create a shallow copy of this KwargInfo, with modifications.
@@ -563,7 +563,7 @@ def typed_kwargs(name: str, *types: KwargInfo, allow_unknown: bool = False) -> T
                             raise InvalidArguments(f'{name} keyword argument "{info.name}" {msg}')
 
                     if info.feature_validator is not None:
-                        for each in info.feature_validator(value):
+                        for each in info.feature_validator(value, f'"{name}" keyword argument "{info.name}"'):
                             each.use(subproject, node)
 
                     if info.deprecated_values is not None:

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -375,11 +375,6 @@ class KwargInfo(T.Generic[_T]):
         different type. This is intended for cases such as the meson DSL using a
         string, but the implementation using an Enum. This should not do
         validation, just conversion.
-    :param deprecated_values: a dictionary mapping a value to the version of
-        meson it was deprecated in. The Value may be any valid value for this
-        argument.
-    :param since_values: a dictionary mapping a value to the version of meson it was
-        added in.
     :param not_set_warning: A warning message that is logged if the kwarg is not
         set by the user.
     :param feature_validator: A callable returning an iterable of FeatureNew | FeatureDeprecated objects.
@@ -390,10 +385,8 @@ class KwargInfo(T.Generic[_T]):
                  default: T.Optional[_T] = None,
                  since: T.Optional[str] = None,
                  since_message: T.Optional[str] = None,
-                 since_values: T.Optional[T.Dict[T.Union[_T, T.Type[T.List], T.Type[T.Dict]], T.Union[str, T.Tuple[str, str]]]] = None,
                  deprecated: T.Optional[str] = None,
                  deprecated_message: T.Optional[str] = None,
-                 deprecated_values: T.Optional[T.Dict[T.Union[_T, T.Type[T.List], T.Type[T.Dict]], T.Union[str, T.Tuple[str, str]]]] = None,
                  feature_validator: T.Optional[T.Callable[[_T, str], T.Iterable[FeatureCheckBase]]] = None,
                  validator: T.Optional[T.Callable[[T.Any], T.Optional[str]]] = None,
                  convertor: T.Optional[T.Callable[[_T], object]] = None,
@@ -405,11 +398,9 @@ class KwargInfo(T.Generic[_T]):
         self.default = default
         self.since = since
         self.since_message = since_message
-        self.since_values = since_values
         self.feature_validator = feature_validator
         self.deprecated = deprecated
         self.deprecated_message = deprecated_message
-        self.deprecated_values = deprecated_values
         self.validator = validator
         self.convertor = convertor
         self.not_set_warning = not_set_warning
@@ -421,10 +412,8 @@ class KwargInfo(T.Generic[_T]):
                default: T.Union[_T, None, _NULL_T] = _NULL,
                since: T.Union[str, None, _NULL_T] = _NULL,
                since_message: T.Union[str, None, _NULL_T] = _NULL,
-               since_values: T.Union[T.Dict[T.Union[_T, T.Type[T.List], T.Type[T.Dict]], T.Union[str, T.Tuple[str, str]]], None, _NULL_T] = _NULL,
                deprecated: T.Union[str, None, _NULL_T] = _NULL,
                deprecated_message: T.Union[str, None, _NULL_T] = _NULL,
-               deprecated_values: T.Union[T.Dict[T.Union[_T, T.Type[T.List], T.Type[T.Dict]], T.Union[str, T.Tuple[str, str]]], None, _NULL_T] = _NULL,
                feature_validator: T.Union[T.Callable[[_T, str], T.Iterable[FeatureCheckBase]], None, _NULL_T] = _NULL,
                validator: T.Union[T.Callable[[_T], T.Optional[str]], None, _NULL_T] = _NULL,
                convertor: T.Union[T.Callable[[_T], TYPE_var], None, _NULL_T] = _NULL) -> 'KwargInfo':
@@ -447,10 +436,8 @@ class KwargInfo(T.Generic[_T]):
             default=default if not isinstance(default, _NULL_T) else self.default,
             since=since if not isinstance(since, _NULL_T) else self.since,
             since_message=since_message if not isinstance(since_message, _NULL_T) else self.since_message,
-            since_values=since_values if not isinstance(since_values, _NULL_T) else self.since_values,
             deprecated=deprecated if not isinstance(deprecated, _NULL_T) else self.deprecated,
             deprecated_message=deprecated_message if not isinstance(deprecated_message, _NULL_T) else self.deprecated_message,
-            deprecated_values=deprecated_values if not isinstance(deprecated_values, _NULL_T) else self.deprecated_values,
             feature_validator=feature_validator if not isinstance(feature_validator, _NULL_T) else self.feature_validator,
             validator=validator if not isinstance(validator, _NULL_T) else self.validator,
             convertor=convertor if not isinstance(convertor, _NULL_T) else self.convertor,
@@ -509,27 +496,6 @@ def typed_kwargs(name: str, *types: KwargInfo, allow_unknown: bool = False) -> T
 
         @wraps(f)
         def wrapper(*wrapped_args: T.Any, **wrapped_kwargs: T.Any) -> T.Any:
-
-            def emit_feature_change(values: T.Dict[_T, T.Union[str, T.Tuple[str, str]]], feature: T.Union[T.Type['FeatureDeprecated'], T.Type['FeatureNew']]) -> None:
-                for n, version in values.items():
-                    warn = False
-                    if isinstance(version, tuple):
-                        version, msg = version
-                    else:
-                        msg = None
-
-                    if n in {dict, list}:
-                        assert isinstance(n, type), 'for mypy'
-                        if isinstance(value, n):
-                            feature.single_use(f'"{name}" keyword argument "{info.name}" of type {n.__name__}', version, subproject, msg, location=node)
-                    elif isinstance(value, (dict, list)):
-                        warn = n in value
-                    else:
-                        warn = n == value
-
-                    if warn:
-                        feature.single_use(f'"{name}" keyword argument "{info.name}" value "{n}"', version, subproject, msg, location=node)
-
             node, _, _kwargs, subproject = get_callee_args(wrapped_args)
             # Cast here, as the convertor function may place something other than a TYPE_var in the kwargs
             kwargs = T.cast('T.Dict[str, object]', _kwargs)
@@ -565,12 +531,6 @@ def typed_kwargs(name: str, *types: KwargInfo, allow_unknown: bool = False) -> T
                     if info.feature_validator is not None:
                         for each in info.feature_validator(value, f'"{name}" keyword argument "{info.name}"'):
                             each.use(subproject, node)
-
-                    if info.deprecated_values is not None:
-                        emit_feature_change(info.deprecated_values, FeatureDeprecated)
-
-                    if info.since_values is not None:
-                        emit_feature_change(info.since_values, FeatureNew)
 
                 elif info.required:
                     raise InvalidArguments(f'{name} is missing required keyword argument "{info.name}"')

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -32,7 +32,7 @@ from .. import mesonlib
 from .. import mlog
 from ..build import CustomTarget, CustomTargetIndex, Executable, GeneratedList, InvalidArguments
 from ..dependencies import Dependency, PkgConfigDependency, InternalDependency
-from ..interpreter.type_checking import DEPENDS_KW, DEPEND_FILES_KW, INSTALL_DIR_KW, INSTALL_KW, NoneType, SOURCES_KW, in_set_validator
+from ..interpreter.type_checking import DEPENDS_KW, DEPEND_FILES_KW, INSTALL_DIR_KW, INSTALL_KW, NoneType, SOURCES_KW, in_set_validator, value_feature_validator
 from ..interpreterbase import noPosargs, noKwargs, FeatureNew, FeatureDeprecated
 from ..interpreterbase import typed_kwargs, KwargInfo, ContainerTypeInfo
 from ..interpreterbase.decorators import typed_pos_args
@@ -1104,11 +1104,11 @@ class GnomeModule(ExtensionModule):
         KwargInfo('includes', ContainerTypeInfo(list, (str, GirTarget)), default=[], listify=True),
         KwargInfo('install_gir', (bool, NoneType), since='0.61.0'),
         KwargInfo('install_dir_gir', (str, bool, NoneType),
-                  deprecated_values={False: ('0.61.0', 'Use install_gir to disable installation')},
+                  feature_validator=value_feature_validator(deprecated={False: ('0.61.0', 'Use install_gir to disable installation')}),
                   validator=lambda x: 'as boolean can only be false' if x is True else None),
         KwargInfo('install_typelib', (bool, NoneType), since='0.61.0'),
         KwargInfo('install_dir_typelib', (str, bool, NoneType),
-                  deprecated_values={False: ('0.61.0', 'Use install_typelib to disable installation')},
+                  feature_validator=value_feature_validator(deprecated={False: ('0.61.0', 'Use install_typelib to disable installation')}),
                   validator=lambda x: 'as boolean can only be false' if x is True else None),
         KwargInfo('link_with', ContainerTypeInfo(list, (build.SharedLibrary, build.StaticLibrary)), default=[], listify=True),
         KwargInfo('namespace', str, required=True),

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -27,7 +27,7 @@ from .. import mesonlib
 from .. import mlog
 from ..coredata import BUILTIN_DIR_OPTIONS
 from ..dependencies import ThreadDependency
-from ..interpreter.type_checking import D_MODULE_VERSIONS_KW, INSTALL_DIR_KW, VARIABLES_KW, NoneType
+from ..interpreter.type_checking import D_MODULE_VERSIONS_KW, INSTALL_DIR_KW, VARIABLES_KW, NoneType, types_feature_validator
 from ..interpreterbase import FeatureNew, FeatureDeprecated
 from ..interpreterbase.decorators import ContainerTypeInfo, KwargInfo, typed_kwargs, typed_pos_args
 
@@ -611,8 +611,14 @@ class PkgConfigModule(NewExtensionModule):
         KwargInfo('version', (str, NoneType)),
         VARIABLES_KW.evolve(name="unescaped_uninstalled_variables", since='0.59.0'),
         VARIABLES_KW.evolve(name="unescaped_variables", since='0.59.0'),
-        VARIABLES_KW.evolve(name="uninstalled_variables", since='0.54.0', since_values={dict: '0.56.0'}),
-        VARIABLES_KW.evolve(since='0.41.0', since_values={dict: '0.56.0'}),
+        VARIABLES_KW.evolve(
+            name="uninstalled_variables", since='0.54.0',
+            feature_validator=types_feature_validator({dict: '0.56.0'}),
+        ),
+        VARIABLES_KW.evolve(
+            since='0.41.0',
+            feature_validator=types_feature_validator({dict: '0.56.0'}),
+        ),
         _PKG_LIBRARIES,
         _PKG_LIBRARIES.evolve(name='libraries_private'),
         _PKG_REQUIRES,

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -181,7 +181,7 @@ class OptionInterpreter:
             (bool, str, ContainerTypeInfo(dict, str), ContainerTypeInfo(list, str)),
             default=False,
             since='0.60.0',
-            feature_validator=lambda x: [FeatureNew('string value to "deprecated" keyword argument', '0.63.0')] if isinstance(x, str) else []
+            feature_validator=lambda x, m: [FeatureNew(f'{m} string value to "deprecated" keyword argument', '0.63.0')] if isinstance(x, str) else []
         ),
         KwargInfo('yield', bool, default=coredata.DEFAULT_YIELDING, since='0.45.0'),
         allow_unknown=True,
@@ -246,7 +246,7 @@ class OptionInterpreter:
             'value',
             (int, str),
             default=True,
-            feature_validator=lambda x: [FeatureDeprecated('number values as strings', '1.1.0', 'use a raw number instead')] if isinstance(x, str) else [],
+            feature_validator=lambda x, m: [FeatureDeprecated(f'{m} number values as strings', '1.1.0', 'use a raw number instead')] if isinstance(x, str) else [],
             convertor=int,
         ),
         KwargInfo('min', (int, NoneType)),

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -21,7 +21,7 @@ from . import mesonlib
 from . import mparser
 from . import mlog
 from .interpreterbase import FeatureNew, typed_pos_args, typed_kwargs, ContainerTypeInfo, KwargInfo, FeatureDeprecated
-from .interpreter.type_checking import NoneType, in_set_validator
+from .interpreter.type_checking import NoneType, in_set_validator, value_feature_validator
 if T.TYPE_CHECKING:
     from .interpreterbase import TYPE_var, TYPE_kwargs
     from .interpreterbase import SubProject
@@ -222,7 +222,8 @@ class OptionInterpreter:
             (bool, str),
             default=True,
             validator=lambda x: None if isinstance(x, bool) or x in {'true', 'false'} else 'boolean options must have boolean values',
-            deprecated_values={'true': ('1.1.0', 'use a boolean, not a string'), 'false': ('1.1.0', 'use a boolean, not a string')},
+            feature_validator=value_feature_validator(
+                deprecated={'true': ('1.1.0', 'use a boolean, not a string'), 'false': ('1.1.0', 'use a boolean, not a string')}),
         ),
     )
     def boolean_parser(self, description: str, args: T.Tuple[bool, _DEPRECATED_ARGS], kwargs: BooleanArgs) -> coredata.UserOption:

--- a/test cases/rust/12 bindgen/test.json
+++ b/test cases/rust/12 bindgen/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "test cases/rust/12 bindgen/meson.build:30: WARNING: Project targets '>= 0.63' but uses feature introduced in '1.0.0': include_directories kwarg of type string. Use include_directories('include') instead"
+      "line": "test cases/rust/12 bindgen/meson.build:30: WARNING: Project targets '>= 0.63' but uses feature introduced in '1.0.0': \"rust.bindgen\" keyword argument \"include_directories\" of type string. Use include_directories('include') instead"
     }
   ]
 }


### PR DESCRIPTION
I originally added these for running FeatureNew checks for enum like string values, where a specific set of values were valid only, in this case for the `test(protocol : ...)` argument, but I also implemented it for looking inside lists and dictionaries. It was later extended to allow checking for specific types, `list` and `dict` in particular, and there is push to extend it to test for any type.

I have two problems with that push that led me to pull the code out of the `KwargInfo` class and put it into separate functions to be fed to `KwargInfo.feature_validator`:
1. type values behave differently in dictionaries than non-type values.
2. typed_kwargs() is already a very large complicated function, simplifying it seems better than making it more complicated

For 1:
```python
KwargInfo('foo', ContainerTypeInfo(dict, (str, int, bool)), since_values={str: '1.0.0'})
KwargInfo('foo', ContainerTypeInfo(dict, str), since_values={'foo': '1.0.0'})
```
don't do the same thing. in the first case it looks through the *values* of the dictionary, and checks their types. In the second case it look through the *keys* and checks that they are valid. Both of these are logically the right thing to do given the inputs (our dictionary keys are always strings), but it's surprising.

For 2:
typed_kwargs is a hot path in our code base, any simplification of it we can achieve will be noticeable. It's also grown quite complex and hard to reason about, so simplification is good from that point of view too.

When i created were two separate, but similar functions, one for types, and one for values. They behave the same way that the original functions did, but with the subtle differences clearly documented, and by separating them into separate functions, they're hopefully more clear to users as well. They also produce exactly the same messages, so from an end user point of view nothing has changed.