### PR TITLE
g-ir-scanner environmental variables

### DIFF
--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -92,6 +92,9 @@ There are several keyword arguments. Many of these map directly to the
 
 * `dependencies`: deps to use during introspection scanning
 * `extra_args`: command line arguments to pass to gir compiler
+* `env`: (*Added 1.2.0*) environment variables to set, such as
+  `{'NAME1': 'value1', 'NAME2': 'value2'}` or `['NAME1=value1', 'NAME2=value2']`,
+  or an [[@env]] object which allows more sophisticated environment juggling.
 * `export_packages`: extra packages the gir file exports
 * `sources`: the list of sources to be scanned for gir data
 * `nsversion`: namespace version

--- a/docs/markdown/snippets/generate_gir_kwarg_env.md
+++ b/docs/markdown/snippets/generate_gir_kwarg_env.md
@@ -1,0 +1,3 @@
+## `gnome.generate_gir()` now supports `env` kwarg
+
+`gnome.generate_gir()` now accepts the `env` kwarg which lets you set environment variables.

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -37,7 +37,7 @@ from ..interpreterbase import noPosargs, noKwargs, FeatureNew, FeatureDeprecated
 from ..interpreterbase import typed_kwargs, KwargInfo, ContainerTypeInfo
 from ..interpreterbase.decorators import typed_pos_args
 from ..mesonlib import (
-    MachineChoice, MesonException, OrderedSet, Popen_safe, join_args,
+    MachineChoice, MesonException, OrderedSet, Popen_safe, join_args, quote_arg
 )
 from ..programs import OverrideProgram
 from ..scripts.gettext import read_linguas
@@ -979,6 +979,9 @@ class GnomeModule(ExtensionModule):
         # settings user could have set in machine file, like PKG_CONFIG_LIBDIR,
         # SYSROOT, etc.
         run_env = PkgConfigDependency.get_env(state.environment, MachineChoice.HOST, uninstalled=True)
