### PR TITLE
Fix for edge case where MKLROOT is None

### DIFF
--- a/mesonbuild/dependencies/scalapack.py
+++ b/mesonbuild/dependencies/scalapack.py
@@ -66,14 +66,17 @@ class MKLPkgConfigDependency(PkgConfigDependency):
         _m = os.environ.get('MKLROOT')
         self.__mklroot = Path(_m).resolve() if _m else None
 
+        if not self.__mklroot:
+            self.is_found = False
+            return
+
         # We need to call down into the normal super() method even if we don't
         # find mklroot, otherwise we won't have all of the instance variables
         # initialized that meson expects.
         super().__init__(name, env, kwargs, language=language)
 
         # Doesn't work with gcc on windows, but does on Linux
-        if (not self.__mklroot or (env.machines[self.for_machine].is_windows()
-                                   and self.clib_compiler.id == 'gcc')):
+        if env.machines[self.for_machine].is_windows() and self.clib_compiler.id == 'gcc':
             self.is_found = False
 
         # This can happen either because we're using GCC, we couldn't find the


### PR DESCRIPTION
Fixes #11172

pkg-config still finds mkl packages even when the intel toolchain is not sourced. This causes issues finding scalapack on systems that have both intel and gcc toolchains used.

```bash
❯ echo $MKLROOT

❯ pkgconf --cflags mkl-dynamic-lp64-iomp
-I/opt/intel/oneapi/mkl/latest/lib/pkgconfig/../../include -I/opt/intel/oneapi/compiler/latest/lib/pkgconfig/../../linux/compiler/include
```

Normally finding scalapack when no intel toolchain exists will raise a Dependency exception when `_set_cargs` is called since pkgconfig cannot find the cflags. However in this case, pkgconfig returns a valid response and `_set_libs` is called but __mklroot is None because the intel toolchain is not sourced and the MKLROOT is not set.

I did not find anything in any of the parent classes that would populate self.__mklroot and the current logic is to return not found is __mkl root is not populated right after the super().init . I think it is safe to move the check for the variable being populated before the super().init. I've tested on my system and the MKL version is found when intel is sourced and the GCC version is found when not sourced as expected.

edit: I've only tested with intel's new ONEAPI. I'm not sure whether the old intel toolchains populate MKLROOT