### PR TITLE
clangformat: don't noisily print status messages for every checked file

### DIFF
--- a/mesonbuild/scripts/clangformat.py
+++ b/mesonbuild/scripts/clangformat.py
@@ -23,10 +23,9 @@ from ..mesonlib import version_compare
 from ..programs import ExternalProgram
 import typing as T
 
-def run_clang_format(fname: Path, exelist: T.List[str], check: bool) -> subprocess.CompletedProcess:
+def run_clang_format(fname: Path, exelist: T.List[str], check: bool, cformat_ver: T.Optional[str]) -> subprocess.CompletedProcess:
     clangformat_10 = False
-    if check:
-        cformat_ver = ExternalProgram('clang-format', exelist).get_version()
+    if check and cformat_ver:
         if version_compare(cformat_ver, '>=10'):
             clangformat_10 = True
             exelist = exelist + ['--dry-run', '--Werror']
@@ -58,4 +57,9 @@ def run(args: T.List[str]) -> int:
         print('Could not execute clang-format "%s"' % ' '.join(exelist))
         return 1
 
-    return run_tool('clang-format', srcdir, builddir, run_clang_format, exelist, options.check)
+    if options.check:
+        cformat_ver = ExternalProgram('clang-format', exelist, silent=True).get_version()
+    else:
+        cformat_ver = None
+
+    return run_tool('clang-format', srcdir, builddir, run_clang_format, exelist, options.check, cformat_ver)


### PR DESCRIPTION
The version lookup should be silent. While we're at it, the version lookup should not be happening more than once, which printing multiple messages indicated we were doing. Pass the version into the per-file function rather than looking it up fresh each time.

Fixes https://github.com/mesonbuild/meson/pull/11054#issuecomment-1430169280