### PR TITLE
Archive shared library in AIX

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3602,8 +3602,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 # they are all built
                 # Add archive file if shared library in AIX for build all.
                 if self.environment.machines[t.for_machine].is_aix(): 
-                    aix_tmp = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*','.a', t.get_outputs()[0].replace('.so','.a'))
-                    targetlist.append(os.path.join(self.get_target_dir(t), t.get_outputs()[0] if not(t.get_outputs()[0].endswith('.so')) else aix_tmp))
+                    aix_tmp = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*', '.a', t.get_outputs()[0].replace('.so','.a'))
+                    targetlist.append(os.path.join(self.get_target_dir(t), aix_tmp))
                 else:
                     targetlist.append(os.path.join(self.get_target_dir(t), t.get_outputs()[0]))
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1034,7 +1034,7 @@ class NinjaBackend(backends.Backend):
         self.add_build(elem)
         #In AIX, we archive shared libraries. If the instance is a shared library, we add a command to archive the shared library
         #object and create the build element.
-        if isinstance(target, build.SharedLibrary) and linker.linker_needs_to_archive():
+        if isinstance(target, build.SharedLibrary) and self.environment.machines[target.for_machine].is_aix():
             elem = NinjaBuildElement(self.all_outputs, linker.get_archive_name(outname), 'AIX_LINKER', [outname])
             self.add_build(elem)
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1032,11 +1032,11 @@ class NinjaBackend(backends.Backend):
         elem = self.generate_link(target, outname, final_obj_list, linker, pch_objects, stdlib_args=stdlib_args)
         self.generate_dependency_scan_target(target, compiled_sources, source2object, generated_source_files, fortran_order_deps)
         self.add_build(elem)
-        #In AIX, we archive shared library. If the instance is a shared library we add a command to archive the shared library
+        #In AIX, we archive shared libraries. If the instance is a shared library, we add a command to archive the shared library
         #object and create the build element.
-        if mesonlib.is_aix() and isinstance(target, build.SharedLibrary):
-            x_outname = outname.replace ('.so', '.a')
-            aix_outname = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*','.a',x_outname)
+        if self.environment.machines[target.for_machine].is_aix() and isinstance(target, build.SharedLibrary):
+            x_outname = outname.replace('.so', '.a')
+            aix_outname = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*', '.a', x_outname)
             aix_final_obj_list = [outname]
             elem = NinjaBuildElement(self.all_outputs, aix_outname, 'AIX_LINKER', aix_final_obj_list)
             self.add_build(elem)
@@ -2311,14 +2311,14 @@ class NinjaBackend(backends.Backend):
 
                 options = self._rsp_options(compiler)
                 self.add_rule(NinjaRule(rule, command, args, description, **options, extra=pool))
-            if mesonlib.is_aix(): 
+            if self.environment.machines[for_machine].is_aix():
                 rule = 'AIX_LINKER{}'.format(self.get_rule_suffix(for_machine))
                 #Archive the shared library and remove the shared library since it is already there in the archive.
                 cmdlist = ['ar']
                 cmdlist += ['-q', '-v']
                 #Remove the shared library since it is already there in the archive.
                 description = 'Archiving AIX shared library'
-                cmdlist+=['$out', '$in', '&&', 'rm', '-f', '$in']
+                cmdlist += ['$out', '$in', '&&', 'rm', '-f', '$in']
                 args = []
                 options = {} 
                 self.add_rule(NinjaRule(rule, cmdlist, args, description, **options, extra=None)) 
@@ -3396,10 +3396,10 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         internal = self.build_target_link_arguments(linker, dependencies)
         #In AIX since shared libraries are archived the dependencies must
         #depend on .a file with the .so and not directly on the .so file.
-        if mesonlib.is_aix ():
+        if self.environment.machines[target.for_machine].is_aix():
             for i, val in enumerate(internal):
-                internal[i] = internal[i].replace ('.so', '.a')
-                internal[i] = re.sub ('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*','.a', internal[i])
+                val = val.replace('.so', '.a')
+                internal[i] = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*', '.a', val)
         commands += internal
         # Only non-static built targets need link args and link dependencies
         if not isinstance(target, build.StaticLibrary):
@@ -3601,9 +3601,9 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 # Add the first output of each target to the 'all' target so that
                 # they are all built
                 #Add archive file if shared library in AIX for build all.
