### PR TITLE
modules/features: Add a module of functions for complex feature interactions

### DIFF
--- a/docs/markdown/Features-module.md
+++ b/docs/markdown/Features-module.md
@@ -1,0 +1,59 @@
+# Features Module
+
+This module provides functions for advanced feature option interactions. It is
+new in Meson 1.2.0
+
+## new
+
+Create a new feature option object with a given name and value:
+```meson
+feat = import('feature').new('name', 'auto')
+```
+
+## any
+
+Provides a mechanism to provide or-like checking. Due to the `mode` option it can be tailored to or the objects to the user's expectations. It returns a boolean, and is best combined with `new` if you want to replace a provided feature.
+
+The mode keyword argument must be one of:
+ - "auto": feat.is_auto() == true
+ - "enabled": feat.is_enabled() == true
+ - "disabled": feat.is_disabled() == true
+ - "allowed": feat.is_disabled() == false
+ - "denied": feat.is_enabled() == true
+
+and defaults to "auto"
+
+```meson
+f1 = get_option('f1')
+f2 = get_option('f2')
+
+feat = import('features')
+
+if not feat.any(f1, f2, mode : 'allowed')
+  error('f1 or f2 must be enabled')
+endif
+```
+
+## and
+
+Provides a mechanism to provide and-like checking. Due to the `mode` option it can be tailored to or the objects to the user's expectations. It returns a boolean, and is best combined with `new` if you want to replace an object.
+
+The mode keyword argument must be one of:
+ - "auto": feat.is_auto() == true
+ - "enabled": feat.is_enabled() == true
+ - "disabled": feat.is_disabled() == true
+ - "allowed": feat.is_disabled() == false
+ - "denied": feat.is_enabled() == true
+
+and defaults to "auto"
+
+```meson
+f1 = get_option('f1')
+f2 = get_option('f2')
+
+feat = import('features')
+
+if feat.all(f1, f2, mode : 'disabled')
+  error('f1 or f2 must be enabled')
+endif
+```

--- a/docs/markdown/_Sidebar.md
+++ b/docs/markdown/_Sidebar.md
@@ -9,6 +9,7 @@
 
 ### [Modules](Module-reference.md)
 
+* [features](Features-module.md)
 * [gnome](Gnome-module.md)
 * [i18n](i18n-module.md)
 * [pkgconfig](Pkgconfig-module.md)

--- a/docs/markdown/snippets/feature_module.md
+++ b/docs/markdown/snippets/feature_module.md
@@ -1,0 +1,3 @@
+## Add a features module
+
+This module adds helpers for working with complex feature object interactions. This provides a way to generate new feature options, as well as two helper methods for doing comparisons

--- a/docs/sitemap.txt
+++ b/docs/sitemap.txt
@@ -41,6 +41,7 @@ index.md
 			Cuda-module.md
 			Dlang-module.md
 			External-Project-module.md
+			Features-module.md
 			Fs-module.md
 			Gnome-module.md
 			Hotdoc-module.md

--- a/docs/theme/extra/templates/navbar_links.html
+++ b/docs/theme/extra/templates/navbar_links.html
@@ -10,6 +10,7 @@
             ("Cuda-module.html","CUDA"), \
             ("Dlang-module.html","Dlang"), \
             ("External-Project-module.html","External Project"), \
+            ("Features-module.html","Features"), \
             ("Fs-module.html","Filesystem"), \
             ("Gnome-module.html","GNOME"), \
             ("Hotdoc-module.html","Hotdoc"), \

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -302,9 +302,10 @@ class UserFeatureOption(UserComboOption):
     static_choices = ['enabled', 'disabled', 'auto']
 
     def __init__(self, description: str, value: T.Any, yielding: bool = DEFAULT_YIELDING,
-                 deprecated: T.Union[bool, str, T.Dict[str, str], T.List[str]] = False):
+                 deprecated: T.Union[bool, str, T.Dict[str, str], T.List[str]] = False,
+                 name: T.Optional[str] = None):
         super().__init__(description, self.static_choices, value, yielding, deprecated)
