### PR TITLE
add support for newer C++ -std= flags on Clang/GCC

### DIFF
--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -154,6 +154,10 @@ class CPPCompiler(CLikeCompiler, Compiler):
             'gnu++17': 'gnu++1z',
             'c++20': 'c++2a',
             'gnu++20': 'gnu++2a',
+            'c++23': 'c++2b',
+            'gnu++23': 'gnu++2b',
+            'c++26': 'c++2c',
+            'gnu++26': 'gnu++2c',
         }
 
         # Currently, remapping is only supported for Clang, Elbrus and GCC

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -216,8 +216,9 @@ class ClangCPPCompiler(ClangCompiler, CPPCompiler):
         })
         opts[key.evolve('std')].choices = [
             'none', 'c++98', 'c++03', 'c++11', 'c++14', 'c++17', 'c++1z',
-            'c++2a', 'c++20', 'gnu++11', 'gnu++14', 'gnu++17', 'gnu++1z',
-            'gnu++2a', 'gnu++20',
+            'c++2a', 'c++20', 'c++2b', 'c++23', 'c++2c', 'c++26', 'gnu++11',
+            'gnu++14', 'gnu++17', 'gnu++1z', 'gnu++2a', 'gnu++20', 'gnu++2b',
+            'gnu++23', 'gnu++2c', 'gnu++26'
         ]
         if self.info.is_windows() or self.info.is_cygwin():
             opts.update({
@@ -392,8 +393,9 @@ class GnuCPPCompiler(GnuCompiler, CPPCompiler):
         })
         cppstd_choices = [
             'none', 'c++98', 'c++03', 'c++11', 'c++14', 'c++17', 'c++1z',
-            'c++2a', 'c++20', 'gnu++03', 'gnu++11', 'gnu++14', 'gnu++17',
-            'gnu++1z', 'gnu++2a', 'gnu++20',
+            'c++2a', 'c++20', 'c++2b', 'c++23', 'c++2c', 'c++26', 'gnu++03',
+            'gnu++11', 'gnu++14', 'gnu++17', 'gnu++1z', 'gnu++2a', 'gnu++20',
+            'gnu++2b', 'gnu++23', 'gnu++2c', 'gnu++26'
         ]
         if version_compare(self.version, '>=12.2.0'):
             cppstd_choices.append('c++23')

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -96,7 +96,9 @@ class ClangObjCPPCompiler(ClangCompiler, ObjCPPCompiler):
         opts.update({
             OptionKey('std', machine=self.for_machine, lang='cpp'): coredata.UserComboOption(
                 'C++ language standard to use',
-                ['none', 'c++98', 'c++11', 'c++14', 'c++17', 'gnu++98', 'gnu++11', 'gnu++14', 'gnu++17'],
+                ['none', 'c++98', 'c++11', 'c++14', 'c++17', 'c++20', 'c++2b',
+                 'gnu++98', 'gnu++11', 'gnu++14', 'gnu++17', 'gnu++20',
+                 'gnu++2b'],
                 'none',
             )
         })

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -517,6 +517,12 @@ class LinuxlikeTests(BasePlatformTests):
         has_cpp20 = (compiler.get_id() not in {'clang', 'gcc'} or
                      compiler.get_id() == 'clang' and _clang_at_least(compiler, '>=10.0.0', None) or
                      compiler.get_id() == 'gcc' and version_compare(compiler.version, '>=10.0.0'))
+        has_cpp23 = (compiler.get_id() not in {'clang', 'gcc'} or
+                     compiler.get_id() == 'clang' and _clang_at_least(compiler, '>=12.0.0', None) or
+                     compiler.get_id() == 'gcc' and version_compare(compiler.version, '>=11.0.0'))
+        has_cpp26 = (compiler.get_id() not in {'clang', 'gcc'} or
+                     compiler.get_id() == 'clang' and _clang_at_least(compiler, '>=17.0.0', None) or
+                     compiler.get_id() == 'gcc' and version_compare(compiler.version, '>=14.0.0'))
         has_c18 = (compiler.get_id() not in {'clang', 'gcc'} or
                    compiler.get_id() == 'clang' and _clang_at_least(compiler, '>=8.0.0', '>=11.0') or
                    compiler.get_id() == 'gcc' and version_compare(compiler.version, '>=8.0.0'))
@@ -532,6 +538,10 @@ class LinuxlikeTests(BasePlatformTests):
             elif '++2a' in v and not has_cpp2a_c17:  # https://en.cppreference.com/w/cpp/compiler_support
                 continue
             elif '++20' in v and not has_cpp20:
+                continue
+            elif ('++23' in v or '++2b' in v) and not has_cpp23:
+                continue
+            elif ('++26' in v or '++2c' in v) and not has_cpp26:
                 continue
             # now C
             elif '17' in v and not has_cpp2a_c17:


### PR DESCRIPTION
Originally was writing this to fix issue https://github.com/mesonbuild/meson/issues/11890 but there were other C++ standard versions not in the lists for a few other compilers, so I've added them as well. Not sure why these lists are hardcoded though.

Closes #9053
Closes #11461
Fixes #11890