### PR TITLE
rust: Store absolute paths in rust-project.json

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2021,10 +2021,14 @@ class NinjaBackend(backends.Backend):
             for rpath_arg in rpath_args:
                 args += ['-C', 'link-arg=' + rpath_arg + ':' + os.path.join(rustc.get_sysroot(), 'lib')]
 
-        self._add_rust_project_entry(target.name, main_rust_file, args, bool(target.subproject),
+        self._add_rust_project_entry(target.name,
+                                     os.path.abspath(os.path.join(self.environment.build_dir, main_rust_file)),
+                                     args,
+                                     bool(target.subproject),
                                      #XXX: There is a fix for this pending
                                      getattr(target, 'rust_crate_type', '') == 'procmacro',
-                                     output, project_deps)
+                                     output,
+                                     project_deps)
 
         compiler_name = self.compiler_to_rule_name(rustc)
         element = NinjaBuildElement(self.all_outputs, target_name, compiler_name, main_rust_file)


### PR DESCRIPTION
As meson requires source_dir!=build_dir and stores the rust-project.json inside the build directory, while software like rust-analyzer expects it at the root of the source directory, manual steps are needed for making them work together.

One option, as described in the documentation, is per project configuration. Another option, that works correctly with compile-commands.json and clangd, is to store a symlink to the file in the build directory at the root of the source directory.

As currently rust-project.json stores paths relative to the location of the file itself and rust-analyzer does not resolve symlinks, this does not work.

To solve this, store absolute paths in rust-project.json as is already done in compile_commands.json for the directory.

----

rust-analyzer PR to resolve symlinks: https://github.com/rust-lang/rust-analyzer/pull/14168

CC @dcbaker