### PR TITLE
msetup: Allow (re)configure of not empty builddir

### DIFF
--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -24,6 +24,7 @@ import argparse
 import tempfile
 import shutil
 import glob
+from pathlib import Path
 
 from . import environment, interpreter, mesonlib
 from . import build
@@ -157,6 +158,8 @@ class MesonApp:
 
     def validate_dirs(self, dir1: str, dir2: str, reconfigure: bool, wipe: bool) -> T.Tuple[str, str]:
         (src_dir, build_dir) = self.validate_core_dirs(dir1, dir2)
+        if Path(build_dir) in Path(src_dir).parents:
+            raise MesonException(f'Build directory {build_dir} cannot be a parent of source directory {src_dir}')
         if not os.listdir(build_dir):
             self.add_vcs_ignore_files(build_dir)
             return src_dir, build_dir
@@ -178,7 +181,7 @@ class MesonApp:
                 # Note that making this an error would not be backward compatible (and also isn't
                 # universally agreed on): https://github.com/mesonbuild/meson/pull/4249.
                 raise SystemExit(0)
-        elif not has_partial_build and 'MESON_RUNNING_IN_PROJECT_TESTS' not in os.environ:
+        elif not has_partial_build and wipe:
             raise MesonException(f'Directory is not empty and does not contain a previous build:\n{build_dir}')
         return src_dir, build_dir
 

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -165,16 +165,21 @@ class MesonApp:
         has_partial_build = os.path.isdir(priv_dir)
         if has_valid_build:
             if not reconfigure and not wipe:
-                print('Directory already configured.\n'
-                      '\nJust run your build command (e.g. ninja) and Meson will regenerate as necessary.\n'
+                print('Directory already configured.\n\n'
+                      'Just run your build command (e.g. ninja) and Meson will regenerate as necessary.\n'
                       'If ninja fails, run "ninja reconfigure" or "meson setup --reconfigure"\n'
-                      'to force Meson to regenerate.\n'
-                      '\nIf build failures persist, run "meson setup --wipe" to rebuild from scratch\n'
-                      'using the same options as passed when configuring the build.'
-                      '\nTo change option values, run "meson configure" instead.')
-                raise SystemExit
+                      'to force Meson to regenerate.\n\n'
+                      'If build failures persist, run "meson setup --wipe" to rebuild from scratch\n'
+                      'using the same options as passed when configuring the build.\n'
+                      'To change option values, run "meson configure" instead.')
+                # FIXME: This returns success and ignores new option values from CLI.
+                # We should either make this a hard error, or update options and
+                # return success.
+                # Note that making this an error would not be backward compatible (and also isn't
+                # universally agreed on): https://github.com/mesonbuild/meson/pull/4249.
+                raise SystemExit(0)
         elif not has_partial_build and 'MESON_RUNNING_IN_PROJECT_TESTS' not in os.environ:
-            raise SystemExit(f'Directory is not empty and does not contain a previous build:\n{build_dir}')
+            raise MesonException(f'Directory is not empty and does not contain a previous build:\n{build_dir}')
         return src_dir, build_dir
 
     def generate(self) -> None:

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1139,7 +1139,7 @@ class AllPlatformTests(BasePlatformTests):
 
     def test_preprocessor_checks_CPPFLAGS(self):
         '''
-        Test that preprocessor compiler checks read CPPFLAGS and also CFLAGS but
+        Test that preprocessor compiler checks read CPPFLAGS and also CFLAGS/CXXFLAGS but
         not LDFLAGS.
         '''
         testdir = os.path.join(self.common_test_dir, '132 get define')
@@ -1150,11 +1150,13 @@ class AllPlatformTests(BasePlatformTests):
         # % and # confuse the MSVC preprocessor
         # !, ^, *, and < confuse lcc preprocessor
         value = 'spaces and fun@$&()-=_+{}[]:;>?,./~`'
-        for env_var in ['CPPFLAGS', 'CFLAGS']:
+        for env_var in [{'CPPFLAGS'}, {'CFLAGS', 'CXXFLAGS'}]:
             env = {}
-            env[env_var] = f'-D{define}="{value}"'
+            for i in env_var:
+                env[i] = f'-D{define}="{value}"'
             env['LDFLAGS'] = '-DMESON_FAIL_VALUE=cflags-read'
             self.init(testdir, extra_args=[f'-D{define}={value}'], override_envvars=env)
+            self.new_builddir()
 
     def test_custom_target_exe_data_deterministic(self):
         testdir = os.path.join(self.common_test_dir, '109 custom target capture')

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -2046,6 +2046,7 @@ class AllPlatformTests(BasePlatformTests):
         self.assertFalse(os.path.isfile(promoted_wrap))
         subprocess.check_call(self.wrap_command + ['promote', 'athing'], cwd=workdir)
         self.assertTrue(os.path.isfile(promoted_wrap))
+        self.new_builddir()  # Ensure builddir is not parent or workdir
         self.init(workdir)
         self.build()
 


### PR DESCRIPTION
This fix regression caused by https://github.com/mesonbuild/meson/pull/11431 and also integrate changes from https://github.com/mesonbuild/meson/pull/11590 and https://github.com/mesonbuild/meson/pull/11427.


Fixes #11418
Closes #11427
Closes #11590