### PR TITLE
fix: fixes html coverage report generation when using clang on linux

### DIFF
--- a/mesonbuild/scripts/coverage.py
+++ b/mesonbuild/scripts/coverage.py
@@ -157,7 +157,7 @@ def coverage(outputs: T.List[str], source_root: str, subproject_root: str, build
                                    '--html-details',
                                    '--print-summary',
                                    '-o', os.path.join(htmloutdir, 'index.html'),
-                                   ])
+                                   ] + gcov_exe_args)
             outfiles.append(('Html', pathlib.Path(htmloutdir, 'index.html')))
         elif outputs:
             print('lcov/genhtml or gcovr >= 3.3 needed to generate Html coverage report')


### PR DESCRIPTION
Currently, when trying to generate an html coverage report when using clang as a compiler and gcovr for the coverage generation on linux, gcov errors out.
This can be easily reproduced by running this when having gcovr installed:

```bash
mkdir test_proj && cd test_proj
meson init -n test_proj -l cpp
CC=clang CXX=clang++ meson build -Db_coverage=true
ninja -C build test
ninja -C build coverage
```

This PR fixes this by also providing the `gcov_exe_args` (which hold the flags to use `llvm-cov-<version> gcov` as the executable) to the coverage producing command, just like in the other calls to generate xml, sonarqube and text output.

I believe this was forgotten in #7196