### PR TITLE
Caching sizeof alignment

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -719,12 +719,12 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
 
     def sizeof(self, typename: str, prefix: str, env: 'Environment', *,
                extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,
-               dependencies: T.Optional[T.List['Dependency']] = None) -> int:
+               dependencies: T.Optional[T.List['Dependency']] = None) -> T.Tuple[int, bool]:
         raise EnvironmentException('Language %s does not support sizeof checks.' % self.get_display_language())
 
     def alignment(self, typename: str, prefix: str, env: 'Environment', *,
                   extra_args: T.Optional[T.List[str]] = None,
-                  dependencies: T.Optional[T.List['Dependency']] = None) -> int:
+                  dependencies: T.Optional[T.List['Dependency']] = None) -> T.Tuple[int, bool]:
         raise EnvironmentException('Language %s does not support alignment checks.' % self.get_display_language())
 
     def has_function(self, funcname: str, prefix: str, env: 'Environment', *,

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -456,11 +456,13 @@ class CrossNoRunException(MesonException):
 
 class RunResult(HoldableObject):
     def __init__(self, compiled: bool, returncode: int = 999,
-                 stdout: str = 'UNDEFINED', stderr: str = 'UNDEFINED'):
+                 stdout: str = 'UNDEFINED', stderr: str = 'UNDEFINED',
+                 cached: bool = False):
         self.compiled = compiled
         self.returncode = returncode
         self.stdout = stdout
         self.stderr = stderr
+        self.cached = cached
 
 
 class CompileResult(HoldableObject):
@@ -688,6 +690,32 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
             extra_args: T.Union[T.List[str], T.Callable[[CompileCheckMode], T.List[str]], None] = None,
             dependencies: T.Optional[T.List['Dependency']] = None) -> RunResult:
         raise EnvironmentException('Language %s does not support run checks.' % self.get_display_language())
+
+    # Caching run() in general seems too risky (no way to know what the program
+    # depends on), but some callers know more about the programs they intend to
+    # run.
+    # For now we just accept code as a string, as that's what internal callers
+    # need anyway. If we wanted to accept files, the cache key would need to
+    # include mtime.
+    def cached_run(self, code: str, env: 'Environment', *,
+                   extra_args: T.Union[T.List[str], T.Callable[[CompileCheckMode], T.List[str]], None] = None,
+                   dependencies: T.Optional[T.List['Dependency']] = None) -> RunResult:
+        run_check_cache = env.coredata.run_check_cache
+        args = self.build_wrapper_args(env, extra_args, dependencies, CompileCheckMode('link'))
+        key = (code, tuple(args))
+        if key in run_check_cache:
+            p = run_check_cache[key]
+            p.cached = True
+            mlog.debug('Using cached run result:')
+            mlog.debug('Code:\n', code)
+            mlog.debug('Args:\n', extra_args)
+            mlog.debug('Cached run returncode:\n', p.returncode)
+            mlog.debug('Cached run stdout:\n', p.stdout)
+            mlog.debug('Cached run stderr:\n', p.stderr)
+        else:
+            p = self.run(code, env, extra_args=extra_args, dependencies=dependencies)
+            run_check_cache[key] = p
+        return p
 
     def sizeof(self, typename: str, prefix: str, env: 'Environment', *,
                extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -735,7 +735,7 @@ class DCompiler(Compiler):
 
     def sizeof(self, typename: str, prefix: str, env: 'Environment', *,
                extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,
-               dependencies: T.Optional[T.List['Dependency']] = None) -> int:
+               dependencies: T.Optional[T.List['Dependency']] = None) -> T.Tuple[int, bool]:
         if extra_args is None:
             extra_args = []
         t = f'''
@@ -745,17 +745,17 @@ class DCompiler(Compiler):
             writeln(({typename}).sizeof);
         }}
         '''
-        res = self.run(t, env, extra_args=extra_args,
-                       dependencies=dependencies)
+        res = self.cached_run(t, env, extra_args=extra_args,
+                              dependencies=dependencies)
         if not res.compiled:
-            return -1
+            return -1, False
         if res.returncode != 0:
             raise mesonlib.EnvironmentException('Could not run sizeof test binary.')
