### PR TITLE
minstall: handle elevation to root better

### DIFF
--- a/docs/markdown/Installing.md
+++ b/docs/markdown/Installing.md
@@ -110,7 +110,9 @@ targets as root. This results in various bad behaviors due to build outputs and
 ninja internal files being owned by root.
 
 Running `meson install` is preferred for several reasons. It can rebuild out of
-date targets and then re-invoke itself as root.
+date targets and then re-invoke itself as root. *(since 1.1.0)* Additionally,
+running `sudo meson install` will drop permissions and rebuild out of date
+targets as the original user, not as root.
 
 *(since 1.1.0)* Re-invoking as root will try to guess the user's preferred method for
 re-running commands as root. The order of precedence is: sudo, doas, pkexec

--- a/docs/markdown/Installing.md
+++ b/docs/markdown/Installing.md
@@ -102,6 +102,20 @@ Telling Meson to run this script at install time is a one-liner.
 The argument is the name of the script file relative to the current
 subdirectory.
 
+## Installing as the superuser
+
+When building as a non-root user, but installing to root-owned locations via
+e.g. `sudo ninja install`, ninja will attempt to rebuild any out of date
+targets as root. This results in various bad behaviors due to build outputs and
+ninja internal files being owned by root.
+
+Running `meson install` is preferred for several reasons. It can rebuild out of
+date targets and then re-invoke itself as root.
+
+*(since 1.1.0)* Re-invoking as root will try to guess the user's preferred method for
+re-running commands as root. The order of precedence is: sudo, doas, pkexec
+(polkit). An elevation tool can be forced by setting `$MESON_ROOT_CMD`.
+
 ## DESTDIR support
 
 Sometimes you need to install to a different directory than the

--- a/docs/markdown/snippets/meson_install_drop_privs.md
+++ b/docs/markdown/snippets/meson_install_drop_privs.md
@@ -1,0 +1,16 @@
+## `sudo meson install` now drops privileges when rebuilding targets
+
+It is common to install projects using sudo, which should not affect build
+outputs but simply install the results. Unfortunately, since the ninja backend
+updates a state file when run, it's not safe to run ninja as root at all.
+
+It has always been possible to carefully build with:
+
+```
+ninja && sudo meson install --no-rebuild
+```
+
+Meson now tries to be extra safe as a general solution. `sudo meson install`
+will attempt to rebuild, but has learned to run `ninja` as the original
+(pre-sudo or pre-doas) user, ensuring that build outputs are generated/compiled
+as non-root.

--- a/docs/markdown/snippets/meson_install_elevate.md
+++ b/docs/markdown/snippets/meson_install_elevate.md
@@ -1,0 +1,9 @@
+## `meson install` now supports user-preferred root elevation tools
+
+Previously, when installing a project, if any files could not be installed due
+to insufficient permissions the install process was automatically re-run using
+polkit. Now it prompts to ask whether that is desirable, and checks for
+CLI-based tools such as sudo or opendoas or `$MESON_ROOT_CMD`, first.
+
+Meson will no longer attempt privilege elevation at all, when not running
+interactively.

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -560,7 +560,7 @@ class Installer:
                 print('Installation failed due to insufficient permissions.')
                 print('Attempting to use polkit to gain elevated privileges...')
                 os.execlp('pkexec', 'pkexec', sys.executable, main_file, *sys.argv[1:],
-                          '-C', os.getcwd())
+                          '-C', os.getcwd(), '--no-rebuild')
             else:
                 raise
 

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -566,10 +566,13 @@ class Installer:
 
             if rootcmd is not None:
                 print('Installation failed due to insufficient permissions.')
-                ans = input(f'Attempt to use {rootcmd} to gain elevated privileges? [y/n] ')
-                if ans not in {'y', 'n'}:
+                for attempt in range(5):
+                    ans = input(f'Attempt to use {rootcmd} to gain elevated privileges? [y/n] ')
+                    if ans in {'y', 'n'}:
+                        break
+                else:
                     raise MesonException('Answer not one of [y/n]')
-                elif ans == 'y':
+                if ans == 'y':
                     os.execlp(rootcmd, rootcmd, sys.executable, main_file, *sys.argv[1:],
                               '-C', os.getcwd(), '--no-rebuild')
             raise


### PR DESCRIPTION
- minstall: when elevating to root, don't allow ninja to rerun
- minstall: rework root elevation prompt for extensibility and behavior
- minstall: drop privileges before running rebuild_all
- minstall: check 5 times for an answer to the elevation prompt
- minstall: add a timeout when waiting for user input for elevation

Now:
- `sudo ninja install` still does ninja as root, and messes things up before running the install target, but `sudo meson install` will actually drop privileges to run ninja, which is a very sensible approach and works, and that's ideally the only thing we want to do
- `meson install` won't ever run polkit or anything else, if there's no tty to interact with the user
- `meson install` has stopped automatically running polkit. Instead, it:
   - searches for 3 different tools, by default sudo which is what people actually want.
   - doesn't automatically run it, but instead asks you if you would like to do so
   - times out after 30 seconds of no response


Fixes #7345
Fixes #7809