### PR TITLE
build: use suffix when getting target id for exes

### DIFF
--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -58,13 +58,16 @@ Builds a default or a specified target of a configured Meson project.
 
 *(since 0.55.0)*
 
-`TARGET` has the following syntax `[PATH/]NAME[:TYPE]`, where:
+`TARGET` has the following syntax `[PATH/]NAME.SUFFIX[:TYPE]`, where:
 - `NAME`: name of the target from `meson.build` (e.g. `foo` from `executable('foo', ...)`).
+- `SUFFIX`: name of the suffix of the target from `meson.build` (e.g. `exe` from `executable('foo', suffix: 'exe', ...)`).
 - `PATH`: path to the target relative to the root `meson.build` file. Note: relative path for a target specified in the root `meson.build` is `./`.
 - `TYPE`: type of the target. Can be one of the following: 'executable', 'static_library', 'shared_library', 'shared_module', 'custom', 'alias', 'run', 'jar'.
 
-`PATH` and/or `TYPE` can be omitted if the resulting `TARGET` can be
+`PATH`, `SUFFIX`, and `TYPE` can all be omitted if the resulting `TARGET` can be
 used to uniquely identify the target in `meson.build`.
+
+Note that `SUFFIX` did not exist prior to 1.3.0.
 
 #### Backend specific arguments
 

--- a/docs/markdown/snippets/executable-suffixes.md
+++ b/docs/markdown/snippets/executable-suffixes.md
@@ -1,0 +1,14 @@
+## Target names for executables now take into account suffixes.
+
+In previous versions of meson, a `meson.build` file like this:
+
+```
+exectuable('foo', 'main.c')
+exectuable('foo', 'main.c', name_suffix: 'bar')
+```
+
+would result in a configure error because meson internally used
+the same id for both executables. This build file is now allowed
+since meson takes into account the `bar` suffix when generating the
+second executable. This allows for executables with the same basename
+but different suffixes to be built in the same subdirectory.

--- a/docs/markdown/snippets/meson_compile_suffixes.md
+++ b/docs/markdown/snippets/meson_compile_suffixes.md
@@ -1,0 +1,7 @@
+## Meson compile command now accepts suffixes for TARGET
+
+The syntax for specifying a target for meson compile is now
+`[PATH_TO_TARGET/]TARGET_NAME.TARGET_SUFFIX[:TARGET_TYPE]` where
+`TARGET_SUFFIX` is the suffix argument given in the build target
+within meson.build. It is optional and `TARGET_NAME` remains
+sufficient if it uniquely resolves to one single target.

--- a/docs/yaml/functions/executable.yaml
+++ b/docs/yaml/functions/executable.yaml
@@ -10,6 +10,9 @@ description: |
 
   The returned object also has methods that are documented in [[@exe]].
 
+  *Since 1.3.0* executable names can be the same across multiple targets as
+  long as they each have a different `name_suffix`.
+
 warnings:
   - The `link_language` kwarg was broken until 0.55.0
 

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -316,6 +316,20 @@ class Backend:
     def get_target_filename_abs(self, target: T.Union[build.Target, build.CustomTargetIndex]) -> str:
         return os.path.join(self.environment.get_build_dir(), self.get_target_filename(target))
 
+    def get_target_debug_filename(self, target: build.BuildTarget) -> T.Optional[str]:
+        assert isinstance(target, build.BuildTarget), target
+        if target.get_debug_filename():
+            debug_filename = target.get_debug_filename()
+            return os.path.join(self.get_target_dir(target), debug_filename)
+        else:
+            return None
+
+    def get_target_debug_filename_abs(self, target: build.BuildTarget) -> T.Optional[str]:
+        assert isinstance(target, build.BuildTarget), target
+        if not target.get_debug_filename():
+            return None
+        return os.path.join(self.environment.get_build_dir(), self.get_target_debug_filename(target))
+
     def get_source_dir_include_args(self, target: build.BuildTarget, compiler: 'Compiler', *, absolute_path: bool = False) -> T.List[str]:
         curdir = target.get_subdir()
         if absolute_path:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2796,16 +2796,18 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         # this is actually doable, please send patches.
 
         if target.has_pch():
