### PR TITLE
rust: PIC is always enabled

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -762,6 +762,10 @@ class BuildTarget(Target):
             raise MesonException('cannot mix structured sources and unstructured sources')
         if self.structured_sources and 'rust' not in self.compilers:
             raise MesonException('structured sources are only supported in Rust targets')
+        if self.uses_rust():
+            # relocation-model=pic is rustc's default and Meson does not
+            # currently have a way to disable PIC.
+            self.pic = True
 
     def __repr__(self):
         repr_str = "<{0} {1}: {2}>"

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -207,8 +207,8 @@ class RustCompiler(Compiler):
         return self._WARNING_LEVELS["0"]
 
     def get_pic_args(self) -> T.List[str]:
-        # This defaults to
-        return ['-C', 'relocation-model=pic']
+        # relocation-model=pic is rustc's default already.
+        return []
 
     def get_pie_args(self) -> T.List[str]:
         # Rustc currently has no way to toggle this, it's controlled by whether


### PR DESCRIPTION
rustc enables PIC by default and Meson currently has no way to force
disabling PIC, it can only force enable or use compiler's default.
