### PR TITLE
compilers: Use an ordered set to store base options

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -27,6 +27,7 @@ from ..mesonlib import (
     HoldableObject,
     EnvironmentException, MesonException,
     Popen_safe, LibType, TemporaryDirectoryWinProof, OptionKey,
+    OrderedSet,
 )
 
 from ..arglist import CompilerArgs
@@ -310,7 +311,7 @@ base_options: 'KeyedOptionDictType' = {
                                                    'from_buildtype'),
 }
 
-def option_enabled(boptions: T.Set[OptionKey], options: 'KeyedOptionDictType',
+def option_enabled(boptions: OrderedSet[OptionKey], options: 'KeyedOptionDictType',
                    option: OptionKey) -> bool:
     try:
         if option not in boptions:
@@ -510,12 +511,12 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         if not hasattr(self, 'file_suffixes'):
             self.file_suffixes = lang_suffixes[self.language]
         if not hasattr(self, 'can_compile_suffixes'):
-            self.can_compile_suffixes = set(self.file_suffixes)
+            self.can_compile_suffixes = OrderedSet(self.file_suffixes)
         self.default_suffix = self.file_suffixes[0]
         self.version = version
         self.full_version = full_version
         self.for_machine = for_machine
-        self.base_options: T.Set[OptionKey] = set()
+        self.base_options: OrderedSet[OptionKey] = OrderedSet()
         self.linker = linker
         self.info = info
         self.is_cross = is_cross

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -18,6 +18,8 @@ import re
 import subprocess
 import typing as T
 
+from mesonbuild.utils.universal import OrderedSet
+
 from .. import mesonlib
 from .. import mlog
 from ..arglist import CompilerArgs
@@ -812,10 +814,10 @@ class GnuDCompiler(GnuCompiler, DCompiler):
                           'everything': (default_warn_args + ['-Wextra', '-Wpedantic'] +
                                          self.supported_warn_args(gnu_common_warning_args))}
 
-        self.base_options = {
+        self.base_options = OrderedSet(
             OptionKey(o) for o in [
              'b_colorout', 'b_sanitize', 'b_staticpic', 'b_vscrt',
-             'b_coverage', 'b_pgo', 'b_ndebug']}
+             'b_coverage', 'b_pgo', 'b_ndebug'])
 
         self._has_color_support = version_compare(self.version, '>=4.9')
         # dependencies were implemented before, but broken - support was fixed in GCC 7.1+
@@ -886,7 +888,7 @@ class LLVMDCompiler(DmdLikeCompilerMixin, DCompiler):
                            exe_wrapper=exe_wrapper, linker=linker,
                            full_version=full_version, is_cross=is_cross)
         DmdLikeCompilerMixin.__init__(self, dmd_frontend_version=find_ldc_dmd_frontend_version(version_output))
-        self.base_options = {OptionKey(o) for o in ['b_coverage', 'b_colorout', 'b_vscrt', 'b_ndebug']}
+        self.base_options = OrderedSet(OptionKey(o) for o in ['b_coverage', 'b_colorout', 'b_vscrt', 'b_ndebug'])
 
     def get_colorout_args(self, colortype: str) -> T.List[str]:
         if colortype == 'always':
@@ -951,7 +953,7 @@ class DmdDCompiler(DmdLikeCompilerMixin, DCompiler):
                            exe_wrapper=exe_wrapper, linker=linker,
                            full_version=full_version, is_cross=is_cross)
         DmdLikeCompilerMixin.__init__(self, version)
-        self.base_options = {OptionKey(o) for o in ['b_coverage', 'b_colorout', 'b_vscrt', 'b_ndebug']}
+        self.base_options = OrderedSet(OptionKey(o) for o in ['b_coverage', 'b_colorout', 'b_vscrt', 'b_ndebug'])
 
     def get_colorout_args(self, colortype: str) -> T.List[str]:
         if colortype == 'always':

