### PR TITLE
tests: Test extern'd globals on MacOS with the Apple Archiver

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2350,7 +2350,7 @@ class NinjaBackend(backends.Backend):
             if static_linker is None:
                 continue
             rule = 'STATIC_LINKER{}'.format(self.get_rule_suffix(for_machine))
-            cmdlist = []
+            cmdlist: T.List[T.Union[str, NinjaCommandArg]] = []
             args = ['$in']
             # FIXME: Must normalize file names with pathlib.Path before writing
             #        them out to fix this properly on Windows. See:
@@ -2364,6 +2364,17 @@ class NinjaBackend(backends.Backend):
             cmdlist += static_linker.get_exelist()
             cmdlist += ['$LINK_ARGS']
             cmdlist += NinjaCommandArg.list(static_linker.get_output_args('$out'), Quoting.none)
+            # The default ar on MacOS (at least through version 12), does not
+            # add extern'd variables to the symbol table by default, and
+            # requires that apple's ranlib be called with a special flag
+            # instead after linking
+            if static_linker.id == 'applear':
+                # This is a bit of a hack, but we assume that that we won't need
+                # an rspfile on MacOS, otherwise the arguments are passed to
+                # ranlib, not to ar
+                cmdlist.extend(args)
+                args = []
+                cmdlist.extend(['&&', 'ranlib', '-c', '$out'])
             description = 'Linking static target $out'
             if num_pools > 0:
                 pool = 'pool = link_pool'

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -349,6 +349,8 @@ class VisualStudioLinker(VisualStudioLikeLinker, StaticLinker):
 
     """Microsoft's lib static linker."""
 
+    id = 'lib'
+
     def __init__(self, exelist: T.List[str], machine: str):
         StaticLinker.__init__(self, exelist)
         VisualStudioLikeLinker.__init__(self, machine)
@@ -357,6 +359,8 @@ class VisualStudioLinker(VisualStudioLikeLinker, StaticLinker):
 class IntelVisualStudioLinker(VisualStudioLikeLinker, StaticLinker):
 
     """Intel's xilib static linker."""
+
+    id = 'xilib'
 
     def __init__(self, exelist: T.List[str], machine: str):
         StaticLinker.__init__(self, exelist)

--- a/test cases/osx/9 global variable ar/libfile.c
+++ b/test cases/osx/9 global variable ar/libfile.c
@@ -1,0 +1,9 @@
+// Source: https://lists.gnu.org/archive/html/libtool/2002-07/msg00025.html
+
+#include <stdio.h>
+
+extern int l2;
+void l1(void)
+{
+  printf("l1 %d\n", l2);
+}

--- a/test cases/osx/9 global variable ar/libfile2.c
+++ b/test cases/osx/9 global variable ar/libfile2.c
@@ -1,0 +1,7 @@
+// Source: https://lists.gnu.org/archive/html/libtool/2002-07/msg00025.html
+
+int l2;
+void l2_func(void)
+{
+  l2 = 77;
+}

--- a/test cases/osx/9 global variable ar/meson.build
+++ b/test cases/osx/9 global variable ar/meson.build
@@ -1,0 +1,6 @@
+# Source: https://lists.gnu.org/archive/html/libtool/2002-07/msg00025.html
+
+project('global variable test', 'c')
+
+lib = static_library('mylib', 'libfile.c', 'libfile2.c')
+test('global variable', executable('prog', 'prog.c', link_with: lib))

--- a/test cases/osx/9 global variable ar/nativefile.ini
+++ b/test cases/osx/9 global variable ar/nativefile.ini
@@ -1,0 +1,2 @@
+[binaries]
+ar = 'ar'

--- a/test cases/osx/9 global variable ar/prog.c
+++ b/test cases/osx/9 global variable ar/prog.c
@@ -1,0 +1,7 @@
+// Source: https://lists.gnu.org/archive/html/libtool/2002-07/msg00025.html
+
+extern void l1(void);
+int main(void)
+{
+  l1();
+}


### PR DESCRIPTION
This is a regression test for:
https://github.com/mesonbuild/meson/issues/11165.

The test was initially merged as part of:
https://github.com/mesonbuild/meson/pull/10628, but had to be reverted.

A second attempt at fixing the root cause also had to be reverted: https://github.com/mesonbuild/meson/pull/10699.

A 3rd attempt got merged but missed this unit test: https://github.com/mesonbuild/meson/pull/11742.