### PR TITLE
runpython: make it work for -c as well

### DIFF
--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -139,11 +139,11 @@ class CommandLineParser:
         parser.add_argument('script_args', nargs=argparse.REMAINDER)
 
     def run_runpython_command(self, options):
-        import runpy
+        sys.argv[1:] = options.script_args
         if options.eval_arg:
             exec(options.script_file)
         else:
-            sys.argv[1:] = options.script_args
+            import runpy
             sys.path.insert(0, os.path.dirname(options.script_file))
             runpy.run_path(options.script_file, run_name='__main__')
         return 0


### PR DESCRIPTION
In commit 4e4f97edb3d475273108b203bc02b04bd6840b06 we added support for runpython to accept `-c 'code to execute'` in addition to just script files. However, doing so would mangle the sys.argv in the executed code -- which assumes, as python itself does, that argv is the stuff after the code to execute. We correctly handled this for script files, but the original addition of -c support pushed this handling into a script-file specific block.