### PR TITLE
add support for newer C++ -std= flags on Clang/GCC

### DIFF
--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -154,6 +154,10 @@ class CPPCompiler(CLikeCompiler, Compiler):
             'gnu++17': 'gnu++1z',
             'c++20': 'c++2a',
             'gnu++20': 'gnu++2a',
+            'c++23': 'c++2b',
+            'gnu++23': 'gnu++2b',
+            'c++26': 'c++2c',
+            'gnu++26': 'gnu++2c',
         }
 
         # Currently, remapping is only supported for Clang, Elbrus and GCC

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -226,6 +226,10 @@ class _StdCPPLibMixin(CompilerMixinBase):
 
 
 class ClangCPPCompiler(_StdCPPLibMixin, ClangCompiler, CPPCompiler):
+
+    _CPP23_VERSION = '>=12.0.0'
+    _CPP26_VERSION = '>=17.0.0'
+
     def __init__(self, ccache: T.List[str], exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo', exe_wrapper: T.Optional['ExternalProgram'] = None,
                  linker: T.Optional['DynamicLinker'] = None,
@@ -252,11 +256,18 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCompiler, CPPCompiler):
             ),
             key.evolve('rtti'): coredata.UserBooleanOption('Enable RTTI', True),
         })
-        opts[key.evolve('std')].choices = [
+        cppstd_choices = [
             'none', 'c++98', 'c++03', 'c++11', 'c++14', 'c++17', 'c++1z',
             'c++2a', 'c++20', 'gnu++11', 'gnu++14', 'gnu++17', 'gnu++1z',
             'gnu++2a', 'gnu++20',
         ]
+        if version_compare(self.version, self._CPP23_VERSION):
+            cppstd_choices.append('c++23')
+            cppstd_choices.append('gnu++23')
+        if version_compare(self.version, self._CPP26_VERSION):
+            cppstd_choices.append('c++26')
+            cppstd_choices.append('gnu++26')
+        opts[key.evolve('std')].choices = cppstd_choices
         if self.info.is_windows() or self.info.is_cygwin():
             opts.update({
                 key.evolve('winlibs'): coredata.UserArrayOption(
@@ -298,7 +309,11 @@ class ArmLtdClangCPPCompiler(ClangCPPCompiler):
 
 
 class AppleClangCPPCompiler(ClangCPPCompiler):
-    pass
+
+    _CPP23_VERSION = '>=13.0.0'
+    # TODO: We don't know which XCode version will include LLVM 17 yet, so
+    # use something absurd.
+    _CPP26_VERSION = '>=99.0.0'
 
 
 class EmscriptenCPPCompiler(EmscriptenMixin, ClangCPPCompiler):
@@ -418,6 +433,9 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCompiler, CPPCompiler):
         if version_compare(self.version, '>=12.2.0'):
             cppstd_choices.append('c++23')
             cppstd_choices.append('gnu++23')
+        if version_compare(self.version, '>=14.0.0'):
+            cppstd_choices.append('c++26')
+            cppstd_choices.append('gnu++26')
         opts[key].choices = cppstd_choices
         if self.info.is_windows() or self.info.is_cygwin():
             opts.update({

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -517,6 +517,15 @@ class LinuxlikeTests(BasePlatformTests):
         has_cpp20 = (compiler.get_id() not in {'clang', 'gcc'} or
                      compiler.get_id() == 'clang' and _clang_at_least(compiler, '>=10.0.0', None) or
                      compiler.get_id() == 'gcc' and version_compare(compiler.version, '>=10.0.0'))
+        has_cpp2b = (compiler.get_id() not in {'clang', 'gcc'} or
+                     compiler.get_id() == 'clang' and _clang_at_least(compiler, '>=12.0.0', None) or
+                     compiler.get_id() == 'gcc' and version_compare(compiler.version, '>=12.2.0'))
+        has_cpp23 = (compiler.get_id() not in {'clang', 'gcc'} or
+                     compiler.get_id() == 'clang' and _clang_at_least(compiler, '>=17.0.0', None) or
+                     compiler.get_id() == 'gcc' and version_compare(compiler.version, '>=12.2.0'))
+        has_cpp26 = (compiler.get_id() not in {'clang', 'gcc'} or
+                     compiler.get_id() == 'clang' and _clang_at_least(compiler, '>=17.0.0', None) or
+                     compiler.get_id() == 'gcc' and version_compare(compiler.version, '>=14.0.0'))
         has_c18 = (compiler.get_id() not in {'clang', 'gcc'} or
                    compiler.get_id() == 'clang' and _clang_at_least(compiler, '>=8.0.0', '>=11.0') or
                    compiler.get_id() == 'gcc' and version_compare(compiler.version, '>=8.0.0'))
@@ -532,6 +541,12 @@ class LinuxlikeTests(BasePlatformTests):
             elif '++2a' in v and not has_cpp2a_c17:  # https://en.cppreference.com/w/cpp/compiler_support
                 continue
             elif '++20' in v and not has_cpp20:
+                continue
+            elif '++2b' in v and not has_cpp2b:
+                continue
+            elif '++23' in v and not has_cpp23:
+                continue
+            elif ('++26' in v or '++2c' in v) and not has_cpp26:
                 continue
             # now C
             elif '17' in v and not has_cpp2a_c17:


### PR DESCRIPTION
Clang compilers do not support c++23 standard.  Add it and add support for c++26 to both Clang and GCC.

Closes #9053