### PR TITLE
rust: disable overflow-checks by default

### DIFF
--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -217,7 +217,7 @@ class RustCompiler(Compiler):
 
     def get_assert_args(self, disable: bool) -> T.List[str]:
         action = "no" if disable else "yes"
-        return ['-C', f'debug-assertions={action}']
+        return ['-C', f'debug-assertions={action}', '-C', 'overflow-checks=no']
 
 
 class ClippyRustCompiler(RustCompiler):

--- a/test cases/rust/5 polyglot static/clib.c
+++ b/test cases/rust/5 polyglot static/clib.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
+#include <stdint.h>
 
-void hello_from_rust(void);
+int32_t hello_from_rust(const int32_t a, const int32_t b);
 
 static void hello_from_c(void) {
     printf("Hello from C!\n");
@@ -8,5 +9,6 @@ static void hello_from_c(void) {
 
 void hello_from_both(void) {
     hello_from_c();
-    hello_from_rust();
+    if (hello_from_rust(2, 3) == 5)
+        printf("Hello from Rust!\n");
 }

--- a/test cases/rust/5 polyglot static/meson.build
+++ b/test cases/rust/5 polyglot static/meson.build
@@ -17,3 +17,10 @@ e = executable('prog', 'prog.c',
                link_with : l,
                install : true)
 test('polyglottest', e)
+
+# Create a version that has overflow-checks on, then run a test to ensure that
+# the overflow-checks is larger than the other version by some ammount
+r2 = static_library('stuff2', 'stuff.rs', rust_crate_type : 'staticlib', rust_args : ['-C', 'overflow-checks=on'])
+l2 = static_library('clib2', 'clib.c')
+e2 = executable('prog2', 'prog.c', link_with : [r2, l2])
+test('overflow-checks', find_program('overflow_size_checks.py'), args : [e, e2])

--- a/test cases/rust/5 polyglot static/overflow_size_checks.py
+++ b/test cases/rust/5 polyglot static/overflow_size_checks.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2023 Intel Corporation
+
+from __future__ import annotations
+import argparse
+import os
+import typing as T
+
+if T.TYPE_CHECKING:
+    class Arguments(T.Protocol):
+        checks_off: str
+        checks_on: str
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('checks_off')
+    parser.add_argument('checks_on')
+    args: Arguments = parser.parse_args()
+
+    off = os.stat(args.checks_off).st_size
+    on = os.stat(args.checks_on).st_size
+
+    assert on > off, f'Expected binary built with overflow-checks to be bigger, but it was smaller. with: "{on}"B, without: "{off}"B'
+
+
+if __name__ == "__main__":
+    main()

--- a/test cases/rust/5 polyglot static/stuff.rs
+++ b/test cases/rust/5 polyglot static/stuff.rs
@@ -1,6 +1,4 @@
-#![crate_name = "stuff"]
-
 #[no_mangle]
-pub extern "C" fn hello_from_rust() {
-    println!("Hello from Rust!");
+pub extern "C" fn hello_from_rust(a: i32, b: i32) -> i32 {
+    a + b
 }


### PR DESCRIPTION
These result in very large binaries when linked, and are not generally useful. A user can turn them back on by passing `-C overflow-checks=yes` manually via `-Drust_args` or the `RUSTFLAGS` environment variable

fixes: #11785