### PR TITLE
tests: fix `test_always_prefer_c_compiler_for_asm`

### DIFF
--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1083,7 +1083,7 @@ class AllPlatformTests(BasePlatformTests):
         for cmd in self.get_compdb():
             # Get compiler
             split = split_args(cmd['command'])
-            if split[0] == 'ccache':
+            if split[0] in ('ccache', 'sccache'):
                 compiler = split[1]
             else:
                 compiler = split[0]


### PR DESCRIPTION
Handle the case where `sccache` is installed and used over `ccache`.