### PR TITLE
tests: fix critical existence failure of doxygen test

### DIFF
--- a/test cases/frameworks/14 doxygen/doc/Doxyfile.in
+++ b/test cases/frameworks/14 doxygen/doc/Doxyfile.in
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = doc
+OUTPUT_DIRECTORY       = "@TOP_BUILDDIR@/doc"
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and

--- a/test cases/frameworks/14 doxygen/doc/meson.build
+++ b/test cases/frameworks/14 doxygen/doc/meson.build
@@ -1,5 +1,5 @@
-cdata.set('TOP_SRCDIR', meson.source_root())
-cdata.set('TOP_BUILDDIR', meson.build_root())
+cdata.set('TOP_SRCDIR', meson.project_source_root())
+cdata.set('TOP_BUILDDIR', meson.project_build_root())
 
 doxyfile = configure_file(input: 'Doxyfile.in',
                           output: 'Doxyfile',

--- a/test cases/frameworks/14 doxygen/meson.build
+++ b/test cases/frameworks/14 doxygen/meson.build
@@ -1,4 +1,4 @@
-project('doxygen test', 'cpp', version : '0.1.0')
+project('doxygen test', 'cpp', version : '0.1.0', meson_version: '>=0.56')
 
 spede_inc = include_directories('include')
 


### PR DESCRIPTION
It was totally subproject-unsafe, and setting a super bad example. This is bad, because doxygen is annoying to get right and we occasionally tell people to go use our example test case.

Fixes #11579