### PR TITLE
BuildTarget: Support per type <lang>_args

### DIFF
--- a/docs/markdown/snippets/both_libraries_different_c_args.md
+++ b/docs/markdown/snippets/both_libraries_different_c_args.md
@@ -1,0 +1,16 @@
+## Dictionary in `<lang>_args` keyword argument
+
+Language arguments can be a dictionary mapping the target type
+(e.g. `static_library`, `shared_library`, etc). This is useful when using
+`library()` or `both_libraries()` to have different flags for the shared and
+static library. In that case all object files will have to be compiled
+twice instead of reusing them for both libraries.
+
+```meson
+cargs = []
+if host_machine.system() == 'windows' and get_option('default_library') != 'shared'
+  cargs = {'static_library': '-DSTATIC_COMPILATION'}
+endif
+
+library('foo', sources, c_args: c_args)
+```

--- a/docs/yaml/functions/_build_target_base.yaml
+++ b/docs/yaml/functions/_build_target_base.yaml
@@ -43,10 +43,15 @@ kwargs:
     description: precompiled header file to use for the given language
 
   <lang>_args:
-    type: list[str]
+    type: list[str] | dict[str, list[str]]
     description: |
       compiler flags to use for the given language;
       eg: `cpp_args` for C++
+      *Since 1.1.0* can be a dictionary mapping the target type
+      (e.g. static_library, shared_library, etc). This is useful when using
+      library() or both_libraries() to have different flags for the shared and
+      static library. In that case all object files will have to be compiled
+      twice instead of reusing them for both libraries.
 
   sources:
     type: str | file | custom_tgt | custom_idx | generated_list | structured_src

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3133,7 +3133,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             # issue for you.
             reuse_object_files = False
         else:
-            reuse_object_files = static_lib.pic
+            reuse_object_files = shared_lib.can_reuse_object_files and static_lib.pic
 
         if reuse_object_files:
             # Replace sources with objects from the shared library to avoid

--- a/test cases/common/178 bothlibraries/libfile.c
+++ b/test cases/common/178 bothlibraries/libfile.c
@@ -1,6 +1,10 @@
 #include "mylib.h"
 
-DO_EXPORT int retval = 42;
+#ifndef TEST_VAL
+#define TEST_VAL 42
+#endif
+
+DO_EXPORT int retval = TEST_VAL;
 
 DO_EXPORT int func(void) {
     return retval;

--- a/test cases/common/178 bothlibraries/main.c
+++ b/test cases/common/178 bothlibraries/main.c
@@ -1,7 +1,13 @@
 #include "mylib.h"
 
 DO_IMPORT int func(void);
+
+#ifndef TEST_VAL
 DO_IMPORT int retval;
+#else
+static int retval = TEST_VAL;
+#endif
+
 
 int main(void) {
     return func() == retval ? 0 : 1;

--- a/test cases/common/178 bothlibraries/meson.build
+++ b/test cases/common/178 bothlibraries/meson.build
@@ -60,3 +60,19 @@ exe = executable('prog-ccpp', 'main2.c',
   c_args : ['-DSTATIC_COMPILATION'],
 )
 test('runtest-ccpp', exe)
+
+# Both libraries should be compiled twice with different cflags. The expected
+# value is different whether we compile against the static or shared library.
+bothlibs = both_libraries('both-diff-c-args', 'libfile.c',
+  c_args: {'static_library': ['-DTEST_VAL=43']},
+)
+exe = executable('both-shared', 'main.c',
+  link_with : bothlibs.get_shared_lib(),
+  c_args: '-DTEST_VAL=42',
+)
+test('runtest-both-shared', exe)
+exe = executable('both-static', 'main.c',
+  link_with : bothlibs.get_static_lib(),
+  c_args: '-DTEST_VAL=43',
+)
+test('runtest-both-static', exe)


### PR DESCRIPTION
This allows having different cflags for static and shared library when using both_libraries().

Fixes: #3304