### PR TITLE
Bash completion additions and fixes (fixes #9077)

### DIFF
--- a/data/shell-completions/bash/meson
+++ b/data/shell-completions/bash/meson
@@ -103,20 +103,28 @@ _meson_complete_filedir() {
   cur=$2
   case $option in
     prefix |\
-    libdir |\
-    libexecdir |\
     bindir |\
-    sbindir |\
-    includedir |\
     datadir |\
-    mandir |\
+    includedir |\
     infodir |\
+    libdir |\
+    licensedir |\
+    libexecdir |\
     localedir |\
-    sysconfdir |\
     localstatedir |\
-    sharedstatedir)
+    mandir |\
+    sbindir |\
+    sharedstatedir |\
+    sysconfdir |\
+    python.platlibdir |\
+    python.purelibdir |\
+    pkg-config-path |\
+    build.pkg-config-path |\
+    cmake-prefix-path |\
+    build.cmake-prefix-path)
       _filedir -d
       ;;
+
     cross-file)
       _filedir
       COMPREPLY+=($(_filedir_in "$XDG_DATA_DIRS"/meson/cross))
@@ -125,6 +133,16 @@ _meson_complete_filedir() {
       COMPREPLY+=($(_filedir_in "$XDG_DATA_HOME"/meson/cross))
       COMPREPLY+=($(_filedir_in ~/.local/share/meson/cross))
       ;;
+
+    native-file)
+      _filedir
+      COMPREPLY+=($(_filedir_in "$XDG_DATA_DIRS"/meson/native))
+      COMPREPLY+=($(_filedir_in /usr/local/share/meson/native))
+      COMPREPLY+=($(_filedir_in /usr/share/meson/native))
+      COMPREPLY+=($(_filedir_in "$XDG_DATA_HOME"/meson/native))
+      COMPREPLY+=($(_filedir_in ~/.local/share/meson/native))
+      ;;
+
     *)
       return 1;;
   esac
