### PR TITLE
dependencies: add pybind11 custom factory

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -659,6 +659,12 @@ The `language` keyword may used.
 
 `method` may be `auto`, `config-tool` or `pkg-config`.
 
+## Pybind11
+
+*(added 1.1.0)*
+
+`method` may be `auto`, `pkg-config`, `config-tool`, or `cmake`.
+
 ## Python3
 
 Python3 is handled specially by Meson:

--- a/docs/markdown/snippets/pybind11_dep.md
+++ b/docs/markdown/snippets/pybind11_dep.md
@@ -1,0 +1,9 @@
+## New pybind11 custom dependency
+
+`dependency('pybind11')` works with pkg-config and cmake without any special
+support, but did not handle the `pybind11-config` script.
+
+This is useful because the config-tool will work out of the box when pybind11
+is installed, but the pkg-config and cmake files are shoved into python's
+site-packages, which makes it impossible to use in an out of the box manner.
+

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -39,7 +39,7 @@ from .misc import (
     dl_factory, openssl_factory, libcrypto_factory, libssl_factory,
 )
 from .platform import AppleFrameworks
-from .python import python_factory as python3_factory
+from .python import python_factory as python3_factory, pybind11_factory
 from .qt import qt4_factory, qt5_factory, qt6_factory
 from .ui import GnuStepDependency, WxDependency, gl_factory, sdl2_factory, vulkan_factory
 
@@ -270,6 +270,7 @@ packages.update({
 
     # from python:
     'python3': python3_factory,
+    'pybind11': pybind11_factory,
 
     # From ui:
     'gl': gl_factory,


### PR DESCRIPTION
This works with pkg-config and cmake without any special support. The custom factory adds further support for config-tool, via `pybind11-config`. This is useful because the config-tool will work out of the box when pybind11 is installed, but the pkg-config and cmake files are shoved into python's site-packages, which is an unfortunate distribution model and makes it impossible to use in an out of the box manner.

It's possible to manually set up the PKG_CONFIG_PATH to detect it anyway, but in case that does not happen, having the config-tool fallback is extremely useful.

Depends on https://github.com/pybind/pybind11/pull/4526 (sort of, the version will be unknown without that PR)