### PR TITLE
Python dependency refactor backport 1.0

### DIFF
--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -152,6 +152,9 @@ class PythonSystemDependency(SystemDependency, _PythonDependencyBase):
         else:
             self._find_libpy(installation, environment)
 
+        if not self.clib_compiler.has_header('Python.h', '', environment, extra_args=self.compile_args):
+            self.is_found = False
+
     def _find_libpy(self, python_holder: 'PythonInstallation', environment: 'Environment') -> None:
         if python_holder.is_pypy:
             if self.major_version == 3:

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -281,7 +281,8 @@ class PythonSystemDependency(SystemDependency, _PythonDependencyBase):
         self.compile_args += ['-I' + path for path in inc_paths if path]
 
         # https://sourceforge.net/p/mingw-w64/mailman/message/30504611/
-        if pyarch == '64' and self.major_version == 2:
+        # https://github.com/python/cpython/pull/100137
+        if pyarch == '64' and mesonlib.version_compare(self.version, '<3.12'):
             self.compile_args += ['-DMS_WIN64']
 
         self.is_found = True


### PR DESCRIPTION
Backports the bug fixes from #11392

But not the deep refactoring that preceded it, which is too risky for backporting.