--- a/mesonbuild/compilers/mixins/arm.py
+++ b/mesonbuild/compilers/mixins/arm.py
@@ -20,7 +20,7 @@ import typing as T
 
 from ... import mesonlib
 from ...linkers import ArmClangDynamicLinker
-from ...mesonlib import OptionKey
+from ...mesonlib import OptionKey, OrderedSet
 from ..compilers import clike_debug_args
 from .clang import clang_color_args
 
@@ -155,10 +155,10 @@ class ArmclangCompiler(Compiler):
             raise mesonlib.EnvironmentException(f'Unsupported Linker {self.linker.exelist}, must be armlink')
         if not mesonlib.version_compare(self.version, '==' + self.linker.version):
             raise mesonlib.EnvironmentException('armlink version does not match with compiler version')
-        self.base_options = {
+        self.base_options = OrderedSet(
             OptionKey(o) for o in
             ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage',
-             'b_ndebug', 'b_staticpic', 'b_colorout']}
+             'b_ndebug', 'b_staticpic', 'b_colorout'])
         # Assembly
         self.can_compile_suffixes.add('s')
 

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -54,8 +54,8 @@ class ClangCompiler(GnuLikeCompiler):
         super().__init__()
         self.defines = defines or {}
         self.base_options.update(
-            {OptionKey('b_colorout'), OptionKey('b_lto_threads'), OptionKey('b_lto_mode'), OptionKey('b_thinlto_cache'),
-             OptionKey('b_thinlto_cache_dir')})
+            [OptionKey('b_colorout'), OptionKey('b_lto_threads'), OptionKey('b_lto_mode'), OptionKey('b_thinlto_cache'),
+             OptionKey('b_thinlto_cache_dir')])
 
         # TODO: this really should be part of the linker base_options, but
         # linkers don't have base_options.

--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -22,7 +22,7 @@ import re
 
 from .gnu import GnuLikeCompiler
 from .gnu import gnu_optimization_args
-from ...mesonlib import Popen_safe, OptionKey
+from ...mesonlib import Popen_safe, OptionKey, OrderedSet
 
 if T.TYPE_CHECKING:
     from ...environment import Environment
@@ -37,7 +37,7 @@ class ElbrusCompiler(GnuLikeCompiler):
 
     def __init__(self) -> None:
         super().__init__()
-        self.base_options = {OptionKey(o) for o in ['b_pgo', 'b_coverage', 'b_ndebug', 'b_staticpic', 'b_lundef', 'b_asneeded']}
+        self.base_options = OrderedSet(OptionKey(o) for o in ['b_pgo', 'b_coverage', 'b_ndebug', 'b_staticpic', 'b_lundef', 'b_asneeded'])
         default_warn_args = ['-Wall']
         self.warn_args = {'0': [],
                           '1': default_warn_args,

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -26,7 +26,7 @@ import typing as T
 
 from ... import mesonlib
 from ... import mlog
-from ...mesonlib import OptionKey
+from ...mesonlib import OptionKey, OrderedSet
 
 if T.TYPE_CHECKING:
     from ..._typing import ImmutableListProtocol
@@ -378,9 +378,9 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
     LINKER_PREFIX = '-Wl,'
 
     def __init__(self) -> None:
-        self.base_options = {
+        self.base_options = OrderedSet(
             OptionKey(o) for o in ['b_pch', 'b_lto', 'b_pgo', 'b_coverage',
-                                   'b_ndebug', 'b_staticpic', 'b_pie']}
+                                   'b_ndebug', 'b_staticpic', 'b_pie'])
         if not (self.info.is_windows() or self.info.is_cygwin() or self.info.is_openbsd()):
             self.base_options.add(OptionKey('b_lundef'))
         if not self.info.is_windows() or self.info.is_cygwin():
