### PR TITLE
Add meson.implementation() method

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -1,5 +1,14 @@
 # Reference tables
 
+## Implementations (since 1.3.0)
+
+These are return values of `meson.implementation()` depending on known
+re-implementations.
+
+| Value | Implementation |
+| ----- | -------------- |
+| meson | Meson          |
+
 ## Compiler ids
 
 These are return values of the `get_id` (Compiler family) and

--- a/docs/markdown/snippets/meson-implementation.md
+++ b/docs/markdown/snippets/meson-implementation.md
@@ -1,0 +1,5 @@
+## `meson.implementation()`
+
+The built-in `meson` object now has an `implementation()` method. It returns the
+current Meson implementation running the build script. In our case, this is
+always `'meson'`.

--- a/docs/yaml/builtins/meson.yaml
+++ b/docs/yaml/builtins/meson.yaml
@@ -128,7 +128,7 @@ methods:
           to install only a subset of the files.
           By default the script has no install tag which means it is not being run when
           `meson install --tags` argument is specified.
-      
+
       dry_run:
         type: bool
         since: 1.1.0
@@ -339,6 +339,12 @@ methods:
     returns: bool
     deprecated: 0.55.0
     description: Use [[meson.can_run_host_binaries]] instead.
+
+  - name: implementation
+    returns: str
+    since: 1.3.0
+    description: |
+      Returns the Meson implementation currently running the build script.
 
   - name: install_dependency_manifest
     returns: void

--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -71,6 +71,7 @@ class MesonMain(MesonInterpreterObject):
                              'global_source_root': self.global_source_root_method,
                              'has_exe_wrapper': self.has_exe_wrapper_method,
                              'has_external_property': self.has_external_property_method,
+                             'implementation': self.implementation_method,
                              'install_dependency_manifest': self.install_dependency_manifest_method,
                              'is_cross_build': self.is_cross_build_method,
                              'is_subproject': self.is_subproject_method,
@@ -289,6 +290,12 @@ class MesonMain(MesonInterpreterObject):
             self.build.environment.need_exe_wrapper() and
             self.build.environment.exe_wrapper is None
         )
+
+    @noPosargs
+    @noKwargs
+    @FeatureNew('meson.implementation', '1.3.0')
+    def implementation_method(self, args: T.List['TYPE_var'], kwargs: 'TYPE_kwargs') -> str:
+        return 'meson'
 
     @noPosargs
     @noKwargs

--- a/test cases/common/264 implementation/meson.build
+++ b/test cases/common/264 implementation/meson.build
@@ -1,0 +1,3 @@
+project('meson.implementation()')
+
+assert(meson.implementation() == get_option('implementation'))

--- a/test cases/common/264 implementation/meson_options.txt
+++ b/test cases/common/264 implementation/meson_options.txt
@@ -1,0 +1,1 @@
+option('implementation', type: 'string', value: 'meson')


### PR DESCRIPTION
This function returns the current Meson implementation running the build script. In our case, this is always 'meson'.