### PR TITLE
Allow default_options and override_options as dictionaries

### DIFF
--- a/docs/markdown/snippets/option_dict.md
+++ b/docs/markdown/snippets/option_dict.md
@@ -1,0 +1,5 @@
+## default_options and override_options may now be dictionaries
+
+Instead of passing them as `default_options : ['key=value']`, they can now be
+passed as `default_options : {'key': 'value'}`, and the same for
+`override_options`.

--- a/docs/yaml/elementary/dict.yml
+++ b/docs/yaml/elementary/dict.yml
@@ -8,8 +8,9 @@ description: |
   You can also iterate over dictionaries with the [`foreach`
   statement](Syntax.md#foreach-statements).
 
-  *(since 0.48.0)* Dictionaries can be added (e.g. `d1 = d2 + d3` and `d1 += d2`).
+  *(since 0.48.0)*: Dictionaries can be added (e.g. `d1 = d2 + d3` and `d1 += d2`).
   Values from the second dictionary overrides values from the first.
+  *(since 0.62.0)*: Dictionary order is guaranteed to be insertion order.
 
 
 methods:

--- a/docs/yaml/functions/_build_target_base.yaml
+++ b/docs/yaml/functions/_build_target_base.yaml
@@ -228,12 +228,13 @@ kwargs:
       Set this to `[]`, or omit the keyword argument for the default behaviour.
 
   override_options:
-    type: list[str]
+    type: list[str] | dict[str]
     since: 0.40.0
     description: |
       takes an array of strings in the same format as `project`'s `default_options`
       overriding the values of these options
       for this target only.
+      *(since 1.2.0)*: A dictionary may now be passed.
 
   gnu_symbol_visibility:
     type: str

--- a/docs/yaml/functions/_build_target_base.yaml
+++ b/docs/yaml/functions/_build_target_base.yaml
@@ -228,7 +228,7 @@ kwargs:
       Set this to `[]`, or omit the keyword argument for the default behaviour.
 
   override_options:
-    type: list[str] | dict[str]
+    type: list[str] | dict[str | bool | int | list[str]]
     since: 0.40.0
     description: |
       takes an array of strings in the same format as `project`'s `default_options`

--- a/docs/yaml/functions/dependency.yaml
+++ b/docs/yaml/functions/dependency.yaml
@@ -78,7 +78,7 @@ varargs:
 
 kwargs:
   default_options:
-    type: list[str] | dict[str]
+    type: list[str] | dict[str | bool | int | list[str]]
     since: 0.38.0
     description: |
       An array of default option values

--- a/docs/yaml/functions/dependency.yaml
+++ b/docs/yaml/functions/dependency.yaml
@@ -78,7 +78,7 @@ varargs:
 
 kwargs:
   default_options:
-    type: list[str]
+    type: list[str] | dict[str]
     since: 0.38.0
     description: |
       An array of default option values
@@ -86,6 +86,7 @@ kwargs:
       (like `default_options` in [[project]], they only have
       effect when Meson is run for the first time, and command line
       arguments override any default options in build files)
+      *(since 1.2.0)*: A dictionary may now be passed.
 
   allow_fallback:
     type: bool

--- a/docs/yaml/functions/project.yaml
+++ b/docs/yaml/functions/project.yaml
@@ -38,7 +38,7 @@ varargs:
 
 kwargs:
   default_options:
-    type: list[str]
+    type: list[str] | dict[str]
     description: |
       Accepts strings in the form `key=value`
       which have the same format as options to `meson configure`.
@@ -53,6 +53,8 @@ kwargs:
       for example, using `c_args` here means that the `CFLAGS`
       environment variable is not used. Consider using
       [[add_project_arguments()]] instead.
+
+      *(since 1.2.0)*: A dictionary may now be passed.
 
   version:
     type: str | file

--- a/docs/yaml/functions/project.yaml
+++ b/docs/yaml/functions/project.yaml
@@ -38,7 +38,7 @@ varargs:
 
 kwargs:
   default_options:
-    type: list[str] | dict[str]
+    type: list[str] | dict[str | bool | int | list[str]]
     description: |
       Accepts strings in the form `key=value`
       which have the same format as options to `meson configure`.

--- a/docs/yaml/functions/subproject.yaml
+++ b/docs/yaml/functions/subproject.yaml
@@ -42,7 +42,7 @@ posargs:
 
 kwargs:
   default_options:
-    type: list[str] | dict[str]
+    type: list[str] | dict[str | bool | int | list[str]]
     since: 0.37.0
     description: |
       An array of default option values

--- a/docs/yaml/functions/subproject.yaml
+++ b/docs/yaml/functions/subproject.yaml
@@ -12,8 +12,9 @@ description: |
     that override those set in the subproject's `meson.options`
     (like `default_options` in `project`, they only have effect when
     Meson is run for the first time, and command line arguments override
-    any default options in build files). *(since 0.54.0)*: `default_library`
-    built-in option can also be overridden.
+    any default options in build files).
+    *(since 0.54.0)*: `default_library` built-in option can also be overridden.
+    *(since 1.2.0)*: A dictionary may be passed instead of array.
   - `version`: works just like the same as in `dependency`.
     It specifies what version the subproject should be, as an example `>=1.0.1`
   - `required` *(since 0.48.0)*: By default, `required` is `true` and
