### PR TITLE
rust: Don't Link non-cdylib/staticlib Rust libraries into non-Rust ta…

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1288,7 +1288,7 @@ class BuildTarget(Target):
             if t in transitive_deps or t in exclude:
                 continue
             transitive_deps.append(t)
-            if isinstance(t, StaticLibrary):
+            if isinstance(t, StaticLibrary) and (not t.uses_rust() or t.rust_crate_type == 'rlib'):
                 transitive_deps += t.get_dependencies(transitive_deps + exclude)
         return transitive_deps
 


### PR DESCRIPTION
Fixes https://github.com/mesonbuild/meson/issues/11721

----

CC @dcbaker @xclaesse 

This is probably wrong but not sure at which other place this should be. This seems to work though.

Another option would be

```diff
diff --git a/mesonbuild/backend/backends.py b/mesonbuild/backend/backends.py
index 4972eabad..3c2137b78 100644
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1034,6 +1034,8 @@ class Backend:
         for d in deps:
             if not d.is_linkable_target():
                 raise RuntimeError(f'Tried to link with a non-library target "{d.get_basename()}".')
+            if d.uses_rust() and d.rust_crate_type not in {'staticlib', 'cdylib'}:
+                continue
             arg = self.get_target_filename_for_linking(d)
             if not arg:
                 continue
```