### PR TITLE
interpreter: ensure os.scandir is closed by using as a context manager

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -103,6 +103,7 @@ import typing as T
 import textwrap
 import importlib
 import copy
+import contextlib
 
 if T.TYPE_CHECKING:
     import argparse
@@ -2496,7 +2497,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         exclude = (set(kwargs['exclude_files']), set(kwargs['exclude_directories']))
 
         srcdir = os.path.join(self.environment.source_dir, self.subdir, args[0])
-        if not os.path.isdir(srcdir) or not any(os.scandir(srcdir)):
+        if not os.path.isdir(srcdir) or not any(os.listdir(srcdir)):
             FeatureNew.single_use('install_subdir with empty directory', '0.47.0', self.subproject, location=node)
             FeatureDeprecated.single_use('install_subdir with empty directory', '0.60.0', self.subproject,
                                          'It worked by accident and is buggy. Use install_emptydir instead.', node)


### PR DESCRIPTION
The [python docs](https://docs.python.org/3/library/os.html#os.scandir) say `os.scandir` returns an object that must be closed. Using a context manager ensures that. It's been possible to use `os.scandir` as a context manager since Python 3.6. `contextlib.nullcontext` has been available since Python 3.7.

I noticed this running meson under a debug python build, which makes `ResourceWarning` visible by default. It may make sense to set up a CI job that removes `ResourceWarning` from the default warning ignore list.