### PR TITLE
Do a better job of detecting libc++ vs libstdc++

### DIFF
--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -442,7 +442,7 @@ class GnuCPPCompiler(GnuCompiler, CPPCompiler):
         search_dirs: T.List[str] = []
         for d in self.get_compiler_dirs(env, 'libraries'):
             search_dirs.append(f'-L{d}')
-        return ['-lstdc++']
+        return search_dirs + ['-lstdc++']
 
 
 class PGICPPCompiler(PGICompiler, CPPCompiler):

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -254,9 +254,7 @@ class ClangCPPCompiler(ClangCompiler, CPPCompiler):
         # be passed to a different compiler with a different set of default
         # search paths, such as when using Clang for C/C++ and gfortran for
         # fortran,
-        search_dirs: T.List[str] = []
-        for d in self.get_compiler_dirs(env, 'libraries'):
-            search_dirs.append(f'-L{d}')
+        search_dirs = [f'-L{d}' for d in self.get_compiler_dirs(env, 'libraries')]
         return search_dirs + ['-lstdc++']
 
 
@@ -271,9 +269,7 @@ class AppleClangCPPCompiler(ClangCPPCompiler):
         # be passed to a different compiler with a different set of default
         # search paths, such as when using Clang for C/C++ and gfortran for
         # fortran,
-        search_dirs: T.List[str] = []
-        for d in self.get_compiler_dirs(env, 'libraries'):
-            search_dirs.append(f'-L{d}')
+        search_dirs = [f'-L{d}' for d in self.get_compiler_dirs(env, 'libraries')]
         return search_dirs + ['-lc++']
 
 
@@ -439,9 +435,7 @@ class GnuCPPCompiler(GnuCompiler, CPPCompiler):
         # be passed to a different compiler with a different set of default
         # search paths, such as when using Clang for C/C++ and gfortran for
         # fortran,
-        search_dirs: T.List[str] = []
-        for d in self.get_compiler_dirs(env, 'libraries'):
-            search_dirs.append(f'-L{d}')
+        search_dirs = [f'-L{d}' for d in self.get_compiler_dirs(env, 'libraries')]
         return search_dirs + ['-lstdc++']
 
 

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -297,13 +297,7 @@ class ArmLtdClangCPPCompiler(ClangCPPCompiler):
 
 
 class AppleClangCPPCompiler(ClangCPPCompiler):
-    def language_stdlib_only_link_flags(self, env: 'Environment') -> T.List[str]:
-        # We need to apply the search prefix here, as these link arguments may
-        # be passed to a different compiler with a different set of default
-        # search paths, such as when using Clang for C/C++ and gfortran for
-        # fortran,
-        search_dirs = [f'-L{d}' for d in self.get_compiler_dirs(env, 'libraries')]
-        return search_dirs + ['-lc++']
+    pass
 
 
 class EmscriptenCPPCompiler(EmscriptenMixin, ClangCPPCompiler):


### PR DESCRIPTION
Because it does matter in some cases, namely when we use rustc to link C++ code.

Fixes: #11921