### PR TITLE
cmake: fix directory separators in generated packageConfig.cmake files

### DIFF
--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -391,7 +391,8 @@ class CmakeModule(ExtensionModule):
         if not os.path.isabs(abs_install_dir):
             abs_install_dir = os.path.join(prefix, install_dir)
 
-        PACKAGE_RELATIVE_PATH = os.path.relpath(prefix, abs_install_dir)
+        # path used in cmake scripts are POSIX even on Windows
+        PACKAGE_RELATIVE_PATH = pathlib.PurePath(os.path.relpath(prefix, abs_install_dir)).as_posix()
         extra = ''
         if re.match('^(/usr)?/lib(64)?/.+', abs_install_dir):
             extra = PACKAGE_INIT_EXT.replace('@absInstallDir@', abs_install_dir)

--- a/test cases/cmake/26 cmake package prefix dir/cmakePackagePrefixDirConfig.cmake.in
+++ b/test cases/cmake/26 cmake package prefix dir/cmakePackagePrefixDirConfig.cmake.in
@@ -1,0 +1,1 @@
+@PACKAGE_INIT@

--- a/test cases/cmake/26 cmake package prefix dir/meson.build
+++ b/test cases/cmake/26 cmake package prefix dir/meson.build
@@ -1,0 +1,19 @@
+project('cmakePackagePrefixDir', 'c', version: '1.0.0')
+
+cmake = import('cmake')
+
+cmake.configure_package_config_file(
+    name: 'cmakePackagePrefixDir',
+    input: 'cmakePackagePrefixDirConfig.cmake.in',
+    configuration: configuration_data(),
+)
+
+# NOTE: can't use fs.read because cmakePackagePrefixDirConfig.cmake is in build_dir
+python = find_program('python3')
+lines = run_command(python, '-c',
+    '[print(line, end="") for line in open("@0@")]'.format(meson.current_build_dir() / 'cmakePackagePrefixDirConfig.cmake'), check : true,
+).stdout().split('\n')
+
+message(lines)
+
+assert(lines[5] == 'get_filename_component(PACKAGE_PREFIX_DIR "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)')

--- a/test cases/cmake/26 cmake package prefix dir/test.json
+++ b/test cases/cmake/26 cmake package prefix dir/test.json
@@ -1,0 +1,5 @@
+{
+  "installed": [
+    {"type": "file", "file": "usr/lib/cmake/cmakePackagePrefixDir/cmakePackagePrefixDirConfig.cmake"}
+  ]
+}


### PR DESCRIPTION
On windows, meson would mix posix and windows dir separators in the computed PACKAGE_RELATIVE_PATH.
Here we force posix directory separator even on Windows. This matches the CMake behavior and fixes interpretation of the resulting path.

Fixes #6955
Fixes #9702