### PR TITLE
ninjabackend: Remove ccache from compile_commands.json

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -520,6 +520,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         self.info = info
         self.is_cross = is_cross
         self.modes: T.List[Compiler] = []
+        self.use_ccache = bool(ccache)
 
     def __repr__(self) -> str:
         repr_str = "<{0}: v{1} `{2}`>"


### PR DESCRIPTION
It confuses vscode's intellisense, causing it to not understand GNUC syntaxes for example. The bug was reported upstream with not much activity: https://github.com/microsoft/vscode-cpptools/issues/7616.