### PR TITLE
asm: Use more backward-compatible invocation syntax for nasm

### DIFF
--- a/mesonbuild/compilers/asm.py
+++ b/mesonbuild/compilers/asm.py
@@ -69,7 +69,7 @@ class NasmCompiler(Compiler):
         return 'd'
 
     def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
-        return ['-MD', '-MQ', outtarget, '-MF', outfile]
+        return ['-MD', outfile, '-MQ', outtarget]
 
     def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
         if self.info.cpu_family not in {'x86', 'x86_64'}:


### PR DESCRIPTION
Before version 2.14.01, -MD required an output filename argument, with `-MD outfile` equivalent to later versions' `-MD -MF outfile`. The older syntax is still supported, and is still listed as the preferred syntax in documentation.

Reference: https://github.com/netwide-assembler/nasm/commit/3475462e  
Resolves: https://github.com/mesonbuild/meson/issues/11395
