### PR TITLE
Sanity Check Reconfigure Fix

### DIFF
--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -181,7 +181,7 @@ class IntrospectionInterpreter(AstInterpreter):
             lang = lang.lower()
             if lang not in self.coredata.compilers[for_machine]:
                 try:
-                    comp = detect_compiler_for(self.environment, lang, for_machine)
+                    comp = detect_compiler_for(self.environment, lang, for_machine, True)
                 except mesonlib.MesonException:
                     # do we even care about introspecting this language?
                     if required:

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -111,11 +111,15 @@ def compiler_from_language(env: 'Environment', lang: str, for_machine: MachineCh
     }
     return lang_map[lang](env, for_machine) if lang in lang_map else None
 
-def detect_compiler_for(env: 'Environment', lang: str, for_machine: MachineChoice) -> T.Optional[Compiler]:
+def detect_compiler_for(env: 'Environment', lang: str, for_machine: MachineChoice, skip_sanity_check: bool) -> T.Optional[Compiler]:
     comp = compiler_from_language(env, lang, for_machine)
-    if comp is not None:
-        assert comp.for_machine == for_machine
-        env.coredata.process_new_compiler(lang, comp, env)
+    if comp is None:
+        return comp
+    assert comp.for_machine == for_machine
+    env.coredata.process_new_compiler(lang, comp, env)
+    if not skip_sanity_check:
+        comp.sanity_check(env.get_scratch_dir(), env)
+    env.coredata.compilers[comp.for_machine][lang] = comp
     return comp
 
 

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -918,7 +918,6 @@ class CoreData:
     def process_new_compiler(self, lang: str, comp: 'Compiler', env: 'Environment') -> None:
         from . import compilers
 
-        self.compilers[comp.for_machine][lang] = comp
         self.add_compiler_options(comp.get_options(), lang, comp.for_machine, env)
 
         enabled_opts: T.List[OptionKey] = []

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1491,13 +1491,12 @@ class Interpreter(InterpreterBase, HoldableObject):
             comp = self.coredata.compilers[for_machine].get(lang)
             if not comp:
                 try:
-                    comp = compilers.detect_compiler_for(self.environment, lang, for_machine)
+                    skip_sanity_check = self.should_skip_sanity_check(for_machine)
+                    if skip_sanity_check:
+                        mlog.log_once('Cross compiler sanity tests disabled via the cross file.')
+                    comp = compilers.detect_compiler_for(self.environment, lang, for_machine, skip_sanity_check)
                     if comp is None:
                         raise InvalidArguments(f'Tried to use unknown language "{lang}".')
