### PR TITLE
utils: fix annotation of pickle_load

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1056,9 +1056,7 @@ def major_versions_differ(v1: str, v2: str) -> bool:
 
 def load(build_dir: str) -> CoreData:
     filename = os.path.join(build_dir, 'meson-private', 'coredata.dat')
-    obj = pickle_load(filename, 'Coredata', CoreData)
-    assert isinstance(obj, CoreData), 'for mypy'
-    return obj
+    return pickle_load(filename, 'Coredata', CoreData)
 
 
 def save(obj: CoreData, build_dir: str) -> str:

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -131,9 +131,7 @@ class DirMaker:
 
 
 def load_install_data(fname: str) -> InstallData:
-    obj = pickle_load(fname, 'InstallData', InstallData)
-    assert isinstance(obj, InstallData), 'fo mypy'
-    return obj
+    return pickle_load(fname, 'InstallData', InstallData)
 
 def is_executable(path: str, follow_symlinks: bool = False) -> bool:
     '''Checks whether any of the "x" bits are set in the source file mode.'''


### PR DESCRIPTION
It's actually Generic, and we should use Generic annotations to get the correct result. This means that we don't have to assert or cast the return type, because mypy just knowns