-                if mesonlib.is_aix():
-                    aix_tmp = re.sub ('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*','.a', t.get_outputs()[0].replace ('.so','.a'))
-                    targetlist.append(os.path.join(self.get_target_dir(t), t.get_outputs()[0] if mesonlib.is_aix() and not(t.get_outputs()[0].endswith('.so')) else aix_tmp))
+                if self.environment.machines[t.for_machine].is_aix(): 
+                    aix_tmp = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*','.a', t.get_outputs()[0].replace('.so','.a'))
+                    targetlist.append(os.path.join(self.get_target_dir(t), t.get_outputs()[0] if not(t.get_outputs()[0].endswith('.so')) else aix_tmp))
                 else:
                     targetlist.append(os.path.join(self.get_target_dir(t), t.get_outputs()[0]))
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1032,8 +1032,8 @@ class NinjaBackend(backends.Backend):
         elem = self.generate_link(target, outname, final_obj_list, linker, pch_objects, stdlib_args=stdlib_args)
         self.generate_dependency_scan_target(target, compiled_sources, source2object, generated_source_files, fortran_order_deps)
         self.add_build(elem)
-        #In AIX, we archive shared libraries. If the instance is a shared library, we add a command to archive the shared library
-        #object and create the build element.
+        # In AIX, we archive shared libraries. If the instance is a shared library, we add a command to archive the shared library
+        # object and create the build element.
         if self.environment.machines[target.for_machine].is_aix() and isinstance(target, build.SharedLibrary):
             x_outname = outname.replace('.so', '.a')
             aix_outname = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*', '.a', x_outname)
@@ -2313,7 +2313,7 @@ class NinjaBackend(backends.Backend):
                 self.add_rule(NinjaRule(rule, command, args, description, **options, extra=pool))
             if self.environment.machines[for_machine].is_aix():
                 rule = 'AIX_LINKER{}'.format(self.get_rule_suffix(for_machine))
-                #Archive the shared library and remove the shared library since it is already there in the archive.
+                # Archive the shared library and remove the shared library since it is already there in the archive.
                 cmdlist = ['ar']
                 cmdlist += ['-q', '-v']
                 #Remove the shared library since it is already there in the archive.
@@ -3394,8 +3394,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         else:
             dependencies = target.get_dependencies()
         internal = self.build_target_link_arguments(linker, dependencies)
-        #In AIX since shared libraries are archived the dependencies must
-        #depend on .a file with the .so and not directly on the .so file.
+        # In AIX since shared libraries are archived the dependencies must
+        # depend on .a file with the .so and not directly on the .so file.
         if self.environment.machines[target.for_machine].is_aix():
             for i, val in enumerate(internal):
                 val = val.replace('.so', '.a')
@@ -3600,7 +3600,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             for t in deps.values():
                 # Add the first output of each target to the 'all' target so that
                 # they are all built
-                #Add archive file if shared library in AIX for build all.
+                # Add archive file if shared library in AIX for build all.
                 if self.environment.machines[t.for_machine].is_aix(): 
                     aix_tmp = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*','.a', t.get_outputs()[0].replace('.so','.a'))
                     targetlist.append(os.path.join(self.get_target_dir(t), t.get_outputs()[0] if not(t.get_outputs()[0].endswith('.so')) else aix_tmp))

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1034,7 +1034,7 @@ class NinjaBackend(backends.Backend):
         self.add_build(elem)
         #In AIX, we archive shared libraries. If the instance is a shared library, we add a command to archive the shared library
         #object and create the build element.
-        if isinstance(target, build.SharedLibrary) and linker.linker_needs_to_archive(): 
+        if isinstance(target, build.SharedLibrary) and linker.linker_needs_to_archive():
             elem = NinjaBuildElement(self.all_outputs, linker.get_archive_name(outname), 'AIX_LINKER', [outname])
             self.add_build(elem)
 
@@ -2313,8 +2313,8 @@ class NinjaBackend(backends.Backend):
                 description = 'Archiving AIX shared library'
                 cmdlist = compiler.get_command_to_archive_shlib()
                 args = []
