### PR TITLE
vcs_tag: Add --always to git describe

### DIFF
--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -754,7 +754,7 @@ def detect_vcs(source_dir: T.Union[str, Path]) -> T.Optional[T.Dict[str, str]]:
             'name': 'git',
             'cmd': 'git',
             'repo_dir': '.git',
-            'get_rev': 'git describe --dirty=+',
+            'get_rev': 'git describe --dirty=+ --always',
             'rev_regex': '(.*)',
             'dep': '.git/logs/HEAD'
         },


### PR DESCRIPTION
This fallbacks to short commit id in case the git repository does not contain any annotated tag, for example before the first release of a project.