### PR TITLE
Remove enforced file system sync

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1092,7 +1092,6 @@ def save(obj: CoreData, build_dir: str) -> str:
     with open(tempfilename, 'wb') as f:
         pickle.dump(obj, f)
         f.flush()
-        os.fsync(f.fileno())
     os.replace(tempfilename, filename)
     return filename
 


### PR DESCRIPTION
This filesystem sync creates heavy waits for us in production use.  When the build filesystem is busy, it can easily result in a 20 or 30 second delay, presumably since each individual `save` operation syncs itself.  If there really should be a `sync` (I think there shouldn't), it would make sense to have this happen once after all files were written.  But then again I don't think a tool like `meson` should enforce a filesystem sync.