### PR TITLE
Fix build using GDC 13

### DIFF
--- a/test cases/d/13 declare dep/meson.build
+++ b/test cases/d/13 declare dep/meson.build
@@ -3,7 +3,7 @@ project('meson-d-sample', 'd',
 )
 
 my_dep = declare_dependency(
-    d_module_versions: ['TestVersion', 1],
+    d_module_versions: ['TestVersion'],
     d_import_dirs: include_directories('views'),
 )
 

--- a/test cases/d/9 features/meson.build
+++ b/test cases/d/9 features/meson.build
@@ -1,5 +1,16 @@
 project('D Features', 'd', default_options : ['debug=false'])
 
+dc = meson.get_compiler('d')
+
+# GDC 13 hard errors if options are given number values.
+# https://github.com/mesonbuild/meson/pull/11996
+
+if dc.get_id() == 'gcc' and dc.version().version_compare('>=13')
+    number_options_supported = false
+else
+    number_options_supported = true
+endif
+
 # ONLY FOR BACKWARDS COMPATIBILITY.
 # DO NOT DO THIS IN NEW CODE!
 # USE include_directories() INSTEAD OF BUILDING
@@ -46,12 +57,13 @@ e_test = executable('dapp_test',
 test('dapp_test', e_test)
 
 # test version level
-e_version_int = executable('dapp_version_int',
-    test_src,
-    d_import_dirs: [data_dir],
-    d_module_versions: ['With_VersionInteger', 3],
-)
-test('dapp_version_int_t', e_version_int, args: ['debug'])
+if number_options_supported
+    e_version_int = executable('dapp_version_int',
+        test_src,
+        d_import_dirs: [data_dir],
+       d_module_versions: ['With_VersionInteger', 3],
+    )
+    test('dapp_version_int_t', e_version_int, args: ['debug'])
 
 # test version level failure
 e_version_int_fail = executable('dapp_version_int_fail',
@@ -60,6 +72,7 @@ e_version_int_fail = executable('dapp_version_int_fail',
     d_module_versions: ['With_VersionInteger', 2],
 )
 test('dapp_version_int_t_fail', e_version_int_fail, args: ['debug'], should_fail: true)
+endif
 
 # test debug conditions: disabled
 e_no_debug = executable('dapp_no_debug',
@@ -69,23 +82,34 @@ e_no_debug = executable('dapp_no_debug',
 )
 test('dapp_no_debug_t_fail', e_no_debug, args: ['debug'], should_fail: true)
 
-# test debug conditions: enabled
-e_debug = executable('dapp_debug',
-    test_src,
-    d_import_dirs: [data_dir],
-    d_module_versions: ['With_Debug'],
-    d_debug: 1,
-)
-test('dapp_debug_t', e_debug, args: ['debug'])
+if number_options_supported
+    # test debug conditions: enabled
+    e_debug = executable('dapp_debug',
+        test_src,
+        d_import_dirs: [data_dir],
+        d_module_versions: ['With_Debug'],
+        d_debug: 1,
+    )
+    test('dapp_debug_t', e_debug, args: ['debug'])
 
-# test debug conditions: integer
-e_debug_int = executable('dapp_debug_int',
-    test_src,
-    d_import_dirs: [data_dir],
-    d_module_versions: ['With_DebugInteger'],
-    d_debug: 3,
-)
-test('dapp_debug_int_t', e_debug_int, args: ['debug'])
+    # test debug conditions: integer
+    e_debug_int = executable('dapp_debug_int',
+        test_src,
+        d_import_dirs: [data_dir],
+        d_module_versions: ['With_DebugInteger'],
+        d_debug: 3,
+    )
+    test('dapp_debug_int_t', e_debug_int, args: ['debug'])
+
+    # test with all debug conditions at once, and with redundant values
+    e_debug_all = executable('dapp_debug_all',
+        test_src,
+        d_import_dirs: [data_dir],
+        d_module_versions: ['With_DebugAll'],
+        d_debug: ['4', 'DebugIdentifier', 2, 'DebugIdentifierUnused'],
+    )
+    test('dapp_debug_all_t', e_debug_all, args: ['debug'])
+endif
 
 # test debug conditions: identifier
 e_debug_ident = executable('dapp_debug_ident',
@@ -95,12 +119,3 @@ e_debug_ident = executable('dapp_debug_ident',
     d_debug: 'DebugIdentifier',
 )
 test('dapp_debug_ident_t', e_debug_ident, args: ['debug'])
-
-# test with all debug conditions at once, and with redundant values
-e_debug_all = executable('dapp_debug_all',
-    test_src,
-    d_import_dirs: [data_dir],
-    d_module_versions: ['With_DebugAll'],
-    d_debug: ['4', 'DebugIdentifier', 2, 'DebugIdentifierUnused'],
-)
-test('dapp_debug_all_t', e_debug_all, args: ['debug'])


### PR DESCRIPTION
Do not run tests that use integers in versions with compiler that do not support them.

Old versions of GDC supported plain integers in version and debug strings but they are deprecated and GDC 13 hard errors on them.