### PR TITLE
Add 'install-name' target property

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -150,6 +150,7 @@ class TargetInstallData:
     optional: bool = False
     tag: T.Optional[str] = None
     can_strip: bool = False
+    install_fname: T.Optional[str] = None
 
     def __post_init__(self, outdir_name: T.Optional[str]) -> None:
         if outdir_name is None:
@@ -1714,7 +1715,7 @@ class Backend:
                                           first_outdir_name,
                                           should_strip, mappings, t.rpath_dirs_to_remove,
                                           t.install_rpath, install_mode, t.subproject,
-                                          tag=tag, can_strip=can_strip)
+                                          tag=tag, can_strip=can_strip, install_fname=t.get_install_fname())
                     d.targets.append(i)
 
                     for alias, to, tag in t.get_aliases():

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3251,10 +3251,13 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 commands += linker.get_std_shared_lib_link_args()
             # All shared libraries are PIC
             commands += linker.get_pic_args()
-            if not isinstance(target, build.SharedModule) or target.force_soname:
+            soname = target.get_install_name()
+            if not isinstance(target, build.SharedModule) or target.force_soname or soname:
+                if not soname:
+                    soname = target.name
                 # Add -Wl,-soname arguments on Linux, -install_name on OS X
                 commands += linker.get_soname_args(
-                    self.environment, target.prefix, target.name, target.suffix,
+                    self.environment, target.prefix, soname, target.suffix,
                     target.soversion, target.darwin_versions)
             # This is only visited when building for Windows using either GCC or Visual Studio
             if target.vs_module_defs and hasattr(linker, 'gen_vs_module_defs_args'):

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -73,6 +73,7 @@ from .type_checking import (
     INSTALL_KW,
     INSTALL_DIR_KW,
     INSTALL_MODE_KW,
+    INSTALL_NAME_KW,
     LINK_WITH_KW,
     LINK_WHOLE_KW,
     CT_INSTALL_TAG_KW,
@@ -1997,6 +1998,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         ENV_KW.evolve(since='0.57.0'),
         INSTALL_KW,
         INSTALL_MODE_KW.evolve(since='0.47.0'),
+        INSTALL_NAME_KW,
         KwargInfo('feed', bool, default=False, since='0.59.0'),
         KwargInfo('capture', bool, default=False),
         KwargInfo('console', bool, default=False, since='0.48.0'),
@@ -2089,6 +2091,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             install=kwargs['install'],
             install_dir=kwargs['install_dir'],
             install_mode=install_mode,
+            install_name=kwargs['install_name'],
             install_tag=kwargs['install_tag'],
             backend=self.backend)
         self.add_target(tg.name, tg)
@@ -2454,6 +2457,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         INSTALL_MODE_KW.evolve(since='0.38.0'),
         INSTALL_TAG_KW.evolve(since='0.60.0'),
         INSTALL_DIR_KW,
+        INSTALL_NAME_KW,
         PRESERVE_PATH_KW.evolve(since='0.64.0'),
     )
     def func_install_data(self, node: mparser.BaseNode,
@@ -2548,6 +2552,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         'configure_file',
         DEPFILE_KW.evolve(since='0.52.0'),
         INSTALL_MODE_KW.evolve(since='0.47.0,'),
+        INSTALL_NAME_KW,
         INSTALL_TAG_KW.evolve(since='0.60.0'),
         KwargInfo('capture', bool, default=False, since='0.41.0'),
         KwargInfo(

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -174,6 +174,13 @@ INSTALL_MODE_KW: KwargInfo[T.List[T.Union[str, bool, int]]] = KwargInfo(
     convertor=_install_mode_convertor,
 )
 
+INSTALL_NAME_KW: KwargInfo[T.Optional[str]] = KwargInfo(
+    'install_name',
+    (str, NoneType),
+    default=None,
+    since='1.3.0',
+)
+
 REQUIRED_KW: KwargInfo[T.Union[bool, UserFeatureOption]] = KwargInfo(
     'required',
     (bool, UserFeatureOption),

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -409,7 +409,10 @@ class Installer:
             dirmaker, outdir = makedirs
             # Create dirs if needed
             dirmaker.makedirs(outdir, exist_ok=True)
-        self.log(f'Installing {from_file} to {outdir}')
+        if os.path.basename(from_file) != os.path.basename(to_file):
+            self.log(f'Installing {from_file} to {to_file}')
+        else:
+            self.log(f'Installing {from_file} to {outdir}')
         if os.path.islink(from_file):
             if not os.path.exists(from_file):
                 # Dangling symlink. Replicate as is.
@@ -728,8 +731,11 @@ class Installer:
             file_copied = False # not set when a directory is copied
             fname = check_for_stampfile(t.fname)
             outdir = get_destdir_path(destdir, fullprefix, t.outdir)
-            outname = os.path.join(outdir, os.path.basename(fname))
-            final_path = os.path.join(d.prefix, t.outdir, os.path.basename(fname))
+            install_fname = t.install_fname
+            if install_fname is None:
+                install_fname = os.path.basename(fname)
+            outname = os.path.join(outdir, install_fname)
+            final_path = os.path.join(d.prefix, t.outdir, install_fname)
             should_strip = t.strip or (t.can_strip and self.options.strip)
             install_rpath = t.install_rpath
             install_name_mappings = t.install_name_mappings
@@ -752,7 +758,7 @@ class Installer:
                         file_copied = self.do_copyfile(wasm_source, wasm_output)
             elif os.path.isdir(fname):
                 fname = os.path.join(d.build_dir, fname.rstrip('/'))
-                outname = os.path.join(outdir, os.path.basename(fname))
+                outname = os.path.join(outdir, install_fname)
                 dm.makedirs(outdir, exist_ok=True)
                 self.do_copydir(d, fname, outname, None, install_mode, dm)
             else:

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -112,6 +112,7 @@ __all__ = [
     'expand_arguments',
     'extract_as_list',
     'first',
+    'flatten_path',
     'generate_list',
     'get_compiler_for_source',
     'get_filenames_templates_dict',
@@ -1089,6 +1090,11 @@ def has_path_sep(name: str, sep: str = '/\\') -> bool:
         if each in name:
             return True
     return False
+
+
+def flatten_path(name: str, sep: str = '/\\', replace: str = '_') -> str:
+    '''Replaces any specified @sep path separators in @name with @replace'''
+    return name.translate(name.maketrans(sep, replace * len(sep)))
 
 
 if is_windows():


### PR DESCRIPTION
The first patch in this series adds a new target property, 'install-name', which supplants the name for purposes of computing the install filename. This allows building multiple targets with the same basename but different install directories.

The second patch adds a backward-compatibility kludge for existing projects which do this by prepending a directory name to the target name. When that occurs, the target basename is used as the default 'install-name' value and then the target name is 'flattened' by replacing directory separators with '_'.

Closes: #4019 