### PR TITLE
Refactor compiler check code

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -19,6 +19,7 @@ import enum
 import itertools
 import typing as T
 from functools import lru_cache
+from dataclasses import dataclass
 
 from .. import coredata
 from .. import mlog
@@ -463,23 +464,17 @@ class RunResult(HoldableObject):
         self.stderr = stderr
 
 
+@dataclass
 class CompileResult(HoldableObject):
-
     """The result of Compiler.compiles (and friends)."""
-
-    def __init__(self, stdo: T.Optional[str] = None, stde: T.Optional[str] = None,
-                 command: T.Optional[T.List[str]] = None,
-                 returncode: int = 999,
-                 input_name: T.Optional[str] = None,
-                 output_name: T.Optional[str] = None,
-                 cached: bool = False):
-        self.stdout = stdo
-        self.stderr = stde
-        self.input_name = input_name
-        self.output_name = output_name
-        self.command = command or []
-        self.cached = cached
-        self.returncode = returncode
+    stdout: T.Optional[str]
+    stderr: T.Optional[str]
+    command: T.Optional[T.List[str]]
+    returncode: int = 999
+    input_name: T.Optional[str] = None
+    output_name: T.Optional[str] = None
+    output_dir: T.Optional[TemporaryDirectoryWinProof] = None
+    cached: bool = False
 
 
 class Compiler(HoldableObject, metaclass=abc.ABCMeta):
@@ -773,74 +768,66 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         """Return an appropriate CompilerArgs instance for this class."""
         return CompilerArgs(self, args)
 
-    @contextlib.contextmanager
     def compile(self, code: 'mesonlib.FileOrString',
                 extra_args: T.Union[None, CompilerArgs, T.List[str]] = None,
                 *, mode: str = 'link', want_output: bool = False,
-                temp_dir: T.Optional[str] = None) -> T.Iterator[T.Optional[CompileResult]]:
-        # TODO: there isn't really any reason for this to be a contextmanager
+                temp_dir: T.Optional[str] = None) -> T.Optional[CompileResult]:
         if extra_args is None:
             extra_args = []
 
-        with TemporaryDirectoryWinProof(dir=temp_dir) as tmpdirname:
-            no_ccache = False
-            if isinstance(code, str):
-                srcname = os.path.join(tmpdirname,
-                                       'testfile.' + self.default_suffix)
-                with open(srcname, 'w', encoding='utf-8') as ofile:
-                    ofile.write(code)
-                # ccache would result in a cache miss
-                no_ccache = True
-                contents = code
+        tmpdirname = TemporaryDirectoryWinProof(dir=temp_dir)
+        no_ccache = False
+        if isinstance(code, str):
+            srcname = os.path.join(tmpdirname.name,
+                                   'testfile.' + self.default_suffix)
+            with open(srcname, 'w', encoding='utf-8') as ofile:
+                ofile.write(code)
+            # ccache would result in a cache miss
+            no_ccache = True
+            contents = code
+        else:
+            srcname = code.fname
+            if not is_object(code.fname):
+                with open(code.fname, encoding='utf-8') as f:
+                    contents = f.read()
             else:
-                srcname = code.fname
-                if not is_object(code.fname):
-                    with open(code.fname, encoding='utf-8') as f:
-                        contents = f.read()
-                else:
-                    contents = '<binary>'
+                contents = '<binary>'
+        # Construct the compiler command-line
+        commands = self.compiler_args()
+        commands.append(srcname)
+        # Preprocess mode outputs to stdout, so no output args
+        output = self._get_compile_output(tmpdirname.name, mode)
+        if mode != 'preprocess':
+            commands += self.get_output_args(output)
+        commands.extend(self.get_compiler_args_for_mode(CompileCheckMode(mode)))
+        # extra_args must be last because it could contain '/link' to
+        # pass args to VisualStudio's linker. In that case everything
+        # in the command line after '/link' is given to the linker.
+        if extra_args:
+            commands += extra_args
+        # Generate full command-line with the exelist
+        command_list = self.get_exelist(ccache=not no_ccache) + commands.to_native()
+        mlog.debug('Running compile:')
+        mlog.debug('Working directory: ', tmpdirname.name)
+        mlog.debug('Command line: ', ' '.join(command_list), '\n')
+        mlog.debug('Code:\n', contents)
+        os_env = os.environ.copy()
+        os_env['LC_ALL'] = 'C'
+        if no_ccache:
+            os_env['CCACHE_DISABLE'] = '1'
+        p, stdo, stde = Popen_safe(command_list, cwd=tmpdirname.name, env=os_env)
+        mlog.debug('Compiler stdout:\n', stdo)
+        mlog.debug('Compiler stderr:\n', stde)
+        result = CompileResult(stdo, stde, command_list, p.returncode, input_name=srcname)
+        if want_output:
+            result.output_name = output
+            result.output_dir = tmpdirname
+        return result
 
