### PR TITLE
ProgressBar: Fix some rendering issues

### DIFF
--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -693,7 +693,7 @@ def run(options: 'Arguments') -> int:
     if not os.path.isdir(subprojects_dir):
         mlog.log('Directory', mlog.bold(src_dir), 'does not seem to have subprojects.')
         return 0
-    r = Resolver(src_dir, 'subprojects', wrap_frontend=True, allow_insecure=options.allow_insecure)
+    r = Resolver(src_dir, 'subprojects', wrap_frontend=True, allow_insecure=options.allow_insecure, silent=True)
     if options.subprojects:
         wraps = [wrap for name, wrap in r.wraps.items() if name in options.subprojects]
     else:

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -285,6 +285,7 @@ class Resolver:
     wrap_mode: WrapMode = WrapMode.default
     wrap_frontend: bool = False
     allow_insecure: bool = False
+    silent: bool = False
 
     def __post_init__(self) -> None:
         self.subdir_root = os.path.join(self.source_dir, self.subdir)
@@ -695,7 +696,8 @@ class Resolver:
                 return hashvalue, tmpfile.name
             sys.stdout.flush()
             progress_bar = ProgressBar(bar_type='download', total=dlsize,
-                                       desc='Downloading')
+                                       desc='Downloading',
+                                       disable=(self.silent or None))
             while True:
                 block = resp.read(blocksize)
                 if block == b'':


### PR DESCRIPTION
- Do not hardcode terminal width of 100 chars, that breaks rendering on smaller terminal. It already uses current console width by default.
- Disable progress bar when downloading from msubprojects because it fetches multiple wraps in parallel.
- Do not display rate when it's not a download.
- Do not display time remaining/elapsed to simplify the rendering.