### PR TITLE
More robust linker detection for armar (TI vs non-TI)

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -204,8 +204,6 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
 
         if any(os.path.basename(x) in {'lib', 'lib.exe', 'llvm-lib', 'llvm-lib.exe', 'xilib', 'xilib.exe'} for x in linker):
             arg = '/?'
-        elif linker_name in {'ar2000', 'ar2000.exe', 'ar430', 'ar430.exe', 'armar', 'armar.exe'}:
-            arg = '?'
         else:
             arg = '--version'
         try:
@@ -234,7 +232,7 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
             return linkers.CcrxLinker(linker)
         if out.startswith('GNU ar') and 'xc16-ar' in linker_name:
             return linkers.Xc16Linker(linker)
-        if 'Texas Instruments Incorporated' in out:
+        if "-->  error: bad option 'e'" in err: # TI
             if 'ar2000' in linker_name:
                 return linkers.C2000Linker(linker)
             else:


### PR DESCRIPTION
Closes #11887

@tolnaisz - I don't actually know what particular `armar` compiler you're using. Can you test this fix on your end?

Instead of using a different version flag (the output of which isn't even parsed), just catch the error that all the TI linkers print when `--version` is specified, which is similar to what we do with other compilers that don't support this flag.

For reference, this is what I get on *all* of `ar430`, `ar2000` and `armar` when given `--version`:
`  -->  error: bad option 'e'`

And what I get for `?` (again, not used any more, just in case we need the specificity in the future):
```
.\ar430.exe ?
MSP430 Archiver                         v18.12.8.LTS
Copyright (c) 2003-2018 Texas Instruments Incorporated

 Syntax : ar430 [arxdt][quvsh][012] archive files ...
          ar430 @command_file
```
```
.\ar2000.exe ?
TMS320C2000 Archiver                    v18.12.8.LTS
Copyright (c) 1996-2018 Texas Instruments Incorporated

 Syntax : ar2000 [arxdt][quvsh][012] archive files ...
          ar2000 @command_file
```
```
.\armar.exe ?
TI ARM Archiver                         v18.12.8.LTS
Copyright (c) 1996-2018 Texas Instruments Incorporated

 Syntax : ar470 [arxdt][quvsh][012] archive files ...
          ar470 @command_file
```