### PR TITLE
Avoid replacing symlinks when installing with --only-changed

### DIFF
--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -437,6 +437,10 @@ class Installer:
         if os.path.exists(link):
             if not os.path.islink(link):
                 raise MesonException(f'Destination {link!r} already exists and is not a symlink')
+            elif self.options.only_changed and os.readlink(link) == target:
+                append_to_log(self.lf, f'# Preserving old symlink {link}\n')
+                self.preserved_file_count += 1
+                return False
             self.remove(link)
         if not self.printed_symlink_error:
             self.log(f'Installing symlink pointing to {target} to {link}')


### PR DESCRIPTION
We are using install --only-changed while other code is concurrently traversing an unchanged part of the tree (a python import), but even though this should be fine it sometimes fails as an unchanged symlink can disappear. To avoid, check if the symlink actually needs to be changed, otherwise leave it as is.