### PR TITLE
Check dub version

### DIFF
--- a/mesonbuild/dependencies/dub.py
+++ b/mesonbuild/dependencies/dub.py
@@ -46,7 +46,7 @@ class DubDependency(ExternalDependency):
 
         if DubDependency.class_dubbin is None and not DubDependency.class_dubbin_searched:
             DubDependency.class_dubbin = self._check_dub()
-
+            DubDependency.class_dubbin_searched = True
         if DubDependency.class_dubbin is None:
             if self.required:
                 raise DependencyException('DUB not found.')
@@ -421,8 +421,6 @@ class DubDependency(ExternalDependency):
                 return None
 
             return (dubbin, dubver)
-
-        DubDependency.class_dubbin_searched = True
 
         found = find()
 

--- a/mesonbuild/dependencies/dub.py
+++ b/mesonbuild/dependencies/dub.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from .base import ExternalDependency, DependencyException, DependencyTypeName
 from .pkgconfig import PkgConfigDependency
-from ..mesonlib import (Popen_safe, OptionKey, join_args)
+from ..mesonlib import (Popen_safe, OptionKey, join_args, version_compare)
 from ..programs import ExternalProgram
 from .. import mlog
 import re
@@ -55,6 +55,14 @@ class DubDependency(ExternalDependency):
             return
 
         assert isinstance(self.dubbin, ExternalProgram)
+
+        # Check if Dub version is compatible with Meson
+        if version_compare(dubver, '>1.31.1'):
+            if self.required:
+                raise DependencyException(f"DUB version {dubver} is not compatible with Meson (can't locate artifacts in Dub cache)")
+            self.is_found = False
+            return
+
         mlog.debug('Determining dependency {!r} with DUB executable '
                    '{!r}'.format(name, self.dubbin.get_path()))
 

--- a/test cases/d/11 dub/meson.build
+++ b/test cases/d/11 dub/meson.build
@@ -1,5 +1,7 @@
 project('dub-example', 'd')
 
+error('MESON_SKIP_TEST: Dub support is broken at the moment (#11773)')
+
 dub_exe = find_program('dub', required : false)
 if not dub_exe.found()
   error('MESON_SKIP_TEST: Dub not found')

--- a/test cases/d/14 dub with deps/meson.build
+++ b/test cases/d/14 dub with deps/meson.build
@@ -1,5 +1,7 @@
 project('dub-with-deps-example', ['d'])
 
+error('MESON_SKIP_TEST: Dub support is broken at the moment (#11773)')
+
 dub_exe = find_program('dub', required : false)
 if not dub_exe.found()
     error('MESON_SKIP_TEST: Dub not found')


### PR DESCRIPTION
Dub versions starting at 1.32 have a new cache directory structure into which Meson doesn't know where to find compatible artifacts.
This PR informs the user of why the dependency can't be found.

```
Found DUB: /home/remi/dlang/dmd-2.103.1/linux/bin64/dub (version 1.32.1)
Run-time dependency vibe-d:http found: NO 

meson.build:35:21: ERROR: Dependency lookup for vibe-d:http with method '' failed: DUB version 1.32.1 is not compatible with Meson (can't locate artifacts in Dub cache)
```

#11773