### PR TITLE
vala: don't build .h, .vala, and .gir if export_dynamic is False

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1075,7 +1075,7 @@ class BuildTarget(Target):
         self.add_pch('c', extract_as_list(kwargs, 'c_pch'))
         self.add_pch('cpp', extract_as_list(kwargs, 'cpp_pch'))
 
-        if not isinstance(self, Executable) or 'export_dynamic' in kwargs:
+        if not isinstance(self, Executable) or kwargs.get('export_dynamic', False):
             self.vala_header = kwargs.get('vala_header', self.name + '.h')
             self.vala_vapi = kwargs.get('vala_vapi', self.name + '.vapi')
             self.vala_gir = kwargs.get('vala_gir', None)


### PR DESCRIPTION
The current check results in *any* value to `export_dynamic` generating vala import targets, even `false`. This is pretty clearly wrong, as it really wants to treat an unset export_dynamic as false.