### PR TITLE
fix regression that broken git-based wraps with dirty contents

### DIFF
--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -216,7 +216,8 @@ class Runner:
             # Note: `--all` is used, and not `--include-untracked`, to prevent
             # a potential error if `.meson-subproject-wrap-hash.txt` matches a
             # gitignore pattern.
-            self.git_verbose(['stash', 'push', '--all', ':!/.meson-subproject-wrap-hash.txt'])
+            # We must add the dot in addition to the negation, because older versions of git have a bug.
+            self.git_verbose(['stash', 'push', '--all', ':!/.meson-subproject-wrap-hash.txt', '.'])
 
     def git_show(self) -> None:
         commit_message = self.git_output(['show', '--quiet', '--pretty=format:%h%n%d%n%s%n[%an]'])


### PR DESCRIPTION
In commit 8da060706c2c34fbea91898509123cb190894f3e we fixed an issue where stashing would ignore untracked files, potentially conflicting with what we reset to.

Unfortunately in the process it broke the functionality entirely, by producing an invalid git command... according to some versions of git. This is actually a git bug, fixed upstream in git 2.37.0 via commit b02fdbc80a41f73ceb6c99e8e27b22285243a335. It causes git itself to re-synthesize the command line for a negation pathspec with a "." rather than "", as that's what is needed to make it match all files other than the negation.

For backwards compatibility to older versions of git, we manually pass the dot pathspec ourselves.