+        # g-ir-scanner uses Python's distutils to find the compiler, which uses 'CC'
+        cc_exelist = state.environment.coredata.compilers.host['c'].get_exelist()
+        run_env.set('CC', [quote_arg(x) for x in cc_exelist], ' ')
 
         return GirTarget(
             girfile,

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -32,7 +32,7 @@ from .. import mesonlib
 from .. import mlog
 from ..build import CustomTarget, CustomTargetIndex, Executable, GeneratedList, InvalidArguments
 from ..dependencies import Dependency, PkgConfigDependency, InternalDependency
-from ..interpreter.type_checking import DEPENDS_KW, DEPEND_FILES_KW, INSTALL_DIR_KW, INSTALL_KW, NoneType, SOURCES_KW, in_set_validator
+from ..interpreter.type_checking import DEPENDS_KW, DEPEND_FILES_KW, ENV_KW, INSTALL_DIR_KW, INSTALL_KW, NoneType, SOURCES_KW, in_set_validator
 from ..interpreterbase import noPosargs, noKwargs, FeatureNew, FeatureDeprecated
 from ..interpreterbase import typed_kwargs, KwargInfo, ContainerTypeInfo
 from ..interpreterbase.decorators import typed_pos_args
@@ -982,6 +982,7 @@ class GnomeModule(ExtensionModule):
         # g-ir-scanner uses Python's distutils to find the compiler, which uses 'CC'
         cc_exelist = state.environment.coredata.compilers.host['c'].get_exelist()
         run_env.set('CC', [quote_arg(x) for x in cc_exelist], ' ')
+        run_env.merge(kwargs['env'])
 
         return GirTarget(
             girfile,
@@ -1026,6 +1027,7 @@ class GnomeModule(ExtensionModule):
             install_dir=[install_dir],
             install_tag=['typelib'],
             build_by_default=kwargs['build_by_default'],
+            env=kwargs['env'],
         )
 
     @staticmethod
@@ -1098,6 +1100,7 @@ class GnomeModule(ExtensionModule):
         INSTALL_KW,
         _BUILD_BY_DEFAULT.evolve(since='0.40.0'),
         _EXTRA_ARGS_KW,
+        ENV_KW.evolve(since='1.2.0'),
         KwargInfo('dependencies', ContainerTypeInfo(list, Dependency), default=[], listify=True),
         KwargInfo('export_packages', ContainerTypeInfo(list, str), default=[], listify=True),
         KwargInfo('fatal_warnings', bool, default=False, since='0.55.0'),

--- a/mesonbuild/utils/core.py
+++ b/mesonbuild/utils/core.py
@@ -99,6 +99,11 @@ class EnvironmentVariables(HoldableObject):
     def get_names(self) -> T.Set[str]:
         return self.varnames
 
+    def merge(self, other: EnvironmentVariables) -> None:
+        for method, name, values, separator in other.envvars:
+            self.varnames.add(name)
+            self.envvars.append((method, name, values, separator))
+
     def set(self, name: str, values: T.List[str], separator: str = os.pathsep) -> None:
         self.varnames.add(name)
         self.envvars.append((self._set, name, values, separator))

--- a/test cases/frameworks/7 gnome/gir/dep1/dep1.h
+++ b/test cases/frameworks/7 gnome/gir/dep1/dep1.h
@@ -1,8 +1,8 @@
 #ifndef MESON_DEP1_H
 #define MESON_DEP1_H
 
-#if !defined (MESON_TEST)
-#error "MESON_TEST not defined."
+#if !defined (MESON_TEST_1)
+#error "MESON_TEST_1 not defined."
 #endif
 
 #include <glib-object.h>

--- a/test cases/frameworks/7 gnome/gir/dep1/dep2/dep2.h
+++ b/test cases/frameworks/7 gnome/gir/dep1/dep2/dep2.h
@@ -1,8 +1,8 @@
 #ifndef MESON_DEP2_H
 #define MESON_DEP2_H
 
-#if !defined (MESON_TEST)
-#error "MESON_TEST not defined."
+#if !defined (MESON_TEST_1)
+#error "MESON_TEST_1 not defined."
 #endif
 
 #include <glib-object.h>

--- a/test cases/frameworks/7 gnome/gir/dep1/dep3/dep3.h
+++ b/test cases/frameworks/7 gnome/gir/dep1/dep3/dep3.h
@@ -1,8 +1,8 @@
 #ifndef MESON_DEP3_H
 #define MESON_DEP3_H
 
-#if !defined (MESON_TEST)
-#error "MESON_TEST not defined."
+#if !defined (MESON_TEST_1)
+#error "MESON_TEST_1 not defined."
 #endif
 
 #include <glib-object.h>

--- a/test cases/frameworks/7 gnome/gir/meson-sample.h
+++ b/test cases/frameworks/7 gnome/gir/meson-sample.h
@@ -1,8 +1,12 @@
 #ifndef MESON_SAMPLE_H
 #define MESON_SAMPLE_H
 
-#if !defined (MESON_TEST)
-#error "MESON_TEST not defined."
+#if !defined (MESON_TEST_1)
+#error "MESON_TEST_1 not defined."
+#endif
+
+#if !defined (MESON_TEST_2)
+#error "MESON_TEST_2 not defined."
 #endif
 
 #include <glib-object.h>

--- a/test cases/frameworks/7 gnome/gir/meson-sample2.h
+++ b/test cases/frameworks/7 gnome/gir/meson-sample2.h
@@ -1,8 +1,8 @@
 #ifndef MESON_SAMPLE2_H
 #define MESON_SAMPLE2_H
 
-#if !defined (MESON_TEST)
-#error "MESON_TEST not defined."
+#if !defined (MESON_TEST_1)
+#error "MESON_TEST_1 not defined."
 #endif
 
 #include <glib-object.h>

--- a/test cases/frameworks/7 gnome/gir/meson.build
+++ b/test cases/frameworks/7 gnome/gir/meson.build
@@ -14,6 +14,7 @@ gen_source = custom_target(
 girlib = shared_library(
   'gir_lib',
   sources : libsources,
+  c_args: '-DMESON_TEST_2',
   dependencies : [gobj, dep1_dep],
   install : true
 )
@@ -28,6 +29,7 @@ girlib2 = shared_library(
 girexe = executable(
   'girprog',
   sources : 'prog.c',
+  c_args: '-DMESON_TEST_2',
   dependencies : [glib, gobj, gir, dep1_dep],
   link_with : girlib
 )
@@ -37,6 +39,7 @@ fake_dep = dependency('no-way-this-exists', required: false)
 gnome.generate_gir(
   girlib, girlib2,
   sources : [libsources, lib2sources, gen_source],
+  env : {'CPPFLAGS': '-DMESON_TEST_2'},
   nsversion : '1.0',
   namespace : 'Meson',
   symbol_prefix : 'meson',

--- a/test cases/frameworks/7 gnome/meson.build
+++ b/test cases/frameworks/7 gnome/meson.build
@@ -23,7 +23,7 @@ endif
 
 cc = meson.get_compiler('c')
 
-add_global_arguments('-DMESON_TEST', language : 'c')
+add_global_arguments('-DMESON_TEST_1', language : 'c')
 if cc.get_id() == 'intel'
   # Ignore invalid GCC pragma warnings from glib
   # https://bugzilla.gnome.org/show_bug.cgi?id=776562


### PR DESCRIPTION
My mission to clean the issue tracker continues, I hope this is welcome.
This time I fixed two 6 year old issues:
Fixes #384
Fixes #1035

Without my patch, `test cases/frameworks/11 gir subproject` fails if gcc is not installed (even if e.g. clang is installed):
```
$ ninja
[7/12] Generating subprojects/mesongir/Meson-1.0.gir with a custom command (wrapped by meson to set env)
FAILED: subprojects/mesongir/Meson-1.0.gir 
env 'PKG_CONFIG_PATH=/home/volker/Sync/git/meson/test cases/frameworks/11 gir subproject/build/meson-uninstalled' /usr/bin/g-ir-scanner --quiet --no-libtool --namespace=Meson --nsversion=1.0 --warn-all --output subprojects/mesongir/Meson-1.0.gir '-I/home/volker/Sync/git/meson/test cases/frameworks/11 gir subproject/subprojects/mesongir' '-I/home/volker/Sync/git/meson/test cases/frameworks/11 gir subproject/build/subprojects/mesongir' '--filelist=/home/volker/Sync/git/meson/test cases/frameworks/11 gir subproject/build/subprojects/mesongir/libgirlib.so.p/Meson_1.0_gir_filelist' --include=GObject-2.0 --symbol-prefix=meson_ --identifier-prefix=Meson --cflags-begin -DMESON_TEST -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/sysprof-4 -I/usr/include/gobject-introspection-1.0 --cflags-end --add-include-path=/usr/share/gir-1.0 '-L/home/volker/Sync/git/meson/test cases/frameworks/11 gir subproject/build/subprojects/mesongir' --library girlib --extra-library=gobject-2.0 --extra-library=glib-2.0 --extra-library=girepository-1.0 --sources-top-dirs '/home/volker/Sync/git/meson/test cases/frameworks/11 gir subproject/subprojects/mesongir' --sources-top-dirs '/home/volker/Sync/git/meson/test cases/frameworks/11 gir subproject/build/subprojects/mesongir'
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/setuptools/_distutils/spawn.py", line 57, in spawn
    proc = subprocess.Popen(cmd, env=env)
  File "/usr/lib/python3.10/subprocess.py", line 971, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.10/subprocess.py", line 1847, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'gcc'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/setuptools/_distutils/unixccompiler.py", line 178, in preprocess
    self.spawn(pp_args)
  File "/usr/lib/python3.10/site-packages/setuptools/_distutils/ccompiler.py", line 1041, in spawn
    spawn(cmd, dry_run=self.dry_run, **kwargs)
  File "/usr/lib/python3.10/site-packages/setuptools/_distutils/spawn.py", line 63, in spawn
    raise DistutilsExecError(
distutils.errors.DistutilsExecError: command 'gcc' failed: No such file or directory

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/g-ir-scanner", line 99, in <module>
    sys.exit(scanner_main(sys.argv))
  File "/usr/lib/gobject-introspection/giscanner/scannermain.py", line 600, in scanner_main
    ss, filenames = create_source_scanner(options, args)
  File "/usr/lib/gobject-introspection/giscanner/scannermain.py", line 471, in create_source_scanner
    ss.parse_files(filenames)
  File "/usr/lib/gobject-introspection/giscanner/sourcescanner.py", line 265, in parse_files
    self._parse(headers)
  File "/usr/lib/gobject-introspection/giscanner/sourcescanner.py", line 311, in _parse
    cc.preprocess(tmp_name_cpp,
  File "/usr/lib/gobject-introspection/giscanner/ccompiler.py", line 309, in preprocess
    self.compiler.preprocess(source=source,
  File "/usr/lib/python3.10/site-packages/setuptools/_distutils/unixccompiler.py", line 180, in preprocess
    raise CompileError(msg)
distutils.errors.CompileError: command 'gcc' failed: No such file or directory
[8/12] Generating symbol file gir/libgirsubproject.so.p/libgirsubproject.so.symbols
ninja: build stopped: subcommand failed.
```
To fix this, meson now sets e.g. CC=clang for g-ir-scanner.

One argument given against setting enivronmental variables using a wrapper was that the wrapper is slow. This is corect, but we already use the wrapper for g-ir-scanner to set PKG_CONFIG_PATH. So my patch should not have a significant performance impact.

There is no need to set CFLAGS for g-ir-scanner, as meson already passes --cflags-begin ... --cflags-end to g-ir-scanner, which g-ir-scanner honours.

No fix for gtkdoc is needed, as meson already passes --cc=clang to gtkdoc and gtkdoc accepts this flag.
g-ir-scanner accepts no --cc=clang flag.

With my patch, I could build the gstreamer documentation on a machine without gcc in my path. Without my patch, I couldn't.

If you want, I can split the fix for #384 and for #1035 into two seperate commits.