### PR TITLE
Add support for b_ndebug to rust

### DIFF
--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -41,6 +41,7 @@ libraries. This has two advantages over hand-rolling ones own with a
 
 - It handles `include_directories`, so one doesn't have to manually convert them to `-I...`
 - It automatically sets up a depfile, making the results more reliable
+- It automatically handles assertions, synchronizing Rust and C/C++ to have the same behavior
 
 
 It takes the following keyword arguments
@@ -81,3 +82,11 @@ r1 = rust.bindgen(
   output : 'out.rs',
 )
 ```
+
+
+*Since 1.1.0* Meson will synchronize assertions for Rust and C/C++  when the
+`b_ndebug` option is set (via `-DNDEBUG` for C/C++, and `-C
+debug-assertions=on` for Rust), and will pass `-DNDEBUG` as an extra argument
+to clang. This allows for reliable wrapping of `-DNDEBUG` controlled behavior
+with `#[cfg(debug_asserions)]` and or `cfg!()`. Before 1.1.0, assertions for Rust
+were never turned on by Meson.

--- a/docs/markdown/snippets/rustc-ndebug.md
+++ b/docs/markdown/snippets/rustc-ndebug.md
@@ -1,0 +1,6 @@
+## Rust now supports the b_ndebug option
+
+Which controls the `debug_assertions` cfg, which in turn controls
+`debug_assert!()` macro. This macro is roughly equivalent to C's `assert()`, as
+it can be toggled with command line options, unlike Rust's `assert!()`, which
+cannot be turned off, and is not designed to be.

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -365,10 +365,10 @@ def get_base_compile_args(options: 'KeyedOptionDictType', compiler: 'Compiler') 
     except KeyError:
         pass
     try:
-        if (options[OptionKey('b_ndebug')].value == 'true' or
-                (options[OptionKey('b_ndebug')].value == 'if-release' and
-                 options[OptionKey('buildtype')].value in {'release', 'plain'})):
-            args += compiler.get_disable_assert_args()
+        disable = (options[OptionKey('b_ndebug')].value == 'true' or
+                   (options[OptionKey('b_ndebug')].value == 'if-release' and
+                    options[OptionKey('buildtype')].value in {'release', 'plain'}))
+        args += compiler.get_assert_args(disable)
     except KeyError:
         pass
     # This does not need a try...except
@@ -1071,7 +1071,12 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
     def get_coverage_link_args(self) -> T.List[str]:
         return self.linker.get_coverage_args()
 
-    def get_disable_assert_args(self) -> T.List[str]:
+    def get_assert_args(self, disable: bool) -> T.List[str]:
+        """Get arguments to enable or disable assertion.
+
+        :param disable: Whether to disable assertions
+        :return: A list of string arguments for this compiler
+        """
         return []
 
     def get_crt_compile_args(self, crt_val: str, buildtype: str) -> T.List[str]:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -334,6 +334,17 @@ def get_option_value(options: 'KeyedOptionDictType', opt: OptionKey, fallback: '
     return v
 
 
+def are_asserts_disabled(options: KeyedOptionDictType) -> bool:
+    """Should debug assertions be disabled
+
+    :param options: OptionDictionary
+    :return: whether to disable assertions or not
+    """
+    return (options[OptionKey('b_ndebug')].value == 'true' or
+            (options[OptionKey('b_ndebug')].value == 'if-release' and
+             options[OptionKey('buildtype')].value in {'release', 'plain'}))
+
+
 def get_base_compile_args(options: 'KeyedOptionDictType', compiler: 'Compiler') -> T.List[str]:
     args = []  # type T.List[str]
     try:
@@ -365,10 +376,7 @@ def get_base_compile_args(options: 'KeyedOptionDictType', compiler: 'Compiler') 
     except KeyError:
         pass
     try:
-        disable = (options[OptionKey('b_ndebug')].value == 'true' or
-                   (options[OptionKey('b_ndebug')].value == 'if-release' and
-                    options[OptionKey('buildtype')].value in {'release', 'plain'}))
-        args += compiler.get_assert_args(disable)
+        args += compiler.get_assert_args(are_asserts_disabled(options))
     except KeyError:
         pass
     # This does not need a try...except

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -787,5 +787,5 @@ class CudaCompiler(Compiler):
     def get_profile_use_args(self) -> T.List[str]:
         return ['-Xcompiler=' + x for x in self.host_compiler.get_profile_use_args()]
 
-    def get_disable_assert_args(self) -> T.List[str]:
-        return self.host_compiler.get_disable_assert_args()
+    def get_assert_args(self, disable: bool) -> T.List[str]:
+        return self.host_compiler.get_assert_args(disable)

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -855,8 +855,10 @@ class GnuDCompiler(GnuCompiler, DCompiler):
             return args
         return args + ['-shared-libphobos']
 
-    def get_disable_assert_args(self) -> T.List[str]:
-        return ['-frelease']
+    def get_assert_args(self, disable: bool) -> T.List[str]:
+        if disable:
+            return ['-frelease']
+        return []
 
 # LDC uses the DMD frontend code to parse and analyse the code.
 # It then uses LLVM for the binary code generation and optimizations.
@@ -927,8 +929,10 @@ class LLVMDCompiler(DmdLikeCompilerMixin, DCompiler):
             return args
         return args + ['-link-defaultlib-shared']
 
-    def get_disable_assert_args(self) -> T.List[str]:
-        return ['--release']
+    def get_assert_args(self, disable: bool) -> T.List[str]:
+        if disable:
+            return ['--release']
+        return []
 
     def rsp_file_syntax(self) -> RSPFileSyntax:
         # We use `mesonlib.is_windows` here because we want to know what the
@@ -1015,8 +1019,10 @@ class DmdDCompiler(DmdLikeCompilerMixin, DCompiler):
             return args
         return args + ['-defaultlib=phobos2', '-debuglib=phobos2']
 
-    def get_disable_assert_args(self) -> T.List[str]:
-        return ['-release']
+    def get_assert_args(self, disable: bool) -> T.List[str]:
+        if disable:
+            return ['-release']
+        return []
 
     def rsp_file_syntax(self) -> RSPFileSyntax:
         return RSPFileSyntax.MSVC

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -1332,8 +1332,10 @@ class CLikeCompiler(Compiler):
         return self.compiles(self.attribute_check_func(name), env,
                              extra_args=self.get_has_func_attribute_extra_args(name))
 
-    def get_disable_assert_args(self) -> T.List[str]:
-        return ['-DNDEBUG']
+    def get_assert_args(self, disable: bool) -> T.List[str]:
+        if disable:
+            return ['-DNDEBUG']
+        return []
 
     @functools.lru_cache(maxsize=None)
     def can_compile(self, src: 'mesonlib.FileOrString') -> bool:

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -62,7 +62,7 @@ class RustCompiler(Compiler):
                          is_cross=is_cross, full_version=full_version,
                          linker=linker)
         self.exe_wrapper = exe_wrapper
