### PR TITLE
Allow default_options and override_options as dictionaries

### DIFF
--- a/docs/markdown/snippets/language args in project are deprecated.md
+++ b/docs/markdown/snippets/language args in project are deprecated.md
@@ -1,0 +1,17 @@
+## Using language arguments in project(default_options) is deprecated
+
+One can place any valid command line option in the `project(default_options)`
+field. The problem is that some of these options result in very strange behavior.
+Case an point is c_args (and friends), which will do the following when placed
+in the project() options:
+
+1. prevent $CFLAGS from being read
+2. prevent the `c_args` from being read from a machine file (cross or native)
+3. be replaced by any arguments passed via -Dc_args
+
+2 Is especially problematic for OS and distro vendors, which often rely on
+setting the compile args they want via $CFLAGS (and friends)
+
+The reality is that most people don't want any of this behavior, and what they
+really want is to use either `add_project_arguments()` or
+`add_global_arguments()`.

--- a/docs/markdown/snippets/option_dict.md
+++ b/docs/markdown/snippets/option_dict.md
@@ -1,0 +1,5 @@
+## default_options and override_options may now be dictionaries
+
+Instead of passing them as `default_options : ['key=value']`, they can now be
+passed as `default_options : {'key': 'value'}`, and the same for
+`override_options`

--- a/docs/yaml/functions/_build_target_base.yaml
+++ b/docs/yaml/functions/_build_target_base.yaml
@@ -228,12 +228,14 @@ kwargs:
       Set this to `[]`, or omit the keyword argument for the default behaviour.
 
   override_options:
-    type: list[str]
+    type: list[str] | dict[str]
     since: 0.40.0
     description: |
       takes an array of strings in the same format as `project`'s `default_options`
       overriding the values of these options
       for this target only.
+
+      *Since 1.1.0* a dictionary may now be passed
 
   gnu_symbol_visibility:
     type: str

--- a/docs/yaml/functions/dependency.yaml
+++ b/docs/yaml/functions/dependency.yaml
@@ -78,7 +78,7 @@ varargs:
 
 kwargs:
   default_options:
-    type: list[str]
+    type: list[str] | dict[str]
     since: 0.38.0
     description: |
       An array of default option values
@@ -86,6 +86,8 @@ kwargs:
       (like `default_options` in [[project]], they only have
       effect when Meson is run for the first time, and command line
       arguments override any default options in build files)
+
+      *Since 1.1.0* a dictionary may now be passed
 
   allow_fallback:
     type: bool

--- a/docs/yaml/functions/project.yaml
+++ b/docs/yaml/functions/project.yaml
@@ -38,7 +38,7 @@ varargs:
 
 kwargs:
   default_options:
-    type: list[str]
+    type: list[str] | dict[str]
     description: |
       Accepts strings in the form `key=value`
       which have the same format as options to `meson configure`.
@@ -53,6 +53,8 @@ kwargs:
       for example, using `c_args` here means that the `CFLAGS`
       environment variable is not used. Consider using
       [[add_project_arguments()]] instead.
+
+      *Since 1.1.0* a dictionary may now be passed
 
   version:
     type: str | file

--- a/docs/yaml/functions/subproject.yaml
+++ b/docs/yaml/functions/subproject.yaml
@@ -8,12 +8,12 @@ description: |
   example a subproject called `foo` must be located in
   `${MESON_SOURCE_ROOT}/subprojects/foo`.
 
-  - `default_options` *(since 0.37.0)*: an array of default option values
-    that override those set in the subproject's `meson_options.txt`
-    (like `default_options` in `project`, they only have effect when
-    Meson is run for the first time, and command line arguments override
-    any default options in build files). *(since 0.54.0)*: `default_library`
-    built-in option can also be overridden.
+  - `default_options` *(since 0.37.0)*: an array or dict of default option
+    values that override those set in the subproject's `meson_options.txt` (like
+    `default_options` in `project`, they only have effect when Meson is run for
+    the first time, and command line arguments override any default options in
+    build files). *(since 0.54.0)*: `default_library` built-in option can also be
+    overridden. *(since 1.1.0)* A dictionary may be passed instead of array
   - `version`: works just like the same as in `dependency`.
     It specifies what version the subproject should be, as an example `>=1.0.1`
   - `required` *(since 0.48.0)*: By default, `required` is `true` and
@@ -41,7 +41,7 @@ posargs:
 
 kwargs:
   default_options:
-    type: list[str]
+    type: list[str] | dict[str]
     since: 0.37.0
     description: |
       An array of default option values
@@ -50,6 +50,8 @@ kwargs:
       Meson is run for the first time, and command line arguments override
       any default options in build files). *(since 0.54.0)*: `default_library`
       built-in option can also be overridden.
