### PR TITLE
fix: handle OSError from fcntl.flock

### DIFF
--- a/mesonbuild/utils/posix.py
+++ b/mesonbuild/utils/posix.py
@@ -34,6 +34,9 @@ class BuildDirLock(BuildDirLockBase):
         except (BlockingIOError, PermissionError):
             self.lockfile.close()
             raise MesonException('Some other Meson process is already using this build directory. Exiting.')
+        except OSError as e:
+            self.lockfile.close()
+            raise MesonException(f'Failed to lock the build directory: {e.strerror}')
 
     def __exit__(self, *args: T.Any) -> None:
         fcntl.flock(self.lockfile, fcntl.LOCK_UN)


### PR DESCRIPTION
I encounter the following error on a workstation:
```console
$ meson setup build
Traceback (most recent call last):
  File "$HOME/.local/lib/python3.6/site-packages/mesonbuild/mesonmain.py", line 148, in run
    return options.run_func(options)
  File "$HOME/.local/lib/python3.6/site-packages/mesonbuild/msetup.py", line 294, in run
    app.generate()
  File "$HOME/.local/lib/python3.6/site-packages/mesonbuild/msetup.py", line 184, in generate
    with mesonlib.BuildDirLock(self.build_dir):
  File "$HOME/.local/lib/python3.6/site-packages/mesonbuild/mesonlib/posix.py", line 32, in __enter__
    fcntl.flock(self.lockfile, fcntl.LOCK_EX | fcntl.LOCK_NB)
OSError: [Errno 95] Operation not supported

ERROR: Unhandled python exception

    This is a Meson bug and should be reported!
NOTICE: You are using Python 3.6 which is EOL. Starting with v0.62.0, Meson will require Python 3.7 or newer
```

From https://docs.python.org/3.11/library/fcntl.html#fcntl.flock,

> If the <code><span>flock()</span></code> fails, an <code><span>OSError</span></code> exception is raised.

Here exclusive lock is not supported, and the raised exception is not catched.