### PR TITLE
cmake: fix empty BOOL generator expression evaluating to true

### DIFF
--- a/mesonbuild/cmake/generator.py
+++ b/mesonbuild/cmake/generator.py
@@ -100,7 +100,7 @@ def parse_generator_expressions(
 
     supported = {
         # Boolean functions
-        'BOOL': lambda x: '0' if x.upper() in {'0', 'FALSE', 'OFF', 'N', 'NO', 'IGNORE', 'NOTFOUND'} or x.endswith('-NOTFOUND') else '1',
+        'BOOL': lambda x: '0' if x.upper() in {'', '0', 'FALSE', 'OFF', 'N', 'NO', 'IGNORE', 'NOTFOUND'} or x.endswith('-NOTFOUND') else '1',
         'AND': lambda x: '1' if all(y == '1' for y in x.split(',')) else '0',
         'OR': lambda x: '1' if any(y == '1' for y in x.split(',')) else '0',
         'NOT': lambda x: '0' if x == '1' else '1',


### PR DESCRIPTION
The [manual](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#genex:BOOL) says:

> Converts string to 0 or 1. Evaluates to 0 if any of the following is true:
> - string is empty,
> - string is a case-insensitive equal of 0, FALSE, OFF, N, NO, IGNORE, or NOTFOUND, or
> - string ends in the suffix -NOTFOUND (case-sensitive).
>
> Otherwise evaluates to 1.

This pull request fix the behavior for the first case ("string is empty"), which currently evaluates to true.

I needed this to properly parse CMake config of [yhirose/cpp-httplib](https://github.com/yhirose/cpp-httplib).