### PR TITLE
configure_file: emit FeatureNew when a cmake-formatted file has too many tokens

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2611,7 +2611,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                 file_encoding = kwargs['encoding']
                 missing_variables, confdata_useless = \
                     mesonlib.do_conf_file(inputs_abs[0], ofile_abs, conf,
-                                          fmt, file_encoding)
+                                          fmt, file_encoding, self.subproject)
                 if missing_variables:
                     var_list = ", ".join(repr(m) for m in sorted(missing_variables))
                     mlog.warning(


### PR DESCRIPTION
In commit 97a72a1c53e68cf53541285075b4000f7c85ccc6 we started to allow cmakedefine with 3 tokens, as cmake expects (unlike mesondefine). This would silently start working even if the declared minimum version was older than 0.54.1