### PR TITLE
default install_tag for python.install_sources() should be "python-runtime"

### DIFF
--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -611,7 +611,7 @@ class PythonInstallation(ExternalProgramHolder):
     )
     def install_sources_method(self, args: T.Tuple[T.List[T.Union[str, mesonlib.File]]],
                                kwargs: 'PyInstallKw') -> 'Data':
-        tag = kwargs['install_tag'] or 'runtime'
+        tag = kwargs['install_tag'] or 'python-runtime'
         pure = kwargs['pure'] if kwargs['pure'] is not None else self.pure
         install_dir = self._get_install_dir_impl(pure, kwargs['subdir'])
         return self.interpreter.install_data_impl(


### PR DESCRIPTION
The default parameter for python.install_sources(install_tag) is set to "runtime" but should be "python-runtime" according to the existing documentation.
- https://mesonbuild.com/Python-module.html#install_sources
- https://mesonbuild.com/Installing.html#installation-tags