### PR TITLE
Add new Featurebroken check, and check for non-commutative equality operator

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3203,13 +3203,13 @@ class Interpreter(InterpreterBase, HoldableObject):
         if 'sources' in kwargs:
             sources += listify(kwargs['sources'])
         if any(isinstance(s, build.BuildTarget) for s in sources):
-            FeatureDeprecated.single_use('passing references to built targets as a source file', '1.1.0', self.subproject,
-                                         'consider using `link_with` or `link_whole` if you meant to link, or dropping them as otherwise they are ignored',
-                                         node)
+            FeatureBroken.single_use('passing references to built targets as a source file', '1.1.0', self.subproject,
+                                     'Consider using `link_with` or `link_whole` if you meant to link, or dropping them as otherwise they are ignored.',
+                                     node)
         if any(isinstance(s, build.ExtractedObjects) for s in sources):
-            FeatureDeprecated.single_use('passing object files as sources', '1.1.0', self.subproject,
-                                         'pass these to the `objects` keyword instead, they are ignored when passed as sources',
-                                         node)
+            FeatureBroken.single_use('passing object files as sources', '1.1.0', self.subproject,
+                                     'Pass these to the `objects` keyword instead, they are ignored when passed as sources.',
+                                     node)
         # Go ahead and drop these here, since they're only allowed through for
         # backwards compatibility anyway
         sources = [s for s in sources

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -33,7 +33,7 @@ from ..interpreterbase import ContainerTypeInfo, InterpreterBase, KwargInfo, typ
 from ..interpreterbase import noPosargs, noKwargs, permittedKwargs, noArgsFlattening, noSecondLevelHolderResolving, unholder_return
 from ..interpreterbase import InterpreterException, InvalidArguments, InvalidCode, SubdirDoneRequest
 from ..interpreterbase import Disabler, disablerIfNotFound
-from ..interpreterbase import FeatureNew, FeatureDeprecated, FeatureNewKwargs, FeatureDeprecatedKwargs
+from ..interpreterbase import FeatureNew, FeatureDeprecated, FeatureBroken, FeatureNewKwargs, FeatureDeprecatedKwargs
 from ..interpreterbase import ObjectHolder, ContextManagerObject
 from ..modules import ExtensionModule, ModuleObject, MutableModuleObject, NewExtensionModule, NotFoundExtensionModule
 from ..cmake import CMakeInterpreter
@@ -2978,6 +2978,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         mlog.log('Build targets in project:', mlog.bold(str(len(self.build.targets))))
         FeatureNew.report(self.subproject)
         FeatureDeprecated.report(self.subproject)
+        FeatureBroken.report(self.subproject)
         if not self.is_subproject():
             self.print_extra_warnings()
             self._print_summary()

--- a/mesonbuild/interpreter/primitives/integer.py
+++ b/mesonbuild/interpreter/primitives/integer.py
@@ -3,13 +3,8 @@
 from __future__ import annotations
 
 from ...interpreterbase import (
-    ObjectHolder,
-    MesonOperator,
-    typed_operator,
-    noKwargs,
-    noPosargs,
-
-    InvalidArguments
+    FeatureBroken, InvalidArguments, MesonOperator, ObjectHolder,
+    noKwargs, noPosargs, typed_operator,
 )
 
 import typing as T
@@ -52,6 +47,13 @@ class IntegerHolder(ObjectHolder[int]):
 
     def display_name(self) -> str:
         return 'int'
+
+    def operator_call(self, operator: MesonOperator, other: TYPE_var) -> TYPE_var:
+        if isinstance(other, bool):
+            FeatureBroken.single_use('int operations with non-int', '1.2.0', self.subproject,
+                                     'It is not commutative and only worked because of leaky Python abstractions.',
+                                     location=self.current_node)
+        return super().operator_call(operator, other)
 
     @noKwargs
     @noPosargs

--- a/mesonbuild/interpreterbase/__init__.py
+++ b/mesonbuild/interpreterbase/__init__.py
@@ -53,6 +53,7 @@ __all__ = [
     'FeatureCheckBase',
     'FeatureNew',
     'FeatureDeprecated',
+    'FeatureBroken',
     'FeatureNewKwargs',
     'FeatureDeprecatedKwargs',
 
@@ -118,6 +119,7 @@ from .decorators import (
     FeatureCheckBase,
     FeatureNew,
     FeatureDeprecated,
+    FeatureBroken,
     FeatureNewKwargs,
     FeatureDeprecatedKwargs,
 )

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -703,7 +703,7 @@ class FeatureNew(FeatureCheckBase):
     # Class variable, shared across all instances
     #
     # Format: {subproject: {feature_version: set(feature_names)}}
-    feature_registry = {}  # type: T.ClassVar[T.Dict[str, T.Dict[str, T.Set[T.Tuple[str, T.Optional[mparser.BaseNode]]]]]]
+    feature_registry = {}
 
     @staticmethod
     def check_version(target_version: str, feature_version: str) -> bool:
@@ -734,7 +734,7 @@ class FeatureDeprecated(FeatureCheckBase):
     # Class variable, shared across all instances
     #
     # Format: {subproject: {feature_version: set(feature_names)}}
-    feature_registry = {}  # type: T.ClassVar[T.Dict[str, T.Dict[str, T.Set[T.Tuple[str, T.Optional[mparser.BaseNode]]]]]]
+    feature_registry = {}
     emit_notice = True
 
     @staticmethod


### PR DESCRIPTION
This lets us unconditionally warn about problematic code constructs in the event that it is so wrong we don't want people to use it in *any* version of meson.

Update some existing FeatureDeprecated to this.

Also implement a new check. In meson:

- `true == 1` is a fatal error: ```The `==` operator of bool does not accept objects of type int```.
- likewise, `true >= 1` is a fatal error: ```Object <[BooleanHolder] holds [bool]: True> of type bool does not support the `<=` operator.```
- likewise, `true + 1` is a fatal error: ```Object <[BooleanHolder] holds [bool]: True> of type bool does not support the `+` operator.```

Due to internal implementation details of python, the reverse was valid:
- `1 == true` was a truthy statement.
- `1 >= true` was also a truthy statement
- `1 + true` had a return value of 2