### PR TITLE
Rust: Replace rust_crate_type with rust_abi

### DIFF
--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -105,3 +105,32 @@ were never turned on by Meson.
 [properties]
 bindgen_clang_arguments = ['--target', 'x86_64-linux-gnu']
 ```
+
+### proc_macro()
+
+```meson
+rustmod.proc_macro(name, sources, ...)
+```
+
+*Since 1.3.0*
+
+This function creates a Rust `proc-macro` crate, similar to:
+```meson
+[[shared_library]](name, sources,
+  rust_crate_type: 'proc-macro',
+  native: true)
+```
+
+`proc-macro` targets can be passed to `link_with` keyword argument of other Rust
+targets.
+
+Only a subset of [[shared_library]] keyword arguments are allowed:
+- rust_args
+- rust_dependency_map
+- sources
+- dependencies
+- extra_files
+- link_args
+- link_depends
+- link_with
+- override_options

--- a/docs/markdown/snippets/rust_crate_type.md
+++ b/docs/markdown/snippets/rust_crate_type.md
@@ -1,0 +1,11 @@
+## Deprecated `rust_crate_type` and replaced by `rust_abi`
+
+The new `rust_abi` keyword argument is accepted by [[shared_library]],
+[[static_library]], [[library]] and [[shared_module]] functions. It can be either
+`'rust'` (the default) or `'c'` strings.
+
+`rust_crate_type` is now deprecated because Meson already knows if it's a shared
+or static library, user only need to specify the ABI (Rust or C).
+
+`proc_macro` crates are now handled by the [`rust.proc_macro()`](Rust-module.md#proc_macro)
+method.

--- a/docs/yaml/functions/_build_target_base.yaml
+++ b/docs/yaml/functions/_build_target_base.yaml
@@ -289,6 +289,7 @@ kwargs:
   rust_crate_type:
     type: str
     since: 0.42.0
+    deprecated: 1.3.0
     description: |
       Set the specific type of rust crate to compile (when compiling rust).
 
@@ -305,6 +306,10 @@ kwargs:
       "proc-macro" is a special rust procedural macro crate.
 
       "proc-macro" is new in 0.62.0.
+
+      *Since 1.3.0* this is deprecated and replaced by "rust_abi" keyword argument.
+      `proc_macro` crates are now handled by the [`rust.proc_macro()`](Rust-module.md#proc_macro)
+      method.
 
   rust_dependency_map:
     type: dict[str]

--- a/docs/yaml/functions/library.yaml
+++ b/docs/yaml/functions/library.yaml
@@ -21,3 +21,14 @@ varargs_inherit: _build_target_base
 kwargs_inherit:
   - shared_library
   - static_library
+
+kwargs:
+  rust_abi:
+    type: str
+    since: 1.3.0
+    description: |
+      Set the specific ABI to compile (when compiling rust).
+      - 'rust' (default): Create a "rlib" or "dylib" crate depending on the library
+        type being build.
+      - 'c': Create a "cdylib" or "staticlib" crate depending on the library
+        type being build.

--- a/docs/yaml/functions/shared_library.yaml
+++ b/docs/yaml/functions/shared_library.yaml
@@ -44,3 +44,11 @@ kwargs:
     description: |
       Specify a Microsoft module definition file for controlling symbol exports,
       etc., on platforms where that is possible (e.g. Windows).
+
+  rust_abi:
+    type: str
+    since: 1.3.0
+    description: |
+      Set the specific ABI to compile (when compiling rust).
+      - 'rust' (default): Create a "dylib" crate.
+      - 'c': Create a "cdylib" crate.

--- a/docs/yaml/functions/shared_module.yaml
+++ b/docs/yaml/functions/shared_module.yaml
@@ -39,3 +39,11 @@ kwargs:
     description: |
       Specify a Microsoft module definition file for controlling symbol exports,
       etc., on platforms where that is possible (e.g. Windows).
+
+  rust_abi:
+    type: str
+    since: 1.3.0
+    description: |
+      Set the specific ABI to compile (when compiling rust).
+      - 'rust' (default): Create a "dylib" crate.
+      - 'c': Create a "cdylib" crate.

--- a/docs/yaml/functions/static_library.yaml
+++ b/docs/yaml/functions/static_library.yaml
@@ -23,3 +23,11 @@ kwargs:
       If `true` the object files in the target will be prelinked,
       meaning that it will contain only one prelinked
       object file rather than the individual object files.
+
+  rust_abi:
+    type: str
+    since: 1.3.0
+    description: |
+      Set the specific ABI to compile (when compiling rust).
+      - 'rust' (default): Create a "rlib" crate.
+      - 'c': Create a "staticlib" crate.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1937,16 +1937,7 @@ class NinjaBackend(backends.Backend):
         if main_rust_file is None:
             raise RuntimeError('A Rust target has no Rust sources. This is weird. Also a bug. Please report')
         target_name = os.path.join(target.subdir, target.get_filename())
-        if isinstance(target, build.Executable):
-            cratetype = 'bin'
-        elif hasattr(target, 'rust_crate_type'):
-            cratetype = target.rust_crate_type
-        elif isinstance(target, build.SharedLibrary):
-            cratetype = 'dylib'
-        elif isinstance(target, build.StaticLibrary):
-            cratetype = 'rlib'
-        else:
-            raise InvalidArguments('Unknown target type for rustc.')
+        cratetype = target.rust_crate_type
         args.extend(['--crate-type', cratetype])
 
         # If we're dynamically linking, add those arguments

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1951,10 +1951,9 @@ class NinjaBackend(backends.Backend):
         # Rustc replaces - with _. spaces or dots are not allowed, so we replace them with underscores
         args += ['--crate-name', target.name.replace('-', '_').replace(' ', '_').replace('.', '_')]
         depfile = os.path.join(target.subdir, target.name + '.d')
-        args += ['--emit', f'dep-info={depfile}', '--emit', 'link']
+        args += ['--emit', f'dep-info={depfile}', '--emit', f'link={target_name}']
+        args += ['--out-dir', self.get_target_private_dir(target)]
         args += target.get_extra_args('rust')
-        output = rustc.get_output_args(os.path.join(target.subdir, target.get_filename()))
-        args += output
         linkdirs = mesonlib.OrderedSet()
         external_deps = target.external_deps.copy()
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1474,7 +1474,7 @@ class BuildTarget(Target):
         links_with_rust_abi = isinstance(t, BuildTarget) and t.uses_rust_abi()
         if not self.uses_rust() and links_with_rust_abi:
             raise InvalidArguments(f'Try to link Rust ABI library {t.name!r} with a non-Rust target {self.name!r}')
-        if self.for_machine is not t.for_machine:
+        if self.for_machine is not t.for_machine and (not links_with_rust_abi or t.rust_crate_type != 'proc-macro'):
             msg = f'Tried to mix libraries for machines {self.for_machine} and {t.for_machine} in target {self.name!r}'
             if self.environment.is_cross_build():
                 raise InvalidArguments(msg + ' This is not possible in a cross build.')

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3247,6 +3247,10 @@ class Interpreter(InterpreterBase, HoldableObject):
 
         name, sources = args
         for_machine = self.machine_from_native_kwarg(kwargs)
+        if kwargs.get('rust_crate_type') == 'proc-macro':
+            # Silently force to native because that's the only sensible value
+            # and rust_crate_type is deprecated any way.
+            for_machine = MachineChoice.BUILD
         if 'sources' in kwargs:
             sources += listify(kwargs['sources'])
         if any(isinstance(s, build.BuildTarget) for s in sources):

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3206,6 +3206,10 @@ class Interpreter(InterpreterBase, HoldableObject):
             # Feel free to submit patches to get this fixed if it is an
             # issue for you.
             reuse_object_files = False
+        elif shared_lib.uses_rust():
+            # FIXME: rustc supports generating both libraries in a single invocation,
+            # but for now compile twice.
+            reuse_object_files = False
         else:
             reuse_object_files = static_lib.pic
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -90,6 +90,7 @@ from .type_checking import (
     SHARED_LIB_KWS,
     SHARED_MOD_KWS,
     SOURCES_KW,
+    SOURCES_VARARGS,
     STATIC_LIB_KWS,
     VARIABLES_KW,
     TEST_KWS,
@@ -121,6 +122,7 @@ if T.TYPE_CHECKING:
     from ..backend.backends import Backend
     from ..interpreterbase.baseobjects import InterpreterObject, TYPE_var, TYPE_kwargs
     from ..programs import OverrideProgram
+    from .type_checking import SourcesVarargsType
 
     # Input source types passed to Targets
     SourceInputs = T.Union[mesonlib.File, build.GeneratedList, build.BuildTarget, build.BothLibraries,
@@ -1820,58 +1822,58 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     @FeatureNewKwargs('executable', '0.42.0', ['implib'])
     @permittedKwargs(build.known_exe_kwargs)
-    @typed_pos_args('executable', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.StructuredSources, build.ExtractedObjects, build.BuildTarget))
+    @typed_pos_args('executable', str, varargs=SOURCES_VARARGS)
     @typed_kwargs('executable', *EXECUTABLE_KWS, allow_unknown=True)
     def func_executable(self, node: mparser.BaseNode,
-                        args: T.Tuple[str, T.List[BuildTargetSource]],
+                        args: T.Tuple[str, SourcesVarargsType],
                         kwargs: kwtypes.Executable) -> build.Executable:
         return self.build_target(node, args, kwargs, build.Executable)
 
     @permittedKwargs(build.known_stlib_kwargs)
-    @typed_pos_args('static_library', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.StructuredSources, build.ExtractedObjects, build.BuildTarget))
+    @typed_pos_args('static_library', str, varargs=SOURCES_VARARGS)
     @typed_kwargs('static_library', *STATIC_LIB_KWS, allow_unknown=True)
     def func_static_lib(self, node: mparser.BaseNode,
-                        args: T.Tuple[str, T.List[BuildTargetSource]],
+                        args: T.Tuple[str, SourcesVarargsType],
                         kwargs: kwtypes.StaticLibrary) -> build.StaticLibrary:
         return self.build_target(node, args, kwargs, build.StaticLibrary)
 
     @permittedKwargs(build.known_shlib_kwargs)
-    @typed_pos_args('shared_library', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.StructuredSources, build.ExtractedObjects, build.BuildTarget))
+    @typed_pos_args('shared_library', str, varargs=SOURCES_VARARGS)
     @typed_kwargs('shared_library', *SHARED_LIB_KWS, allow_unknown=True)
     def func_shared_lib(self, node: mparser.BaseNode,
-                        args: T.Tuple[str, T.List[BuildTargetSource]],
+                        args: T.Tuple[str, SourcesVarargsType],
                         kwargs: kwtypes.SharedLibrary) -> build.SharedLibrary:
         holder = self.build_target(node, args, kwargs, build.SharedLibrary)
         holder.shared_library_only = True
         return holder
 
     @permittedKwargs(known_library_kwargs)
-    @typed_pos_args('both_libraries', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.StructuredSources, build.ExtractedObjects, build.BuildTarget))
+    @typed_pos_args('both_libraries', str, varargs=SOURCES_VARARGS)
     @typed_kwargs('both_libraries', *LIBRARY_KWS, allow_unknown=True)
     def func_both_lib(self, node: mparser.BaseNode,
-                      args: T.Tuple[str, T.List[BuildTargetSource]],
+                      args: T.Tuple[str, SourcesVarargsType],
                       kwargs: kwtypes.Library) -> build.BothLibraries:
         return self.build_both_libraries(node, args, kwargs)
 
     @FeatureNew('shared_module', '0.37.0')
     @permittedKwargs(build.known_shmod_kwargs)
-    @typed_pos_args('shared_module', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.StructuredSources, build.ExtractedObjects, build.BuildTarget))
+    @typed_pos_args('shared_module', str, varargs=SOURCES_VARARGS)
     @typed_kwargs('shared_module', *SHARED_MOD_KWS, allow_unknown=True)
     def func_shared_module(self, node: mparser.BaseNode,
-                           args: T.Tuple[str, T.List[BuildTargetSource]],
+                           args: T.Tuple[str, SourcesVarargsType],
                            kwargs: kwtypes.SharedModule) -> build.SharedModule:
         return self.build_target(node, args, kwargs, build.SharedModule)
 
     @permittedKwargs(known_library_kwargs)
-    @typed_pos_args('library', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.StructuredSources, build.ExtractedObjects, build.BuildTarget))
+    @typed_pos_args('library', str, varargs=SOURCES_VARARGS)
     @typed_kwargs('library', *LIBRARY_KWS, allow_unknown=True)
     def func_library(self, node: mparser.BaseNode,
-                     args: T.Tuple[str, T.List[BuildTargetSource]],
+                     args: T.Tuple[str, SourcesVarargsType],
                      kwargs: kwtypes.Library) -> build.Executable:
         return self.build_library(node, args, kwargs)
 
     @permittedKwargs(build.known_jar_kwargs)
-    @typed_pos_args('jar', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.ExtractedObjects, build.BuildTarget))
+    @typed_pos_args('jar', str, varargs=SOURCES_VARARGS)
     @typed_kwargs('jar', *JAR_KWS, allow_unknown=True)
     def func_jar(self, node: mparser.BaseNode,
                  args: T.Tuple[str, T.List[T.Union[str, mesonlib.File, build.GeneratedTypes]]],
@@ -1880,10 +1882,10 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     @FeatureNewKwargs('build_target', '0.40.0', ['link_whole', 'override_options'])
     @permittedKwargs(known_build_target_kwargs)
-    @typed_pos_args('build_target', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.StructuredSources, build.ExtractedObjects, build.BuildTarget))
+    @typed_pos_args('build_target', str, varargs=SOURCES_VARARGS)
     @typed_kwargs('build_target', *BUILD_TARGET_KWS, allow_unknown=True)
     def func_build_target(self, node: mparser.BaseNode,
-                          args: T.Tuple[str, T.List[BuildTargetSource]],
+                          args: T.Tuple[str, SourcesVarargsType],
                           kwargs: kwtypes.BuildTarget
                           ) -> T.Union[build.Executable, build.StaticLibrary, build.SharedLibrary,
                                        build.SharedModule, build.BothLibraries, build.Jar]:

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -498,6 +498,21 @@ TEST_KWS: T.List[KwargInfo] = [
     KwargInfo('verbose', bool, default=False, since='0.62.0'),
 ]
 
+# Cannot have a default value because we need to check that rust_crate_type and
+# rust_abi are mutually exclusive.
+RUST_CRATE_TYPE_KW: KwargInfo[T.Union[str, None]] = KwargInfo(
+    'rust_crate_type', (str, NoneType),
+    since='0.42.0',
+    since_values={'proc-macro': '0.62.0'},
+    deprecated='1.3.0',
+    deprecated_message='Use rust_abi or rust.proc_macro() instead.',
+    validator=in_set_validator({'bin', 'lib', 'rlib', 'dylib', 'cdylib', 'staticlib', 'proc-macro'}))
+
+RUST_ABI_KW: KwargInfo[T.Union[str, None]] = KwargInfo(
+    'rust_abi', (str, NoneType),
+    since='1.3.0',
+    validator=in_set_validator({'rust', 'c'}))
+
 # Applies to all build_target like classes
 _ALL_TARGET_KWS: T.List[KwargInfo] = [
     OVERRIDE_OPTIONS_KW,
@@ -506,6 +521,7 @@ _ALL_TARGET_KWS: T.List[KwargInfo] = [
 # Applies to all build_target classes except jar
 _BUILD_TARGET_KWS: T.List[KwargInfo] = [
     *_ALL_TARGET_KWS,
+    RUST_CRATE_TYPE_KW,
 ]
 
 def _validate_win_subsystem(value: T.Optional[str]) -> T.Optional[str]:
@@ -575,6 +591,11 @@ EXECUTABLE_KWS = [
     *_EXCLUSIVE_EXECUTABLE_KWS,
 ]
 
+# Arguments exclusive to library types
+_EXCLUSIVE_LIB_KWS: T.List[KwargInfo] = [
+    RUST_ABI_KW,
+]
+
 # Arguments exclusive to StaticLibrary. These are separated to make integrating
 # them into build_target easier
 _EXCLUSIVE_STATIC_LIB_KWS: T.List[KwargInfo] = []
@@ -583,6 +604,7 @@ _EXCLUSIVE_STATIC_LIB_KWS: T.List[KwargInfo] = []
 STATIC_LIB_KWS = [
     *_BUILD_TARGET_KWS,
     *_EXCLUSIVE_STATIC_LIB_KWS,
+    *_EXCLUSIVE_LIB_KWS,
 ]
 
 # Arguments exclusive to SharedLibrary. These are separated to make integrating
@@ -597,6 +619,7 @@ _EXCLUSIVE_SHARED_LIB_KWS: T.List[KwargInfo] = [
 SHARED_LIB_KWS = [
     *_BUILD_TARGET_KWS,
     *_EXCLUSIVE_SHARED_LIB_KWS,
+    *_EXCLUSIVE_LIB_KWS,
 ]
 
 # Arguments exclusive to SharedModule. These are separated to make integrating
@@ -607,6 +630,7 @@ _EXCLUSIVE_SHARED_MOD_KWS: T.List[KwargInfo] = []
 SHARED_MOD_KWS = [
     *_BUILD_TARGET_KWS,
     *_EXCLUSIVE_SHARED_MOD_KWS,
+    *_EXCLUSIVE_LIB_KWS,
 ]
 
 # Arguments exclusive to JAR. These are separated to make integrating
@@ -625,6 +649,7 @@ JAR_KWS = [
 # Arguments used by both_library and library
 LIBRARY_KWS = [
     *_BUILD_TARGET_KWS,
+    *_EXCLUSIVE_LIB_KWS,
     *_EXCLUSIVE_SHARED_LIB_KWS,
     *_EXCLUSIVE_SHARED_MOD_KWS,
     *_EXCLUSIVE_STATIC_LIB_KWS,

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -30,6 +30,7 @@ if T.TYPE_CHECKING:
 
     _FullEnvInitValueType = T.Union[EnvironmentVariables, T.List[str], T.List[T.List[str]], EnvInitValueType, str, None]
     PkgConfigDefineType = T.Optional[T.Tuple[str, str]]
+    SourcesVarargsType = T.List[T.Union[str, File, CustomTarget, CustomTargetIndex, GeneratedList, StructuredSources, ExtractedObjects, BuildTarget]]
 
 
 def in_set_validator(choices: T.Set[str]) -> T.Callable[[str], T.Optional[str]]:
@@ -463,6 +464,8 @@ SOURCES_KW: KwargInfo[T.List[T.Union[str, File, CustomTarget, CustomTargetIndex,
     listify=True,
     default=[],
 )
+
+SOURCES_VARARGS = (str, File, CustomTarget, CustomTargetIndex, GeneratedList, StructuredSources, ExtractedObjects, BuildTarget)
 
 VARIABLES_KW: KwargInfo[T.Dict[str, str]] = KwargInfo(
     'variables',

--- a/test cases/failing/53 wrong shared crate type/meson.build
+++ b/test cases/failing/53 wrong shared crate type/meson.build
@@ -1,7 +1,0 @@
-project('test')
-
-if not add_languages('rust', required: false)
-  error('MESON_SKIP_TEST test requires rust compiler')
-endif
-
-shared_library('mytest', 'foo.rs', rust_crate_type : 'staticlib')

--- a/test cases/failing/53 wrong shared crate type/test.json
+++ b/test cases/failing/53 wrong shared crate type/test.json
@@ -1,7 +1,0 @@
-{
-  "stdout": [
-    {
-      "line": "test cases/failing/53 wrong shared crate type/meson.build:7:0: ERROR: Crate type \"staticlib\" invalid for dynamic libraries; must be \"dylib\", \"cdylib\", or \"proc-macro\""
-    }
-  ]
-}

--- a/test cases/failing/54 wrong static crate type/meson.build
+++ b/test cases/failing/54 wrong static crate type/meson.build
@@ -1,7 +1,0 @@
-project('test')
-
-if not add_languages('rust', required: false)
-  error('MESON_SKIP_TEST test requires rust compiler')
-endif
-
-static_library('mytest', 'foo.rs', rust_crate_type : 'cdylib')

--- a/test cases/failing/54 wrong static crate type/test.json
+++ b/test cases/failing/54 wrong static crate type/test.json
@@ -1,7 +1,0 @@
-{
-  "stdout": [
-    {
-      "line": "test cases/failing/54 wrong static crate type/meson.build:7:0: ERROR: Crate type \"cdylib\" invalid for static libraries; must be \"rlib\" or \"staticlib\""
-    }
-  ]
-}

--- a/test cases/rust/18 proc-macro/meson.build
+++ b/test cases/rust/18 proc-macro/meson.build
@@ -18,3 +18,16 @@ main = executable(
 )
 
 test('main_test', main)
+
+rust = import('rust')
+
+pm = rust.proc_macro('proc_macro_examples2', 'proc.rs')
+
+main = executable(
+  'main2',
+  'use.rs',
+  link_with : pm,
+  rust_dependency_map : {'proc_macro_examples2' : 'proc_macro_examples'}
+)
+
+test('main_test2', main)

--- a/test cases/rust/4 polyglot/meson.build
+++ b/test cases/rust/4 polyglot/meson.build
@@ -47,8 +47,9 @@ foreach crate_type : ['lib', 'rlib', 'dylib', 'cdylib', 'staticlib', 'proc-macro
         install: true)
       test(f'polyglottest-@name@', e)
     else
-      # FIXME: Verify that linking Rust ABI with C ABI executable raises an error.
-      # Currently it only fails at build time.
+      testcase expect_error('Try to link Rust ABI library .*', how: 're')
+        executable(f'prog-@name@', 'prog.c', link_with: l)
+      endtestcase
     endif
   endforeach
 endforeach

--- a/test cases/rust/4 polyglot/meson.build
+++ b/test cases/rust/4 polyglot/meson.build
@@ -4,6 +4,51 @@ if host_machine.system() == 'darwin'
   error('MESON_SKIP_TEST: does not work right on macos, please fix!')
 endif
 
-l = shared_library('stuff', 'stuff.rs', rust_crate_type: 'cdylib', install : true)
-e = executable('prog', 'prog.c', link_with : l, install : true)
-test('polyglottest', e)
+cc = meson.get_compiler('c')
+
+# Test all combinations of crate and target types.
+# - 'clib' gets translated to `rust_abi: 'c'` instead.
+# - '' gets translated to no kwargs.
+allowed_map = {
+  'static_library': ['rlib', 'staticlib', 'lib', 'clib', ''],
+  'shared_library': ['dylib', 'cdylib', 'lib', 'proc-macro', 'clib', ''],
+  'both_libraries': ['lib', 'clib', ''],
+}
+foreach crate_type : ['lib', 'rlib', 'dylib', 'cdylib', 'staticlib', 'proc-macro', 'clib', '', 'invalid']
+  foreach target_type, allowed : allowed_map
+    name = f'stuff_@crate_type@_@target_type@'.underscorify()
+    src = crate_type == 'proc-macro' ? 'proc.rs' : 'stuff.rs'
+    if crate_type not in allowed
+      # Note: in the both_libraries() case it is possible that the static part
+      # is still being built because the shared part raised an error but we
+      # don't rollback correctly.
+      testcase expect_error('(Crate type .* invalid for .*)|(.*must be one of.*not invalid)', how: 're')
+        build_target(name, src,
+          target_type: target_type,
+          rust_crate_type: crate_type,
+          install: true)
+      endtestcase
+      continue
+    endif
+    rust_kwargs = {}
+    if crate_type == 'clib'
+      rust_kwargs = {'rust_abi': 'c'}
+    elif crate_type != ''
+      rust_kwargs = {'rust_crate_type': crate_type}
+    endif
+    l = build_target(name, src,
+      target_type: target_type,
+      kwargs: rust_kwargs,
+      install: true)
+    if crate_type in ['cdylib', 'staticlib', 'clib']
+      e = executable(f'prog-@name@', 'prog.c',
+        link_with: l,
+        rust_dependency_map: {name: 'stuff'},
+        install: true)
+      test(f'polyglottest-@name@', e)
+    else
+      # FIXME: Verify that linking Rust ABI with C ABI executable raises an error.
+      # Currently it only fails at build time.
+    endif
+  endforeach
+endforeach

--- a/test cases/rust/4 polyglot/proc.rs
+++ b/test cases/rust/4 polyglot/proc.rs
@@ -1,0 +1,7 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+#[proc_macro]
+pub fn make_answer(_item: TokenStream) -> TokenStream {
+    "fn answer() -> u32 { 42 }".parse().unwrap()
+}

--- a/test cases/rust/4 polyglot/stuff.rs
+++ b/test cases/rust/4 polyglot/stuff.rs
@@ -1,5 +1,3 @@
-#![crate_name = "stuff"]
-
 #[no_mangle]
 pub extern fn f() {
     println!("Hello from Rust!");

--- a/test cases/rust/4 polyglot/test.json
+++ b/test cases/rust/4 polyglot/test.json
@@ -1,10 +1,92 @@
 {
   "installed": [
-    {"type": "exe", "file": "usr/bin/prog"},
-    {"type": "pdb", "file": "usr/bin/prog"},
-    {"type": "file", "platform": "gcc", "file": "usr/lib/libstuff.so"},
-    {"type": "file", "platform": "msvc", "file": "usr/bin/stuff.dll"},
-    {"type": "file", "platform": "msvc", "file": "usr/lib/stuff.dll.lib"},
-    {"type": "pdb", "file": "usr/bin/stuff"}
+    {"type": "exe", "file": "usr/bin/prog-stuff_clib_both_libraries"},
+    {"type": "pdb", "file": "usr/bin/prog-stuff_clib_both_libraries"},
+    {"type": "pdb",  "file": "usr/bin/stuff_clib_both_libraries.pdb"},
+    {"type": "file", "platform": "gcc", "file": "usr/lib/libstuff_clib_both_libraries.so"},
+    {"type": "file", "platform": "msvc", "file": "usr/bin/stuff_clib_both_libraries.dll"},
+    {"type": "file", "platform": "msvc", "file": "usr/lib/stuff_clib_both_libraries.dll.lib"},
+    {"type": "file", "file": "usr/lib/libstuff_clib_both_libraries.a"},
+
+    {"type": "exe", "file": "usr/bin/prog-stuff_clib_shared_library"},
+    {"type": "pdb", "file": "usr/bin/prog-stuff_clib_shared_library"},
+    {"type": "pdb",  "file": "usr/bin/stuff_clib_shared_library.pdb"},
+    {"type": "file", "platform": "gcc", "file": "usr/lib/libstuff_clib_shared_library.so"},
+    {"type": "file", "platform": "msvc", "file": "usr/bin/stuff_clib_shared_library.dll"},
+    {"type": "file", "platform": "msvc", "file": "usr/lib/stuff_clib_shared_library.dll.lib"},
+
+    {"type": "exe", "file": "usr/bin/prog-stuff_clib_static_library"},
+    {"type": "pdb", "file": "usr/bin/prog-stuff_clib_static_library"},
+    {"type": "file", "file": "usr/lib/libstuff_clib_static_library.a"},
+
+    {"type": "exe", "file": "usr/bin/prog-stuff_cdylib_shared_library"},
+    {"type": "pdb", "file": "usr/bin/prog-stuff_cdylib_shared_library"},
+    {"type": "pdb",  "file": "usr/bin/stuff_cdylib_shared_library.pdb"},
+    {"type": "file", "platform": "gcc", "file": "usr/lib/libstuff_cdylib_shared_library.so"},
+    {"type": "file", "platform": "msvc", "file": "usr/bin/stuff_cdylib_shared_library.dll"},
+    {"type": "file", "platform": "msvc", "file": "usr/lib/stuff_cdylib_shared_library.dll.lib"},
+
+    {"type": "exe", "file": "usr/bin/prog-stuff_staticlib_static_library"},
+    {"type": "pdb", "file": "usr/bin/prog-stuff_staticlib_static_library"},
+    {"type": "file", "file": "usr/lib/libstuff_staticlib_static_library.a"},
+
+    {"type": "pdb",  "file": "usr/bin/stuff__both_libraries.pdb"},
+    {"type": "file", "platform": "gcc", "file": "usr/lib/libstuff__both_libraries.so"},
+    {"type": "file", "platform": "gcc", "file": "usr/lib/libstuff__both_libraries.rlib"},
+    {"type": "file", "platform": "msvc", "file": "usr/lib/libstuff__both_libraries.rlib"},
+    {"type": "file", "platform": "msvc", "file": "usr/bin/stuff__both_libraries.dll"},
+    {"type": "file", "platform": "msvc", "file": "usr/lib/stuff__both_libraries.dll.lib"},
+
+    {"type": "file", "platform": "gcc", "file": "usr/lib/libstuff__static_library.rlib"},
+    {"type": "file", "platform": "msvc", "file": "usr/lib/libstuff__static_library.rlib"},
+
+    {"type": "pdb",  "file": "usr/bin/stuff_proc_macro_shared_library.pdb"},
+    {"type": "file", "platform": "gcc", "file": "usr/lib/libstuff_proc_macro_shared_library.so"},
+    {"type": "file", "platform": "msvc", "file": "usr/bin/stuff_proc_macro_shared_library.dll"},
+    {"type": "file", "platform": "msvc", "file": "usr/lib/stuff_proc_macro_shared_library.dll.lib"},
+
+    {"type": "pdb",  "file": "usr/bin/stuff_lib_both_libraries.pdb"},
+    {"type": "file", "platform": "gcc", "file": "usr/lib/libstuff_lib_both_libraries.rlib"},
+    {"type": "file", "platform": "gcc", "file": "usr/lib/libstuff_lib_both_libraries.so"},
+    {"type": "file", "platform": "msvc", "file": "usr/bin/stuff_lib_both_libraries.dll"},
+    {"type": "file", "platform": "msvc", "file": "usr/lib/libstuff_lib_both_libraries.rlib"},
+    {"type": "file", "platform": "msvc", "file": "usr/lib/stuff_lib_both_libraries.dll.lib"},
+
+    {"type": "file", "platform": "gcc", "file": "usr/lib/libstuff_rlib_static_library.rlib"},
+    {"type": "file", "platform": "msvc", "file": "usr/lib/libstuff_rlib_static_library.rlib"},
+
+    {"type": "file", "platform": "gcc", "file": "usr/lib/libstuff_lib_static_library.rlib"},
+    {"type": "file", "platform": "msvc", "file": "usr/lib/libstuff_lib_static_library.rlib"},
+
+    {"type": "pdb",  "file": "usr/bin/stuff__shared_library.pdb"},
+    {"type": "file", "platform": "gcc", "file": "usr/lib/libstuff__shared_library.so"},
+    {"type": "file", "platform": "msvc", "file": "usr/bin/stuff__shared_library.dll"},
+    {"type": "file", "platform": "msvc", "file": "usr/lib/stuff__shared_library.dll.lib"},
+
+    {"type": "pdb",  "file": "usr/bin/stuff_lib_shared_library.pdb"},
+    {"type": "file", "platform": "gcc", "file": "usr/lib/libstuff_lib_shared_library.so"},
+    {"type": "file", "platform": "msvc", "file": "usr/bin/stuff_lib_shared_library.dll"},
+    {"type": "file", "platform": "msvc", "file": "usr/lib/stuff_lib_shared_library.dll.lib"},
+
+    {"type": "pdb",  "file": "usr/bin/stuff_dylib_shared_library.pdb"},
+    {"type": "file", "platform": "gcc", "file": "usr/lib/libstuff_dylib_shared_library.so"},
+    {"type": "file", "platform": "msvc", "file": "usr/lib/stuff_dylib_shared_library.dll.lib"},
+    {"type": "file", "platform": "msvc", "file": "usr/bin/stuff_dylib_shared_library.dll"},
+
+    {"type": "pdb",  "file": "usr/bin/stuff_cdylib_both_libraries.pdb"},
+    {"type": "file", "platform": "gcc", "file": "usr/lib/libstuff_cdylib_both_libraries.so"},
+    {"type": "file", "platform": "gcc", "file": "usr/lib/libstuff_cdylib_both_libraries.so"},
+    {"type": "file", "platform": "msvc", "file": "usr/bin/stuff_cdylib_both_libraries.dll"},
+    {"type": "file", "platform": "msvc", "file": "usr/lib/stuff_cdylib_both_libraries.dll.lib"},
+
+    {"type": "pdb",  "file": "usr/bin/stuff_proc_macro_both_libraries.pdb"},
+    {"type": "file", "platform": "gcc", "file": "usr/lib/libstuff_proc_macro_both_libraries.so"},
+    {"type": "file", "platform": "msvc", "file": "usr/bin/stuff_proc_macro_both_libraries.dll"},
+    {"type": "file", "platform": "msvc", "file": "usr/lib/stuff_proc_macro_both_libraries.dll.lib"},
+
+    {"type": "pdb",  "file": "usr/bin/stuff_dylib_both_libraries.pdb"},
+    {"type": "file", "platform": "gcc", "file": "usr/lib/libstuff_dylib_both_libraries.so"},
+    {"type": "file", "platform": "msvc", "file": "usr/bin/stuff_dylib_both_libraries.dll"},
+    {"type": "file", "platform": "msvc", "file": "usr/lib/stuff_dylib_both_libraries.dll.lib"}
   ]
 }


### PR DESCRIPTION
-    Rust: Fix both_libraries() case
    
    Rustc does not produce object files we can reuse to build both
    libraries. Ideally this should be done with a single target that has
    both `--crate-type` arguments instead of having 2 different build rules.
    
    As temporary workaround, build twice and ensure they don't get conflicts
    in intermediary files created by rustc by passing target's private
    directory as --out-dir.
    
    See https://github.com/rust-lang/rust/issues/111083.

-    Rust: Use Popen_safe_logged in sanity checks

-    Rust: Fix proc-macro usage when cross compiling
    
    Force BUILD machine and allow to link with HOST machine.

-    Rust: Prevent linking Rust ABI with C library/executable

-    Rust: Remove unit test already covered in "rust/4 polyglot"

-    Rust: Replace rust_crate_type with rust_abi
    
    Meson already knows if it's a shared or static library, user only need
    to specify the ABI (Rust or C).

-    Rust: Add a rust.proc_macro() method

-    interpreter: Use common definition for sources type

-    interpreter: Allow regex matching in expect_error()
