### PR TITLE
build: use self.compilers instead of all_compilers for stdlib langs

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1630,10 +1630,13 @@ You probably should put it in link_with instead.''')
 
     def get_used_stdlib_args(self, link_language: str) -> T.List[str]:
         all_compilers = self.environment.coredata.compilers[self.for_machine]
-        all_langs = set(all_compilers).union(self.get_langs_used_by_deps())
+        all_langs = set(self.compilers).union(self.get_langs_used_by_deps())
         stdlib_args: T.List[str] = []
         for dl in all_langs:
             if dl != link_language and (dl, link_language) not in self._MASK_LANGS:
+                # We need to use all_compilers here because
+                # get_langs_used_by_deps could return a language from a
+                # subproject
                 stdlib_args.extend(all_compilers[dl].language_stdlib_only_link_flags(self.environment))
         return stdlib_args
 


### PR DESCRIPTION
We need a union of the compilers used by the target, and by those used by all dependencies, not all the compilers in all projects. We do, however, need to look compilers up from all possible compilers, as a dependency that is a subproject could use a language not present in the current project.

@xclaesse, as pointed out on IRC. I was wrong though, we didn't need an intersection, we needed the target's compilers