-                options = {} 
-                self.add_rule(NinjaRule(rule, cmdlist, args, description, **options, extra=None)) 
+                options = {}
+                self.add_rule(NinjaRule(rule, cmdlist, args, description, **options, extra=None))
 
         args = self.environment.get_build_command() + \
             ['--internal',
@@ -3594,9 +3594,9 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 # they are all built
                 #Add archive file if shared library in AIX for build all.
                 if isinstance(t, build.SharedLibrary):
-                     linker, stdlib_args = self.determine_linker_and_stdlib_args(t)
-                     if isinstance(t, build.SharedLibrary) and linker.linker_needs_to_archive(): 
-                         t.get_outputs()[0] = linker.get_archive_name(t.get_outputs()[0])
+                    if self.environment.machines[t.for_machine].is_aix():
+                        linker, stdlib_args = self.determine_linker_and_stdlib_args(t)
+                        t.get_outputs()[0] = linker.get_archive_name(t.get_outputs()[0])
                 targetlist.append(os.path.join(self.get_target_dir(t), t.get_outputs()[0]))
 
             elem = NinjaBuildElement(self.all_outputs, targ, 'phony', targetlist)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1032,13 +1032,10 @@ class NinjaBackend(backends.Backend):
         elem = self.generate_link(target, outname, final_obj_list, linker, pch_objects, stdlib_args=stdlib_args)
         self.generate_dependency_scan_target(target, compiled_sources, source2object, generated_source_files, fortran_order_deps)
         self.add_build(elem)
-        # In AIX, we archive shared libraries. If the instance is a shared library, we add a command to archive the shared library
-        # object and create the build element.
-        if self.environment.machines[target.for_machine].is_aix() and isinstance(target, build.SharedLibrary):
-            x_outname = outname.replace('.so', '.a')
-            aix_outname = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*', '.a', x_outname)
-            aix_final_obj_list = [outname]
-            elem = NinjaBuildElement(self.all_outputs, aix_outname, 'AIX_LINKER', aix_final_obj_list)
+        #In AIX, we archive shared libraries. If the instance is a shared library, we add a command to archive the shared library
+        #object and create the build element.
+        if isinstance(target, build.SharedLibrary) and linker.linker_needs_to_archive(): 
+            elem = NinjaBuildElement(self.all_outputs, linker.get_archive_name(outname), 'AIX_LINKER', [outname])
             self.add_build(elem)
 
     def should_use_dyndeps_for_target(self, target: 'build.BuildTarget') -> bool:
@@ -2313,12 +2310,8 @@ class NinjaBackend(backends.Backend):
                 self.add_rule(NinjaRule(rule, command, args, description, **options, extra=pool))
             if self.environment.machines[for_machine].is_aix():
                 rule = 'AIX_LINKER{}'.format(self.get_rule_suffix(for_machine))
-                # Archive the shared library and remove the shared library since it is already there in the archive.
-                cmdlist = ['ar']
-                cmdlist += ['-q', '-v']
-                #Remove the shared library since it is already there in the archive.
                 description = 'Archiving AIX shared library'
-                cmdlist += ['$out', '$in', '&&', 'rm', '-f', '$in']
+                cmdlist = compiler.get_command_to_archive_shlib()
                 args = []
                 options = {} 
                 self.add_rule(NinjaRule(rule, cmdlist, args, description, **options, extra=None)) 
@@ -3394,12 +3387,11 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         else:
             dependencies = target.get_dependencies()
         internal = self.build_target_link_arguments(linker, dependencies)
-        # In AIX since shared libraries are archived the dependencies must
-        # depend on .a file with the .so and not directly on the .so file.
+        #In AIX since shared libraries are archived the dependencies must
+        #depend on .a file with the .so and not directly on the .so file.
         if self.environment.machines[target.for_machine].is_aix():
             for i, val in enumerate(internal):
-                val = val.replace('.so', '.a')
-                internal[i] = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*', '.a', val)
+                internal[i] = linker.get_archive_name(val)
         commands += internal
         # Only non-static built targets need link args and link dependencies
         if not isinstance(target, build.StaticLibrary):
@@ -3600,12 +3592,12 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             for t in deps.values():
                 # Add the first output of each target to the 'all' target so that
                 # they are all built
-                # Add archive file if shared library in AIX for build all.
-                if self.environment.machines[t.for_machine].is_aix(): 
-                    aix_tmp = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*', '.a', t.get_outputs()[0].replace('.so','.a'))
-                    targetlist.append(os.path.join(self.get_target_dir(t), aix_tmp))
-                else:
-                    targetlist.append(os.path.join(self.get_target_dir(t), t.get_outputs()[0]))
+                #Add archive file if shared library in AIX for build all.
+                if isinstance(t, build.SharedLibrary):
+                     linker, stdlib_args = self.determine_linker_and_stdlib_args(t)
+                     if isinstance(t, build.SharedLibrary) and linker.linker_needs_to_archive(): 
+                         t.get_outputs()[0] = linker.get_archive_name(t.get_outputs()[0])
+                targetlist.append(os.path.join(self.get_target_dir(t), t.get_outputs()[0]))
 
             elem = NinjaBuildElement(self.all_outputs, targ, 'phony', targetlist)
             self.add_build(elem)

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -944,10 +944,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         return self.linker.get_archive_name(filename)
 
     def get_command_to_archive_shlib(self) -> T.List[str]:
-        return self.linker.get_command_to_archive_shlib() 
-
-    def linker_needs_to_archive(self) -> bool:
-        return self.linker.linker_needs_to_archive()
+        return self.linker.get_command_to_archive_shlib()
 
     def thread_flags(self, env: 'Environment') -> T.List[str]:
         return []

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -940,6 +940,15 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         return self.linker.build_rpath_args(
             env, build_dir, from_dir, rpath_paths, build_rpath, install_rpath)
 
+    def get_archive_name(self, filename):
+        return self.linker.get_archive_name(filename)
+
+    def get_command_to_archive_shlib(self):
+        return self.linker.get_command_to_archive_shlib() 
+
+    def linker_needs_to_archive(self):
+        return self.linker.linker_needs_to_archive()
+
     def thread_flags(self, env: 'Environment') -> T.List[str]:
         return []
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -940,13 +940,13 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         return self.linker.build_rpath_args(
             env, build_dir, from_dir, rpath_paths, build_rpath, install_rpath)
 
-    def get_archive_name(self, filename):
+    def get_archive_name(self, filename: str) -> str:
         return self.linker.get_archive_name(filename)
 
-    def get_command_to_archive_shlib(self):
+    def get_command_to_archive_shlib(self) -> T.List[str]:
         return self.linker.get_command_to_archive_shlib() 
 
-    def linker_needs_to_archive(self):
+    def linker_needs_to_archive(self) -> bool:
         return self.linker.linker_needs_to_archive()
 
     def thread_flags(self, env: 'Environment') -> T.List[str]:

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -351,7 +351,7 @@ class MachineInfo(HoldableObject):
         """
         return self.system == 'gnu'
 
-    def is_aix(self)  -> bool:
+    def is_aix(self) -> bool:
         """
         Machine is aix?
         """

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -351,6 +351,12 @@ class MachineInfo(HoldableObject):
         """
         return self.system == 'gnu'
 
+    def is_aix(self)  -> bool:
+        """
+        Machine is aix?
+        """
+        return self.system == 'aix'
+
     def is_irix(self) -> bool:
         """Machine is IRIX?"""
         return self.system.startswith('irix')

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -572,7 +572,7 @@ class DynamicLinker(metaclass=abc.ABCMeta):
 
     def get_archive_name(self, filename: str) -> str:
         #Only used by AIX.
-        return []
+        return str()
 
     def get_command_to_archive_shlib(self) -> T.List[str]:
         #Only used by AIX.

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -570,13 +570,13 @@ class DynamicLinker(metaclass=abc.ABCMeta):
                         suffix: str, soversion: str, darwin_versions: T.Tuple[str, str]) -> T.List[str]:
         return []
 
