### PR TITLE
rust: fix prefer-dynamic behavior

### DIFF
--- a/docs/markdown/Rust.md
+++ b/docs/markdown/Rust.md
@@ -65,3 +65,11 @@ be configured to use the file as it's not in the source root (Meson does not
 write files into the source directory). [See the upstream
 docs](https://rust-analyzer.github.io/manual.html#non-cargo-based-projects) for
 more information on how to configure that.
+
+## Linking with standard libraries
+
+Meson will link the Rust standard libraries (e.g. libstd) statically, unless the
+target is a proc macro or dylib, or it depends on a dylib, in which case [`-C
+prefer-dynamic`](https://doc.rust-lang.org/rustc/codegen-options/index.html#prefer-dynamic)
+will be passed to the Rust compiler, and the standard libraries will be
+dynamically linked.

--- a/test cases/rust/18 proc-macro/meson.build
+++ b/test cases/rust/18 proc-macro/meson.build
@@ -13,7 +13,8 @@ pm = shared_library(
 main = executable(
   'main',
   'use.rs',
-  link_with : pm
+  link_with : pm,
+  rust_args : ['-C', 'panic=abort'],
 )
 
 test('main_test', main)


### PR DESCRIPTION
<details>
<summary>Original description</summary>

I noticed when building a project that uses a proc macro that Meson passed `-C prefer-dynamic` for the executable, and not the proc macro, while cargo passed `-C prefer-dynamic` for the proc macro, but not for the executable.  Meson's behavior broke setting `-C panic=abort` on the executable.

The change here is to try to match Cargo's behavior for `prefer-dynamic` as closely as possible.  The relevant code in Cargo is this:

```rust
let prefer_dynamic = (unit.target.for_host() && !unit.target.is_custom_build())
    || (contains_dy_lib && !cx.is_primary_package(unit));
```

`for_host()` means either a proc macro, plugin, or build script, and then `is_custom_build()` also means build script.  `contains_dy_lib` just means whether `--crate-type dylib` is passed, and `is_primary_package()` is whether the user directly specified the package on the command line (i.e. it's not just a dependency).  So Cargo will always build proc macros and plugins with `-C prefer-dynamic`, and it will also do so for dylibs unless the user asked for them to be built directly.  Meson doesn't really have a concept of building things differently depending on whether they were explicitly requested (fortunately), so here I've chosen to always set `-C prefer-dynamic` for dylibs.

There is no other case where Cargo sets `-C prefer-dynamic` — it doesn't care what dependencies the crate in question has at all.

I've opened this as a draft, because I don't understand what the comment about multiple implementations of crates means.  I couldn't find much elaboration in the commit message or PR that added it.  I assume that Meson added `-C prefer-dynamic` based on dependencies for a reason, but unless I understand what that reason is, I can't test that I'm not breaking anything (since it doesn't seem to have a corresponding test), so understanding that is pretty critical to moving forward.

I've added `-C panic=abort` to the proc macro test, so that there's test coverage for `-C prefer-dynamic` being incorrectly enabled on non-dylib dependencies of proc macros.  All Rust tests pass.

If accepted, this would fix https://github.com/mesonbuild/meson/issues/7576.

---

</details>

I noticed when building a project that uses a proc macro that Meson passed `-C prefer-dynamic` for the executable, and not the proc macro, while cargo passed `-C prefer-dynamic` for the proc macro, but not for the executable.  Meson's behavior broke setting `-C panic=abort` on the executable.

As far as we can tell, because we explicitly pass each library path to rustc, the only thing `-C prefer-dynamic` affects in Meson is how the standard libraries are linked.  Generally, one does not want the standard libraries to be dynamically linked, because if the Rust compiler is ever updated, anything linked against the old standard libraries will likely break, due to the lack of a stable Rust ABI. Therefore, I've reorganised Meson's behavior around the principle that the standard libraries should only be dynamically linked when Rust dynamic linking has already been opted into in some other way.  The details of how this manifests are now explained in the documentation.

Fixes https://github.com/mesonbuild/meson/issues/7576.