### PR TITLE
bytesize start on using typed_kwargs for build_targets

### DIFF
--- a/docs/markdown/snippets/deprecate_build_target_jar.md
+++ b/docs/markdown/snippets/deprecate_build_target_jar.md
@@ -1,0 +1,8 @@
+## Deprecate 'jar' as a build_target type
+
+The point of `build_target()` is that what is produced can be conditionally
+changed. However, `jar()` has a significant number of non-overlapping arguments
+from other build_targets, including the kinds of sources it can include. Because
+of this crafting a `build_target` that can be used as a Jar and as something
+else is incredibly hard to do. As such, it has been deprecated, and using
+`jar()` directly is recomended.

--- a/docs/yaml/functions/build_target.yaml
+++ b/docs/yaml/functions/build_target.yaml
@@ -12,7 +12,7 @@ description: |
   - `static_library` (see [[static_library]])
   - `both_libraries` (see [[both_libraries]])
   - `library` (see [[library]])
-  - `jar` (see [[jar]])
+  - `jar` (see [[jar]])*
 
   This declaration:
 
@@ -32,6 +32,9 @@ description: |
 
   The returned object also has methods that are documented in [[@build_tgt]].
 
+  *"jar" is deprecated because it is fundementally a different thing than the
+  other build_target types.
+
 posargs_inherit: _build_target_base
 varargs_inherit: _build_target_base
 kwargs_inherit:
@@ -42,4 +45,4 @@ kwargs_inherit:
 kwargs:
   target_type:
     type: str
-    description: The actual target to build
+    description: The actual target type to build

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1150,10 +1150,6 @@ class BuildTarget(Target):
                                         (str, bool))
         self.install_mode = kwargs.get('install_mode', None)
         self.install_tag = stringlistify(kwargs.get('install_tag', [None]))
-        main_class = kwargs.get('main_class', '')
-        if not isinstance(main_class, str):
-            raise InvalidArguments('Main class must be a string')
-        self.main_class = main_class
         if isinstance(self, Executable):
             # This kwarg is deprecated. The value of "none" means that the kwarg
             # was not specified and win_subsystem should be used instead.
@@ -2913,6 +2909,7 @@ class Jar(BuildTarget):
         self.filename = self.name + '.jar'
         self.outputs = [self.filename]
         self.java_args = kwargs.get('java_args', [])
+        self.main_class = kwargs.get('main_class', '')
         self.java_resources: T.Optional[StructuredSources] = kwargs.get('java_resources', None)
 
     def get_main_class(self):

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1877,17 +1877,12 @@ class Interpreter(InterpreterBase, HoldableObject):
                           kwargs: kwtypes.BuildTarget
                           ) -> T.Union[build.Executable, build.StaticLibrary, build.SharedLibrary,
                                        build.SharedModule, build.BothLibraries, build.Jar]:
-        if 'target_type' not in kwargs:
-            raise InterpreterException('Missing target_type keyword argument')
-        target_type = kwargs.pop('target_type')
+        target_type = kwargs['target_type']
         if target_type == 'executable':
             return self.build_target(node, args, kwargs, build.Executable)
         elif target_type == 'shared_library':
             return self.build_target(node, args, kwargs, build.SharedLibrary)
         elif target_type == 'shared_module':
-            FeatureNew.single_use(
-                'build_target(target_type: \'shared_module\')',
-                '0.51.0', self.subproject, location=node)
             return self.build_target(node, args, kwargs, build.SharedModule)
         elif target_type == 'static_library':
             return self.build_target(node, args, kwargs, build.StaticLibrary)
@@ -1895,10 +1890,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             return self.build_both_libraries(node, args, kwargs)
         elif target_type == 'library':
             return self.build_library(node, args, kwargs)
