### PR TITLE
clang: -fprofile-correction isn't a valid flag.

### DIFF
--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -445,7 +445,7 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
         return ['-fprofile-generate']
 
     def get_profile_use_args(self) -> T.List[str]:
-        return ['-fprofile-use', '-fprofile-correction']
+        return ['-fprofile-use']
 
     def get_gui_app_args(self, value: bool) -> T.List[str]:
         return ['-mwindows' if value else '-mconsole']
@@ -644,3 +644,6 @@ class GnuCompiler(GnuLikeCompiler):
         if linker == 'mold' and mesonlib.version_compare(version, '>=12.0.1'):
             return ['-fuse-ld=mold']
         return super().use_linker_args(linker, version)
+
+    def get_profile_use_args(self) -> T.List[str]:
+        return super().get_profile_use_args() + ['-fprofile-correction']


### PR DESCRIPTION
As per subject. It noisy and I'd rather not set `-Wno-ignored-optimization-argument`:

```
clang++ main.cpp -fprofile-correction
clang-15: warning: optimization flag '-fprofile-correction' is not supported [-Wignored-optimization-argument]
```

From #2159. I'm afraid I don't know if any other GCC frontend compilers have the same issue and whether it's better to change GnuLikeCompiler / GnuCompiler instead.

Thanks