### PR TITLE
Add a system method for obtaining GL dependency on Linux OS

### DIFF
--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -45,12 +45,20 @@ class GLDependencySystem(SystemDependency):
             self.link_args = ['-framework', 'OpenGL']
             # FIXME: Detect version using self.clib_compiler
             return
-        if self.env.machines[self.for_machine].is_windows():
+        elif self.env.machines[self.for_machine].is_windows():
             self.is_found = True
             # FIXME: Use self.clib_compiler.find_library()
             self.link_args = ['-lopengl32']
             # FIXME: Detect version using self.clib_compiler
             return
+        else:
+            links = self.clib_compiler.find_library('GL', environment, [])
+            has_header = self.clib_compiler.has_header('GL/gl.h', '', environment)[0]
+            if links and has_header:
+                self.is_found = True
+                self.link_args = links
+            elif links:
+                raise DependencyException('Found GL runtime library but no development header files')
 
 class GnuStepDependency(ConfigToolDependency):
 


### PR DESCRIPTION
Following discussion https://github.com/mesonbuild/meson/discussions/11554 highlighting the fact that although MacOS X and Windows have a special implementation to acquire the 'system' GL library, Linux does not (it may not even be shipped with the system).
This pull request provides an option for Linux operating systems to query the C compiler directly for the GL library, and then assigns the returned flags to this dependency, if it is found.
