### PR TITLE
remove totally invalid gcc arguments from cross file

### DIFF
--- a/cross/ubuntu-armhf.txt
+++ b/cross/ubuntu-armhf.txt
@@ -1,8 +1,8 @@
 [binaries]
 # we could set exe_wrapper = qemu-arm-static but to test the case
 # when cross compiled binaries can't be run we don't do that
-c = ['/usr/bin/arm-linux-gnueabihf-gcc', '--target', 'arm-unknown-linux-gnueabihf']
-cpp = ['/usr/bin/arm-linux-gnueabihf-g++', '--target', 'arm-unknown-linux-gnueabihf']
+c = ['/usr/bin/arm-linux-gnueabihf-gcc']
+cpp = ['/usr/bin/arm-linux-gnueabihf-g++']
 rust = ['rustc', '--target', 'arm-unknown-linux-gnueabihf', '-C', 'linker=/usr/bin/arm-linux-gnueabihf-gcc-7']
 ar = '/usr/arm-linux-gnueabihf/bin/ar'
 strip = '/usr/arm-linux-gnueabihf/bin/strip'


### PR DESCRIPTION
Partial revert of commit cf23e341878286790885352fd1d6548be5798391. This mostly moved existing arguments to the "right" location, but also introduced new arguments that didn't previously exist -- which was wrong.

... also, these cross files are used by CI (if they have a corresponding .json file) and this change broke the CI. Because --target isn't a valid gcc option, although clang/rustc do accept it. For GCC, the argument parser decides you wanted --target-help, which prints documentation text and then quits.

/cc @bonzini 