### PR TITLE
mtest: try a bit harder to avoid weird non-parseable output at startup

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1608,7 +1608,8 @@ class TestHarness:
             if not self.options.no_rebuild:
                 teststdo = subprocess.run(self.ninja + ['-n', 'build.ninja'], capture_output=True).stdout
                 if b'ninja: no work to do.' not in teststdo and b'samu: nothing to do' not in teststdo:
-                    ret = subprocess.run(self.ninja + ['build.ninja'])
+                    stdo = sys.stderr if self.options.list else sys.stdout
+                    ret = subprocess.run(self.ninja + ['build.ninja'], stdout=stdo.fileno())
                     if ret.returncode != 0:
                         raise TestException(f'Could not configure {self.options.wd!r}')
 

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1906,9 +1906,9 @@ class TestHarness:
                     # succeed on an invalid pattern.
                     raise MesonException(f'{arg} test name does not match any test')
 
-    def get_tests(self) -> T.List[TestSerialisation]:
+    def get_tests(self, errorfile: T.Optional[T.IO] = sys.stdout) -> T.List[TestSerialisation]:
         if not self.tests:
-            print('No tests defined.')
+            print('No tests defined.', file=errorfile)
             return []
 
         tests = [t for t in self.tests if self.test_suitable(t)]
@@ -1916,7 +1916,7 @@ class TestHarness:
             tests = list(self.tests_from_args(tests))
 
         if not tests:
-            print('No suitable tests defined.')
+            print('No suitable tests defined.', file=errorfile)
             return []
 
         return tests
@@ -2074,7 +2074,7 @@ class TestHarness:
                 await l.finish(self)
 
 def list_tests(th: TestHarness) -> bool:
-    tests = th.get_tests()
+    tests = th.get_tests(errorfile=sys.stderr)
     for t in tests:
         print(th.get_pretty_suite(t))
     return not tests

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1606,9 +1606,11 @@ class TestHarness:
             # happen before rebuild_deps(), because we need the correct list of
             # tests and their dependencies to compute
             if not self.options.no_rebuild:
-                ret = subprocess.run(self.ninja + ['build.ninja']).returncode
-                if ret != 0:
-                    raise TestException(f'Could not configure {self.options.wd!r}')
+                teststdo = subprocess.run(self.ninja + ['-n', 'build.ninja'], capture_output=True).stdout
+                if b'ninja: no work to do.' not in teststdo and b'samu: nothing to do' not in teststdo:
+                    ret = subprocess.run(self.ninja + ['build.ninja'])
+                    if ret.returncode != 0:
+                        raise TestException(f'Could not configure {self.options.wd!r}')
 
             self.build_data = build.load(os.getcwd())
             if not self.options.setup:


### PR DESCRIPTION
In commit 628effb3698e85e403351d2705d576cf4ee8c50c we started verifying the build.ninja file was up to date before even `--list`ing tests, because we could end up with incorrect information. This meant that ninja always runs at startup, and typically returns "no work to do", which ended up listed as "one of" the tests.

Instead of unconditionally running ninja attached to the console, first check it in dry-run mode with stdout intercepted, to see if ninja considers itself up to date. If it is, continue. Only if an actual refresh is needed, do we run it while attached to the console.

In the garden path, this avoids useless information. In cases where we'd already print a full meson reconfigure log, we continue to do so.

/cc @anarazel 