### PR TITLE
Add exclude_files and exclude_dirs to install_plan introspection data

### DIFF
--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -70,7 +70,7 @@ class BasicPythonExternalProgram(ExternalProgram):
             'link_libpython': False,
             'sysconfig_paths': {},
             'paths': {},
-            'platform': 'sentinal',
+            'platform': 'sentinel',
             'suffix': 'sentinel',
             'variables': {},
             'version': '0.0',

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -592,7 +592,7 @@ class Installer:
         self.log(f'Stripping target {fname!r}.')
         if is_osx():
             # macOS expects dynamic objects to be stripped with -x maximum.
-            # To also strip the debug info, -S must be added.
+            # To also strip the debug info, -S must be added.
             # See: https://www.unix.com/man-page/osx/1/strip/
             returncode, stdo, stde = self.Popen_safe(strip_bin + ['-S', '-x', outname])
         else:

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -146,11 +146,19 @@ def list_install_plan(installdata: backends.InstallData) -> T.Dict[str, T.Dict[s
             if key == 'headers':  # in the headers, install_path_name is the directory
                 install_path_name = os.path.join(install_path_name, os.path.basename(data.path))
 
-            plan[data_type] = plan.get(data_type, {})
-            plan[data_type][data.path] = {
+            entry = {
                 'destination': install_path_name,
                 'tag': data.tag or None,
             }
+
+            if key == 'install_subdirs':
+                exclude_files, exclude_dirs = data.exclude or ([], [])
+                entry['exclude_dirs'] = list(exclude_dirs)
+                entry['exclude_files'] = list(exclude_files)
+
+            plan[data_type] = plan.get(data_type, {})
+            plan[data_type][data.path] = entry
+
     return plan
 
 def get_target_dir(coredata: cdata.CoreData, subdir: str) -> str:

--- a/test cases/unit/98 install all targets/excludes/excluded.txt
+++ b/test cases/unit/98 install all targets/excludes/excluded.txt
@@ -1,0 +1,1 @@
+Excluded

--- a/test cases/unit/98 install all targets/excludes/excluded/placeholder.txt
+++ b/test cases/unit/98 install all targets/excludes/excluded/placeholder.txt
@@ -1,0 +1,1 @@
+Placeholder

--- a/test cases/unit/98 install all targets/excludes/installed.txt
+++ b/test cases/unit/98 install all targets/excludes/installed.txt
@@ -1,0 +1,1 @@
+Installed

--- a/test cases/unit/98 install all targets/meson.build
+++ b/test cases/unit/98 install all targets/meson.build
@@ -94,6 +94,12 @@ install_subdir('custom_files',
   install_dir: get_option('datadir'),
   install_tag: 'custom',
 )
+install_subdir('excludes',
+  install_dir: get_option('datadir'),
+  install_tag: 'custom',
+  exclude_directories: 'excluded',
+  exclude_files: 'excluded.txt',
+)
 
 # First is custom, 2nd is devel, 3rd has no tag
 custom_target('ct3',

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -4233,6 +4233,8 @@ class AllPlatformTests(BasePlatformTests):
             Path(installpath, 'usr/share/out3-custom.txt'),
             Path(installpath, 'usr/share/custom_files'),
             Path(installpath, 'usr/share/custom_files/data.txt'),
+            Path(installpath, 'usr/share/excludes'),
+            Path(installpath, 'usr/share/excludes/installed.txt'),
             Path(installpath, 'usr/lib'),
             Path(installpath, 'usr/lib/libbothcustom.a'),
             Path(installpath, 'usr/' + shared_lib_name('bothcustom')),
@@ -4440,7 +4442,15 @@ class AllPlatformTests(BasePlatformTests):
             'install_subdirs': {
                 f'{testdir}/custom_files': {
                     'destination': '{datadir}/custom_files',
-                    'tag': 'custom'
+                    'tag': 'custom',
+                    'exclude_dirs': [],
+                    'exclude_files': [],
+                },
+                f'{testdir}/excludes': {
+                    'destination': '{datadir}/excludes',
+                    'tag': 'custom',
+                    'exclude_dirs': ['excluded'],
+                    'exclude_files': ['excluded.txt'],
                 }
             }
         }


### PR DESCRIPTION
These are necessary for projects outside Meson itself that want to extend the 'meson install' functionality as meson-python does to assemble Python package wheels from Meson projects.

Fixes #11426.