### PR TITLE
rust: Convert dashes in crate names to underscores

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1908,8 +1908,13 @@ class NinjaBackend(backends.Backend):
                 # specify `extern CRATE_NAME=OUTPUT_FILE` for each Rust
                 # dependency, so that collisions with libraries in rustc's
                 # sysroot don't cause ambiguity
-                args += ['--extern', '{}={}'.format(d.name, os.path.join(d.subdir, d.filename))]
-                project_deps.append(RustDep(d.name, self.rust_crates[d.name].order))
+                #
+                # Also convert crate names with dashes to underscores like
+                # cargo does as dashes can't be used as parts of identifiers
+                # in Rust
+                d_name = d.name.replace('-', '_')
+                args += ['--extern', '{}={}'.format(d_name, os.path.join(d.subdir, d.filename))]
+                project_deps.append(RustDep(d_name, self.rust_crates[d.name].order))
             elif d.typename == 'static library':
                 # Rustc doesn't follow Meson's convention that static libraries
                 # are called .a, and import libraries are .lib, so we have to
@@ -1946,8 +1951,13 @@ class NinjaBackend(backends.Backend):
                 # specify `extern CRATE_NAME=OUTPUT_FILE` for each Rust
                 # dependency, so that collisions with libraries in rustc's
                 # sysroot don't cause ambiguity
-                args += ['--extern', '{}={}'.format(d.name, os.path.join(d.subdir, d.filename))]
-                project_deps.append(RustDep(d.name, self.rust_crates[d.name].order))
+                #
+                # Also convert crate names with dashes to underscores like
+                # cargo does as dashes can't be used as parts of identifiers
+                # in Rust
+                d_name = d.name.replace('-', '_')
+                args += ['--extern', '{}={}'.format(d_name, os.path.join(d.subdir, d.filename))]
+                project_deps.append(RustDep(d_name, self.rust_crates[d.name].order))
             else:
                 if rustc.linker.id in {'link', 'lld-link'}:
                     if verbatim:


### PR DESCRIPTION
Dashes can't be used as identifiers in Rust and cargo is converting dashes in crate names to underscores for the same reason.

----

CC @dcbaker 