### PR TITLE
Fix the use of setup's '--profile-self' path …

### DIFF
--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -231,7 +231,7 @@ class MesonApp:
             raise
 
         cdf: T.Optional[str] = None
-        captured_compile_args = None
+        captured_compile_args: T.Optional[dict] = None
         try:
             dumpfile = os.path.join(env.get_scratch_dir(), 'build.dat')
             # We would like to write coredata as late as possible since we use the existence of
@@ -246,7 +246,9 @@ class MesonApp:
             if self.options.profile:
                 fname = f'profile-{intr.backend.name}-backend.log'
                 fname = os.path.join(self.build_dir, 'meson-logs', fname)
-                profile.runctx('intr.backend.generate()', globals(), locals(), filename=fname)
+                profile.runctx('gen_result = intr.backend.generate(capture, vslite_ctx)', globals(), locals(), filename=fname)
+                captured_compile_args = locals()['gen_result']
+                assert captured_compile_args is None or isinstance(captured_compile_args, dict)
             else:
                 captured_compile_args = intr.backend.generate(capture, vslite_ctx)
 


### PR DESCRIPTION
... after recent change to the backend 'generate(...) ' signature for '--genvslite':  profile.runctx('...') now constructs the correct cmd string and also extracts the return result from 'locals()'.

This is in reference to [this PR comment](https://github.com/mesonbuild/meson/pull/11049#discussion_r1249610852)

mypy's type-checking was complaining that this '_generate(...)  -> T.Optional[dict]:' func now might be returning the Any type, after, I presume, seeing me assign the result out of the 'locals()' dictionary to 'captured_compile_args'.  I thought mypy is supposed to deduce type narrowing with 'asserts' and 'isinstance', but that doesn't seem to be the case here 🤷‍♂️ so I've had to add a mypy type check error suppression comment on the return line.