### PR TITLE
fix: make check for ccache for Rust linkers more robust

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -29,6 +29,7 @@ import shutil
 import tempfile
 import os
 import typing as T
+import os.path
 
 if T.TYPE_CHECKING:
     from .compilers import Compiler
@@ -983,7 +984,7 @@ def detect_rust_compiler(env: 'Environment', for_machine: MachineChoice) -> Rust
                     extra_args['machine'] = cc.linker.machine
                 else:
                     exelist = cc.linker.exelist + cc.linker.get_always_args()
-                    if 'ccache' in exelist[0]:
+                    if 'ccache' in os.path.basename(exelist[0]) and len(exelist) > 1:
                         del exelist[0]
                     c = exelist.pop(0)
                     compiler.extend(cls.use_linker_args(c, ''))


### PR DESCRIPTION
Fixes #11586

A very naive approach to fix  #11586. I have no experience with Meson and the context of the code I'm changing. So please excuse any beginner mistake and help me with how this should be done the proper way.

I assume this check wants to remove a potential `ccache` first argument for Rust linkers. I assume the authors original intention was to do the following transformations

```
ccache cc -> cc
ccache.exe cc -> cc
```
but not 
```
/home/ccache-gcc/bin/gcc -> <nothing>
```