### PR TITLE
compilers: fix detection of ifx compiler

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -26,7 +26,7 @@ from .. import mesonlib
 from ..mesonlib import (
     HoldableObject,
     EnvironmentException, MesonException,
-    Popen_safe, LibType, TemporaryDirectoryWinProof, OptionKey,
+    Popen_safe_logged, LibType, TemporaryDirectoryWinProof, OptionKey,
 )
 
 from ..arglist import CompilerArgs
@@ -855,15 +855,12 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
             command_list = self.get_exelist(ccache=not no_ccache) + commands.to_native()
             mlog.debug('Running compile:')
             mlog.debug('Working directory: ', tmpdirname)
-            mlog.debug('Command line: ', ' '.join(command_list), '\n')
             mlog.debug('Code:\n', contents)
             os_env = os.environ.copy()
             os_env['LC_ALL'] = 'C'
             if no_ccache:
                 os_env['CCACHE_DISABLE'] = '1'
-            p, stdo, stde = Popen_safe(command_list, cwd=tmpdirname, env=os_env)
-            mlog.debug('Compiler stdout:\n', stdo)
-            mlog.debug('Compiler stderr:\n', stde)
+            p, stdo, stde = Popen_safe_logged(command_list, msg='Command line', cwd=tmpdirname, env=os_env)
 
             result = CompileResult(stdo, stde, command_list, p.returncode, input_name=srcname)
             if want_output:

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from ..mesonlib import (
     MesonException, EnvironmentException, MachineChoice, join_args,
-    search_version, is_windows, Popen_safe, windows_proof_rm,
+    search_version, is_windows, Popen_safe, Popen_safe_logged, windows_proof_rm,
 )
 from ..envconfig import BinaryTable
 from .. import mlog
@@ -327,12 +327,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
 
         cmd = compiler + [arg]
         try:
-            mlog.debug('-----')
-            mlog.debug(f'Detecting compiler via: {join_args(cmd)}')
-            p, out, err = Popen_safe(cmd)
-            mlog.debug(f'compiler returned {p}')
-            mlog.debug(f'compiler stdout:\n{out}')
-            mlog.debug(f'compiler stderr:\n{err}')
+            p, out, err = Popen_safe_logged(cmd, msg='Detecting compiler via')
         except OSError as e:
             popen_exceptions[join_args(cmd)] = e
             continue

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -209,7 +209,7 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
         else:
             arg = '--version'
         try:
-            p, out, err = Popen_safe(linker + [arg])
+            p, out, err = Popen_safe_logged(linker + [arg], msg='Detecting linker via')
         except OSError as e:
             popen_exceptions[join_args(linker + [arg])] = e
             continue
@@ -626,7 +626,7 @@ def detect_cuda_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
     for compiler in compilers:
         arg = '--version'
         try:
-            p, out, err = Popen_safe(compiler + [arg])
+            p, out, err = Popen_safe_logged(compiler + [arg], msg='Detecting compiler via')
         except OSError as e:
             popen_exceptions[join_args(compiler + [arg])] = e
             continue
@@ -664,7 +664,7 @@ def detect_fortran_compiler(env: 'Environment', for_machine: MachineChoice) -> C
     for compiler in compilers:
         for arg in ['--version', '-V']:
             try:
-                p, out, err = Popen_safe(compiler + [arg])
+                p, out, err = Popen_safe_logged(compiler + [arg], msg='Detecting compiler via')
             except OSError as e:
                 popen_exceptions[join_args(compiler + [arg])] = e
                 continue
