### PR TITLE
Update supported STDs.

### DIFF
--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -96,7 +96,7 @@ class ClangObjCPPCompiler(ClangCompiler, ObjCPPCompiler):
         opts.update({
             OptionKey('std', machine=self.for_machine, lang='cpp'): coredata.UserComboOption(
                 'C++ language standard to use',
-                ['none', 'c++98', 'c++11', 'c++14', 'c++17', 'gnu++98', 'gnu++11', 'gnu++14', 'gnu++17'],
+                ['none', 'c++98', 'c++11', 'c++14', 'c++17', 'c++20', 'gnu++98', 'gnu++11', 'gnu++14', 'gnu++17', 'gnu++20'],
                 'none',
             )
         })


### PR DESCRIPTION
This PR adds missing `c++20` and `gnu++20` to the Objective-C++ compiler.