### PR TITLE
doc: fix descriptions of dependency and find_program

### DIFF
--- a/docs/yaml/functions/find_program.yaml
+++ b/docs/yaml/functions/find_program.yaml
@@ -98,10 +98,10 @@ kwargs:
       instead of a not-found object.
 
   version:
-    type: str
+    type: str | list[str]
     since: 0.52.0
     description: |
-      specifies the required version, see
+      Specifies the required version, see
       [[dependency]] for argument format. The version of the program
       is determined by running `program_name --version` command. If stdout is empty
       it fallbacks to stderr. If the output contains more text than simply a version


### PR DESCRIPTION
They accept list as documented:
https://github.com/mesonbuild/meson/blob/616bf1f79d855c6d5494f71806ce42961d8ce85e/docs/yaml/functions/dependency.yaml#L189