### PR TITLE
Fix "meson subprojects checkout -b" regression

### DIFF
--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -249,9 +249,10 @@ class Runner:
         return True
 
     def git_checkout(self, revision: str, create: bool = False) -> bool:
-        cmd = ['checkout', '--ignore-other-worktrees', revision, '--']
+        cmd = ['checkout', '--ignore-other-worktrees']
         if create:
-            cmd.insert(1, '-b')
+            cmd.append('-b')
+        cmd += [revision, '--']
         try:
             # Stash local changes, commits can always be found back in reflog, to
             # avoid any data lost by mistake.


### PR DESCRIPTION
The argument position is wrong since
https://github.com/mesonbuild/meson/commit/1c631ec8abd34df9971ab03faf22d709f1c54348