### PR TITLE
Fix failing test common/178 on older macos

### DIFF
--- a/test cases/common/178 bothlibraries/meson.build
+++ b/test cases/common/178 bothlibraries/meson.build
@@ -54,7 +54,8 @@ test('runtest-both-2', exe_both2)
 # both_libraries the static has no sources and thus no compilers, resulting in
 # the executable linking using the C compiler.
 # https://github.com/Netflix/vmaf/issues/1107
-libccpp = both_libraries('ccpp', 'foo.cpp', 'libfile.c')
+libccpp = both_libraries('ccpp', 'foo.cpp', 'libfile.c',
+  cpp_args : ['-std=c++11'])
 exe = executable('prog-ccpp', 'main2.c',
   link_with: libccpp.get_static_lib(),
   c_args : ['-DSTATIC_COMPILATION'],


### PR DESCRIPTION
Test case `common/178 bothlibraries` fails on MacOS Catalina (which has Apple clang 12) because the C++ part uses C++11 features without specifying a `-std=`flag, and the default for that compiler is not C++11. I know that most or all modern systems out there will not need this flag, but it does not do any harm and there may be some older or less well-known compiler versions which need it.

```
% meson compile -C builddir
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: /usr/local/bin/ninja -C '/Projects/meson/test cases/common/178 bothlibraries/builddir'
ninja: Entering directory `/Projects/meson/test cases/common/178 bothlibraries/builddir'
[25/28] Compiling C++ object libccpp.dylib.p/foo.cpp.o
FAILED: libccpp.dylib.p/foo.cpp.o 
c++ -Ilibccpp.dylib.p -I. -I.. -fcolor-diagnostics -Wall -Winvalid-pch -O0 -g -MD -MQ libccpp.dylib.p/foo.cpp.o -MF libccpp.dylib.p/foo.cpp.o.d -o libccpp.dylib.p/foo.cpp.o -c ../foo.cpp
../foo.cpp:9:5: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]
    auto bptr = std::make_shared<int>(0);
    ^
In file included from ../foo.cpp:1:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:4405:26: error: no matching constructor for initialization of '_CntrlBlk' (aka '__shared_ptr_emplace<int, allocator<int> >')
    ::new(__hold2.get()) _CntrlBlk(__a2, _VSTD::forward<_Args>(__args)...);
                         ^         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../foo.cpp:9:22: note: in instantiation of function template specialization 'std::__1::make_shared<int, int>' requested here
    auto bptr = std::make_shared<int>(0);
                     ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:3580:9: note: candidate constructor [with _A0 = int] not viable: expects an l-value for 2nd argument
        __shared_ptr_emplace(_Alloc __a, _A0& __a0)
        ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:3585:9: note: candidate constructor template not viable: requires 3 arguments, but 2 were provided
        __shared_ptr_emplace(_Alloc __a, _A0& __a0, _A1& __a1)
        ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:3590:9: note: candidate constructor template not viable: requires 4 arguments, but 2 were provided
        __shared_ptr_emplace(_Alloc __a, _A0& __a0, _A1& __a1, _A2& __a2)
        ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:3566:5: note: candidate constructor not viable: requires single argument '__a', but 2 arguments were provided
    __shared_ptr_emplace(_Alloc __a)
    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:3559:7: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 2 were provided
class __shared_ptr_emplace
      ^
1 warning and 1 error generated.
ninja: build stopped: subcommand failed.
```