### PR TITLE
add required keyword to "has" functions: has_function has_type has_member has_members

### DIFF
--- a/docs/markdown/snippets/required_keyword_for_has_functions.md
+++ b/docs/markdown/snippets/required_keyword_for_has_functions.md
@@ -1,0 +1,19 @@
+## All compiler `has_*` methods support the `required` keyword
+
+Now instead of
+
+```meson
+assert(cc.has_function('some_function'))
+assert(cc.has_type('some_type'))
+assert(cc.has_member('struct some_type', 'x'))
+assert(cc.has_members('struct some_type', ['x', 'y']))
+```
+
+we can use
+
+```meson
+cc.has_function('some_function', required: true)
+cc.has_type('some_type', required: true)
+cc.has_member('struct some_type', 'x', required: true)
+cc.has_members('struct some_type', ['x', 'y'], required: true)
+```

--- a/docs/yaml/objects/compiler.yaml
+++ b/docs/yaml/objects/compiler.yaml
@@ -143,6 +143,19 @@ methods:
         When set to a [`feature`](Build-options.md#features) option, the feature
         will control if it is searched and whether to fail if not found.
 
+- name: _required
+  returns: void
+  description: You have found a bug if you can see this!
+  kwargs:
+    required:
+      type: bool | feature
+      default: false
+      since: 1.1.0
+      description:
+        When set to `true`, Meson will halt if the check fails.
+
+        When set to a [`feature`](Build-options.md#features) option, the feature
+        will control if it is searched and whether to fail if not found.
 
 # Star of the actual functions
 - name: version
@@ -196,7 +209,9 @@ methods:
 - name: has_member
   returns: bool
   description: Returns true if the type has the specified member.
-  kwargs_inherit: compiler._common
+  kwargs_inherit:
+    - compiler._common
+    - compiler._required
   posargs:
     typename:
       type: str
@@ -208,7 +223,9 @@ methods:
 - name: has_members
   returns: bool
   description: Returns `true` if the type has *all* the specified members.
-  kwargs_inherit: compiler._common
+  kwargs_inherit:
+    - compiler._common
+    - compiler._required
   posargs:
     typename:
       type: str
@@ -225,7 +242,9 @@ methods:
     Returns true if the given function is provided
     by the standard library or a library passed in with the `args` keyword.
 
-  kwargs_inherit: compiler._common
+  kwargs_inherit:
+    - compiler._common
+    - compiler._required
   posargs:
     funcname:
       type: str
@@ -234,7 +253,9 @@ methods:
 - name: has_type
   returns: bool
   description: Returns `true` if the specified token is a type.
-  kwargs_inherit: compiler._common
+  kwargs_inherit:
+    - compiler._common
+    - compiler._required
   posargs:
     typename:
       type: str
@@ -457,6 +478,8 @@ methods:
     argument:
       type: str
       description: The argument to check.
+  kwargs_inherit:
+    - compiler._required
 
 - name: has_multi_arguments
   since: 0.37.0
@@ -469,6 +492,8 @@ methods:
     name: arg
     type: str
     description: The arguments to check.
+  kwargs_inherit:
+    - compiler._required
 
 - name: get_supported_arguments
   returns: list[str]
@@ -515,6 +540,8 @@ methods:
     argument:
       type: str
       description: The argument to check.
+  kwargs_inherit:
+    - compiler._required
 
 - name: has_multi_link_arguments
   since: 0.46.0
@@ -527,6 +554,8 @@ methods:
     name: arg
     type: str
     description: The link arguments to check.
+  kwargs_inherit:
+    - compiler._required
 
 - name: get_supported_link_arguments
   returns: list[str]
@@ -556,10 +585,6 @@ methods:
     Given a list of strings, returns the first argument that passes the
     [[compiler.has_link_argument]] test or an empty array if none pass.
 
-
-
-
-
 - name: has_function_attribute
   returns: bool
   since: 0.48.0
@@ -573,6 +598,8 @@ methods:
     name:
       type: str
       description: The attribute name to check.
+  kwargs_inherit:
+    - compiler._required
 
 - name: get_supported_function_attributes
   returns: list[str]

--- a/docs/yaml/objects/compiler.yaml
+++ b/docs/yaml/objects/compiler.yaml
@@ -150,7 +150,7 @@ methods:
     required:
       type: bool | feature
       default: false
-      since: 1.1.0
+      since: 1.3.0
       description:
         When set to `true`, Meson will halt if the check fails.
 

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -171,7 +171,7 @@ _COMMON_KWS: T.List[KwargInfo] = [_ARGS_KW, _DEPENDENCIES_KW, _INCLUDE_DIRS_KW, 
 _COMPILES_KWS: T.List[KwargInfo] = [_NAME_KW, _ARGS_KW, _DEPENDENCIES_KW, _INCLUDE_DIRS_KW, _NO_BUILTIN_ARGS_KW]
 
 _HEADER_KWS: T.List[KwargInfo] = [REQUIRED_KW.evolve(since='0.50.0', default=False), *_COMMON_KWS]
-_HAS_REQUIRED_KW = REQUIRED_KW.evolve(since='1.1.0', default=False)
+_HAS_REQUIRED_KW = REQUIRED_KW.evolve(since='1.3.0', default=False)
 
 class CompilerHolder(ObjectHolder['Compiler']):
     preprocess_uid = itertools.count()

--- a/test cases/common/262 required keyword in has functions/meson.build
+++ b/test cases/common/262 required keyword in has functions/meson.build
@@ -1,0 +1,67 @@
+project('required keyword in has functions', 'c')
+
+cc = meson.get_compiler('c')
+opt = get_option('opt')
+
+cc.has_function('printf', prefix : '#include<stdio.h>', required : true)
+cc.has_type('time_t', prefix : '#include<time.h>', required : true)
+cc.has_member('struct tm', 'tm_sec', prefix : '#include<time.h>', required : true)
+cc.has_members('struct tm', ['tm_sec', 'tm_min'], prefix : '#include<time.h>', required : true)
+cc.has_header('time.h', required : true)
+cc.has_header_symbol('time.h', 'time', required : true)
+
+assert(not cc.has_function('printf', prefix : '#include<stdio.h>', required : opt))
+assert(not cc.has_type('time_t', prefix : '#include<time.h>', required : opt))
+assert(not cc.has_member('struct tm', 'tm_sec', prefix : '#include<time.h>', required : opt))
+assert(not cc.has_members('struct tm', ['tm_sec', 'tm_min'], prefix : '#include<time.h>', required : opt))
+assert(not cc.has_header('time.h', required : opt))
+assert(not cc.has_header_symbol('time.h', 'time', required : opt))
+
+# compiler.has_argument
+if cc.get_id() == 'msvc'
+  is_arg = '/O2'
+else
+  is_arg = '-O2'
+endif
+cc.has_argument(is_arg, required: true)
+assert(not cc.has_argument(is_arg, required: opt))
+
+# compiler.has_multi_arguments
+if cc.get_id() == 'gcc'
+  pre_arg = '-Wformat'
+  arg = '-Werror=format-security'
+  cc.has_multi_arguments([pre_arg, arg], required: true)
+  assert(not cc.has_multi_arguments(pre_arg, arg, required: opt))
+endif
+
+# compiler.has_link_argument
+if cc.get_argument_syntax() == 'msvc'
+  is_arg = '/OPT:REF'
+else
+  is_arg = '-Wl,-L/tmp'
+endif
+cc.has_link_argument(is_arg, required: true)
+assert(not cc.has_link_argument(is_arg, required: opt))
+
+# compiler.has_function_attribute
+if not ['pgi', 'msvc', 'clang-cl', 'intel-cl'].contains(cc.get_id())
+  a = 'aligned'
+  cc.has_function_attribute(a, required: true)
+  assert(not cc.has_function_attribute(a, required: opt))
+endif
+
+testcase expect_error('''compiler.has_function keyword argument 'required' was of type str but should have been one of: bool, UserFeatureOption''')
+  cc.has_function('printf', required : 'not a bool')
+endtestcase
+
+testcase expect_error('''C function 'asdfkawlegsdiovapfjhkr' not usable''')
+  cc.has_function('asdfkawlegsdiovapfjhkr', required : true)
+endtestcase
+
+testcase expect_error('''C header 'asdfkawlegsdiovapfjhkr.h' not found''')
+  cc.has_header('asdfkawlegsdiovapfjhkr.h', required : true)
+endtestcase
+
+testcase expect_error('''C symbol time_not_found not found in header time.h''')
+  cc.has_header_symbol('time.h', 'time_not_found', required : true)
+endtestcase

--- a/test cases/common/262 required keyword in has functions/meson_options.txt
+++ b/test cases/common/262 required keyword in has functions/meson_options.txt
@@ -1,0 +1,1 @@
+option('opt', type: 'feature', value: 'disabled')


### PR DESCRIPTION
add `required` keyword as in [compiler.check_header](https://mesonbuild.com/Reference-manual_returned_compiler.html#compilercheck_header)

so instead of

```meson
some_dep = dependency('some_name')
assert(cc.has_function('some_function', dependencies: [some_dep]))
```

i can write

```meson
some_dep = dependency('some_name')
cc.has_function('some_function', dependencies: [some_dep], required: true)
```

... etc

fix #7541

todo

* [x] add tests
* [x] add docs
