### PR TITLE
rust: Don't allow spaces/dashes in Rust library names

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1892,8 +1892,8 @@ class NinjaBackend(backends.Backend):
             args.extend(rustc.get_linker_always_args())
 
         args += self.generate_basic_compiler_args(target, rustc, False)
-        # Rustc replaces - with _. spaces are not allowed, so we replace them with underscores
-        args += ['--crate-name', target.name.replace('-', '_').replace(' ', '_')]
+        # Rustc replaces - with _. spaces or dots are not allowed, so we replace them with underscores
+        args += ['--crate-name', target.name.replace('-', '_').replace(' ', '_').replace('.', '_')]
         depfile = os.path.join(target.subdir, target.name + '.d')
         args += ['--emit', f'dep-info={depfile}', '--emit', 'link']
         args += target.get_extra_args('rust')

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1988,8 +1988,8 @@ class StaticLibrary(BuildTarget):
             elif self.rust_crate_type not in ['rlib', 'staticlib']:
                 raise InvalidArguments(f'Crate type "{self.rust_crate_type}" invalid for static libraries; must be "rlib" or "staticlib"')
             # See https://github.com/rust-lang/rust/issues/110460
-            if self.rust_crate_type == 'rlib' and any(c in self.name for c in ['-', ' ']):
-                raise InvalidArguments('Rust crate types "dylib" and "proc-macro" do not allow spaces or dashes in the library name '
+            if self.rust_crate_type == 'rlib' and any(c in self.name for c in ['-', ' ', '.']):
+                raise InvalidArguments('Rust crate type "rlib" does not allow spaces, periods or dashes in the library name '
                                        'due to a limitation of rustc. Replace them with underscores, for example')
         # By default a static library is named libfoo.a even on Windows because
         # MSVC does not have a consistent convention for what static libraries
@@ -2082,8 +2082,8 @@ class SharedLibrary(BuildTarget):
             elif self.rust_crate_type not in ['dylib', 'cdylib', 'proc-macro']:
                 raise InvalidArguments(f'Crate type "{self.rust_crate_type}" invalid for dynamic libraries; must be "dylib", "cdylib", or "proc-macro"')
             # See https://github.com/rust-lang/rust/issues/110460
-            if self.rust_crate_type != 'cdylib' and any(c in self.name for c in ['-', ' ']):
-                raise InvalidArguments('Rust crate types "dylib" and "proc-macro" do not allow spaces or dashes in the library name '
+            if self.rust_crate_type != 'cdylib' and any(c in self.name for c in ['-', ' ', '.']):
+                raise InvalidArguments('Rust crate types "dylib" and "proc-macro" do not allow spaces, periods or dashes in the library name '
                                        'due to a limitation of rustc. Replace them with underscores, for example')
 
         if not hasattr(self, 'prefix'):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1987,6 +1987,10 @@ class StaticLibrary(BuildTarget):
             # Don't let configuration proceed with a non-static crate type
             elif self.rust_crate_type not in ['rlib', 'staticlib']:
                 raise InvalidArguments(f'Crate type "{self.rust_crate_type}" invalid for static libraries; must be "rlib" or "staticlib"')
+            # See https://github.com/rust-lang/rust/issues/110460
+            if self.rust_crate_type == 'rlib' and any(c in self.name for c in ['-', ' ']):
+                raise InvalidArguments('Rust crate types "dylib" and "proc-macro" do not allow spaces or dashes in the library name '
+                                       'due to a limitation of rustc. Replace them with underscores, for example')
         # By default a static library is named libfoo.a even on Windows because
         # MSVC does not have a consistent convention for what static libraries
         # are called. The MSVC CRT uses libfoo.lib syntax but nothing else uses
@@ -2077,6 +2081,11 @@ class SharedLibrary(BuildTarget):
             # Don't let configuration proceed with a non-dynamic crate type
             elif self.rust_crate_type not in ['dylib', 'cdylib', 'proc-macro']:
                 raise InvalidArguments(f'Crate type "{self.rust_crate_type}" invalid for dynamic libraries; must be "dylib", "cdylib", or "proc-macro"')
+            # See https://github.com/rust-lang/rust/issues/110460
+            if self.rust_crate_type != 'cdylib' and any(c in self.name for c in ['-', ' ']):
+                raise InvalidArguments('Rust crate types "dylib" and "proc-macro" do not allow spaces or dashes in the library name '
+                                       'due to a limitation of rustc. Replace them with underscores, for example')
+
         if not hasattr(self, 'prefix'):
             self.prefix = None
         if not hasattr(self, 'suffix'):


### PR DESCRIPTION
The library names are directly mapped to filenames by meson while the
crate name gets spaces/dashes replaced by underscores. This works fine
to a certain degree except that rustc expects a certain filename scheme
for rlibs that matches the crate name.
    
When using such a library as a dependency of a dependency compilation
will fail with a confusing error message.
    
See https://github.com/rust-lang/rust/issues/110460

----

CC @dcbaker 