### PR TITLE
environment.py: detect_cpu: Fix mips32 detection on mips64

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -339,6 +339,11 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
         # AIX always returns powerpc, check here for 64-bit
         if any_compiler_has_define(compilers, '__64BIT__'):
             trial = 'ppc64'
+    # MIPS64 is able to run MIPS32 code natively, so there is a chance that
+    # such mixture mentioned above exists.
+    elif trial == 'mips64':
+        if not any_compiler_has_define(compilers, '__mips64'):
+            trial = 'mips'
 
     if trial not in known_cpu_families:
         mlog.warning(f'Unknown CPU family {trial!r}, please report this at '
@@ -377,7 +382,10 @@ def detect_cpu(compilers: CompilersDict) -> str:
         if '64' not in trial:
             trial = 'mips'
         else:
-            trial = 'mips64'
+            if not any_compiler_has_define(compilers, '__mips64'):
+                trial = 'mips'
+            else:
+                trial = 'mips64'
     elif trial == 'ppc':
         # AIX always returns powerpc, check here for 64-bit
         if any_compiler_has_define(compilers, '__64BIT__'):

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1579,12 +1579,12 @@ class InternalTests(unittest.TestCase):
             ('ppc', 'ppc'),
             ('macppc', 'ppc'),
             ('power macintosh', 'ppc'),
-            ('mips64el', 'mips64'),
-            ('mips64', 'mips64'),
+            ('mips64el', 'mips'),
+            ('mips64', 'mips'),
             ('mips', 'mips'),
             ('mipsel', 'mips'),
-            ('ip30', 'mips64'),
-            ('ip35', 'mips64'),
+            ('ip30', 'mips'),
+            ('ip35', 'mips'),
             ('parisc64', 'parisc'),
             ('sun4u', 'sparc64'),
             ('sun4v', 'sparc64'),
@@ -1602,7 +1602,7 @@ class InternalTests(unittest.TestCase):
                     self.assertEqual(actual, expected)
 
         with mock.patch('mesonbuild.environment.any_compiler_has_define', mock.Mock(return_value=True)):
-            for test, expected in [('x86_64', 'x86'), ('aarch64', 'arm'), ('ppc', 'ppc64')]:
+            for test, expected in [('x86_64', 'x86'), ('aarch64', 'arm'), ('ppc', 'ppc64'), ('mips64', 'mips64')]:
                 with self.subTest(test, has_define=True), mock_trial(test):
                     actual = mesonbuild.environment.detect_cpu_family({})
                     self.assertEqual(actual, expected)
@@ -1624,8 +1624,8 @@ class InternalTests(unittest.TestCase):
             ('x64', 'x86_64'),
             ('i86pc', 'x86_64'),
             ('earm', 'arm'),
-            ('mips64el', 'mips64'),
-            ('mips64', 'mips64'),
+            ('mips64el', 'mips'),
+            ('mips64', 'mips'),
             ('mips', 'mips'),
             ('mipsel', 'mips'),
             ('aarch64', 'aarch64'),
@@ -1639,7 +1639,7 @@ class InternalTests(unittest.TestCase):
                     self.assertEqual(actual, expected)
 
         with mock.patch('mesonbuild.environment.any_compiler_has_define', mock.Mock(return_value=True)):
-            for test, expected in [('x86_64', 'i686'), ('aarch64', 'arm'), ('ppc', 'ppc64')]:
+            for test, expected in [('x86_64', 'i686'), ('aarch64', 'arm'), ('ppc', 'ppc64'), ('mips64', 'mips64')]:
                 with self.subTest(test, has_define=True), mock_trial(test):
                     actual = mesonbuild.environment.detect_cpu({})
                     self.assertEqual(actual, expected)


### PR DESCRIPTION
MIPS64 can run MIPS32 code natively, so there is a chance that a mixture of MIPS64 kernel and MIPS32 userland exists. Before this Meson just treats such mixture as mips64, because `uname -m` returns mips64.

So in this case we have to check compiler builtin defines for actual architecture and CPU in use.

Fixes #11671.