### PR TITLE
add __main__.py

### DIFF
--- a/mesonbuild/__main__.py
+++ b/mesonbuild/__main__.py
@@ -1,0 +1,4 @@
+from mesonbuild.mesonmain import main
+import sys
+
+sys.exit(main())


### PR DESCRIPTION
this allows to run python -m mesonbuild. Can be useful to ensure meson run with a specific python interpreter.