### PR TITLE
Python dependency refactor

### DIFF
--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -34,11 +34,12 @@ from .mpi import mpi_factory
 from .scalapack import scalapack_factory
 from .misc import (
     BlocksDependency, OpenMPDependency, cups_factory, curses_factory, gpgme_factory,
-    libgcrypt_factory, libwmf_factory, netcdf_factory, pcap_factory, python3_factory,
+    libgcrypt_factory, libwmf_factory, netcdf_factory, pcap_factory,
     shaderc_factory, threads_factory, ThreadDependency, iconv_factory, intl_factory,
     dl_factory, openssl_factory, libcrypto_factory, libssl_factory,
 )
 from .platform import AppleFrameworks
+from .python import python3_factory
 from .qt import qt4_factory, qt5_factory, qt6_factory
 from .ui import GnuStepDependency, WxDependency, gl_factory, sdl2_factory, vulkan_factory
 
@@ -250,7 +251,6 @@ packages.update({
     'curses': curses_factory,
     'netcdf': netcdf_factory,
     'openmp': OpenMPDependency,
-    'python3': python3_factory,
     'threads': threads_factory,
     'pcap': pcap_factory,
     'cups': cups_factory,
@@ -267,6 +267,9 @@ packages.update({
 
     # From platform:
     'appleframeworks': AppleFrameworks,
+
+    # from python:
+    'python3': python3_factory,
 
     # From ui:
     'gl': gl_factory,

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -39,7 +39,7 @@ from .misc import (
     dl_factory, openssl_factory, libcrypto_factory, libssl_factory,
 )
 from .platform import AppleFrameworks
-from .python import python3_factory
+from .python import python_factory as python3_factory
 from .qt import qt4_factory, qt5_factory, qt6_factory
 from .ui import GnuStepDependency, WxDependency, gl_factory, sdl2_factory, vulkan_factory
 

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -15,15 +15,12 @@
 # This file contains the detection logic for miscellaneous external dependencies.
 from __future__ import annotations
 
-from pathlib import Path
 import functools
 import re
-import sysconfig
 import typing as T
 
 from .. import mesonlib
 from .. import mlog
-from ..environment import detect_cpu_family
 from .base import DependencyException, DependencyMethods
 from .base import BuiltinDependency, SystemDependency
 from .cmake import CMakeDependency
@@ -186,108 +183,6 @@ class BlocksDependency(SystemDependency):
 
             self.is_found = True
 
-
-class Python3DependencySystem(SystemDependency):
-    def __init__(self, name: str, environment: 'Environment', kwargs: T.Dict[str, T.Any]) -> None:
-        super().__init__(name, environment, kwargs)
-
-        if not environment.machines.matches_build_machine(self.for_machine):
-            return
-        if not environment.machines[self.for_machine].is_windows():
-            return
-
-        self.name = 'python3'
-        # We can only be sure that it is Python 3 at this point
-        self.version = '3'
-        self._find_libpy3_windows(environment)
-
-    @staticmethod
-    def get_windows_python_arch() -> T.Optional[str]:
-        pyplat = sysconfig.get_platform()
-        if pyplat == 'mingw':
-            pycc = sysconfig.get_config_var('CC')
-            if pycc.startswith('x86_64'):
-                return '64'
-            elif pycc.startswith(('i686', 'i386')):
-                return '32'
-            else:
-                mlog.log(f'MinGW Python built with unknown CC {pycc!r}, please file a bug')
-                return None
-        elif pyplat == 'win32':
-            return '32'
-        elif pyplat in {'win64', 'win-amd64'}:
-            return '64'
-        mlog.log(f'Unknown Windows Python platform {pyplat!r}')
-        return None
-
-    def get_windows_link_args(self) -> T.Optional[T.List[str]]:
-        pyplat = sysconfig.get_platform()
-        if pyplat.startswith('win'):
-            vernum = sysconfig.get_config_var('py_version_nodot')
-            if self.static:
-                libpath = Path('libs') / f'libpython{vernum}.a'
-            else:
-                comp = self.get_compiler()
-                if comp.id == "gcc":
-                    libpath = Path(f'python{vernum}.dll')
-                else:
-                    libpath = Path('libs') / f'python{vernum}.lib'
-            lib = Path(sysconfig.get_config_var('base')) / libpath
-        elif pyplat == 'mingw':
-            if self.static:
-                libname = sysconfig.get_config_var('LIBRARY')
-            else:
-                libname = sysconfig.get_config_var('LDLIBRARY')
-            lib = Path(sysconfig.get_config_var('LIBDIR')) / libname
-        if not lib.exists():
-            mlog.log('Could not find Python3 library {!r}'.format(str(lib)))
-            return None
-        return [str(lib)]
-
-    def _find_libpy3_windows(self, env: 'Environment') -> None:
-        '''
-        Find python3 libraries on Windows and also verify that the arch matches
-        what we are building for.
-        '''
-        pyarch = self.get_windows_python_arch()
-        if pyarch is None:
-            self.is_found = False
-            return
-        arch = detect_cpu_family(env.coredata.compilers.host)
-        if arch == 'x86':
-            arch = '32'
-        elif arch == 'x86_64':
-            arch = '64'
-        else:
-            # We can't cross-compile Python 3 dependencies on Windows yet
-            mlog.log(f'Unknown architecture {arch!r} for',
-                     mlog.bold(self.name))
-            self.is_found = False
-            return
-        # Pyarch ends in '32' or '64'
-        if arch != pyarch:
-            mlog.log('Need', mlog.bold(self.name), 'for {}-bit, but '
-                     'found {}-bit'.format(arch, pyarch))
-            self.is_found = False
-            return
-        # This can fail if the library is not found
-        largs = self.get_windows_link_args()
-        if largs is None:
-            self.is_found = False
-            return
-        self.link_args = largs
-        # Compile args
-        inc = sysconfig.get_path('include')
-        platinc = sysconfig.get_path('platinclude')
-        self.compile_args = ['-I' + inc]
-        if inc != platinc:
-            self.compile_args.append('-I' + platinc)
-        self.version = sysconfig.get_config_var('py_version')
-        self.is_found = True
-
-    @staticmethod
-    def log_tried() -> str:
-        return 'sysconfig'
 
 class PcapDependencyConfigTool(ConfigToolDependency):
 
@@ -668,17 +563,6 @@ pcap_factory = DependencyFactory(
     [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL],
     configtool_class=PcapDependencyConfigTool,
     pkgconfig_name='libpcap',
-)
-
-python3_factory = DependencyFactory(
-    'python3',
-    [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM, DependencyMethods.EXTRAFRAMEWORK],
-    system_class=Python3DependencySystem,
-    # There is no version number in the macOS version number
-    framework_name='Python',
-    # There is a python in /System/Library/Frameworks, but that's python 2.x,
-    # Python 3 will always be in /Library
-    extra_kwargs={'paths': ['/Library/Frameworks']},
 )
 
 threads_factory = DependencyFactory(

--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -188,6 +188,9 @@ class PythonSystemDependency(SystemDependency, _PythonDependencyBase):
         if mesonlib.is_windows() and self.get_windows_python_arch() == '64' and self.major_version == 2:
             self.compile_args += ['-DMS_WIN64']
 
+        if not self.clib_compiler.has_header('Python.h', '', environment, extra_args=self.compile_args):
+            self.is_found = False
+
     def find_libpy(self, environment: 'Environment') -> None:
         if self.is_pypy:
             if self.major_version == 3:

--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -1,0 +1,141 @@
+# Copyright 2022 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from pathlib import Path
+import sysconfig
+import typing as T
+
+from .. import mlog
+from .base import DependencyMethods, SystemDependency
+from .factory import DependencyFactory
+from ..environment import detect_cpu_family
+
+if T.TYPE_CHECKING:
+    from ..environment import Environment
+
+
+class Python3DependencySystem(SystemDependency):
+    def __init__(self, name: str, environment: 'Environment', kwargs: T.Dict[str, T.Any]) -> None:
+        super().__init__(name, environment, kwargs)
+
+        if not environment.machines.matches_build_machine(self.for_machine):
+            return
+        if not environment.machines[self.for_machine].is_windows():
+            return
+
+        self.name = 'python3'
+        # We can only be sure that it is Python 3 at this point
+        self.version = '3'
+        self._find_libpy3_windows(environment)
+
+    @staticmethod
+    def get_windows_python_arch() -> T.Optional[str]:
+        pyplat = sysconfig.get_platform()
+        if pyplat == 'mingw':
+            pycc = sysconfig.get_config_var('CC')
+            if pycc.startswith('x86_64'):
+                return '64'
+            elif pycc.startswith(('i686', 'i386')):
+                return '32'
+            else:
+                mlog.log(f'MinGW Python built with unknown CC {pycc!r}, please file a bug')
+                return None
+        elif pyplat == 'win32':
+            return '32'
+        elif pyplat in {'win64', 'win-amd64'}:
+            return '64'
+        mlog.log(f'Unknown Windows Python platform {pyplat!r}')
+        return None
+
+    def get_windows_link_args(self) -> T.Optional[T.List[str]]:
+        pyplat = sysconfig.get_platform()
+        if pyplat.startswith('win'):
+            vernum = sysconfig.get_config_var('py_version_nodot')
+            if self.static:
+                libpath = Path('libs') / f'libpython{vernum}.a'
+            else:
+                comp = self.get_compiler()
+                if comp.id == "gcc":
+                    libpath = Path(f'python{vernum}.dll')
+                else:
+                    libpath = Path('libs') / f'python{vernum}.lib'
+            lib = Path(sysconfig.get_config_var('base')) / libpath
+        elif pyplat == 'mingw':
+            if self.static:
+                libname = sysconfig.get_config_var('LIBRARY')
+            else:
+                libname = sysconfig.get_config_var('LDLIBRARY')
+            lib = Path(sysconfig.get_config_var('LIBDIR')) / libname
+        if not lib.exists():
+            mlog.log('Could not find Python3 library {!r}'.format(str(lib)))
+            return None
+        return [str(lib)]
+
+    def _find_libpy3_windows(self, env: 'Environment') -> None:
+        '''
+        Find python3 libraries on Windows and also verify that the arch matches
+        what we are building for.
+        '''
+        pyarch = self.get_windows_python_arch()
+        if pyarch is None:
+            self.is_found = False
+            return
+        arch = detect_cpu_family(env.coredata.compilers.host)
+        if arch == 'x86':
+            arch = '32'
+        elif arch == 'x86_64':
+            arch = '64'
+        else:
+            # We can't cross-compile Python 3 dependencies on Windows yet
+            mlog.log(f'Unknown architecture {arch!r} for',
+                     mlog.bold(self.name))
+            self.is_found = False
+            return
+        # Pyarch ends in '32' or '64'
+        if arch != pyarch:
+            mlog.log('Need', mlog.bold(self.name), 'for {}-bit, but '
+                     'found {}-bit'.format(arch, pyarch))
+            self.is_found = False
+            return
+        # This can fail if the library is not found
+        largs = self.get_windows_link_args()
+        if largs is None:
+            self.is_found = False
+            return
+        self.link_args = largs
+        # Compile args
+        inc = sysconfig.get_path('include')
+        platinc = sysconfig.get_path('platinclude')
+        self.compile_args = ['-I' + inc]
+        if inc != platinc:
+            self.compile_args.append('-I' + platinc)
+        self.version = sysconfig.get_config_var('py_version')
+        self.is_found = True
+
+    @staticmethod
+    def log_tried() -> str:
+        return 'sysconfig'
+
+
+python3_factory = DependencyFactory(
+    'python3',
+    [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM, DependencyMethods.EXTRAFRAMEWORK],
+    system_class=Python3DependencySystem,
+    # There is no version number in the macOS version number
+    framework_name='Python',
+    # There is a python in /System/Library/Frameworks, but that's python 2.x,
+    # Python 3 will always be in /Library
+    extra_kwargs={'paths': ['/Library/Frameworks']},
+)

--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -190,7 +190,8 @@ class PythonSystemDependency(SystemDependency, _PythonDependencyBase):
         self.compile_args += ['-I' + path for path in inc_paths if path]
 
         # https://sourceforge.net/p/mingw-w64/mailman/message/30504611/
-        if mesonlib.is_windows() and self.get_windows_python_arch() == '64' and self.major_version == 2:
+        # https://github.com/python/cpython/pull/100137
+        if mesonlib.is_windows() and self.get_windows_python_arch() == '64' and mesonlib.version_compare(self.version, '<3.12'):
             self.compile_args += ['-DMS_WIN64']
 
         if not self.clib_compiler.has_header('Python.h', '', environment, extra_args=self.compile_args):

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -25,11 +25,11 @@ from .. import mesonlib
 from .. import mlog
 from ..coredata import UserFeatureOption
 from ..build import known_shmod_kwargs
-from ..dependencies import (DependencyMethods, PkgConfigDependency, NotFoundDependency, SystemDependency, ExtraFrameworkDependency,
+from ..dependencies import (DependencyMethods, NotFoundDependency, SystemDependency,
                             DependencyTypeName, ExternalDependency)
 from ..dependencies.base import process_method_kw
 from ..dependencies.detect import get_dep_identifier
-from ..dependencies.python import BasicPythonExternalProgram
+from ..dependencies.python import BasicPythonExternalProgram, PythonFrameworkDependency, PythonPkgConfigDependency, _PythonDependencyBase
 from ..environment import detect_cpu_family
 from ..interpreter import ExternalProgramHolder, extract_required_kwarg, permitted_dependency_kwargs
 from ..interpreter import primitives as P_OBJ
@@ -66,67 +66,10 @@ if T.TYPE_CHECKING:
         modules: T.List[str]
         pure: T.Optional[bool]
 
-    _Base = ExternalDependency
-else:
-    _Base = object
-
 
 mod_kwargs = {'subdir'}
 mod_kwargs.update(known_shmod_kwargs)
 mod_kwargs -= {'name_prefix', 'name_suffix'}
-
-
-class _PythonDependencyBase(_Base):
-
-    def __init__(self, python_holder: 'BasicPythonExternalProgram', embed: bool):
-        self.embed = embed
-        self.version: str = python_holder.info['version']
-        self.platform = python_holder.info['platform']
-        self.variables = python_holder.info['variables']
-        self.paths = python_holder.info['paths']
-        self.is_pypy = python_holder.info['is_pypy']
-        self.link_libpython = python_holder.info['link_libpython']
-        self.info: T.Optional[T.Dict[str, str]] = None
-        if mesonlib.version_compare(self.version, '>= 3.0'):
-            self.major_version = 3
-        else:
-            self.major_version = 2
-
-
-class PythonPkgConfigDependency(PkgConfigDependency, _PythonDependencyBase):
-
-    def __init__(self, name: str, environment: 'Environment',
-                 kwargs: T.Dict[str, T.Any], installation: 'BasicPythonExternalProgram',
-                 libpc: bool = False):
-        if libpc:
-            mlog.debug(f'Searching for {name!r} via pkgconfig lookup in LIBPC')
-        else:
-            mlog.debug(f'Searching for {name!r} via fallback pkgconfig lookup in default paths')
-
-        PkgConfigDependency.__init__(self, name, environment, kwargs)
-        _PythonDependencyBase.__init__(self, installation, kwargs.get('embed', False))
-
-        if libpc and not self.is_found:
-            mlog.debug(f'"python-{self.version}" could not be found in LIBPC, this is likely due to a relocated python installation')
-
-        # The "-embed" version of python.pc was introduced in 3.8, and distutils
-        # extension linking was changed to be considered a non embed usage. Before
-        # then, this dependency always uses the embed=True file because that is the
-        # only one that exists,
-        #
-        # On macOS and some Linux distros (Debian) distutils doesn't link extensions
-        # against libpython, even on 3.7 and below. We call into distutils and
-        # mirror its behavior. See https://github.com/mesonbuild/meson/issues/4117
-        if not self.embed and not self.link_libpython and mesonlib.version_compare(self.version, '< 3.8'):
-            self.link_args = []
-
-
-class PythonFrameworkDependency(ExtraFrameworkDependency, _PythonDependencyBase):
-
-    def __init__(self, name: str, environment: 'Environment',
-                 kwargs: T.Dict[str, T.Any], installation: 'BasicPythonExternalProgram'):
-        ExtraFrameworkDependency.__init__(self, name, environment, kwargs)
-        _PythonDependencyBase.__init__(self, installation, kwargs.get('embed', False))
 
 
 class PythonSystemDependency(SystemDependency, _PythonDependencyBase):

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -282,10 +282,11 @@ class PythonSystemDependency(SystemDependency, _PythonDependencyBase):
 
 
 def python_factory(env: 'Environment', for_machine: 'MachineChoice',
-                   kwargs: T.Dict[str, T.Any], methods: T.List[DependencyMethods],
+                   kwargs: T.Dict[str, T.Any],
                    installation: 'PythonExternalProgram') -> T.List['DependencyGenerator']:
     # We can't use the factory_methods decorator here, as we need to pass the
     # extra installation argument
+    methods = process_method_kw({DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM}, kwargs)
     embed = kwargs.get('embed', False)
     candidates: T.List['DependencyGenerator'] = []
     pkg_version = installation.info['variables'].get('LDVERSION') or installation.info['version']
@@ -507,10 +508,9 @@ class PythonInstallation(ExternalProgramHolder):
 
         new_kwargs = kwargs.copy()
         new_kwargs['required'] = False
-        methods = process_method_kw({DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM}, kwargs)
         # it's theoretically (though not practically) possible to not bind dep, let's ensure it is.
         dep: Dependency = NotFoundDependency('python', self.interpreter.environment)
-        for d in python_factory(self.interpreter.environment, for_machine, new_kwargs, methods, self.held_object):
+        for d in python_factory(self.interpreter.environment, for_machine, new_kwargs, self.held_object):
             dep = d()
             if dep.found():
                 break

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -338,78 +338,6 @@ def python_factory(env: 'Environment', for_machine: 'MachineChoice',
     return candidates
 
 
-INTROSPECT_COMMAND = '''\
-import os.path
-import sysconfig
-import json
-import sys
-import distutils.command.install
-
-def get_distutils_paths(scheme=None, prefix=None):
-    import distutils.dist
-    distribution = distutils.dist.Distribution()
-    install_cmd = distribution.get_command_obj('install')
-    if prefix is not None:
-        install_cmd.prefix = prefix
-    if scheme:
-        install_cmd.select_scheme(scheme)
-    install_cmd.finalize_options()
-    return {
-        'data': install_cmd.install_data,
-        'include': os.path.dirname(install_cmd.install_headers),
-        'platlib': install_cmd.install_platlib,
-        'purelib': install_cmd.install_purelib,
-        'scripts': install_cmd.install_scripts,
-    }
-
-# On Debian derivatives, the Python interpreter shipped by the distribution uses
-# a custom install scheme, deb_system, for the system install, and changes the
-# default scheme to a custom one pointing to /usr/local and replacing
-# site-packages with dist-packages.
-# See https://github.com/mesonbuild/meson/issues/8739.
-# XXX: We should be using sysconfig, but Debian only patches distutils.
-
-if 'deb_system' in distutils.command.install.INSTALL_SCHEMES:
-    paths = get_distutils_paths(scheme='deb_system')
-    install_paths = get_distutils_paths(scheme='deb_system', prefix='')
-else:
-    paths = sysconfig.get_paths()
-    empty_vars = {'base': '', 'platbase': '', 'installed_base': ''}
-    install_paths = sysconfig.get_paths(vars=empty_vars)
-
-def links_against_libpython():
-    from distutils.core import Distribution, Extension
-    cmd = Distribution().get_command_obj('build_ext')
-    cmd.ensure_finalized()
-    return bool(cmd.get_libraries(Extension('dummy', [])))
-
-variables = sysconfig.get_config_vars()
-variables.update({'base_prefix': getattr(sys, 'base_prefix', sys.prefix)})
-
-if sys.version_info < (3, 0):
-    suffix = variables.get('SO')
-elif sys.version_info < (3, 8, 7):
-    # https://bugs.python.org/issue?@action=redirect&bpo=39825
-    from distutils.sysconfig import get_config_var
-    suffix = get_config_var('EXT_SUFFIX')
-else:
-    suffix = variables.get('EXT_SUFFIX')
-
-print(json.dumps({
-  'variables': variables,
-  'paths': paths,
-  'sysconfig_paths': sysconfig.get_paths(),
-  'install_paths': install_paths,
-  'version': sysconfig.get_python_version(),
-  'platform': sysconfig.get_platform(),
-  'is_pypy': '__pypy__' in sys.builtin_module_names,
-  'is_venv': sys.prefix != variables['base_prefix'],
-  'link_libpython': links_against_libpython(),
-  'suffix': suffix,
-}))
-'''
-
-
 class PythonExternalProgram(ExternalProgram):
     def __init__(self, name: str, command: T.Optional[T.List[str]] = None,
                  ext_prog: T.Optional[ExternalProgram] = None):
@@ -447,13 +375,12 @@ class PythonExternalProgram(ExternalProgram):
 
     def sanity(self, state: T.Optional['ModuleState'] = None) -> bool:
         # Sanity check, we expect to have something that at least quacks in tune
-        from tempfile import NamedTemporaryFile
-        with NamedTemporaryFile(suffix='.py', delete=False, mode='w', encoding='utf-8') as tf:
-            tmpfilename = tf.name
-            tf.write(INTROSPECT_COMMAND)
-        cmd = self.get_command() + [tmpfilename]
-        p, stdout, stderr = mesonlib.Popen_safe(cmd)
-        os.unlink(tmpfilename)
+
+        import importlib.resources
+
+        with importlib.resources.path('mesonbuild.scripts', 'python_info.py') as f:
+            cmd = self.get_command() + [str(f)]
+            p, stdout, stderr = mesonlib.Popen_safe(cmd)
         try:
             info = json.loads(stdout)
         except json.JSONDecodeError:

--- a/mesonbuild/scripts/python_info.py
+++ b/mesonbuild/scripts/python_info.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+# ignore all lints for this file, since it is run by python2 as well
+
+# type: ignore
+# pylint: disable=deprecated-module
+
+import os.path
+import sysconfig
+import json
+import sys
+import distutils.command.install
+
+def get_distutils_paths(scheme=None, prefix=None):
+    import distutils.dist
+    distribution = distutils.dist.Distribution()
+    install_cmd = distribution.get_command_obj('install')
+    if prefix is not None:
+        install_cmd.prefix = prefix
+    if scheme:
+        install_cmd.select_scheme(scheme)
+    install_cmd.finalize_options()
+    return {
+        'data': install_cmd.install_data,
+        'include': os.path.dirname(install_cmd.install_headers),
+        'platlib': install_cmd.install_platlib,
+        'purelib': install_cmd.install_purelib,
+        'scripts': install_cmd.install_scripts,
+    }
+
+# On Debian derivatives, the Python interpreter shipped by the distribution uses
+# a custom install scheme, deb_system, for the system install, and changes the
+# default scheme to a custom one pointing to /usr/local and replacing
+# site-packages with dist-packages.
+# See https://github.com/mesonbuild/meson/issues/8739.
+# XXX: We should be using sysconfig, but Debian only patches distutils.
+
+if 'deb_system' in distutils.command.install.INSTALL_SCHEMES:
+    paths = get_distutils_paths(scheme='deb_system')
+    install_paths = get_distutils_paths(scheme='deb_system', prefix='')
+else:
+    paths = sysconfig.get_paths()
+    empty_vars = {'base': '', 'platbase': '', 'installed_base': ''}
+    install_paths = sysconfig.get_paths(vars=empty_vars)
+
+def links_against_libpython():
+    from distutils.core import Distribution, Extension
+    cmd = Distribution().get_command_obj('build_ext')
+    cmd.ensure_finalized()
+    return bool(cmd.get_libraries(Extension('dummy', [])))
+
+variables = sysconfig.get_config_vars()
+variables.update({'base_prefix': getattr(sys, 'base_prefix', sys.prefix)})
+
+if sys.version_info < (3, 0):
+    suffix = variables.get('SO')
+elif sys.version_info < (3, 8, 7):
+    # https://bugs.python.org/issue?@action=redirect&bpo=39825
+    from distutils.sysconfig import get_config_var
+    suffix = get_config_var('EXT_SUFFIX')
+else:
+    suffix = variables.get('EXT_SUFFIX')
+
+print(json.dumps({
+  'variables': variables,
+  'paths': paths,
+  'sysconfig_paths': sysconfig.get_paths(),
+  'install_paths': install_paths,
+  'version': sysconfig.get_python_version(),
+  'platform': sysconfig.get_platform(),
+  'is_pypy': '__pypy__' in sys.builtin_module_names,
+  'is_venv': sys.prefix != variables['base_prefix'],
+  'link_libpython': links_against_libpython(),
+  'suffix': suffix,
+}))

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -63,7 +63,6 @@ if T.TYPE_CHECKING:
     from mesonbuild.environment import Environment
     from mesonbuild._typing import Protocol
     from concurrent.futures import Future
-    from mesonbuild.modules.python import PythonIntrospectionDict
 
     class CompilerArgumentType(Protocol):
         cross_file: str


### PR DESCRIPTION
This moves the python dependency factory out of modules/python.py and into dependencies/python.py. As a result, we get some consistency -- particularly, bugfixes! for the sysconfig resolver for `dependency('python3')`. It's also a lot cleaner, and easier to read modules/.

Finally, fix bad overlinking in the sysconfig dependency.