### PR TITLE
Better 'link_whole' description and add '.vs' to '.gitignore'

### DIFF
--- a/docs/yaml/functions/_build_target_base.yaml
+++ b/docs/yaml/functions/_build_target_base.yaml
@@ -123,8 +123,10 @@ kwargs:
     type: list[lib | custom_tgt | custom_idx]
     since: 0.40.0
     description: |
-      Links all contents of the given static libraries
-      whether they are used by not, equivalent to the `-Wl,--whole-archive` argument flag of GCC.
+      Links all contents of the given static libraries whether they are used or
+      not, equivalent to the `-Wl,--whole-archive` argument flag of GCC, or the
+      '/WHOLEARCHIVE' MSVC linker option. This allows the linked target to
+      re-export symbols from all objects in the static libraries.
 
       *(since 0.41.0)* If passed a list that list will be flattened.
 


### PR DESCRIPTION
Opening the meson directory in visual studio generates a '.vs' dir for various visual studio things that shouldn't be tracked as git changes, so have added '.vs' to '.gitignore'.

Also, since I wasted a bit of time struggling to figure out how certain missing function exports in a .dll were disappearing and how best to ensure they're preserved, and eventually trying 'link_whole', I thought the description could be improved to explicitly add that 'link_whole' uses the MSVC linker option '/WHOLEARCHIVE', which propagates/re-exports exported  symbols from all objects of a static lib.