### PR TITLE
pkgconfig module: fix traceback on invalid missing description

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -424,8 +424,8 @@ class PkgConfigModule(NewExtensionModule):
         return ('${prefix}' / libdir).as_posix()
 
     def _generate_pkgconfig_file(self, state: ModuleState, deps: DependenciesHelper,
-                                 subdirs: T.List[str], name: T.Optional[str],
-                                 description: T.Optional[str], url: str, version: str,
+                                 subdirs: T.List[str], name: str,
+                                 description: str, url: str, version: str,
                                  pcfile: str, conflicts: T.List[str],
                                  variables: T.List[T.Tuple[str, str]],
                                  unescaped_variables: T.List[T.Tuple[str, str]],
@@ -638,11 +638,13 @@ class PkgConfigModule(NewExtensionModule):
         else:
             if kwargs['version'] is None:
                 FeatureNew.single_use('pkgconfig.generate implicit version keyword', '0.46.0', state.subproject)
+            msg = ('pkgconfig.generate: if a library is not passed as a '
+                   'positional argument, the {!r} keyword argument is '
+                   'required.')
             if kwargs['name'] is None:
-                raise build.InvalidArguments(
-                    'pkgconfig.generate: if a library is not passed as a '
-                    'positional argument, the name keyword argument is '
-                    'required.')
+                raise build.InvalidArguments(msg.format('name'))
+            if kwargs['description'] is None:
+                raise build.InvalidArguments(msg.format('description'))
 
         dataonly = kwargs['dataonly']
         if dataonly:

--- a/test cases/common/44 pkgconfig-gen/meson.build
+++ b/test cases/common/44 pkgconfig-gen/meson.build
@@ -176,3 +176,12 @@ pkgg.generate(
   description : 'Check that variables can be single string',
   variables: 'foo=bar',
 )
+
+# without a mainlib, name/description are mandatory
+testcase expect_error('pkgconfig.generate: if a library is not passed as a positional argument, the \'name\' keyword argument is required.')
+  pkgg.generate(description: 'empty data')
+endtestcase
+
+testcase expect_error('pkgconfig.generate: if a library is not passed as a positional argument, the \'description\' keyword argument is required.')
+  pkgg.generate(name: 'foobar')
+endtestcase


### PR DESCRIPTION
If the optional first "mainlib" argument is there, then we infer several values. Otherwise, some of those values fall back to a generic default, and two of them -- name and description -- fall back to being mandatory.

In commit e84f293f672a372d2434d0ce4fa39d3f902b6ce8, we removed validation for description as part of refactoring that never actually validated anything.