-        return int(res.stdout)
+        return int(res.stdout), res.cached
 
     def alignment(self, typename: str, prefix: str, env: 'Environment', *,
                   extra_args: T.Optional[T.List[str]] = None,
-                  dependencies: T.Optional[T.List['Dependency']] = None) -> int:
+                  dependencies: T.Optional[T.List['Dependency']] = None) -> T.Tuple[int, bool]:
         if extra_args is None:
             extra_args = []
         t = f'''
@@ -774,7 +774,7 @@ class DCompiler(Compiler):
         align = int(res.stdout)
         if align == 0:
             raise mesonlib.EnvironmentException(f'Could not determine alignment of {typename}. Sorry. You might want to file a bug.')
-        return align
+        return align, res.cached
 
     def has_header(self, hname: str, prefix: str, env: 'Environment', *,
                    extra_args: T.Union[None, T.List[str], T.Callable[['CompileCheckMode'], T.List[str]]] = None,

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -39,7 +39,7 @@ import typing as T
 
 if T.TYPE_CHECKING:
     from . import dependencies
-    from .compilers.compilers import Compiler, CompileResult
+    from .compilers.compilers import Compiler, CompileResult, RunResult
     from .dependencies.detect import TV_DepID
     from .environment import Environment
     from .mesonlib import OptionOverrideProxy, FileOrString
@@ -49,6 +49,8 @@ if T.TYPE_CHECKING:
     MutableKeyedOptionDictType = T.Dict['OptionKey', 'UserOption[T.Any]']
     KeyedOptionDictType = T.Union[MutableKeyedOptionDictType, OptionOverrideProxy]
     CompilerCheckCacheKey = T.Tuple[T.Tuple[str, ...], str, FileOrString, T.Tuple[str, ...], str]
+    # code, args
+    RunCheckCacheKey = T.Tuple[str, T.Tuple[str, ...]]
 
     # typeshed
     StrOrBytesPath = T.Union[str, bytes, os.PathLike[str], os.PathLike[bytes]]
@@ -474,6 +476,7 @@ class CoreData:
             DependencyCache(self.options, MachineChoice.HOST))
 
         self.compiler_check_cache: T.Dict['CompilerCheckCacheKey', 'CompileResult'] = OrderedDict()
+        self.run_check_cache: T.Dict['RunCheckCacheKey', 'RunResult'] = OrderedDict()
 
         # CMake cache
         self.cmake_cache: PerMachine[CMakeStateCache] = PerMachine(CMakeStateCache(), CMakeStateCache())

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -272,10 +272,12 @@ class CompilerHolder(ObjectHolder['Compiler']):
     def alignment_method(self, args: T.Tuple[str], kwargs: 'AlignmentKw') -> int:
         typename = args[0]
         deps, msg = self._determine_dependencies(kwargs['dependencies'], compile_only=self.compiler.is_cross)
-        result = self.compiler.alignment(typename, kwargs['prefix'], self.environment,
-                                         extra_args=kwargs['args'],
-                                         dependencies=deps)
-        mlog.log('Checking for alignment of', mlog.bold(typename, True), msg, mlog.bold(str(result)))
+        result, cached = self.compiler.alignment(typename, kwargs['prefix'], self.environment,
+                                                 extra_args=kwargs['args'],
+                                                 dependencies=deps)
+        cached_msg = mlog.blue('(cached)') if cached else ''
+        mlog.log('Checking for alignment of',
+                 mlog.bold(typename, True), msg, mlog.bold(str(result)), cached_msg)
         return result
 
     @typed_pos_args('compiler.run', (str, mesonlib.File))
@@ -419,9 +421,11 @@ class CompilerHolder(ObjectHolder['Compiler']):
         element = args[0]
         extra_args = functools.partial(self._determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
         deps, msg = self._determine_dependencies(kwargs['dependencies'], compile_only=self.compiler.is_cross)
-        esize = self.compiler.sizeof(element, kwargs['prefix'], self.environment,
-                                     extra_args=extra_args, dependencies=deps)
-        mlog.log('Checking for size of', mlog.bold(element, True), msg, mlog.bold(str(esize)))
+        esize, cached = self.compiler.sizeof(element, kwargs['prefix'], self.environment,
+                                             extra_args=extra_args, dependencies=deps)
+        cached_msg = mlog.blue('(cached)') if cached else ''
+        mlog.log('Checking for size of',
+                 mlog.bold(element, True), msg, mlog.bold(str(esize)), cached_msg)
         return esize
 
     @FeatureNew('compiler.get_define', '0.40.0')

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -275,7 +275,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
         result = self.compiler.alignment(typename, kwargs['prefix'], self.environment,
                                          extra_args=kwargs['args'],
                                          dependencies=deps)
-        mlog.log('Checking for alignment of', mlog.bold(typename, True), msg, result)
+        mlog.log('Checking for alignment of', mlog.bold(typename, True), msg, mlog.bold(str(result)))
         return result
 
     @typed_pos_args('compiler.run', (str, mesonlib.File))
@@ -421,7 +421,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
         deps, msg = self._determine_dependencies(kwargs['dependencies'], compile_only=self.compiler.is_cross)
         esize = self.compiler.sizeof(element, kwargs['prefix'], self.environment,
                                      extra_args=extra_args, dependencies=deps)
-        mlog.log('Checking for size of', mlog.bold(element, True), msg, esize)
+        mlog.log('Checking for size of', mlog.bold(element, True), msg, mlog.bold(str(esize)))
         return esize
 
     @FeatureNew('compiler.get_define', '0.40.0')


### PR DESCRIPTION
cc.sizeof() and cc.alignment() are easily cacheable tests that currently aren't cached, because they internally use Compiler.run(). This series introduces Compiler.cached_run() and then uses it to make .sizeof(), .alignment() cached.

This reduces the re-configure time in postgres from 11.285s to 10.225s (average of three runs). The effect on the time until meson.build processing is done is bigger, the time until "Found ninja" goes from 7.134s to 6.014s. The build.ninja generation could stand some profiling attention...
