### PR TITLE
Update HDF5 module

### DIFF
--- a/mesonbuild/dependencies/hdf5.py
+++ b/mesonbuild/dependencies/hdf5.py
@@ -143,13 +143,6 @@ class HDF5ConfigToolDependency(ConfigToolDependency):
             elif Path(arg).is_file():
                 self.link_args.append(arg)
 
-        # If the language is not C we need to add C as a subdependency
-        if language != 'c':
-            nkwargs = kwargs.copy()
-            nkwargs['language'] = 'c'
-            # I'm being too clever for mypy and pylint
-            self.is_found = self._add_sub_dependency(hdf5_factory(environment, for_machine, nkwargs))  # pylint: disable=no-value-for-parameter
-
     def _sanitize_version(self, ver: str) -> str:
         v = re.search(r'\s*HDF5 Version: (\d+\.\d+\.\d+)', ver)
         return v.group(1)

--- a/mesonbuild/dependencies/hdf5.py
+++ b/mesonbuild/dependencies/hdf5.py
@@ -98,12 +98,15 @@ class HDF5ConfigToolDependency(ConfigToolDependency):
 
         if language == 'c':
             cenv = 'CC'
+            lenv = 'C'
             tools = ['h5cc', 'h5pcc']
         elif language == 'cpp':
             cenv = 'CXX'
+            lenv = 'CXX'
             tools = ['h5c++', 'h5pc++']
         elif language == 'fortran':
             cenv = 'FC'
+            lenv = 'F'
             tools = ['h5fc', 'h5pfc']
         else:
             raise DependencyException('How did you get here?')
@@ -120,11 +123,11 @@ class HDF5ConfigToolDependency(ConfigToolDependency):
         compiler = environment.coredata.compilers[for_machine][language]
         try:
             os.environ[f'HDF5_{cenv}'] = join_args(compiler.get_exelist())
-            os.environ[f'HDF5_{cenv}LINKER'] = join_args(compiler.get_linker_exelist())
+            os.environ[f'HDF5_{lenv}LINKER'] = join_args(compiler.get_linker_exelist())
             super().__init__(name, environment, nkwargs, language)
         finally:
             del os.environ[f'HDF5_{cenv}']
-            del os.environ[f'HDF5_{cenv}LINKER']
+            del os.environ[f'HDF5_{lenv}LINKER']
         if not self.is_found:
             return
 

--- a/test cases/frameworks/25 hdf5/main.cpp
+++ b/test cases/frameworks/25 hdf5/main.cpp
@@ -1,29 +1,19 @@
 #include <iostream>
-#include "hdf5.h"
+#include "H5Cpp.h"
 
 
 int main(void)
 {
-herr_t ier;
 unsigned maj, min, rel;
 
-ier = H5open();
-if (ier) {
-    std::cerr << "Unable to initialize HDF5: " << ier << std::endl;
+try {
+    H5::H5Library::open();
+    H5::H5Library::getLibVersion(maj, min, rel);
+    std::cout << "C++ HDF5 version " << maj << "." << min << "." << rel << std::endl;
+    H5::H5Library::close();
+    return EXIT_SUCCESS;
+} catch (H5::LibraryIException &e) {
+    std::cerr << "Exception caught from HDF5: " << e.getDetailMsg() << std::endl;
     return EXIT_FAILURE;
 }
-
-ier = H5get_libversion(&maj, &min, &rel);
-if (ier) {
-    std::cerr << "HDF5 did not initialize!" << std::endl;
-    return EXIT_FAILURE;
-}
-std::cout << "C++ HDF5 version " << maj << "." << min << "." << rel << std::endl;
-
-ier = H5close();
-if (ier) {
-    std::cerr << "Unable to close HDF5: " << ier << std::endl;
-    return EXIT_FAILURE;
-}
-return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Fix wrong env vars and remove redundant C subdependency.

This patch fixes two problems with the HDF5 module. First one is env vars for the HDF5 compile tool. The custom linker is expected to be in `HDF5_CLINKER` var in case of C (see https://github.com/HDFGroup/hdf5/blob/develop/bin/h5cc.in#L97) and in `HDF5_FLINKER` in case of fortran (see https://github.com/HDFGroup/hdf5/blob/develop/fortran/src/h5fc.in#L93).

The second problem is C subdependency for C++ and fortran. The original code for this behaviour was written by @scivision 4 years ago. Unfortunately, he left no contact information, so I wasn't able to ask him why it was implemented the way it was. All my attempts to contact him failed. @scivision if you are reading this, please comment. The way subdependency is implemented now - it is broken (see #11925). Also, it is unneeded. The C libs are indeed needed, which is why both C++ and fortran tools include them in the link list (see https://github.com/HDFGroup/hdf5/blob/develop/c%2B%2B/src/h5c%2B%2B.in#L315 and https://github.com/HDFGroup/hdf5/blob/develop/fortran/src/h5fc.in#L303).

This patch may introduce regressions for the projects that previously set up HDF5 dependency with the wrong `language` parameter, because now you won't get a C-dependency automatically, you need to do it explicitly.

Fixes #11925