-    def get_archive_name(self, filename):
+    def get_archive_name(self, filename: str) -> str:
         return []
 
-    def linker_needs_to_archive(self):
-        return False 
+    def linker_needs_to_archive(self) -> bool:
+        return False
 
-    def get_command_to_archive_shlib(self):
+    def get_command_to_archive_shlib(self) -> T.List[str]:
         return []
 
 
@@ -1478,22 +1478,22 @@ class AIXDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
     def get_allow_undefined_args(self) -> T.List[str]:
         return self._apply_prefix(['-berok'])
 
-    def get_archive_name(self, filename):
+    def get_archive_name(self, filename: str) -> str:
         # In AIX we allow the shared library name to have the lt_version and so_version.
-        # But the archive name must just be .a . 
+        # But the archive name must just be .a .
         # For Example shared object can have the name libgio.so.0.7200.1 but the archive
-        # must have the name libgio.a having libgio.a (libgio.so.0.7200.1) in the 
-        # archive. This regular expression is to do the same. 
+        # must have the name libgio.a having libgio.a (libgio.so.0.7200.1) in the
+        # archive. This regular expression is to do the same.
         filename = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*', '.a', filename.replace ('.so', '.a'))
         return filename
 
-    def linker_needs_to_archive(self):
+    def linker_needs_to_archive(self) -> bool:
         return True
 
