### PR TITLE
Add support for Metrowerks C/C++ compilers

### DIFF
--- a/cross/metrowerks-arm.txt
+++ b/cross/metrowerks-arm.txt
@@ -1,0 +1,28 @@
+# This file assumes that the path to your Metrowerks Embedded ARM
+# toolchain is added to the environment(PATH) variable, so that
+# Meson can find the binaries while building.
+
+# You should also do one of the following to ensure Meson can
+# locate the .lcf linker script:
+# - Add the cross directory to PATH as well
+# - Edit c_link_args and cpp_link_args with the full
+#   path to the .lcf file on your machine
+
+[binaries]
+c = 'mwccarm'
+c_ld = 'mwldarm'
+cpp = 'mwccarm'
+cpp_ld = 'mwldarm'
+ar = 'mwldarm'
+as = 'mwasmarm'
+
+[built-in options]
+c_args = ['-lang', 'c99', '-D_NITRO', '-nosyspath']
+c_link_args = 'metrowerks.lcf'
+cpp_args = ['-lang', 'c++', '-D_NITRO', '-nosyspath']
+cpp_link_args = 'metrowerks.lcf'
+
+[host_machine]
+system = 'bare metal'
+cpu_family = 'arm'
+endian = 'little'

--- a/cross/metrowerks-eppc.txt
+++ b/cross/metrowerks-eppc.txt
@@ -1,0 +1,28 @@
+# This file assumes that the path to your Metrowerks toolchain
+# of choice is added to the environment(PATH) variable, so that
+# Meson can find the binaries while building.
+
+# You should also do one of the following to ensure Meson can
+# locate the .lcf linker script:
+# - Add the cross directory to PATH as well
+# - Edit c_link_args and cpp_link_args with the full
+#   path to the lcf file on your machine
+
+[binaries]
+c = 'mwcceppc'
+c_ld = 'mwldeppc'
+cpp = 'mwcceppc'
+cpp_ld = 'mwldeppc'
+ar = 'mwldeppc'
+as = 'mwasmeppc'
+
+[built-in options]
+c_args = ['-lang', 'c99', '-nosyspath']
+c_link_args = 'metrowerks.lcf'
+cpp_args = ['-lang', 'c++', '-nosyspath']
+cpp_link_args = 'metrowerks.lcf'
+
+[host_machine]
+system = 'bare metal'
+cpu_family = 'ppc'
+endian = 'little'

--- a/cross/metrowerks.lcf
+++ b/cross/metrowerks.lcf
@@ -1,0 +1,18 @@
+# General-purpose linker script for Metrowerks toolchains.
+# This script will link a blank application. Its only purpose
+# is to allow the toolchains to run Meson tests. To link an
+# actual application, you need to write your own fine-tuned lcf.
+
+MEMORY {
+    TEST (RWX) : ORIGIN=0, LENGTH=0
+}
+
+SECTIONS {
+    .TEST:{
+        * (.text)
+	  * (.data)
+	  * (.rodata)
+	  * (.bss)
+        __startup=.;
+    } > TEST
+}

--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -25,6 +25,8 @@ These are return values of the `get_id` (Compiler family) and
 | lcc       | Elbrus C/C++/Fortran Compiler    |                 |
 | llvm      | LLVM-based compiler (Swift, D)   |                 |
 | mono      | Xamarin C# compiler              |                 |
+| mwccarm   | Metrowerks C/C++ compiler for Embedded ARM         |                 |
+| mwcceppc  | Metrowerks C/C++ compiler for Embedded PowerPC     |                 |
 | msvc      | Microsoft Visual Studio          | msvc            |
 | nagfor    | The NAG Fortran compiler         |                 |
 | nvidia_hpc| NVidia HPC SDK compilers         |                 |
@@ -69,6 +71,8 @@ These are return values of the `get_linker_id` method in a compiler object.
 | pgi        | Portland/Nvidia PGI                         |
 | nvlink     | Nvidia Linker used with cuda                |
 | ccomp      | CompCert used as the linker driver          |
+| mwldarm    | The Metrowerks Linker with the ARM interface, used with mwccarm only |
+| mwldeppc   | The Metrowerks Linker with the PowerPC interface, used with mwcceppc only |
 
 For languages that don't have separate dynamic linkers such as C# and Java, the
 `get_linker_id` will return the compiler name.

