### PR TITLE
fix data collection with pyinstaller

### DIFF
--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -176,8 +176,8 @@ project_meson_versions = collections.defaultdict(str)  # type: T.DefaultDict[str
 
 from glob import glob
 
-if os.path.basename(sys.executable) == 'meson.exe':
-    # In Windows and using the MSI installed executable.
+if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+    # using a PyInstaller bundle, e.g. the MSI installed executable
     python_command = [sys.executable, 'runpython']
 else:
     python_command = [sys.executable]

--- a/packaging/hook-mesonbuild.py
+++ b/packaging/hook-mesonbuild.py
@@ -21,7 +21,7 @@ def get_all_modules_from_dir(dirname):
     modules = ['mesonbuild.' + modname + '.' + x for x in modules if not x.startswith('_')]
     return modules
 
-datas += collect_data_files('mesonbuild.scripts')
+datas += collect_data_files('mesonbuild.scripts', include_py_files=True, excludes=['**/__pycache__'])
 datas += collect_data_files('mesonbuild.cmake.data')
 datas += collect_data_files('mesonbuild.dependencies.data')
 


### PR DESCRIPTION
pyinstaller considers .py files to not be data by default. The entire architecture of pyinstaller is, in fact, different from zipapp or unpacked modules -- because it actually has to use a resource loader with on-disk files *separate* from the module itself. So just because a file gets packaged in the application does not mean it's usable as an importlib.resources compatible resource.

Although we collect data files in general, we need to make sure that .py files are collected from scripts, because we may try to run them standalone from an external process.

Fixes #11689
