### PR TITLE
hotdoc module: properly error out when configuring fails

### DIFF
--- a/mesonbuild/modules/hotdoc.py
+++ b/mesonbuild/modules/hotdoc.py
@@ -247,7 +247,8 @@ class HotdocTargetBuilder:
         ncwd = os.path.join(self.sourcedir, self.subdir)
         mlog.log('Generating Hotdoc configuration for: ', mlog.bold(self.name))
         os.chdir(ncwd)
-        self.hotdoc.run_hotdoc(self.flatten_config_command())
+        if self.hotdoc.run_hotdoc(self.flatten_config_command()) != 0:
+            raise MesonException('hotdoc failed to configure')
         os.chdir(cwd)
 
     def ensure_file(self, value):


### PR DESCRIPTION
We used to just abort during configure because we ran in-process and hotdoc's argparse would leak into our own process space. Now we fail to handle this case and succeed at configuring, only for building to fail because the hotdoc config file doesn't exist.