### PR TITLE
mtest: Add support for --exclude flag

### DIFF
--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -293,6 +293,11 @@ Run only `specific_test_1` and `specific_test_2`:
 meson test -C builddir specific_test_1 specific_test_2
 ```
 
+Run all tests except for `specific_test_1` and `specific_test_2` *(since 1.4.0)*:
+```
+meson test -C builddir --exclude specific_test_1 --exclude specific_test_2
+```
+
 ### wrap
 
 {{ wrap_usage.inc }}

--- a/docs/markdown/Unit-tests.md
+++ b/docs/markdown/Unit-tests.md
@@ -153,6 +153,12 @@ Specify test(s) by name like:
 $ meson test A D
 ```
 
+Since version *1.4.0*, individual tests can be excluded from running with the `--exclude` flag:
+
+```console
+$ meson test --exclude A --exclude C
+```
+
 Tests belonging to a suite `suite` can be run as follows
 
 ```console

--- a/docs/markdown/snippets/mtest_exclude.md
+++ b/docs/markdown/snippets/mtest_exclude.md
@@ -1,0 +1,3 @@
+## `meson test` allows excluding individual tests
+
+The `test` subcommand now accepts `--exclude` argument, expecting the same syntax as used by positional arguments.

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -71,6 +71,16 @@ GNU_ERROR_RETURNCODE = 99
 # Exit if 3 Ctrl-C's are received within one second
 MAX_CTRLC = 3
 
+ItemType = T.TypeVar('ItemType')
+
+class UniversalSet(T.Generic[ItemType]):
+    """A set-like object that contains everything."""
+    def __contains__(self, item: ItemType) -> bool:
+        return True
+
+    def add(self, item: ItemType) -> None:
+        pass
+
 def is_windows() -> bool:
     platname = platform.system().lower()
     return platname == 'windows'
@@ -128,6 +138,10 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
                         help='Only run tests belonging to the given suite.')
     parser.add_argument('--no-suite', default=[], dest='exclude_suites', action='append', metavar='SUITE',
                         help='Do not run tests belonging to the given suite.')
+    parser.add_argument('-x', '--exclude', default=[], dest='exclude_tests', action='append', metavar='TEST',
+                        help='Do not run test with this name. "testname" to exclude all tests with that name, '
+                        '"subprojname:testname" to specifically exclude "testname" from "subprojname", '
+                        '"subprojname:" to exclude all tests defined by "subprojname".')
     parser.add_argument('--no-stdsplit', default=True, dest='split', action='store_false',
                         help='Do not split stderr and stdout in test logs.')
     parser.add_argument('--print-errorlogs', default=False, action='store_true',
@@ -1849,36 +1863,49 @@ class TestHarness:
 
         return True
 
-    def tests_from_args(self, tests: T.List[TestSerialisation]) -> T.Generator[TestSerialisation, None, None]:
+    @staticmethod
+    def make_selection_checker(patterns: T.List[str], should_match_if_no_patterns: bool = False) -> T.Callable[[TestSerialisation], bool]:
         '''
-        Allow specifying test names like "meson test foo1 foo2", where test('foo1', ...)
+        Allow specifying test names like "foo1", which will match test('foo1', ...)
 
         Also support specifying the subproject to run tests from like
-        "meson test subproj:" (all tests inside subproj) or "meson test subproj:foo1"
-        to run foo1 inside subproj. Coincidentally also "meson test :foo1" to
+        "subproj:" (all tests inside subproj) or "subproj:foo1"
+        to run foo1 inside subproj. Coincidentally also ":foo1" to
         run all tests with that name across all subprojects, which is
-        identical to "meson test foo1"
+        identical to "foo1"
         '''
-        for arg in self.options.args:
-            if ':' in arg:
-                subproj, name = arg.split(':', maxsplit=1)
+        if not patterns:
+            return lambda _: should_match_if_no_patterns
+
+        unqualified: T.Set[str] = set()
+        qualified: T.Dict[str, T.Union[T.Set[str], UniversalSet[str]]] = defaultdict(set)
+
+        for pattern in patterns:
+            if ':' in pattern:
+                subproj, name = pattern.split(':', maxsplit=1)
             else:
-                subproj, name = '', arg
-            for t in tests:
-                if subproj and t.project_name != subproj:
-                    continue
-                if name and t.name != name:
-                    continue
-                yield t
+                subproj, name = '', pattern
+
+            if subproj == '':
+                unqualified.add(name)
+            elif name == '':
+                qualified[subproj] = UniversalSet()
+            else:
+                qualified[subproj].add(name)
+
+        def is_selected(t: TestSerialisation) -> bool:
+            return (t.name in qualified[t.project_name] or t.name in unqualified)
+
+        return is_selected
 
     def get_tests(self) -> T.List[TestSerialisation]:
         if not self.tests:
             print('No tests defined.')
             return []
 
-        tests = [t for t in self.tests if self.test_suitable(t)]
-        if self.options.args:
-            tests = list(self.tests_from_args(tests))
+        is_selected = TestHarness.make_selection_checker(self.options.args, should_match_if_no_patterns=True)
+        is_excluded = TestHarness.make_selection_checker(self.options.exclude_tests)
+        tests = [t for t in self.tests if self.test_suitable(t) and is_selected(t) and not is_excluded(t)]
 
         if not tests:
             print('No suitable tests defined.')


### PR DESCRIPTION
As a side effect, tests matching multiple patterns are no longer run multiple times. This used to happen for example when there was a test `testname` in subproject `subprojname` and user ran `meson test subprojname: testname`.

Fixes: https://github.com/mesonbuild/meson/issues/6999
