### PR TITLE
remove dead code

### DIFF
--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -94,7 +94,6 @@ __all__ = [
     'generate_list',
     'get_compiler_for_source',
     'get_filenames_templates_dict',
-    'get_library_dirs',
     'get_variable_regex',
     'get_wine_shortpath',
     'git',
@@ -984,52 +983,6 @@ def default_libexecdir() -> str:
 
 def default_prefix() -> str:
     return 'c:/' if is_windows() else '/usr/local'
-
-
-def get_library_dirs() -> T.List[str]:
-    if is_windows():
-        return ['C:/mingw/lib'] # TODO: get programmatically
-    if is_osx():
-        return ['/usr/lib'] # TODO: get programmatically
-    # The following is probably Debian/Ubuntu specific.
-    # /usr/local/lib is first because it contains stuff
-    # installed by the sysadmin and is probably more up-to-date
-    # than /usr/lib. If you feel that this search order is
-    # problematic, please raise the issue on the mailing list.
-    unixdirs = ['/usr/local/lib', '/usr/lib', '/lib']
-
-    if is_freebsd():
-        return unixdirs
-    # FIXME: this needs to be further genericized for aarch64 etc.
-    machine = platform.machine()
-    if machine in {'i386', 'i486', 'i586', 'i686'}:
-        plat = 'i386'
-    elif machine.startswith('arm'):
-        plat = 'arm'
-    else:
-        plat = ''
-
-    # Solaris puts 32-bit libraries in the main /lib & /usr/lib directories
-    # and 64-bit libraries in platform specific subdirectories.
-    if is_sunos():
-        if machine == 'i86pc':
-            plat = 'amd64'
-        elif machine.startswith('sun4'):
-            plat = 'sparcv9'
-
-    usr_platdir = Path('/usr/lib/') / plat
-    if usr_platdir.is_dir():
-        unixdirs += [str(x) for x in (usr_platdir).iterdir() if x.is_dir()]
-    if os.path.exists('/usr/lib64'):
-        unixdirs.append('/usr/lib64')
-
-    lib_platdir = Path('/lib/') / plat
-    if lib_platdir.is_dir():
-        unixdirs += [str(x) for x in (lib_platdir).iterdir() if x.is_dir()]
-    if os.path.exists('/lib64'):
-        unixdirs.append('/lib64')
-
-    return unixdirs
 
 
 def has_path_sep(name: str, sep: str = '/\\') -> bool:


### PR DESCRIPTION
We shouldn't be hardcoding library dirs anyway. And we usually get this from the compiler.

This function has been unused since its users were moved to use the compiler method, in the following commits:
- a1a4f66e6d915c1f6aae2ead02cf5631b10c76f1
- a3856be1d50eaefe32fee5d3347d55d934d15b50
- 08224dafcba1b694fb624553e7d84deb565aae22