### PR TITLE
Revert "debug cygwin CI"

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -289,7 +289,6 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
         trial = platform.processor().lower()
     else:
         trial = platform.machine().lower()
-    mlog.debug(f'detecting CPU family based on trial={trial!r}')
     if trial.startswith('i') and trial.endswith('86'):
         trial = 'x86'
     elif trial == 'bepc':


### PR DESCRIPTION
This reverts commit 79d7891746a7864a1407d48eac8a753b225ec6c3.

This debug print probably should not have ended up live. Moreover, the function it debugs is, surprisingly, called rather often. Adding I/O to it causes it to begin to noticeably lag, on the scale of adding actual *minutes* to a setup run.

Fixes #11322