### PR TITLE
Replace dashes in Java package names with underscores when generating native headers

### DIFF
--- a/mesonbuild/modules/java.py
+++ b/mesonbuild/modules/java.py
@@ -75,13 +75,16 @@ class JavaModule(NewExtensionModule):
         classes = T.cast('T.List[str]', kwargs.get('classes'))
         package = kwargs.get('package')
 
+        if package:
+            sanitized_package = package.replace("-", "_").replace(".", "_")
+
         headers: T.List[str] = []
         for clazz in classes:
-            underscore_clazz = clazz.replace(".", "_")
+            sanitized_clazz = clazz.replace(".", "_")
             if package:
-                headers.append(f'{package.replace(".", "_")}_{underscore_clazz}.h')
+                headers.append(f'{sanitized_package}_{sanitized_clazz}.h')
             else:
-                headers.append(f'{underscore_clazz}.h')
+                headers.append(f'{sanitized_clazz}.h')
 
         javac = self.__get_java_compiler(state)
 


### PR DESCRIPTION
This was causing a ninja issue where the native headers were always being generated because io.github.hse-project.hse_Hse.h was being expected, but io.github.hse_project.hse_Hse.h was actually generated.