### PR TITLE
Fix command line vs. native file precedence error on regen

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -487,6 +487,7 @@ class Environment:
             os.makedirs(self.scratch_dir, exist_ok=True)
             os.makedirs(self.log_dir, exist_ok=True)
             os.makedirs(self.info_dir, exist_ok=True)
+            coredata.read_cmd_line_file(self.build_dir, options)
             try:
                 self.coredata = coredata.load(self.get_build_dir())  # type: coredata.CoreData
                 self.first_invocation = False
@@ -495,7 +496,6 @@ class Environment:
             except coredata.MesonVersionMismatchException as e:
                 # This is routine, but tell the user the update happened
                 mlog.log('Regenerating configuration from scratch:', str(e))
-                coredata.read_cmd_line_file(self.build_dir, options)
                 self.create_new_coredata(options)
             except MesonException as e:
                 # If we stored previous command line options, we can recover from
@@ -503,7 +503,6 @@ class Environment:
                 if os.path.isfile(coredata.get_cmd_line_file(self.build_dir)):
                     mlog.warning('Regenerating configuration from scratch.', fatal=False)
                     mlog.log('Reason:', mlog.red(str(e)))
-                    coredata.read_cmd_line_file(self.build_dir, options)
                     self.create_new_coredata(options)
                 else:
                     raise e

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1210,21 +1210,18 @@ class Interpreter(InterpreterBase, HoldableObject):
         else:
             self.project_default_options = kwargs['default_options']
 
-        # Do not set default_options on reconfigure otherwise it would override
-        # values previously set from command line. That means that changing
-        # default_options in a project will trigger a reconfigure but won't
-        # have any effect.
-        #
         # If this is the first invocation we always need to initialize
         # builtins, if this is a subproject that is new in a re-invocation we
         # need to initialize builtins for that
         if self.environment.first_invocation or (self.subproject != '' and self.subproject not in self.coredata.initialized_subprojects):
-            default_options = self.project_default_options.copy()
-            default_options.update(self.default_project_options)
             self.coredata.init_builtins(self.subproject)
             self.coredata.initialized_subprojects.add(self.subproject)
-        else:
-            default_options = {}
+
+        # Apply the default_options. We do this even on reconfigure, which means
+        # changing the default_options will also update the configured option, if
+        # it was not overridden on the command line.
+        default_options = self.project_default_options.copy()
+        default_options.update(self.default_project_options)
         self.coredata.set_default_options(default_options, self.subproject, self.environment)
 
         if not self.is_subproject():

--- a/unittests/machinefiletests.py
+++ b/unittests/machinefiletests.py
@@ -440,6 +440,7 @@ class NativeFileTests(BasePlatformTests):
         testcase = os.path.join(self.common_test_dir, '40 options')
         config = self.helper_create_native_file({'project options': {'other_one': True}})
         self.init(testcase, extra_args=['--native-file', config, '-Dother_one=false'])
+        self.init(testcase, extra_args=['--reconfigure'])
 
     def test_user_options_subproject(self):
         testcase = os.path.join(self.unit_test_dir, '78 user options for subproject')


### PR DESCRIPTION
Fixes https://github.com/mesonbuild/meson/issues/11930

The [logic in `Environment.__init__`](https://github.com/mesonbuild/meson/blob/9a6a95483c4d3c4f91824f1a7e52fc781e111043/mesonbuild/environment.py#L479-L498) only loads the options specified from the `setup` command line if the `CoreData` failed to load. This means on regeneration (`setup --reconfigure`) the options as seen by `get_option()` will not include the effect of command line options.

This PR makes the call to `read_cmd_line_file` non-conditional to fix the issue. `test_user_options_command_line_overrides` is extended to cover this case.

**ADD:** This PR also makes the application of `default_options` similarly non-conditional. Note that this means changing `default_options` now will change the option during the following reconfigure (if it wasn't set on the command line`). This is a deviation from the behavior of 1.1.1 and prior.