### PR TITLE
doc: Use better name for builtin/return object title

### DIFF
--- a/docs/refman/generatormd.py
+++ b/docs/refman/generatormd.py
@@ -281,6 +281,7 @@ class GeneratorMD(GeneratorBase):
     def _write_object(self, obj: Object) -> None:
         data = {
             'name': obj.name,
+            'title': obj.long_name if obj.obj_type == ObjectType.RETURNED else obj.name,
             'description': obj.description,
             'notes': obj.notes,
             'warnings': obj.warnings,

--- a/docs/refman/templates/object.mustache
+++ b/docs/refman/templates/object.mustache
@@ -1,6 +1,6 @@
 ---
 short-description: "{{obj_type_name}} object: {{long_name}}"
-title: {{name}}{{#extends}} (extends {{.}}){{/extends}}
+title: {{title}}
 render-subpages: false
 ...
 # {{long_name}} (`{{name}}`{{#extends}} extends [[@{{.}}]]{{/extends}})


### PR DESCRIPTION
The title is used only in the sidebar. There is no need to have "extends" information there. For returned objects the actual name is not meaningful so it's better to use the long name. For builtin objects the name is important because that's the global variable name.