### PR TITLE
compilers: strip get_define output

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -688,7 +688,7 @@ class CLikeCompiler(Compiler):
         # Get the preprocessed value after the delimiter,
         # minus the extra newline at the end and
         # merge string literals.
-        return self._concatenate_string_literals(p.stdout.split(delim + '\n')[-1][:-1]), cached
+        return self._concatenate_string_literals(p.stdout.split(delim + '\n')[-1][:-1]).strip(), cached
 
     def get_return_value(self, fname: str, rtype: str, prefix: str,
                          env: 'Environment', extra_args: T.Optional[T.List[str]],

--- a/test cases/common/132 get define/test.json
+++ b/test cases/common/132 get define/test.json
@@ -1,0 +1,10 @@
+{
+  "matrix": {
+    "options": {
+      "c_std": [
+        { "val": "none" },
+        { "val": "c11" }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Fixes get_define() for MSVC. cl (tested with 19.36.32535) seems to always add trailing space character when substituting, even if macro is not defined. Since they cannot contain spaces it is safe to simply strip parsed value.

Also I'm certain is was working correctly not so long ago, so it might be a change in recent MSVC that triggered this.

Fixes #10179
Closes #10182