-            tfilename = self.get_target_filename_abs(target)
+            tfilename = self.get_target_debug_filename_abs(target)
+            if not tfilename:
+                tfilename = self.get_target_filename_abs(target)
             return compiler.get_compile_debugfile_args(tfilename, pch=True)
         else:
             return compiler.get_compile_debugfile_args(objfile, pch=False)
 
-    def get_link_debugfile_name(self, linker, target, outname) -> T.Optional[str]:
-        return linker.get_link_debugfile_name(outname)
+    def get_link_debugfile_name(self, linker, target) -> T.Optional[str]:
+        return linker.get_link_debugfile_name(self.get_target_debug_filename(target))
 
-    def get_link_debugfile_args(self, linker, target, outname):
-        return linker.get_link_debugfile_args(outname)
+    def get_link_debugfile_args(self, linker, target):
+        return linker.get_link_debugfile_args(self.get_target_debug_filename(target))
 
     def generate_llvm_ir_compile(self, target, src):
         base_proxy = target.get_options()
@@ -3437,8 +3439,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         commands += linker.get_buildtype_linker_args(target.get_option(OptionKey('buildtype')))
         # Add /DEBUG and the pdb filename when using MSVC
         if target.get_option(OptionKey('debug')):
-            commands += self.get_link_debugfile_args(linker, target, outname)
-            debugfile = self.get_link_debugfile_name(linker, target, outname)
+            commands += self.get_link_debugfile_args(linker, target)
+            debugfile = self.get_link_debugfile_name(linker, target)
             if debugfile is not None:
                 implicit_outs += [debugfile]
         # Add link args specific to this BuildTarget type, such as soname args,

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -737,6 +737,8 @@ class BuildTarget(Target):
         self.name_prefix_set = False
         self.name_suffix_set = False
         self.filename = 'no_name'
+        # The debugging information file this target will generate
+        self.debug_filename = None
         # The list of all files outputted by this target. Useful in cases such
         # as Vala which generates .vapi and .h besides the compiled output.
         self.outputs = [self.filename]
@@ -1261,6 +1263,14 @@ class BuildTarget(Target):
 
     def get_filename(self) -> str:
         return self.filename
+
+    def get_debug_filename(self) -> T.Optional[str]:
+        """
+        The name of debuginfo file that will be created by the compiler
+
+        Returns None if the build won't create any debuginfo file
+        """
+        return self.debug_filename
 
     def get_outputs(self) -> T.List[str]:
         return self.outputs

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -634,8 +634,11 @@ class Target(HoldableObject, metaclass=abc.ABCMeta):
         return my_id
 
     def get_id(self) -> str:
+        name = self.name
+        if getattr(self, 'name_suffix_set', False):
+            name += '.' + self.suffix
         return self.construct_id_from_path(
-            self.subdir, self.name, self.type_suffix())
+            self.subdir, name, self.type_suffix())
 
     def process_kwargs_base(self, kwargs: T.Dict[str, T.Any]) -> None:
         if 'build_by_default' in kwargs:
@@ -1992,7 +1995,14 @@ class Executable(BuildTarget):
             and self.environment.coredata.get_option(OptionKey("debug"))
         )
         if create_debug_file:
-            self.debug_filename = self.name + '.pdb'
+            # If the target is has a standard exe extension (i.e. 'foo.exe'),
+            # then the pdb name simply becomes 'foo.pdb'. If the extension is
+            # something exotic, then include that in the name for uniqueness
+            # reasons (e.g. 'foo_com.pdb').
+            name = self.name
+            if getattr(self, 'suffix', 'exe') != 'exe':
+                name += '_' + self.suffix
+            self.debug_filename = name + '.pdb'
 
     def process_kwargs(self, kwargs):
         super().process_kwargs(kwargs)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3181,8 +3181,12 @@ class Interpreter(InterpreterBase, HoldableObject):
         # To permit an executable and a shared library to have the
         # same name, such as "foo.exe" and "libfoo.a".
         idname = tobj.get_id()
