### PR TITLE
Make vsenv, cross_file and native_file readonly builtin option

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -94,8 +94,9 @@ machine](#specifying-options-per-machine) section for details.
 | werror                                 | false         | Treat warnings as errors                                       | no             | yes               |
 | wrap_mode {default, nofallback,<br>nodownload, forcefallback, nopromote} | default | Wrap mode to use                 | no             | no                |
 | force_fallback_for                     | []            | Force fallback for those dependencies                          | no             | no                |
-| cross_file      | []            | File describing cross compilation environment                                         | no             | no |
-| native_file      | []            | File containing overrides for native compilation environment                         | no             | no |
+| cross_file      | []            | File describing cross compilation environment                                        | no             | no |
+| native_file     | []            | File containing overrides for native compilation environment                         | no             | no |
+| vsenv           | false         | Activate Visual Studio environment                                                   | no             | no |
 
 <a name="build-type-options"></a> For setting optimization levels and
 toggling debug, you can either set the `buildtype` option, or you can

--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -94,6 +94,8 @@ machine](#specifying-options-per-machine) section for details.
 | werror                                 | false         | Treat warnings as errors                                       | no             | yes               |
 | wrap_mode {default, nofallback,<br>nodownload, forcefallback, nopromote} | default | Wrap mode to use                 | no             | no                |
 | force_fallback_for                     | []            | Force fallback for those dependencies                          | no             | no                |
+| cross_file      | []            | File describing cross compilation environment                                         | no             | no |
+| native_file      | []            | File containing overrides for native compilation environment                         | no             | no |
 
 <a name="build-type-options"></a> For setting optimization levels and
 toggling debug, you can either set the `buildtype` option, or you can

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -574,7 +574,7 @@ class NinjaBackend(backends.Backend):
 
     def generate(self):
         ninja = environment.detect_ninja_command_and_version(log=True)
-        if self.build.need_vsenv:
+        if self.environment.coredata.get_option(OptionKey('vsenv')):
             builddir = Path(self.environment.get_build_dir())
             try:
                 # For prettier printing, reduce to a relative path. If

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -272,7 +272,6 @@ class Build:
             environment.is_cross_build(), {}, {})
         self.devenv: T.List[EnvironmentVariables] = []
         self.modules: T.List[str] = []
-        self.need_vsenv = False
 
     def get_build_targets(self):
         build_targets = OrderedDict()

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -25,7 +25,7 @@ import re
 import textwrap
 import typing as T
 
-
+from . import coredata
 from . import environment
 from . import dependencies
 from . import mlog
