### PR TITLE
boost: fallback for boost root from conan

### DIFF
--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -663,6 +663,11 @@ class BoostDependency(SystemDependency):
                 boost_root = boost_pc.get_pkgconfig_variable('prefix', [], None)
                 if boost_root:
                     roots += [Path(boost_root)]
+                else:
+                    # If prefix is not set in boost.pc, but we already found libs,
+                    # those libs are probably located inside the boost root...
+                    roots.extend(Path(la[2:]).parent
+                                 for la in boost_pc.link_args if la.startswith('-L'))
         except DependencyException:
             pass
 


### PR DESCRIPTION
The `boost.pc` file generated from conan does not contain `prefix`. It causes the boost dependency to not find its root directory.

However, since boost libs were already found, we can search in the found lib directories as a fallback for setting the boost prefix.

This is probably related to #5438. Not sure if it is exactly the same issue, because there are many different discussions in that issue...