### PR TITLE
python module: add an automatic byte-compilation step

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -351,6 +351,7 @@ install prefix. For example: if the install prefix is `/usr` and the
 
 | Option           | Default value | Possible values             | Description |
 | ------           | ------------- | -----------------           | ----------- |
+| bytecompile      | 0             | integer from -1 to 2        | What bytecode optimization level to use (Since 1.2.0) |
 | install_env      | prefix        | {auto,prefix,system,venv}   | Which python environment to install to (Since 0.62.0) |
 | platlibdir       |               | Directory path              | Directory for site-specific, platform-specific files (Since 0.60.0) |
 | purelibdir       |               | Directory path              | Directory for site-specific, non-platform-specific files  (Since 0.60.0) |
@@ -373,3 +374,13 @@ installation is a virtualenv, and use `venv` or `system` as appropriate (but
 never `prefix`). This option is mutually exclusive with the `platlibdir`/`purelibdir`.
 
 For backwards compatibility purposes, the default `install_env` is `prefix`.
+
+*Since 1.2.0* The `python.bytecompile` option can be used to enable compiling
+python bytecode. Bytecode has 3 optimization levels:
+
+- 0, bytecode without optimizations
+- 1, bytecode with some optimizations
+- 2, bytecode with some more optimizations
+
+To this, Meson adds level `-1`, which is to not attempt to compile bytecode at
+all.

--- a/docs/markdown/snippets/python_bytecompile.md
+++ b/docs/markdown/snippets/python_bytecompile.md
@@ -1,0 +1,4 @@
+## Python module can now compile bytecode
+
+A new builtin option is available: `-Dpython.bytecompile=2`. It can be used to
+compile bytecode for all pure python files installed via the python module.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -499,7 +499,8 @@ class Backend:
             feed: T.Optional[bool] = None,
             env: T.Optional[build.EnvironmentVariables] = None,
             tag: T.Optional[str] = None,
-            verbose: bool = False) -> 'ExecutableSerialisation':
+            verbose: bool = False,
+            installdir_map: T.Optional[T.Dict[str, str]] = None) -> 'ExecutableSerialisation':
 
         # XXX: cmd_args either need to be lowered to strings, or need to be checked for non-string arguments, right?
         exe, *raw_cmd_args = cmd
