### PR TITLE
rust: Add new `rust_dependency_map` target configuration

### DIFF
--- a/docs/markdown/snippets/rust_dependency_map.md
+++ b/docs/markdown/snippets/rust_dependency_map.md
@@ -1,0 +1,18 @@
+## Support for defining crate names of Rust dependencies in Rust targets
+
+Rust supports defining a different crate name for a dependency than what the
+actual crate name during compilation of that dependency was.
+
+This allows using multiple versions of the same crate at once, or simply using
+a shorter name of the crate for convenience.
+
+```meson
+a_dep = dependency('some-very-long-name')
+
+my_executable = executable('my-executable', 'src/main.rs',
+  rust_dependency_map : {
+    'some_very_long_name' : 'a',
+  },
+  dependencies : [a_dep],
+)
+```

--- a/docs/yaml/functions/_build_target_base.yaml
+++ b/docs/yaml/functions/_build_target_base.yaml
@@ -302,3 +302,13 @@ kwargs:
       "proc-macro" is a special rust procedural macro crate.
 
       "proc-macro" is new in 0.62.0.
+
+  rust_dependency_map:
+    type: dict[str]
+    since: 1.2.0
+    description: |
+      On rust targets this provides a map of library names to the crate name
+      with which it would be available inside the rust code.
+
+      This allows renaming similar to the dependency renaming feature of cargo
+      or `extern crate foo as bar` inside rust code.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -74,7 +74,7 @@ lang_arg_kwargs |= {
 }
 
 vala_kwargs = {'vala_header', 'vala_gir', 'vala_vapi'}
-rust_kwargs = {'rust_crate_type'}
+rust_kwargs = {'rust_crate_type', 'rust_dependency_map'}
 cs_kwargs = {'resources', 'cs_args'}
 
 buildtarget_kwargs = {
@@ -1235,6 +1235,13 @@ class BuildTarget(Target):
             permitted = ['default', 'internal', 'hidden', 'protected', 'inlineshidden']
             if self.gnu_symbol_visibility not in permitted:
                 raise InvalidArguments('GNU symbol visibility arg {} not one of: {}'.format(self.gnu_symbol_visibility, ', '.join(permitted)))
+
+        rust_dependency_map = kwargs.get('rust_dependency_map', {})
+        if not isinstance(rust_dependency_map, dict):
+            raise InvalidArguments(f'Invalid rust_dependency_map "{rust_dependency_map}": must be a dictionary.')
+        if any(not isinstance(v, str) for v in rust_dependency_map.values()):
+            raise InvalidArguments(f'Invalid rust_dependency_map "{rust_dependency_map}": must be a dictionary with string values.')
+        self.rust_dependency_map = rust_dependency_map
 
     def validate_win_subsystem(self, value: str) -> str:
         value = value.lower()

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3181,6 +3181,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             raise InterpreterException(f'Unknown default_library value: {default_library}.')
 
     def build_target(self, node: mparser.BaseNode, args, kwargs, targetclass):
+        @FeatureNewKwargs('build target', '1.2.0', ['rust_dependency_map'])
         @FeatureNewKwargs('build target', '0.42.0', ['rust_crate_type', 'build_rpath', 'implicit_include_directories'])
         @FeatureNewKwargs('build target', '0.41.0', ['rust_args'])
         @FeatureNewKwargs('build target', '0.38.0', ['build_by_default'])

--- a/test cases/rust/17 staticlib link staticlib/branch.rs
+++ b/test cases/rust/17 staticlib link staticlib/branch.rs
@@ -1,4 +1,4 @@
 #[no_mangle]
 pub extern "C" fn what_have_we_here() -> i32 {
-    leaf::HOW_MANY * leaf::HOW_MANY
+    myleaf::HOW_MANY * myleaf::HOW_MANY
 }

--- a/test cases/rust/17 staticlib link staticlib/meson.build
+++ b/test cases/rust/17 staticlib link staticlib/meson.build
@@ -3,6 +3,6 @@ project('staticlib link staticlib', 'c', 'rust')
 leaf = static_library('leaf', 'leaf.rs', rust_crate_type : 'rlib')
 # Even though leaf is linked using link_with, this gets implicitly promoted to link_whole because
 # it is an internal Rust project.
-branch = static_library('branch', 'branch.rs', link_with: leaf, rust_crate_type : 'staticlib', install : true)
+branch = static_library('branch', 'branch.rs', link_with: leaf, rust_crate_type : 'staticlib', rust_dependency_map : { 'leaf' : 'myleaf' }, install : true)
 e = executable('prog', 'prog.c', link_with : branch, install : true)
 test('linktest', e)


### PR DESCRIPTION
This allows changing the crate name with which a library ends up being available inside the Rust code, similar to cargo's dependency renaming feature or `extern crate foo as bar` inside Rust code.

----

Only the top commit is interesting here, the others are from other PRs but they change related code.

CC @dcbaker who suggested this as a possible solution.