### PR TITLE
msetup: Update options when builddir is already configured

### DIFF
--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -244,6 +244,17 @@ Configures a build directory for the Meson project.
 was no COMMAND supplied). However, supplying the command is necessary to avoid
 clashes with future added commands, so "setup" should be used explicitly.
 
+*Since 1.1.0* `--reconfigure` is allowed even if the build directory does not
+already exist, that argument is ignored in that case.
+
+*Since 1.3.0* If the build directory already exists, options are updated with
+their new value given on the command line (`-Dopt=value`). Unless `--reconfigure`
+is also specified, this won't reconfigure immediately. This has the same behaviour
+as `meson configure <builddir> -Dopt=value`.
+
+*Since 1.3.0* It is possible to clear the cache and reconfigure in a single command
+with `meson setup --clearcache --reconfigure <builddir>`.
+
 {{ setup_arguments.inc }}
 
 See [Meson introduction

--- a/docs/markdown/snippets/msetup.md
+++ b/docs/markdown/snippets/msetup.md
@@ -1,0 +1,13 @@
+## Update options with `meson setup <builddir> -Dopt=value`
+
+If the build directory already exists, options are updated with their new value
+given on the command line (`-Dopt=value`). Unless `--reconfigure` is also specified,
+this won't reconfigure immediately. This has the same behaviour as
+`meson configure <builddir> -Dopt=value`.
+
+Previous Meson versions were simply a no-op.
+
+## Clear persistent cache with `meson setup --clearcache`
+
+Just like `meson configure --clearcache`, it is now possible to clear the cache
+and reconfigure in a single command with `meson setup --clearcache --reconfigure <builddir>`.

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -301,9 +301,7 @@ class Conf:
         for m in mismatching:
             mlog.log(f'{m[0]:21}{m[1]:10}{m[2]:10}')
 
-def run(options: argparse.Namespace) -> int:
-    coredata.parse_cmd_line_options(options)
-    builddir = os.path.abspath(os.path.realpath(options.builddir))
+def run_impl(options: argparse.Namespace, builddir: str) -> int:
     print_only = not options.cmd_line_options and not options.clearcache
     c = None
     try:
@@ -334,3 +332,8 @@ def run(options: argparse.Namespace) -> int:
         # Pager quit before we wrote everything.
         pass
     return 0
+
+def run(options: argparse.Namespace) -> int:
+    coredata.parse_cmd_line_options(options)
+    builddir = os.path.abspath(os.path.realpath(options.builddir))
+    return run_impl(options, builddir)

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -303,6 +303,13 @@ class BasePlatformTests(TestCase):
             ensure_backend_detects_changes(self.backend)
         self._run(self.mconf_command + arg + [self.builddir])
 
+    def getconf(self, optname: str):
+        opts = self.introspect('--buildoptions')
+        for x in opts:
+            if x.get('name') == optname:
+                return x.get('value')
+        self.fail(f'Option {optname} not found')
+
     def wipe(self):
         windows_proof_rmtree(self.builddir)
 

--- a/unittests/platformagnostictests.py
+++ b/unittests/platformagnostictests.py
@@ -183,6 +183,13 @@ class PlatformAgnosticTests(BasePlatformTests):
         Path(self.builddir, 'dummy').touch()
         self.init(testdir, extra_args=['--reconfigure'])
 
+        # Setup a valid builddir should update options but not reconfigure
+        self.assertEqual(self.getconf('buildtype'), 'debug')
+        o = self.init(testdir, extra_args=['-Dbuildtype=release'])
+        self.assertIn('Directory already configured', o)
+        self.assertNotIn('The Meson build system', o)
+        self.assertEqual(self.getconf('buildtype'), 'release')
+
         # Wipe of empty builddir should work
         self.new_builddir()
         self.init(testdir, extra_args=['--wipe'])


### PR DESCRIPTION
    `meson setup -Dfoo=bar builddir` command returns success but does not
    update options.
    
    This now also update options. It is useful because it means
    `meson setup -Dfoo=bar builddir && ninja -C builddir` works regardless
    whether builddir already exists or not, and when done in a script,
    changing options in the script will automatically trigger a reconfigure
    if needed. This was already possible by always passing --reconfigure
    argument, but that triggers a reconfigure even when options did not
    change.
