### PR TITLE
Display more timestamps when profiling ninja

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -628,11 +628,15 @@ class NinjaBackend(backends.Backend):
 
             for t in ProgressBar(self.build.get_targets().values(), desc='Generating targets'):
                 self.generate_target(t)
+            mlog.log_timestamp("Targets generated")
             self.add_build_comment(NinjaComment('Test rules'))
             self.generate_tests()
+            mlog.log_timestamp("Tests generated")
             self.add_build_comment(NinjaComment('Install rules'))
             self.generate_install()
+            mlog.log_timestamp("Install generated")
             self.generate_dist()
+            mlog.log_timestamp("Dist generated")
             key = OptionKey('b_coverage')
             if (key in self.environment.coredata.options and
                     self.environment.coredata.options[key].value):
@@ -640,12 +644,14 @@ class NinjaBackend(backends.Backend):
                 if gcovr_exe or (lcov_exe and genhtml_exe):
                     self.add_build_comment(NinjaComment('Coverage rules'))
                     self.generate_coverage_rules(gcovr_exe, gcovr_version)
+                    mlog.log_timestamp("Coverage rules generated")
                 else:
                     # FIXME: since we explicitly opted in, should this be an error?
                     # The docs just say these targets will be created "if possible".
                     mlog.warning('Need gcovr or lcov/genhtml to generate any coverage reports')
             self.add_build_comment(NinjaComment('Suffix'))
             self.generate_utils()
+            mlog.log_timestamp("Utils generated")
             self.generate_ending()
 
             self.write_rules(outfile)
@@ -1363,6 +1369,7 @@ class NinjaBackend(backends.Backend):
     def write_builds(self, outfile):
         for b in ProgressBar(self.build_elements, desc='Writing build.ninja'):
             b.write(outfile)
+        mlog.log_timestamp("build.ninja generated")
 
     def generate_phony(self):
         self.add_build_comment(NinjaComment('Phony build target, always out of date'))

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -204,7 +204,7 @@ class Summary:
     def dump_value(self, arr, list_sep, indent):
         lines_sep = '\n' + ' ' * indent
         if list_sep is None:
-            mlog.log(*arr, sep=lines_sep)
+            mlog.log(*arr, sep=lines_sep, display_timestamp=False)
             return
         max_len = shutil.get_terminal_size().columns
         line = []
@@ -218,7 +218,7 @@ class Summary:
                 line = []
             line.append(v)
             line_len += v_len
-        mlog.log(*line, sep=list_sep)
+        mlog.log(*line, sep=list_sep, display_timestamp=False)
 
 known_library_kwargs = (
     build.known_shlib_kwargs |

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -200,9 +200,9 @@ class _Logger:
         self.log_file = open(os.path.join(logdir, self._LOG_FNAME), 'w', encoding='utf-8')
         self.log_fatal_warnings = fatal_warnings
 
-    def process_markup(self, args: T.Sequence[TV_Loggable], keep: bool) -> T.List[str]:
+    def process_markup(self, args: T.Sequence[TV_Loggable], keep: bool, display_timestamp: bool = True) -> T.List[str]:
         arr = []  # type: T.List[str]
-        if self.log_timestamp_start is not None:
+        if self.log_timestamp_start is not None and display_timestamp:
             arr = ['[{:.3f}]'.format(time.monotonic() - self.log_timestamp_start)]
         for arg in args:
             if arg is None:
@@ -240,21 +240,21 @@ class _Logger:
             print(cleaned, end='')
 
     def debug(self, *args: TV_Loggable, sep: T.Optional[str] = None,
-              end: T.Optional[str] = None) -> None:
-        arr = process_markup(args, False)
+              end: T.Optional[str] = None, display_timestamp: bool = True) -> None:
+        arr = process_markup(args, False, display_timestamp)
         if self.log_file is not None:
             print(*arr, file=self.log_file, sep=sep, end=end)
             self.log_file.flush()
 
     def _log(self, *args: TV_Loggable, is_error: bool = False,
              nested: bool = True, sep: T.Optional[str] = None,
-             end: T.Optional[str] = None) -> None:
-        arr = process_markup(args, False)
+             end: T.Optional[str] = None, display_timestamp: bool = True) -> None:
+        arr = process_markup(args, False, display_timestamp)
         if self.log_file is not None:
             print(*arr, file=self.log_file, sep=sep, end=end)
             self.log_file.flush()
         if colorize_console():