@@ -234,6 +234,7 @@ class Build:
     """
 
     def __init__(self, environment: environment.Environment):
+        self.version = coredata.version
         self.project_name = 'name of master project'
         self.project_version = None
         self.environment = environment
@@ -2907,11 +2908,20 @@ def get_sources_string_names(sources, backend):
 def load(build_dir: str) -> Build:
     filename = os.path.join(build_dir, 'meson-private', 'build.dat')
     try:
-        return pickle_load(filename, 'Build data', Build)
+        b = pickle_load(filename, 'Build data', Build)
+        # We excluded coredata when saving Build object, load it separately
+        b.environment.coredata = coredata.load(build_dir)
+        return b
     except FileNotFoundError:
         raise MesonException(f'No such build data file as {filename!r}.')
 
 
 def save(obj: Build, filename: str) -> None:
-    with open(filename, 'wb') as f:
-        pickle.dump(obj, f)
+    # Exclude coredata because we pickle it separately already
+    cdata = obj.environment.coredata
+    obj.environment.coredata = None
+    try:
+        with open(filename, 'wb') as f:
+            pickle.dump(obj, f)
+    finally:
+        obj.environment.coredata = cdata

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1243,6 +1243,7 @@ BUILTIN_CORE_OPTIONS: 'MutableKeyedOptionDictType' = OrderedDict([
                                              readonly=True, action='append')),
     (OptionKey('cross_file'), BuiltinOption(UserArrayOption, 'File describing cross compilation environment', [],
                                             readonly=True, action='append')),
+    (OptionKey('vsenv'), BuiltinOption(UserBooleanOption, 'Activate Visual Studio environment', False, readonly=True)),
 
     # Pkgconfig module
     (OptionKey('relocatable', module='pkgconfig'),

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -467,6 +467,13 @@ class Environment:
             self.scratch_dir = ''
             self.create_new_coredata(options)
 
+        # We want `meson setup --reconfigure --cross-file foo.txt` to work if
+        # the initial setup had the same foo.txt file. For that we need to
+        # resolve the full path again so we can check the value did not change.
+        if not self.first_invocation:
+            self.coredata.resolve_config_files(options, self.scratch_dir, "cross")
+            self.coredata.resolve_config_files(options, self.scratch_dir, "native")
+
         ## locally bind some unfrozen configuration
 
         # Stores machine infos, the only *three* machine one because we have a

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1349,10 +1349,6 @@ class Interpreter(InterpreterBase, HoldableObject):
         # Add automatic section with all user defined options
         if self.user_defined_options:
             values = collections.OrderedDict()
-            if self.user_defined_options.cross_file:
-                values['Cross files'] = self.user_defined_options.cross_file
-            if self.user_defined_options.native_file:
-                values['Native files'] = self.user_defined_options.native_file
             sorted_options = sorted(self.user_defined_options.cmd_line_options.items())
             values.update({str(k): v for k, v in sorted_options})
             if values:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1256,9 +1256,9 @@ class Interpreter(InterpreterBase, HoldableObject):
             # vs backend version we need. But after setting default_options in case
             # the project sets vs backend by default.
             backend = self.coredata.get_option(OptionKey('backend'))
-            force_vsenv = self.user_defined_options.vsenv or backend.startswith('vs')
-            if mesonlib.setup_vsenv(force_vsenv):
-                self.build.need_vsenv = True
+            vsenv = self.coredata.get_option(OptionKey('vsenv'))
+            force_vsenv = vsenv or backend.startswith('vs')
+            mesonlib.setup_vsenv(force_vsenv)
 
         self.add_languages(proj_langs, True, MachineChoice.HOST)
         self.add_languages(proj_langs, False, MachineChoice.BUILD)

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -333,8 +333,8 @@ def run(options: 'argparse.Namespace') -> int:
     if options.targets and options.clean:
         raise MesonException('`TARGET` and `--clean` can\'t be used simultaneously')
 
-    cdata = coredata.load(options.wd)
     b = build.load(options.wd)
+    cdata = b.environment.coredata
     vsenv_active = setup_vsenv(b.need_vsenv)
     if vsenv_active:
         mlog.log(mlog.green('INFO:'), 'automatically activated MSVC compiler environment')

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -26,7 +26,6 @@ from pathlib import Path
 
 from . import mlog
 from . import mesonlib
-from . import coredata
 from .mesonlib import MesonException, RealPathAction, join_args, setup_vsenv
 from mesonbuild.environment import detect_ninja
 from mesonbuild.coredata import UserArrayOption
@@ -335,8 +334,8 @@ def run(options: 'argparse.Namespace') -> int:
 
     b = build.load(options.wd)
     cdata = b.environment.coredata
-    vsenv_active = setup_vsenv(b.need_vsenv)
-    if vsenv_active:
+    need_vsenv = T.cast('bool', cdata.get_option(mesonlib.OptionKey('vsenv')))
+    if setup_vsenv(need_vsenv):
         mlog.log(mlog.green('INFO:'), 'automatically activated MSVC compiler environment')
 
     cmd = []    # type: T.List[str]

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -72,7 +72,7 @@ class Conf:
         if os.path.isdir(os.path.join(self.build_dir, 'meson-private')):
             self.build = build.load(self.build_dir)
             self.source_dir = self.build.environment.get_source_dir()
-            self.coredata = coredata.load(self.build_dir)
+            self.coredata = self.build.environment.coredata
             self.default_values_only = False
         elif os.path.isfile(os.path.join(self.build_dir, environment.build_filename)):
             # Make sure that log entries in other parts of meson don't interfere with the JSON output

--- a/mesonbuild/mdevenv.py
+++ b/mesonbuild/mdevenv.py
@@ -159,7 +159,8 @@ def run(options: argparse.Namespace) -> int:
     b = build.load(options.builddir)
     workdir = options.workdir or options.builddir
 
-    setup_vsenv(b.need_vsenv)  # Call it before get_env to get vsenv vars as well
+    need_vsenv = T.cast('bool', b.environment.coredata.get_option(OptionKey('vsenv')))
+    setup_vsenv(need_vsenv) # Call it before get_env to get vsenv vars as well
     dump_fmt = options.dump_format if options.dump else None
     devenv, varnames = get_env(b, dump_fmt)
     if options.dump:

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -24,11 +24,13 @@ import subprocess
 import tarfile
 import tempfile
 import hashlib
+import typing as T
+
 from glob import glob
 from pathlib import Path
 from mesonbuild.environment import detect_ninja
 from mesonbuild.mesonlib import (MesonException, RealPathAction, quiet_git,
-                                 windows_proof_rmtree, setup_vsenv)
+                                 windows_proof_rmtree, setup_vsenv, OptionKey)
 from mesonbuild.msetup import add_arguments as msetup_argparse
 from mesonbuild.wrap import wrap
 from mesonbuild import mlog, build, coredata
@@ -284,7 +286,7 @@ def create_cmdline_args(bld_root):
     args = parser.parse_args([])
     coredata.parse_cmd_line_options(args)
     coredata.read_cmd_line_file(bld_root, args)
-    args.cmd_line_options.pop(coredata.OptionKey('backend'), '')
+    args.cmd_line_options.pop(OptionKey('backend'), '')
     return shlex.split(coredata.format_cmd_line_options(args))
 
 def determine_archives_to_generate(options):
@@ -302,7 +304,8 @@ def run(options):
     if not buildfile.is_file():
         raise MesonException(f'Directory {options.wd!r} does not seem to be a Meson build directory.')
     b = build.load(options.wd)
-    setup_vsenv(b.need_vsenv)
+    need_vsenv = T.cast('bool', b.environment.coredata.get_option(OptionKey('vsenv')))
+    setup_vsenv(need_vsenv)
     # This import must be load delayed, otherwise it will get the default
     # value of None.
     from mesonbuild.mesonlib import get_meson_command

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -187,7 +187,8 @@ def run(options: 'argparse.Namespace') -> int:
             raise SystemExit
 
         b = build.load(options.builddir)
-        vsenv_active = mesonlib.setup_vsenv(b.need_vsenv)
+        need_vsenv = T.cast('bool', b.environment.coredata.get_option(mesonlib.OptionKey('vsenv')))
+        vsenv_active = mesonlib.setup_vsenv(need_vsenv)
         if vsenv_active:
             mlog.log(mlog.green('INFO:'), 'automatically activated MSVC compiler environment')
 

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -27,7 +27,8 @@ import typing as T
 from . import build
 from . import environment
 from .backend.backends import InstallData
-from .mesonlib import MesonException, Popen_safe, RealPathAction, is_windows, setup_vsenv, pickle_load, is_osx
+from .mesonlib import (MesonException, Popen_safe, RealPathAction, is_windows,
+                       setup_vsenv, pickle_load, is_osx, OptionKey)
 from .scripts import depfixer, destdir_join
 from .scripts.meson_exe import run_exe
 try:
@@ -757,7 +758,8 @@ def run(opts: 'ArgumentType') -> int:
         sys.exit('Install data not found. Run this command in build directory root.')
     if not opts.no_rebuild:
         b = build.load(opts.wd)
-        setup_vsenv(b.need_vsenv)
+        need_vsenv = T.cast('bool', b.environment.coredata.get_option(OptionKey('vsenv')))
+        setup_vsenv(need_vsenv)
         if not rebuild_all(opts.wd):
             sys.exit(-1)
     os.chdir(opts.wd)

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -44,10 +44,6 @@ syntax: glob
 
 def add_arguments(parser: argparse.ArgumentParser) -> None:
     coredata.register_builtin_arguments(parser)
-    parser.add_argument('--vsenv', action='store_true',
-                        help='Setup Visual Studio environment even when other compilers are found, ' +
-                             'abort if Visual Studio is not found. This option has no effect on other ' +
-                             'platforms than Windows. Defaults to True when using "vs" backend.')
     parser.add_argument('-v', '--version', action='version',
                         version=coredata.version)
     parser.add_argument('--profile-self', action='store_true', dest='profile',

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -44,14 +44,6 @@ syntax: glob
 
 def add_arguments(parser: argparse.ArgumentParser) -> None:
     coredata.register_builtin_arguments(parser)
-    parser.add_argument('--native-file',
-                        default=[],
-                        action='append',
-                        help='File containing overrides for native compilation environment.')
-    parser.add_argument('--cross-file',
-                        default=[],
-                        action='append',
-                        help='File describing cross compilation environment.')
     parser.add_argument('--vsenv', action='store_true',
                         help='Setup Visual Studio environment even when other compilers are found, ' +
                              'abort if Visual Studio is not found. This option has no effect on other ' +
@@ -253,10 +245,6 @@ class MesonApp:
             self._finalize_devenv(b, intr)
             build.save(b, dumpfile)
             if env.first_invocation:
-                # Use path resolved by coredata because they could have been
-                # read from a pipe and wrote into a private file.
-                self.options.cross_file = env.coredata.cross_files
-                self.options.native_file = env.coredata.config_files
                 coredata.write_cmd_line_file(self.build_dir, self.options)
             else:
                 coredata.update_cmd_line_file(self.build_dir, self.options)

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -46,7 +46,8 @@ from . import mlog
 from .coredata import major_versions_differ, MesonVersionMismatchException
 from .coredata import version as coredata_version
 from .mesonlib import (MesonException, OrderedSet, RealPathAction,
-                       get_wine_shortpath, join_args, split_args, setup_vsenv)
+                       get_wine_shortpath, join_args, split_args, setup_vsenv,
+                       OptionKey)
 from .mintro import get_infodir, load_info_file
 from .programs import ExternalProgram
 from .backend.backends import TestProtocol, TestSerialisation
@@ -2102,7 +2103,8 @@ def run(options: argparse.Namespace) -> int:
             return 1
 
     b = build.load(options.wd)
-    setup_vsenv(b.need_vsenv)
+    need_vsenv = T.cast('bool', b.environment.coredata.get_option(OptionKey('vsenv')))
+    setup_vsenv(need_vsenv)
 
     with TestHarness(options) as th:
         try:

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -2126,6 +2126,8 @@ _BUILTIN_NAMES = {
     'force_fallback_for',
     'pkg_config_path',
     'cmake_prefix_path',
+    'cross_file',
+    'native_file',
 }
 
 

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -2128,6 +2128,7 @@ _BUILTIN_NAMES = {
     'cmake_prefix_path',
     'cross_file',
     'native_file',
+    'vsenv',
 }
 
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -148,8 +148,6 @@ class FakeCompilerOptions:
 # TODO: use a typing.Protocol here
 def get_fake_options(prefix: str = '') -> argparse.Namespace:
     opts = argparse.Namespace()
-    opts.native_file = []
-    opts.cross_file = None
     opts.wrap_mode = None
     opts.prefix = prefix
     opts.cmd_line_options = {}

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -457,7 +457,7 @@ class InternalTests(unittest.TestCase):
         configfile.flush()
         configfile.close()
         opts = get_fake_options()
-        opts.cross_file = (configfilename,)
+        opts.cmd_line_options[OptionKey('cross_file')] = configfilename
         env = get_fake_env(opts=opts)
         detected_value = env.need_exe_wrapper()
         os.unlink(configfilename)
@@ -472,7 +472,7 @@ class InternalTests(unittest.TestCase):
         config.write(configfile)
         configfile.close()
         opts = get_fake_options()
-        opts.cross_file = (configfilename,)
+        opts.cmd_line_options[OptionKey('cross_file')] = configfilename
         env = get_fake_env(opts=opts)
         forced_value = env.need_exe_wrapper()
         os.unlink(configfilename)


### PR DESCRIPTION
- Make --vsenv a readonly builtin option
    
We need to remember its value when reconfiguring, but the Build object
is not reused, only coredata is.

- Make cross_file and native_file read only builtin option

- coredata: Do not pickle it twice    

Exclude coredata from build.dat because it gets pickled separately
already.

- Allow --reconfigure of empty builddir
    
This allows to run setup command regardless whether the builddir has
been configured or not previously. This is useful for example with
scripts that always repeat all options.
  meson setup builddir --reconfigure -Dfoo=bar