@@ -132,41 +150,63 @@ _meson_complete_filedir() {
 }
 
 _meson-setup() {
-
   shortopts=(
     h
     D
     v
   )
 
+  # backend-startup-project is currently VS backend only.
+
   longopts=(
     help
     prefix
+    bindir
+    datadir
+    includedir
+    infodir
     libdir
     libexecdir
-    bindir
-    sbindir
-    includedir
-    datadir
-    mandir
-    infodir
+    licensedir
     localedir
-    sysconfdir
     localstatedir
+    mandir
+    sbindir
     sharedstatedir
+    sysconfdir
+    auto-features
     backend
     buildtype
+    debug
+    default-library
+    errorlogs
+    install-umask
+    layout
+    optimization
+    prefer-static
+    stdsplit
     strip
     unity
-    werror
-    layout
-    default-library
+    unity-size
     warnlevel
-    stdsplit
-    errorlogs
-    cross-file
-    version
+    werror
     wrap-mode
+    force-fallback-for
+    pkgconfig.relocatable
+    python.install-env
+    python.platlibdir
+    python.purelibdir
+    pkg-config-path
+    build.pkg-config-path
+    cmake-prefix-path
+    build.cmake-prefix-path
+    native-file
+    cross-file
+    vsenv
+    version
+    fatal-meson-warnings
+    reconfigure
+    wipe
   )
 
   local cur prev
@@ -204,7 +244,6 @@ _meson-setup() {
 }
 
 _meson-configure() {
-
   shortopts=(
     h
     D
@@ -212,7 +251,49 @@ _meson-configure() {
 
   longopts=(
     help
+    prefix
+    bindir
+    datadir
+    includedir
+    infodir
+    libdir
+    libexecdir
+    licensedir
+    localedir
+    localstatedir
+    mandir
+    sbindir
+    sharedstatedir
+    sysconfdir
+    auto-features
+    backend
+    buildtype
+    debug
+    default-library
+    errorlogs
+    install-umask
+    layout
+    optimization
+    prefer-static
+    stdsplit
+    strip
+    unity
+    unity-size
+    warnlevel
+    werror
+    wrap-mode
+    force-fallback-for
+    backend-startup-project
+    pkgconfig.relocatable
+    python.install-env
+    python.platlibdir
+    python.purelibdir
+    pkg-config-path
+    build.pkg-config-path
+    cmake-prefix-path
+    build.cmake-prefix-path
     clearcache
+    no-pager
   )
 
   local cur prev
@@ -259,17 +340,27 @@ _meson-install() {
 _meson-introspect() {
   shortopts=(
     h
+    a
+    i
+    f
   )
 
   longopts=(
-    targets
-    installed
-    buildsystem-files
-    buildoptions
-    tests
+    ast
     benchmarks
+    buildoptions
+    buildsystem-files
     dependencies
+    scan-dependencies
+    installed
+    install-plan
     projectinfo
+    targets
+    tests
+    backend
+    all
+    indent
+    force-object-output
   )
 
   local cur prev
@@ -306,7 +397,6 @@ _meson-init() {
     C
     n
     e
-    e
     d
     l
     b
@@ -315,14 +405,15 @@ _meson-init() {
 
   longopts=(
     help
-	name
-	executable
-	deps
-	language
-	builddir
-	force
-	type
-	version
+    name
+    executable
+    deps
+    language
+    build
+    builddir
+    force
+    type
+    version
   )
 
   if [[ "$cur" == "--"* ]]; then
@@ -340,6 +431,7 @@ _meson-init() {
 
 _meson-test() {
   shortopts=(
+    h
     q
     v
     t
@@ -347,21 +439,24 @@ _meson-test() {
   )
 
   longopts=(
-    quiet
-    verbose
-    timeout-multiplier
+    help
+    maxfail
     repeat
     no-rebuild
     gdb
+    gdb-path
     list
-    wrapper --wrap
-    no-suite
+    wrapper
     suite
+    no-suite
     no-stdsplit
     print-errorlogs
     benchmark
     logbase
     num-processes
+    verbose
+    quiet
+    timeout-multiplier
     setup
     test-args
   )
@@ -369,7 +464,7 @@ _meson-test() {
   local cur prev
   if _get_comp_words_by_ref -n ':' cur prev &>/dev/null; then
     case $prev in
-      --repeat)
+      --maxfail | --repeat)
         # number, can't be completed
         return
         ;;
@@ -377,7 +472,7 @@ _meson-test() {
         _command_offset $COMP_CWORD
         return
         ;;
-      -C)
+      --gdb-path | -C)
         _filedir -d
         return
         ;;

--- a/data/shell-completions/bash/meson
+++ b/data/shell-completions/bash/meson
@@ -149,6 +149,25 @@ _meson_complete_filedir() {
   return 0
 }
 
+_meson_compgen_options() {
+  local -r cur=$1
+
+  if [[ ${cur:0:2} == -- ]]; then
+    COMPREPLY+=($(compgen -P '--' -W '${longopts[*]}' -- "${cur:2}"))
+  elif [[ ${cur:0:1} == - ]]; then
+    if [[ ${#cur} == 1 ]]; then
+      # Only add longopts if cur not "-something"
+      COMPREPLY+=($(compgen -P '--' -W '${longopts[*]}' -- ""))
+    fi
+
+    COMPREPLY+=($(compgen -P '-' -W '${shortopts[*]}' -- "${cur:1}"))
+  else
+    return 1
+  fi
+
+  return 0
+}
+
 _meson-setup() {
   shortopts=(
     h
@@ -210,14 +229,16 @@ _meson-setup() {
   )
 
   local cur prev
-  if _get_comp_words_by_ref cur prev &>/dev/null &&
-    [ "${prev:0:2}" = '--' ] && _meson_complete_option "${prev:2}" "$cur"; then
-    return
-  elif _get_comp_words_by_ref cur prev &>/dev/null &&
-    [ "${prev:0:1}" = '-' ] && [ "${prev:1:2}" != '-' ] && _meson_complete_option "${prev:1}"; then
-    return
-  elif _get_comp_words_by_ref -n '=' cur prev &>/dev/null; then
-    if [ $prev == -D ]; then
+  if _get_comp_words_by_ref cur prev &>/dev/null; then
+    if [[ ${prev:0:2} == -- ]] && _meson_complete_option "${prev:2}" "$cur"; then
+      return
+    elif [[ ${prev:0:1} == - ]] && [[ ${prev:1:2} != - ]] && _meson_complete_option "${prev:1}"; then
+      return
+    fi
+  fi
+
+  if _get_comp_words_by_ref -n '=' cur prev &>/dev/null; then
+    if [[ $prev == -D ]]; then
       _meson_complete_option "$cur"
       return
     fi
@@ -225,19 +246,14 @@ _meson-setup() {
     cur="${COMP_WORDS[COMP_CWORD]}"
   fi
 
-  if [[ "$cur" == "--"* ]]; then
-    COMPREPLY+=($(compgen -P '--' -W '${longopts[*]}' -- "${cur:2}"))
-  elif [[ "$cur" == "-"* ]]; then
-    COMPREPLY+=($(compgen -P '--' -W '${longopts[*]}' -- "${cur:2}"))
-    COMPREPLY+=($(compgen -P '-' -W '${shortopts[*]}' -- "${cur:1}"))
-  else
+  if ! _meson_compgen_options "$cur"; then
     _filedir -d
-    if [ -z "$cur" ]; then
-    COMPREPLY+=($(compgen -P '--' -W '${longopts[*]}'))
-    COMPREPLY+=($(compgen -P '-' -W '${shortopts[*]}'))
+    if [[ -z $cur ]]; then
+      COMPREPLY+=($(compgen -P '--' -W '${longopts[*]}'))
+      COMPREPLY+=($(compgen -P '-' -W '${shortopts[*]}'))
     fi
 
-    if [ $COMP_CWORD -eq 1 ]; then
+    if [[ $COMP_CWORD == 1 ]]; then
       COMPREPLY+=($(compgen -W "${meson_subcommands[*]}" -- "$cur"))
     fi
   fi
@@ -298,7 +314,7 @@ _meson-configure() {
 
   local cur prev
   if _get_comp_words_by_ref -n '=' cur prev &>/dev/null; then
-    if [ $prev == -D ]; then
+    if [[ $prev == -D ]]; then
       _meson_complete_option "$cur"
       return
     fi
@@ -306,25 +322,20 @@ _meson-configure() {
     cur="${COMP_WORDS[COMP_CWORD]}"
   fi
 
-  if [[ "$cur" == "--"* ]]; then
-    COMPREPLY+=($(compgen -P '--' -W '${longopts[*]}' -- "${cur:2}"))
-  elif [[ "$cur" == "-"* ]]; then
-    COMPREPLY+=($(compgen -P '--' -W '${longopts[*]}' -- "${cur:2}"))
-    COMPREPLY+=($(compgen -P '-' -W '${shortopts[*]}' -- "${cur:1}"))
-  else
+  if ! _meson_compgen_options "$cur"; then
     for dir in "${COMP_WORDS[@]}"; do
-      if [ -d "$dir" ]; then
+      if [[ -d "$dir" ]]; then
         break
       fi
       dir=.
     done
-    if [ ! -d "$dir/meson-private" ]; then
+    if [[ ! -d "$dir/meson-private" ]]; then
       _filedir -d
     fi
 
-    if [ -z "$cur" ]; then
-    COMPREPLY+=($(compgen -P '--' -W '${longopts[*]}'))
-    COMPREPLY+=($(compgen -P '-' -W '${shortopts[*]}'))
+    if [[ -z $cur ]]; then
+      COMPREPLY+=($(compgen -P '--' -W '${longopts[*]}'))
+      COMPREPLY+=($(compgen -P '-' -W '${shortopts[*]}'))
     fi
   fi
 }
@@ -368,12 +379,7 @@ _meson-introspect() {
     cur="${COMP_WORDS[COMP_CWORD]}"
   fi
 
-  if [[ "$cur" == "--"* ]]; then
-    COMPREPLY+=($(compgen -P '--' -W '${longopts[*]}' -- "${cur:2}"))
-  elif [[ "$cur" == "-"* ]]; then
-    COMPREPLY+=($(compgen -P '--' -W '${longopts[*]}' -- "${cur:2}"))
-    COMPREPLY+=($(compgen -P '-' -W '${shortopts[*]}' -- "${cur:1}"))
-  else
+  if ! _meson_compgen_options "$cur"; then
     for dir in "${COMP_WORDS[@]}"; do
       if [ -d "$dir" ]; then
         break
@@ -416,17 +422,12 @@ _meson-init() {
     version
   )
 
-  if [[ "$cur" == "--"* ]]; then
-    COMPREPLY+=($(compgen -P '--' -W '${longopts[*]}' -- "${cur:2}"))
-  elif [[ "$cur" == "-"* && ${#cur} -gt 1 ]]; then
-    COMPREPLY+=($(compgen -P '-' -W '${shortopts[*]}' -- "${cur:1}"))
-  else
-    if [ -z "$cur" ]; then
+  if ! _meson_compgen_options "$cur"; then
+    if [[ -z $cur ]]; then
       COMPREPLY+=($(compgen -P '--' -W '${longopts[*]}'))
       COMPREPLY+=($(compgen -P '-' -W '${shortopts[*]}'))
     fi
   fi
-
 }
 
 _meson-test() {
@@ -520,11 +521,7 @@ for test in json.load(sys.stdin):
     cur="${COMP_WORDS[COMP_CWORD]}"
   fi
 
-  if [[ "$cur" == "--"* ]]; then
-    COMPREPLY+=($(compgen -P '--' -W '${longopts[*]}' -- "${cur:2}"))
-  elif [[ "$cur" == "-"* && ${#cur} -gt 1 ]]; then
-    COMPREPLY+=($(compgen -P '-' -W '${shortopts[*]}' -- "${cur:1}"))
-  else
+  if ! _meson_compgen_options "$cur"; then
     for dir in "${COMP_WORDS[@]}"; do
       if [ -d "$dir" ]; then
         break

--- a/data/shell-completions/bash/meson
+++ b/data/shell-completions/bash/meson
@@ -469,14 +469,17 @@ _meson-test() {
         # number, can't be completed
         return
         ;;
+
       --wrapper)
         _command_offset $COMP_CWORD
         return
         ;;
+
       --gdb-path | -C)
         _filedir -d
         return
         ;;
+
       --suite | --no-suite)
         for i in "${!COMP_WORDS[@]}"; do
           opt="${COMP_WORDS[i]}"
@@ -488,31 +491,40 @@ _meson-test() {
           esac
           dir=.
         done
-        suites=($(python3 -c 'import sys, json;
+
+        suites=$(meson introspect "$dir" --tests | python3 -c 'import sys, json;
 for test in json.load(sys.stdin):
   for suite in test["suite"]:
     print(suite)
-    ' <<< "$(meson introspect "$dir" --tests)"))
-# TODO
-        COMPREPLY+=($(compgen -W "${suites[*]}" -- "$cur"))
+' 2> /dev/null)
+# TODO - what?
+
+        if [[ $? == 0 ]]; then
+          COMPREPLY+=($(compgen -W "${suites[*]}" -- "$cur"))
+        fi
         return
         ;;
+
       --logbase)
         # free string, can't be completed
         return
         ;;
+
       --num-processes)
         # number, can't be completed
         return
         ;;
+
       -t | --timeout-multiplier)
         # number, can't be completed
         return
         ;;
+
       --setup)
         # TODO
         return
         ;;
+
       --test-args)
         return
         ;;
@@ -528,6 +540,7 @@ for test in json.load(sys.stdin):
       fi
       dir=.
     done
+
     if [ ! -d "$dir/meson-private" ]; then
       _filedir -d
     fi
@@ -542,11 +555,15 @@ for test in json.load(sys.stdin):
       esac
       dir=.
     done
-    tests=($(python3 -c 'import sys, json;
+
+    tests=$(meson introspect "$dir" --tests | python3 -c 'import sys, json;
 for test in json.load(sys.stdin):
   print(test["name"])
-' <<< "$(meson introspect "$dir" --tests)"))
-    COMPREPLY+=($(compgen -W "${tests[*]}" -- "$cur"))
+' 2> /dev/null)
+
+    if [[ $? == 0 ]]; then
+      COMPREPLY+=($(compgen -W "${tests[*]}" -- "$cur"))
+    fi
 
     if [ -z "$cur" ]; then
       COMPREPLY+=($(compgen -P '--' -W '${longopts[*]}' -- "${cur:2}"))

--- a/data/shell-completions/bash/meson
+++ b/data/shell-completions/bash/meson
@@ -564,7 +564,27 @@ _meson-subprojects() {
 }
 
 _meson-help() {
-  : # Nothing to do
+  longopts=(
+    setup
+    configure
+    dist
+    install
+    introspect
+    init
+    test
+    wrap
+    subprojects
+    rewrite
+    compile
+    devenv
+    env2mfile
+  )
+
+  local cur prev
+
+  if _get_comp_words_by_ref cur prev &>/dev/null; then
+    COMPREPLY+=($(compgen -W '${longopts[*]}' -- "${cur}"))
+  fi
 }
 
 _meson-rewrite() {
@@ -572,7 +592,48 @@ _meson-rewrite() {
 }
 
 _meson-compile() {
-  : TODO
+  shortopts=(
+    h
+    C
+    j
+    l
+    v
+  )
+
+  longopts=(
+    help
+    clean
+    jobs
+    load-average
+    verbose
+    ninja-args
+    vs-args
+    xcode-args
+  )
+
+  local cur prev
+  if _get_comp_words_by_ref cur prev &>/dev/null; then
+    if [[ ${prev:0:2} == -- ]] && _meson_complete_option "${prev:2}" "$cur"; then
+      return
+    elif [[ ${prev:0:1} == - ]] && [[ ${prev:1:2} != - ]] && _meson_complete_option "${prev:1}"; then
+      return
+    fi
+  else
+    cur="${COMP_WORDS[COMP_CWORD]}"
+  fi
+
+  if ! _meson_compgen_options "$cur"; then
+    _filedir -d
+
+    if [[ -z $cur ]]; then
+      COMPREPLY+=($(compgen -P '--' -W '${longopts[*]}'))
+      COMPREPLY+=($(compgen -P '-' -W '${shortopts[*]}'))
+    fi
+
+    if [[ $COMP_CWORD == 1 ]]; then
+      COMPREPLY+=($(compgen -W "${meson_subcommands[*]}" -- "$cur"))
+    fi
+  fi
 }
 
 _meson-devenv() {


### PR DESCRIPTION
The bash completion code seems to be missing some love! Here's some improvements, if such a thing is possible with any bash completion code. Shudder.

### Fixes

`meson test<tab>`
```
meson testTraceback (most recent call last):
  File "<string>", line 2, in <module>
  File "/usr/lib64/python3.11/json/__init__.py", line 293, in load
    return loads(fp.read(),
           ^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```
Now completes to `meson test `.

`meson setup -X<tab>` (where X is a known short option) completed to `meson setup -`. Now `meson setup -X `.

`meson setup -X<tab>` (where X is an unknown short option) completed to `meson setup --`. Now `meson setup -X`.

(And similar for other commands.)

### Features

* `meson compile` completion (useful)
* `meson help` completion (not so much)
* Added missing options to current completions

Thanks
