### PR TITLE
rust: Treat cdylib/staticlib like a normal C lib for whole_link_targe…

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1977,7 +1977,7 @@ class NinjaBackend(backends.Backend):
 
         for d in target.link_whole_targets:
             linkdirs.add(d.subdir)
-            if d.uses_rust():
+            if d.uses_rust() and d.rust_crate_type not in ['staticlib', 'cdylib']:
                 # specify `extern CRATE_NAME=OUTPUT_FILE` for each Rust
                 # dependency, so that collisions with libraries in rustc's
                 # sysroot don't cause ambiguity


### PR DESCRIPTION
…t too

----

This case was missed in https://github.com/mesonbuild/meson/pull/11676

CC @dcbaker @nirbheek