### PR TITLE
Add "format" subcommand

### DIFF
--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -376,3 +376,13 @@ format should be used. There are currently 3 formats supported:
   seems to be properly supported by vscode.
 
 {{ devenv_arguments.inc }}
+
+### format
+
+*(since 1.1.0)*
+
+{{ format_usage.inc }}
+
+Reformat source files using tools like clang-format or GNU indent.
+
+{{ format_arguments.inc }}

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3434,7 +3434,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         if target_name in self.all_outputs:
             return
         cmd = self.environment.get_build_command() + \
-            ['--internal', 'clang' + name, self.environment.source_dir, self.environment.build_dir] + \
+            ['--internal', 'clang' + name, '--sourcedir', self.environment.source_dir, '--builddir', self.environment.build_dir] + \
             extra_args
         elem = self.create_phony_target(self.all_outputs, target_name, 'CUSTOM_COMMAND', 'PHONY')
         elem.add_item('COMMAND', cmd)

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -71,7 +71,7 @@ class CommandLineParser:
     def __init__(self):
         # only import these once we do full argparse processing
         from . import mconf, mdist, minit, minstall, mintro, msetup, mtest, rewriter, msubprojects, munstable_coredata, mcompile, mdevenv
-        from .scripts import env2mfile
+        from .scripts import env2mfile, clangformat
         from .wrap import wraptool
         import shutil
 
@@ -109,6 +109,8 @@ class CommandLineParser:
                          help_msg='Run commands in developer environment')
         self.add_command('env2mfile', env2mfile.add_arguments, env2mfile.run,
                          help_msg='Convert current environment to a cross or native file')
+        self.add_command('format', clangformat.add_arguments, clangformat.run_cli,
+                         help_msg='Format source files using tools such as clang-format (Since 1.1.0)')
         # Add new commands above this line to list them in help command
         self.add_command('help', self.add_help_arguments, self.run_help_command,
                          help_msg='Print help of a subcommand')

--- a/mesonbuild/scripts/clangformat.py
+++ b/mesonbuild/scripts/clangformat.py
@@ -15,15 +15,31 @@ from __future__ import annotations
 
 import argparse
 import difflib
+import shutil
+import shlex
 from pathlib import Path
 
-from .run_tool import run_tool
+from . import run_tool
+from ..compilers import cpp_suffixes, c_suffixes
 from ..environment import detect_clangformat
 from ..mesonlib import Popen_safe
 from .. import mlog
 import typing as T
 
-def run_clang_format(fname: Path, exelist: T.List[str], check: bool) -> int:
+def add_arguments(parser: 'argparse.ArgumentParser') -> None:
+    parser.add_argument('--check', action='store_true',
+                        help='Dry run, print diff and return an error if any file needs reformatting.')
+    parser.add_argument('--sourcedir', default='.',
+                        help='The source directory (Optional if files are specified).')
+    parser.add_argument('--builddir', default=None,
+                        help='Directory to ignore, usually the build directory (Optional).')
+    parser.add_argument('--tool', default=None,
+                        help='Command to reformat a single file passed as extra argument. ' +
+                             'Must print formatted file on stdout. (Default clang-format).')
+    parser.add_argument('files', nargs='*', type=Path,
+                        help='Files to reformat (defaults to all source files).')
+
+def run_formatter(fname: Path, exelist: T.List[str], check: bool) -> int:
     cmd = exelist + [str(fname)]
     try:
         p, o, e = Popen_safe(cmd)
@@ -61,19 +77,39 @@ def run_clang_format(fname: Path, exelist: T.List[str], check: bool) -> int:
 
     return 0
 
+def run_cli(options: T.Any) -> int:
+    '''Run from "meson format"'''
+    if options.tool:
+        exelist = shlex.split(options.tool)
+        name = Path(exelist[0]).stem
+        argv0 = shutil.which(exelist[0])
+        if not argv0:
+            mlog.error(f'Could not find {options.tool}')
+            return 1
+        exelist = [argv0] + exelist[1:]
+    else:
+        name = 'clang-format'
+        exelist = detect_clangformat()
+        if not exelist:
+            mlog.error(f'Could not find {name}')
+            return 1
+        exelist.append('-style=file')
+
+    if options.files:
+        globs = [options.files]
+        ignore: T.Set[str] = set()
+    else:
+        srcdir = Path(options.sourcedir)
+        globs, ignore = run_tool.defaults(name, srcdir)
+        if options.builddir:
+            ignore.add(str(Path(options.builddir, '*')))
+
+    suffixes = c_suffixes | cpp_suffixes
+    return run_tool.run(globs, ignore, suffixes, run_formatter, exelist, options.check)
+
 def run(args: T.List[str]) -> int:
