### PR TITLE
docs: build rework

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,10 @@ Minimum required version of hotdoc is *0.8.9*.
 
 Instructions on how to install hotdoc are [here](https://hotdoc.github.io/installing.html).
 
+Our custom hotdoc extensions require:
+- [chevron](https://pypi.org/project/chevron)
+- [strictyaml](https://pypi.org/project/strictyaml)
+
 ## Building the documentation
 
 From the Meson repository root dir:

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -51,6 +51,8 @@ refman_man = custom_target(
         '--force-color',
         '--no-modules',
     ],
+    install: true,
+    install_dir: get_option('mandir') / 'man3',
 )
 
 # Everything past here is HTML resources.

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -1,5 +1,11 @@
 project('Meson documentation', version: '1.0')
 
+yaml_modname = get_option('unsafe_yaml') ? 'yaml' : 'strictyaml'
+py = import('python').find_installation('python3', modules: [yaml_modname], required: false)
+if not py.found()
+    error(f'Cannot build documentation without yaml support')
+endif
+
 cur_bdir = meson.current_build_dir()
 
 sitemap = files('sitemap.txt')
@@ -105,6 +111,10 @@ genrelnotes = custom_target(
 sitemap = genrelnotes[0]
 
 hotdoc_prog = find_program('hotdoc', version: '>=0.13.7')
+py = import('python').find_installation('python3', modules: ['chevron'], required: false)
+if not py.found()
+    error('Building the HTML docs requires the chevron module to render generated markdown pages')
+endif
 
 hotdoc = import('hotdoc')
 documentation = hotdoc.generate_doc(meson.project_name(),

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -17,6 +17,7 @@ docs_gen = custom_target(
 
 sitemap = files('sitemap.txt')
 
+yaml_loader = get_option('unsafe_yaml') ? 'fastyaml' : 'yaml'
 genrefman = find_program('./genrefman.py')
 refman_binary = custom_target(
     'gen_refman_bin',
@@ -25,7 +26,7 @@ refman_binary = custom_target(
     depfile: 'reman_dep.d',
     command: [
         genrefman,
-        '-l', 'yaml',
+        '-l', yaml_loader,
         '-g', 'pickle',
         '-o', '@OUTPUT@',
         '--depfile', '@DEPFILE@',

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -2,19 +2,6 @@ project('Meson documentation', version: '1.0')
 
 cur_bdir = meson.current_build_dir()
 
-# Only the script knows which files are being generated
-docs_gen = custom_target(
-    'gen_docs',
-    input: files('markdown/index.md'),
-    output: 'gen_docs.stamp',
-    command: [
-        files('../tools/regenerate_docs.py'),
-        '--output-dir', cur_bdir,
-        '--dummy-output-file', '@OUTPUT@',
-    ],
-    build_by_default: true,
-    install: false)
-
 sitemap = files('sitemap.txt')
 
 yaml_loader = get_option('unsafe_yaml') ? 'fastyaml' : 'yaml'
@@ -32,6 +19,57 @@ refman_binary = custom_target(
         '--depfile', '@DEPFILE@',
         '--force-color',
     ]
+)
+
+refman_json = custom_target(
+    'gen_refman_json',
+    build_by_default: true,
+    input: refman_binary,
+    output: 'reference_manual.json',
+    command: [
+        genrefman,
+        '-l', 'pickle',
+        '-g', 'json',
+        '-i', '@INPUT@',
+        '-o', '@OUTPUT@',
+        '--force-color',
+    ],
+)
+test('validate_docs', find_program('./jsonvalidator.py'), args: [refman_json])
+
+refman_man = custom_target(
+    'gen_refman_man',
+    build_by_default: true,
+    input: refman_binary,
+    output: 'meson-reference.3',
+    command: [
+        genrefman,
+        '-l', 'pickle',
+        '-g', 'man',
+        '-i', '@INPUT@',
+        '-o', '@OUTPUT@',
+        '--force-color',
+        '--no-modules',
+    ],
+)
+
+# Everything past here is HTML resources.
+if not get_option('html')
+    subdir_done()
+endif
+
+# Only the script knows which files are being generated
+docs_gen = custom_target(
+    'gen_docs',
+    input: files('markdown/index.md'),
+    output: 'gen_docs.stamp',
+    command: [
+        files('../tools/regenerate_docs.py'),
+        '--output-dir', cur_bdir,
+        '--dummy-output-file', '@OUTPUT@',
+    ],
+    build_by_default: true,
+    install: false,
 )
 
 refman_md = custom_target(
@@ -52,37 +90,6 @@ refman_md = custom_target(
 )
 sitemap = refman_md[0]
 
-refman_json = custom_target(
-    'gen_refman_json',
-    build_by_default: true,
-    input: refman_binary,
-    output: 'reference_manual.json',
-    command: [
-        genrefman,
-        '-l', 'pickle',
-        '-g', 'json',
-        '-i', '@INPUT@',
-        '-o', '@OUTPUT@',
-        '--force-color',
-    ],
-)
-
-refman_man = custom_target(
-    'gen_refman_man',
-    build_by_default: true,
-    input: refman_binary,
-    output: 'meson-reference.3',
-    command: [
-        genrefman,
-        '-l', 'pickle',
-        '-g', 'man',
-        '-i', '@INPUT@',
-        '-o', '@OUTPUT@',
-        '--force-color',
-        '--no-modules',
-    ],
-)
-
 genrelnotes = custom_target(
     output: ['sitemap-genrelnotes.txt'],
     build_always_stale: true,
@@ -94,8 +101,6 @@ genrelnotes = custom_target(
     ]
 )
 sitemap = genrelnotes[0]
-
-test('validate_docs', find_program('./jsonvalidator.py'), args: [refman_json])
 
 hotdoc_prog = find_program('hotdoc', version: '>=0.13.7')
 

--- a/docs/meson_options.txt
+++ b/docs/meson_options.txt
@@ -1,2 +1,4 @@
 option('unsafe_yaml', type: 'boolean', value: false,
     description: 'disable safety checks and use a faster, but less correct YAML loader')
+option('html', type: 'boolean', value: true,
+    description: 'build the hotdoc-based HTML documentation')

--- a/docs/meson_options.txt
+++ b/docs/meson_options.txt
@@ -1,0 +1,2 @@
+option('unsafe_yaml', type: 'boolean', value: false,
+    description: 'disable safety checks and use a faster, but less correct YAML loader')


### PR DESCRIPTION
- add meson option to control use of "fastyaml" loader by @annacrombie 
- add meson option to skip building HTML documentation and "just" build the man page
- check for required python modules at setup time. Closes #11772