### PR TITLE
mtest: do not warn when the TAP stream version is 12

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1059,7 +1059,7 @@ class TestRunTAP(TestRun):
     async def parse(self, harness: 'TestHarness', lines: T.AsyncIterator[str]) -> None:
         res = None
         warnings = [] # type: T.List[TAPParser.UnknownLine]
-        version: T.Optional[int] = None
+        version = 12
 
         async for i in TAPParser().parse_async(lines):
             if isinstance(i, TAPParser.Version):
@@ -1078,9 +1078,6 @@ class TestRunTAP(TestRun):
                 self.additional_error += 'TAP parsing error: ' + i.message
                 res = TestResult.ERROR
 
-        if version is None:
-            self.warnings.append('Unknown TAP version. The first line MUST be `TAP version <int>`. Assuming version 12.')
-            version = 12
         if warnings:
             unknown = str(mlog.yellow('UNKNOWN'))
             width = len(str(max(i.lineno for i in warnings)))


### PR DESCRIPTION
Partial rollback of commit b7a5c384a1f1ba80c09904e7ef4f5160bdae3345. The rationale was based on a confusing wording of the TAP14 spec, which is under discussion for clarification / amendment.

TAP14 doesn't (shouldn't) really say that missing a version line is potentially an error. Rather, this is the correct way to denote TAP12, which a TAP14 harness may not understand or try to parse. The intention was never to suggest that harnesses "should" take exception to the missing version line on the grounds that one should really add a version line.

So, stop emitting an annoying warning for something that's valid usage. Meson understands TAP12 and that's okay.

However, we do need to keep the part of that commit which set the version to 12 if it was otherwise unspecified. But instead of distinguishing between None and a version, just default to 12.