+
+      *Since 1.1.0* a dictionary may now be passed
 
   version:
     type: str

--- a/mesonbuild/interpreter/dependencyfallbacks.py
+++ b/mesonbuild/interpreter/dependencyfallbacks.py
@@ -19,7 +19,7 @@ if T.TYPE_CHECKING:
 
 class DependencyFallbacksHolder(MesonInterpreterObject):
     def __init__(self, interpreter: 'Interpreter', names: T.List[str], allow_fallback: T.Optional[bool] = None,
-                 default_options: T.Optional[T.List[str]] = None) -> None:
+                 default_options: T.Optional[T.Dict[OptionKey, str]] = None) -> None:
         super().__init__(subproject=interpreter.subproject)
         self.interpreter = interpreter
         self.subproject = interpreter.subproject
@@ -30,7 +30,7 @@ class DependencyFallbacksHolder(MesonInterpreterObject):
         self.allow_fallback = allow_fallback
         self.subproject_name: T.Optional[str] = None
         self.subproject_varname: T.Optional[str] = None
-        self.subproject_kwargs = {'default_options': default_options or []}
+        self.subproject_kwargs = {'default_options': default_options or {}}
         self.names: T.List[str] = []
         self.forcefallback: bool = False
         self.nofallback: bool = False
@@ -114,12 +114,11 @@ class DependencyFallbacksHolder(MesonInterpreterObject):
         # dependency('foo', static: true) should implicitly add
         # default_options: ['default_library=static']
         static = kwargs.get('static')
-        default_options = stringlistify(func_kwargs.get('default_options', []))
-        if static is not None and not any('default_library' in i for i in default_options):
+        default_options = func_kwargs.get('default_options', {})
+        if static is not None and 'default_library' not in default_options:
             default_library = 'static' if static else 'shared'
-            opt = f'default_library={default_library}'
-            mlog.log(f'Building fallback subproject with {opt}')
-            default_options.append(opt)
+            mlog.log(f'Building fallback subproject with default_library={default_library}')
+            default_options[OptionKey('default_library')] = default_library
             func_kwargs['default_options'] = default_options
 
         # Configure the subproject

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -79,6 +79,7 @@ from .type_checking import (
     INSTALL_TAG_KW,
     LANGUAGE_KW,
     NATIVE_KW,
+    OVERRIDE_OPTIONS_KW,
     PRESERVE_PATH_KW,
     REQUIRED_KW,
     SOURCES_KW,
@@ -1770,6 +1771,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     @FeatureDeprecatedKwargs('executable', '0.56.0', ['gui_app'], extra_message="Use 'win_subsystem' instead.")
     @permittedKwargs(build.known_exe_kwargs)
     @typed_pos_args('executable', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.StructuredSources, build.ExtractedObjects, build.BuildTarget))
+    @typed_kwargs('executable', OVERRIDE_OPTIONS_KW, allow_unknown=True)
     def func_executable(self, node: mparser.BaseNode,
                         args: T.Tuple[str, T.List[BuildTargetSource]],
                         kwargs) -> build.Executable:
@@ -1777,6 +1779,7 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     @permittedKwargs(build.known_stlib_kwargs)
     @typed_pos_args('static_library', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.StructuredSources, build.ExtractedObjects, build.BuildTarget))
+    @typed_kwargs('static_libraries', OVERRIDE_OPTIONS_KW, allow_unknown=True)
     def func_static_lib(self, node: mparser.BaseNode,
                         args: T.Tuple[str, T.List[BuildTargetSource]],
                         kwargs) -> build.StaticLibrary:
@@ -1784,6 +1787,7 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     @permittedKwargs(build.known_shlib_kwargs)
     @typed_pos_args('shared_library', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.StructuredSources, build.ExtractedObjects, build.BuildTarget))
+    @typed_kwargs('shared_libraries', OVERRIDE_OPTIONS_KW, allow_unknown=True)
     def func_shared_lib(self, node: mparser.BaseNode,
                         args: T.Tuple[str, T.List[BuildTargetSource]],
                         kwargs) -> build.SharedLibrary:
@@ -1793,6 +1797,7 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     @permittedKwargs(known_library_kwargs)
     @typed_pos_args('both_libraries', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.StructuredSources, build.ExtractedObjects, build.BuildTarget))
+    @typed_kwargs('both_libraries', OVERRIDE_OPTIONS_KW, allow_unknown=True)
     def func_both_lib(self, node: mparser.BaseNode,
                       args: T.Tuple[str, T.List[BuildTargetSource]],
                       kwargs) -> build.BothLibraries:
