### PR TITLE
interpreter: Add testcase..endtestcase clause support

### DIFF
--- a/mesonbuild/interpreterbase/__init__.py
+++ b/mesonbuild/interpreterbase/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
     'ObjectHolder',
     'IterableObject',
     'MutableInterpreterObject',
+    'ContextManagerObject',
 
     'MesonOperator',
 
@@ -80,6 +81,7 @@ from .baseobjects import (
     ObjectHolder,
     IterableObject,
     MutableInterpreterObject,
+    ContextManagerObject,
 
     TV_fw_var,
     TV_fw_args,

--- a/mesonbuild/interpreterbase/baseobjects.py
+++ b/mesonbuild/interpreterbase/baseobjects.py
@@ -22,6 +22,7 @@ import textwrap
 
 import typing as T
 from abc import ABCMeta
+from contextlib import AbstractContextManager
 
 if T.TYPE_CHECKING:
     from typing_extensions import Protocol
@@ -180,3 +181,7 @@ class IterableObject(metaclass=ABCMeta):
 
     def size(self) -> int:
         raise MesonBugException(f'size not implemented for {self.__class__.__name__}')
+
+class ContextManagerObject(MesonInterpreterObject, AbstractContextManager):
+    def __init__(self, subproject: 'SubProject') -> None:
+        super().__init__(subproject=subproject)

--- a/test cases/common/261 testcase clause/meson.build
+++ b/test cases/common/261 testcase clause/meson.build
@@ -1,0 +1,37 @@
+project('testcase clause')
+
+# To make sure unreachable code is not executed.
+unreachable = true
+
+# Verify assertion exception gets catched and dropped.
+testcase expect_error('Assert failed: false')
+  assert(false)
+  unreachable = false
+endtestcase
+assert(unreachable)
+
+# The inner testcase raises an exception because it did not receive the expected
+# error message. The outer testcase catches the inner testcase exception and
+# drop it.
+testcase expect_error('Expecting error \'something\' but got \'Assert failed: false\'')
+  testcase expect_error('something')
+    assert(false)
+    unreachable = false
+  endtestcase
+  unreachable = false
+endtestcase
+assert(unreachable)
+
+# The inner testcase raises an exception because it did not receive an
+# exception. The outer testcase catches the inner testcase exception and
+# drop it.
+testcase expect_error('Expecting an error but code block succeeded')
+  testcase expect_error('something')
+    reached = true
+  endtestcase
+  unreachable = false
+endtestcase
+assert(reached)
+assert(unreachable)
+
+message('all good')

--- a/test cases/common/261 testcase clause/test.json
+++ b/test cases/common/261 testcase clause/test.json
@@ -1,0 +1,9 @@
+{
+  "stdout": [
+    {
+      "line": ".*all good",
+      "match": "re",
+      "count": 1
+    }
+  ]
+}

--- a/unittests/datatests.py
+++ b/unittests/datatests.py
@@ -219,11 +219,14 @@ class DataTests(unittest.TestCase):
             name = name.replace('_', '-')
             self.assertIn(name, html)
 
+    @unittest.mock.patch.dict(os.environ)
     def test_vim_syntax_highlighting(self):
         '''
         Ensure that vim syntax highlighting files were updated for new
         functions in the global namespace in build files.
         '''
+        # Disable unit test specific syntax
+        del os.environ['MESON_RUNNING_IN_PROJECT_TESTS']
         env = get_fake_env()
         interp = Interpreter(FakeBuild(env), mock=True)
         with open('data/syntax-highlighting/vim/syntax/meson.vim', encoding='utf-8') as f:
@@ -231,11 +234,14 @@ class DataTests(unittest.TestCase):
             defined = set([a.strip() for a in res.group().split('\\')][1:])
             self.assertEqual(defined, set(chain(interp.funcs.keys(), interp.builtin.keys())))
 
+    @unittest.mock.patch.dict(os.environ)
     def test_all_functions_defined_in_ast_interpreter(self):
         '''
         Ensure that the all functions defined in the Interpreter are also defined
         in the AstInterpreter (and vice versa).
         '''
+        # Disable unit test specific syntax
+        del os.environ['MESON_RUNNING_IN_PROJECT_TESTS']
         env = get_fake_env()
         interp = Interpreter(FakeBuild(env), mock=True)
         astint = AstInterpreter('.', '', '')


### PR DESCRIPTION
This is currently only enabled when running unit tests to facilitate writing failing unit tests.

Fixes: #11394