-        elif target_type == 'jar':
-            return self.build_target(node, args, kwargs, build.Jar)
-        else:
-            raise InterpreterException('Unknown target_type.')
+        return self.build_target(node, args, kwargs, build.Jar)
 
     @noPosargs
     @typed_kwargs(

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -50,12 +50,16 @@ from .interpreterobjects import (
     NullSubprojectInterpreter,
 )
 from .type_checking import (
+    BUILD_TARGET_KWS,
     COMMAND_KW,
     CT_BUILD_ALWAYS,
     CT_BUILD_ALWAYS_STALE,
     CT_BUILD_BY_DEFAULT,
     CT_INPUT_KW,
     CT_INSTALL_DIR_KW,
+    EXECUTABLE_KWS,
+    JAR_KWS,
+    LIBRARY_KWS,
     MULTI_OUTPUT_KW,
     OUTPUT_KW,
     DEFAULT_OPTIONS,
@@ -78,10 +82,12 @@ from .type_checking import (
     INSTALL_TAG_KW,
     LANGUAGE_KW,
     NATIVE_KW,
-    OVERRIDE_OPTIONS_KW,
     PRESERVE_PATH_KW,
     REQUIRED_KW,
+    SHARED_LIB_KWS,
+    SHARED_MOD_KWS,
     SOURCES_KW,
+    STATIC_LIB_KWS,
     VARIABLES_KW,
     TEST_KWS,
     NoneType,
@@ -1805,7 +1811,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     @FeatureDeprecatedKwargs('executable', '0.56.0', ['gui_app'], extra_message="Use 'win_subsystem' instead.")
     @permittedKwargs(build.known_exe_kwargs)
     @typed_pos_args('executable', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.StructuredSources, build.ExtractedObjects, build.BuildTarget))
-    @typed_kwargs('executable', OVERRIDE_OPTIONS_KW, allow_unknown=True)
+    @typed_kwargs('executable', *EXECUTABLE_KWS, allow_unknown=True)
     def func_executable(self, node: mparser.BaseNode,
                         args: T.Tuple[str, T.List[BuildTargetSource]],
                         kwargs: kwtypes.Executable) -> build.Executable:
@@ -1813,7 +1819,7 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     @permittedKwargs(build.known_stlib_kwargs)
     @typed_pos_args('static_library', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.StructuredSources, build.ExtractedObjects, build.BuildTarget))
-    @typed_kwargs('static_library', OVERRIDE_OPTIONS_KW, allow_unknown=True)
+    @typed_kwargs('static_library', *STATIC_LIB_KWS, allow_unknown=True)
     def func_static_lib(self, node: mparser.BaseNode,
                         args: T.Tuple[str, T.List[BuildTargetSource]],
                         kwargs: kwtypes.StaticLibrary) -> build.StaticLibrary:
@@ -1821,7 +1827,7 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     @permittedKwargs(build.known_shlib_kwargs)
     @typed_pos_args('shared_library', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.StructuredSources, build.ExtractedObjects, build.BuildTarget))
-    @typed_kwargs('shared_library', OVERRIDE_OPTIONS_KW, allow_unknown=True)
+    @typed_kwargs('shared_library', *SHARED_LIB_KWS, allow_unknown=True)
     def func_shared_lib(self, node: mparser.BaseNode,
                         args: T.Tuple[str, T.List[BuildTargetSource]],
                         kwargs: kwtypes.SharedLibrary) -> build.SharedLibrary:
@@ -1831,7 +1837,7 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     @permittedKwargs(known_library_kwargs)
     @typed_pos_args('both_libraries', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.StructuredSources, build.ExtractedObjects, build.BuildTarget))
-    @typed_kwargs('both_libraries', OVERRIDE_OPTIONS_KW, allow_unknown=True)
+    @typed_kwargs('both_libraries', *LIBRARY_KWS, allow_unknown=True)
     def func_both_lib(self, node: mparser.BaseNode,
                       args: T.Tuple[str, T.List[BuildTargetSource]],
                       kwargs: kwtypes.Library) -> build.BothLibraries:
