### PR TITLE
wrap: detect network timeouts 20x faster

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -54,7 +54,7 @@ try:
 except ImportError:
     has_ssl = False
 
-REQ_TIMEOUT = 600.0
+REQ_TIMEOUT = 30.0
 WHITELIST_SUBDOMAIN = 'wrapdb.mesonbuild.com'
 
 ALL_TYPES = ['file', 'git', 'hg', 'svn']


### PR DESCRIPTION
When downloading wrap content, we need to know at some point if the server is going to respond with "hello, yes, I'm here and I have data for you". The alternative is to sometimes infinitely hang.

In commit 8f7781f1d6bf36c064b39e7d0794c686f1b78665 we added such a timeout, but using an extremely generously high number -- ten minutes. We don't need to wait this long just to find out if the other end exists, so decrease that time to 30 seconds, whch is still ludicrously generous but not quite as much so.

See https://github.com/bugaevc/wl-clipboard/issues/182#issuecomment-1625346745