-        self.name: T.Optional[str] = None  # TODO: Refactor options to all store their name
+        self.name: T.Optional[str] = name  # TODO: Refactor options to all store their name
 
     def is_enabled(self) -> bool:
         return self.value == 'enabled'

--- a/mesonbuild/modules/features.py
+++ b/mesonbuild/modules/features.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2023 Intel Corporation
+
+from __future__ import annotations
+
+import typing as T
+
+from . import ExtensionModule, ModuleReturnValue, ModuleInfo
+from ..coredata import UserFeatureOption
+from ..interpreter.type_checking import in_set_validator
+from ..interpreterbase import InvalidArguments, KwargInfo, typed_kwargs, typed_pos_args, noKwargs, TYPE_kwargs
+
+if T.TYPE_CHECKING:
+    from typing_extensions import Literal, TypedDict
+
+    from ..interpreter import Interpreter
+    from . import ModuleState
+
+    PRED_MODE = Literal['auto', 'enabled', 'disabled', 'allowed', 'denied']
+
+    class AnyKWArgs(TypedDict):
+
+        mode: PRED_MODE
+
+
+_PRED_MODE_KW = KwargInfo(
+    'mode', str, default='allowed',
+    validator=in_set_validator({'auto', 'enabled', 'disabled', 'allowed', 'denied'}),
+)
+
+
+class FeatureModule(ExtensionModule):
+
+    """Helper functions for working with Features"""
+
+    INFO = ModuleInfo('features', '1.2.0', unstable=True)
+
+    def __init__(self, interpreter: Interpreter) -> None:
+        super().__init__(interpreter)
+        self.methods.update({
+            'new': self.new,
+        })
+
+    @typed_pos_args('feature.new', str, str)
+    @noKwargs
+    def new(self, state: ModuleState, args: T.Tuple[str, str], kwargs: TYPE_kwargs) -> ModuleReturnValue:
+        """Create a new UserFeatureOption with the given name and initial value."""
+        name, value = args
+        if value not in {'auto', 'enabled', 'disabled'}:
+            raise InvalidArguments('feature.new: second argument must be one of: "auto", "enabled", "disabled". Not', value)
+
+        feat = UserFeatureOption('', value, False, name=name)
+
+        return ModuleReturnValue(feat, [])
+
+    @staticmethod
+    def _get_pred_func(mode: PRED_MODE) -> T.Callable[[UserFeatureOption], bool]:
+        """Get a preddicate testing function for the all and any methods.
+
+        :param mode: The mode to test for
+        :return: A callable which returns true when the predicate matches, otherwise false
+        """
+        if mode == 'auto':
+            return lambda x: x.is_auto()
+        elif mode == 'enabled':
+            return lambda x: x.is_enabled()
+        elif mode == 'disabled':
+            return lambda x: x.is_disabled()
+        elif mode == 'allowed':
+            return lambda x: not x.is_disabled()
+        return lambda x: not x.is_enabled()
+
+    @typed_pos_args('feature.any', varargs=UserFeatureOption, min_varargs=1)
+    @typed_kwargs('feature.all', _PRED_MODE_KW)
+    def any(self, state: ModuleState,
+            args: T.Tuple[T.List[UserFeatureOption]],
+            kwargs: AnyKWArgs) -> bool:
+        """Decide if any of the feature options are of the given value.
+
+        value may be one of:
+            enabled -- a value is enabled
+            disabled -- a value is disabled
+            auto -- a value is auto
+            allowed -- a value is not disabled
+            denied -- a value is not enabled
+
+        For example:
+            opt = feature.new('opt', 'auto') \\
+                .disable_auto_if(
+                    feature.any(EnabledOption, DisabledOption, value : 'auto'))
+        """
+        pred = self._get_pred_func(kwargs['mode'])
+        return any(pred(x) for x in args[0])
+
+    @typed_pos_args('feature.all', varargs=UserFeatureOption, min_varargs=1)
+    @typed_kwargs('feature.all', _PRED_MODE_KW)
+    def all(self, state: ModuleState,
+            args: T.Tuple[T.List[UserFeatureOption]],
+            kwargs: AnyKWArgs) -> bool:
+        """Decide if all of the feature options are of the given value.
+
+        value may be one of:
+            enabled -- a value is enabled
+            disabled -- a value is disabled
+            auto -- a value is auto
+            allowed -- a value is not disabled
+            denied -- a value is not enabled
+
+        For example:
+            opt = feature.new('opt', 'auto') \\
+                .disable_auto_if(
+                    feature.all(EnabledOption, DisabledOption, value : 'auto'))
+        """
+        pred = self._get_pred_func(kwargs['mode'])
+        return all(pred(x) for x in args[0])
+
+
+def initialize(interp: Interpreter) -> FeatureModule:
+    return FeatureModule(interp)

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -44,6 +44,7 @@ modules = [
     'mesonbuild/msubprojects.py',
     'mesonbuild/modules/__init__.py',
     'mesonbuild/modules/external_project.py',
+    'mesonbuild/modules/features.py',
     'mesonbuild/modules/fs.py',
     'mesonbuild/modules/gnome.py',
     'mesonbuild/modules/i18n.py',

--- a/test cases/common/263 feature module/meson.build
+++ b/test cases/common/263 feature module/meson.build
@@ -1,0 +1,7 @@
+project('feature module', meson_version : '>= 1.2.0')
+
+feat = import('unstable-features')
+
+new = feat.new('new', 'auto')
+
+assert(new.auto(), 'new feature does not have correct value')


### PR DESCRIPTION
Feature options are a powerful tool in the Meson toolbox, especially for dealing with dependencies. We provide a set of useful methods for interactions between options, but there are a handful of cases we don't handle, and don't make sense to add to features as methods.

One of the most requested features is the ability to generate feature options within the meson.build environments. That's a trivial add for a module.

The other big request we get is for allowing logical operations, `and` and `or`. Which present a problem for features since no one can agree on what `and` means. do `f1 and f2` mean `f1.allowed() and f2.allowed()`, `f1.enabled() and f2.enabled()`,  `f1.value == f2.value()`, etc. the same problem exists for `or`. This PR proposes a robust solution, using `any` and `all` methods, which a mode keyword. This allows 2+ options to be compared with a predicate that is user selected of either:

 auto : feat.is_auto()
 enabled : feat.is_enabled()
 disabled : feat.is_disabled()
 allowed : not feat.is_disabled()
 denied : not feat.is_enabled()

Which gives a user all of the possible combinations of options.

I have several specific use-cases in Mesa that revolve around combining features. For example:
```meson
with_microsoft_clc = get_option('microsoft-clc').enabled()
if ['x86_64'].contains(host_machine.cpu_family())
  with_intel_clc = get_option('intel-clc').enabled()
  with_intel_vk_rt = with_intel_vk and with_intel_clc
else
  with_intel_clc = false
  with_intel_vk_rt = false
endif
with_clc = with_microsoft_clc or with_intel_clc
with_libclc = with_clc
```
but this isn't actually what we want. What we actually want is:
```meson
feat = import('features')
with_intel_clc = get_option('intel-clc') \
  .disable_if(host_machine.system() != 'x86_64', error_message : ...)
with_intel_vk_rt = feat.new('intel-vulkan-runtime', 'auto') \
  .disable_if(not with_intel_vk, error_message : ...) \
  .disable_if(with_intel_clc.disabled(), error_message : ...)
with_clc = feat.new('shared clc', feat.any(with_intel_clc, with_microsoft_clc, mode : 'allowed') ? 'enabled' : 'disabled')
with_libclc = with_clc
```
Which would allow us to disable/enable dependencies.