### PR TITLE
Haiku paths support

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -23,7 +23,9 @@ from .mesonlib import (
     HoldableObject,
     MesonException, EnvironmentException, MachineChoice, PerMachine,
     PerMachineDefaultable, default_libdir, default_libexecdir,
-    default_prefix, split_args, OptionKey, OptionType, stringlistify,
+    default_prefix, default_datadir, default_includedir, default_infodir,
+    default_localedir, default_mandir, default_sbindir, default_sysconfdir,
+    split_args, OptionKey, OptionType, stringlistify,
     pickle_load, replace_if_different
 )
 from .wrap import WrapMode
@@ -1195,18 +1197,18 @@ class BuiltinOption(T.Generic[_T, _U]):
 BUILTIN_DIR_OPTIONS: 'MutableKeyedOptionDictType' = OrderedDict([
     (OptionKey('prefix'),          BuiltinOption(UserStringOption, 'Installation prefix', default_prefix())),
     (OptionKey('bindir'),          BuiltinOption(UserStringOption, 'Executable directory', 'bin')),
-    (OptionKey('datadir'),         BuiltinOption(UserStringOption, 'Data file directory', 'share')),
-    (OptionKey('includedir'),      BuiltinOption(UserStringOption, 'Header file directory', 'include')),
-    (OptionKey('infodir'),         BuiltinOption(UserStringOption, 'Info page directory', 'share/info')),
+    (OptionKey('datadir'),         BuiltinOption(UserStringOption, 'Data file directory', default_datadir())),
+    (OptionKey('includedir'),      BuiltinOption(UserStringOption, 'Header file directory', default_includedir())),
+    (OptionKey('infodir'),         BuiltinOption(UserStringOption, 'Info page directory', default_infodir())),
     (OptionKey('libdir'),          BuiltinOption(UserStringOption, 'Library directory', default_libdir())),
     (OptionKey('licensedir'),      BuiltinOption(UserStringOption, 'Licenses directory', '')),
     (OptionKey('libexecdir'),      BuiltinOption(UserStringOption, 'Library executable directory', default_libexecdir())),
-    (OptionKey('localedir'),       BuiltinOption(UserStringOption, 'Locale data directory', 'share/locale')),
+    (OptionKey('localedir'),       BuiltinOption(UserStringOption, 'Locale data directory', default_localedir())),
     (OptionKey('localstatedir'),   BuiltinOption(UserStringOption, 'Localstate data directory', 'var')),
-    (OptionKey('mandir'),          BuiltinOption(UserStringOption, 'Manual page directory', 'share/man')),
-    (OptionKey('sbindir'),         BuiltinOption(UserStringOption, 'System executable directory', 'sbin')),
+    (OptionKey('mandir'),          BuiltinOption(UserStringOption, 'Manual page directory', default_mandir())),
+    (OptionKey('sbindir'),         BuiltinOption(UserStringOption, 'System executable directory', default_sbindir())),
     (OptionKey('sharedstatedir'),  BuiltinOption(UserStringOption, 'Architecture-independent data directory', 'com')),
-    (OptionKey('sysconfdir'),      BuiltinOption(UserStringOption, 'Sysconf data directory', 'etc')),
+    (OptionKey('sysconfdir'),      BuiltinOption(UserStringOption, 'Sysconf data directory', default_sysconfdir())),
 ])
 
 BUILTIN_CORE_OPTIONS: 'MutableKeyedOptionDictType' = OrderedDict([

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -701,6 +701,9 @@ class PkgConfigModule(NewExtensionModule):
             if mesonlib.is_freebsd():
                 pkgroot = os.path.join(_as_str(state.environment.coredata.get_option(mesonlib.OptionKey('prefix'))), 'libdata', 'pkgconfig')
                 pkgroot_name = os.path.join('{prefix}', 'libdata', 'pkgconfig')
+            elif mesonlib.is_haiku():
+                pkgroot = os.path.join(_as_str(state.environment.coredata.get_option(mesonlib.OptionKey('prefix'))), 'develop', 'lib', 'pkgconfig')
+                pkgroot_name = os.path.join('{prefix}', 'develop', 'lib', 'pkgconfig')
             else:
                 pkgroot = os.path.join(_as_str(state.environment.coredata.get_option(mesonlib.OptionKey('libdir'))), 'pkgconfig')
                 pkgroot_name = os.path.join('{libdir}', 'pkgconfig')

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -82,6 +82,13 @@ __all__ = [
     'default_libdir',
     'default_libexecdir',
     'default_prefix',
+    'default_datadir',
+    'default_includedir',
+    'default_infodir',
+    'default_localedir',
+    'default_mandir',
+    'default_sbindir',
+    'default_sysconfdir',
     'detect_subprojects',
     'detect_vcs',
     'do_conf_file',
@@ -977,12 +984,60 @@ def default_libdir() -> str:
 
 
 def default_libexecdir() -> str:
+    if is_haiku():
+        return 'lib'
     # There is no way to auto-detect this, so it must be set at build time
     return 'libexec'
 
 
 def default_prefix() -> str:
-    return 'c:/' if is_windows() else '/usr/local'
+    if is_windows():
+        return 'c:/'
+    if is_haiku():
+        return '/boot/system/non-packaged'
+    return '/usr/local'
+
+
+def default_datadir() -> str:
+    if is_haiku():
+        return 'data'
+    return 'share'
+
+
+def default_includedir() -> str:
+    if is_haiku():
+        return 'develop/headers'
+    return 'include'
+
+
+def default_infodir() -> str:
+    if is_haiku():
+        return 'documentation/info'
+    return 'share/info'
+
+
+def default_localedir() -> str:
+    if is_haiku():
+        return 'data/locale'
+    return 'share/locale'
+
+
+def default_mandir() -> str:
+    if is_haiku():
+        return 'documentation/man'
+    return 'share/man'
+
+
+def default_sbindir() -> str:
+    if is_haiku():
+        return 'bin'
+    return 'sbin'
+
+
+def default_sysconfdir() -> str:
+    if is_haiku():
+        return 'settings'
+    return 'etc'
 
 
 def has_path_sep(name: str, sep: str = '/\\') -> bool:


### PR DESCRIPTION
This patch set correct install path used by Haiku operating system (https://www.haiku-os.org/). Currently Haiku use after install Bash scripts to adjust install locations to Haiku native ones, but it is a hack and native Meson support would be preferred.

Background:

Haiku (and its descendent BeOS) use its own file system hierarchy that significantly differs from other UNIX-like systems. There are four install prefixes recognized by system:

1. $HOME/config/non-packaged
2. $HOME/config
3. /boot/system/non-packaged
4. /boot/non-packaged

`/boot` is a mount point of a volume containing currently booted system installation (something like `C:` in Windows, not boot loader data as in Linux). `non-packaged` directories means software not managed by package manager and installed manually (such as `ninja install`).

All development-related files such as pkg-config *.pc files, C/C++ headers, static libraries, symbolic links to dynamic libraries, compilers etc. should be installed to `$prefix/develop` directory.

Summary:
| Command | Haiku path |
| --- | --- |
| `prefix` | `/boot/system/non-packaged` |
| `bindir` | `bin` |
| `datadir` | `data` |
| `includedir` | `develop/headers` |
| `infodir` | `documentation/info` |
| `libdir` | `lib` (runtime), `develop/lib` (static libraries, symlinks for compiler use) |
| `libexecdir` | `lib` |
| `localedir` | `data/locale` |
| `mandir` | `documentation/man` |
| `sbindir` | `bin` |
| `sysconfdir` | `settings` |
| `pkgconfig` | `develop/lib/pkgconfig`, `data/pkgconfig` |

Example install layout:
```
> tree install
install
├── develop
│   ├── headers
│   │   ├── EGL
│   │   │   ├── egl.h
│   │   │   ├── eglext.h
│   │   │   └── eglplatform.h
│   │   ├── GL
│   │   │   ├── gl.h
│   │   │   ├── glcorearb.h
│   │   │   └── glext.h
│   │   ├── GLES
│   │   │   ├── egl.h
│   │   │   ├── gl.h
│   │   │   ├── glext.h
│   │   │   └── glplatform.h
│   │   ├── GLES2
│   │   │   ├── gl2.h
│   │   │   ├── gl2ext.h
│   │   │   └── gl2platform.h
│   │   ├── GLES3
│   │   │   ├── gl3.h
│   │   │   ├── gl31.h
│   │   │   ├── gl32.h
│   │   │   ├── gl3ext.h
│   │   │   └── gl3platform.h
│   │   ├── glvnd
│   │   │   ├── GLdispatchABI.h
│   │   │   ├── libeglabi.h
│   │   │   └── libglxabi.h
│   │   ├── KHR
│   │   │   └── khrplatform.h
│   │   └── opengl
│   │       ├── GLRenderer.h
│   │       ├── GLView.h
│   │       └── OpenGLKit.h
│   └── lib
│       ├── libEGL.so -> ../../lib/libEGL.so.1
│       ├── libGL.so -> ../../lib/libGL.so.1
│       ├── libGLdispatch.so -> ../../lib/libGLdispatch.so.0
│       ├── libGLESv1_CM.so -> ../../lib/libGLESv1_CM.so.1
│       ├── libGLESv2.so -> ../../lib/libGLESv2.so.2
│       ├── libOpenGL.so -> ../../lib/libOpenGL.so.0
│       └── pkgconfig
│           ├── egl.pc
│           ├── gl.pc
│           ├── glesv1_cm.pc
│           ├── glesv2.pc
│           ├── libglvnd.pc
│           └── opengl.pc
└── lib
    ├── libEGL.so.1 -> libEGL.so.1.1.0
    ├── libEGL.so.1.1.0
    ├── libGL.so.1 -> libGL.so.1.0.0
    ├── libGL.so.1.0.0
    ├── libGLdispatch.so.0 -> libGLdispatch.so.0.0.0
    ├── libGLdispatch.so.0.0.0
    ├── libGLESv1_CM.so.1 -> libGLESv1_CM.so.1.2.0
    ├── libGLESv1_CM.so.1.2.0
    ├── libGLESv2.so.2 -> libGLESv2.so.2.1.0
    ├── libGLESv2.so.2.1.0
    ├── libOpenGL.so.0 -> libOpenGL.so.0.0.0
    └── libOpenGL.so.0.0.0
```

Patch do not correctly handle symlinks to dynamic libraries used by compiler yet.