### PR TITLE
Make --vsenv a readonly builtin option

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -74,11 +74,11 @@ machine](#specifying-options-per-machine) section for details.
 
 | Option                                 | Default value | Description                                                    | Is per machine | Is per subproject |
 | -------------------------------------- | ------------- | -----------                                                    | -------------- | ----------------- |
-| auto_features {enabled, disabled, auto} | auto       | Override value of all 'auto' features                          | no             | no                |
-| backend {ninja, vs,<br>vs2010, vs2012, vs2013, vs2015, vs2017, vs2019, vs2022, xcode, none} | ninja | Backend to use  | no             | no                |
-| buildtype {plain, debug,<br>debugoptimized, release, minsize, custom} | debug |  Build type to use                    | no             | no                |
+| auto_features {enabled, disabled, auto} | auto         | Override value of all 'auto' features                          | no             | no                |
+| backend {ninja, vs,<br>vs2010, vs2012, vs2013, vs2015, vs2017, vs2019, vs2022, xcode, none} | ninja | Backend to use    | no             | no                |
+| buildtype {plain, debug,<br>debugoptimized, release, minsize, custom} | debug | Build type to use                       | no             | no                |
 | debug                                  | true          | Enable debug symbols and other information                     | no             | no                |
-| default_library {shared, static, both} | shared      | Default library type                                           | no             | yes               |
+| default_library {shared, static, both} | shared        | Default library type                                           | no             | yes               |
 | errorlogs                              | true          | Whether to print the logs from failing tests.                  | no             | no                |
 | install_umask {preserve, 0000-0777}    | 022           | Default umask to apply on permissions of installed files       | no             | no                |
 | layout {mirror,flat}                   | mirror        | Build directory layout                                         | no             | no                |
@@ -92,8 +92,9 @@ machine](#specifying-options-per-machine) section for details.
 | unity_size {>=2}                       | 4             | Unity file block size                                          | no             | no                |
 | warning_level {0, 1, 2, 3, everything} | 1             | Set the warning level. From 0 = none to everything = highest   | no             | yes               |
 | werror                                 | false         | Treat warnings as errors                                       | no             | yes               |
-| wrap_mode {default, nofallback,<br>nodownload, forcefallback, nopromote} | default | Wrap mode to use                 | no             | no                |
+| wrap_mode {default, nofallback,<br>nodownload, forcefallback, nopromote} | default | Wrap mode to use                   | no             | no                |
 | force_fallback_for                     | []            | Force fallback for those dependencies                          | no             | no                |
+| vsenv                                  | false         | Activate Visual Studio environment                             | no             | no                |
 
 #### Details for `backend`
 
@@ -139,6 +140,21 @@ table for most common compilers.
 | everything    | -Weverything             | /Wall |
 
 Clang's `-Weverything` is emulated on GCC by passing all known warning flags.
+
+#### Details for `vsenv`
+
+The `--vsenv` argument is supported since `0.60.0`, `-Dvsenv=true` syntax is supported
+since `1.1.0`.
+
+Since `0.59.0`, meson automatically activates a Visual Studio environment on Windows
+for all its subcommands, but only if no other compilers (e.g. `gcc` or `clang`)
+are found, and silently continues if Visual Studio activation fails.
+
+Setting the `vsenv` option to `true` forces Visual Studio activation even when other
+compilers are found. It also make Meson abort with an error message when activation
+fails.
+
+`vsenv` is `true` by default when using the `vs` backend.
 
 ## Base options
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -574,7 +574,7 @@ class NinjaBackend(backends.Backend):
 
     def generate(self):
         ninja = environment.detect_ninja_command_and_version(log=True)
-        if self.build.need_vsenv:
+        if self.environment.coredata.get_option(OptionKey('vsenv')):
             builddir = Path(self.environment.get_build_dir())
             try:
                 # For prettier printing, reduce to a relative path. If

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -274,7 +274,6 @@ class Build:
             environment.is_cross_build(), {}, {})
         self.devenv: T.List[EnvironmentVariables] = []
         self.modules: T.List[str] = []
