### PR TITLE
minstall: do not drop privileges if msetup also ran under sudo

### DIFF
--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -778,10 +778,18 @@ def rebuild_all(wd: str, backend: str) -> bool:
                 orig_user = env.pop('SUDO_USER')
                 orig_uid = env.pop('SUDO_UID', 0)
                 orig_gid = env.pop('SUDO_GID', 0)
-                homedir = pwd.getpwuid(int(orig_uid)).pw_dir
+                try:
+                    homedir = pwd.getpwuid(int(orig_uid)).pw_dir
+                except KeyError:
+                    # `sudo chroot` leaves behind stale variable and builds as root without a user
+                    return None, None
             elif os.environ.get('DOAS_USER') is not None:
                 orig_user = env.pop('DOAS_USER')
-                pwdata = pwd.getpwnam(orig_user)
+                try:
+                    pwdata = pwd.getpwnam(orig_user)
+                except KeyError:
+                    # `doas chroot` leaves behind stale variable and builds as root without a user
+                    return None, None
                 orig_uid = pwdata.pw_uid
                 orig_gid = pwdata.pw_gid
                 homedir = pwdata.pw_dir

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -788,6 +788,10 @@ def rebuild_all(wd: str, backend: str) -> bool:
             else:
                 return None, None
 
+            if os.stat(os.path.join(wd, 'build.ninja')).st_uid != int(orig_uid):
+                # the entire build process is running with sudo, we can't drop privileges
+                return None, None
+
             env['USER'] = orig_user
             env['HOME'] = homedir
 


### PR DESCRIPTION
A user might run `sudo somewrapper` to build and install something with meson, and it is not actually possible to drop privileges and build, since the build directory is also owned by root.

A common case of this is `sudo pip install` for projects using meson-python or other python build-backends that wrap around meson.

Fixes #11662
Fixes #11665