### PR TITLE
emit FeatureNew warning for compiler.preprocess used multiple times

### DIFF
--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -776,6 +776,9 @@ class CompilerHolder(ObjectHolder['Compiler']):
                                   location=self.current_node)
 
         tg_counter = next(self.preprocess_uid[self.interpreter.subdir])
+        if tg_counter > 0:
+            FeatureNew.single_use('compiler.preprocess used multiple times', '1.1.0', self.subproject,
+                                  location=self.current_node)
         tg_name = f'preprocessor_{tg_counter}'
         tg = build.CompileTarget(
             tg_name,

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -658,7 +658,7 @@ class FeatureCheckBase(metaclass=abc.ABCMeta):
         fv = cls.feature_registry[subproject]
         tv = cls.get_target_version(subproject)
         for version in sorted(fv.keys()):
-            message = ', '.join(sorted(f"'{i[0]}'" for i in fv[version]))
+            message = ', '.join(sorted({f"'{i[0]}'" for i in fv[version]}))
             if cls.check_version(tv, version):
                 notice_str += '\n * {}: {{{}}}'.format(version, message)
             else:

--- a/test cases/common/40 options/test.json
+++ b/test cases/common/40 options/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": " * 1.1.0: {'\"boolean option\" keyword argument \"value\" of type str', '\"boolean option\" keyword argument \"value\" of type str', '\"integer option\" keyword argument \"value\" of type str'}"
+      "line": " * 1.1.0: {'\"boolean option\" keyword argument \"value\" of type str', '\"integer option\" keyword argument \"value\" of type str'}"
     }
   ]
 }


### PR DESCRIPTION
In commit c2a55bfe43fae1b44cf49a083297d6755c89e1cc multiple bugs were fixed, but a FeatureNew was only added for the one that was mentioned in the commit message.

Make sure to warn users about the reliability of the one that wasn't mentioned, too.