@@ -1840,7 +1846,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     @FeatureNew('shared_module', '0.37.0')
     @permittedKwargs(build.known_shmod_kwargs)
     @typed_pos_args('shared_module', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.StructuredSources, build.ExtractedObjects, build.BuildTarget))
-    @typed_kwargs('shared_module', OVERRIDE_OPTIONS_KW, allow_unknown=True)
+    @typed_kwargs('shared_module', *SHARED_MOD_KWS, allow_unknown=True)
     def func_shared_module(self, node: mparser.BaseNode,
                            args: T.Tuple[str, T.List[BuildTargetSource]],
                            kwargs: kwtypes.SharedModule) -> build.SharedModule:
@@ -1848,7 +1854,7 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     @permittedKwargs(known_library_kwargs)
     @typed_pos_args('library', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.StructuredSources, build.ExtractedObjects, build.BuildTarget))
-    @typed_kwargs('library', OVERRIDE_OPTIONS_KW, allow_unknown=True)
+    @typed_kwargs('library', *LIBRARY_KWS, allow_unknown=True)
     def func_library(self, node: mparser.BaseNode,
                      args: T.Tuple[str, T.List[BuildTargetSource]],
                      kwargs: kwtypes.Library) -> build.Executable:
@@ -1856,7 +1862,7 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     @permittedKwargs(build.known_jar_kwargs)
     @typed_pos_args('jar', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.ExtractedObjects, build.BuildTarget))
-    @typed_kwargs('jar', OVERRIDE_OPTIONS_KW, allow_unknown=True)
+    @typed_kwargs('jar', *JAR_KWS, allow_unknown=True)
     def func_jar(self, node: mparser.BaseNode,
                  args: T.Tuple[str, T.List[T.Union[str, mesonlib.File, build.GeneratedTypes]]],
                  kwargs: kwtypes.Jar) -> build.Jar:
@@ -1865,7 +1871,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     @FeatureNewKwargs('build_target', '0.40.0', ['link_whole', 'override_options'])
     @permittedKwargs(known_build_target_kwargs)
     @typed_pos_args('build_target', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.StructuredSources, build.ExtractedObjects, build.BuildTarget))
-    @typed_kwargs('build_target', OVERRIDE_OPTIONS_KW, allow_unknown=True)
+    @typed_kwargs('build_target', *BUILD_TARGET_KWS, allow_unknown=True)
     def func_build_target(self, node: mparser.BaseNode,
                           args: T.Tuple[str, T.List[BuildTargetSource]],
                           kwargs: kwtypes.BuildTarget

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1808,7 +1808,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     @typed_kwargs('executable', OVERRIDE_OPTIONS_KW, allow_unknown=True)
     def func_executable(self, node: mparser.BaseNode,
                         args: T.Tuple[str, T.List[BuildTargetSource]],
-                        kwargs) -> build.Executable:
+                        kwargs: kwtypes.Executable) -> build.Executable:
         return self.build_target(node, args, kwargs, build.Executable)
 
     @permittedKwargs(build.known_stlib_kwargs)
@@ -1816,7 +1816,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     @typed_kwargs('static_library', OVERRIDE_OPTIONS_KW, allow_unknown=True)
     def func_static_lib(self, node: mparser.BaseNode,
                         args: T.Tuple[str, T.List[BuildTargetSource]],
-                        kwargs) -> build.StaticLibrary:
+                        kwargs: kwtypes.StaticLibrary) -> build.StaticLibrary:
         return self.build_target(node, args, kwargs, build.StaticLibrary)
 
     @permittedKwargs(build.known_shlib_kwargs)
@@ -1824,7 +1824,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     @typed_kwargs('shared_library', OVERRIDE_OPTIONS_KW, allow_unknown=True)
     def func_shared_lib(self, node: mparser.BaseNode,
                         args: T.Tuple[str, T.List[BuildTargetSource]],
-                        kwargs) -> build.SharedLibrary:
+                        kwargs: kwtypes.SharedLibrary) -> build.SharedLibrary:
         holder = self.build_target(node, args, kwargs, build.SharedLibrary)
         holder.shared_library_only = True
         return holder
