### PR TITLE
cmake: find dependencies with bare library names on all platforms

### DIFF
--- a/mesonbuild/cmake/tracetargets.py
+++ b/mesonbuild/cmake/tracetargets.py
@@ -50,8 +50,8 @@ def resolve_cmake_trace_targets(target_name: str,
                 res.libraries += [curr]
             elif Path(curr).is_absolute() and Path(curr).exists():
                 res.libraries += [curr]
-            elif env.machines.build.is_windows() and reg_is_maybe_bare_lib.match(curr) and clib_compiler:
-                # On Windows, CMake library dependencies can be passed as bare library names,
+            elif reg_is_maybe_bare_lib.match(curr) and clib_compiler:
+                # CMake library dependencies can be passed as bare library names,
                 # CMake brute-forces a combination of prefix/suffix combinations to find the
                 # right library. Assume any bare argument passed which is not also a CMake
                 # target must be a system library we should try to link against.


### PR DESCRIPTION
This removes the "if Windows" restriction.  I'm not sure why there was one.

The [CMake doc](https://cmake.org/cmake/help/latest/command/target_link_libraries.html) mention this as a possible input:

> - **A plain library name**: The generated link line will ask the linker to search for the library (e.g. foo becomes -lfoo or foo.lib).
> The library name/flag is treated as a command-line string fragment and will be used with no extra quoting or escaping.

I'm pretty sure this is (was?) also the typical way to link with glibc libs like `m`, `dl` etc.

I encountered this when depending on openssl from vcpkg, meson was not finding (nor linking) `dl`.