### PR TITLE
coredata: Do not pickle it twice

### DIFF
--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -26,7 +26,6 @@ from pathlib import Path
 
 from . import mlog
 from . import mesonlib
-from . import coredata
 from .mesonlib import MesonException, RealPathAction, join_args, setup_vsenv
 from mesonbuild.environment import detect_ninja
 from mesonbuild.coredata import UserArrayOption
@@ -331,8 +330,8 @@ def run(options: 'argparse.Namespace') -> int:
     if options.targets and options.clean:
         raise MesonException('`TARGET` and `--clean` can\'t be used simultaneously')
 
-    cdata = coredata.load(options.wd)
     b = build.load(options.wd)
+    cdata = b.environment.coredata
     vsenv_active = setup_vsenv(b.need_vsenv)
     if vsenv_active:
         mlog.log(mlog.green('INFO:'), 'automatically activated MSVC compiler environment')

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -72,7 +72,7 @@ class Conf:
         if os.path.isdir(os.path.join(self.build_dir, 'meson-private')):
             self.build = build.load(self.build_dir)
             self.source_dir = self.build.environment.get_source_dir()
-            self.coredata = coredata.load(self.build_dir)
+            self.coredata = self.build.environment.coredata
             self.default_values_only = False
         elif os.path.isfile(os.path.join(self.build_dir, environment.build_filename)):
             # Make sure that log entries in other parts of meson don't interfere with the JSON output


### PR DESCRIPTION
Exclude coredata from build.dat because it gets pickled separately already.