### PR TITLE
avoid endless reconfigure loops when a build directory is copied around

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1293,7 +1293,9 @@ class NinjaBackend(backends.Backend):
             ['--internal',
              'regenerate',
              self.environment.get_source_dir(),
-             self.environment.get_build_dir()]
+             # Ninja always runs from the build_dir. This includes cases where the user moved the
+             # build directory and invalidated most references. Make sure it still regenerates.
+             '.']
         self.add_rule(NinjaRule('REGENERATE_BUILD',
                                 c, [],
                                 'Regenerating build files.',


### PR DESCRIPTION
ninja's configured command for regenerating a build directory on any action that *requires* reconfiguring, specifies the source and build directories as they were known during initial project generation. This means that if the build directory is no longer the *same* build directory, we will regenerate... the original location, rather than the location we want.

After that, ninja notices that build.ninja is still out of date, so it goes and reconfigures again. And again. And again.

This is probably broken intentions, but endless reconfigure loops are a kind of evil beyond all evils. There are no valid options here whatsoever other than:
- doing what the user actually meant
- spawning a clear error message describing why meson refuses to work, then exiting with a fatal error

But it turns out that it's actually pretty easy to do what the user actually meant, and reconfigure the current build directory instead of the original one. This permanently breaks the link between the two.

Fixes #6131