@@ -560,7 +561,7 @@ class Backend:
         workdir = workdir or self.environment.get_build_dir()
         return ExecutableSerialisation(exe_cmd + cmd_args, env,
                                        exe_wrapper, workdir,
-                                       extra_paths, capture, feed, tag, verbose)
+                                       extra_paths, capture, feed, tag, verbose, installdir_map)
 
     def as_meson_exe_cmdline(self, exe: T.Union[str, mesonlib.File, build.BuildTarget, build.CustomTarget, programs.ExternalProgram],
                              cmd_args: T.Sequence[T.Union[str, mesonlib.File, build.BuildTarget, build.CustomTarget, programs.ExternalProgram]],

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1266,6 +1266,8 @@ BUILTIN_CORE_OPTIONS: 'MutableKeyedOptionDictType' = OrderedDict([
      BuiltinOption(UserBooleanOption, 'Generate pkgconfig files as relocatable', False)),
 
     # Python module
+    (OptionKey('bytecompile', module='python'),
+     BuiltinOption(UserIntegerOption, 'Whether to compile bytecode', (-1, 2, 0))),
     (OptionKey('install_env', module='python'),
      BuiltinOption(UserComboOption, 'Which python environment to install to', 'prefix', choices=['auto', 'prefix', 'system', 'venv'])),
     (OptionKey('platlibdir', module='python'),

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -31,7 +31,7 @@ if T.TYPE_CHECKING:
     from ..interpreterbase import TYPE_var, TYPE_kwargs
     from ..programs import OverrideProgram
     from ..wrap import WrapMode
-    from ..build import EnvironmentVariables, Executable
+    from ..build import Executable
     from ..dependencies import Dependency
 
 class ModuleState:
@@ -219,8 +219,8 @@ class NewExtensionModule(ModuleObject):
     def found() -> bool:
         return True
 
-    def get_devenv(self) -> T.Optional['EnvironmentVariables']:
-        return None
+    def postconf_hook(self, b: build.Build) -> None:
+        pass
 
 # FIXME: Port all modules to stop using self.interpreter and use API on
 # ModuleState instead. Modules should stop using this class and instead use

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -784,8 +784,9 @@ class GnomeModule(ExtensionModule):
             self.devenv = build.EnvironmentVariables()
         self.devenv.prepend(varname, [value])
 
-    def get_devenv(self) -> T.Optional[build.EnvironmentVariables]:
-        return self.devenv
+    def postconf_hook(self, b: build.Build) -> None:
+        if self.devenv is not None:
+            b.devenv.append(self.devenv)
 
     def _get_gir_dep(self, state: 'ModuleState') -> T.Tuple[Dependency, T.Union[build.Executable, 'ExternalProgram', 'OverrideProgram'],
                                                             T.Union[build.Executable, 'ExternalProgram', 'OverrideProgram']]:

--- a/mesonbuild/scripts/pycompile.py
+++ b/mesonbuild/scripts/pycompile.py
@@ -1,0 +1,67 @@
+# Copyright 2016 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ignore all lints for this file, since it is run by python2 as well
+
+# type: ignore
+# pylint: disable=deprecated-module
+
+import json, os, subprocess, sys
+from compileall import compile_file
+
+destdir = os.environ.get('DESTDIR')
+quiet = int(os.environ.get('MESON_INSTALL_QUIET', 0))
+
+def destdir_join(d1, d2):
+    if not d1:
+        return d2
+    # c:\destdir + c:\prefix must produce c:\destdir\prefix
+    parts = os.path.splitdrive(d2)
+    return d1 + parts[1]
+
+def compileall(files):
+    for f in files:
+        if destdir is not None:
+            ddir = os.path.dirname(f)
+            fullpath = destdir_join(destdir, f)
+        else:
+            ddir = None
+            fullpath = f
+
+        if os.path.isdir(fullpath):
+            for root, _, files in os.walk(fullpath):
+                ddir = os.path.dirname(os.path.splitdrive(f)[0] + root[len(destdir):])
+                for dirf in files:
+                    if dirf.endswith('.py'):
+                        fullpath = os.path.join(root, dirf)
+                        compile_file(fullpath, ddir, force=True, quiet=quiet)
+        else:
+            compile_file(fullpath, ddir, force=True, quiet=quiet)
+
+def run(manifest):
+    data_file = os.path.join(os.path.dirname(__file__), manifest)
+    with open(data_file, 'rb') as f:
+        dat = json.load(f)
+    compileall(dat)
+
+if __name__ == '__main__':
+    manifest = sys.argv[1]
+    run(manifest)
+    if len(sys.argv) > 2:
+        optlevel = int(sys.argv[2])
+        # python2 only needs one or the other
+        if optlevel == 1 or (sys.version_info >= (3,) and optlevel > 0):
+            subprocess.check_call([sys.executable, '-O'] + sys.argv[:2])
+        if optlevel == 2:
+            subprocess.check_call([sys.executable, '-OO'] + sys.argv[:2])

--- a/mesonbuild/utils/core.py
+++ b/mesonbuild/utils/core.py
@@ -152,6 +152,7 @@ class ExecutableSerialisation:
     feed: T.Optional[bool] = None
     tag: T.Optional[str] = None
     verbose: bool = False
+    installdir_map: T.Optional[T.Dict[str, str]] = None
 
     def __post_init__(self) -> None:
         self.pickled = False

--- a/test cases/common/252 install data structured/meson.build
+++ b/test cases/common/252 install data structured/meson.build
@@ -1,4 +1,4 @@
-project('install structured data')
+project('install structured data', default_options: ['python.bytecompile=-1'])
 
 install_data(
     'dir1/file1',

--- a/test cases/python/2 extmodule/blaster.py.in
+++ b/test cases/python/2 extmodule/blaster.py.in
@@ -8,4 +8,4 @@ if not isinstance(result, int):
     raise SystemExit('Returned result not an integer.')
 
 if result != 1:
-    raise SystemExit(f'Returned result {result} is not 1.')
+    raise SystemExit('Returned result {} is not 1.'.format(result))

--- a/test cases/python/2 extmodule/ext/meson.build
+++ b/test cases/python/2 extmodule/ext/meson.build
@@ -4,6 +4,12 @@ pylib = py.extension_module('tachyon',
   install: true,
 )
 
+pylib2 = py2.extension_module('tachyon',
+  'tachyon_module.c',
+  c_args: '-DMESON_MODULENAME="tachyon"',
+  install: true,
+)
+
 subdir('nested')
 subdir('wrongdir')
 pypathdir = meson.current_build_dir()

--- a/test cases/python/2 extmodule/ext/nested/meson.build
+++ b/test cases/python/2 extmodule/ext/nested/meson.build
@@ -13,3 +13,20 @@ py.install_sources(
   pure: false,
   subdir: 'nested',
 )
+
+
+py2.extension_module('tachyon',
+  '../tachyon_module.c',
+  c_args: '-DMESON_MODULENAME="nested.tachyon"',
+  install: true,
+  subdir: 'nested'
+)
+py2.install_sources(
+  configure_file(
+    input: '../../blaster.py.in',
+    output: 'blaster.py',
+    configuration: {'tachyon_module': 'nested.tachyon'}
+  ),
+  pure: false,
+  subdir: 'nested',
+)

--- a/test cases/python/2 extmodule/ext/tachyon_module.c
+++ b/test cases/python/2 extmodule/ext/tachyon_module.c
@@ -1,5 +1,5 @@
 /*
-  Copyright 2016 The Meson development team
+  Copyright 2018 The Meson development team
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -27,7 +27,11 @@ static PyObject* phaserize(PyObject *self, PyObject *args) {
         return NULL;
 
     result = strcmp(message, "shoot") ? 0 : 1;
+#if PY_VERSION_HEX < 0x03000000
+    return PyInt_FromLong(result);
+#else
     return PyLong_FromLong(result);
+#endif
 }
 
 static PyMethodDef TachyonMethods[] = {
@@ -36,9 +40,14 @@ static PyMethodDef TachyonMethods[] = {
     {NULL, NULL, 0, NULL}
 };
 
+#if PY_VERSION_HEX < 0x03000000
+PyMODINIT_FUNC inittachyon(void) {
+    Py_InitModule("tachyon", TachyonMethods);
+}
+#else
 static struct PyModuleDef tachyonmodule = {
    PyModuleDef_HEAD_INIT,
-   MESON_MODULENAME,
+   "tachyon",
    NULL,
    -1,
    TachyonMethods
@@ -47,3 +56,4 @@ static struct PyModuleDef tachyonmodule = {
 PyMODINIT_FUNC PyInit_tachyon(void) {
     return PyModule_Create(&tachyonmodule);
 }
+#endif

--- a/test cases/python/2 extmodule/ext/wrongdir/meson.build
+++ b/test cases/python/2 extmodule/ext/wrongdir/meson.build
@@ -4,3 +4,9 @@ py.extension_module('tachyon',
   install: true,
   install_dir: get_option('libdir')
 )
+py2.extension_module('tachyon',
+  '../tachyon_module.c',
+  c_args: '-DMESON_MODULENAME="tachyon"',
+  install: true,
+  install_dir: get_option('libdir')
+)

--- a/test cases/python/2 extmodule/meson.build
+++ b/test cases/python/2 extmodule/meson.build
@@ -1,5 +1,5 @@
 project('Python extension module', 'c',
-  default_options : ['buildtype=release', 'werror=true'])
+  default_options : ['buildtype=release', 'werror=true', 'python.bytecompile=-1'])
 # Because Windows Python ships only with optimized libs,
 # we must build this project the same way.
 

--- a/test cases/python/2 extmodule/meson.build
+++ b/test cases/python/2 extmodule/meson.build
@@ -10,6 +10,7 @@ endif
 
 py_mod = import('python')
 py = py_mod.find_installation()
+py2 = py_mod.find_installation('python2', required: get_option('python2'), disabler: true)
 py_dep = py.dependency(required: false)
 
 if not py_dep.found()
@@ -31,6 +32,12 @@ test('extmod',
 
 py.install_sources(blaster, pure: false)
 py.install_sources(blaster, subdir: 'pure')
+install_subdir('subinst', install_dir: py.get_install_dir(pure: false))
+
+py2.install_sources(blaster, pure: false)
+py2.install_sources(blaster, subdir: 'pure')
+install_subdir('subinst', install_dir: py2.get_install_dir(pure: false))
+
 
 py3_pkg_dep = dependency('python3', method: 'pkg-config', required : false)
 if py3_pkg_dep.found()

--- a/test cases/python/2 extmodule/meson_options.txt
+++ b/test cases/python/2 extmodule/meson_options.txt
@@ -1,0 +1,1 @@
+option('python2', type: 'feature', value: 'disabled')

--- a/test cases/python/2 extmodule/subinst/printer.py
+++ b/test cases/python/2 extmodule/subinst/printer.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+
+print('subinst')

--- a/test cases/python/2 extmodule/subinst/submod/printer.py
+++ b/test cases/python/2 extmodule/subinst/submod/printer.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+
+print('subinst.submod')

--- a/test cases/python/2 extmodule/test.json
+++ b/test cases/python/2 extmodule/test.json
@@ -7,6 +7,8 @@
     { "type": "python_file", "file": "usr/@PYTHON_PLATLIB@/nested/blaster.py" },
     { "type": "python_lib",  "file": "usr/@PYTHON_PLATLIB@/nested/tachyon" },
     { "type": "py_implib",   "file": "usr/@PYTHON_PLATLIB@/nested/tachyon" },
+    { "type": "python_file", "file": "usr/@PYTHON_PLATLIB@/subinst/printer.py" },
+    { "type": "python_file", "file": "usr/@PYTHON_PLATLIB@/subinst/submod/printer.py" },
     { "type": "python_lib",  "file": "usr/lib/tachyon" },
     { "type": "py_implib",   "file": "usr/lib/tachyon" }
   ]

--- a/test cases/python/7 install path/meson.build
+++ b/test cases/python/7 install path/meson.build
@@ -1,7 +1,8 @@
 project('install path',
   default_options: [
+    'python.bytecompile=-1',
     'python.purelibdir=/pure',
-    'python.platlibdir=/plat'
+    'python.platlibdir=/plat',
   ]
 )
 

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -45,6 +45,11 @@ from run_tests import (
 )
 
 
+# magic attribute used by unittest.result.TestResult._is_relevant_tb_level
+# This causes tracebacks to hide these internal implementation details,
+# e.g. for assertXXX helpers.
+__unittest = True
+
 class BasePlatformTests(TestCase):
     prefix = '/usr'
     libdir = 'lib'

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -484,3 +484,6 @@ class BasePlatformTests(TestCase):
     def assertPathDoesNotExist(self, path):
         m = f'Path {path!r} should not exist'
         self.assertFalse(os.path.exists(path), msg=m)
+
+    def assertLength(self, val, length):
+        assert len(val) == length, f'{val} is not length {length}'

--- a/unittests/helpers.py
+++ b/unittests/helpers.py
@@ -204,3 +204,11 @@ def get_path_without_cmd(cmd: str, path: str) -> str:
         paths.discard(dirname)
         path = pathsep.join([str(p) for p in paths])
     return path
+
+def xfail_if_jobname(name: str):
+    if os.environ.get('MESON_CI_JOBNAME') == name:
+        return unittest.expectedFailure
+
+    def wrapper(func):
+        return func
+    return wrapper

--- a/unittests/pythontests.py
+++ b/unittests/pythontests.py
@@ -12,18 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import unittest
-import pathlib
-import subprocess
+import glob, os, pathlib, shutil, subprocess, unittest
 
 from run_tests import (
     Backend
 )
 
 from .allplatformstests import git_init
-
 from .baseplatformtests import BasePlatformTests
+
 from mesonbuild.mesonlib import TemporaryDirectoryWinProof
 
 class PythonTests(BasePlatformTests):
@@ -60,3 +57,34 @@ python = pymod.find_installation('python3', required: true)
             git_init(dirstr)
             self.init(dirstr)
             subprocess.check_call(self.meson_command + ['dist', '-C', self.builddir], stdout=subprocess.DEVNULL)
+
+    def _test_bytecompile(self, py2=False):
+        testdir = os.path.join(self.src_root, 'test cases', 'python', '2 extmodule')
+
+        self.init(testdir, extra_args=['-Dpython2=auto', '-Dpython.bytecompile=1'])
+        self.build()
+        self.install()
+
+        count = 0
+        for root, dirs, files in os.walk(self.installdir):
+            for file in files:
+                realfile = os.path.join(root, file)
+                if file.endswith('.py'):
+                    cached = glob.glob(realfile+'?') + glob.glob(os.path.join(root, '__pycache__', os.path.splitext(file)[0] + '*.pyc'))
+                    self.assertEqual(len(cached), 2)
+                    count += 1
+        # there are 5 files x 2 installations
+        if py2:
+            self.assertEqual(count, 10)
+        else:
+            self.assertEqual(count, 5)
+
+    def test_bytecompile_multi(self):
+        if not shutil.which('python2'):
+            raise self.skipTest('python2 not installed')
+        self._test_bytecompile(True)
+
+    def test_bytecompile_single(self):
+        if shutil.which('python2'):
+            raise self.skipTest('python2 installed, already tested')
+        self._test_bytecompile()


### PR DESCRIPTION
For all source `*.py` files installed via either py.install_sources() or an `install_dir: py.get_install_dir()`, produce `*.pyc` files at install time. Controllable via a module option.
