### PR TITLE
Better pymod.find_installation() on Windows

### DIFF
--- a/docs/markdown/Python-module.md
+++ b/docs/markdown/Python-module.md
@@ -37,7 +37,10 @@ If provided, it can be:
 - One of `python2` or `python3`: in either case, the module will try
   some alternative names: `py -2` or `py -3` on Windows, and `python`
   everywhere. In the latter case, it will check whether the version
-  provided by the sysconfig module matches the required major version
+  provided by the sysconfig module matches the required major version.
+
+  *Since 1.2.0*, searching for minor version (e.g. `python3.11`) also
+  works on Windows.
 
 Keyword arguments are the following:
 

--- a/docs/markdown/snippets/python-find-version.md
+++ b/docs/markdown/snippets/python-find-version.md
@@ -1,0 +1,6 @@
+## Find more specific python version on Windows
+
+You can now use `python3.x`, where `x` is the minor version,
+to find a more specific version of python on Windows, when
+using the python module. On other platforms, it was already
+working as `python3.x` is the executable name.

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -332,7 +332,8 @@ class PythonModule(ExtensionModule):
             # named python is available and has a compatible version, let's use
             # it
             if not python.found() and name_or_path in {'python2', 'python3'}:
-                python = PythonExternalProgram('python')
+                tmp_python = ExternalProgram.from_entry(display_name, 'python')
+                python = PythonExternalProgram(name_or_path, ext_prog=tmp_python)
 
         if python.found():
             if python.sanity(state):

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -345,7 +345,7 @@ class PythonModule(ExtensionModule):
                 else:
                     mlog.warning(sanitymsg, location=state.current_node)
 
-        return NonExistingExternalProgram()
+        return NonExistingExternalProgram(python.name)
 
     @disablerIfNotFound
     @typed_pos_args('python.find_installation', optargs=[str])
@@ -413,11 +413,11 @@ class PythonModule(ExtensionModule):
         if not python.found():
             if required:
                 raise mesonlib.MesonException('{} not found'.format(name_or_path or 'python'))
-            return NonExistingExternalProgram()
+            return NonExistingExternalProgram(python.name)
         elif missing_modules:
             if required:
                 raise mesonlib.MesonException('{} is missing modules: {}'.format(name_or_path or 'python', ', '.join(missing_modules)))
-            return NonExistingExternalProgram()
+            return NonExistingExternalProgram(python.name)
         else:
             python = copy.copy(python)
             python.pure = kwargs['pure']

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -300,12 +300,12 @@ class PythonModule(ExtensionModule):
     # https://www.python.org/dev/peps/pep-0397/
     @staticmethod
     def _get_win_pythonpath(name_or_path: str) -> T.Optional[str]:
-        if name_or_path not in ['python2', 'python3']:
+        if not name_or_path.startswith(('python2', 'python3')):
             return None
         if not shutil.which('py'):
             # program not installed, return without an exception
             return None
-        ver = {'python2': '-2', 'python3': '-3'}[name_or_path]
+        ver = f'-{name_or_path[6:]}'
         cmd = ['py', ver, '-c', "import sysconfig; print(sysconfig.get_config_var('BINDIR'))"]
         _, stdout, _ = mesonlib.Popen_safe(cmd)
         directory = stdout.strip()


### PR DESCRIPTION
- Fixes the fallback for `python2` when python2 is not installed (Fixes #11057)
- Allow to find `python3.xx`, or any version allowed by `py.exe` launcher.
- Better logging when python is not found (Fixes #11686)