### PR TITLE
msubprojects: apply diff files as well as patches

### DIFF
--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -577,6 +577,7 @@ class Runner:
                 self.log('  -> Not downloaded yet')
                 return True
             self.wrap_resolver.apply_patch()
+            self.wrap_resolver.apply_diff_files()
             return True
         if options.save:
             if 'patch_directory' not in self.wrap.values:


### PR DESCRIPTION
This brings meson subprojects packagefiles --apply into line with every other part of meson that interacts with packagefiles.