### PR TITLE
tests: avoid unexpected failure when cmake is not installed

### DIFF
--- a/test cases/failing/111 empty fallback/test.json
+++ b/test cases/failing/111 empty fallback/test.json
@@ -1,7 +1,8 @@
 {
     "stdout": [
         {
-            "line": "test cases/failing/111 empty fallback/meson.build:6:0: ERROR: Dependency \"foo\" not found, tried pkgconfig and cmake"
+            "match": "re",
+            "line": "test cases/failing/111 empty fallback/meson.build:6:0: ERROR: Dependency \"foo\" not found.*"
         }
     ]
 }


### PR DESCRIPTION
This test case checks stdout and demands a `dependency()` lookup fail. The resulting error message can be different depending on whether cmake is installed, or not. For cmake-specific tests we would simply skip the test if cmake is not installed, but here we can just fine-tune the pattern matching we use to determine if the test failed "correctly".

Fixes #11320