+    '''Run from "ninja clang-format"'''
     parser = argparse.ArgumentParser()
-    parser.add_argument('--check', action='store_true')
-    parser.add_argument('sourcedir')
-    parser.add_argument('builddir')
+    add_arguments(parser)
     options = parser.parse_args(args)
-
-    srcdir = Path(options.sourcedir)
-    builddir = Path(options.builddir)
-
-    exelist = detect_clangformat()
-    if not exelist:
-        print('Could not execute clang-format "%s"' % ' '.join(exelist))
-        return 1
-
-    return run_tool('clang-format', srcdir, builddir, run_clang_format, exelist, options.check)
+    return run_cli(options)

--- a/mesonbuild/scripts/clangtidy.py
+++ b/mesonbuild/scripts/clangtidy.py
@@ -17,7 +17,8 @@ import argparse
 import subprocess
 from pathlib import Path
 
-from .run_tool import run_tool
+from ..compilers import cpp_suffixes, c_suffixes
+from . import run_tool
 import typing as T
 
 def run_clang_tidy(fname: Path, builddir: Path) -> int:
@@ -25,11 +26,14 @@ def run_clang_tidy(fname: Path, builddir: Path) -> int:
 
 def run(args: T.List[str]) -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument('sourcedir')
-    parser.add_argument('builddir')
+    parser.add_argument('--sourcedir')
+    parser.add_argument('--builddir')
     options = parser.parse_args(args)
 
     srcdir = Path(options.sourcedir)
     builddir = Path(options.builddir)
 
-    return run_tool('clang-tidy', srcdir, builddir, run_clang_tidy, builddir)
+    globs, ignore = run_tool.defaults('clang-tidy', srcdir)
+    ignore.add(str(builddir / '*'))
+    suffixes = c_suffixes | cpp_suffixes
+    return run_tool.run(globs, ignore, suffixes, run_clang_tidy, builddir)

--- a/mesonbuild/scripts/clangtidy.py
+++ b/mesonbuild/scripts/clangtidy.py
@@ -20,8 +20,8 @@ from pathlib import Path
 from .run_tool import run_tool
 import typing as T
 
-def run_clang_tidy(fname: Path, builddir: Path) -> subprocess.CompletedProcess:
-    return subprocess.run(['clang-tidy', '-p', str(builddir), str(fname)])
+def run_clang_tidy(fname: Path, builddir: Path) -> int:
+    return subprocess.run(['clang-tidy', '-p', str(builddir), str(fname)]).returncode
 
 def run(args: T.List[str]) -> int:
     parser = argparse.ArgumentParser()

--- a/mesonbuild/scripts/run_tool.py
+++ b/mesonbuild/scripts/run_tool.py
@@ -22,9 +22,6 @@ from ..compilers import lang_suffixes
 from ..mesonlib import quiet_git
 import typing as T
 
-if T.TYPE_CHECKING:
-    import subprocess
-
 def parse_pattern_file(fname: Path) -> T.List[str]:
     patterns = []
     try:
@@ -37,7 +34,7 @@ def parse_pattern_file(fname: Path) -> T.List[str]:
         pass
     return patterns
 
-def run_tool(name: str, srcdir: Path, builddir: Path, fn: T.Callable[..., subprocess.CompletedProcess], *args: T.Any) -> int:
+def run_tool(name: str, srcdir: Path, builddir: Path, fn: T.Callable[..., int], *args: T.Any) -> int:
     patterns = parse_pattern_file(srcdir / f'.{name}-include')
     globs: T.Union[T.List[T.List[Path]], T.List[T.Generator[Path, None, None]]]
     if patterns:
@@ -64,5 +61,5 @@ def run_tool(name: str, srcdir: Path, builddir: Path, fn: T.Callable[..., subpro
                 continue
             futures.append(e.submit(fn, f, *args))
         if futures:
-            returncode = max(x.result().returncode for x in futures)
+            returncode = max(x.result() for x in futures)
     return returncode


### PR DESCRIPTION
This gives more control over clang-format and clang-format-check ninja
targets.
    
- It allows passing a list of files to check, usually changed files from
  a PR or pre-commit hook.
- Use different tool than clang-format, the only requirement is to print
  reformatted file on stdout.
- Run formatter tool multiple times in case line splitting is not stable in first run.
- Print colored diff telling exactly what needs to be reformatted  when in --check node.