### PR TITLE
environment: separate illumos and Solaris kernels in Machines

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -175,7 +175,8 @@ Native names as returned by the `.kernel()` method.
 | netbsd  | |
 | nt      | |
 | xnu                 | Kernel of various Apple OSes    |
-| sunos | |
+| illumos             | Kernel derived from OpenSolaris by community efforts |
+| solaris             | Kernel derived from OpenSolaris by Oracle |
 | dragonfly | |
 | haiku| |
 | none                 | For e.g. bare metal embedded    |


### PR DESCRIPTION
While both kernels are derived from the OpenSolaris project of Sun, they have diverged and code that works with one may not work with the other. As such, we should provide different values for them. This was requested by both Oracle and the illumos upstreams.

Fixes: #11922