@@ -41,15 +42,16 @@ posargs:
 
 kwargs:
   default_options:
-    type: list[str]
+    type: list[str] | dict[str]
     since: 0.37.0
     description: |
       An array of default option values
       that override those set in the subproject's `meson.options`
       (like `default_options` in [[project]], they only have effect when
       Meson is run for the first time, and command line arguments override
-      any default options in build files). *(since 0.54.0)*: `default_library`
-      built-in option can also be overridden.
+      any default options in build files).
+      *(since 0.54.0)*: `default_library` built-in option can also be overridden.
+      *(since 1.2.0)*: A dictionary may now be passed.
 
   version:
     type: str

--- a/mesonbuild/interpreter/dependencyfallbacks.py
+++ b/mesonbuild/interpreter/dependencyfallbacks.py
@@ -19,7 +19,7 @@ if T.TYPE_CHECKING:
 
 class DependencyFallbacksHolder(MesonInterpreterObject):
     def __init__(self, interpreter: 'Interpreter', names: T.List[str], allow_fallback: T.Optional[bool] = None,
-                 default_options: T.Optional[T.List[str]] = None) -> None:
+                 default_options: T.Optional[T.Dict[OptionKey, str]] = None) -> None:
         super().__init__(subproject=interpreter.subproject)
         self.interpreter = interpreter
         self.subproject = interpreter.subproject
@@ -30,7 +30,7 @@ class DependencyFallbacksHolder(MesonInterpreterObject):
         self.allow_fallback = allow_fallback
         self.subproject_name: T.Optional[str] = None
         self.subproject_varname: T.Optional[str] = None
-        self.subproject_kwargs = {'default_options': default_options or []}
+        self.subproject_kwargs = {'default_options': default_options or {}}
         self.names: T.List[str] = []
         self.forcefallback: bool = False
         self.nofallback: bool = False
@@ -114,12 +114,11 @@ class DependencyFallbacksHolder(MesonInterpreterObject):
         # dependency('foo', static: true) should implicitly add
         # default_options: ['default_library=static']
         static = kwargs.get('static')
-        default_options = stringlistify(func_kwargs.get('default_options', []))
-        if static is not None and not any('default_library' in i for i in default_options):
+        default_options = func_kwargs.get('default_options', {})
+        if static is not None and 'default_library' not in default_options:
             default_library = 'static' if static else 'shared'
-            opt = f'default_library={default_library}'
-            mlog.log(f'Building fallback subproject with {opt}')
-            default_options.append(opt)
+            mlog.log(f'Building fallback subproject with default_library={default_library}')
+            default_options[OptionKey('default_library')] = default_library
             func_kwargs['default_options'] = default_options
 
         # Configure the subproject

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -12,7 +12,7 @@ from typing_extensions import TypedDict, Literal, Protocol
 from .. import build
 from .. import coredata
 from ..compilers import Compiler
-from ..mesonlib import MachineChoice, File, FileMode, FileOrString
+from ..mesonlib import MachineChoice, File, FileMode, FileOrString, OptionKey
 from ..modules.cmake import CMakeSubprojectOptions
 from ..programs import ExternalProgram
 
@@ -203,7 +203,7 @@ class Project(TypedDict):
 
     version: T.Optional[FileOrString]
     meson_version: T.Optional[str]
-    default_options: T.List[str]
+    default_options: T.Dict[OptionKey, str]
     license: T.List[str]
     subproject_dir: str
 
@@ -298,13 +298,13 @@ class ConfigureFile(TypedDict):
 
 class Subproject(ExtractRequired):
 
-    default_options: T.List[str]
+    default_options: T.Dict[OptionKey, str]
     version: T.List[str]
 
 
 class DoSubproject(ExtractRequired):
 
-    default_options: T.List[str]
+    default_options: T.Dict[OptionKey, str]
     version: T.List[str]
     cmake_options: T.List[str]
     options: T.Optional[CMakeSubprojectOptions]

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -203,7 +203,7 @@ class Project(TypedDict):
 
     version: T.Optional[FileOrString]
     meson_version: T.Optional[str]
-    default_options: T.Dict[OptionKey, str]
+    default_options: T.Dict[OptionKey, T.Union[str, int, bool, T.List[str]]]
     license: T.List[str]
     subproject_dir: str
 