--- a/docs/markdown/snippets/add_metrowerks_compiler.md
+++ b/docs/markdown/snippets/add_metrowerks_compiler.md
@@ -1,0 +1,5 @@
+## Added Metrowerks C/C++ toolchains
+
+Added support for the Metrowerks Embedded ARM and Metrowerks Embedded PowerPC toolchains (https://www.nxp.com/docs/en/reference-manual/CWMCUKINCMPREF.pdf).
+
+The implementation is somewhat experimental. It has been tested on a few projects and works fairly well, but may have issues.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2405,7 +2405,12 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             output = []
         else:
             output = NinjaCommandArg.list(compiler.get_output_args('$out'), Quoting.none)
-        command = compiler.get_exelist() + ['$ARGS'] + depargs + output + compiler.get_compile_only_args() + ['$in']
+
+        if 'mwcc' in compiler.id:
+            output[0].s = '-precompile'
+            command = compiler.get_exelist() + ['$ARGS'] + depargs + output + ['$in'] # '-c' must be removed
+        else:
+            command = compiler.get_exelist() + ['$ARGS'] + depargs + output + compiler.get_compile_only_args() + ['$in']
         description = 'Precompiling header $in'
         if compiler.get_argument_syntax() == 'msvc':
             deps = 'msvc'
@@ -2982,6 +2987,13 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         dep = dst + '.' + compiler.get_depfile_suffix()
         return commands, dep, dst, []  # Gcc does not create an object file during pch generation.
 
+    def generate_mwcc_pch_command(self, target, compiler, pch):
+        commands = self._generate_single_compile(target, compiler)
+        dst = os.path.join(self.get_target_private_dir(target),
+                           os.path.basename(pch) + '.' + compiler.get_pch_suffix())
+        dep = os.path.splitext(dst)[0] + '.' + compiler.get_depfile_suffix()
+        return commands, dep, dst, []  # mwcc compilers do not create an object file during pch generation.
+
     def generate_pch(self, target, header_deps=None):
         header_deps = header_deps if header_deps is not None else []
         pch_objects = []
@@ -3000,6 +3012,10 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             elif compiler.id == 'intel':
                 # Intel generates on target generation
                 continue
+            elif 'mwcc' in compiler.id:
+                src = os.path.join(self.build_to_src, target.get_source_subdir(), pch[0])
+                (commands, dep, dst, objs) = self.generate_mwcc_pch_command(target, compiler, pch[0])
+                extradep = None
             else:
                 src = os.path.join(self.build_to_src, target.get_source_subdir(), pch[0])
                 (commands, dep, dst, objs) = self.generate_gcc_pch_command(target, compiler, pch[0])

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1865,6 +1865,9 @@ class Executable(BuildTarget):
             elif ('c' in self.compilers and self.compilers['c'].get_id() in {'ti', 'c2000'} or
                   'cpp' in self.compilers and self.compilers['cpp'].get_id() in {'ti', 'c2000'}):
                 self.suffix = 'out'
+            elif ('c' in self.compilers and self.compilers['c'].get_id() in {'mwccarm', 'mwcceppc'} or
+                  'cpp' in self.compilers and self.compilers['cpp'].get_id() in {'mwccarm', 'mwcceppc'}):
+                self.suffix = 'nef'
             else:
                 self.suffix = machine.get_exe_suffix()
         self.filename = self.name

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -39,6 +39,8 @@ from .mixins.clang import ClangCompiler
 from .mixins.elbrus import ElbrusCompiler
 from .mixins.pgi import PGICompiler
 from .mixins.emscripten import EmscriptenMixin
+from .mixins.metrowerks import MetrowerksCompiler
+from .mixins.metrowerks import mwccarm_instruction_set_args, mwcceppc_instruction_set_args
 
 if T.TYPE_CHECKING:
     from .compilers import CompileCheckMode
@@ -889,3 +891,60 @@ class TICPPCompiler(TICompiler, CPPCompiler):
 class C2000CPPCompiler(TICPPCompiler):
     # Required for backwards compat with projects created before ti-cgt support existed
     id = 'c2000'
+
+class MetrowerksCPPCompilerARM(MetrowerksCompiler, CPPCompiler):
+    id = 'mwccarm'
+
+    def __init__(self, ccache: T.List[str], exelist: T.List[str], version: str, for_machine: MachineChoice,
+                 is_cross: bool, info: 'MachineInfo',
+                 exe_wrapper: T.Optional['ExternalProgram'] = None,
+                 linker: T.Optional['DynamicLinker'] = None,
+                 full_version: T.Optional[str] = None):
+        CPPCompiler.__init__(self, ccache, exelist, version, for_machine, is_cross,
+                             info, exe_wrapper, linker=linker, full_version=full_version)
+        MetrowerksCompiler.__init__(self)
+
+    def get_instruction_set_args(self, instruction_set: str) -> T.Optional[T.List[str]]:
+        return mwccarm_instruction_set_args.get(instruction_set, None)
+
+    def get_options(self) -> 'MutableKeyedOptionDictType':
+        opts = CPPCompiler.get_options(self)
+        key = OptionKey('std', machine=self.for_machine, lang=self.language)
+        opts[key].choices = ['none']
+        return opts
+
+    def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+        args = []
+        std = options[OptionKey('std', machine=self.for_machine, lang=self.language)]
+        if std.value != 'none':
+            args.append('-lang')
+            args.append(std.value)
+        return args
+
+class MetrowerksCPPCompilerEmbeddedPowerPC(MetrowerksCompiler, CPPCompiler):
+    id = 'mwcceppc'
+
+    def __init__(self, ccache: T.List[str], exelist: T.List[str], version: str, for_machine: MachineChoice,
+                 is_cross: bool, info: 'MachineInfo',
+                 exe_wrapper: T.Optional['ExternalProgram'] = None,
+                 linker: T.Optional['DynamicLinker'] = None,
+                 full_version: T.Optional[str] = None):
+        CPPCompiler.__init__(self, ccache, exelist, version, for_machine, is_cross,
+                             info, exe_wrapper, linker=linker, full_version=full_version)
+        MetrowerksCompiler.__init__(self)
+
+    def get_instruction_set_args(self, instruction_set: str) -> T.Optional[T.List[str]]:
+        return mwcceppc_instruction_set_args.get(instruction_set, None)
+
+    def get_options(self) -> 'MutableKeyedOptionDictType':
+        opts = CPPCompiler.get_options(self)
+        key = OptionKey('std', machine=self.for_machine, lang=self.language)
+        opts[key].choices = ['none']
+        return opts
+
+    def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+        args = []
+        std = options[OptionKey('std', machine=self.for_machine, lang=self.language)]
+        if std.value != 'none':
+            args.append('-lang ' + std.value)
+        return args

--- a/mesonbuild/compilers/mixins/metrowerks.py
+++ b/mesonbuild/compilers/mixins/metrowerks.py
@@ -1,0 +1,232 @@
+# Copyright 2012-2019 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+"""Representations specific to the Metrowerks/Freescale Embedded C/C++ compiler family."""
+
+import os
+import typing as T
+
+from ...mesonlib import EnvironmentException, OptionKey
+
+if T.TYPE_CHECKING:
+    from ...envconfig import MachineInfo
+    from ...compilers.compilers import Compiler, CompileCheckMode
+else:
+    # This is a bit clever, for mypy we pretend that these mixins descend from
+    # Compiler, so we get all of the methods and attributes defined for us, but
+    # for runtime we make them descend from object (which all classes normally
+    # do). This gives up DRYer type checking, with no runtime impact
+    Compiler = object
+
+mwcc_buildtype_args = {
+    'plain': [],
+    'debug': ['-g'],
+    'debugoptimized': ['-g', '-O4'],
+    'release': ['-O4,p'],
+    'minsize': ['-Os'],
+    'custom': [],
+}  # type: T.Dict[str, T.List[str]]
+
+mwccarm_instruction_set_args = {
+    'generic': ['-proc', 'generic'],
+    'v4': ['-proc', 'v4'],
+    'v4t': ['-proc', 'v4t'],
+    'v5t': ['-proc', 'v5t'],
+    'v5te': ['-proc', 'v5te'],
+    'v6': ['-proc', 'v6'],
+    'arm7tdmi': ['-proc', 'arm7tdmi'],
+    'arm710t': ['-proc', 'arm710t'],
+    'arm720t': ['-proc', 'arm720t'],
+    'arm740t': ['-proc', 'arm740t'],
+    'arm7ej': ['-proc', 'arm7ej'],
+    'arm9tdmi': ['-proc', 'arm9tdmi'],
+    'arm920t': ['-proc', 'arm920t'],
+    'arm922t': ['-proc', 'arm922t'],
+    'arm940t': ['-proc', 'arm940t'],
+    'arm9ej': ['-proc', 'arm9ej'],
+    'arm926ej': ['-proc', 'arm926ej'],
+    'arm946e': ['-proc', 'arm946e'],
+    'arm966e': ['-proc', 'arm966e'],
+    'arm1020e': ['-proc', 'arm1020e'],
+    'arm1022e': ['-proc', 'arm1022e'],
+    'arm1026ej': ['-proc', 'arm1026ej'],
+    'dbmx1': ['-proc', 'dbmx1'],
+    'dbmxl': ['-proc', 'dbmxl'],
+    'XScale': ['-proc', 'XScale'],
+    'pxa255': ['-proc', 'pxa255'],
+    'pxa261': ['-proc', 'pxa261'],
+    'pxa262': ['-proc', 'pxa262'],
+    'pxa263': ['-proc', 'pxa263']
+}  # type: T.Dict[str, T.List[str]]
+
+mwcceppc_instruction_set_args = {
+    'generic': ['-proc', 'generic'],
+    '401': ['-proc', '401'],
+    '403': ['-proc', '403'],
+    '505': ['-proc', '505'],
+    '509': ['-proc', '509'],
+    '555': ['-proc', '555'],
+    '601': ['-proc', '601'],
+    '602': ['-proc', '602'],
+    '603': ['-proc', '603'],
+    '603e': ['-proc', '603e'],
+    '604': ['-proc', '604'],
+    '604e': ['-proc', '604e'],
+    '740': ['-proc', '740'],
+    '750': ['-proc', '750'],
+    '801': ['-proc', '801'],
+    '821': ['-proc', '821'],
+    '823': ['-proc', '823'],
+    '850': ['-proc', '850'],
+    '860': ['-proc', '860'],
+    '7400': ['-proc', '7400'],
+    '7450': ['-proc', '7450'],
+    '8240': ['-proc', '8240'],
+    '8260': ['-proc', '8260'],
+    'e500': ['-proc', 'e500'],
+    'gekko': ['-proc', 'gekko'],
+}  # type: T.Dict[str, T.List[str]]
+
+mwcc_optimization_args = {
+    'plain': [],
+    '0': ['-O0'],
+    'g': ['-Op'],
+    '1': ['-O1'],
+    '2': ['-O2'],
+    '3': ['-O3'],
+    's': ['-Os']
+}  # type: T.Dict[str, T.List[str]]
+
+mwcc_debug_args = {
+    False: [],
+    True: ['-g']
+}  # type: T.Dict[bool, T.List[str]]
+
+
+class MetrowerksCompiler(Compiler):
+    id = 'mwcc'
+
+    # These compilers can actually invoke the linker, but they choke on
+    # linker-specific flags. So it's best to invoke the linker directly
+    INVOKES_LINKER = False
+
+    def __init__(self) -> None:
+        if not self.is_cross:
+            raise EnvironmentException(f'{id} supports only cross-compilation.')
+
+        self.base_options = {
+            OptionKey(o) for o in ['b_pch', 'b_ndebug']}
+
+        default_warn_args = []  # type: T.List[str]
+        self.warn_args = {'0': ['-w', 'off'],
+                          '1': default_warn_args,
+                          '2': default_warn_args + ['-w', 'most'],
+                          '3': default_warn_args + ['-w', 'all'],
+                          'everything': default_warn_args + ['-w', 'full']}  # type: T.Dict[str, T.List[str]]
+
+    def depfile_for_object(self, objfile: str) -> T.Optional[str]:
+        # Earlier versions of these compilers do not support specifying
+        # a custom name for a depfile, and can only generate '<input_file>.d'
+        return os.path.splitext(objfile)[0] + '.' + self.get_depfile_suffix()
+
+    def get_always_args(self) -> T.List[str]:
+        return ['-gccinc']
+
+    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
+        return mwcc_buildtype_args[buildtype]
+
+    def get_compiler_check_args(self, mode: CompileCheckMode) -> T.List[str]:
+        return []
+
+    def get_compile_only_args(self) -> T.List[str]:
+        return ['-c']
+
+    def get_debug_args(self, is_debug: bool) -> T.List[str]:
+        return mwcc_debug_args[is_debug]
+
+    def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
+        # Check comment in depfile_for_object()
+        return ['-gccdep', '-MD']
+
+    def get_depfile_suffix(self) -> str:
+        return 'd'
+
+    def get_include_args(self, path: str, is_system: bool) -> T.List[str]:
+        if not path:
+            path = '.'
+        return ['-I' + path]
+
+    def get_no_optimization_args(self) -> T.List[str]:
+        return ['-opt', 'off']
+
+    def get_no_stdinc_args(self) -> T.List[str]:
+        return ['-nostdinc']
+
+    def get_no_stdlib_link_args(self) -> T.List[str]:
+        return ['-nostdlib']
+
+    def get_optimization_args(self, optimization_level: str) -> T.List[str]:
+        return mwcc_optimization_args[optimization_level]
+
+    def get_output_args(self, target: str) -> T.List[str]:
+        return ['-o', target]
+
+    def get_pic_args(self) -> T.List[str]:
+        return ['-pic']
+
+    def get_preprocess_only_args(self) -> T.List[str]:
+        return ['-E']
+
+    def get_preprocess_to_file_args(self) -> T.List[str]:
+        return ['-P']
+
+    def get_pch_use_args(self, pch_dir: str, header: str) -> T.List[str]:
+        return ['-prefix', self.get_pch_name(header)]
+
+    def get_pch_name(self, name: str) -> str:
+        return os.path.basename(name) + '.' + self.get_pch_suffix()
+
+    def get_pch_suffix(self) -> str:
+        return 'mch'
+
+    def get_warn_args(self, level: str) -> T.List[str]:
+        return self.warn_args[level]
+
+    def get_werror_args(self) -> T.List[str]:
+        return ['-w', 'error']
+
+    @classmethod
+    def _unix_args_to_native(cls, args: T.List[str], info: MachineInfo) -> T.List[str]:
+        result = []
+        for i in args:
+            if i.startswith('-D'):
+                i = '-D' + i[2:]
+            if i.startswith('-I'):
+                i = '-I' + i[2:]
+            if i.startswith('-Wl,-rpath='):
+                continue
+            elif i == '--print-search-dirs':
+                continue
+            elif i.startswith('-L'):
+                continue
+            result.append(i)
+        return result
+
+    def compute_parameters_with_absolute_paths(self, parameter_list: T.List[str], build_dir: str) -> T.List[str]:
+        for idx, i in enumerate(parameter_list):
+            if i[:2] == '-I':
+                parameter_list[idx] = i[:9] + os.path.normpath(os.path.join(build_dir, i[9:]))
+
+        return parameter_list

--- a/mesonbuild/linkers/__init__.py
+++ b/mesonbuild/linkers/__init__.py
@@ -36,6 +36,9 @@ from .linkers import (
     AIXArLinker,
     PGIStaticLinker,
     NvidiaHPC_StaticLinker,
+    MetrowerksStaticLinker,
+    MetrowerksStaticLinkerARM,
+    MetrowerksStaticLinkerEmbeddedPowerPC,
 
     DynamicLinker,
     PosixDynamicLinkerMixin,
@@ -58,6 +61,9 @@ from .linkers import (
     PGIDynamicLinker,
     NvidiaHPC_DynamicLinker,
     NAGDynamicLinker,
+    MetrowerksLinker,
+    MetrowerksLinkerARM,
+    MetrowerksLinkerEmbeddedPowerPC,
 
     VisualStudioLikeLinkerMixin,
     MSVCDynamicLinker,
@@ -98,6 +104,9 @@ __all__ = [
     'AppleArLinker',
     'PGIStaticLinker',
     'NvidiaHPC_StaticLinker',
+    'MetrowerksStaticLinker',
+    'MetrowerksStaticLinkerARM',
+    'MetrowerksStaticLinkerEmbeddedPowerPC',
 
     'DynamicLinker',
     'PosixDynamicLinkerMixin',
@@ -120,6 +129,9 @@ __all__ = [
     'PGIDynamicLinker',
     'NvidiaHPC_DynamicLinker',
     'NAGDynamicLinker',
+    'MetrowerksLinker',
+    'MetrowerksLinkerARM',
+    'MetrowerksLinkerEmbeddedPowerPC',
 
     'VisualStudioLikeLinkerMixin',
     'MSVCDynamicLinker',

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -327,6 +327,28 @@ class AIXArLinker(ArLikeLinker):
     std_args = ['-csr', '-Xany']
 
 
+class MetrowerksStaticLinker(StaticLinker):
+
+    def can_linker_accept_rsp(self) -> bool:
+        return True
+
+    def get_linker_always_args(self) -> T.List[str]:
+        return ['-library']
+
+    def get_output_args(self, target: str) -> T.List[str]:
+        return ['-o', target]
+
+    def rsp_file_syntax(self) -> RSPFileSyntax:
+        return RSPFileSyntax.GCC
+
+
+class MetrowerksStaticLinkerARM(MetrowerksStaticLinker):
+    id = 'mwldarm'
+
+
+class MetrowerksStaticLinkerEmbeddedPowerPC(MetrowerksStaticLinker):
+    id = 'mwldeppc'
+
 def prepare_rpaths(raw_rpaths: T.Tuple[str, ...], build_dir: str, from_dir: str) -> T.List[str]:
     # The rpaths we write must be relative if they point to the build dir,
     # because otherwise they have different length depending on the build
@@ -1554,3 +1576,46 @@ class CudaLinker(PosixDynamicLinkerMixin, DynamicLinker):
     def get_soname_args(self, env: 'Environment', prefix: str, shlib_name: str,
                         suffix: str, soversion: str, darwin_versions: T.Tuple[str, str]) -> T.List[str]:
         return []
+
+
+class MetrowerksLinker(DynamicLinker):
+
+    def __init__(self, exelist: T.List[str], for_machine: mesonlib.MachineChoice,
+                 *, version: str = 'unknown version'):
+        super().__init__(exelist, for_machine, '', [],
+                         version=version)
+
+    def fatal_warnings(self) -> T.List[str]:
+        return ['-w', 'error']
+
+    def get_allow_undefined_args(self) -> T.List[str]:
+        return []
+
+    def get_accepts_rsp(self) -> bool:
+        return True
+
+    def get_lib_prefix(self) -> str:
+        return ""
+
+    def get_linker_always_args(self) -> T.List[str]:
+        return []
+
+    def get_output_args(self, target: str) -> T.List[str]:
+        return ['-o', target]
+
+    def get_search_args(self, dirname: str) -> T.List[str]:
+        return self._apply_prefix('-L' + dirname)
+
+    def invoked_by_compiler(self) -> bool:
+        return False
+
+    def rsp_file_syntax(self) -> RSPFileSyntax:
+        return RSPFileSyntax.GCC
+
+
+class MetrowerksLinkerARM(MetrowerksLinker):
+    id = 'mwldarm'
+
+
+class MetrowerksLinkerEmbeddedPowerPC(MetrowerksLinker):
+    id = 'mwldeppc'

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -212,7 +212,9 @@ class InstalledFile:
                     suffix = '{}.{}'.format(suffix, '.'.join(self.version))
             return p.with_suffix(suffix)
         elif self.typ == 'exe':
-            if env.machines.host.is_windows() or env.machines.host.is_cygwin():
+            if 'mwcc' in canonical_compiler:
+                return p.with_suffix('.nef')
+            elif env.machines.host.is_windows() or env.machines.host.is_cygwin():
                 return p.with_suffix('.exe')
         elif self.typ == 'pdb':
             if self.version:


### PR DESCRIPTION
Hello meson devs!

I added preliminary support for the Metrowerks C/C++ compiler(s). Metrowerks is a company with a focus on providing toolchains targeting embedded systems. It was acquired in 2005 by Freescale Semiconductors, which itself was acquired by NXP Semiconductors in 2015. However, the tools are still named after Metrowerks (they are prefixed with 'mw'), so I believe Meson should do the same.

While all Metrowerks compilers share a common CLI, I decided to focus on the Embedded ARM and PowerPC toolchains for the time being. They contain a C/C++ compiler, a standalone assembler, and a linker that acts both as a static and dynamic linker. The linker is compatible with GNU AR archives, but does not support thin archives.

I suppose this isn't perfect on first try (plus I don't usually develop in Python), so just let me know what to adapt :)

Best regards, Nomura

