### PR TITLE
macos: map arm64e to aarch64, map "whole" architecture strings

### DIFF
--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -702,15 +702,23 @@ def darwin_get_object_archs(objpath: str) -> 'ImmutableListProtocol[str]':
         mlog.debug(f'lipo {objpath}: {stderr}')
         return None
     stdo = stdo.rsplit(': ', 1)[1]
+
     # Convert from lipo-style archs to meson-style CPUs
-    stdo = stdo.replace('i386', 'x86')
-    stdo = stdo.replace('arm64', 'aarch64')
-    stdo = stdo.replace('ppc7400', 'ppc')
-    stdo = stdo.replace('ppc970', 'ppc')
+    map_arch = {
+        'i386': 'x86',
+        'arm64': 'aarch64',
+        'arm64e': 'aarch64',
+        'ppc7400': 'ppc',
+        'ppc970': 'ppc',
+    }
+    lipo_archs = stdo.split()
+    meson_archs = [map_arch.get(lipo_arch, lipo_arch) for lipo_arch in lipo_archs]
+
     # Add generic name for armv7 and armv7s
     if 'armv7' in stdo:
-        stdo += ' arm'
-    return stdo.split()
+        meson_archs.append('arm')
+
+    return meson_archs
 
 def windows_detect_native_arch() -> str:
     """

--- a/unittests/darwintests.py
+++ b/unittests/darwintests.py
@@ -148,3 +148,8 @@ class DarwinTests(BasePlatformTests):
         testdir = os.path.join(self.objcpp_test_dir, '1 simple')
         self.init(testdir)
         self.assertIn('-std=c++14', self.get_compdb()[0]['command'])
+
+    def test_darwin_get_object_archs(self):
+        from mesonbuild.mesonlib import darwin_get_object_archs
+        archs = darwin_get_object_archs('/System/Library/CoreServices/Encodings/libSymbolConverter.dylib')
+        self.assertEqual(archs, ['x86_64', 'aarch64'])


### PR DESCRIPTION
Some macos libraries use arm64e instead of arm64 as architecture. Due to the string replace approach taken so far, we'd end up with aarch64e as architecture, which the rest of meson doesn't know.

Move architecture mapping to map whole architecture names and add arm64e -> aarch64 mapping.

This change doesn't touch the case for armv7[s], where we add arm, rather than replace armv7[s], but it's certainly not in line with the other mappings.

Fixes: #9493
Closes: #10718