### PR TITLE
Basic support for TI Arm Clang toolchain

### DIFF
--- a/docs/markdown/snippets/ti_armclang.md
+++ b/docs/markdown/snippets/ti_armclang.md
@@ -1,0 +1,3 @@
+## Basic support for TI Arm Clang (tiarmclang)
+
+Support for TI's newer [Clang-based ARM toolchain](https://www.ti.com/tool/ARM-CGT).

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -228,14 +228,13 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
             return linkers.CcrxLinker(linker)
         if out.startswith('GNU ar') and 'xc16-ar' in linker_name:
             return linkers.Xc16Linker(linker)
-        if "-->  error: bad option 'e'" in err: # TI
+        if 'Texas Instruments Incorporated' in out:
             if 'ar2000' in linker_name:
                 return linkers.C2000Linker(linker)
+            elif 'ar6000' in linker_name:
+                return linkers.C6000Linker(linker)
             else:
                 return linkers.TILinker(linker)
-        if 'Texas Instruments Incorporated' in out:
-            if 'ar6000' in linker_name:
-                return linkers.C6000Linker(linker)
         if out.startswith('The CompCert'):
             return linkers.CompCertLinker(linker)
         if out.strip().startswith('Metrowerks') or out.strip().startswith('Freescale'):
@@ -441,8 +440,8 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
            'TI ARM C/C++ Compiler': (c.TICCompiler, cpp.TICPPCompiler, linkers.TIDynamicLinker),
            'MSP430 C/C++': (c.TICCompiler, cpp.TICPPCompiler, linkers.TIDynamicLinker)
         }
-        for indentifier, compiler_classes in ti_compilers.items():
-            if indentifier in out:
+        for identifier, compiler_classes in ti_compilers.items():
+            if identifier in out:
                 cls = compiler_classes[0] if lang == 'c' else compiler_classes[1]
                 lnk = compiler_classes[2]
                 env.coredata.add_lang_args(cls.language, cls, for_machine, env)

--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -138,7 +138,7 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
 
     v = search_version(o + e)
     linker: DynamicLinker
-    if 'LLD' in o.split('\n', maxsplit=1)[0]:
+    if 'LLD' in o.split('\n', maxsplit=1)[0] or 'tiarmlnk' in e:
         if isinstance(comp_class.LINKER_PREFIX, str):
             cmd = compiler + override + [comp_class.LINKER_PREFIX + '-v'] + extra_args
         else:


### PR DESCRIPTION
The linker identifies itself with a custom name on stderr when given the --version flag:
```
fatal error: invalid option:  --version
tiarmclang: error: tiarmlnk command failed with exit code 1 (use -v to see invocation)
```

And the error for invalid options is different:
```
fatal error: invalid option:  --allow-shlib-undefined
```
Note _two_ spaces between the colon and the bad flag.

Compiler successfully identified afterwards as:
```
C compiler for the host machine: C:/ti/ti-cgt-armllvm_2.1.2.LTS\bin/tiarmclang.exe (clang 2.1.2 "TI Arm Clang Compiler 2.1.2.LTS")
C linker for the host machine: C:/ti/ti-cgt-armllvm_2.1.2.LTS\bin/tiarmclang.exe ld.lld unknown version
```

~As noted in the changelog, `b_lundef=false` and `b_asneeded=false` are both needed due to being unsupported flags, not sure if this is fine as-is (Google indexes meson changelogs pretty well) or whether they should be automagically disabled inside the LLD linker class.~