### PR TITLE
ZlibSystemDependency: pass libtype to clib_compiler.find_library

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2090,13 +2090,14 @@ class NinjaBackend(backends.Backend):
                 if a in rustc.native_static_libs:
                     # Exclude link args that rustc already add by default
                     continue
-                if a.endswith(('.dll', '.so', '.dylib')):
+                if a.endswith(('.dll', '.so', '.dylib', '.a', '.lib')):
                     dir_, lib = os.path.split(a)
                     linkdirs.add(dir_)
                     lib, ext = os.path.splitext(lib)
                     if lib.startswith('lib'):
                         lib = lib[3:]
-                    args.extend(['-l', f'dylib={lib}'])
+                    _type = 'static' if a.endswith(('.a', '.lib')) else 'dylib'
+                    args.extend(['-l', f'{_type}={lib}'])
                 elif a.startswith('-L'):
                     args.append(a)
                 elif a.startswith('-l'):

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -536,7 +536,7 @@ class ZlibSystemDependency(SystemDependency):
             else:
                 libs = ['z']
             for lib in libs:
-                l = self.clib_compiler.find_library(lib, environment, [])
+                l = self.clib_compiler.find_library(lib, environment, [], self.libtype)
                 h = self.clib_compiler.has_header('zlib.h', '', environment, dependencies=[self])
                 if l and h[0]:
                     self.is_found = True


### PR DESCRIPTION
Makes it stop reporting that it found a static zlib on Solaris which does not ship a static library file for libz, and thus allows "test cases/rust/13 external c dependencies" to pass.

Fixes #10906

On Solaris 11.4.57, this changes the results of that rust test case from:
```
 [SUCCESS]   rust: 13 external c dependencies    (static=False method=cmake)
 [SUCCESS]   rust: 13 external c dependencies    (static=False method=pkg-config)
 [SUCCESS]   rust: 13 external c dependencies    (static=False method=system)
 [SUCCESS]   rust: 13 external c dependencies    (static=True method=cmake)
  [ERROR]    rust: 13 external c dependencies    (static=True method=system)
During: build
Reason: Compiling source code failed.
```
to
```
 [SUCCESS]   rust: 13 external c dependencies    (static=False method=cmake)
 [SUCCESS]   rust: 13 external c dependencies    (static=False method=pkg-config)
 [SUCCESS]   rust: 13 external c dependencies    (static=False method=system)
 [SUCCESS]   rust: 13 external c dependencies    (static=True method=cmake)
 [SKIPPED]   rust: 13 external c dependencies    (static=True method=system)
Reason: Could not find a static zlib
```