### PR TITLE
rust: Use the corresponding rustc version when clippy-driver is chose…

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -952,7 +952,18 @@ def detect_rust_compiler(env: 'Environment', for_machine: MachineChoice) -> Rust
         # Clippy is a wrapper around rustc, but it doesn't have rustc in it's
         # output. We can otherwise treat it as rustc.
         if 'clippy' in out:
-            out = 'rustc'
+            # clippy returns its own version and not the rustc version by
+            # default so try harder here to get the correct version.
+            # Also replace the whole output with the rustc output in
+            # case this is later used for other purposes.
+            arg = ['--rustc', '--version']
+            try:
+                out = Popen_safe(compiler + arg)[1]
+            except OSError as e:
+                popen_exceptions[join_args(compiler + arg)] = e
+                continue
+            version = search_version(out)
+
             cls = rust.ClippyRustCompiler
 
         if 'rustc' in out:


### PR DESCRIPTION
…n as Rust compiler

By default clippy-driver will report its own version, which is not very useful to check the toolchain version. Instead make sure to extract the actual toolchain version here.

----

CC @dcbaker