### PR TITLE
mtest: wildcard selection

### DIFF
--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -281,6 +281,12 @@ Run tests for the configure Meson project.
 
 See [the unit test documentation](Unit-tests.md) for more info.
 
+Since *1.2.0* you can use wildcards in *args* for test names.
+For example, "bas*" will match all test with names beginning with "bas".
+
+Since *1.2.0* it is an error to provide a test name or wildcard that
+does not match any test.
+
 #### Examples:
 
 Run tests for the project:

--- a/docs/markdown/Unit-tests.md
+++ b/docs/markdown/Unit-tests.md
@@ -153,6 +153,27 @@ Specify test(s) by name like:
 $ meson test A D
 ```
 
+You can run tests from specific (sub)project:
+
+```console
+$ meson test (sub)project_name:
+```
+
+or a specific test in a specific project:
+
+```console
+$ meson test (sub)project_name:test_name
+```
+
+Since version *1.2.0*, you can use wildcards in project
+and test names. For instance, to run all tests beginning with
+"foo" and all tests from projects beginning with "bar":
+
+```console
+$ meson test "foo*" "bar*:"
+```
+
+
 Tests belonging to a suite `suite` can be run as follows
 
 ```console

--- a/docs/markdown/snippets/test_name_filters.md
+++ b/docs/markdown/snippets/test_name_filters.md
@@ -1,0 +1,9 @@
+## Wildcards in list of tests to run
+
+The `meson test` command now accepts wildcards in the list of test names.
+For example `meson test basic*` will run all tests whose name begins
+with "basic".
+
+meson will report an error if the given test name does not match any
+existing test. meson will log a warning if two redundant test names
+are given (for example if you give both "proj:basic" and "proj:").

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -818,6 +818,30 @@ class AllPlatformTests(BasePlatformTests):
         o = self._run(self.mtest_command + ['--list', '--no-rebuild'])
         self.assertNotIn('Regenerating build files.', o)
 
+    def test_unexisting_test_name(self):
+        testdir = os.path.join(self.unit_test_dir, '4 suite selection')
+        self.init(testdir)
+        self.build()
+
+        self.assertRaises(subprocess.CalledProcessError, self._run, self.mtest_command + ['notatest'])
+
+    def test_select_test_using_wildcards(self):
+        testdir = os.path.join(self.unit_test_dir, '4 suite selection')
+        self.init(testdir)
+        self.build()
+
+        o = self._run(self.mtest_command + ['--list', 'mainprj*'])
+        self.assertIn('mainprj-failing_test', o)
+        self.assertIn('mainprj-successful_test_no_suite', o)
+        self.assertNotIn('subprj', o)
+
+        o = self._run(self.mtest_command + ['--list', '*succ*', 'subprjm*:'])
+        self.assertIn('mainprj-successful_test_no_suite', o)
+        self.assertIn('subprjmix-failing_test', o)
+        self.assertIn('subprjmix-successful_test', o)
+        self.assertIn('subprjsucc-successful_test_no_suite', o)
+        self.assertNotIn('subprjfail-failing_test', o)
+
     def test_build_by_default(self):
         testdir = os.path.join(self.common_test_dir, '129 build by default')
         self.init(testdir)


### PR DESCRIPTION
Allow the use of wildcards (e.g. *) to match test names in `meson test`.

Raise an error is given test name does not match any test.

Optimize the search by looping through the list of tests only once.