### PR TITLE
Cython depfile support

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2234,10 +2234,14 @@ class NinjaBackend(backends.Backend):
         description = 'Compiling Cython source $in'
         command = compiler.get_exelist()
 
-        args = ['$ARGS', '$in']
+        depargs = compiler.get_dependency_gen_args('$out', '$DEPFILE')
+        depfile = '$out.dep' if depargs else None
+
+        args = depargs + ['$ARGS', '$in']
         args += NinjaCommandArg.list(compiler.get_output_args('$out'), Quoting.none)
         self.add_rule(NinjaRule(rule, command + args, [],
                                 description,
+                                depfile=depfile,
                                 extra='restat = 1'))
 
     def generate_rust_compile_rules(self, compiler):

--- a/mesonbuild/compilers/cython.py
+++ b/mesonbuild/compilers/cython.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import typing as T
 
 from .. import coredata
-from ..mesonlib import EnvironmentException, OptionKey
+from ..mesonlib import EnvironmentException, OptionKey, version_compare
 from .compilers import Compiler
 
 if T.TYPE_CHECKING:
@@ -39,6 +39,14 @@ class CythonCompiler(Compiler):
         # Cython doesn't have optimization levels itself, the underlying
         # compiler might though
         return []
+
+    def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
+        if version_compare(self.version, '>=0.29.33'):
+            return ['-M']
+        return []
+
+    def get_depfile_suffix(self) -> str:
+        return 'dep'
 
     def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
         code = 'print("hello world")'

--- a/test cases/cython/2 generated sources/meson.build
+++ b/test cases/cython/2 generated sources/meson.build
@@ -90,6 +90,11 @@ includestuff_ext = py3.extension_module(
   dependencies: stuff_pxi_dep
 )
 
+simpleinclude_ext = py3.extension_module(
+  'simpleinclude',
+  'simpleinclude.pyx',
+)
+
 subdir('libdir')
 
 test(

--- a/test cases/cython/2 generated sources/simpleinclude.pyx
+++ b/test cases/cython/2 generated sources/simpleinclude.pyx
@@ -1,0 +1,1 @@
+include "simplestuff.pxi"

--- a/test cases/cython/2 generated sources/simplestuff.pxi
+++ b/test cases/cython/2 generated sources/simplestuff.pxi
@@ -1,0 +1,2 @@
+def func2():
+    print("Hello world")


### PR DESCRIPTION
Cython 0.29.33 is now out, and supports emitting depfiles for incremental rebuild detection. When support is detected, emit this in the compiler rules.

@rgommers @lithomas1 @dnicolodi

Fixes #9049