### PR TITLE
backends: fix source dir stripping from rpaths

### DIFF
--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1657,6 +1657,48 @@ class AllPlatformTests(BasePlatformTests):
             self.build()
             self.run_tests()
 
+    def test_prebuilt_shared_lib_rpath_same_prefix(self) -> None:
+        (cc, _, object_suffix, shared_suffix) = self.detect_prebuild_env()
+        orig_tdir = os.path.join(self.unit_test_dir, '17 prebuilt shared')
+
+        # Put the shared library in a location that shares a common prefix with
+        # the source directory:
+        #
+        #   .../
+        #       foo-lib/
+        #               libalexandria.so
+        #       foo/
+        #           meson.build
+        #           ...
+        #
+        # This allows us to check that the .../foo-lib/libalexandria.so path is
+        # preserved correctly when meson processes it.
+        with tempfile.TemporaryDirectory() as d:
+            libdir = os.path.join(d, 'foo-lib')
+            os.mkdir(libdir)
+
+            source = os.path.join(orig_tdir, 'alexandria.c')
+            objectfile = os.path.join(libdir, 'alexandria.' + object_suffix)
+            impfile = os.path.join(libdir, 'alexandria.lib')
+            if cc.get_argument_syntax() == 'msvc':
+                shlibfile = os.path.join(libdir, 'alexandria.' + shared_suffix)
+            elif is_cygwin():
+                shlibfile = os.path.join(libdir, 'cygalexandria.' + shared_suffix)
+            else:
+                shlibfile = os.path.join(libdir, 'libalexandria.' + shared_suffix)
+            # Ensure MSVC extra files end up in the directory that gets deleted
+            # at the end
+            with chdir(libdir):
+                self.build_shared_lib(cc, source, objectfile, shlibfile, impfile)
+
+            tdir = os.path.join(d, 'foo')
+            shutil.copytree(orig_tdir, tdir)
+
+            # Run the test
+            self.init(tdir, extra_args=[f'-Dsearch_dir={libdir}'])
+            self.build()
+            self.run_tests()
+
     def test_underscore_prefix_detection_list(self) -> None:
         '''
         Test the underscore detection hardcoded lookup list


### PR DESCRIPTION
Commit e88887be4a08 ("Only remove substring if it is part of string") removed the source dir from the rpath when the following check succeeds:
```python
if absdir.startswith(self.environment.get_source_dir()):
    rel_to_src = absdir[len(self.environment.get_source_dir()) + 1:]
````
For example, absdir '/myproject/foo' starts with source dir '/myproject', so we want to generate the relative path 'foo'.

This code doesn't work with absdir '/myproject-libs/foo' though, because we'll incorrectly turn it into a relative path 'libs/foo' after stripping away '/myproject-'.

Use os.path.commonpath() instead of str.startswith() so path components are correctly handled.

Cc: Niklas Claesson <niklas.claesson@cosylab.com>
Signed-off-by: Stefan Hajnoczi <stefanha@gmail.com>