### PR TITLE
Allow targetting Meson 1.2.0 when version is 1.1.99

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -61,6 +61,16 @@ if T.TYPE_CHECKING:
 # But the corresponding Git tag needs to be '0.1.0rc1'
 version = '1.1.99'
 
+# The next stable version when we are in dev. This is used to allow projects to
+# require meson version >=1.2.0 when using 1.1.99. FeatureNew won't warn when
+# using a feature introduced in 1.2.0 when using Meson 1.1.99.
+stable_version = version
+if stable_version.endswith('.99'):
+    stable_version_array = stable_version.split('.')
+    stable_version_array[-1] = '0'
+    stable_version_array[-2] = str(int(version[-2]) + 1)
+    stable_version = '.'.join(stable_version_array)
+
 backendlist = ['ninja', 'vs', 'vs2010', 'vs2012', 'vs2013', 'vs2015', 'vs2017', 'vs2019', 'vs2022', 'xcode', 'none']
 
 DEFAULT_YIELDING = False

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -526,7 +526,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                 raise InterpreterException(f'Module returned a value of unknown type {v!r}.')
 
     def handle_meson_version(self, pv: str, location: mparser.BaseNode) -> None:
-        if not mesonlib.version_compare(coredata.version, pv):
+        if not mesonlib.version_compare(coredata.stable_version, pv):
             raise InterpreterException.from_node(f'Meson version is {coredata.version} but project requires {pv}', node=location)
         mesonlib.project_meson_versions[self.subproject] = pv
 


### PR DESCRIPTION
When a project targets a dev version of Meson (e.g. 1.1.99) for experimenting, this allows to use:

  project(..., meson_version: '>=1.2.0')

It avoids getting warnings when using FeatureNew for features introduced in 1.2.0.