-    def get_command_to_archive_shlib(self):
+    def get_command_to_archive_shlib(self) -> T.List[str]:
         # Archive shared library object and remove the shared library object,
-        # since it already exists in the archive. 
-        command = ['ar', '-q', '-v', '$out', '$in', '&&', 'rm', '-f', '$in'] 
+        # since it already exists in the archive.
+        command = ['ar', '-q', '-v', '$out', '$in', '&&', 'rm', '-f', '$in']
         return command
 
     def get_link_whole_for(self, args: T.List[str]) -> T.List[str]:

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -571,12 +571,11 @@ class DynamicLinker(metaclass=abc.ABCMeta):
         return []
 
     def get_archive_name(self, filename: str) -> str:
+        #Only used by AIX.
         return []
 
-    def linker_needs_to_archive(self) -> bool:
-        return False
-
     def get_command_to_archive_shlib(self) -> T.List[str]:
+        #Only used by AIX.
         return []
 
 
@@ -1484,11 +1483,8 @@ class AIXDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
         # For Example shared object can have the name libgio.so.0.7200.1 but the archive
         # must have the name libgio.a having libgio.a (libgio.so.0.7200.1) in the
         # archive. This regular expression is to do the same.
-        filename = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*', '.a', filename.replace ('.so', '.a'))
+        filename = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*', '.a', filename.replace('.so', '.a'))
         return filename
-
-    def linker_needs_to_archive(self) -> bool:
-        return True
 
     def get_command_to_archive_shlib(self) -> T.List[str]:
         # Archive shared library object and remove the shared library object,

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -17,6 +17,7 @@ import abc
 import enum
 import os
 import typing as T
+import re
 
 from .. import mesonlib
 from ..mesonlib import EnvironmentException, MesonException
@@ -567,6 +568,15 @@ class DynamicLinker(metaclass=abc.ABCMeta):
 
     def get_soname_args(self, env: 'Environment', prefix: str, shlib_name: str,
                         suffix: str, soversion: str, darwin_versions: T.Tuple[str, str]) -> T.List[str]:
+        return []
+
+    def get_archive_name(self, filename):
+        return []
+
+    def linker_needs_to_archive(self):
+        return False 
+
+    def get_command_to_archive_shlib(self):
         return []
 
 
@@ -1467,6 +1477,24 @@ class AIXDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
 
     def get_allow_undefined_args(self) -> T.List[str]:
         return self._apply_prefix(['-berok'])
+
+    def get_archive_name(self, filename):
+        # In AIX we allow the shared library name to have the lt_version and so_version.
+        # But the archive name must just be .a . 
+        # For Example shared object can have the name libgio.so.0.7200.1 but the archive
+        # must have the name libgio.a having libgio.a (libgio.so.0.7200.1) in the 
+        # archive. This regular expression is to do the same. 
+        filename = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*', '.a', filename.replace ('.so', '.a'))
+        return filename
+
+    def linker_needs_to_archive(self):
+        return True
+
+    def get_command_to_archive_shlib(self):
+        # Archive shared library object and remove the shared library object,
+        # since it already exists in the archive. 
+        command = ['ar', '-q', '-v', '$out', '$in', '&&', 'rm', '-f', '$in'] 
+        return command
 
     def get_link_whole_for(self, args: T.List[str]) -> T.List[str]:
         # AIX's linker always links the whole archive: "The ld command

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -710,9 +710,9 @@ class Installer:
 
     def install_targets(self, d: InstallData, dm: DirMaker, destdir: str, fullprefix: str) -> None:
         for t in d.targets:
-            #In AIX, we archive our shared libraries.  When we install any package in AIX we need to
-            #install the archive in which the shared library exists. The below code does the same.
-            #We change the .so files having lt_version or so_version to archive file install. 
+            # In AIX, we archive our shared libraries.  When we install any package in AIX we need to
+            # install the archive in which the shared library exists. The below code does the same.
+            # We change the .so files having lt_version or so_version to archive file install. 
             if self.environment.machines[t.for_machine].is_aix():
                 if '.so' in t.fname:
                     aix_fname = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*', '.a', t.fname.replace ('.so', '.a'))

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -23,6 +23,7 @@ import shutil
 import subprocess
 import sys
 import typing as T
