### PR TITLE
wrap: ensure the tempfile used for downloading is closed

### DIFF
--- a/.github/workflows/os_comp.yml
+++ b/.github/workflows/os_comp.yml
@@ -56,6 +56,21 @@ jobs:
     - name: Upload coverage report
       run: ./ci/upload_cov.sh "OS Comp [${{ matrix.cfg.name }}]"
 
+  pypy:
+    name: 'Arch / PyPy'
+    runs-on: ubuntu-latest
+    container: mesonbuild/arch:latest
+    env:
+      MESON_CI_JOBNAME_UPDATE: linux-arch-gcc-pypy
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run tests
+      run: |
+        source /ci/env_vars.sh
+        export MESON_CI_JOBNAME=$MESON_CI_JOBNAME_UPDATE
+        pypy3 run_tests.py
+
   ubuntu-rolling:
     name: 'Ubuntu Rolling'
     runs-on: ubuntu-latest

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -676,7 +676,7 @@ class Resolver:
             except urllib.error.URLError as e:
                 mlog.log(str(e))
                 raise WrapException(f'could not get {urlstring} is the internet available?')
-        with contextlib.closing(resp) as resp:
+        with contextlib.closing(resp) as resp, tmpfile as tmpfile:
             try:
                 dlsize = int(resp.info()['Content-Length'])
             except TypeError:

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -1104,7 +1104,7 @@ def detect_tests_to_run(only: T.Dict[str, T.List[str]], use_tmp: bool) -> T.List
         TestCategory('swift', 'swift', backend not in (Backend.ninja, Backend.xcode) or not shutil.which('swiftc')),
         # CUDA tests on Windows: use Ninja backend:  python run_project_tests.py --only cuda --backend ninja
         TestCategory('cuda', 'cuda', backend not in (Backend.ninja, Backend.xcode) or not shutil.which('nvcc')),
-        TestCategory('python3', 'python3', backend is not Backend.ninja),
+        TestCategory('python3', 'python3', backend is not Backend.ninja or 'python3' not in sys.executable),
         TestCategory('python', 'python'),
         TestCategory('fpga', 'fpga', shutil.which('yosys') is None),
         TestCategory('frameworks', 'frameworks'),
@@ -1591,7 +1591,7 @@ if __name__ == '__main__':
     clear_transitive_files()
 
     print('Meson build system', meson_version, 'Project Tests')
-    print('Using python', sys.version.split('\n')[0])
+    print('Using python', sys.version.split('\n')[0], f'({sys.executable!r})')
     if 'VSCMD_VER' in os.environ:
         print('VSCMD version', os.environ['VSCMD_VER'])
     setup_commands(options.backend)

--- a/run_tests.py
+++ b/run_tests.py
@@ -343,6 +343,10 @@ def print_system_info():
     print('')
     print(flush=True)
 
+def subprocess_call(cmd, **kwargs):
+    print(f'$ {mesonlib.join_args(cmd)}')
+    return subprocess.call(cmd, **kwargs)
+
 def main():
     print_system_info()
     parser = argparse.ArgumentParser()
@@ -380,7 +384,7 @@ def main():
         cmd = mesonlib.python_command + ['run_meson_command_tests.py', '-v']
         if options.failfast:
             cmd += ['--failfast']
-        returncode += subprocess.call(cmd, env=env)
+        returncode += subprocess_call(cmd, env=env)
         if options.failfast and returncode != 0:
             return returncode
         if no_unittests:
@@ -393,11 +397,11 @@ def main():
             cmd = mesonlib.python_command + ['run_unittests.py', '--backend=' + backend.name, '-v']
             if options.failfast:
                 cmd += ['--failfast']
-            returncode += subprocess.call(cmd, env=env)
+            returncode += subprocess_call(cmd, env=env)
             if options.failfast and returncode != 0:
                 return returncode
         cmd = mesonlib.python_command + ['run_project_tests.py'] + sys.argv[1:]
-        returncode += subprocess.call(cmd, env=env)
+        returncode += subprocess_call(cmd, env=env)
     else:
         cross_test_args = mesonlib.python_command + ['run_cross_test.py']
         for cf in options.cross:
@@ -408,7 +412,7 @@ def main():
                 cmd += ['--failfast']
             if options.cross_only:
                 cmd += ['--cross-only']
-            returncode += subprocess.call(cmd, env=env)
+            returncode += subprocess_call(cmd, env=env)
             if options.failfast and returncode != 0:
                 return returncode
     return returncode

--- a/test cases/frameworks/11 gir subproject/test.json
+++ b/test cases/frameworks/11 gir subproject/test.json
@@ -9,5 +9,5 @@
     {"type": "expr", "file": "usr/lib/?libgirlib.so"},
     {"type": "file", "platform": "cygwin", "file": "usr/lib/libgirsubproject.dll.a"}
   ],
-  "skip_on_jobname": ["azure", "cygwin", "macos", "msys2"]
+  "skip_on_jobname": ["azure", "cygwin", "macos", "msys2", "pypy"]
 }

--- a/test cases/frameworks/7 gnome/test.json
+++ b/test cases/frameworks/7 gnome/test.json
@@ -36,5 +36,5 @@
     {"type": "file", "file": "usr/include/simple-resources.h"},
     {"type": "file", "file": "usr/include/generated-gdbus.h"}
   ],
-  "skip_on_jobname": ["azure", "cygwin", "macos", "msys2"]
+  "skip_on_jobname": ["azure", "cygwin", "macos", "msys2", "pypy"]
 }


### PR DESCRIPTION
This is generally a good idea, and the tempfile is already instructed to not auto-delete on close. It also fixes a bug on PyPy, where the file isn't valid because it's not explicitly closed. This is probably due to the garbage collection modes -- in CPython, the object goes out of scope and gets automatically closed before we actually attempt to unpack it.

Fixes #11246