### PR TITLE
correctly handle rebuild dependencies on LINGUAS

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1282,7 +1282,9 @@ class GnomeModule(ExtensionModule):
 
         langs = kwargs['languages']
         if not langs:
-            langs = read_linguas(os.path.join(state.environment.source_dir, state.subdir))
+            langs, def_file = read_linguas(os.path.join(state.environment.source_dir, state.subdir))
+            if def_file:
+                self.interpreter.add_build_def_file(def_file)
 
         media = kwargs['media']
         symlinks = kwargs['symlink_media']

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -276,7 +276,9 @@ class I18nModule(ExtensionModule):
         install_dir = kwargs['install_dir'] or state.environment.coredata.get_option(mesonlib.OptionKey('localedir'))
         assert isinstance(install_dir, str), 'for mypy'
         if not languages:
-            languages = read_linguas(path.join(state.environment.source_dir, state.subdir))
+            languages, def_file = read_linguas(path.join(state.environment.source_dir, state.subdir))
+            if def_file:
+                self.interpreter.add_build_def_file(def_file)
         for l in languages:
             po_file = mesonlib.File.from_source_file(state.environment.source_dir,
                                                      state.subdir, l+'.po')

--- a/mesonbuild/scripts/gettext.py
+++ b/mesonbuild/scripts/gettext.py
@@ -31,7 +31,7 @@ parser.add_argument('--msgmerge', default='msgmerge')
 parser.add_argument('--msginit', default='msginit')
 parser.add_argument('--extra-args', default='')
 
-def read_linguas(src_sub: str) -> T.List[str]:
+def read_linguas(src_sub: str) -> T.Tuple[T.List[str], T.Optional[str]]:
     # Syntax of this file is documented here:
     # https://www.gnu.org/software/gettext/manual/html_node/po_002fLINGUAS.html
     linguas = os.path.join(src_sub, 'LINGUAS')
@@ -42,10 +42,10 @@ def read_linguas(src_sub: str) -> T.List[str]:
                 line = line.strip()
                 if line and not line.startswith('#'):
                     langs += line.split()
-        return langs
+        return langs, linguas
     except (FileNotFoundError, PermissionError):
         print(f'Could not find file LINGUAS in {src_sub}')
-        return []
+        return [], None
 
 def run_potgen(src_sub: str, xgettext: str, pkgname: str, datadirs: str, args: T.List[str], source_root: str) -> int:
     listfile = os.path.join(src_sub, 'POTFILES.in')
@@ -83,7 +83,7 @@ def run(args: T.List[str]) -> int:
     src_sub = os.path.join(options.source_root, subdir)
 
     if not langs:
-        langs = read_linguas(src_sub)
+        langs = read_linguas(src_sub)[0]
 
     if subcmd == 'pot':
         return run_potgen(src_sub, options.xgettext, options.pkgname, options.datadirs, extra_args, options.source_root)


### PR DESCRIPTION
In the gnome and i18n modules we check for an optional LINGUAS file containing the list of languages, and this adds new build/install rules. But if the LINGUAS file gets updated, we did not notice, so the build was stale. Add it as a regen dependency.