@@ -1834,7 +1834,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     @typed_kwargs('both_libraries', OVERRIDE_OPTIONS_KW, allow_unknown=True)
     def func_both_lib(self, node: mparser.BaseNode,
                       args: T.Tuple[str, T.List[BuildTargetSource]],
-                      kwargs) -> build.BothLibraries:
+                      kwargs: kwtypes.Library) -> build.BothLibraries:
         return self.build_both_libraries(node, args, kwargs)
 
     @FeatureNew('shared_module', '0.37.0')
@@ -1843,7 +1843,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     @typed_kwargs('shared_module', OVERRIDE_OPTIONS_KW, allow_unknown=True)
     def func_shared_module(self, node: mparser.BaseNode,
                            args: T.Tuple[str, T.List[BuildTargetSource]],
-                           kwargs) -> build.SharedModule:
+                           kwargs: kwtypes.SharedModule) -> build.SharedModule:
         return self.build_target(node, args, kwargs, build.SharedModule)
 
     @permittedKwargs(known_library_kwargs)
@@ -1851,7 +1851,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     @typed_kwargs('library', OVERRIDE_OPTIONS_KW, allow_unknown=True)
     def func_library(self, node: mparser.BaseNode,
                      args: T.Tuple[str, T.List[BuildTargetSource]],
-                     kwargs) -> build.Executable:
+                     kwargs: kwtypes.Library) -> build.Executable:
         return self.build_library(node, args, kwargs)
 
     @permittedKwargs(build.known_jar_kwargs)
@@ -1859,7 +1859,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     @typed_kwargs('jar', OVERRIDE_OPTIONS_KW, allow_unknown=True)
     def func_jar(self, node: mparser.BaseNode,
                  args: T.Tuple[str, T.List[T.Union[str, mesonlib.File, build.GeneratedTypes]]],
-                 kwargs) -> build.Jar:
+                 kwargs: kwtypes.Jar) -> build.Jar:
         return self.build_target(node, args, kwargs, build.Jar)
 
     @FeatureNewKwargs('build_target', '0.40.0', ['link_whole', 'override_options'])
@@ -1868,8 +1868,9 @@ class Interpreter(InterpreterBase, HoldableObject):
     @typed_kwargs('build_target', OVERRIDE_OPTIONS_KW, allow_unknown=True)
     def func_build_target(self, node: mparser.BaseNode,
                           args: T.Tuple[str, T.List[BuildTargetSource]],
-                          kwargs) -> T.Union[build.Executable, build.StaticLibrary, build.SharedLibrary,
-                                             build.SharedModule, build.BothLibraries, build.Jar]:
+                          kwargs: kwtypes.BuildTarget
+                          ) -> T.Union[build.Executable, build.StaticLibrary, build.SharedLibrary,
+                                       build.SharedModule, build.BothLibraries, build.Jar]:
         if 'target_type' not in kwargs:
             raise InterpreterException('Missing target_type keyword argument')
         target_type = kwargs.pop('target_type')

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -352,4 +352,5 @@ class BuildTarget(Library):
 
 
 class Jar(_BaseBuildTarget):
-    pass
+
+    main_class: str

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -308,3 +308,48 @@ class DoSubproject(ExtractRequired):
     version: T.List[str]
     cmake_options: T.List[str]
     options: T.Optional[CMakeSubprojectOptions]
