### PR TITLE
msvc: prevent conversion of -L... options

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -10,6 +10,7 @@ from ..mesonlib import (
 from ..envconfig import BinaryTable
 from .. import mlog
 
+from ..compilers.mixins.visualstudio import VisualStudioLikeCompiler
 from ..linkers import guess_win_linker, guess_nix_linker
 
 import subprocess
@@ -204,6 +205,7 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
         if "xilib: executing 'lib'" in err:
             return linkers.IntelVisualStudioLinker(linker, getattr(compiler, 'machine', None))
         if '/OUT:' in out.upper() or '/OUT:' in err.upper():
+            T.cast(VisualStudioLikeCompiler, compiler).extract_compile_args(out)
             return linkers.VisualStudioLinker(linker, getattr(compiler, 'machine', None))
         if 'ar-Error-Unknown switch: --version' in err:
             return linkers.PGIStaticLinker(linker)
@@ -492,9 +494,11 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
             # As of this writing, CCache does not support MSVC but sccache does.
             if 'sccache' not in ccache:
                 ccache = []
-            return cls(
+            result = cls(
                 ccache, compiler, version, for_machine, is_cross, info, target,
                 exe_wrap, full_version=cl_signature, linker=linker)
+            T.cast(VisualStudioLikeCompiler, result).extract_compile_args(out)
+            return result
         if 'PGI Compilers' in out:
             cls = c.PGICCompiler if lang == 'c' else cpp.PGICPPCompiler
             env.coredata.add_lang_args(cls.language, cls, for_machine, env)

--- a/test cases/frameworks/25 hdf5/meson.build
+++ b/test cases/frameworks/25 hdf5/meson.build
@@ -1,4 +1,4 @@
-project('hdf5_framework', 'c')
+project('hdf5_framework', 'c', default_options: ['cpp_std=c++11'])
 
 # NOTE: all HDF5 languages must have HDF5 C library working.
 

--- a/test cases/unit/116 empty project/expected_mods.json
+++ b/test cases/unit/116 empty project/expected_mods.json
@@ -184,6 +184,8 @@
       "mesonbuild.compilers",
       "mesonbuild.compilers.compilers",
       "mesonbuild.compilers.detect",
+      "mesonbuild.compilers.mixins",
+      "mesonbuild.compilers.mixins.visualstudio",
       "mesonbuild.coredata",
       "mesonbuild.dependencies",
       "mesonbuild.dependencies.base",

--- a/unittests/platformagnostictests.py
+++ b/unittests/platformagnostictests.py
@@ -250,7 +250,7 @@ class PlatformAgnosticTests(BasePlatformTests):
             expected = json.load(f)['meson']['modules']
 
         self.assertEqual(data['modules'], expected)
-        self.assertEqual(data['count'], 68)
+        self.assertEqual(data['count'], 70)
 
     def test_meson_package_cache_dir(self):
         # Copy testdir into temporary directory to not pollute meson source tree.


### PR DESCRIPTION
Fixes #11670. See https://learn.microsoft.com/en-us/cpp/build/reference/compiler-options-listed-alphabetically?view=msvc-170 and https://learn.microsoft.com/en-us/cpp/build/reference/linker-options?view=msvc-170 for reference