### PR TITLE
introspect: avoid crashing when add_languages for an optional language fails

### DIFF
--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -422,7 +422,13 @@ def exception(e: Exception, prefix: T.Optional[AnsiDecorator] = None) -> None:
     if prefix:
         args.append(prefix)
     args.append(str(e))
-    log(*args)
+
+    restore = log_disable_stdout
+    if restore:
+        enable()
+    log(*args, is_error=True)
+    if restore:
+        disable()
 
 # Format a list for logging purposes as a string. It separates
 # all but the last item with commas, and the last with 'and'.


### PR DESCRIPTION
Because that is what the real interpreter does, too. It logs a failure and carries on.

Bonus: make `mlog.exception()` actually print errors.