### PR TITLE
Allow --reconfigure and --wipe of empty builddir

### DIFF
--- a/docs/markdown/snippets/reconfigure.md
+++ b/docs/markdown/snippets/reconfigure.md
@@ -1,0 +1,10 @@
+## Allow --reconfigure and --wipe of empty builddir
+
+`meson setup --reconfigure builddir` and `meson setup --wipe builddir` are now
+accepting `builddir/` to be empty or containing a previously failed setup attempt.
+Note that in that case previously passed command line options must be repeated
+as only a successful build saves configured options.
+
+This is useful for example with scripts that always repeat all options,
+`meson setup builddir --wipe -Dfoo=bar` will always work regardless whether
+it is a first invocation or not.

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -89,9 +89,9 @@ class MesonApp:
                     try:
                         restore.append((shutil.copy(filename, d), filename))
                     except FileNotFoundError:
-                        raise MesonException(
-                            'Cannot find cmd_line.txt. This is probably because this '
-                            'build directory was configured with a meson version < 0.49.0.')
+                        # validate_dirs() already verified that build_dir has
+                        # a partial build or is empty.
+                        pass
 
                 coredata.read_cmd_line_file(self.build_dir, options)
 
@@ -120,7 +120,7 @@ class MesonApp:
     def validate_core_dirs(self, dir1: str, dir2: str) -> T.Tuple[str, str]:
         if dir1 is None:
             if dir2 is None:
-                if not os.path.exists('meson.build') and os.path.exists('../meson.build'):
+                if not self.has_build_file('.') and self.has_build_file('..'):
                     dir2 = '..'
                 else:
                     raise MesonException('Must specify at least one directory name.')
@@ -151,8 +151,6 @@ class MesonApp:
         raise MesonException(f'Neither directory contains a build file {environment.build_filename}.')
 
     def add_vcs_ignore_files(self, build_dir: str) -> None:
-        if os.listdir(build_dir):
-            return
         with open(os.path.join(build_dir, '.gitignore'), 'w', encoding='utf-8') as ofile:
             ofile.write(git_ignore_file)
         with open(os.path.join(build_dir, '.hgignore'), 'w', encoding='utf-8') as ofile:
@@ -160,9 +158,13 @@ class MesonApp:
 
     def validate_dirs(self, dir1: str, dir2: str, reconfigure: bool, wipe: bool) -> T.Tuple[str, str]:
         (src_dir, build_dir) = self.validate_core_dirs(dir1, dir2)
-        self.add_vcs_ignore_files(build_dir)
-        priv_dir = os.path.join(build_dir, 'meson-private/coredata.dat')
-        if os.path.exists(priv_dir):
+        if not os.listdir(build_dir):
+            self.add_vcs_ignore_files(build_dir)
+            return src_dir, build_dir
+        priv_dir = os.path.join(build_dir, 'meson-private')
+        has_valid_build = os.path.exists(os.path.join(priv_dir, 'coredata.dat'))
+        has_partial_build = os.path.isdir(priv_dir)
+        if has_valid_build:
             if not reconfigure and not wipe:
                 print('Directory already configured.\n'
                       '\nJust run your build command (e.g. ninja) and Meson will regenerate as necessary.\n'
@@ -172,10 +174,8 @@ class MesonApp:
                       'using the same options as passed when configuring the build.'
                       '\nTo change option values, run "meson configure" instead.')
                 raise SystemExit
-        else:
-            has_cmd_line_file = os.path.exists(coredata.get_cmd_line_file(build_dir))
-            if (wipe and not has_cmd_line_file) or (not wipe and reconfigure):
-                raise SystemExit(f'Directory does not contain a valid build tree:\n{build_dir}')
+        elif not has_partial_build and 'MESON_RUNNING_IN_PROJECT_TESTS' not in os.environ:
+            raise SystemExit(f'Directory is not empty and does not contain a previous build:\n{build_dir}')
         return src_dir, build_dir
 
     def generate(self) -> None:


### PR DESCRIPTION
This allows to run setup command regardless whether the builddir has been configured or not previously. This is useful for example with scripts that always repeat all options.
  meson setup builddir --reconfigure -Dfoo=bar