-        if idname in self.build.targets:
-            raise InvalidCode(f'Tried to create target "{name}", but a target of that name already exists.')
+        for t in self.build.targets.values():
+            if t.get_id() == idname:
+                raise InvalidCode(f'Tried to create target "{name}", but a target of that name already exists.')
+            if isinstance(tobj, build.Executable) and isinstance(t, build.Executable) and t.name == tobj.name:
+                FeatureNew.single_use('multiple executables with the same name but different suffixes',
+                                      '1.3.0', self.subproject, location=self.current_node)
 
         if isinstance(tobj, build.BuildTarget):
             self.add_languages(tobj.missing_languages, True, tobj.for_machine)

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -1272,8 +1272,7 @@ class VisualStudioLikeLinkerMixin(DynamicLinkerBase):
         return self._apply_prefix('/DLL')
 
     def get_debugfile_name(self, targetfile: str) -> str:
-        basename = targetfile.rsplit('.', maxsplit=1)[0]
-        return basename + '.pdb'
+        return targetfile
 
     def get_debugfile_args(self, targetfile: str) -> T.List[str]:
         return self._apply_prefix(['/DEBUG', '/PDB:' + self.get_debugfile_name(targetfile)])

--- a/test cases/unit/119 executable suffix/main.c
+++ b/test cases/unit/119 executable suffix/main.c
@@ -1,0 +1,1 @@
+int main(void) { return 0; }

--- a/test cases/unit/119 executable suffix/meson.build
+++ b/test cases/unit/119 executable suffix/meson.build
@@ -1,0 +1,3 @@
+project('exectuable suffix', 'c')
+foo = executable('foo', 'main.c')
+foo_bin = executable('foo', 'main.c', name_suffix: 'bin')

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -2049,6 +2049,15 @@ class AllPlatformTests(BasePlatformTests):
         self.assertPathExists(exe2)
         self.assertNotEqual(exe1, exe2)
 
+        # Wipe and run the compile command against the target names
+        self.init(testdir, extra_args=['--wipe'])
+        self._run([*self.meson_command, 'compile', '-C', self.builddir, './foo'])
+        self._run([*self.meson_command, 'compile', '-C', self.builddir, './foo.bin'])
+        self.assertPathExists(exe1)
+        self.assertPathExists(exe2)
+        self.assertNotEqual(exe1, exe2)
+
+
     def opt_has(self, name, value):
         res = self.introspect('--buildoptions')
         found = False

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -2039,6 +2039,16 @@ class AllPlatformTests(BasePlatformTests):
         original = get_opt()
         self.assertDictEqual(original, expected)
 
+    def test_executable_names(self):
+        testdir = os.path.join(self.unit_test_dir, '119 executable suffix')
+        self.init(testdir)
+        self.build()
+        exe1 = os.path.join(self.builddir, 'foo' + exe_suffix)
+        exe2 = os.path.join(self.builddir, 'foo.bin')
+        self.assertPathExists(exe1)
+        self.assertPathExists(exe2)
+        self.assertNotEqual(exe1, exe2)
+
     def opt_has(self, name, value):
         res = self.introspect('--buildoptions')
         found = False


### PR DESCRIPTION
The type suffix is used when determining the id of a target. This is important since having multiple targets with the same id isn't allowed. Because the type suffix is unconditionally `@exe`, this made it impossible to have targets of the same name but with different suffixes in the same directory (i.e. foo and foo.bin). An easy way to fix this is to simply alter the type suffix if a name_suffix kwarg is passed in executable. Basically, just change it to @ + suffix instead of `@exe`. If no name_suffix is available, then leave it as `@exe` like before.

Not sure if this needs to be documented somewhere. I didn't attempt to change how libraries worked since that seemed a lot more obscure to me, but one could do something similar.