### PR TITLE
Fix niche cases when linking static libs

### DIFF
--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -283,8 +283,7 @@ class IntrospectionInterpreter(AstInterpreter):
         kwargs_reduced['_allow_no_sources'] = True
         target = targetclass(name, self.subdir, self.subproject, for_machine, empty_sources, [], objects,
                              self.environment, self.coredata.compilers[for_machine], kwargs_reduced)
-        target.process_compilers()
-        target.process_compilers_late([])
+        target.process_compilers_late()
 
         new_target = {
             'name': target.get_basename(),

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3066,7 +3066,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 extradep = None
             pch_objects += objs
             rulename = self.compiler_to_pch_rule_name(compiler)
-            elem = NinjaBuildElement(self.all_outputs, dst, rulename, src)
+            elem = NinjaBuildElement(self.all_outputs, objs + [dst], rulename, src)
             if extradep is not None:
                 elem.add_dep(extradep)
             self.add_header_deps(target, elem, header_deps)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -412,6 +412,7 @@ class ExtractedObjects(HoldableObject):
     genlist: T.List['GeneratedTypes'] = field(default_factory=list)
     objlist: T.List[T.Union[str, 'File', 'ExtractedObjects']] = field(default_factory=list)
     recursive: bool = True
+    pch: bool = False
 
     def __post_init__(self) -> None:
         if self.target.is_unity:
@@ -1017,7 +1018,7 @@ class BuildTarget(Target):
 
     def extract_all_objects(self, recursive: bool = True) -> ExtractedObjects:
         return ExtractedObjects(self, self.sources, self.generated, self.objects,
-                                recursive)
+                                recursive, pch=True)
 
     def get_all_link_deps(self) -> ImmutableListProtocol[BuildTargetTypes]:
         return self.get_transitive_link_deps()

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1428,7 +1428,7 @@ You probably should put it in link_with instead.''')
                     raise InvalidArguments(msg + ' This is not possible in a cross build.')
                 else:
                     mlog.warning(msg + ' This will fail in cross build.')
-            if isinstance(self, StaticLibrary):
+            if isinstance(self, StaticLibrary) and not self.uses_rust():
                 if isinstance(t, (CustomTarget, CustomTargetIndex)) or t.uses_rust():
                     # There are cases we cannot do this, however. In Rust, for
                     # example, this can't be done with Rust ABI libraries, though

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -17,7 +17,6 @@ from collections import defaultdict, OrderedDict
 from dataclasses import dataclass, field, InitVar
 from functools import lru_cache
 import abc
-import copy
 import hashlib
 import itertools, pathlib
 import os
@@ -988,18 +987,6 @@ class BuildTarget(Target):
                     'Link_depends arguments must be strings, Files, '
                     'or a Custom Target, or lists thereof.')
 
-    def get_original_kwargs(self):
-        return self.kwargs
-
-    def copy_kwargs(self, kwargs):
-        self.kwargs = copy.copy(kwargs)
-        for k, v in self.kwargs.items():
-            if isinstance(v, list):
-                self.kwargs[k] = listify(v, flatten=True)
-        for t in ['dependencies', 'link_with', 'include_directories', 'sources']:
-            if t in self.kwargs:
-                self.kwargs[t] = listify(self.kwargs[t], flatten=True)
-
     def extract_objects(self, srclist: T.List[T.Union['FileOrString', 'GeneratedTypes']]) -> ExtractedObjects:
         sources_set = set(self.sources)
         generated_set = set(self.generated)
@@ -1073,7 +1060,7 @@ class BuildTarget(Target):
 
     def process_kwargs(self, kwargs):
         self.process_kwargs_base(kwargs)
-        self.copy_kwargs(kwargs)
+        self.original_kwargs = kwargs
         kwargs.get('modules', [])
         self.need_install = kwargs.get('install', self.need_install)
         llist = extract_as_list(kwargs, 'link_with')

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -213,7 +213,7 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
         return ['/DEF:' + defsfile]
 
     def gen_pch_args(self, header: str, source: str, pchname: str) -> T.Tuple[str, T.List[str]]:
-        objname = os.path.splitext(pchname)[0] + '.obj'
+        objname = os.path.splitext(source)[0] + '.obj'
         return objname, ['/Yc' + header, '/Fp' + pchname, '/Fo' + objname]
 
     def openmp_flags(self) -> T.List[str]:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3132,9 +3132,8 @@ class Interpreter(InterpreterBase, HoldableObject):
             raise InvalidCode(f'Tried to create target "{name}", but a target of that name already exists.')
 
         if isinstance(tobj, build.BuildTarget):
-            missing_languages = tobj.process_compilers()
-            self.add_languages(missing_languages, True, tobj.for_machine)
-            tobj.process_compilers_late(missing_languages)
+            self.add_languages(tobj.missing_languages, True, tobj.for_machine)
+            tobj.process_compilers_late()
             self.add_stdlib_info(tobj)
 
         self.build.targets[idname] = tobj

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -139,7 +139,7 @@ class RustModule(ExtensionModule):
         tkwargs['args'] = extra_args + ['--test', '--format', 'pretty']
         tkwargs['protocol'] = 'rust'
 
-        new_target_kwargs = base_target.kwargs.copy()
+        new_target_kwargs = base_target.original_kwargs.copy()
         # Don't mutate the shallow copied list, instead replace it with a new
         # one
         new_target_kwargs['rust_args'] = new_target_kwargs.get('rust_args', []) + ['--test']

--- a/test cases/rust/5 polyglot static/meson.build
+++ b/test cases/rust/5 polyglot static/meson.build
@@ -9,7 +9,18 @@ deps = [
 extra_winlibs = meson.get_compiler('c').get_id() in ['msvc', 'clang-cl'] ? ['userenv.lib', 'ws2_32.lib', 'bcrypt.lib'] : []
 
 r = static_library('stuff', 'stuff.rs', rust_crate_type : 'staticlib')
-l = static_library('clib', 'clib.c', link_with : r, install : true)
+
+# clib is installed static library and stuff is not installed. That means that
+# to be usable clib must link_whole stuff. Meson automatically promote to link_whole,
+# as it would do with C libraries, but then cannot extract objects from stuff and
+# thus should error out.
+# FIXME: We should support this use-case in the future.
+testcase expect_error('Cannot link_whole a custom or Rust target into a static library')
+  l = static_library('clib', 'clib.c', link_with : r, install : true)
+endtestcase
+
+l = static_library('clib', 'clib.c', link_with : r)
+
 e = executable('prog', 'prog.c',
                dependencies: deps,
                link_with : l,

--- a/test cases/rust/5 polyglot static/test.json
+++ b/test cases/rust/5 polyglot static/test.json
@@ -1,7 +1,6 @@
 {
   "installed": [
     {"type": "exe", "file": "usr/bin/prog"},
-    {"type": "pdb", "file": "usr/bin/prog"},
-    {"type": "file", "file": "usr/lib/libclib.a"}
+    {"type": "pdb", "file": "usr/bin/prog"}
   ]
 }

--- a/test cases/unit/113 complex link cases/main.c
+++ b/test cases/unit/113 complex link cases/main.c
@@ -1,0 +1,6 @@
+int s3(void);
+
+int main(int argc, char *argv[])
+{
+    return s3();
+}

--- a/test cases/unit/113 complex link cases/meson.build
+++ b/test cases/unit/113 complex link cases/meson.build
@@ -1,0 +1,40 @@
+project('complex link cases', 'c')
+
+# In all tests, e1 uses s3 which uses s2 which uses s1.
+
+# Executable links with s3 and s1 but not s2 because it is included in s3.
+s1 = static_library('t1-s1', 's1.c')
+s2 = static_library('t1-s2', 's2.c', link_with: s1)
+s3 = static_library('t1-s3', 's3.c', link_whole: s2)
+e = executable('t1-e1', 'main.c', link_with: s3)
+
+# s3 is installed but not s1 so it has to include s1 too.
+# Executable links only s3 because it contains s1 and s2.
+s1 = static_library('t2-s1', 's1.c')
+s2 = static_library('t2-s2', 's2.c', link_with: s1)
+s3 = static_library('t2-s3', 's3.c', link_whole: s2, install: true)
+e = executable('t2-e1', 'main.c', link_with: s3)
+
+# Executable needs to link with s3 only
+s1 = static_library('t3-s1', 's1.c')
+s2 = static_library('t3-s2', 's2.c', link_with: s1)
+s3 = shared_library('t3-s3', 's3.c', link_with: s2)
+e = executable('t3-e1', 'main.c', link_with: s3)
+
+# Executable needs to link with s3 and s2
+s1 = static_library('t4-s1', 's1.c')
+s2 = shared_library('t4-s2', 's2.c', link_with: s1)
+s3 = static_library('t4-s3', 's3.c', link_with: s2)
+e = executable('t4-e1', 'main.c', link_with: s3)
+
+# Executable needs to link with s3 and s1
+s1 = shared_library('t5-s1', 's1.c')
+s2 = static_library('t5-s2', 's2.c', link_with: s1)
+s3 = static_library('t5-s3', 's3.c', link_with: s2, install: true)
+e = executable('t5-e1', 'main.c', link_with: s3)
+
+# Executable needs to link with s3 and s2
+s1 = static_library('t6-s1', 's1.c')
+s2 = static_library('t6-s2', 's2.c', link_with: s1, install: true)
+s3 = static_library('t6-s3', 's3.c', link_with: s2, install: true)
+e = executable('t6-e1', 'main.c', link_with: s3)

--- a/test cases/unit/113 complex link cases/s1.c
+++ b/test cases/unit/113 complex link cases/s1.c
@@ -1,0 +1,3 @@
+int s1(void) {
+    return 1;
+}

--- a/test cases/unit/113 complex link cases/s2.c
+++ b/test cases/unit/113 complex link cases/s2.c
@@ -1,0 +1,5 @@
+int s1(void);
+
+int s2(void) {
+    return s1() + 1;
+}

--- a/test cases/unit/113 complex link cases/s3.c
+++ b/test cases/unit/113 complex link cases/s3.c
@@ -1,0 +1,5 @@
+int s2(void);
+
+int s3(void) {
+    return s2() + 1;
+}

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -4376,8 +4376,7 @@ class AllPlatformTests(BasePlatformTests):
                            structured_sources=None,
                            objects=[], environment=env, compilers=env.coredata.compilers[MachineChoice.HOST],
                            kwargs={})
-            target.process_compilers()
-            target.process_compilers_late([])
+            target.process_compilers_late()
             return target.filename
 
         shared_lib_name = lambda name: output_name(name, SharedLibrary)


### PR DESCRIPTION
Case 1:
- Prog links to static lib A
- A link_whole to static lib B
- B link to static lib C
- Prog dependencies should be A and C but not B which is already included in A.

Case 2:
- Same as case 1, but with A being installed.
- To be useful, A must also include all objects from C that is not installed.
- Prog only need to link on A.