### PR TITLE
qt: Allow specifying separate tools for qt4/5/6

### DIFF
--- a/docs/yaml/objects/feature.yaml
+++ b/docs/yaml/objects/feature.yaml
@@ -100,7 +100,7 @@ methods:
 
     ```
     use_llvm = get_option('llvm').enable_if(with_clang).enable_if(with_llvm_libs)
-    dep_llvm = dependency('llvm', require : use_llvm)
+    dep_llvm = dependency('llvm', required: use_llvm)
     ```
 
   posargs:
@@ -132,7 +132,7 @@ methods:
     ```
     use_os_feature = get_option('foo') \
       .disable_if(host_machine.system() == 'darwin', error_message : 'os feature not supported on MacOS')
-    dep_os_feature = dependency('os_feature', require : use_os_feature)
+    dep_os_feature = dependency('os_feature', required: use_os_feature)
     ```
 
   posargs:

--- a/mesonbuild/dependencies/qt.py
+++ b/mesonbuild/dependencies/qt.py
@@ -252,11 +252,11 @@ class QmakeQtDependency(_QtBase, ConfigToolDependency, metaclass=abc.ABCMeta):
 
     """Find Qt using Qmake as a config-tool."""
 
-    tool_name = 'qmake'
     version_arg = '-v'
 
     def __init__(self, name: str, env: 'Environment', kwargs: T.Dict[str, T.Any]):
         _QtBase.__init__(self, name, kwargs)
+        self.tool_name = f'qmake{self.qtver}'
         self.tools = [f'qmake{self.qtver}', f'qmake-{self.name}', 'qmake']
 
         # Add additional constraints that the Qt version is met, but preserve

--- a/test cases/frameworks/15 llvm/meson.build
+++ b/test cases/frameworks/15 llvm/meson.build
@@ -18,7 +18,7 @@ if(method == 'combination')
   )
 
   # Bump the version along till the LLVM bug is fixed
-  if static and d.version().startswith('16.0') and d.version()[5].to_int() <= 2
+  if static and d.version().startswith('16.0') and d.version()[5].to_int() <= 4
     message('Skipping modules with cmake, see https://github.com/mesonbuild/meson/issues/11642')
     llvm_cm_dep = dependency(
       'llvm',
@@ -81,7 +81,7 @@ else
   endif
 
   # Bump the version along till the LLVM bug is fixed
-  if static and method == 'cmake' and d.version().startswith('16.0') and d.version()[5].to_int() <= 2
+  if static and method == 'cmake' and d.version().startswith('16.0') and d.version()[5].to_int() <= 4
     message('Skipping modules with cmake, see https://github.com/mesonbuild/meson/issues/11642')
     llvm_dep = dependency(
       'llvm',

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -152,7 +152,8 @@ foreach qt : ['qt4', 'qt5', 'qt6']
     endif
 
     # Check we can apply a version constraint
-    dependency(qt, modules: qt_modules, version: '>=@0@'.format(qtdep.version()), method : get_option('method'))
+    accept_versions = ['>=@0@'.format(qtdep.version()), '<@0@'.format(qtdep.version()[0].to_int() + 1)]
+    dependency(qt, modules: qt_modules, version: accept_versions, method : get_option('method'))
 
   endif
 endforeach


### PR DESCRIPTION
Currently you can only use one of qt4, qt5, qt6 in a single project when using a machine file because the config-tool lookup for qt only looks at `qmake` in the machine files, instead of looking up the binary names directly.

Allow specifying `qmake` `qmake4` `qmake5` and `qmake6`.

This is necessary for gstreamer, which can build separate qt5 and qt6 plugins that are distributed as static libraries, so the user can pick which one to use.