### PR TITLE
tests: allow a long test to have more time to complete before timing out

### DIFF
--- a/test cases/common/254 long output/meson.build
+++ b/test cases/common/254 long output/meson.build
@@ -1,5 +1,5 @@
 project('long-stderr', 'c')
 
 dumper = executable('dumper', 'dumper.c')
-test('dump-test', dumper)
-test('dump-test-TAP', dumper, protocol : 'tap')
+test('dump-test', dumper, timeout: 60)
+test('dump-test-TAP', dumper, protocol : 'tap', timeout: 60)


### PR DESCRIPTION
This test is intended to test really long output, so it prints 100k lines of stdout/stderr. It completes in two seconds on my machine, but the default 30-second timeout is apparently too much for CI, because on Windows we often get flaky tests due to this. e.g. we'll get within 200 lines of the end.

Bump the CI time by x2. We know this isn't particularly surprising behavior, and allowing it to request another 30 seconds won't hang the CI. But it will save us from some spurious failures and restarted jobs.