### PR TITLE
dependencies: add custom atomic dependency

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -317,6 +317,16 @@ dep = dependency('appleframeworks', modules : 'foundation')
 
 These dependencies can never be found for non-OSX hosts.
 
+## atomic (stdatomic)
+
+*(added 1.7.0)*
+
+Provides access to the atomic operations library. This first attempts
+to look for a valid atomic external library before trying to fallback
+to what is provided by the C runtime libraries.
+
+`method` may be `auto`, `builtin` or `system`.
+
 ## Blocks
 
 Enable support for Clang's blocks extension.

--- a/docs/markdown/snippets/atomic-dependency.md
+++ b/docs/markdown/snippets/atomic-dependency.md
@@ -1,0 +1,9 @@
+## New custom dependency for atomic
+
+```
+dependency('atomic')
+```
+
+checks for the availability of the atomic operation library. First, it looks
+for the atomic library. If that is not found, then it will try to use what is
+provided by the libc.

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -220,6 +220,7 @@ packages.defaults.update({
     'shaderc': 'misc',
     'iconv': 'misc',
     'intl': 'misc',
+    'atomic': 'misc',
     'dl': 'misc',
     'openssl': 'misc',
     'libcrypto': 'misc',


### PR DESCRIPTION
Almost exactly the same as how the dl dependency works. On certain systems (like BSDs that use clang), stdatomic is provided by compiler-rt and doesn't need a separate library explictly linked. On a typical GNU/LINUX system, atomic is a separate library that must be explictly found and linked against. So just add a builtin and system method for these two use cases.