### PR TITLE
run_unittests: don't assume run from same directory

### DIFF
--- a/run_unittests.py
+++ b/run_unittests.py
@@ -135,7 +135,7 @@ def main():
         # Let there be colors!
         if 'CI' in os.environ:
             pytest_args += ['--color=yes']
-        pytest_args += ['./run_unittests.py']
+        pytest_args += [__file__]
         pytest_args += convert_args(sys.argv[1:])
         # Always disable pytest-cov because we use a custom setup
         try:


### PR DESCRIPTION
For user-facing scripts it's nice to not assume they're run from the same directory. For example, when testing multiple Python versions by hand on a physical computer, without having to have all of the Python bin's on PATH. 

This is relevant say with the Python.org download binaries for Windows, which by default install to %LOCALAPPDATA%\Programs\Python\Python3x without version-named executables. I.e. python.exe not python3.12.exe