### PR TITLE
Make `dependency('foo', static: true, method: 'cmake') link statically

### DIFF
--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -388,6 +388,7 @@ class CMakeDependency(ExternalDependency):
             cmake_opts += ['-DARCHS={}'.format(';'.join(self.cmakeinfo.archs))]
             cmake_opts += [f'-DVERSION={package_version}']
             cmake_opts += ['-DCOMPS={}'.format(';'.join([x[0] for x in comp_mapped]))]
+            cmake_opts += [f'-DSTATIC={self.static}']
             cmake_opts += args
             cmake_opts += self.traceparser.trace_args()
             cmake_opts += toolchain.get_cmake_args()

--- a/mesonbuild/dependencies/data/CMakeLists.txt
+++ b/mesonbuild/dependencies/data/CMakeLists.txt
@@ -8,6 +8,10 @@ set(PACKAGE_FOUND FALSE)
 set(_packageName "${NAME}")
 string(TOUPPER "${_packageName}" PACKAGE_NAME)
 
+if("${STATIC}" STREQUAL "True")
+  set("${NAME}_USE_STATIC_LIBS" "ON")
+endif()
+
 while(TRUE)
   if ("${VERSION}" STREQUAL "")
     find_package("${NAME}" QUIET COMPONENTS ${COMPS})

--- a/test cases/rust/13 external c dependencies/test.json
+++ b/test cases/rust/13 external c dependencies/test.json
@@ -12,7 +12,8 @@
       ]
     },
     "exclude": [
-      { "static": true, "method": "pkg-config" }
+      { "static": true, "method": "pkg-config" },
+      { "static": true, "method": "cmake" }
     ]
   }
 }


### PR DESCRIPTION
Fixes #1709

Why did I remove the `{ "static": true, "method": "cmake" }` testcase?
Before my PR, it actually linked dynamically, so it never *really* worked. Now it fails for the same reason that `{ "static": true, "method": "pkg-config" }` fails.