@@ -827,7 +827,7 @@ def _detect_objc_or_objcpp_compiler(env: 'Environment', lang: str, for_machine: 
     for compiler in compilers:
         arg = ['--version']
         try:
-            p, out, err = Popen_safe(compiler + arg)
+            p, out, err = Popen_safe_logged(compiler + arg, msg='Detecting compiler via')
         except OSError as e:
             popen_exceptions[join_args(compiler + arg)] = e
             continue
@@ -877,7 +877,7 @@ def detect_java_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
         exelist = [defaults['java'][0]]
 
     try:
-        p, out, err = Popen_safe(exelist + ['-version'])
+        p, out, err = Popen_safe_logged(exelist + ['-version'], msg='Detecting compiler via')
     except OSError:
         raise EnvironmentException('Could not execute Java compiler: {}'.format(join_args(exelist)))
     if 'javac' in out or 'javac' in err:
@@ -898,7 +898,7 @@ def detect_cs_compiler(env: 'Environment', for_machine: MachineChoice) -> Compil
     info = env.machines[for_machine]
     for comp in compilers:
         try:
-            p, out, err = Popen_safe(comp + ['--version'])
+            p, out, err = Popen_safe_logged(comp + ['--version'], msg='Detecting compiler via')
         except OSError as e:
             popen_exceptions[join_args(comp + ['--version'])] = e
             continue
@@ -927,7 +927,7 @@ def detect_cython_compiler(env: 'Environment', for_machine: MachineChoice) -> Co
     popen_exceptions: T.Dict[str, Exception] = {}
     for comp in compilers:
         try:
-            err = Popen_safe(comp + ['-V'])[2]
+            err = Popen_safe_logged(comp + ['-V'], msg='Detecting compiler via')[2]
         except OSError as e:
             popen_exceptions[join_args(comp + ['-V'])] = e
             continue
@@ -950,7 +950,7 @@ def detect_vala_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
         exelist = [defaults['vala'][0]]
 
     try:
-        p, out = Popen_safe(exelist + ['--version'])[0:2]
+        p, out = Popen_safe_logged(exelist + ['--version'], msg='Detecting compiler via')[0:2]
     except OSError:
         raise EnvironmentException('Could not execute Vala compiler: {}'.format(join_args(exelist)))
     version = search_version(out)
@@ -975,7 +975,7 @@ def detect_rust_compiler(env: 'Environment', for_machine: MachineChoice) -> Rust
     for compiler in compilers:
         arg = ['--version']
         try:
-            out = Popen_safe(compiler + arg)[1]
+            out = Popen_safe_logged(compiler + arg, msg='Detecting compiler via')[1]
         except OSError as e:
             popen_exceptions[join_args(compiler + arg)] = e
             continue
@@ -1198,7 +1198,7 @@ def detect_swift_compiler(env: 'Environment', for_machine: MachineChoice) -> Com
         exelist = [defaults['swift'][0]]
 
     try:
-        p, _, err = Popen_safe(exelist + ['-v'])
+        p, _, err = Popen_safe_logged(exelist + ['-v'], msg='Detecting compiler via')
     except OSError:
         raise EnvironmentException('Could not execute Swift compiler: {}'.format(join_args(exelist)))
     version = search_version(err)
@@ -1234,7 +1234,7 @@ def detect_nasm_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
             default_path = os.path.join(os.environ['ProgramFiles'], 'NASM')
             comp[0] = shutil.which(comp[0], path=default_path) or comp[0]
         try:
-            output = Popen_safe(comp + ['--version'])[1]
+            output = Popen_safe_logged(comp + ['--version'], msg='Detecting compiler via')[1]
         except OSError as e:
             popen_exceptions[' '.join(comp + ['--version'])] = e
             continue

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -749,7 +749,7 @@ def detect_fortran_compiler(env: 'Environment', for_machine: MachineChoice) -> C
                     compiler, version, for_machine, is_cross, info,
                     exe_wrap, full_version=full_version, linker=linker)
 