+import re
 
 from . import build, coredata, environment
 from .backend.backends import InstallData
@@ -709,6 +710,13 @@ class Installer:
 
     def install_targets(self, d: InstallData, dm: DirMaker, destdir: str, fullprefix: str) -> None:
         for t in d.targets:
+            #In AIX, we archive our shared libraries. During install section we need to install the
+            #archive in which the shared library exists. Hence in the below code we change the
+            #shared library install that can have both so_version and lt_version to archive install.
+            if mesonlib.is_aix():
+                if '.so' in t.fname:
+                    aix_fname = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*','.a',t.fname.replace ('.so', '.a'))
+                    t.fname = aix_fname
             if not self.should_install(t):
                 continue
             if not os.path.exists(t.fname):

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -715,7 +715,7 @@ class Installer:
             # We change the .so files having lt_version or so_version to archive file install.
             if is_aix():
                 if '.so' in t.fname:
-                    t.fname = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*', '.a', t.fname.replace ('.so', '.a'))
+                    t.fname = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*', '.a', t.fname.replace('.so', '.a'))
             if not self.should_install(t):
                 continue
             if not os.path.exists(t.fname):

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -710,12 +710,12 @@ class Installer:
 
     def install_targets(self, d: InstallData, dm: DirMaker, destdir: str, fullprefix: str) -> None:
         for t in d.targets:
-            #In AIX, we archive our shared libraries. During install section we need to install the
-            #archive in which the shared library exists. Hence in the below code we change the
-            #shared library install that can have both so_version and lt_version to archive install.
-            if mesonlib.is_aix():
+            #In AIX, we archive our shared libraries.  When we install any package in AIX we need to
+            #install the archive in which the shared library exists. The below code does the same.
+            #We change the .so files having lt_version or so_version to archive file install. 
+            if self.environment.machines[t.for_machine].is_aix():
                 if '.so' in t.fname:
-                    aix_fname = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*','.a',t.fname.replace ('.so', '.a'))
+                    aix_fname = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*', '.a', t.fname.replace ('.so', '.a'))
                     t.fname = aix_fname
             if not self.should_install(t):
                 continue

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -712,11 +712,10 @@ class Installer:
         for t in d.targets:
             # In AIX, we archive our shared libraries.  When we install any package in AIX we need to
             # install the archive in which the shared library exists. The below code does the same.
-            # We change the .so files having lt_version or so_version to archive file install. 
+            # We change the .so files having lt_version or so_version to archive file install.
             if is_aix():
                 if '.so' in t.fname:
-                    aix_fname = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*', '.a', t.fname.replace ('.so', '.a'))
-                    t.fname = aix_fname
+                    t.fname = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*', '.a', t.fname.replace ('.so', '.a'))
             if not self.should_install(t):
                 continue
             if not os.path.exists(t.fname):

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -28,7 +28,7 @@ import re
 from . import build, coredata, environment
 from .backend.backends import InstallData
 from .mesonlib import (MesonException, Popen_safe, RealPathAction, is_windows,
-                       setup_vsenv, pickle_load, is_osx, OptionKey)
+                       is_aix, setup_vsenv, pickle_load, is_osx, OptionKey)
 from .scripts import depfixer, destdir_join
 from .scripts.meson_exe import run_exe
 try:
@@ -713,7 +713,7 @@ class Installer:
             # In AIX, we archive our shared libraries.  When we install any package in AIX we need to
             # install the archive in which the shared library exists. The below code does the same.
             # We change the .so files having lt_version or so_version to archive file install. 
-            if self.environment.machines[t.for_machine].is_aix():
+            if is_aix():
                 if '.so' in t.fname:
                     aix_fname = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*', '.a', t.fname.replace ('.so', '.a'))
                     t.fname = aix_fname


### PR DESCRIPTION
This PR is to fix the issue discussed in https://github.com/mesonbuild/meson/issues/10532

This code change to ensure we archive shared libraries in AIX.

The things we do are:
Archive shared library
Install archived shared library
Build all must build the archived shared library
blibpath must have the archived shared library dependency.