### PR TITLE
nasm: Link with windows CRT libs when nasm is used as linker language

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,6 +94,8 @@ jobs:
   - bash: ci/intel-scripts/cache_exclude_windows.sh
     displayName: exclude unused files from cache
     condition: and(ne(variables.CACHE_RESTORED, 'true'), eq(variables.ifort, 'true'))
+  - script: choco install -y nasm
+    displayName: install NASM
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '3.7'

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -84,7 +84,7 @@ source_suffixes = all_suffixes - header_suffixes
 # List of languages that by default consume and output libraries following the
 # C ABI; these can generally be used interchangeably
 # This must be sorted, see sort_clink().
-clib_langs = ('objcpp', 'cpp', 'objc', 'c', 'fortran')
+clib_langs = ('objcpp', 'cpp', 'objc', 'c', 'nasm', 'fortran')
 # List of languages that can be linked with C code directly by the linker
 # used in build.py:process_compilers() and build.py:get_dynamic_linker()
 # This must be sorted, see sort_clink().

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -189,6 +189,9 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
             trials = [['xilib']]
         elif is_windows() and compiler.id == 'pgi': # this handles cpp / nvidia HPC, in addition to just c/fortran
             trials = [['ar']]  # For PGI on Windows, "ar" is just a wrapper calling link/lib.
+        elif is_windows() and compiler.id == 'nasm':
+            # This may well be LINK.EXE if it's under a MSVC environment
+            trials = [defaults['vs_static_linker'], defaults['clang_cl_static_linker']] + default_linkers
         else:
             trials = default_linkers
     popen_exceptions = {}

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1443,7 +1443,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                         mlog.log_once('Cross compiler sanity tests disabled via the cross file.')
                     else:
                         comp.sanity_check(self.environment.get_scratch_dir(), self.environment)
-                except Exception:
+                except mesonlib.MesonException:
                     if not required:
                         mlog.log('Compiler for language',
                                  mlog.bold(lang), 'for the', machine_name,

--- a/test cases/nasm/2 asm language/meson.build
+++ b/test cases/nasm/2 asm language/meson.build
@@ -5,6 +5,14 @@ if not host_machine.cpu_family().startswith('x86')
   error('MESON_SKIP_TEST: nasm only supported for x86 and x86_64')
 endif
 
+if host_machine.system() == 'windows'
+  error('MESON_SKIP_TEST: this test asm is not made for Windows')
+endif
+
+if meson.backend().startswith('vs')
+  error('MESON_SKIP_TEST: VS backend does not recognise NASM yet')
+endif
+
 if not add_languages('nasm', required: false)
   nasm = find_program('nasm', 'yasm', required: false)
   assert(not nasm.found())

--- a/test cases/nasm/3 nasm only/dummy.asm
+++ b/test cases/nasm/3 nasm only/dummy.asm
@@ -1,0 +1,4 @@
+global dummy
+section .rdata align=16
+dummy:
+  dd 0x00010203

--- a/test cases/nasm/3 nasm only/dummy.def
+++ b/test cases/nasm/3 nasm only/dummy.def
@@ -1,0 +1,2 @@
+EXPORTS
+	dummy

--- a/test cases/nasm/3 nasm only/meson.build
+++ b/test cases/nasm/3 nasm only/meson.build
@@ -1,0 +1,17 @@
+project('nasm only')
+
+if not add_languages('nasm', required: false)
+  error('MESON_SKIP_TEST: nasm not found')
+endif
+
+if meson.backend().startswith('vs')
+  error('MESON_SKIP_TEST: VS backend does not recognise NASM yet')
+endif
+
+sources = files('dummy.asm')
+
+dummy = library(
+    'dummy',
+    sources,
+    vs_module_defs: 'dummy.def',
+)


### PR DESCRIPTION
- nasm: Link with windows CRT libs when nasm is used as linker language

- ci: Install NASM on MSVC jobs

- interpreter: Do not ignore all exceptions when adding compiler
    
Suppressing all exceptions was hidding even syntax errors in compiler
source code. If a compiler cannot be found, a MesonException is raised,
we should only expect that type.
