### PR TITLE
Fix wrong linker env for HDF5

### DIFF
--- a/mesonbuild/dependencies/hdf5.py
+++ b/mesonbuild/dependencies/hdf5.py
@@ -98,12 +98,15 @@ class HDF5ConfigToolDependency(ConfigToolDependency):
 
         if language == 'c':
             cenv = 'CC'
+            lenv = 'C'
             tools = ['h5cc', 'h5pcc']
         elif language == 'cpp':
             cenv = 'CXX'
+            lenv = 'CXX'
             tools = ['h5c++', 'h5pc++']
         elif language == 'fortran':
             cenv = 'FC'
+            lenv = 'F'
             tools = ['h5fc', 'h5pfc']
         else:
             raise DependencyException('How did you get here?')
@@ -120,11 +123,11 @@ class HDF5ConfigToolDependency(ConfigToolDependency):
         compiler = environment.coredata.compilers[for_machine][language]
         try:
             os.environ[f'HDF5_{cenv}'] = join_args(compiler.get_exelist())
-            os.environ[f'HDF5_{cenv}LINKER'] = join_args(compiler.get_linker_exelist())
+            os.environ[f'HDF5_{lenv}LINKER'] = join_args(compiler.get_linker_exelist())
             super().__init__(name, environment, nkwargs, language)
         finally:
             del os.environ[f'HDF5_{cenv}']
-            del os.environ[f'HDF5_{cenv}LINKER']
+            del os.environ[f'HDF5_{lenv}LINKER']
         if not self.is_found:
             return
 


### PR DESCRIPTION
h5cc expects the variable ```HDF5_CLINKER``` instead of ```HDF5_CCLINKER``` (see https://github.com/HDFGroup/hdf5/blob/develop/bin/h5cc.in#L97). The same way h5fc expects ```HDF5_FLINKER``` (see https://github.com/HDFGroup/hdf5/blob/develop/fortran/src/h5fc.in#L93). The h5c++ does expect ```HDF5_CXXLINKER```, although it was only fixed in august 2021 (see HDFGroup/hdf5#924), before that it was also ```HDF5_CLINKER```.