@@ -298,13 +298,13 @@ class ConfigureFile(TypedDict):
 
 class Subproject(ExtractRequired):
 
-    default_options: T.Dict[OptionKey, str]
+    default_options: T.Dict[OptionKey, T.Union[str, int, bool, T.List[str]]]
     version: T.List[str]
 
 
 class DoSubproject(ExtractRequired):
 
-    default_options: T.Dict[OptionKey, str]
+    default_options: T.Dict[OptionKey, T.Union[str, int, bool, T.List[str]]]
     version: T.List[str]
     cmake_options: T.List[str]
     options: T.Optional[CMakeSubprojectOptions]

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -281,21 +281,25 @@ COMMAND_KW: KwargInfo[T.List[T.Union[str, BuildTarget, CustomTarget, CustomTarge
     default=[],
 )
 
-def _override_options_convertor(raw: T.List[str]) -> T.Dict[OptionKey, str]:
-    output: T.Dict[OptionKey, str] = {}
-    for each in raw:
-        k, v = split_equal_string(each)
-        output[OptionKey.from_string(k)] = v
-    return output
+def _override_options_convertor(raw: T.Union[str, T.List[str], T.Dict[str, str]]) -> T.Dict[OptionKey, str]:
+    if isinstance(raw, str):
+        raw = [raw]
+    if isinstance(raw, list):
+        output: T.Dict[OptionKey, str] = {}
+        for each in raw:
+            k, v = split_equal_string(each)
+            output[OptionKey.from_string(k)] = v
+        return output
+    return {OptionKey.from_string(k): v for k, v in raw.items()}
 
 
-OVERRIDE_OPTIONS_KW: KwargInfo[T.List[str]] = KwargInfo(
+OVERRIDE_OPTIONS_KW: KwargInfo[T.Union[str, T.Dict[str, str], T.List[str]]] = KwargInfo(
     'override_options',
-    ContainerTypeInfo(list, str),
-    listify=True,
-    default=[],
+    (str, ContainerTypeInfo(list, str), ContainerTypeInfo(dict, str)),
+    default={},
     validator=_options_validator,
     convertor=_override_options_convertor,
+    since_values={dict: '1.2.0'},
 )
 
 
@@ -385,14 +389,7 @@ INCLUDE_DIRECTORIES: KwargInfo[T.List[T.Union[str, IncludeDirs]]] = KwargInfo(
     default=[],
 )
 
-# for cases like default_options and override_options
-DEFAULT_OPTIONS: KwargInfo[T.List[str]] = KwargInfo(
-    'default_options',
-    ContainerTypeInfo(list, str),
-    listify=True,
-    default=[],
-    validator=_options_validator,
-)
+DEFAULT_OPTIONS = OVERRIDE_OPTIONS_KW.evolve(name='default_options')
 
 ENV_METHOD_KW = KwargInfo('method', str, default='set', since='0.62.0',
                           validator=in_set_validator({'set', 'prepend', 'append'}))

--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -431,7 +431,7 @@ class CmakeModule(ExtensionModule):
             'required': kwargs_['required'],
             'options': kwargs_['options'],
             'cmake_options': kwargs_['cmake_options'],
-            'default_options': [],
+            'default_options': {},
             'version': [],
         }
         subp = self.interpreter.do_subproject(dirname, 'cmake', kw)

--- a/test cases/common/264 default_options dict/lib.c
+++ b/test cases/common/264 default_options dict/lib.c
@@ -1,0 +1,1 @@
+#warning Make sure this is not fatal

--- a/test cases/common/264 default_options dict/meson.build
+++ b/test cases/common/264 default_options dict/meson.build
@@ -1,0 +1,22 @@
+project('test default options', 'c',
+    default_options: {
+        'bool': true,
+        'int': 42,
+        'str': 'foo',
+        'array': ['foo'],
+        'werror': true,
+    },
+)
+
+assert(get_option('bool') == true)
+assert(get_option('int') == 42)
+assert(get_option('str') == 'foo')
+assert(get_option('array') == ['foo'])
+assert(get_option('werror') == true)
+
+cc = meson.get_compiler('c')
+
+# MSVC does not support #warning
+if cc.get_id() != 'msvc'
+  static_library('foo', 'lib.c', override_options: {'werror': false})
+endif

--- a/test cases/common/264 default_options dict/meson_options.txt
+++ b/test cases/common/264 default_options dict/meson_options.txt
@@ -1,0 +1,4 @@
+option('bool', type: 'boolean', value: false)
+option('int', type: 'integer', value: 0)
+option('str', type: 'string', value: 'bar')
+option('array', type: 'array', value: ['bar'])


### PR DESCRIPTION
This takes https://github.com/mesonbuild/meson/pull/11493 but excluding the part where we deprecate `c_args` and friends. In addition it add support for setting other types than string options in the dictionary.