-        self.base_options.add(OptionKey('b_colorout'))
+        self.base_options.update({OptionKey(o) for o in ['b_colorout', 'b_ndebug']})
         if 'link' in self.linker.id:
             self.base_options.add(OptionKey('b_vscrt'))
 
@@ -196,6 +196,10 @@ class RustCompiler(Compiler):
         # Rustc currently has no way to toggle this, it's controlled by whether
         # pic is on by rustc
         return []
+
+    def get_assert_args(self, disable: bool) -> T.List[str]:
+        action = "no" if disable else "yes"
+        return ['-C', f'debug-assertions={action}']
 
 
 class ClippyRustCompiler(RustCompiler):

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -19,6 +19,7 @@ import typing as T
 from . import ExtensionModule, ModuleReturnValue, ModuleInfo
 from .. import mlog
 from ..build import BothLibraries, BuildTarget, CustomTargetIndex, Executable, ExtractedObjects, GeneratedList, IncludeDirs, CustomTarget, StructuredSources
+from ..compilers.compilers import are_asserts_disabled
 from ..dependencies import Dependency, ExternalLibrary
 from ..interpreter.type_checking import DEPENDENCIES_KW, TEST_KWS, OUTPUT_KW, INCLUDE_DIRECTORIES, include_dir_string_new
 from ..interpreterbase import ContainerTypeInfo, InterpreterException, KwargInfo, typed_kwargs, typed_pos_args, noPosargs
@@ -198,6 +199,8 @@ class RustModule(ExtensionModule):
             # bindgen always uses clang, so it's safe to hardcode -I here
             clang_args.extend([f'-I{x}' for x in i.to_string_list(
                 state.environment.get_source_dir(), state.environment.get_build_dir())])
+        if are_asserts_disabled(state.environment.coredata.options):
+            clang_args.append('-DNDEBUG')
 
         for de in kwargs['dependencies']:
             for i in de.get_include_dirs():

--- a/test cases/rust/1 basic/meson.build
+++ b/test cases/rust/1 basic/meson.build
@@ -1,4 +1,4 @@
-project('rustprog', 'rust')
+project('rustprog', 'rust', default_options : ['b_ndebug=true'])
 
 e = executable('rust-program', 'prog.rs',
   rust_args : ['-C', 'lto'], # Just a test
@@ -7,3 +7,14 @@ e = executable('rust-program', 'prog.rs',
 test('rusttest', e)
 
 subdir('subdir')
+
+# this should fail due to debug_assert
+test(
+  'debug_assert_on',
+  executable(
+    'rust-program2',
+    'prog.rs',
+    override_options : ['b_ndebug=false'],
+  ),
+  should_fail : true,
+)

--- a/test cases/rust/1 basic/prog.rs
+++ b/test cases/rust/1 basic/prog.rs
@@ -1,4 +1,5 @@
 fn main() {
     let foo = "rust compiler is working";
+    debug_assert!(false, "debug_asserts on!");
     println!("{}", foo);
 }


### PR DESCRIPTION
Rust has a `debug_assert!()` macro, which is designed to be toggled on the command line. It is on by default in debug builds, and off by default in release builds, in cargo. This matches what meson's b_ndebug does in `if-release` mode. In addition, this fixes an oversight in the rust module where bindgen wouldn't be passed `-DNDEBUG` when `b_ndebug=false`.

Fixes #11438