### PR TITLE
Fix warning_level=everything with GCC 8

### DIFF
--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -196,10 +196,12 @@ gnu_common_warning_args = {
         "-Wduplicated-branches",
     ],
     "8.1.0": [
-        "-Wattribute-alias=2",
         "-Wcast-align=strict",
         "-Wsuggest-attribute=cold",
         "-Wsuggest-attribute=malloc",
+    ],
+    "9.1.0": [
+        "-Wattribute-alias=2",
     ],
     "10.1.0": [
         "-Wanalyzer-too-complex",


### PR DESCRIPTION
Moves this warning to start with GCC 9 to avoid issues during the 8 series.  See the commit message for details.