### PR TITLE
minstall: print the filename in case of PermissionError

### DIFF
--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -403,13 +403,15 @@ class Installer:
                 append_to_log(self.lf, f'# Preserving old file {to_file}\n')
                 self.preserved_file_count += 1
                 return False
+            self.log(f'Installing {from_file} to {outdir}')
             self.remove(to_file)
-        elif makedirs:
-            # Unpack tuple
-            dirmaker, outdir = makedirs
-            # Create dirs if needed
-            dirmaker.makedirs(outdir, exist_ok=True)
-        self.log(f'Installing {from_file} to {outdir}')
+        else:
+            self.log(f'Installing {from_file} to {outdir}')
+            if makedirs:
+                # Unpack tuple
+                dirmaker, outdir = makedirs
+                # Create dirs if needed
+                dirmaker.makedirs(outdir, exist_ok=True)
         if os.path.islink(from_file):
             if not os.path.exists(from_file):
                 # Dangling symlink. Replicate as is.


### PR DESCRIPTION
Previously the log had no indication of which file failed to install, merely a list of files already installed. Printing the actually failing file allows a user to narrow down which part of the install fails.

---
One of the projects I worked on installed to the system udev dir (regardless of prefix) but narrowing that down was frustrating. There's no indication what failed, so it's hard to guess which option didn't take the custom prefix I used. And while it asked for pkexec there too was no indication *why* it needed the privileges.

This patch fixes it, at least this way we can narrow down which file/group of files is affected.