### PR TITLE
windows: Fix detection of the llvm-rc resource compiler

### DIFF
--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -97,6 +97,7 @@ class WindowsModule(ExtensionModule):
 
         for (arg, match, rc_type) in [
                 ('/?', '^.*Microsoft.*Resource Compiler.*$', ResourceCompilerType.rc),
+                ('/?', 'LLVM Resource Converter.*$', ResourceCompilerType.rc),
                 ('--version', '^.*GNU windres.*$', ResourceCompilerType.windres),
                 ('--version', '^.*Wine Resource Compiler.*$', ResourceCompilerType.wrc),
         ]:


### PR DESCRIPTION
By default, clang-cl based environments use rc.exe as resource compiler. However, when cross compiling with clang-cl, one might want to use llvm-rc instead.

Try to detect llvm-rc based on the output from "$CMD /?".

This requires a very recent llvm-rc; previosly, the output of "/?" with llvm-rc was very generic and didn't explicitly indicate that it actually was llvm-rc. This was changed in
https://github.com/llvm/llvm-project/commit/bab6902eba55026a829d232629f99ac276936ef0 which will be included in the upcoming LLVM 17.0.0 release.

Contrary to the other regexes, don't include the preceding parts of the line in the log printout, as it includes an unhelpful "OVERVIEW:" prefix.