### PR TITLE
wrap: Check for common "provides" typo

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -224,6 +224,8 @@ class PackageDefinition:
                 self.diff_files.append(path)
 
     def parse_provide_section(self, config: configparser.ConfigParser) -> None:
+        if config.has_section('provides'):
+            raise WrapException('Unexpected "[provides]" section, did you mean "[provide]"?')
         if config.has_section('provide'):
             for k, v in config['provide'].items():
                 if k == 'dependency_names':


### PR DESCRIPTION
It is a common mistake that is hard to find because Meson silently
ignore unknown sections. Better have an explicit error message.
