### PR TITLE
dependencies/llvm: strip default include dirs 

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -552,8 +552,19 @@ def strip_system_libdirs(environment: 'Environment', for_machine: MachineChoice,
     in the system path, and a different version not in the system path if they
     want to link against the non-system path version.
     """
-    exclude = {f'-L{p}' for p in environment.get_compiler_system_dirs(for_machine)}
+    exclude = {f'-L{p}' for p in environment.get_compiler_system_lib_dirs(for_machine)}
     return [l for l in link_args if l not in exclude]
+
+def strip_system_includedirs(environment: 'Environment', for_machine: MachineChoice, include_args: T.List[str]) -> T.List[str]:
+    """Remove -I<system path> arguments.
+
+    leaving these in will break builds where user want dependencies with system
+    include-type used in rust.bindgen targets as if will cause system headers
+    to not be found.
+    """
+
+    exclude = {f'-I{p}' for p in environment.get_compiler_system_include_dirs(for_machine)}
+    return [i for i in include_args if i not in exclude]
 
 def process_method_kw(possible: T.Iterable[DependencyMethods], kwargs: T.Dict[str, T.Any]) -> T.List[DependencyMethods]:
     method = kwargs.get('method', 'auto')  # type: T.Union[DependencyMethods, str]

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -31,7 +31,7 @@ from mesonbuild.interpreterbase.decorators import FeatureDeprecated
 from .. import mesonlib, mlog
 from ..environment import get_llvm_tool_names
 from ..mesonlib import version_compare, version_compare_many, search_version, stringlistify, extract_as_list
-from .base import DependencyException, DependencyMethods, detect_compiler, strip_system_libdirs, SystemDependency, ExternalDependency, DependencyTypeName
+from .base import DependencyException, DependencyMethods, detect_compiler, strip_system_includedirs, strip_system_libdirs, SystemDependency, ExternalDependency, DependencyTypeName
 from .cmake import CMakeDependency
 from .configtool import ConfigToolDependency
 from .factory import DependencyFactory
@@ -438,6 +438,7 @@ class LLVMDependencyCMake(CMakeDependency):
             defs = defs[0].split(' ')
         temp = ['-I' + x for x in inc_dirs] + defs
         self.compile_args += [x for x in temp if x not in self.compile_args]
+        self.compile_args = strip_system_includedirs(env, self.for_machine, self.compile_args)
         if not self._add_sub_dependency(threads_factory(env, self.for_machine, {})):
             self.is_found = False
             return

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -838,7 +838,7 @@ class Environment:
     def get_datadir(self) -> str:
         return self.coredata.get_option(OptionKey('datadir'))
 
-    def get_compiler_system_dirs(self, for_machine: MachineChoice):
+    def get_compiler_system_lib_dirs(self, for_machine: MachineChoice):
         for comp in self.coredata.compilers[for_machine].values():
             if comp.id == 'clang':
                 index = 1
@@ -856,6 +856,18 @@ class Environment:
             raise mesonlib.MesonException('Could not calculate system search dirs')
         out = out.split('\n')[index].lstrip('libraries: =').split(':')
         return [os.path.normpath(p) for p in out]
+
+    def get_compiler_system_include_dirs(self, for_machine: MachineChoice):
+        for comp in self.coredata.compilers[for_machine].values():
+            if comp.id == 'clang':
+                break
+            elif comp.id == 'gcc':
+                break
+        else:
+            # This option is only supported by gcc and clang. If we don't get a
+            # GCC or Clang compiler return and empty list.
+            return []
+        return comp.get_default_include_dirs()
 
     def need_exe_wrapper(self, for_machine: MachineChoice = MachineChoice.HOST):
         value = self.properties[for_machine].get('needs_exe_wrapper', None)

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -1487,9 +1487,9 @@ class AIXDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
             all_paths.add(os.path.join(build_dir, p))
         # We should consider allowing the $LIBPATH environment variable
         # to override sys_path.
-        sys_path = env.get_compiler_system_dirs(self.for_machine)
+        sys_path = env.get_compiler_system_lib_dirs(self.for_machine)
         if len(sys_path) == 0:
-            # get_compiler_system_dirs doesn't support our compiler.
+            # get_compiler_system_lib_dirs doesn't support our compiler.
             # Use the default system library path
             all_paths.update(['/usr/lib', '/lib'])
         else:


### PR DESCRIPTION
Fixes an issue with rust.bindgen if a cmake LLVM dependency with the
system include_type is getting used as a dependency.

Needed for https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/21612