### PR TITLE
fix python.version() not working

### DIFF
--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -75,6 +75,7 @@ class BasicPythonExternalProgram(ExternalProgram):
             self.name = name
             self.command = ext_prog.command
             self.path = ext_prog.path
+            self.cached_version = None
 
         # We want strong key values, so we always populate this with bogus data.
         # Otherwise to make the type checkers happy we'd have to do .get() for

--- a/test cases/python/1 basic/meson.build
+++ b/test cases/python/1 basic/meson.build
@@ -8,6 +8,9 @@ if py_version.version_compare('< 3.2')
   error('MESON_SKIP_TEST python 3 required for tests')
 endif
 
+py_full_version = py.version()
+message(f'Using python version: @py_full_version@')
+
 py_purelib = py.get_path('purelib')
 if not (py_purelib.endswith('site-packages') or py_purelib.endswith('dist-packages'))
   error('Python3 purelib path seems invalid? ' + py_purelib)


### PR DESCRIPTION
`import('python').find_installation('python').version()` causes exception because of a missing initialization