### PR TITLE
rust: Require `native: true` for `proc-macro` targets and allow linki…

### DIFF
--- a/test cases/rust/18 proc-macro/meson.build
+++ b/test cases/rust/18 proc-macro/meson.build
@@ -8,6 +8,7 @@ pm = shared_library(
   'proc_macro_examples',
   'proc.rs',
   rust_crate_type : 'proc-macro',
+  native: true,
 )
 
 main = executable(


### PR DESCRIPTION
…ng into targets for other platforms

proc-macros are basically compiler extensions and must be compiled for the build machine so that the compiler can load and execute it at runtime.

Without this, cross-compilation of targets that use proc-macro dependencies is going to fail.

Fixes https://github.com/mesonbuild/meson/issues/11702