@@ -1801,6 +1806,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     @FeatureNew('shared_module', '0.37.0')
     @permittedKwargs(build.known_shmod_kwargs)
     @typed_pos_args('shared_module', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.StructuredSources, build.ExtractedObjects, build.BuildTarget))
+    @typed_kwargs('shared_module', OVERRIDE_OPTIONS_KW, allow_unknown=True)
     def func_shared_module(self, node: mparser.BaseNode,
                            args: T.Tuple[str, T.List[BuildTargetSource]],
                            kwargs) -> build.SharedModule:
@@ -1808,6 +1814,7 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     @permittedKwargs(known_library_kwargs)
     @typed_pos_args('library', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.StructuredSources, build.ExtractedObjects, build.BuildTarget))
+    @typed_kwargs('library', OVERRIDE_OPTIONS_KW, allow_unknown=True)
     def func_library(self, node: mparser.BaseNode,
                      args: T.Tuple[str, T.List[BuildTargetSource]],
                      kwargs) -> build.Executable:
@@ -1815,6 +1822,7 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     @permittedKwargs(build.known_jar_kwargs)
     @typed_pos_args('jar', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.ExtractedObjects, build.BuildTarget))
+    @typed_kwargs('jar', OVERRIDE_OPTIONS_KW, allow_unknown=True)
     def func_jar(self, node: mparser.BaseNode,
                  args: T.Tuple[str, T.List[T.Union[str, mesonlib.File, build.GeneratedTypes]]],
                  kwargs) -> build.Jar:
@@ -1823,6 +1831,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     @FeatureNewKwargs('build_target', '0.40.0', ['link_whole', 'override_options'])
     @permittedKwargs(known_build_target_kwargs)
     @typed_pos_args('build_target', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.StructuredSources, build.ExtractedObjects, build.BuildTarget))
