### PR TITLE
handle more gettext variants

### DIFF
--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -285,7 +285,7 @@ class I18nModule(ExtensionModule):
                 path.join(state.subdir, l, 'LC_MESSAGES'),
                 state.subproject,
                 state.environment,
-                [self.tools['msgfmt'], '@INPUT@', '-o', '@OUTPUT@'],
+                [self.tools['msgfmt'], '-o', '@OUTPUT@', '@INPUT@'],
                 [po_file],
                 [f'{packagename}.mo'],
                 install=install,


### PR DESCRIPTION
- A POSIX-style msgfmt may only accept POSIX-style arguments, be compatible there. This is especially interesting since the next edition of POSIX defines msgfmt, but at least the Solaris native msgfmt triggers this meson bug anyway.
- merge_file is a GNU-specific concept workflow, so require GNU gettext. This fails on Solaris before and after the patch, but the patch makes it a configure time error telling you what software to install, instead of a build time "invalid argument".

/cc @alanc 

/cc @awilfox @q66 this should work fine with gettext-tiny based on my limited local testing -- gettext-tiny shims this out and sets wildly big version numbers to make sure it matches any conceivable version check. I can't grep for `--xml` or `--desktop` in the help text, apparently.

Partial fix for Solaris/Illumos, handles one of the issues raised in #11700