### PR TITLE
python dependency: avoid redefinition warnings for MS_WIN64

### DIFF
--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -209,7 +209,7 @@ class PythonSystemDependency(SystemDependency, _PythonDependencyBase):
         # https://sourceforge.net/p/mingw-w64/mailman/message/30504611/
         # https://github.com/python/cpython/pull/100137
         if mesonlib.is_windows() and self.get_windows_python_arch() == '64' and mesonlib.version_compare(self.version, '<3.12'):
-            self.compile_args += ['-DMS_WIN64']
+            self.compile_args += ['-DMS_WIN64=']
 
         if not self.clib_compiler.has_header('Python.h', '', environment, extra_args=self.compile_args):
             self.is_found = False

--- a/test cases/common/117 shared module/meson.build
+++ b/test cases/common/117 shared module/meson.build
@@ -36,5 +36,6 @@ test('import test 2', e, args : m2)
 
 # Shared module that does not export any symbols
 shared_module('nosyms', 'nosyms.c',
+  override_options: ['werror=false'],
   install : true,
   install_dir : join_paths(get_option('libdir'), 'modules'))

--- a/test cases/common/147 simd/simd_mmx.c
+++ b/test cases/common/147 simd/simd_mmx.c
@@ -45,14 +45,16 @@ void increment_mmx(float arr[4]) {
      * enough to fit in int16;
      */
     int i;
+    /* This is unused due to below comment about GCC 8.
     __m64 packed = _mm_set_pi16(arr[3], arr[2], arr[1], arr[0]);
     __m64 incr = _mm_set1_pi16(1);
     __m64 result = _mm_add_pi16(packed, incr);
-    /* Should be
+    int64_t unpacker = (int64_t)(result);
+     */
+    /* The above should be
      * int64_t unpacker = _m_to_int64(result);
      * but it does not exist on 32 bit platforms for some reason.
      */
-    int64_t unpacker = (int64_t)(result);
     _mm_empty();
     for(i=0; i<4; i++) {
       /* This fails on GCC 8 when optimizations are enabled.

--- a/test cases/common/148 shared module resolving symbol in executable/prog.c
+++ b/test cases/common/148 shared module resolving symbol in executable/prog.c
@@ -30,7 +30,7 @@ int main(int argc, char **argv)
   int expected, actual;
   fptr importedfunc;
 
-  if (argc=0) {};  // noop
+  (void)argc;  // noop
 
 #ifdef _WIN32
   HMODULE h = LoadLibraryA(argv[1]);

--- a/test cases/common/245 custom target index source/main.c
+++ b/test cases/common/245 custom target index source/main.c
@@ -1,8 +1,10 @@
 #include <assert.h>
 #include "gen.h"
 
-int main(int argc)
+int main(int argc, char **argv)
 {
+  (void)argv;
+
   assert(argc == 3);
   return genfunc();
 }

--- a/test cases/python/2 extmodule/meson.build
+++ b/test cases/python/2 extmodule/meson.build
@@ -1,5 +1,5 @@
 project('Python extension module', 'c',
-  default_options : ['buildtype=release'])
+  default_options : ['buildtype=release', 'werror=true'])
 # Because Windows Python ships only with optimized libs,
 # we must build this project the same way.
 

--- a/test cases/rust/12 bindgen/dependencies/meson.build
+++ b/test cases/rust/12 bindgen/dependencies/meson.build
@@ -12,6 +12,8 @@ external_dep_rs = rust.bindgen(
 external_dep = static_library(
   'external_dep',
   [external_dep_rs],
+  # for generated code, do not lint
+  rust_args: ['-A', 'warnings'],
   dependencies : dep_zlib.partial_dependency(links : true),
 )
 


### PR DESCRIPTION
pyconfig.h defines it in limited cases, but as empty, rather than as "1" which is what command-line defines generally do. Explicitly define it as a compatible definition so the compiler does not log a warning that the value has changed.

Fixes #11592