### PR TITLE
Revert "backends: Cache creation of install data"

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1605,7 +1605,6 @@ class Backend:
             mlog.log(f'Running postconf script {name!r}')
             run_exe(s, env)
 
-    @lru_cache(maxsize=1)
     def create_install_data(self) -> InstallData:
         strip_bin = self.environment.lookup_binary_entry(MachineChoice.HOST, 'strip')
         if strip_bin is None:

--- a/test cases/unit/39 external, internal library rpath/built library/meson.build
+++ b/test cases/unit/39 external, internal library rpath/built library/meson.build
@@ -2,6 +2,8 @@ project('built library', 'c')
 
 cc = meson.get_compiler('c')
 
+import('python').find_installation().install_sources('foo.py')
+
 if host_machine.system() != 'cygwin'
   # bar_in_system has undefined symbols, but still must be found
   bar_system_dep = cc.find_library('bar_in_system')


### PR DESCRIPTION
This reverts commit 904b47085fdd985175b4b2c3224f65b9d33f04d7.

This is not a real bottleneck, and we want to create it thrice -- once before the backend is generated. The final install data needs to be created fresh.

Fixes https://bugs.gentoo.org/910050