### PR TITLE
remove /utf-8 option when /validate-charset- is present

### DIFF
--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -260,7 +260,9 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
                 continue
             # cl.exe does not allow specifying both, so remove /utf-8 that we
             # added automatically in the case the user overrides it manually.
-            elif i.startswith('/source-charset:') or i.startswith('/execution-charset:'):
+            elif (i.startswith('/source-charset:')
+                    or i.startswith('/execution-charset:')
+                    or i == '/validate-charset-'):
                 try:
                     result.remove('/utf-8')
                 except ValueError:


### PR DESCRIPTION
With VisualStudio, the `/validate-charset-` option conflicts with `/uft-8` option. This PR prevents a warning when `/validate-charset-` options is present. 