+
+
+class _BaseBuildTarget(TypedDict):
+
+    """Arguments used by all BuildTarget like functions.
+
+    This really exists because Jar is so different than all of the other
+    BuildTarget functions.
+    """
+
+    override_options: T.Dict[OptionKey, T.Union[str, int, bool, T.List[str]]]
+
+
+class _BuildTarget(_BaseBuildTarget):
+
+    """Arguments shared by non-JAR functions"""
+
+
+class Executable(_BuildTarget):
+    pass
+
+
+class StaticLibrary(_BuildTarget):
+    pass
+
+
+class SharedLibrary(_BuildTarget):
+    pass
+
+
+class SharedModule(_BuildTarget):
+    pass
+
+
+class Library(_BuildTarget):
+
+    """For library, both_library, and as a base for build_target"""
+
+
+class BuildTarget(Library):
+    pass
+
+
+class Jar(_BaseBuildTarget):
+    pass

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -354,3 +354,4 @@ class BuildTarget(Library):
 class Jar(_BaseBuildTarget):
 
     main_class: str
+    java_resources: T.Optional[build.StructuredSources]

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -348,7 +348,9 @@ class Library(_BuildTarget):
 
 
 class BuildTarget(Library):
-    pass
+
+    target_type: Literal['executable', 'shared_library', 'static_library',
+                         'shared_module', 'both_libraries', 'library', 'jar']
 
 
 class Jar(_BaseBuildTarget):

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -555,7 +555,8 @@ LIBRARY_KWS = [
 BUILD_TARGET_KWS = [
     *LIBRARY_KWS,
     *_EXCLUSIVE_EXECUTABLE_KWS,
-    *_EXCLUSIVE_JAR_KWS,
+    *[a.evolve(deprecated='1.3.0', deprecated_message='The use of "jar" in "build_target()" is deprecated, and this argument is only used by jar()')
+      for a in _EXCLUSIVE_JAR_KWS],
     KwargInfo(
         'target_type',
         str,
@@ -566,6 +567,9 @@ BUILD_TARGET_KWS = [
         }),
         since_values={
             'shared_module': '0.51.0',
+        },
+        deprecated_values={
+            'jar': ('1.3.0', 'use the "jar()" function directly'),
         }
     )
 ]

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -479,3 +479,78 @@ TEST_KWS: T.List[KwargInfo] = [
     KwargInfo('suite', ContainerTypeInfo(list, str), listify=True, default=['']),  # yes, a list of empty string
     KwargInfo('verbose', bool, default=False, since='0.62.0'),
 ]