+    @typed_kwargs('build_target', OVERRIDE_OPTIONS_KW, allow_unknown=True)
     def func_build_target(self, node: mparser.BaseNode,
                           args: T.Tuple[str, T.List[BuildTargetSource]],
                           kwargs) -> T.Union[build.Executable, build.StaticLibrary, build.SharedLibrary,

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -259,6 +259,20 @@ permitted_dependency_kwargs = {
     'version',
 }
 
+def _gen_deprecated_default_options() -> T.Dict[str, T.Tuple[str, str]]:
+    ret: T.Dict[str, T.Tuple[str, str]] = {}
+    for lang, envvar in compilers.compilers.CFLAGS_MAPPING.items():
+        arg = f'{lang}_args'
+        ret[arg] = ('1.1.0', f'Settings this prevents meson from reading {envvar}, '
+                             f'and will be overriden by users passing -D{arg} on the command line. '
+                             'Consider using add_project_arguments or add_global_arguments instead')
+        arg = f'{lang}_link_args'
+        ret[arg] = ('1.1.0', 'Settings this prevents meson from reading LDFLAGS, '
+                             f'and will be overriden by users passing -D{arg} on the command line. '
+                             'Consider using add_project_arguments or add_global_arguments instead')
+    return ret
+
+
 implicit_check_false_warning = """You should add the boolean check kwarg to the run_command call.
          It currently defaults to false,
          but it will default to true in future releases of meson.
@@ -1150,7 +1164,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     @typed_pos_args('project', str, varargs=str)
     @typed_kwargs(
         'project',
-        DEFAULT_OPTIONS,
+        DEFAULT_OPTIONS.evolve(deprecated_values=_gen_deprecated_default_options()),
         KwargInfo('meson_version', (str, NoneType)),
         KwargInfo(
             'version',

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -12,7 +12,7 @@ from typing_extensions import TypedDict, Literal, Protocol
 from .. import build
 from .. import coredata
 from ..compilers import Compiler
-from ..mesonlib import MachineChoice, File, FileMode, FileOrString
+from ..mesonlib import MachineChoice, File, FileMode, FileOrString, OptionKey
 from ..modules.cmake import CMakeSubprojectOptions
 from ..programs import ExternalProgram
 
@@ -203,7 +203,7 @@ class Project(TypedDict):
 
     version: T.Optional[FileOrString]
     meson_version: T.Optional[str]
-    default_options: T.List[str]
+    default_options: T.Dict[OptionKey, str]
     license: T.List[str]
     subproject_dir: str
 
@@ -298,13 +298,13 @@ class ConfigureFile(TypedDict):
 
 class Subproject(ExtractRequired):
 
-    default_options: T.List[str]
+    default_options: T.Dict[OptionKey, str]
     version: T.List[str]
 
 
 class DoSubproject(ExtractRequired):
 
-    default_options: T.List[str]
+    default_options: T.Dict[OptionKey, str]
     version: T.List[str]
     cmake_options: T.List[str]
     options: T.Optional[CMakeSubprojectOptions]

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -387,14 +387,7 @@ def include_dir_string_new(val: T.List[T.Union[str, IncludeDirs]]) -> T.Iterable
         yield FeatureNew('include_directories kwarg of type string', '1.0.0',
                          f'Use include_directories({str_msg}) instead')
 
-# for cases like default_options and override_options
-DEFAULT_OPTIONS: KwargInfo[T.List[str]] = KwargInfo(
-    'default_options',
-    ContainerTypeInfo(list, str),
-    listify=True,
-    default=[],
-    validator=_options_validator,
-)
+DEFAULT_OPTIONS = OVERRIDE_OPTIONS_KW.evolve(name='default_options')
 
 ENV_METHOD_KW = KwargInfo('method', str, default='set', since='0.62.0',
                           validator=in_set_validator({'set', 'prepend', 'append'}))

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -279,21 +279,25 @@ COMMAND_KW: KwargInfo[T.List[T.Union[str, BuildTarget, CustomTarget, CustomTarge
     default=[],
 )
 
-def _override_options_convertor(raw: T.List[str]) -> T.Dict[OptionKey, str]:
-    output: T.Dict[OptionKey, str] = {}
-    for each in raw:
-        k, v = split_equal_string(each)
-        output[OptionKey.from_string(k)] = v
-    return output
+def _override_options_convertor(raw: T.Union[str, T.List[str], T.Dict[str, str]]) -> T.Dict[OptionKey, str]:
+    if isinstance(raw, str):
+        raw = [raw]
+    if isinstance(raw, list):
+        output: T.Dict[OptionKey, str] = {}
+        for each in raw:
+            k, v = split_equal_string(each)
+            output[OptionKey.from_string(k)] = v
+        return output
+    return {OptionKey.from_string(k): v for k, v in raw.items()}
 
 
-OVERRIDE_OPTIONS_KW: KwargInfo[T.List[str]] = KwargInfo(
+OVERRIDE_OPTIONS_KW: KwargInfo[T.Union[str, T.Dict[str, str], T.List[str]]] = KwargInfo(
     'override_options',
-    ContainerTypeInfo(list, str),
-    listify=True,
-    default=[],
+    (str, ContainerTypeInfo(list, str), ContainerTypeInfo(dict, str)),
+    default={},
     validator=_options_validator,
     convertor=_override_options_convertor,
+    since_values={dict: '1.1.0'},
 )
 
 

--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -435,7 +435,7 @@ class CmakeModule(ExtensionModule):
             'required': kwargs_['required'],
             'options': kwargs_['options'],
             'cmake_options': kwargs_['cmake_options'],
-            'default_options': [],
+            'default_options': {},
             'version': [],
         }
         subp = self.interpreter.do_subproject(dirname, 'cmake', kw)

--- a/test cases/common/1 trivial/meson.build
+++ b/test cases/common/1 trivial/meson.build
@@ -1,7 +1,8 @@
 # Comment on the first line
 project('trivial test',
   # Comment inside a function call + array for language list
-  ['c'], default_options: ['buildtype=debug'],
+  ['c'],
+  default_options: {'buildtype': 'debug'},
   meson_version : '>=0.52.0')
 #this is a comment
 sources = 'trivial.c'

--- a/test cases/common/1 trivial/meson.build
+++ b/test cases/common/1 trivial/meson.build
@@ -2,8 +2,8 @@
 project('trivial test',
   # Comment inside a function call + array for language list
   ['c'],
-  default_options: {'buildtype': 'debug'},
-  meson_version : '>=0.52.0')
+  default_options: {'buildtype': 'debug', 'c_args': '-DFOO'},
+  meson_version : '>=1.0.0')
 #this is a comment
 sources = 'trivial.c'
 

--- a/test cases/common/216 custom target input extracted objects/libdir/meson.build
+++ b/test cases/common/216 custom target input extracted objects/libdir/meson.build
@@ -18,4 +18,4 @@ subobjlib = static_library('subobject', sublibsrc)
 
 objlib = static_library('object', 'source.c', ctsrc, gensrc,
                         objects: subobjlib.extract_all_objects(recursive: false),
-                        override_options : ['unity=off'])
+                        override_options : {'unity': 'off'})


### PR DESCRIPTION
And deprecate passing c_args to project(default_options).

The former seems pretty tame, we already store them as dictionaries internally, so exposing that seems fine, especially now that we have order guaranteed dictionaries.

I don't think the latter will be controversial, since it is a never ending source of headaches and bug reports