### PR TITLE
Stop using replace_if_different() for coredata pickle file

### DIFF
--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -90,8 +90,8 @@ class Conf:
     def clear_cache(self):
         self.coredata.clear_deps_cache()
 
-    def set_options(self, options):
-        self.coredata.set_options(options)
+    def set_options(self, options) -> bool:
+        return self.coredata.set_options(options)
 
     def save(self):
         # Do nothing when using introspection
@@ -308,9 +308,8 @@ def run(options):
 
         save = False
         if options.cmd_line_options:
-            c.set_options(options.cmd_line_options)
+            save = c.set_options(options.cmd_line_options)
             coredata.update_cmd_line_file(builddir, options)
-            save = True
         elif options.clearcache:
             c.clear_cache()
             save = True

--- a/test cases/unit/108 configure same noop/meson_options.txt
+++ b/test cases/unit/108 configure same noop/meson_options.txt
@@ -1,5 +1,6 @@
-option(
-  'opt',
-  type : 'string',
-  value: '',
-)
+option('string', type : 'string', value: '')
+option('boolean', type : 'boolean', value: false)
+option('combo', type : 'combo', choices : ['one', 'two', 'three'], value: 'one')
+option('integer', type : 'integer', value: 5)
+option('array', type : 'array', value: ['one', 'two'])
+option('feature', type : 'feature', value : 'enabled')


### PR DESCRIPTION
This was added in f774609 to only change the access time of the coredata file if the coredata struct actually changed. However, this doesn't work as pickle serializations aren't guaranteed to be stable. Instead, let's manually check if options have changed values and skip the save if they haven't changed.