### PR TITLE
docs: gnome: mention that compile_resources adds dependencies by default

### DIFF
--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -40,6 +40,8 @@ takes two positional arguments. The first one is the name of the
 resource and the second is the XML file containing the resource
 definitions. If the name is `foobar`, Meson will generate a header
 file called `foobar.h`, which you can then include in your sources.
+The resources specified are automatically added as dependencies of the
+generated target.
 
 * `c_name`: passed to the resource compiler as an argument after
   `--c-name`


### PR DESCRIPTION
It is not very clear from the documentation that the dependencies in the resource file are added as default dependencies to the target.

I've seen this at least in evince and gnome-control-center, and fixed it there. Just a justification that it might not have been very clear for some other people apart from me.