-            # Construct the compiler command-line
-            commands = self.compiler_args()
-            commands.append(srcname)
-
-            # Preprocess mode outputs to stdout, so no output args
-            output = self._get_compile_output(tmpdirname, mode)
-            if mode != 'preprocess':
-                commands += self.get_output_args(output)
-            commands.extend(self.get_compiler_args_for_mode(CompileCheckMode(mode)))
-
-            # extra_args must be last because it could contain '/link' to
-            # pass args to VisualStudio's linker. In that case everything
-            # in the command line after '/link' is given to the linker.
-            if extra_args:
-                commands += extra_args
-            # Generate full command-line with the exelist
-            command_list = self.get_exelist(ccache=not no_ccache) + commands.to_native()
-            mlog.debug('Running compile:')
-            mlog.debug('Working directory: ', tmpdirname)
-            mlog.debug('Command line: ', ' '.join(command_list), '\n')
-            mlog.debug('Code:\n', contents)
-            os_env = os.environ.copy()
-            os_env['LC_ALL'] = 'C'
-            if no_ccache:
-                os_env['CCACHE_DISABLE'] = '1'
-            p, stdo, stde = Popen_safe(command_list, cwd=tmpdirname, env=os_env)
-            mlog.debug('Compiler stdout:\n', stdo)
-            mlog.debug('Compiler stderr:\n', stde)
-
-            result = CompileResult(stdo, stde, command_list, p.returncode, input_name=srcname)
-            if want_output:
-                result.output_name = output
-            yield result
-
-    @contextlib.contextmanager
     def cached_compile(self, code: 'mesonlib.FileOrString', cdata: coredata.CoreData, *,
                        extra_args: T.Union[None, T.List[str], CompilerArgs] = None,
                        mode: str = 'link',
-                       temp_dir: T.Optional[str] = None) -> T.Iterator[T.Optional[CompileResult]]:
-        # TODO: There's isn't really any reason for this to be a context manager
-
+                       temp_dir: T.Optional[str] = None) -> T.Optional[CompileResult]:
         # Calculate the key
         textra_args = tuple(extra_args) if extra_args is not None else tuple()  # type: T.Tuple[str, ...]
         key = (tuple(self.exelist), self.version, code, textra_args, mode)  # type: coredata.CompilerCheckCacheKey
@@ -854,11 +841,11 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
             mlog.debug('Code:\n', code)
             mlog.debug('Cached compiler stdout:\n', p.stdout)
             mlog.debug('Cached compiler stderr:\n', p.stderr)
-            yield p
+            return p
         else:
-            with self.compile(code, extra_args=extra_args, mode=mode, want_output=False, temp_dir=temp_dir) as p:
-                cdata.compiler_check_cache[key] = p
-                yield p
+            p = self.compile(code, extra_args=extra_args, mode=mode, want_output=False, temp_dir=temp_dir)
+            cdata.compiler_check_cache[key] = p
+            return p
 
     def get_colorout_args(self, colortype: str) -> T.List[str]:
         # TODO: colortype can probably be an emum
@@ -1231,13 +1218,12 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         args += extra_args
         return args
 
-    @contextlib.contextmanager
     def _build_wrapper(self, code: 'mesonlib.FileOrString', env: 'Environment',
                        extra_args: T.Union[None, CompilerArgs, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,
                        dependencies: T.Optional[T.List['Dependency']] = None,
                        mode: str = 'compile', want_output: bool = False,
                        disable_cache: bool = False,
-                       temp_dir: str = None) -> T.Iterator[T.Optional[CompileResult]]:
+                       temp_dir: str = None) -> T.Optional[CompileResult]:
         """Helper for getting a cacched value when possible.
 
         This method isn't meant to be called externally, it's mean to be
@@ -1245,19 +1231,17 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         """
         args = self.build_wrapper_args(env, extra_args, dependencies, CompileCheckMode(mode))
         if disable_cache or want_output:
-            with self.compile(code, extra_args=args, mode=mode, want_output=want_output, temp_dir=env.scratch_dir) as r:
-                yield r
+            return self.compile(code, extra_args=args, mode=mode, want_output=want_output, temp_dir=env.scratch_dir)
         else:
-            with self.cached_compile(code, env.coredata, extra_args=args, mode=mode, temp_dir=env.scratch_dir) as r:
-                yield r
+            return self.cached_compile(code, env.coredata, extra_args=args, mode=mode, temp_dir=env.scratch_dir)
 
     def compiles(self, code: 'mesonlib.FileOrString', env: 'Environment', *,
                  extra_args: T.Union[None, T.List[str], CompilerArgs, T.Callable[[CompileCheckMode], T.List[str]]] = None,
                  dependencies: T.Optional[T.List['Dependency']] = None,
                  mode: str = 'compile',
                  disable_cache: bool = False) -> T.Tuple[bool, bool]:
-        with self._build_wrapper(code, env, extra_args, dependencies, mode, disable_cache=disable_cache) as p:
-            return p.returncode == 0, p.cached
+        p = self._build_wrapper(code, env, extra_args, dependencies, mode, disable_cache=disable_cache)
+        return p.returncode == 0, p.cached
 
     def links(self, code: 'mesonlib.FileOrString', env: 'Environment', *,
               compiler: T.Optional['Compiler'] = None,
@@ -1266,10 +1250,10 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
               mode: str = 'compile',
               disable_cache: bool = False) -> T.Tuple[bool, bool]:
         if compiler:
-            with compiler._build_wrapper(code, env, dependencies=dependencies, want_output=True) as r:
-                objfile = mesonlib.File.from_absolute_file(r.output_name)
-                return self.compiles(objfile, env, extra_args=extra_args,
-                                     dependencies=dependencies, mode='link', disable_cache=True)
+            r = compiler._build_wrapper(code, env, dependencies=dependencies, want_output=True)
+            objfile = mesonlib.File.from_absolute_file(r.output_name)
+            return self.compiles(objfile, env, extra_args=extra_args,
+                                 dependencies=dependencies, mode='link', disable_cache=True)
 
         return self.compiles(code, env, extra_args=extra_args,
                              dependencies=dependencies, mode='link', disable_cache=disable_cache)

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -17,6 +17,7 @@ import abc
 import contextlib, os.path, re
 import enum
 import itertools
