### PR TITLE
feat(nvidia_hpc): support C/C++ `-std`

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -345,6 +345,21 @@ class NvidiaHPC_CCompiler(PGICompiler, CCompiler):
                            info, exe_wrapper, linker=linker, full_version=full_version)
         PGICompiler.__init__(self)
 
+    def get_options(self) -> 'MutableKeyedOptionDictType':
+        opts = CCompiler.get_options(self)
+        c_stds = ['none', 'c89', 'gnu89', 'c90', 'gnu90', 'c99', 'gnu99', 'c11', 'gnu11']
+        if version_compare(self.version, '>=22.9.0'):
+            c_stds += ['c17', 'gnu17', 'c18', 'gnu18']
+        key = OptionKey('std', lang=self.language, machine=self.for_machine)
+        opts[key].choices = c_stds
+        return opts
+
+    def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+        args = []
+        std = options[OptionKey('std', lang=self.language, machine=self.for_machine)]
+        if std.value != 'none':
+            args.append('-std=' + std.value)
+        return args
 
 class ElbrusCCompiler(ElbrusCompiler, CCompiler):
     def __init__(self, ccache: T.List[str], exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -155,7 +155,7 @@ class CPPCompiler(CLikeCompiler, Compiler):
         }
 
         # Currently, remapping is only supported for Clang, Elbrus and GCC
-        assert self.id in frozenset(['clang', 'lcc', 'gcc', 'emscripten', 'armltdclang', 'intel-llvm'])
+        assert self.id in frozenset(['clang', 'lcc', 'gcc', 'emscripten', 'armltdclang', 'intel-llvm', 'nvidia_hpc'])
 
         if cpp_std not in CPP_FALLBACKS:
             # 'c++03' and 'c++98' don't have fallback types
@@ -460,6 +460,23 @@ class NvidiaHPC_CPPCompiler(PGICompiler, CPPCompiler):
         CPPCompiler.__init__(self, ccache, exelist, version, for_machine, is_cross,
                              info, exe_wrapper, linker=linker, full_version=full_version)
         PGICompiler.__init__(self)
+
+    def get_options(self) -> 'MutableKeyedOptionDictType':
+        opts = CPPCompiler.get_options(self)
+        cpp_stds = ['none', 'c++98', 'gnu++98', 'c++03', 'gnu++98', 'c++11', 'gnu++11']
+        if version_compare(self.version, '>=22.9.0'):
+            cpp_stds += ['c++14', 'gnu++14', 'c++17', 'gnu++17', 'c++20', 'gnu+20']
+        key = OptionKey('std', lang=self.language, machine=self.for_machine)
+        opts[key].choices = cpp_stds
+        return opts
+
+    def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+        args = []
+        key = OptionKey('std', lang=self.language, machine=self.for_machine)
+        std = options[key]
+        if std.value != 'none':
+            args.append(self._find_best_cpp_std(std.value))
+        return args
 
 
 class ElbrusCPPCompiler(ElbrusCompiler, CPPCompiler):


### PR DESCRIPTION
The author has only NVIDIA 22.9.0, so information on older versions is missed.

For example, https://docs.nvidia.com/hpc-sdk/archive/20.7/hpc-sdk-release-notes/index.html#platform-requirements shows *requirements* but NVIDIA’s C/C++ support status is missed.