### PR TITLE
respect `meson_version` very early

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -528,6 +528,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     def handle_meson_version(self, pv: str, location: mparser.BaseNode) -> None:
         if not mesonlib.version_compare(coredata.version, pv):
             raise InterpreterException.from_node(f'Meson version is {coredata.version} but project requires {pv}', node=location)
+        mesonlib.project_meson_versions[self.subproject] = pv
 
     def handle_meson_version_from_ast(self) -> None:
         if not self.ast.lines:
@@ -1170,7 +1171,6 @@ class Interpreter(InterpreterBase, HoldableObject):
         # for things like deprecation testing.
         if kwargs['meson_version']:
             self.handle_meson_version(kwargs['meson_version'], node)
-            mesonlib.project_meson_versions[self.subproject] = kwargs['meson_version']
 
         if os.path.exists(self.option_file):
             oi = optinterpreter.OptionInterpreter(self.subproject)

--- a/mesonbuild/interpreterbase/interpreterbase.py
+++ b/mesonbuild/interpreterbase/interpreterbase.py
@@ -117,6 +117,7 @@ class InterpreterBase:
         assert isinstance(code, str)
         try:
             self.ast = mparser.Parser(code, mesonfile).parse()
+            self.handle_meson_version_from_ast()
         except mparser.ParseException as me:
             me.file = mesonfile
             # try to detect parser errors from new syntax added by future

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -47,7 +47,7 @@ class ParseException(MesonException):
         self.lineno = lineno
         self.colno = colno
 
-class BlockParseException(MesonException):
+class BlockParseException(ParseException):
     def __init__(
                 self,
                 text: str,
@@ -67,7 +67,7 @@ class BlockParseException(MesonException):
             # Followed by a caret to show the block start
             # Followed by underscores
             # Followed by a caret to show the block end.
-            super().__init__("{}\n{}\n{}".format(text, line, '{}^{}^'.format(' ' * start_colno, '_' * (colno - start_colno - 1))))
+            MesonException.__init__(self, "{}\n{}\n{}".format(text, line, '{}^{}^'.format(' ' * start_colno, '_' * (colno - start_colno - 1))))
         else:
             # If block start and end are on different lines, it is formatted as:
             # Error message
@@ -76,7 +76,7 @@ class BlockParseException(MesonException):
             # Followed by a message saying where the block started.
             # Followed by the line of the block start.
             # Followed by a caret for the block start.
-            super().__init__("%s\n%s\n%s\nFor a block that started at %d,%d\n%s\n%s" % (text, line, '%s^' % (' ' * colno), start_lineno, start_colno, start_line, "%s^" % (' ' * start_colno)))
+            MesonException.__init__(self, "%s\n%s\n%s\nFor a block that started at %d,%d\n%s\n%s" % (text, line, '%s^' % (' ' * colno), start_lineno, start_colno, start_line, "%s^" % (' ' * start_colno)))
         self.lineno = lineno
         self.colno = colno
 

--- a/test cases/common/33 run program/meson.build
+++ b/test cases/common/33 run program/meson.build
@@ -1,4 +1,4 @@
-project('run command', version : run_command('get-version.py', check : true).stdout().strip())
+project('run command', version : run_command('get-version.py', check : true).stdout().strip(), meson_version: '>=0.1.0')
 
 if build_machine.system() == 'windows'
   c = run_command('cmd', '/c', 'echo', 'hello', check: false)

--- a/test cases/common/33 run program/test.json
+++ b/test cases/common/33 run program/test.json
@@ -1,0 +1,8 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/common/33 run program/meson.build:1: WARNING: Project targets '>=0.1.0' but uses feature introduced in '0.47.0': check arg in run_command.",
+      "comment": "This triggers on line 1 -- the line with the project() function"
+    }
+  ]
+}

--- a/test cases/failing/130 invalid ast/meson.build
+++ b/test cases/failing/130 invalid ast/meson.build
@@ -1,0 +1,3 @@
+project('invalid ast crash', meson_version: '0.1.0')
+
+= >%@

--- a/test cases/failing/130 invalid ast/test.json
+++ b/test cases/failing/130 invalid ast/test.json
@@ -1,0 +1,9 @@
+{
+  "stdout": [
+    {
+      "match": "re",
+      "line": "test cases/failing/130 invalid ast/meson.build:1:44: ERROR: Meson version is [0-9.]+ but project requires 0.1.0"
+    }
+  ]
+}
+

--- a/test cases/failing/131 invalid project function/meson.build
+++ b/test cases/failing/131 invalid project function/meson.build
@@ -1,0 +1,1 @@
+project('invalid project function with bad kwargs', meson_version: '0.1.0', unknown_kwarg: 'val')

--- a/test cases/failing/131 invalid project function/test.json
+++ b/test cases/failing/131 invalid project function/test.json
@@ -1,0 +1,9 @@
+{
+  "stdout": [
+    {
+      "match": "re",
+      "line": "test cases/failing/131 invalid project function/meson.build:1:67: ERROR: Meson version is [0-9.]+ but project requires 0.1.0"
+    }
+  ]
+}
+

--- a/test cases/failing/20 version/test.json
+++ b/test cases/failing/20 version/test.json
@@ -2,7 +2,7 @@
   "stdout": [
     {
       "match": "re",
-      "line": "test cases/failing/20 version/meson\\.build:1:0: ERROR: Meson version is .* but project requires >100\\.0\\.0"
+      "line": "test cases/failing/20 version/meson\\.build:1:44: ERROR: Meson version is .* but project requires >100\\.0\\.0"
     }
   ]
 }


### PR DESCRIPTION
- [`handle meson_version even when the build file fails to parse`](https://github.com/eli-schwartz/meson/commit/41280fed96907eeee184dba513f15a80339e796b)

  If we add new syntax to meson.build, this syntax can cause old versions of Meson to crash. We currently cannot escape from that by setting a `meson_version: '>=X.Y'` to inform people what version to upgrade to
- [`interpreter: report FeatureNew for kwargs to project()`](https://github.com/eli-schwartz/meson/commit/20745af22e6b7ccbc61c2192d18e464e4d9e1523)

  FeatureNew is never triggered except by code running on the second line. This includes stuff like `version: run_command(..., check: true).stdout().strip()`