-                    if self.should_skip_sanity_check(for_machine):
-                        mlog.log_once('Cross compiler sanity tests disabled via the cross file.')
-                    else:
-                        comp.sanity_check(self.environment.get_scratch_dir(), self.environment)
                 except mesonlib.MesonException:
                     if not required:
                         mlog.log('Compiler for language',

--- a/mesonbuild/modules/java.py
+++ b/mesonbuild/modules/java.py
@@ -42,7 +42,7 @@ class JavaModule(NewExtensionModule):
 
     def __get_java_compiler(self, state: ModuleState) -> Compiler:
         if 'java' not in state.environment.coredata.compilers[MachineChoice.BUILD]:
-            detect_compiler_for(state.environment, 'java', MachineChoice.BUILD)
+            detect_compiler_for(state.environment, 'java', MachineChoice.BUILD, False)
         return state.environment.coredata.compilers[MachineChoice.BUILD]['java']
 
     @FeatureNew('java.generate_native_headers', '0.62.0')

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -841,7 +841,7 @@ class AllPlatformTests(BasePlatformTests):
         testdir = os.path.join("test cases/cython", '2 generated sources')
         env = get_fake_env(testdir, self.builddir, self.prefix)
         try:
-            detect_compiler_for(env, "cython", MachineChoice.HOST)
+            detect_compiler_for(env, "cython", MachineChoice.HOST, True)
         except EnvironmentException:
             raise SkipTest("Cython is not installed")
         self.init(testdir)
@@ -866,7 +866,7 @@ class AllPlatformTests(BasePlatformTests):
         testdir = os.path.join("test cases/cython", '2 generated sources')
         env = get_fake_env(testdir, self.builddir, self.prefix)
         try:
-            cython = detect_compiler_for(env, "cython", MachineChoice.HOST)
+            cython = detect_compiler_for(env, "cython", MachineChoice.HOST, True)
             if not version_compare(cython.version, '>=0.29.33'):
                 raise SkipTest('Cython is too old')
         except EnvironmentException:
@@ -2141,7 +2141,7 @@ class AllPlatformTests(BasePlatformTests):
         env = get_fake_env()
         for l in ['cpp', 'cs', 'd', 'java', 'cuda', 'fortran', 'objc', 'objcpp', 'rust']:
             try:
-                comp = detect_compiler_for(env, l, MachineChoice.HOST)
+                comp = detect_compiler_for(env, l, MachineChoice.HOST, True)
                 with tempfile.TemporaryDirectory() as d:
                     comp.sanity_check(d, env)
                 langs.append(l)
@@ -2158,7 +2158,7 @@ class AllPlatformTests(BasePlatformTests):
                 if is_windows() and lang == 'fortran' and target_type == 'library':
                     # non-Gfortran Windows Fortran compilers do not do shared libraries in a Fortran standard way
                     # see "test cases/fortran/6 dynamic"
-                    fc = detect_compiler_for(env, 'fortran', MachineChoice.HOST)
+                    fc = detect_compiler_for(env, 'fortran', MachineChoice.HOST, True)
                     if fc.get_id() in {'intel-cl', 'pgi'}:
                         continue
                 # test empty directory
@@ -4177,18 +4177,18 @@ class AllPlatformTests(BasePlatformTests):
             env = get_fake_env()
 
             # Get the compiler so we know which compiler class to mock.
-            cc =  detect_compiler_for(env, 'c', MachineChoice.HOST)
+            cc =  detect_compiler_for(env, 'c', MachineChoice.HOST, True)
             cc_type = type(cc)
 
             # Test a compiler that acts as a linker
             with mock.patch.object(cc_type, 'INVOKES_LINKER', True):
-                cc =  detect_compiler_for(env, 'c', MachineChoice.HOST)
+                cc =  detect_compiler_for(env, 'c', MachineChoice.HOST, True)
                 link_args = env.coredata.get_external_link_args(cc.for_machine, cc.language)
                 self.assertEqual(sorted(link_args), sorted(['-DCFLAG', '-flto']))
 
             # And one that doesn't
             with mock.patch.object(cc_type, 'INVOKES_LINKER', False):
-                cc =  detect_compiler_for(env, 'c', MachineChoice.HOST)
+                cc =  detect_compiler_for(env, 'c', MachineChoice.HOST, True)
                 link_args = env.coredata.get_external_link_args(cc.for_machine, cc.language)
                 self.assertEqual(sorted(link_args), sorted(['-flto']))
 


### PR DESCRIPTION
Let's say you have the following meson.build file:
```meson
project('demo', 'c')
add_languages('objc', required: false)
```
and a machine with no objc compiler. Without my patch, meson does this:
```
$ /old/meson.py setup build
The Meson build system
Version: 1.1.99
Source dir: /home/volker/Documents/mesoncases/9431/many
Build dir: /home/volker/Documents/mesoncases/9431/many/build
Build type: native build
Project name: demo
Project version: undefined
C compiler for the host machine: cc (gcc 12.2.1 "cc (GCC) 12.2.1 20230201")
C linker for the host machine: cc ld.bfd 2.40
Host machine cpu family: x86_64
Host machine cpu: x86_64
Compiler for language objc for the build machine not found.
Compiler for language objc for the host machine not found.
Build targets in project: 0

Found ninja-1.11.1 at /usr/bin/ninja
$ /old/meson.py setup build --reconfigure
The Meson build system
Version: 1.1.99
Source dir: /home/volker/Documents/mesoncases/9431/many
Build dir: /home/volker/Documents/mesoncases/9431/many/build
Build type: native build
Project name: demo
Project version: undefined
C compiler for the host machine: cc (gcc 12.2.1 "cc (GCC) 12.2.1 20230201")
C linker for the host machine: cc ld.bfd 2.40
Host machine cpu family: x86_64
Host machine cpu: x86_64
Objective-C compiler for the host machine: cc (gcc 12.2.1)
Objective-C linker for the host machine: cc ld.bfd 2.40
Build targets in project: 0

Found ninja-1.11.1 at /usr/bin/ninja
```
During the initial configure, it prints 
```
Compiler for language objc for the build machine not found.
Compiler for language objc for the host machine not found.
```
(which is correct), but during the reconfigure, it prints
```
Objective-C compiler for the host machine: cc (gcc 12.2.1)
Objective-C linker for the host machine: cc ld.bfd 2.40
```
which is wrong, since my gcc 12.2.1 cannot compile objc. With my patch, meson prints 
```
Compiler for language objc for the build machine not found.
Compiler for language objc for the host machine not found.
```
both during the inital configure and the reconfigure.

How did this bug happen:
Without my patch, meson checks if a objc compiler exists. If it does, the compiler is added to self.environment.compilers. Then the compiler is sanity-tested and added to self.compilers if this succeeded. 
The gcc 12.2.1 exists, but fails the sanity check as a objc compiler. Thus, it gets added to self.environment.compilers but not self.compilers. Since no objc compiler exists in self.compilers the "not found" message is printed. In the reconfigure, self.environment.compilers is loaded from the disk and gcc 12.2.1 is copied from self.environment.compilers to self.compilers without another sanity check. Since now self.compilers contains a objc compiler the `Objective-C compiler for the host machine: cc (gcc 12.2.1)` message is printed.

With my patch, the compiler is only added to self.environment.compilers if the sanity check succeded. I.e. I moved the sanity check in front of "adding the compiler to self.environment.compilers". That way, gcc 12.2.1 won't up in self.environment.compilers as a objc compiler.