+import subprocess
 import typing as T
 from functools import lru_cache
 from dataclasses import dataclass
@@ -463,18 +464,92 @@ class RunResult(HoldableObject):
         self.stdout = stdout
         self.stderr = stderr
 
-
-@dataclass
 class CompileResult(HoldableObject):
-    """The result of Compiler.compiles (and friends)."""
-    stdout: T.Optional[str]
-    stderr: T.Optional[str]
-    command: T.Optional[T.List[str]]
-    returncode: int = 999
-    input_name: T.Optional[str] = None
-    output_name: T.Optional[str] = None
-    output_dir: T.Optional[TemporaryDirectoryWinProof] = None
-    cached: bool = False
+    """The result of Compiler.compiles (and friends).
+
+    This is a base class that contains only the result and can be pickled into
+    the persistent cache.
+    """
+    def __init__(self, command: T.List[str],
+                 returncode: T.Optional[int] = None,
+                 stdout: T.Optional[str] = None,
+                 stderr: T.Optional[str] = None) -> None:
+        self.command = command
+        self._returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+        self.cached = True
+
+    @property
+    def returncode(self) -> int:
+        self._wait()
+        assert self._returncode is not None
+        return self._returncode
+
+    @property
+    def stdout(self) -> str:
+        self._wait()
+        assert self._stdout is not None
+        return self._stdout
+
+    @property
+    def stderr(self) -> str:
+        self._wait()
+        assert self._stderr is not None
+        return self._stderr
+
+    def _wait(self) -> None:
+        pass
+
+
+class CompileProcess(CompileResult):
+    """A in-progress Compiler.compiles (and friends) process.
+
+    This subclass holds in-progress compilation and blocks only when the result
+    is actually needed. This allows having multiple compilations running in
+    parallel.
+    """
+    def __init__(self, command: T.List[str], input_name: str, output_name: str,
+                 output_dir: TemporaryDirectoryWinProof, process: subprocess.Popen,
+                 code: str) -> None:
+        super().__init__(command)
+        self.input_name = input_name
+        self._output_name = output_name
+        self.output_dir = output_dir
+        self.process = process
+        self.code = code
+        self.cached = False
+        self._finished = False
+        self._cdata: T.Optional[coredata.CoreData] = None
+        self._key: T.Optional['coredata.CompilerCheckCacheKey'] = None
+
+    @property
+    def output_name(self) -> str:
+        self._wait()
+        return self._output_name
+
+    def set_cache_info(self, cdata: coredata.CoreData, key: 'coredata.CompilerCheckCacheKey') -> None:
+        self._cdata = cdata
+        self._key = key
+
+    def _wait(self) -> None:
+        if self._finished:
+            return
+        self._finished = True
+        self._stdout, self._stderr = self.process.communicate()
+        self._returncode = self.process.returncode
+        if self._cdata and self._key:
+            # Now that the result is known, we can save it into the persistent
+            # cache. Make a copy containing only needed information that can be
+            # pickled.
+            cached = CompileResult(self.command, self._returncode, self._stdout, self._stderr)
+            self._cdata.compiler_check_cache[self._key] = cached
+        mlog.debug('Running compile:')
+        mlog.debug('Working directory: ', self.output_dir.name)
+        mlog.debug('Command line: ', ' '.join(self.command), '\n')
+        mlog.debug('Code:\n', self.code)
+        mlog.debug('Compiler stdout:\n', self._stdout)
+        mlog.debug('Compiler stderr:\n', self._stderr)
 
 
 class Compiler(HoldableObject, metaclass=abc.ABCMeta):
