### PR TITLE
rust: Treat staticlib/cdylib Rust libraries like static/shared libraries from any other language

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1904,7 +1904,10 @@ class NinjaBackend(backends.Backend):
         # TODO: we likely need to use verbatim to handle name_prefix and name_suffix
         for d in target.link_targets:
             linkdirs.add(d.subdir)
-            if d.uses_rust():
+            # staticlib and cdylib provide a plain C ABI, i.e. contain no Rust
+            # metadata. As such they should be treated like any other external
+            # link target
+            if d.uses_rust() and d.rust_crate_type not in ['staticlib', 'cdylib']:
                 # specify `extern CRATE_NAME=OUTPUT_FILE` for each Rust
                 # dependency, so that collisions with libraries in rustc's
                 # sysroot don't cause ambiguity

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2000,12 +2000,16 @@ class NinjaBackend(backends.Backend):
             if d == '':
                 d = '.'
             args += ['-L', d]
-        has_shared_deps = any(isinstance(dep, build.SharedLibrary) for dep in target.get_dependencies())
+        target_deps = target.get_dependencies()
+        has_shared_deps = any(isinstance(dep, build.SharedLibrary) for dep in target_deps)
         if isinstance(target, build.SharedLibrary) or has_shared_deps:
-            # add prefer-dynamic if any of the Rust libraries we link
-            # against are dynamic, otherwise we'll end up with
-            # multiple implementations of crates
-            args += ['-C', 'prefer-dynamic']
+            has_rust_shared_deps = any(isinstance(dep, build.SharedLibrary) and dep.uses_rust() and dep.rust_crate_type != 'cdylib'
+                                       for dep in target_deps)
+            if cratetype != 'cdylib' or has_rust_shared_deps:
+                # add prefer-dynamic if any of the Rust libraries we link
+                # against are dynamic or this is a dynamic library itself,
+                # otherwise we'll end up with multiple implementations of crates
+                args += ['-C', 'prefer-dynamic']
 
             # build the usual rpath arguments as well...
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1918,7 +1918,7 @@ class NinjaBackend(backends.Backend):
                 d_name = d.name.replace('-', '_')
                 args += ['--extern', '{}={}'.format(d_name, os.path.join(d.subdir, d.filename))]
                 project_deps.append(RustDep(d_name, self.rust_crates[d.name].order))
-            elif d.typename == 'static library':
+            elif isinstance(d, build.StaticLibrary):
                 # Rustc doesn't follow Meson's convention that static libraries
                 # are called .a, and import libraries are .lib, so we have to
                 # manually handle that.


### PR DESCRIPTION
Both types don't provide any Rust metadata but just a plain C ABI, so treat them as such.

With the two main commits here we make sure that a cdylib doesn't dynamically link to std unless it links to actual Rust shared libraries (`dylib`, not `cdylib`), and that no special Rust handling for them is performed by the compiler.

The third commit is just a trivial cleanup.

The main reason why I looked into this was because I'm creating a cdylib and it should be self-contained, i.e. not depend on the shared version of the Rust standard library. I.e. the same behaviour you'd get with cargo with this crate type.

----

CC @dcbaker 