-            arr = process_markup(args, True)
+            arr = process_markup(args, True, display_timestamp)
         if not self.log_errors_only or is_error:
             force_print(*arr, nested=nested, sep=sep, end=end)
 
@@ -270,11 +270,12 @@ class _Logger:
     def log(self, *args: TV_Loggable, is_error: bool = False,
             once: bool = False, nested: bool = True,
             sep: T.Optional[str] = None,
-            end: T.Optional[str] = None) -> None:
+            end: T.Optional[str] = None,
+            display_timestamp: bool = True) -> None:
         if once:
-            self._log_once(*args, is_error=is_error, nested=nested, sep=sep, end=end)
+            self._log_once(*args, is_error=is_error, nested=nested, sep=sep, end=end, display_timestamp=display_timestamp)
         else:
-            self._log(*args, is_error=is_error, nested=nested, sep=sep, end=end)
+            self._log(*args, is_error=is_error, nested=nested, sep=sep, end=end, display_timestamp=display_timestamp)
 
     def log_timestamp(self, *args: TV_Loggable) -> None:
         if self.log_timestamp_start:
@@ -282,7 +283,7 @@ class _Logger:
 
     def _log_once(self, *args: TV_Loggable, is_error: bool = False,
                   nested: bool = True, sep: T.Optional[str] = None,
-                  end: T.Optional[str] = None) -> None:
+                  end: T.Optional[str] = None, display_timestamp: bool = True) -> None:
         """Log variant that only prints a given message one time per meson invocation.
 
         This considers ansi decorated values by the values they wrap without
@@ -298,7 +299,7 @@ class _Logger:
         if t in self.logged_once:
             return
         self.logged_once.add(t)
-        self._log(*args, is_error=is_error, nested=nested, sep=sep, end=end)
+        self._log(*args, is_error=is_error, nested=nested, sep=sep, end=end, display_timestamp=display_timestamp)
 
     def _log_error(self, severity: _Severity, *rargs: TV_Loggable,
                    once: bool = False, fatal: bool = True,

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -276,6 +276,10 @@ class _Logger:
         else:
             self._log(*args, is_error=is_error, nested=nested, sep=sep, end=end)
 
+    def log_timestamp(self, *args: TV_Loggable) -> None:
+        if self.log_timestamp_start:
+            self.log(*args)
+
     def _log_once(self, *args: TV_Loggable, is_error: bool = False,
                   nested: bool = True, sep: T.Optional[str] = None,
                   end: T.Optional[str] = None) -> None:
@@ -419,6 +423,7 @@ get_log_dir = _logger.get_log_dir
 get_warning_count = _logger.get_warning_count
 initialize = _logger.initialize
 log = _logger.log
+log_timestamp = _logger.log_timestamp
 nested = _logger.nested
 nested_warnings = _logger.nested_warnings
 no_logging = _logger.no_logging

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -293,6 +293,8 @@ class MesonApp:
                 with open(fname, 'w', encoding='utf-8') as f:
                     json.dump(data, f)
 
+                mlog.log("meson setup completed")  # Display timestamp
+
         except Exception as e:
             mintro.write_meson_info_file(b, [e])
             if cdf is not None:


### PR DESCRIPTION
When running setup with `--profile-self` option,
there are currently no logs after "Found ninja...". However, there are
still some lengthy processes for generating targets and ninja.build.

This add more log entries, when profiling, only for the purpose of
displaying the timestamps of the different steps in ninja generation.

Also fix timestamps displayed twice in summary sections.