### PR TITLE
dependencies: allow config-tool to fallback to default program names

### DIFF
--- a/mesonbuild/dependencies/configtool.py
+++ b/mesonbuild/dependencies/configtool.py
@@ -43,6 +43,7 @@ class ConfigToolDependency(ExternalDependency):
     tool_name: T.Optional[str] = None
     version_arg = '--version'
     skip_version: T.Optional[str] = None
+    allow_default_for_cross = False
     __strip_version = re.compile(r'^[0-9][0-9.]+')
 
     def __init__(self, name: str, environment: 'Environment', kwargs: T.Dict[str, T.Any], language: T.Optional[str] = None):
@@ -85,7 +86,7 @@ class ConfigToolDependency(ExternalDependency):
         best_match: T.Tuple[T.Optional[T.List[str]], T.Optional[str]] = (None, None)
         for potential_bin in find_external_program(
                 self.env, self.for_machine, self.tool_name,
-                self.tool_name, self.tools, allow_default_for_cross=False):
+                self.tool_name, self.tools, allow_default_for_cross=self.allow_default_for_cross):
             if not potential_bin.found():
                 continue
             tool = potential_bin.get_command()

--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -55,6 +55,9 @@ class Pybind11ConfigToolDependency(ConfigToolDependency):
 
     tools = ['pybind11-config']
 
+    # any version of the tool is valid, since this is header-only
+    allow_default_for_cross = True
+
     # pybind11 in 2.10.4 added --version, sanity-check another flag unique to it
     # in the meantime
     skip_version = '--pkgconfigdir'


### PR DESCRIPTION
If the dependency permits it, we can just do a PATH search instead of mandating that it be listed in the cross file. This is useful for the limited case where a specific dependency is known to be compatible with any machine choice.

Mark the pybind11 dependency as supporting this. It's a valid choice because pybind11 is a header-only C++ library.

See https://github.com/contourpy/contourpy/pull/226#issuecomment-1533685324

/cc @ianthomas23