### PR TITLE
fs: Warn when passing empty strings

### DIFF
--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -21,6 +21,8 @@ line options in `meson_options.txt`, native-file or cross-file.
 Where possible, symlinks and parent directory notation are resolved to an
 absolute path.
 
+**Note**: Empty string arguments will resolve to the current directory and may therefore produce undesired results (`fs.exists('')` is always true).
+
 ### exists
 
 Takes a single string argument and returns true if an entity with that

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -126,6 +126,8 @@ class FSModule(ExtensionModule):
     @noKwargs
     @typed_pos_args('fs.exists', str)
     def exists(self, state: 'ModuleState', args: T.Tuple[str], kwargs: T.Dict[str, T.Any]) -> bool:
+        if args[0] == '':
+            mlog.deprecation('Passing an empty string to fs.exists() is deprecated as it will always resolve to current dir')
         return self._resolve_dir(state, args[0]).exists()
 
     @noKwargs
@@ -143,6 +145,8 @@ class FSModule(ExtensionModule):
     @noKwargs
     @typed_pos_args('fs.is_dir', str)
     def is_dir(self, state: 'ModuleState', args: T.Tuple[str], kwargs: T.Dict[str, T.Any]) -> bool:
+        if args[0] == '':
+            mlog.deprecation('Passing an empty string to fs.is_dir() is deprecated as it will always resolve to current dir')
         return self._resolve_dir(state, args[0]).is_dir()
 
     @noKwargs

--- a/test cases/common/220 fs module/meson.build
+++ b/test cases/common/220 fs module/meson.build
@@ -6,6 +6,10 @@ fs = import('fs')
 
 f = files('meson.build')
 
+assert(fs.exists(''), 'Empty arg was not found.')
+assert(fs.is_dir(''), 'Empty arg not detected as a dir.')
+assert(not fs.is_file(''), 'Empty arg detected as a file.')
+
 assert(fs.exists('meson.build'), 'Existing file reported as missing.')
 assert(not fs.exists('nonexisting'), 'Nonexisting file was found.')
 


### PR DESCRIPTION
An empty argument resolves to the current dir as pathlib.Path is used
underneath. This is a very unexpected behavior for fs.exists() and
fs.is_dir().

Fixes: #8559