### PR TITLE
test cases/vala: Fix clang error during int to pointer coercion

### DIFF
--- a/test cases/vala/5 target glib/GLib.Thread.vala
+++ b/test cases/vala/5 target glib/GLib.Thread.vala
@@ -1,4 +1,4 @@
-extern int get_ret_code ();
+extern void * get_ret_code ();
 
 public class MyThread : Object {
     public int x_times { get; private set; }

--- a/test cases/vala/5 target glib/retcode.c
+++ b/test cases/vala/5 target glib/retcode.c
@@ -1,5 +1,5 @@
-int
+void *
 get_ret_code (void)
 {
-  return 42;
+  return (void *) (int) 42;
 }


### PR DESCRIPTION
```
clang [...] -c valaprog.p/GLib.Thread.c
../test cases/vala/5 target glib/GLib.Thread.vala:17:17: error: incompatible integer to pointer conversion passing 'gint' (aka 'int') to parameter of type 'gpointer' (aka 'void *') [-Wint-conversion]
        g_thread_exit (get_ret_code ());
                       ^~~~~~~~~~~~~~~
/usr/include/glib-2.0/glib/gthread.h:158:66: note: passing argument to parameter 'retval' here
void            g_thread_exit                   (gpointer        retval);
                                                                 ^
1 error generated.
```

Already tested in the stable branch: 

https://github.com/mesonbuild/meson/actions/runs/4112669496/jobs/7097877168

https://github.com/mesonbuild/meson/actions/runs/4112669496/jobs/7097877356