### PR TITLE
Allow setting per subproject value on yielding project option

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -35,7 +35,7 @@ from .mesonlib import (
     File, MesonException, MachineChoice, PerMachine, OrderedSet, listify,
     extract_as_list, typeslistify, stringlistify, classify_unity_sources,
     get_filenames_templates_dict, substitute_values, has_path_sep,
-    OptionKey, PerMachineDefaultable, OptionOverrideProxy,
+    OptionKey, PerMachineDefaultable,
     MesonBugException, EnvironmentVariables, pickle_load,
 )
 from .compilers import (
@@ -43,6 +43,7 @@ from .compilers import (
     is_known_suffix, detect_static_linker
 )
 from .interpreterbase import FeatureNew, FeatureDeprecated
+from .coredata import OptionsView
 
 if T.TYPE_CHECKING:
     from typing_extensions import Literal
@@ -533,7 +534,7 @@ class Target(HoldableObject, metaclass=abc.ABCMeta):
                    for k, v in overrides.items()}
         else:
             ovr = {}
-        self.options = OptionOverrideProxy(ovr, self.environment.coredata.options, self.subproject)
+        self.options = OptionsView(self.environment.coredata.options, self.subproject, ovr)
         # XXX: this should happen in the interpreter
         if has_path_sep(self.name):
             # Fix failing test 53 when this becomes an error.
@@ -653,7 +654,7 @@ class Target(HoldableObject, metaclass=abc.ABCMeta):
             else:
                 self.options.overrides[k] = v
 
-    def get_options(self) -> OptionOverrideProxy:
+    def get_options(self) -> OptionsView:
         return self.options
 
     def get_option(self, key: 'OptionKey') -> T.Union[str, int, bool, 'WrapMode']:

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -21,7 +21,7 @@ import typing as T
 from .. import coredata
 from .. import mlog
 from ..mesonlib import (
-    EnvironmentException, Popen_safe, OptionOverrideProxy,
+    EnvironmentException, Popen_safe,
     is_windows, LibType, OptionKey, version_compare,
 )
 from .compilers import (Compiler, cuda_buildtype_args, cuda_optimization_args,
@@ -650,7 +650,7 @@ class CudaCompiler(Compiler):
         host_options = {key: options.get(key, opt) for key, opt in self.host_compiler.get_options().items()}
         std_key = OptionKey('std', machine=self.for_machine, lang=self.host_compiler.language)
         overrides = {std_key: 'none'}
-        return OptionOverrideProxy(overrides, host_options)
+        return coredata.OptionsView(host_options, overrides=overrides)
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args = self.get_ccbin_args(options)

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -198,8 +198,6 @@ class Conf:
         for k, o in sorted(options.items()):
             printable_value = o.printable_value()
             root = k.as_root()
-            if o.yielding and k.subproject and root in self.coredata.options:
-                printable_value = '<inherited from main project>'
             if isinstance(o, coredata.UserFeatureOption) and o.is_auto():
                 printable_value = auto.printable_value()
             self.add_option(str(root), o.description, printable_value, o.choices)

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -289,7 +289,7 @@ def list_buildoptions(coredata: cdata.CoreData, subprojects: T.Optional[T.List[s
             test_options[k] = v
         elif k.is_builtin():
             core_options[k] = v
-            if not v.yielding:
+            if v.yielding:
                 for s in subprojects:
                     core_options[k.evolve(subproject=s)] = v
 

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -29,7 +29,6 @@ from itertools import tee
 from tempfile import TemporaryDirectory, NamedTemporaryFile
 import typing as T
 import textwrap
-import copy
 import pickle
 import errno
 
@@ -41,7 +40,6 @@ if T.TYPE_CHECKING:
 
     from .._typing import ImmutableListProtocol
     from ..build import ConfigurationData
-    from ..coredata import KeyedOptionDictType, UserOption
     from ..environment import Environment
     from ..compilers.compilers import Compiler
     from ..interpreterbase.baseobjects import SubProject
@@ -78,7 +76,6 @@ __all__ = [
     'GitException',
     'OptionKey',
     'dump_conf_header',
-    'OptionOverrideProxy',
     'OptionType',
     'OrderedSet',
     'PerMachine',
@@ -2048,53 +2045,6 @@ def generate_list(func: T.Callable[..., T.Generator[_T, None, None]]) -> T.Calla
         return list(func(*args, **kwargs))
 
     return wrapper
-
-
-class OptionOverrideProxy(collections.abc.Mapping):
-    '''Mimic an option list but transparently override selected option
-    values.
-    '''
-
-    # TODO: the typing here could be made more explicit using a TypeDict from
-    # python 3.8 or typing_extensions
-
-    def __init__(self, overrides: T.Dict['OptionKey', T.Any], options: 'KeyedOptionDictType',
-                 subproject: T.Optional[str] = None):
-        self.overrides = overrides
-        self.options = options
-        self.subproject = subproject
-
-    def __getitem__(self, key: 'OptionKey') -> 'UserOption':
-        # FIXME: This is fundamentally the same algorithm than interpreter.get_option_internal().
-        # We should try to share the code somehow.
-        key = key.evolve(subproject=self.subproject)
-        if not key.is_project():
-            opt = self.options.get(key)
-            if opt is None or opt.yielding:
-                opt = self.options[key.as_root()]
-        else:
-            opt = self.options[key]
-            if opt.yielding:
-                opt = self.options.get(key.as_root(), opt)
-        override_value = self.overrides.get(key.as_root())
-        if override_value is not None:
-            opt = copy.copy(opt)
-            opt.set_value(override_value)
-        return opt
-
-    def __iter__(self) -> T.Iterator['OptionKey']:
-        return iter(self.options)
-
-    def __len__(self) -> int:
-        return len(self.options)
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, OptionOverrideProxy):
-            return NotImplemented
-        t1 = (self.overrides, self.subproject, self.options)
-        t2 = (other.overrides, other.subproject, other.options)
-        return t1 == t2
-
 
 class OptionType(enum.IntEnum):
 


### PR DESCRIPTION
Currently setting a value on yielding project option is silently ignored. This allows overriding the value inherited from main project, in the same way per-subproject builtin options works.

https://mesonbuild.com/Builtin-options.html#specifying-options-per-subproject The value is overridden in this order:
- Value from parent project
- Value from subproject's default_options if set
- Value from subproject() default_options if set
- Value from command line if set

How it works:
- Yielding options, regardless of their type, take their initial value from their corresponding option in the main project. After initial creation, their value can be changed independently from the main project. Each subproject has its own entry in coredata.options dictionary.
- Non-yielding built-in options are global, only the main project has an entry in coredata.options dictionary. That's the case of most built-in options.
- Non-yielding project options are local to each subproject, they do not inherit their initial value from main project.

It means that after initial setup, changing the value on the main project no longer will affect subprojects that have the same yielding option. Which may sound bad, but is actually more consistent with how builtin options like default_library works.

This refactor all option accesses through OptionsView (renamed from OptionOverrideProxy) to ensure the same logic applies in every code paths.