@@ -570,7 +570,7 @@ class GnuCompiler(GnuLikeCompiler):
     def __init__(self, defines: T.Optional[T.Dict[str, str]]):
         super().__init__()
         self.defines = defines or {}
-        self.base_options.update({OptionKey('b_colorout'), OptionKey('b_lto_threads')})
+        self.base_options.update([OptionKey('b_colorout'), OptionKey('b_lto_threads')])
 
     def get_colorout_args(self, colortype: str) -> T.List[str]:
         if mesonlib.version_compare(self.version, '>=4.9.0'):

--- a/mesonbuild/compilers/mixins/intel.py
+++ b/mesonbuild/compilers/mixins/intel.py
@@ -77,9 +77,9 @@ class IntelGnuLikeCompiler(GnuLikeCompiler):
         # It does have IPO, which serves much the same purpose as LOT, but
         # there is an unfortunate rule for using IPO (you can't control the
         # name of the output file) which break assumptions meson makes
-        self.base_options = {mesonlib.OptionKey(o) for o in [
+        self.base_options = mesonlib.OrderedSet(mesonlib.OptionKey(o) for o in [
             'b_pch', 'b_lundef', 'b_asneeded', 'b_pgo', 'b_coverage',
-            'b_ndebug', 'b_staticpic', 'b_pie']}
+            'b_ndebug', 'b_staticpic', 'b_pie'])
         self.lang_header = 'none'
 
     def get_pch_suffix(self) -> str:

--- a/mesonbuild/compilers/mixins/pgi.py
+++ b/mesonbuild/compilers/mixins/pgi.py
@@ -20,7 +20,7 @@ import os
 from pathlib import Path
 
 from ..compilers import clike_debug_args, clike_optimization_args
-from ...mesonlib import OptionKey
+from ...mesonlib import OptionKey, OrderedSet
 
 if T.TYPE_CHECKING:
     from ...environment import Environment
@@ -47,7 +47,7 @@ class PGICompiler(Compiler):
     id = 'pgi'
 
     def __init__(self) -> None:
-        self.base_options = {OptionKey('b_pch')}
+        self.base_options = OrderedSet([OptionKey('b_pch')])
 
         default_warn_args = ['-Minform=inform']
         self.warn_args: T.Dict[str, T.List[str]] = {

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -119,7 +119,7 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
     INVOKES_LINKER = False
 
     def __init__(self, target: str):
-        self.base_options = {mesonlib.OptionKey(o) for o in ['b_pch', 'b_ndebug', 'b_vscrt']} # FIXME add lto, pgo and the like
+        self.base_options = mesonlib.OrderedSet(mesonlib.OptionKey(o) for o in ['b_pch', 'b_ndebug', 'b_vscrt']) # FIXME add lto, pgo and the like
         self.target = target
         self.is_64 = ('x64' in target) or ('x86_64' in target)
         # do some canonicalization of target machine

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -17,7 +17,7 @@ import os.path
 import typing as T
 
 from .. import mlog
-from ..mesonlib import EnvironmentException, version_compare, OptionKey
+from ..mesonlib import EnvironmentException, version_compare, OptionKey, OrderedSet
 
 from .compilers import Compiler, LibType
 
@@ -35,7 +35,7 @@ class ValaCompiler(Compiler):
                  is_cross: bool, info: 'MachineInfo'):
         super().__init__([], exelist, version, for_machine, info, is_cross=is_cross)
         self.version = version
-        self.base_options = {OptionKey('b_colorout')}
+        self.base_options = OrderedSet([OptionKey('b_colorout')])
 
     def needs_static_linker(self) -> bool:
         return False # Because compiles into C.


### PR DESCRIPTION
Sets are not ordered in python and the base_options field is pickled, leading to unstable coredata pickles that always change even if no options are modified with configure, causing unnecessary reconfigures.

Let's use ordered sets which makes sure the coredata pickle is stable as well, which makes sure meson doesn't reconfigure if no options were actually changed.