### PR TITLE
fix regression in precomputing CMAKE_SIZEOF_VOID_P

### DIFF
--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -267,7 +267,7 @@ class CmakeModule(ExtensionModule):
         if not compiler:
             raise mesonlib.MesonException('Requires a C or C++ compiler to compute sizeof(void *).')
 
-        return compiler.sizeof('void *', '', env)
+        return compiler.sizeof('void *', '', env)[0]
 
     def detect_cmake(self, state):
         if self.cmake_detected:


### PR DESCRIPTION
fixes https://github.com/NixOS/nixpkgs/issues/229358
restores the pre caching behavior (https://github.com/mesonbuild/meson/commit/808d5934dd6c6a6c16f66e9dc51dae6e83e02cef)