### PR TITLE
respect the machine file binary overrides, even if it doesn't exist

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1484,7 +1484,9 @@ class Interpreter(InterpreterBase, HoldableObject):
             if not isinstance(p, str):
                 raise InterpreterException('Executable name must be a string')
             prog = ExternalProgram.from_bin_list(self.environment, for_machine, p)
-            if prog.found():
+            # if the machine file specified something, it may be a regular
+            # not-found program but we still want to return that
+            if not isinstance(prog, NonExistingExternalProgram):
                 return prog
         return None
 


### PR DESCRIPTION
If someone specifies a binary in a machine file, but the resulting prog.found() is false because it doesn't actually exist on disk, then the user was probably trying to disable finding that program. But find_program() currently doesn't distinguish between a machine file lookup returning a not-found program, and returning a dummy program because there's no entry at all.

Explicitly check for a dummy program, rather than checking if the program was found, before deciding whether to discard the lookup results and continue trying other program lookup methods.

/cc @thesamesam here you go