### PR TITLE
compilers: fix checks handling of internal dependencies

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -451,6 +451,10 @@ class CLikeCompiler(Compiler):
         for d in dependencies:
             # Add compile flags needed by dependencies
             cargs += d.get_compile_args()
+            system_incdir = d.get_include_type() == 'system'
+            for i in d.get_include_dirs():
+                for idir in i.to_string_list(env.get_source_dir(), env.get_build_dir()):
+                    cargs.extend(self.get_include_args(idir, system_incdir))
             if mode is CompileCheckMode.LINK:
                 # Add link flags needed to find dependencies
                 largs += d.get_link_args()

--- a/test cases/common/262 internal dependency includes in checks/include/test_262_header.h
+++ b/test cases/common/262 internal dependency includes in checks/include/test_262_header.h
@@ -1,0 +1,1 @@
+int foo(void);

--- a/test cases/common/262 internal dependency includes in checks/meson.build
+++ b/test cases/common/262 internal dependency includes in checks/meson.build
@@ -1,0 +1,7 @@
+project('test 262', 'c')
+
+cc = meson.get_compiler('c')
+
+internal_dep = declare_dependency(include_directories: 'include')
+
+assert(cc.has_header_symbol('test_262_header.h', 'foo', dependencies: internal_dep))


### PR DESCRIPTION
The include directories were not passed to the compiler.