### PR TITLE
avoid clearing the dependency cache unnecessarily based on wrap-mode

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -704,12 +704,6 @@ class CoreData:
 
         if key.name == 'buildtype':
             dirty |= self._set_others_from_buildtype(value)
-        elif key.name in {'wrap_mode', 'force_fallback_for'}:
-            # We could have the system dependency cached for a dependency that
-            # is now forced to use subproject fallback. We probably could have
-            # more fine-grained cache invalidation, but better be safe.
-            self.clear_deps_cache()
-            dirty = True
 
         return dirty
 

--- a/mesonbuild/interpreter/dependencyfallbacks.py
+++ b/mesonbuild/interpreter/dependencyfallbacks.py
@@ -220,6 +220,8 @@ class DependencyFallbacksHolder(MesonInterpreterObject):
                 mlog.log('Dependency', mlog.bold(self._display_name),
                          'found:', mlog.red('NO'), *info)
                 return cached_dep
+        elif self.forcefallback and self.subproject_name:
+            cached_dep = None
         else:
             info = [mlog.blue('(cached)')]
             cached_dep = self.coredata.deps[for_machine].get(identifier)


### PR DESCRIPTION
We actually do not and should not care about wrap-mode at all for this. We want to cache dependency lookups whenever humanly possible, but only use them in cases where we would anyways be using them -- which in particular means if we said to force a subproject fallback for this dep, we want to bypass the cache.

Currently, we handle this by always looking up the cache for all dependencies, but clearing the cache at startup if a reconfigure means we are changing our resolution strategy. This is bad -- we might have many dependencies that are worth caching, and only one dependency that should stop being cached and use a subproject instead.

The simple solution is to handle the forcefallback case when doing a cache lookup, and not do a cache lookup at all. Now we don't have to nuke the entire cache. In fact, if a future reconfigure changes the forcefallback state back to not being forced, we can reuse the original cached dependency, which is still there.

Closes #11828