+
+# Applies to all build_target like classes
+_ALL_TARGET_KWS: T.List[KwargInfo] = [
+    OVERRIDE_OPTIONS_KW,
+]
+
+# Applies to all build_target classes except jar
+_BUILD_TARGET_KWS: T.List[KwargInfo] = [
+    *_ALL_TARGET_KWS,
+]
+
+# Arguments exclusive to Executable. These are separated to make integrating
+# them into build_target easier
+_EXCLUSIVE_EXECUTABLE_KWS: T.List[KwargInfo] = []
+
+# The total list of arguments used by Executable
+EXECUTABLE_KWS = [
+    *_BUILD_TARGET_KWS,
+    *_EXCLUSIVE_EXECUTABLE_KWS,
+]
+
+# Arguments exclusive to StaticLibrary. These are separated to make integrating
+# them into build_target easier
+_EXCLUSIVE_STATIC_LIB_KWS: T.List[KwargInfo] = []
+
+# The total list of arguments used by StaticLibrary
+STATIC_LIB_KWS = [
+    *_BUILD_TARGET_KWS,
+    *_EXCLUSIVE_STATIC_LIB_KWS,
+]
+
+# Arguments exclusive to SharedLibrary. These are separated to make integrating
+# them into build_target easier
+_EXCLUSIVE_SHARED_LIB_KWS: T.List[KwargInfo] = []
+
+# The total list of arguments used by SharedLibrary
+SHARED_LIB_KWS = [
+    *_BUILD_TARGET_KWS,
+    *_EXCLUSIVE_SHARED_LIB_KWS,
+]
+
+# Arguments exclusive to SharedModule. These are separated to make integrating
+# them into build_target easier
+_EXCLUSIVE_SHARED_MOD_KWS: T.List[KwargInfo] = []
+
+# The total list of arguments used by SharedModule
+SHARED_MOD_KWS = [
+    *_BUILD_TARGET_KWS,
+    *_EXCLUSIVE_SHARED_MOD_KWS,
+]
+
+# Arguments exclusive to JAR. These are separated to make integrating
+# them into build_target easier
+_EXCLUSIVE_JAR_KWS: T.List[KwargInfo] = []
+
+# The total list of arguments used by JAR
+JAR_KWS = [
+    *_ALL_TARGET_KWS,
+    *_EXCLUSIVE_JAR_KWS,
+]
+
+# Arguments used by both_library and library
+LIBRARY_KWS = [
+    *_BUILD_TARGET_KWS,
+    *_EXCLUSIVE_SHARED_LIB_KWS,
+    *_EXCLUSIVE_SHARED_MOD_KWS,
+    *_EXCLUSIVE_STATIC_LIB_KWS,
+]
+
+# Arguments used by build_Target
+BUILD_TARGET_KWS = [
+    *LIBRARY_KWS,
+    *_EXCLUSIVE_EXECUTABLE_KWS,
+    *_EXCLUSIVE_JAR_KWS,
+]

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -10,7 +10,7 @@ import typing as T
 from .. import compilers
 from ..build import (CustomTarget, BuildTarget,
                      CustomTargetIndex, ExtractedObjects, GeneratedList, IncludeDirs,
-                     BothLibraries, SharedLibrary, StaticLibrary, Jar, Executable)
+                     BothLibraries, SharedLibrary, StaticLibrary, Jar, Executable, StructuredSources)
 from ..coredata import UserFeatureOption
 from ..dependencies import Dependency, InternalDependency
 from ..interpreterbase.decorators import KwargInfo, ContainerTypeInfo
@@ -534,6 +534,7 @@ SHARED_MOD_KWS = [
 # them into build_target easier
 _EXCLUSIVE_JAR_KWS: T.List[KwargInfo] = [
     KwargInfo('main_class', str, default=''),
+    KwargInfo('java_resources', (StructuredSources, NoneType), since='0.62.0'),
 ]
 
 # The total list of arguments used by JAR

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -532,7 +532,9 @@ SHARED_MOD_KWS = [
 
 # Arguments exclusive to JAR. These are separated to make integrating
 # them into build_target easier
-_EXCLUSIVE_JAR_KWS: T.List[KwargInfo] = []
+_EXCLUSIVE_JAR_KWS: T.List[KwargInfo] = [
+    KwargInfo('main_class', str, default=''),
+]
 
 # The total list of arguments used by JAR
 JAR_KWS = [

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -556,4 +556,16 @@ BUILD_TARGET_KWS = [
     *LIBRARY_KWS,
     *_EXCLUSIVE_EXECUTABLE_KWS,
     *_EXCLUSIVE_JAR_KWS,
+    KwargInfo(
+        'target_type',
+        str,
+        required=True,
+        validator=in_set_validator({
+            'executable', 'shared_library', 'static_library', 'shared_module',
+            'both_libraries', 'library', 'jar'
+        }),
+        since_values={
+            'shared_module': '0.51.0',
+        }
+    )
 ]


### PR DESCRIPTION
I'd like to start landing the build_targets typed_kwargs work. This is an attempt to build a first, bitsize chunk that (hopefully) has nothing contentious in it. As a high level overview this adds:

 - the stubs in the kwargs module for annotating the functions
 - structured stubs in the type_checking module to make sharing arguments between the various functions easier (and uses them in the interpreter)
 - adds the exclusive Jar arguments as an example of how this sharing works
 - add typing checking for build_target(target_type)
 - deprecates the jar value for build_target(target_type), which as has been discussed before was, in retrospect, a design mistake. This requires the jar arguments to `KwargInfo`'d so that we can properly deprecate them in `build_target`