-        self.need_vsenv = False
 
     def get_build_targets(self):
         build_targets = OrderedDict()

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1259,6 +1259,7 @@ BUILTIN_CORE_OPTIONS: 'MutableKeyedOptionDictType' = OrderedDict([
     (OptionKey('werror'),          BuiltinOption(UserBooleanOption, 'Treat warnings as errors', False, yielding=False)),
     (OptionKey('wrap_mode'),       BuiltinOption(UserComboOption, 'Wrap mode', 'default', choices=['default', 'nofallback', 'nodownload', 'forcefallback', 'nopromote'])),
     (OptionKey('force_fallback_for'), BuiltinOption(UserArrayOption, 'Force fallback for those subprojects', [])),
+    (OptionKey('vsenv'),           BuiltinOption(UserBooleanOption, 'Activate Visual Studio environment', False, readonly=True)),
 
     # Pkgconfig module
     (OptionKey('relocatable', module='pkgconfig'),

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1291,9 +1291,9 @@ class Interpreter(InterpreterBase, HoldableObject):
             # vs backend version we need. But after setting default_options in case
             # the project sets vs backend by default.
             backend = self.coredata.get_option(OptionKey('backend'))
-            force_vsenv = self.user_defined_options.vsenv or backend.startswith('vs')
-            if mesonlib.setup_vsenv(force_vsenv):
-                self.build.need_vsenv = True
+            vsenv = self.coredata.get_option(OptionKey('vsenv'))
+            force_vsenv = vsenv or backend.startswith('vs')
+            mesonlib.setup_vsenv(force_vsenv)
 
         self.add_languages(proj_langs, True, MachineChoice.HOST)
         self.add_languages(proj_langs, False, MachineChoice.BUILD)

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -333,8 +333,8 @@ def run(options: 'argparse.Namespace') -> int:
 
     b = build.load(options.wd)
     cdata = b.environment.coredata
-    vsenv_active = setup_vsenv(b.need_vsenv)
-    if vsenv_active:
+    need_vsenv = T.cast('bool', cdata.get_option(mesonlib.OptionKey('vsenv')))
+    if setup_vsenv(need_vsenv):
         mlog.log(mlog.green('INFO:'), 'automatically activated MSVC compiler environment')
 
     cmd = []    # type: T.List[str]

--- a/mesonbuild/mdevenv.py
+++ b/mesonbuild/mdevenv.py
@@ -159,7 +159,8 @@ def run(options: argparse.Namespace) -> int:
     b = build.load(options.builddir)
     workdir = options.workdir or options.builddir
 
-    setup_vsenv(b.need_vsenv)  # Call it before get_env to get vsenv vars as well
+    need_vsenv = T.cast('bool', b.environment.coredata.get_option(OptionKey('vsenv')))
+    setup_vsenv(need_vsenv) # Call it before get_env to get vsenv vars as well
     dump_fmt = options.dump_format if options.dump else None
     devenv, varnames = get_env(b, dump_fmt)
     if options.dump:

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -24,11 +24,13 @@ import subprocess
 import tarfile
 import tempfile
 import hashlib
+import typing as T
+
 from glob import glob
 from pathlib import Path
 from mesonbuild.environment import detect_ninja
 from mesonbuild.mesonlib import (MesonException, RealPathAction, quiet_git,
-                                 windows_proof_rmtree, setup_vsenv)
+                                 windows_proof_rmtree, setup_vsenv, OptionKey)
 from mesonbuild.msetup import add_arguments as msetup_argparse
 from mesonbuild.wrap import wrap
 from mesonbuild import mlog, build, coredata
@@ -285,7 +287,7 @@ def create_cmdline_args(bld_root):
     args = parser.parse_args([])
     coredata.parse_cmd_line_options(args)
     coredata.read_cmd_line_file(bld_root, args)
-    args.cmd_line_options.pop(coredata.OptionKey('backend'), '')
+    args.cmd_line_options.pop(OptionKey('backend'), '')
     return shlex.split(coredata.format_cmd_line_options(args))
 
 def determine_archives_to_generate(options):
@@ -303,7 +305,8 @@ def run(options):
     if not buildfile.is_file():
         raise MesonException(f'Directory {options.wd!r} does not seem to be a Meson build directory.')
     b = build.load(options.wd)
-    setup_vsenv(b.need_vsenv)
+    need_vsenv = T.cast('bool', b.environment.coredata.get_option(OptionKey('vsenv')))
+    setup_vsenv(need_vsenv)
     # This import must be load delayed, otherwise it will get the default
     # value of None.
     from mesonbuild.mesonlib import get_meson_command

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -187,7 +187,8 @@ def run(options: 'argparse.Namespace') -> int:
             raise SystemExit
 
         b = build.load(options.builddir)
-        vsenv_active = mesonlib.setup_vsenv(b.need_vsenv)
+        need_vsenv = T.cast('bool', b.environment.coredata.get_option(mesonlib.OptionKey('vsenv')))
+        vsenv_active = mesonlib.setup_vsenv(need_vsenv)
         if vsenv_active:
             mlog.log(mlog.green('INFO:'), 'automatically activated MSVC compiler environment')
 

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -26,7 +26,8 @@ import typing as T
 
 from . import build, coredata, environment
 from .backend.backends import InstallData
-from .mesonlib import MesonException, Popen_safe, RealPathAction, is_windows, setup_vsenv, pickle_load, is_osx
+from .mesonlib import (MesonException, Popen_safe, RealPathAction, is_windows,
+                       setup_vsenv, pickle_load, is_osx, OptionKey)
 from .scripts import depfixer, destdir_join
 from .scripts.meson_exe import run_exe
 try:
@@ -816,7 +817,8 @@ def run(opts: 'ArgumentType') -> int:
         sys.exit('Install data not found. Run this command in build directory root.')
     if not opts.no_rebuild:
         b = build.load(opts.wd)
-        setup_vsenv(b.need_vsenv)
+        need_vsenv = T.cast('bool', b.environment.coredata.get_option(OptionKey('vsenv')))
+        setup_vsenv(need_vsenv)
         backend = T.cast('str', b.environment.coredata.get_option(coredata.OptionKey('backend')))
         if not rebuild_all(opts.wd, backend):
             sys.exit(-1)

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -52,10 +52,6 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
                         default=[],
                         action='append',
                         help='File describing cross compilation environment.')
-    parser.add_argument('--vsenv', action='store_true',
-                        help='Setup Visual Studio environment even when other compilers are found, ' +
-                             'abort if Visual Studio is not found. This option has no effect on other ' +
-                             'platforms than Windows. Defaults to True when using "vs" backend.')
     parser.add_argument('-v', '--version', action='version',
                         version=coredata.version)
     parser.add_argument('--profile-self', action='store_true', dest='profile',

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -2096,7 +2096,8 @@ def run(options: argparse.Namespace) -> int:
             return 1
 
     b = build.load(options.wd)
-    setup_vsenv(b.need_vsenv)
+    need_vsenv = T.cast('bool', b.environment.coredata.get_option(OptionKey('vsenv')))
+    setup_vsenv(need_vsenv)
 
     if not options.no_rebuild:
         backend = b.environment.coredata.get_option(OptionKey('backend'))

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -2144,6 +2144,7 @@ _BUILTIN_NAMES = {
     'force_fallback_for',
     'pkg_config_path',
     'cmake_prefix_path',
+    'vsenv',
 }
 
 


### PR DESCRIPTION
We need to remember its value when reconfiguring, but the Build object is not reused, only coredata is.

This also makes CLI more consistent by allowing `-Dvsenv=true` syntax.

Fixes: #11309