-            if 'ifx (IFORT)' in out:
+            if 'ifx (IFORT)' in out or 'ifx (IFX)' in out:
                 cls = fortran.IntelLLVMFortranCompiler
                 linker = guess_nix_linker(env, compiler, cls, version, for_machine)
                 return cls(

--- a/mesonbuild/dependencies/configtool.py
+++ b/mesonbuild/dependencies/configtool.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 from .base import ExternalDependency, DependencyException, DependencyTypeName
-from ..mesonlib import listify, Popen_safe, split_args, version_compare, version_compare_many
+from ..mesonlib import listify, Popen_safe, Popen_safe_logged, split_args, version_compare, version_compare_many
 from ..programs import find_external_program
 from .. import mlog
 import re
@@ -143,12 +143,7 @@ class ConfigToolDependency(ExternalDependency):
         return self.config is not None
 
     def get_config_value(self, args: T.List[str], stage: str) -> T.List[str]:
-        p, out, err = Popen_safe(self.config + args)
-        mlog.debug(f'Called `{mesonlib.join_args(self.config+args)}` -> {p.returncode}')
-        if out:
-            mlog.debug(f'stdout:\n{out}\n-----------')
-        if err:
-            mlog.debug(f'stderr:\n{err}\n-----------')
+        p, out, err = Popen_safe_logged(self.config + args)
         if p.returncode != 0:
             if self.required:
                 raise DependencyException(f'Could not generate {stage} for {self.name}.\n{err}')

--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from .base import ExternalDependency, DependencyException, sort_libpaths, DependencyTypeName
-from ..mesonlib import OptionKey, OrderedSet, PerMachine, Popen_safe
+from ..mesonlib import OptionKey, OrderedSet, PerMachine, Popen_safe, Popen_safe_logged
 from ..programs import find_external_program, ExternalProgram
 from .. import mlog
 from pathlib import PurePath
@@ -122,15 +122,8 @@ class PkgConfigDependency(ExternalDependency):
     def _call_pkgbin_real(self, args: T.List[str], env: T.Dict[str, str]) -> T.Tuple[int, str, str]:
         assert isinstance(self.pkgbin, ExternalProgram)
         cmd = self.pkgbin.get_command() + args
-        p, out, err = Popen_safe(cmd, env=env)
-        rc, out, err = p.returncode, out.strip(), err.strip()
-        call = ' '.join(cmd)
-        mlog.debug(f"Called `{call}` -> {rc}")
-        if out:
-            mlog.debug(f'stdout:\n{out}\n-----------')
-        if err:
-            mlog.debug(f'stderr:\n{err}\n-----------')
-        return rc, out, err
+        p, out, err = Popen_safe_logged(cmd, env=env)
+        return p.returncode, out.strip(), err.strip()
 
     @staticmethod
     def get_env(environment: 'Environment', for_machine: MachineChoice,

--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from .. import mlog
 from ..mesonlib import (
     EnvironmentException,
-    Popen_safe, join_args, search_version
+    Popen_safe, Popen_safe_logged, join_args, search_version
 )
 from .linkers import (
     AppleDynamicLinker,
@@ -157,11 +157,7 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
         check_args += override
 
     mlog.debug('-----')
-    mlog.debug(f'Detecting linker via: {join_args(compiler + check_args)}')
-    p, o, e = Popen_safe(compiler + check_args)
-    mlog.debug(f'linker returned {p}')
-    mlog.debug(f'linker stdout:\n{o}')
-    mlog.debug(f'linker stderr:\n{e}')
+    p, o, e = Popen_safe_logged(compiler + check_args, msg='Detecting linker via')
 
     v = search_version(o + e)
     linker: DynamicLinker
@@ -170,11 +166,7 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
             cmd = compiler + override + [comp_class.LINKER_PREFIX + '-v'] + extra_args
         else:
             cmd = compiler + override + comp_class.LINKER_PREFIX + ['-v'] + extra_args
-        mlog.debug('-----')
-        mlog.debug(f'Detecting LLD linker via: {join_args(cmd)}')
-        _, newo, newerr = Popen_safe(cmd)
-        mlog.debug(f'linker stdout:\n{newo}')
-        mlog.debug(f'linker stderr:\n{newerr}')
+        _, newo, newerr = Popen_safe_logged(cmd, msg='Detecting LLD linker via')
 
         lld_cls: T.Type[DynamicLinker]
         if 'ld64.lld' in newerr:
@@ -211,11 +203,7 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
             cmd = compiler + [comp_class.LINKER_PREFIX + '-v'] + extra_args
         else:
             cmd = compiler + comp_class.LINKER_PREFIX + ['-v'] + extra_args
-        mlog.debug('-----')
-        mlog.debug(f'Detecting Apple linker via: {join_args(cmd)}')
-        _, newo, newerr = Popen_safe(cmd)
-        mlog.debug(f'linker stdout:\n{newo}')
-        mlog.debug(f'linker stderr:\n{newerr}')
+        _, newo, newerr = Popen_safe_logged(cmd, msg='Detecting Apple linker via')
 
         for line in newerr.split('\n'):
             if 'PROJECT:ld' in line:

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -144,6 +144,7 @@ __all__ = [
     'path_is_in_root',
     'pickle_load',
     'Popen_safe',
+    'Popen_safe_logged',
     'quiet_git',
     'quote_arg',
     'relative_to_if_possible',
@@ -1509,6 +1510,21 @@ def Popen_safe_legacy(args: T.List[str], write: T.Optional[str] = None,
             e = e.decode(encoding=sys.stderr.encoding, errors='replace').replace('\r\n', '\n')
         else:
             e = e.decode(errors='replace').replace('\r\n', '\n')
+    return p, o, e
+
+
+def Popen_safe_logged(args: T.List[str], msg: str = 'Called', **kwargs: T.Any) -> T.Tuple['subprocess.Popen[str]', str, str]:
+    '''
+    Wrapper around Popen_safe that assumes standard piped o/e and logs this to the meson log.
+    '''
+    p, o, e = Popen_safe(args, **kwargs)
+    rc, out, err = p.returncode, o.strip(), e.strip()
+    mlog.debug('-----------')
+    mlog.debug(f'{msg}: `{join_args(args)}` -> {rc}')
+    if out:
+        mlog.debug(f'stdout:\n{out}\n-----------')
+    if err:
+        mlog.debug(f'stderr:\n{err}\n-----------')
     return p, o, e
 
 

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -33,7 +33,7 @@ import mesonbuild.environment
 import mesonbuild.coredata
 import mesonbuild.modules.gnome
 from mesonbuild.mesonlib import (
-    is_cygwin, join_args, windows_proof_rmtree, python_command
+    is_cygwin, join_args, split_args, windows_proof_rmtree, python_command
 )
 import mesonbuild.modules.pkgconfig
 
@@ -343,9 +343,10 @@ class BasePlatformTests(TestCase):
         Fetch a list command-lines run by meson for compiler checks.
         Each command-line is returned as a list of arguments.
         '''
-        prefix = 'Command line:'
+        prefix = 'Command line: `'
+        suffix = '` -> 0\n'
         with self._open_meson_log() as log:
-            cmds = [l[len(prefix):].split() for l in log if l.startswith(prefix)]
+            cmds = [split_args(l[len(prefix):-len(suffix)]) for l in log if l.startswith(prefix)]
             return cmds
 
     def get_meson_log_sanitychecks(self):


### PR DESCRIPTION
The version output scraping for identifying strings checked for "IFORT" in parentheses after the executable name, which is probably a mistake by Intel. Current versions of ifx have "IFX" in parentheses there.

Detect both.

Fixes #11873