### PR TITLE
Allow to fallback to cmake subproject

### DIFF
--- a/docs/markdown/Wrap-dependency-system-manual.md
+++ b/docs/markdown/Wrap-dependency-system-manual.md
@@ -87,6 +87,10 @@ previously reserved to `wrap-file`:
   `subprojects/packagefiles`.
 - `diff_files` - *Since 0.63.0* Comma-separated list of local diff files (see
   [Diff files](#diff-files) below).
+- `method` - *Since 1.3.0* The build system used by this subproject. Defaults to `meson`.
+  Supported methods:
+  - `meson` requires `meson.build` file.
+  - `cmake` requires `CMakeLists.txt` file. [See details](#cmake-wraps).
 
 ### Specific to wrap-file
 - `source_url` - download url to retrieve the wrap-file source archive
@@ -289,6 +293,26 @@ program_names = myprog, otherprog
 With such wrap file, `find_program('myprog')` will automatically
 fallback to use the subproject, assuming it uses
 `meson.override_find_program('myprog')`.
+
+### CMake wraps
+
+Since the CMake module does not know the public name of the provided
+dependencies, a CMake `.wrap` file cannot use the `dependency_names = foo`
+syntax. Instead, the `dep_name = <target_name>_dep` syntax should be used, where
+`<target_name>` is the name of a CMake library with all non alphanumeric
+characters replaced by underscores `_`.
+
+For example, a CMake project that contains `add_library(foo-bar ...)` in its
+`CMakeList.txt` and that applications would usually find using the dependency
+name `foo-bar-1.0` (e.g. via pkg-config) would have a wrap file like this:
+
+```ini
+[wrap-file]
+...
+method = cmake
+[provide]
+foo-bar-1.0 = foo_bar_dep
+```
 
 ## Using wrapped projects
 

--- a/docs/markdown/snippets/wrap.md
+++ b/docs/markdown/snippets/wrap.md
@@ -1,0 +1,12 @@
+## Automatic fallback to `cmake` subproject
+
+CMake subprojects have been supported for a while using the `cmake.subproject()`
+module method. However until now it was not possible to use a CMake subproject
+as fallback in a `dependency()` call.
+
+A wrap file can now specify the method used to build it by setting the `method`
+key in the wrap file's first section. The method defaults to `meson`.
+
+Supported methods:
+- `meson` requires `meson.build` file.
+- `cmake` requires `CMakeLists.txt` file. [See details](Wrap-dependency-system-manual.md#cmake-wraps).

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -56,7 +56,6 @@ if T.TYPE_CHECKING:
     from .common import CMakeConfiguration, TargetOptions
     from .traceparser import CMakeGeneratorTarget
     from .._typing import ImmutableListProtocol
-    from ..build import Build
     from ..backend.backends import Backend
     from ..environment import Environment
 
@@ -766,10 +765,9 @@ class ConverterCustomTarget:
         mlog.log('  -- depends:      ', mlog.bold(str(self.depends)))
 
 class CMakeInterpreter:
-    def __init__(self, build: 'Build', subdir: Path, src_dir: Path, install_prefix: Path, env: 'Environment', backend: 'Backend'):
-        self.build = build
+    def __init__(self, subdir: Path, install_prefix: Path, env: 'Environment', backend: 'Backend'):
         self.subdir = subdir
-        self.src_dir = src_dir
+        self.src_dir = Path(env.get_source_dir(), subdir)
         self.build_dir_rel = subdir / '__CMake_build'
         self.build_dir = Path(env.get_build_dir()) / self.build_dir_rel
         self.install_prefix = install_prefix

--- a/mesonbuild/interpreter/dependencyfallbacks.py
+++ b/mesonbuild/interpreter/dependencyfallbacks.py
@@ -127,7 +127,7 @@ class DependencyFallbacksHolder(MesonInterpreterObject):
         func_kwargs.setdefault('version', [])
         if 'default_options' in kwargs and isinstance(kwargs['default_options'], str):
             func_kwargs['default_options'] = listify(kwargs['default_options'])
-        self.interpreter.do_subproject(subp_name, 'meson', func_kwargs)
+        self.interpreter.do_subproject(subp_name, func_kwargs)
         return self._get_subproject_dep(subp_name, varname, kwargs)
 
     def _get_subproject(self, subp_name: str) -> T.Optional[SubprojectHolder]:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -919,7 +919,6 @@ class Interpreter(InterpreterBase, HoldableObject):
                 return self.disabled_subproject(subp_name, exception=e)
             raise e
 
-        subdir_abs = os.path.join(self.environment.get_source_dir(), subdir)
         os.makedirs(os.path.join(self.build.environment.get_build_dir(), subdir), exist_ok=True)
         self.global_args_frozen = True
 
@@ -933,7 +932,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             if method == 'meson':
                 return self._do_subproject_meson(subp_name, subdir, default_options, kwargs)
             elif method == 'cmake':
-                return self._do_subproject_cmake(subp_name, subdir, subdir_abs, default_options, kwargs)
+                return self._do_subproject_cmake(subp_name, subdir, default_options, kwargs)
             else:
                 raise mesonlib.MesonBugException(f'The method {method} is invalid for the subproject {subp_name}')
         # Invalid code is always an error
@@ -998,18 +997,17 @@ class Interpreter(InterpreterBase, HoldableObject):
         self.build.subprojects[subp_name] = subi.project_version
         return self.subprojects[subp_name]
 
-    def _do_subproject_cmake(self, subp_name: str, subdir: str, subdir_abs: str,
+    def _do_subproject_cmake(self, subp_name: str, subdir: str,
                              default_options: T.Dict[OptionKey, str],
                              kwargs: kwtypes.DoSubproject) -> SubprojectHolder:
         from ..cmake import CMakeInterpreter
         with mlog.nested(subp_name):
-            new_build = self.build.copy()
             prefix = self.coredata.options[OptionKey('prefix')].value
 
             from ..modules.cmake import CMakeSubprojectOptions
             options = kwargs.get('options') or CMakeSubprojectOptions()
             cmake_options = kwargs.get('cmake_options', []) + options.cmake_options
-            cm_int = CMakeInterpreter(new_build, Path(subdir), Path(subdir_abs), Path(prefix), new_build.environment, self.backend)
+            cm_int = CMakeInterpreter(Path(subdir), Path(prefix), self.build.environment, self.backend)
             cm_int.initialise(cmake_options)
             cm_int.analyse()
 

--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -435,7 +435,7 @@ class CmakeModule(ExtensionModule):
             'default_options': {},
             'version': [],
         }
-        subp = self.interpreter.do_subproject(dirname, 'cmake', kw)
+        subp = self.interpreter.do_subproject(dirname, kw, force_method='cmake')
         if not subp.found():
             return subp
         return CMakeSubproject(subp)

--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -189,7 +189,7 @@ class Runner:
             # cached.
             windows_proof_rmtree(self.repo_dir)
             try:
-                self.wrap_resolver.resolve(self.wrap.name, 'meson')
+                self.wrap_resolver.resolve(self.wrap.name)
                 self.log('  -> New version extracted')
                 return True
             except WrapException as e:
@@ -292,7 +292,7 @@ class Runner:
                 # Delete existing directory and redownload
                 windows_proof_rmtree(self.repo_dir)
                 try:
-                    self.wrap_resolver.resolve(self.wrap.name, 'meson')
+                    self.wrap_resolver.resolve(self.wrap.name)
                     self.update_git_done()
                     return True
                 except WrapException as e:
@@ -464,7 +464,7 @@ class Runner:
             self.log('  -> Already downloaded')
             return True
         try:
-            self.wrap_resolver.resolve(self.wrap.name, 'meson')
+            self.wrap_resolver.resolve(self.wrap.name)
             self.log('  -> done')
         except WrapException as e:
             self.log('  ->', mlog.red(str(e)))

--- a/test cases/cmake/26 dependency fallback/main.cpp
+++ b/test cases/cmake/26 dependency fallback/main.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+#include <cmMod.hpp>
+
+using namespace std;
+
+int main(void) {
+  cmModClass obj("Hello");
+  cout << obj.getStr() << endl;
+  return 0;
+}

--- a/test cases/cmake/26 dependency fallback/meson.build
+++ b/test cases/cmake/26 dependency fallback/meson.build
@@ -1,0 +1,30 @@
+project('cmakeSubTest', ['c', 'cpp'])
+
+# Fallback to a CMake subproject
+sub_dep = dependency('cmModLib++')
+exe1 = executable('main', ['main.cpp'], dependencies: [sub_dep])
+test('test1', exe1)
+
+# Subproject contains both meson.build and CMakeLists.txt. It should default
+# to meson but wrap force cmake.
+subproject('force_cmake')
+
+testcase expect_error('Wrap method \'notfound\' is not supported, must be one of: meson, cmake')
+  subproject('broken_method')
+endtestcase
+
+# With method=meson we can't use cmake.subproject()
+cmake = import('cmake')
+testcase expect_error('Wrap method is \'meson\' but we are trying to configure it with cmake')
+  cmake.subproject('meson_method')
+endtestcase
+
+# cmake.subproject() force cmake method even if meson.build exists.
+testcase expect_error('Subproject exists but has no CMakeLists.txt file.')
+  cmake.subproject('meson_subp')
+endtestcase
+
+# Without specifying the method it defaults to meson even if CMakeLists.txt exists.
+testcase expect_error('Subproject exists but has no meson.build file.')
+  subproject('cmake_subp')
+endtestcase

--- a/test cases/cmake/26 dependency fallback/subprojects/broken_method.wrap
+++ b/test cases/cmake/26 dependency fallback/subprojects/broken_method.wrap
@@ -1,0 +1,2 @@
+[wrap-file]
+method=notfound

--- a/test cases/cmake/26 dependency fallback/subprojects/cmMod.wrap
+++ b/test cases/cmake/26 dependency fallback/subprojects/cmMod.wrap
@@ -1,0 +1,5 @@
+[wrap-file]
+method = cmake
+
+[provide]
+cmModLib++ = cmModLib___dep

--- a/test cases/cmake/26 dependency fallback/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/26 dependency fallback/subprojects/cmMod/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(cmMod)
+set(CMAKE_CXX_STANDARD 14)
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+add_definitions("-DDO_NOTHING_JUST_A_FLAG=1")
+
+add_library(cmModLib++ SHARED cmMod.cpp)
+target_compile_definitions(cmModLib++ PRIVATE MESON_MAGIC_FLAG=21)
+target_compile_definitions(cmModLib++ INTERFACE MESON_MAGIC_FLAG=42)
+
+# Test PCH support
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16.0")
+    target_precompile_headers(cmModLib++ PRIVATE "cpp_pch.hpp")
+endif()
+
+include(GenerateExportHeader)
+generate_export_header(cmModLib++)

--- a/test cases/cmake/26 dependency fallback/subprojects/cmMod/cmMod.cpp
+++ b/test cases/cmake/26 dependency fallback/subprojects/cmMod/cmMod.cpp
@@ -1,0 +1,15 @@
+#include "cmMod.hpp"
+
+using namespace std;
+
+#if MESON_MAGIC_FLAG != 21
+#error "Invalid MESON_MAGIC_FLAG (private)"
+#endif
+
+cmModClass::cmModClass(string foo) {
+  str = foo + " World";
+}
+
+string cmModClass::getStr() const {
+  return str;
+}

--- a/test cases/cmake/26 dependency fallback/subprojects/cmMod/cmMod.hpp
+++ b/test cases/cmake/26 dependency fallback/subprojects/cmMod/cmMod.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "cmmodlib++_export.h"
+#include <string>
+
+#if MESON_MAGIC_FLAG != 42 && MESON_MAGIC_FLAG != 21
+#error "Invalid MESON_MAGIC_FLAG"
+#endif
+
+class CMMODLIB___EXPORT cmModClass {
+private:
+  std::string str;
+
+public:
+  cmModClass(std::string foo);
+
+  std::string getStr() const;
+};

--- a/test cases/cmake/26 dependency fallback/subprojects/cmMod/cpp_pch.hpp
+++ b/test cases/cmake/26 dependency fallback/subprojects/cmMod/cpp_pch.hpp
@@ -1,0 +1,2 @@
+#include <vector>
+#include <string>

--- a/test cases/cmake/26 dependency fallback/subprojects/cmake_subp/CMakeLists.txt
+++ b/test cases/cmake/26 dependency fallback/subprojects/cmake_subp/CMakeLists.txt
@@ -1,0 +1,2 @@
+cmake_minimum_required(VERSION 3.5)
+project(cmModDummy)

--- a/test cases/cmake/26 dependency fallback/subprojects/force_cmake.wrap
+++ b/test cases/cmake/26 dependency fallback/subprojects/force_cmake.wrap
@@ -1,0 +1,2 @@
+[wrap-file]
+method=cmake

--- a/test cases/cmake/26 dependency fallback/subprojects/force_cmake/CMakeLists.txt
+++ b/test cases/cmake/26 dependency fallback/subprojects/force_cmake/CMakeLists.txt
@@ -1,0 +1,2 @@
+cmake_minimum_required(VERSION 3.5)
+project(cmModBoth)

--- a/test cases/cmake/26 dependency fallback/subprojects/force_cmake/meson.build
+++ b/test cases/cmake/26 dependency fallback/subprojects/force_cmake/meson.build
@@ -1,0 +1,4 @@
+project('both methods')
+
+# Ensure the meson method is not used.
+notfound()

--- a/test cases/cmake/26 dependency fallback/subprojects/meson_method.wrap
+++ b/test cases/cmake/26 dependency fallback/subprojects/meson_method.wrap
@@ -1,0 +1,2 @@
+[wrap-file]
+method=meson

--- a/test cases/cmake/26 dependency fallback/subprojects/meson_subp/meson.build
+++ b/test cases/cmake/26 dependency fallback/subprojects/meson_subp/meson.build
@@ -1,0 +1,1 @@
+project('dummy')


### PR DESCRIPTION
The method can be overriden by setting `method` key in the wrap file
and always defaults to 'meson'.  The dependency object can be retrieved
without the need of specific module API thanks to
meson.override_dependency() mechanism. cmake.subproject() is still
needed in case specific cmake options needs to be passed.
    
This also makes easier to extend to other methods in the future e.g.
cargo.
