### PR TITLE
rust: Don't pass dependency compile arguments to the compiler

### DIFF
--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -28,6 +28,7 @@ if T.TYPE_CHECKING:
     from ..linkers import DynamicLinker
     from ..mesonlib import MachineChoice
     from ..programs import ExternalProgram
+    from ..dependencies import Dependency
 
 
 rust_optimization_args = {
@@ -152,6 +153,12 @@ class RustCompiler(Compiler):
                 'none',
             ),
         }
+
+    def get_dependency_compile_args(self, dep: 'Dependency') -> T.List[str]:
+        # Rust doesn't have dependency compile arguments so simply return
+        # nothing here. Dependencies are linked and all required metadata is
+        # provided by the linker flags.
+        return []
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args = []

--- a/test cases/rust/16 internal c dependencies/meson.build
+++ b/test cases/rust/16 internal c dependencies/meson.build
@@ -3,12 +3,16 @@ project('internal dependencies', 'c', 'rust')
 test_prog = find_program('test.py')
 
 static = static_library('static', 'lib.c', c_args : '-DMODE="static"')
-exe = executable('static', 'main.rs', link_with : static)
+# Add some -I compiler arguments to make sure they're not passed to the Rust
+# compiler when handling the dependency.
+static_dep = declare_dependency(link_with : static, compile_args : ['-Idoesnotexist'])
+exe = executable('static', 'main.rs', dependencies : static_dep)
 test('static linkage', test_prog, args : [exe, 'This is a static C library'])
 
 # Shared linkage with rust doesn't work on macOS with meson, yet
 if host_machine.system() != 'darwin'
   shared = shared_library('shared', 'lib.c', c_args : '-DMODE="shared"')
-  exe = executable('shared', 'main.rs', link_with : shared)
+  shared_dep = declare_dependency(link_with : shared, compile_args : ['-Idoesnotexist'])
+  exe = executable('shared', 'main.rs', dependencies : shared_dep)
   test('shared linkage', test_prog, args : [exe, 'This is a shared C library'])
 endif


### PR DESCRIPTION
Rust doesn't have a concept of dependency compile arguments, i.e. something like headers. Dependencies are linked in and all required metadata is provided by the linker flags.

----

This shows up when using e.g. a pkg-config dependency as dependency of a Rust target. Without this, `-I` and other compile flags are passed to the Rust compiler, which makes no sense.