### PR TITLE
wrap: Always pass posix paths to patch

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -794,7 +794,8 @@ class Resolver:
                 raise WrapException(f'Diff file "{path}" does not exist')
             relpath = os.path.relpath(str(path), self.dirname)
             if PATCH:
-                cmd = [PATCH, '-f', '-p1', '-i', relpath]
+                # Always pass a POSIX path to patch, because on Windows it's MSYS
+                cmd = [PATCH, '-f', '-p1', '-i', str(Path(relpath).as_posix())]
             elif GIT:
                 # If the `patch` command is not available, fall back to `git
                 # apply`. The `--work-tree` is necessary in case we're inside a


### PR DESCRIPTION
`patch` on Windows is provided by MSYS, which only understands POSIX paths, with `/`. Using Windows paths with `\` results in a "file not found" error.

We got a little lucky here because the path is relative, so the drive letter difference doesn't affect us.