@@ -561,8 +636,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
 
     def get_define(self, dname: str, prefix: str, env: 'Environment',
                    extra_args: T.Union[T.List[str], T.Callable[[CompileCheckMode], T.List[str]]],
-                   dependencies: T.List['Dependency'],
-                   disable_cache: bool = False) -> T.Tuple[str, bool]:
+                   dependencies: T.List['Dependency']) -> T.Tuple[str, bool]:
         raise EnvironmentException('%s does not support get_define ' % self.get_id())
 
     def compute_int(self, expression: str, low: T.Optional[int], high: T.Optional[int],
@@ -768,13 +842,12 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         """Return an appropriate CompilerArgs instance for this class."""
         return CompilerArgs(self, args)
 
-    def compile(self, code: 'mesonlib.FileOrString',
-                extra_args: T.Union[None, CompilerArgs, T.List[str]] = None,
-                *, mode: str = 'link', want_output: bool = False,
-                temp_dir: T.Optional[str] = None) -> T.Optional[CompileResult]:
-        if extra_args is None:
-            extra_args = []
-
+    def compile(self, code: 'mesonlib.FileOrString', env: T.Optional['Environment'] = None,
+                extra_args: T.Union[None, CompilerArgs, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,
+                dependencies: T.Optional[T.List['Dependency']] = None,
+                mode: str = 'link') -> CompileProcess:
+        extra_args = self.build_wrapper_args(env, extra_args, dependencies, CompileCheckMode(mode))
+        temp_dir = env.scratch_dir if env else None
         tmpdirname = TemporaryDirectoryWinProof(dir=temp_dir)
         no_ccache = False
         if isinstance(code, str):
@@ -803,39 +876,29 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         # extra_args must be last because it could contain '/link' to
         # pass args to VisualStudio's linker. In that case everything
         # in the command line after '/link' is given to the linker.
-        if extra_args:
-            commands += extra_args
+        commands += extra_args
         # Generate full command-line with the exelist
         command_list = self.get_exelist(ccache=not no_ccache) + commands.to_native()
-        mlog.debug('Running compile:')
-        mlog.debug('Working directory: ', tmpdirname.name)
-        mlog.debug('Command line: ', ' '.join(command_list), '\n')
-        mlog.debug('Code:\n', contents)
         os_env = os.environ.copy()
         os_env['LC_ALL'] = 'C'
         if no_ccache:
             os_env['CCACHE_DISABLE'] = '1'
-        p, stdo, stde = Popen_safe(command_list, cwd=tmpdirname.name, env=os_env)
-        mlog.debug('Compiler stdout:\n', stdo)
-        mlog.debug('Compiler stderr:\n', stde)
-        result = CompileResult(stdo, stde, command_list, p.returncode, input_name=srcname)
-        if want_output:
-            result.output_name = output
-            result.output_dir = tmpdirname
-        return result
+        p = subprocess.Popen(command_list, cwd=tmpdirname.name, env=os_env,
+                             universal_newlines=True,
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return CompileProcess(command_list, srcname, output, tmpdirname, p, contents)
 
-    def cached_compile(self, code: 'mesonlib.FileOrString', cdata: coredata.CoreData, *,
-                       extra_args: T.Union[None, T.List[str], CompilerArgs] = None,
-                       mode: str = 'link',
-                       temp_dir: T.Optional[str] = None) -> T.Optional[CompileResult]:
+    def cached_compile(self, code: 'mesonlib.FileOrString', env: 'Environment',
+                       extra_args: T.Union[None, CompilerArgs, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,
+                       dependencies: T.Optional[T.List['Dependency']] = None,
+                       mode: str = 'link') -> CompileResult:
         # Calculate the key
-        textra_args = tuple(extra_args) if extra_args is not None else tuple()  # type: T.Tuple[str, ...]
-        key = (tuple(self.exelist), self.version, code, textra_args, mode)  # type: coredata.CompilerCheckCacheKey
+        args = self.build_wrapper_args(env, extra_args, dependencies, CompileCheckMode(mode))
+        key: 'coredata.CompilerCheckCacheKey' = (tuple(self.exelist), self.version, code, tuple(args), mode)
 
         # Check if not cached, and generate, otherwise get from the cache
-        if key in cdata.compiler_check_cache:
-            p = cdata.compiler_check_cache[key]
-            p.cached = True
+        p = env.coredata.compiler_check_cache.get(key)
+        if p is not None:
             mlog.debug('Using cached compile:')
             mlog.debug('Cached command line: ', ' '.join(p.command), '\n')
             mlog.debug('Code:\n', code)
@@ -843,8 +906,8 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
             mlog.debug('Cached compiler stderr:\n', p.stderr)
             return p
         else:
-            p = self.compile(code, extra_args=extra_args, mode=mode, want_output=False, temp_dir=temp_dir)
-            cdata.compiler_check_cache[key] = p
+            p = self.compile(code, env, extra_args, dependencies, mode)
+            p.set_cache_info(env.coredata, key)
             return p
 
     def get_colorout_args(self, colortype: str) -> T.List[str]:
@@ -1181,7 +1244,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         """Arguments to the compiler to turn off all optimizations."""
         return []
 
-    def build_wrapper_args(self, env: 'Environment',
+    def build_wrapper_args(self, env: T.Optional['Environment'],
                            extra_args: T.Union[None, CompilerArgs, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]],
                            dependencies: T.Optional[T.List['Dependency']],
                            mode: CompileCheckMode = CompileCheckMode.COMPILE) -> CompilerArgs:
@@ -1208,49 +1271,34 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
                 # Add link flags needed to find dependencies
                 args += d.get_link_args()
 
-        if mode is CompileCheckMode.COMPILE:
+        if env and mode is CompileCheckMode.COMPILE:
             # Add DFLAGS from the env
             args += env.coredata.get_external_args(self.for_machine, self.language)
-        elif mode is CompileCheckMode.LINK:
+        elif env and mode is CompileCheckMode.LINK:
             # Add LDFLAGS from the env
             args += env.coredata.get_external_link_args(self.for_machine, self.language)
         # extra_args must override all other arguments, so we add them last
         args += extra_args
         return args
 
-    def _build_wrapper(self, code: 'mesonlib.FileOrString', env: 'Environment',
-                       extra_args: T.Union[None, CompilerArgs, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,
-                       dependencies: T.Optional[T.List['Dependency']] = None,
-                       mode: str = 'compile', want_output: bool = False,
-                       disable_cache: bool = False,
-                       temp_dir: str = None) -> T.Optional[CompileResult]:
-        """Helper for getting a cacched value when possible.
-
-        This method isn't meant to be called externally, it's mean to be
-        wrapped by other methods like compiles() and links().
-        """
-        args = self.build_wrapper_args(env, extra_args, dependencies, CompileCheckMode(mode))
-        if disable_cache or want_output:
-            return self.compile(code, extra_args=args, mode=mode, want_output=want_output, temp_dir=env.scratch_dir)
-        else:
-            return self.cached_compile(code, env.coredata, extra_args=args, mode=mode, temp_dir=env.scratch_dir)
-
     def compiles(self, code: 'mesonlib.FileOrString', env: 'Environment', *,
                  extra_args: T.Union[None, T.List[str], CompilerArgs, T.Callable[[CompileCheckMode], T.List[str]]] = None,
                  dependencies: T.Optional[T.List['Dependency']] = None,
                  mode: str = 'compile',
                  disable_cache: bool = False) -> T.Tuple[bool, bool]:
-        p = self._build_wrapper(code, env, extra_args, dependencies, mode, disable_cache=disable_cache)
+        if disable_cache:
+            p: CompileResult = self.compile(code, env, extra_args, dependencies, mode)
+        else:
+            p = self.cached_compile(code, env, extra_args, dependencies, mode)
         return p.returncode == 0, p.cached
 
     def links(self, code: 'mesonlib.FileOrString', env: 'Environment', *,
               compiler: T.Optional['Compiler'] = None,
               extra_args: T.Union[None, T.List[str], CompilerArgs, T.Callable[[CompileCheckMode], T.List[str]]] = None,
               dependencies: T.Optional[T.List['Dependency']] = None,
-              mode: str = 'compile',
               disable_cache: bool = False) -> T.Tuple[bool, bool]:
         if compiler:
-            r = compiler._build_wrapper(code, env, dependencies=dependencies, want_output=True)
+            r = compiler.compile(code, env, dependencies=dependencies)
             objfile = mesonlib.File.from_absolute_file(r.output_name)
             return self.compiles(objfile, env, extra_args=extra_args,
                                  dependencies=dependencies, mode='link', disable_cache=True)

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -127,13 +127,13 @@ class CPPCompiler(CLikeCompiler, Compiler):
         # 2. even if it did have an env object, that might contain another more
         #    recent -std= argument, which might lead to a cascaded failure.
         CPP_TEST = 'int i = static_cast<int>(0);'
-        with self.compile(CPP_TEST, extra_args=[cpp_std_value], mode='compile') as p:
-            if p.returncode == 0:
-                mlog.debug(f'Compiler accepts {cpp_std_value}:', 'YES')
-                return True
-            else:
-                mlog.debug(f'Compiler accepts {cpp_std_value}:', 'NO')
-                return False
+        p = self.compile(CPP_TEST, extra_args=[cpp_std_value], mode='compile')
+        if p.returncode == 0:
+            mlog.debug(f'Compiler accepts {cpp_std_value}:', 'YES')
+            return True
+        else:
+            mlog.debug(f'Compiler accepts {cpp_std_value}:', 'NO')
+            return False
 
     @functools.lru_cache()
     def _find_best_cpp_std(self, cpp_std: str) -> str:

--- a/mesonbuild/compilers/cython.py
+++ b/mesonbuild/compilers/cython.py
@@ -50,9 +50,9 @@ class CythonCompiler(Compiler):
 
     def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
         code = 'print("hello world")'
-        with self.cached_compile(code, environment.coredata) as p:
-            if p.returncode != 0:
-                raise EnvironmentException(f'Cython compiler {self.id!r} cannot compile programs')
+        p = self.cached_compile(code, environment.coredata)
+        if p.returncode != 0:
+            raise EnvironmentException(f'Cython compiler {self.id!r} cannot compile programs')
 
     def get_buildtype_args(self, buildtype: str) -> T.List[str]:
         # Cython doesn't implement this, but Meson requires an implementation

--- a/mesonbuild/compilers/cython.py
+++ b/mesonbuild/compilers/cython.py
@@ -50,7 +50,7 @@ class CythonCompiler(Compiler):
 
     def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
         code = 'print("hello world")'
-        p = self.cached_compile(code, environment.coredata)
+        p = self.cached_compile(code, environment)
         if p.returncode != 0:
             raise EnvironmentException(f'Cython compiler {self.id!r} cannot compile programs')
 

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -713,7 +713,7 @@ class DCompiler(Compiler):
         if need_exe_wrapper and self.exe_wrapper is None:
             raise compilers.CrossNoRunException('Can not run test applications in this cross environment.')
         extra_args = self._get_compile_extra_args(extra_args)
-        p = self._build_wrapper(code, env, extra_args, dependencies, mode='link', want_output=True)
+        p = self.compile(code, env, extra_args, dependencies, mode='link')
         if p.returncode != 0:
             mlog.debug(f'Could not compile test file {p.input_name}: {p.returncode}\n')
             return compilers.RunResult(False)

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -713,19 +713,19 @@ class DCompiler(Compiler):
         if need_exe_wrapper and self.exe_wrapper is None:
             raise compilers.CrossNoRunException('Can not run test applications in this cross environment.')
         extra_args = self._get_compile_extra_args(extra_args)
-        with self._build_wrapper(code, env, extra_args, dependencies, mode='link', want_output=True) as p:
-            if p.returncode != 0:
-                mlog.debug(f'Could not compile test file {p.input_name}: {p.returncode}\n')
-                return compilers.RunResult(False)
-            if need_exe_wrapper:
-                cmdlist = self.exe_wrapper.get_command() + [p.output_name]
-            else:
-                cmdlist = [p.output_name]
-            try:
-                pe, so, se = mesonlib.Popen_safe(cmdlist)
-            except Exception as e:
-                mlog.debug(f'Could not run: {cmdlist} (error: {e})\n')
-                return compilers.RunResult(False)
+        p = self._build_wrapper(code, env, extra_args, dependencies, mode='link', want_output=True)
+        if p.returncode != 0:
+            mlog.debug(f'Could not compile test file {p.input_name}: {p.returncode}\n')
+            return compilers.RunResult(False)
+        if need_exe_wrapper:
+            cmdlist = self.exe_wrapper.get_command() + [p.output_name]
+        else:
+            cmdlist = [p.output_name]
+        try:
+            pe, so, se = mesonlib.Popen_safe(cmdlist)
+        except Exception as e:
+            mlog.debug(f'Could not run: {cmdlist} (error: {e})\n')
+            return compilers.RunResult(False)
 
         mlog.debug('Program stdout:\n')
         mlog.debug(so)

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -475,19 +475,19 @@ class CLikeCompiler(Compiler):
         need_exe_wrapper = env.need_exe_wrapper(self.for_machine)
         if need_exe_wrapper and self.exe_wrapper is None:
             raise compilers.CrossNoRunException('Can not run test applications in this cross environment.')
-        with self._build_wrapper(code, env, extra_args, dependencies, mode='link', want_output=True) as p:
-            if p.returncode != 0:
-                mlog.debug(f'Could not compile test file {p.input_name}: {p.returncode}\n')
-                return compilers.RunResult(False)
-            if need_exe_wrapper:
-                cmdlist = self.exe_wrapper.get_command() + [p.output_name]
-            else:
-                cmdlist = [p.output_name]
-            try:
-                pe, so, se = mesonlib.Popen_safe(cmdlist)
-            except Exception as e:
-                mlog.debug(f'Could not run: {cmdlist} (error: {e})\n')
-                return compilers.RunResult(False)
+        p = self._build_wrapper(code, env, extra_args, dependencies, mode='link', want_output=True)
+        if p.returncode != 0:
+            mlog.debug(f'Could not compile test file {p.input_name}: {p.returncode}\n')
+            return compilers.RunResult(False)
+        if need_exe_wrapper:
+            cmdlist = self.exe_wrapper.get_command() + [p.output_name]
+        else:
+            cmdlist = [p.output_name]
+        try:
+            pe, so, se = mesonlib.Popen_safe(cmdlist)
+        except Exception as e:
+            mlog.debug(f'Could not run: {cmdlist} (error: {e})\n')
+            return compilers.RunResult(False)
 
         mlog.debug('Program stdout:\n')
         mlog.debug(so)
@@ -676,17 +676,16 @@ class CLikeCompiler(Compiler):
         {delim}\n{dname}'''
         args = self.build_wrapper_args(env, extra_args, dependencies,
                                        mode=CompileCheckMode.PREPROCESS).to_native()
-        func = functools.partial(self.cached_compile, code, env.coredata, extra_args=args, mode='preprocess')
         if disable_cache:
-            func = functools.partial(self.compile, code, extra_args=args, mode='preprocess', temp_dir=env.scratch_dir)
-        with func() as p:
-            cached = p.cached
-            if p.returncode != 0:
-                raise mesonlib.EnvironmentException(f'Could not get define {dname!r}')
+            p = self.compile(code, extra_args=args, mode='preprocess', temp_dir=env.scratch_dir)
+        else:
+            p = self.cached_compile(code, env.coredata, extra_args=args, mode='preprocess')
+        if p.returncode != 0:
+             raise mesonlib.EnvironmentException(f'Could not get define {dname!r}')
         # Get the preprocessed value after the delimiter,
         # minus the extra newline at the end and
         # merge string literals.
-        return self._concatenate_string_literals(p.stdout.split(delim + '\n')[-1][:-1]), cached
+        return self._concatenate_string_literals(p.stdout.split(delim + '\n')[-1][:-1]), p.cached
 
     def get_return_value(self, fname: str, rtype: str, prefix: str,
                          env: 'Environment', extra_args: T.Optional[T.List[str]],
@@ -917,22 +916,22 @@ class CLikeCompiler(Compiler):
         '''
         args = self.get_compiler_check_args(CompileCheckMode.COMPILE)
         n = '_symbols_have_underscore_prefix_searchbin'
-        with self._build_wrapper(code, env, extra_args=args, mode='compile', want_output=True, temp_dir=env.scratch_dir) as p:
-            if p.returncode != 0:
-                raise RuntimeError(f'BUG: Unable to compile {n!r} check: {p.stderr}')
-            if not os.path.isfile(p.output_name):
-                raise RuntimeError(f'BUG: Can\'t find compiled test code for {n!r} check')
-            with open(p.output_name, 'rb') as o:
-                for line in o:
-                    # Check if the underscore form of the symbol is somewhere
-                    # in the output file.
-                    if b'_' + symbol_name in line:
-                        mlog.debug("Underscore prefix check found prefixed function in binary")
-                        return True
-                    # Else, check if the non-underscored form is present
-                    elif symbol_name in line:
-                        mlog.debug("Underscore prefix check found non-prefixed function in binary")
-                        return False
+        p = self._build_wrapper(code, env, extra_args=args, mode='compile', want_output=True, temp_dir=env.scratch_dir)
+        if p.returncode != 0:
+            raise RuntimeError(f'BUG: Unable to compile {n!r} check: {p.stderr}')
+        if not os.path.isfile(p.output_name):
+            raise RuntimeError(f'BUG: Can\'t find compiled test code for {n!r} check')
+        with open(p.output_name, 'rb') as o:
+            for line in o:
+                # Check if the underscore form of the symbol is somewhere
+                # in the output file.
+                if b'_' + symbol_name in line:
+                    mlog.debug("Underscore prefix check found prefixed function in binary")
+                    return True
+                # Else, check if the non-underscored form is present
+                elif symbol_name in line:
+                    mlog.debug("Underscore prefix check found non-prefixed function in binary")
+                    return False
         raise RuntimeError(f'BUG: {n!r} check did not find symbol string in binary')
 
     def _symbols_have_underscore_prefix_define(self, env: 'Environment') -> T.Optional[bool]:
@@ -952,18 +951,17 @@ class CLikeCompiler(Compiler):
         #endif
         {delim}MESON_UNDERSCORE_PREFIX
         '''
-        with self._build_wrapper(code, env, mode='preprocess', want_output=False, temp_dir=env.scratch_dir) as p:
-            if p.returncode != 0:
-                raise RuntimeError(f'BUG: Unable to preprocess _symbols_have_underscore_prefix_define check: {p.stdout}')
-            symbol_prefix = p.stdout.partition(delim)[-1].rstrip()
-
-            mlog.debug(f'Queried compiler for function prefix: __USER_LABEL_PREFIX__ is "{symbol_prefix!s}"')
-            if symbol_prefix == '_':
-                return True
-            elif symbol_prefix == '':
-                return False
-            else:
-                return None
+        p = self._build_wrapper(code, env, mode='preprocess', want_output=False, temp_dir=env.scratch_dir)
+        if p.returncode != 0:
+            raise RuntimeError(f'BUG: Unable to preprocess _symbols_have_underscore_prefix_define check: {p.stdout}')
+        symbol_prefix = p.stdout.partition(delim)[-1].rstrip()
+        mlog.debug(f'Queried compiler for function prefix: __USER_LABEL_PREFIX__ is "{symbol_prefix!s}"')
+        if symbol_prefix == '_':
+            return True
+        elif symbol_prefix == '':
+            return False
+        else:
+            return None
 
     def _symbols_have_underscore_prefix_list(self, env: 'Environment') -> T.Optional[bool]:
         '''

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -460,10 +460,10 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
     @functools.lru_cache()
     def _get_search_dirs(self, env: 'Environment') -> str:
         extra_args = ['--print-search-dirs']
-        with self._build_wrapper('', env, extra_args=extra_args,
-                                 dependencies=None, mode='compile',
-                                 want_output=True) as p:
-            return p.stdout
+        p = self._build_wrapper('', env, extra_args=extra_args,
+                                dependencies=None, mode='compile',
+                                want_output=True)
+        return p.stdout
 
     def _split_fetch_real_dirs(self, pathstr: str) -> T.List[str]:
         # We need to use the path separator used by the compiler for printing
@@ -613,12 +613,12 @@ class GnuCompiler(GnuLikeCompiler):
         # For some compiler command line arguments, the GNU compilers will
         # emit a warning on stderr indicating that an option is valid for a
         # another language, but still complete with exit_success
-        with self._build_wrapper(code, env, args, None, mode) as p:
-            result = p.returncode == 0
-            if self.language in {'cpp', 'objcpp'} and 'is valid for C/ObjC' in p.stderr:
-                result = False
-            if self.language in {'c', 'objc'} and 'is valid for C++/ObjC++' in p.stderr:
-                result = False
+        p = self._build_wrapper(code, env, args, None, mode)
+        result = p.returncode == 0
+        if self.language in {'cpp', 'objcpp'} and 'is valid for C/ObjC' in p.stderr:
+            result = False
+        if self.language in {'c', 'objc'} and 'is valid for C++/ObjC++' in p.stderr:
+            result = False
         return result, p.cached
 
     def get_has_func_attribute_extra_args(self, name: str) -> T.List[str]:

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -460,9 +460,7 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
     @functools.lru_cache()
     def _get_search_dirs(self, env: 'Environment') -> str:
         extra_args = ['--print-search-dirs']
-        p = self._build_wrapper('', env, extra_args=extra_args,
-                                dependencies=None, mode='compile',
-                                want_output=True)
+        p = self.cached_compile('', env, extra_args=extra_args)
         return p.stdout
 
     def _split_fetch_real_dirs(self, pathstr: str) -> T.List[str]:
@@ -613,7 +611,7 @@ class GnuCompiler(GnuLikeCompiler):
         # For some compiler command line arguments, the GNU compilers will
         # emit a warning on stderr indicating that an option is valid for a
         # another language, but still complete with exit_success
-        p = self._build_wrapper(code, env, args, None, mode)
+        p = self.cached_compile(code, env, args, mode=mode)
         result = p.returncode == 0
         if self.language in {'cpp', 'objcpp'} and 'is valid for C/ObjC' in p.stderr:
             result = False

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -309,7 +309,7 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
     # http://stackoverflow.com/questions/15259720/how-can-i-make-the-microsoft-c-compiler-treat-unknown-flags-as-errors-rather-t
     def has_arguments(self, args: T.List[str], env: 'Environment', code: str, mode: str) -> T.Tuple[bool, bool]:
         warning_text = '4044' if mode == 'link' else '9002'
-        p = self._build_wrapper(code, env, extra_args=args, mode=mode)
+        p = self.cached_compile(code, env, extra_args=args, mode=mode)
         if p.returncode != 0:
             return False, p.cached
         return not (warning_text in p.stderr or warning_text in p.stdout), p.cached

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -309,10 +309,10 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
     # http://stackoverflow.com/questions/15259720/how-can-i-make-the-microsoft-c-compiler-treat-unknown-flags-as-errors-rather-t
     def has_arguments(self, args: T.List[str], env: 'Environment', code: str, mode: str) -> T.Tuple[bool, bool]:
         warning_text = '4044' if mode == 'link' else '9002'
-        with self._build_wrapper(code, env, extra_args=args, mode=mode) as p:
-            if p.returncode != 0:
-                return False, p.cached
-            return not (warning_text in p.stderr or warning_text in p.stdout), p.cached
+        p = self._build_wrapper(code, env, extra_args=args, mode=mode)
+        if p.returncode != 0:
+            return False, p.cached
+        return not (warning_text in p.stderr or warning_text in p.stdout), p.cached
 
     def get_compile_debugfile_args(self, rel_obj: str, pch: bool = False) -> T.List[str]:
         pdbarr = rel_obj.split('.')[:-1]

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -100,10 +100,10 @@ class ValaCompiler(Compiler):
             extra_flags += self.get_compile_only_args()
         else:
             extra_flags += environment.coredata.get_external_link_args(self.for_machine, self.language)
-        with self.cached_compile(code, environment.coredata, extra_args=extra_flags, mode='compile') as p:
-            if p.returncode != 0:
-                msg = f'Vala compiler {self.name_string()!r} can not compile programs'
-                raise EnvironmentException(msg)
+        p = self.cached_compile(code, environment.coredata, extra_args=extra_flags, mode='compile')
+        if p.returncode != 0:
+            msg = f'Vala compiler {self.name_string()!r} can not compile programs'
+            raise EnvironmentException(msg)
 
     def get_buildtype_args(self, buildtype: str) -> T.List[str]:
         if buildtype in {'debug', 'debugoptimized', 'minsize'}:
@@ -122,9 +122,9 @@ class ValaCompiler(Compiler):
             args += env.coredata.get_external_args(self.for_machine, self.language)
             vapi_args = ['--pkg', libname]
             args += vapi_args
-            with self.cached_compile(code, env.coredata, extra_args=args, mode='compile') as p:
-                if p.returncode == 0:
-                    return vapi_args
+            p = self.cached_compile(code, env.coredata, extra_args=args, mode='compile')
+            if p.returncode == 0:
+                return vapi_args
         # Not found? Try to find the vapi file itself.
         for d in extra_dirs:
             vapi = os.path.join(d, libname + '.vapi')

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -100,7 +100,7 @@ class ValaCompiler(Compiler):
             extra_flags += self.get_compile_only_args()
         else:
             extra_flags += environment.coredata.get_external_link_args(self.for_machine, self.language)
-        p = self.cached_compile(code, environment.coredata, extra_args=extra_flags, mode='compile')
+        p = self.cached_compile(code, environment, extra_args=extra_flags, mode='compile')
         if p.returncode != 0:
             msg = f'Vala compiler {self.name_string()!r} can not compile programs'
             raise EnvironmentException(msg)
@@ -122,7 +122,7 @@ class ValaCompiler(Compiler):
             args += env.coredata.get_external_args(self.for_machine, self.language)
             vapi_args = ['--pkg', libname]
             args += vapi_args
-            p = self.cached_compile(code, env.coredata, extra_args=args, mode='compile')
+            p = self.cached_compile(code, env, extra_args=args, mode='compile')
             if p.returncode == 0:
                 return vapi_args
         # Not found? Try to find the vapi file itself.

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -704,6 +704,10 @@ class CoreData:
         self.deps.host.clear()
         self.deps.build.clear()
 
+    def clear_cache(self):
+        self.clear_deps_cache()
+        self.compiler_check_cache.clear()
+
     def get_nondefault_buildtype_args(self):
         result = []
         value = self.options[OptionKey('buildtype')].value

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -114,7 +114,7 @@ class OpenMPDependency(SystemDependency):
             return
         try:
             openmp_date = self.clib_compiler.get_define(
-                '_OPENMP', '', self.env, self.clib_compiler.openmp_flags(), [self], disable_cache=True)[0]
+                '_OPENMP', '', self.env, self.clib_compiler.openmp_flags(), [self])[0]
         except mesonlib.EnvironmentException as e:
             mlog.debug('OpenMP support not available in the compiler')
             mlog.debug(e)
@@ -179,7 +179,7 @@ class BlocksDependency(SystemDependency):
                 return callback();
             }'''
 
-        p = self.clib_compiler.compile(source, extra_args=self.compile_args + self.link_args)
+        p = self.clib_compiler.compile(source, environment, extra_args=self.compile_args + self.link_args)
         if p.returncode != 0:
             mlog.log(mlog.red('ERROR:'), 'Compiler does not support blocks extension.')
             return

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -179,12 +179,11 @@ class BlocksDependency(SystemDependency):
                 return callback();
             }'''
 
-        with self.clib_compiler.compile(source, extra_args=self.compile_args + self.link_args) as p:
-            if p.returncode != 0:
-                mlog.log(mlog.red('ERROR:'), 'Compiler does not support blocks extension.')
-                return
-
-            self.is_found = True
+        p = self.clib_compiler.compile(source, extra_args=self.compile_args + self.link_args)
+        if p.returncode != 0:
+            mlog.log(mlog.red('ERROR:'), 'Compiler does not support blocks extension.')
+            return
+        self.is_found = True
 
 
 class Python3DependencySystem(SystemDependency):

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -88,7 +88,7 @@ class Conf:
             raise ConfException(f'Directory {build_dir} is neither a Meson build directory nor a project source directory.')
 
     def clear_cache(self):
-        self.coredata.clear_deps_cache()
+        self.coredata.clear_cache()
 
     def set_options(self, options):
         self.coredata.set_options(options)


### PR DESCRIPTION
-    mconf: Also clear compiler cache with --clearcache

-    compilers: Wait until result is needed before blocking on compilation
    
    This does not change much yet because we usually check the returncode
    immediately, but in the future it will allow running multiple checks in
    parallel, especially in batch APIs like get_supported_arguments().
    
    - compile() bypass the cache and is used when the output is needed, for
      example to run it.
    - cached_compile() is used when only returncode, stdout or stderr are
      needed.

-    compilers: Remove useless contextmanager in compile functions
    
    Replace it by keeping a reference to the TemporaryDirectory when caller
    wants the output.
