### PR TITLE
vs2010backend: Implement vcxproj filter tree generation

### DIFF
--- a/docs/markdown/snippets/visual_studio_filter_generation.md
+++ b/docs/markdown/snippets/visual_studio_filter_generation.md
@@ -1,0 +1,7 @@
+## Visual Studio VCXProj Filter Generation
+
+Meson will now generate .vcxproj.filter files that mirror the directory
+structure of the project when `--layout mirror` is used (default).
+
+This makes working with large Meson projects that are organized by folder
+in Visual Studio much easier.

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -894,6 +894,7 @@ class Vs2010Backend(backends.Backend):
 
         sources, headers, objects, languages = self.split_sources(target.sources)
         down = self.target_to_build_root(target)
+
         def add_element(type_name, elements):
             for i in elements:
                 path = i.fname.replace('/', '\\')


### PR DESCRIPTION
Adds a vcxproj filter generator that mirrors the directory structure.
This will only be generated if the "mirror" layout is set.

This is useful as Visual Studio doesn't support showing a folder tree and using a solution at the same time.
Many projects organize themselves by folder structure.

This was requested by my friend who was finding using Meson + Visual Studio IDE impossible to work with due to there being thousands of files dumped into the project root.

Other build systems such as Premake also offer this functionality, so it would be nice to at least have feature parity here.