### PR TITLE
dependencies: allow to fallback on CMake to find the SDL2 library

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -728,10 +728,10 @@ your own risk.
 ## SDL2
 
 SDL2 can be located using `pkg-confg`, the `sdl2-config` config tool,
-or as an OSX framework.
+as an OSX framework, or `cmake`.
 
-`method` may be `auto`, `config-tool`, `extraframework` or
-`pkg-config`.
+`method` may be `auto`, `config-tool`, `extraframework`,
+`pkg-config` or `cmake`.
 
 ## Shaderc
 

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -252,8 +252,9 @@ gl_factory = DependencyFactory(
 
 sdl2_factory = DependencyFactory(
     'sdl2',
-    [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.EXTRAFRAMEWORK],
+    [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.EXTRAFRAMEWORK, DependencyMethods.CMAKE],
     configtool_class=SDL2DependencyConfigTool,
+    cmake_name='SDL2',
 )
 
 vulkan_factory = DependencyFactory(

--- a/test cases/frameworks/16 sdl2/meson_options.txt
+++ b/test cases/frameworks/16 sdl2/meson_options.txt
@@ -1,6 +1,6 @@
 option(
     'method',
     type : 'combo',
-    choices : ['auto', 'pkg-config', 'config-tool', 'sdlconfig', 'extraframework'],
+    choices : ['auto', 'pkg-config', 'config-tool', 'sdlconfig', 'extraframework', 'cmake'],
     value : 'auto',
 )

--- a/test cases/frameworks/16 sdl2/test.json
+++ b/test cases/frameworks/16 sdl2/test.json
@@ -6,7 +6,8 @@
         { "val": "pkg-config" },
         { "val": "config-tool" },
         { "val": "sdlconfig" },
-        { "val": "extraframework", "skip_on_os": ["!darwin"], "skip_on_jobname": ["macos"] }
+        { "val": "extraframework", "skip_on_os": ["!darwin"], "skip_on_jobname": ["macos"] },
+        { "val": "cmake", "skip_on_jobname": ["bionic"] }
       ]
     }
   },


### PR DESCRIPTION
On Windows, the SDL2 library is generally provided with only CMake config files. This commit allows meson to fallback on CMake as a last resort to find the SDL2 library.

The commit fixes the following example on Windows (powershell):
``` shell
mkdir C:\src\project_name
cd C:\src\project_name
meson init --language=c --name=myproject --version=0.1
# Add the following line to meson.build:
# sdl2 = dependency("sdl2", required: true)
Invoke-WebRequest -Uri https://github.com/libsdl-org/SDL/releases/download/release-2.26.5/SDL2-devel-2.26.5-VC.zip -OutFile SDL2.zip
Expand-Archive .\SDL2.zip -DestinationPath .
$env:CMAKE_PREFIX_PATH="C:\src\project_name\SDL2-2.26.5\cmake"
meson setup builddir
```
Without this commit, meson outputs:
```
The Meson build system
Version: 1.1.99
Source dir: C:\src\project_name
Build dir: C:\src\project_name\builddir
Build type: native build
Project name: myproject
Project version: 0.1
Activating VS 17.5.3
C compiler for the host machine: cl (msvc 19.35.32216.1 "Compilateur d'optimisation Microsoft (R) C/C++ version�19.35.32216.1 pour x64")
C linker for the host machine: link link 14.35.32216.1
Host machine cpu family: x86_64
Host machine cpu: x86_64
Did not find pkg-config by name 'pkg-config'
Found Pkg-config: NO
sdl2-config found: NO
Run-time dependency sdl2 found: NO (tried config-tool)
```
With this commit, meson outputs:
```
The Meson build system
Version: 1.1.99
Source dir: C:\src\project_name
Build dir: C:\src\project_name\builddir
Build type: native build
Project name: myproject
Project version: 0.1
Activating VS 17.5.3
C compiler for the host machine: cl (msvc 19.35.32216.1 "Compilateur d'optimisation Microsoft (R) C/C++ version�19.35.32216.1 pour x64")
C linker for the host machine: link link 14.35.32216.1
Host machine cpu family: x86_64
Host machine cpu: x86_64
Did not find pkg-config by name 'pkg-config'
Found Pkg-config: NO
sdl2-config found: NO
Found CMake: C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.EXE (3.25.1)
Run-time dependency sdl2 found: YES 2.26.5
Build targets in project: 1

Found ninja-1.11.0 at "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja\ninja.EXE"
```


