### PR TITLE
Fix test failures on Darwin on a case-sensitive fs

### DIFF
--- a/test cases/failing/78 framework dependency with version/meson.build
+++ b/test cases/failing/78 framework dependency with version/meson.build
@@ -5,4 +5,4 @@ if host_machine.system() != 'darwin'
 endif
 
 # do individual frameworks have a meaningful version to test?  And multiple frameworks might be listed...
-dep = dependency('appleframeworks', modules: 'foundation', version: '>0')
+dep = dependency('appleframeworks', modules: 'Foundation', version: '>0')

--- a/test cases/objc/2 nsstring/meson.build
+++ b/test cases/objc/2 nsstring/meson.build
@@ -1,7 +1,7 @@
 project('nsstring', 'objc')
 
 if host_machine.system() == 'darwin'
-  dep = dependency('appleframeworks', modules : 'foundation')
+  dep = dependency('appleframeworks', modules : 'Foundation')
 elif host_machine.system() == 'cygwin'
   error('MESON_SKIP_TEST GNUstep is not packaged for Cygwin.')
 else

--- a/test cases/osx/6 multiframework/meson.build
+++ b/test cases/osx/6 multiframework/meson.build
@@ -4,7 +4,7 @@ project('multiframework', 'objc')
 # that causes a build failure when defining two modules. The
 # arguments for the latter module overwrote the arguments for
 # the first one rather than adding to them.
-cocoa_dep = dependency('appleframeworks', modules : ['AppKit', 'foundation'])
+cocoa_dep = dependency('appleframeworks', modules : ['AppKit', 'Foundation'])
 
 executable('deptester',
   'main.m',


### PR DESCRIPTION
This issue was encounetered while working on a contribution to nixpkgs. Nix allows the store to be installed on a separate, case-sensitive APFS volume. When the store is on a case-sensitive volume, these tests fail because they try to use `foundation` instead of `Foundation`.