### PR TITLE
ciimage: fix pathological brokenness in Debian packaging of python

### DIFF
--- a/ci/ciimage/common.sh
+++ b/ci/ciimage/common.sh
@@ -39,9 +39,11 @@ dub_fetch() {
 }
 
 install_minimal_python_packages() {
+  rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED
   python3 -m pip install "${base_python_pkgs[@]}" $*
 }
 
 install_python_packages() {
+  rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED
   python3 -m pip install "${base_python_pkgs[@]}" "${python_pkgs[@]}" $*
 }

--- a/test cases/java/3 args/meson.build
+++ b/test cases/java/3 args/meson.build
@@ -1,8 +1,8 @@
 project('simplejava', 'java')
 
-add_project_arguments('-target', '1.7', language : 'java')
+add_project_arguments('-target', '1.8', language : 'java')
 
 javaprog = jar('myprog', 'com/mesonbuild/Simple.java',
   main_class : 'com.mesonbuild.Simple',
-  java_args : ['-source', '1.7'])
+  java_args : ['-source', '1.8'])
 test('mytest', javaprog)


### PR DESCRIPTION
In this case, PEP 668 was created to allow a thing that Debian wanted, which is for `pip install foobar` to not break the system python. This despite the fact that the system python is fine, unless you use sudo pip which is discouraged for separate reasons, and it is in fact quite natural to install additional packages to the user site-packages.

It isn't even the job of the operating system to decide whether the user site-packages is broken, whether the operating system gets the answer correct or not -- it is the job of the operating system to decide whether the operating system is broken, and that can be solved by e.g. enforcing a shebang policy for distribution-packaged software, which distros like Fedora do, and mandating not only that python shebangs do not contain `/usr/bin/env`, but that they *do* contain -s.

Anyway, this entire kerfuffle is mostly just a bit of pointless interactive churn, but it bites pretty hard for our use case, which is a container image which is fortunately tested before deployment, so instead of failing to deploy because of theoretical conflicts with the base system (we specifically need base system integration...) we fail to deploy because 5 minutes into pulling apt updates at the very beginning, pip refuses point-blank to work. I especially do not know why it is the job of the operating system to throw errors intended for interactive users at people baking "appliance" containers who cannot "break" the system python anyway.

Fix this by doing what Debian and Ubuntu should both have done from the beginning, and opting containers out of this questionable feature entirely.

Note that CI images may still not actually complete their build/test cycle and be updated, because e.g. LLVM 16 issues tracked by #11642 or glib ASAN issues tracked by #11754.