### PR TITLE
Scalapack dependency fix

### DIFF
--- a/docs/markdown/Shipping-prebuilt-binaries-as-wraps.md
+++ b/docs/markdown/Shipping-prebuilt-binaries-as-wraps.md
@@ -34,3 +34,11 @@ Note that often libraries compiled with different compilers (or even
 compiler flags) might not be compatible. If you do this, then you are
 responsible for verifying that your libraries are compatible, Meson
 will not check things for you.
+
+## Note for Linux libraries
+
+A precompiled linux shared library (.so) requires a soname field to be properly installed. If the soname field is missing, binaries referencing the library will require a hard link to the location of the library at install time (`/path/to/your/project/subprojects/precompiledlibrary/lib.so` instead of `$INSTALL_PREFIX/lib/lib.so`) after installation.
+
+You should change the compilation options for the precompiled library to avoid this issue. If recompiling is not an option, you can use the [patchelf](https://github.com/NixOS/patchelf) tool with the command `patchelf --set-soname libfoo.so libfoo.so` to edit the precompiled library after the fact.
+
+Meson generally guarantees any library it compiles has a soname. One notable exception is libraries built with the [[shared_module]] function.

--- a/mesonbuild/dependencies/scalapack.py
+++ b/mesonbuild/dependencies/scalapack.py
@@ -63,14 +63,17 @@ class MKLPkgConfigDependency(PkgConfigDependency):
         _m = os.environ.get('MKLROOT')
         self.__mklroot = Path(_m).resolve() if _m else None
 
+        if not self.__mklroot:
+            self.is_found = False
+            return
+
         # We need to call down into the normal super() method even if we don't
         # find mklroot, otherwise we won't have all of the instance variables
         # initialized that meson expects.
         super().__init__(name, env, kwargs, language=language)
 
         # Doesn't work with gcc on windows, but does on Linux
-        if (not self.__mklroot or (env.machines[self.for_machine].is_windows()
-                                   and self.clib_compiler.id == 'gcc')):
+        if env.machines[self.for_machine].is_windows() and self.clib_compiler.id == 'gcc':
             self.is_found = False
 
         # This can happen either because we're using GCC, we couldn't find the


### PR DESCRIPTION
pkg-config still finds mkl packages even when the intel toolchain is not sourced. This causes issues on systems that have both intel and gcc toolchains used.

``` bash
❯ echo $MKLROOT

❯ pkgconf --cflags mkl-dynamic-lp64-iomp
-I/opt/intel/oneapi/mkl/latest/lib/pkgconfig/../../include -I/opt/intel/oneapi/compiler/latest/lib/pkgconfig/../../linux/compiler/include
```

Normally finding scalapack when no intel toolchain exists will raise a Dependency exception when _set_cargs is called since pkgconfig cannot find the cflags. However in this case, pkgconfig returns a valid response and _set_libs is called but __mklroot is None because the intel toolchain is not sourced and the MKLROOT is not set.

I did not find anything in any of the parent classes that would populate self.__mklroot and the current logic is to return not found is __mkl root is not populated right after the super().__init__. I think it is safe to move the check for the variable being populated before the super().__init__. I've tested on my system and the MKL version is found when intel is sourced and the GCC version is found when not sourced as expected.