### PR TITLE
azure pipelines: fix branch patterns to support 1.x release branches

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ trigger:
     include:
     - 'master'
     # Release branches
-    - '0.*'
+    - '1.*'
   paths:
     include:
       - 'mesonbuild'


### PR DESCRIPTION
I would like to use the same pattern rule as github actions uses:

'[0-9]+.[0-9]+'

But azure pipelines doesn't document what the syntax here is, and it scares me that perhaps the reason we didn't already do this is because it doesn't work at all.