### PR TITLE
repair install_mode support for uid/gid effectively everywhere

### DIFF
--- a/docs/yaml/functions/configure_file.yaml
+++ b/docs/yaml/functions/configure_file.yaml
@@ -20,6 +20,9 @@ description: |
   this function will copy the file provided in `input:` to a file in the
   build directory with the name `output:` in the current directory.
 
+warnings:
+  - the `install_mode` kwarg ignored integer values between 0.62 -- 1.1.0.
+
 kwargs:
   capture:
     type: bool

--- a/docs/yaml/functions/custom_target.yaml
+++ b/docs/yaml/functions/custom_target.yaml
@@ -52,6 +52,9 @@ notes:
     is not portable, notably to Windows. Instead, consider using a
     `native: true` [[executable]], or a python script.
 
+warnings:
+  - the `install_mode` kwarg ignored integer values between 0.60.0 -- 1.1.0.
+
 optargs:
   name:
     type: str

--- a/docs/yaml/functions/install_data.yaml
+++ b/docs/yaml/functions/install_data.yaml
@@ -10,6 +10,9 @@ varargs:
   type: file | str
   description: Files to install.
 
+warnings:
+  - the `install_mode` kwarg ignored integer values between 0.59.0 -- 1.1.0.
+
 kwargs:
   install_dir:
     type: str

--- a/docs/yaml/functions/install_emptydir.yaml
+++ b/docs/yaml/functions/install_emptydir.yaml
@@ -6,6 +6,9 @@ description: |
   argument. If the directory exists and is not empty, the contents are left in
   place.
 
+warnings:
+  - the `install_mode` kwarg ignored integer values before 1.1.0.
+
 varargs:
   name: dirpath
   type: str

--- a/docs/yaml/functions/install_headers.yaml
+++ b/docs/yaml/functions/install_headers.yaml
@@ -41,6 +41,9 @@ varargs:
   type: file | str
   description: Header files to install.
 
+warnings:
+  - the `install_mode` kwarg ignored integer values between 0.59.0 -- 1.1.0.
+
 kwargs:
   install_dir:
     type: str

--- a/docs/yaml/functions/install_man.yaml
+++ b/docs/yaml/functions/install_man.yaml
@@ -15,6 +15,9 @@ varargs:
   type: file | str
   description: Man pages to install.
 
+warnings:
+  - the `install_mode` kwarg ignored integer values between 0.59.0 -- 1.1.0.
+
 kwargs:
   install_mode:
     type: list[str | int]

--- a/docs/yaml/functions/install_subdir.yaml
+++ b/docs/yaml/functions/install_subdir.yaml
@@ -56,6 +56,9 @@ example: |
     new_directory/
   ```
 
+warnings:
+  - the `install_mode` kwarg ignored integer values between 0.59.0 -- 1.1.0.
+
 posargs:
   subdir_name:
     type: str

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -191,7 +191,7 @@ class UserUmaskOption(UserIntegerOption, UserOption[T.Union[str, OctalInt]]):
         return format(self.value, '04o')
 
     def validate_value(self, value: T.Any) -> T.Union[str, OctalInt]:
-        if value is None or value == 'preserve':
+        if value == 'preserve':
             return 'preserve'
         return OctalInt(super().validate_value(value))
 

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -97,8 +97,17 @@ def _install_mode_validator(mode: T.List[T.Union[str, bool, int]]) -> T.Optional
 def _install_mode_convertor(mode: T.Optional[T.List[T.Union[str, bool, int]]]) -> FileMode:
     """Convert the DSL form of the `install_mode` keyword argument to `FileMode`"""
 
-    # this has already been validated by the validator
-    return FileMode(*(m if isinstance(m, str) else None for m in mode))
+    if not mode:
+        return FileMode()
+
+    # This has already been validated by the validator. False denotes "use
+    # default". mypy is totally incapable of understanding it, because
+    # generators clobber types via homogeneous return. But also we *must*
+    # convert the first element different from the rest
+    m1 = mode[0] if isinstance(mode[0], str) else None
+    rest = (m if isinstance(m, (str, int)) else None for m in mode[1:])
+
+    return FileMode(m1, *rest)
 
 
 def _lower_strlist(input: T.List[str]) -> T.List[str]:

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -95,13 +95,8 @@ def _install_mode_validator(mode: T.List[T.Union[str, bool, int]]) -> T.Optional
 
 
 def _install_mode_convertor(mode: T.Optional[T.List[T.Union[str, bool, int]]]) -> FileMode:
-    """Convert the DSL form of the `install_mode` keyword argument to `FileMode`
+    """Convert the DSL form of the `install_mode` keyword argument to `FileMode`"""
 
-    This is not required, and if not required returns None
-
-    TODO: It's not clear to me why this needs to be None and not just return an
-    empty FileMode.
-    """
     # this has already been validated by the validator
     return FileMode(*(m if isinstance(m, str) else None for m in mode))
 


### PR DESCRIPTION
We silently dropped all integer values to install_mode since the original implementation of doing this in KwargInfo, in commit 596c8d4af50d0e5a25ee0ee1e177e46b6c7ad22e.

This happened because install_mode is supposed to convert False (exactly) to None, and otherwise pass all arguments in place. But a generator is homogeneous and attempting to do this correctly produced a mypy error that FileMode arguments were allowed to be ints -- well of course they are -- so that resulted in the convertor... treating ints like False instead, to make mypy happy.

Fixes #11538