### PR TITLE
use typed_kargs for Executable gui_app and win_subsystem

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3277,16 +3277,13 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
     def get_target_type_link_args_post_dependencies(self, target, linker):
         commands = []
         if isinstance(target, build.Executable):
-            # If gui_app is significant on this platform, add the appropriate linker arguments.
+            # If win_subsystem is significant on this platform, add the appropriate linker arguments.
             # Unfortunately this can't be done in get_target_type_link_args, because some misguided
             # libraries (such as SDL2) add -mwindows to their link flags.
             m = self.environment.machines[target.for_machine]
 
             if m.is_windows() or m.is_cygwin():
-                if target.gui_app is not None:
-                    commands += linker.get_gui_app_args(target.gui_app)
-                else:
-                    commands += linker.get_win_subsystem_args(target.win_subsystem)
+                commands += linker.get_win_subsystem_args(target.win_subsystem)
         return commands
 
     def get_link_whole_args(self, linker, target):

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1645,13 +1645,9 @@ class Vs2010Backend(backends.Backend):
             conftype = 'Makefile'
         elif isinstance(target, build.Executable):
             conftype = 'Application'
-            if target.gui_app is not None:
-                if not target.gui_app:
-                    subsystem = 'Console'
-            else:
-                # If someone knows how to set the version properly,
-                # please send a patch.
-                subsystem = target.win_subsystem.split(',')[0]
+            # If someone knows how to set the version properly,
+            # please send a patch.
+            subsystem = target.win_subsystem.split(',')[0]
         elif isinstance(target, build.StaticLibrary):
             conftype = 'StaticLibrary'
         elif isinstance(target, build.SharedLibrary):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1152,10 +1152,10 @@ class BuildTarget(Target):
             # was not specified and win_subsystem should be used instead.
             self.gui_app = None
             if kwargs.get('gui_app') is not None:
-                if 'win_subsystem' in kwargs:
+                if kwargs.get('win_subsystem') is not None:
                     raise InvalidArguments('Can specify only gui_app or win_subsystem for a target, not both.')
                 self.gui_app = kwargs['gui_app']
-            self.win_subsystem = self.validate_win_subsystem(kwargs.get('win_subsystem', 'console'))
+            self.win_subsystem = kwargs.get('win_subsystem', 'console')
         elif 'gui_app' in kwargs:
             raise InvalidArguments('Argument gui_app can only be used on executables.')
         elif 'win_subsystem' in kwargs:
@@ -1239,12 +1239,6 @@ class BuildTarget(Target):
         if any(not isinstance(v, str) for v in rust_dependency_map.values()):
             raise InvalidArguments(f'Invalid rust_dependency_map "{rust_dependency_map}": must be a dictionary with string values.')
         self.rust_dependency_map = rust_dependency_map
-
-    def validate_win_subsystem(self, value: str) -> str:
-        value = value.lower()
-        if re.fullmatch(r'(boot_application|console|efi_application|efi_boot_service_driver|efi_rom|efi_runtime_driver|native|posix|windows)(,\d+(\.\d+)?)?', value) is None:
-            raise InvalidArguments(f'Invalid value for win_subsystem: {value}.')
-        return value
 
     def _extract_pic_pie(self, kwargs, arg: str, option: str):
         # Check if we have -fPIC, -fpic, -fPIE, or -fpie in cflags

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1147,19 +1147,12 @@ class BuildTarget(Target):
                                         (str, bool))
         self.install_mode = kwargs.get('install_mode', None)
         self.install_tag = stringlistify(kwargs.get('install_tag', [None]))
-        if isinstance(self, Executable):
-            # This kwarg is deprecated. The value of "none" means that the kwarg
-            # was not specified and win_subsystem should be used instead.
-            self.gui_app = None
+        if not isinstance(self, Executable):
+            # build_target will always populate these as `None`, which is fine
             if kwargs.get('gui_app') is not None:
-                if kwargs.get('win_subsystem') is not None:
-                    raise InvalidArguments('Can specify only gui_app or win_subsystem for a target, not both.')
-                self.gui_app = kwargs['gui_app']
-            self.win_subsystem = kwargs.get('win_subsystem', 'console')
-        elif 'gui_app' in kwargs:
-            raise InvalidArguments('Argument gui_app can only be used on executables.')
-        elif 'win_subsystem' in kwargs:
-            raise InvalidArguments('Argument win_subsystem can only be used on executables.')
+                raise InvalidArguments('Argument gui_app can only be used on executables.')
+            if kwargs.get('win_subsystem') is not None:
+                raise InvalidArguments('Argument win_subsystem can only be used on executables.')
         extra_files = extract_as_list(kwargs, 'extra_files')
         for i in extra_files:
             assert isinstance(i, File)
@@ -1901,6 +1894,7 @@ class Executable(BuildTarget):
             kwargs['pie'] = environment.coredata.options[key].value
         super().__init__(name, subdir, subproject, for_machine, sources, structured_sources, objects,
                          environment, compilers, kwargs)
+        self.win_subsystem = kwargs.get('win_subsystem') or 'console'
         # Check for export_dynamic
         self.export_dynamic = kwargs.get('export_dynamic', False)
         if not isinstance(self.export_dynamic, bool):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1151,12 +1151,10 @@ class BuildTarget(Target):
             # This kwarg is deprecated. The value of "none" means that the kwarg
             # was not specified and win_subsystem should be used instead.
             self.gui_app = None
-            if 'gui_app' in kwargs:
+            if kwargs.get('gui_app') is not None:
                 if 'win_subsystem' in kwargs:
                     raise InvalidArguments('Can specify only gui_app or win_subsystem for a target, not both.')
                 self.gui_app = kwargs['gui_app']
-                if not isinstance(self.gui_app, bool):
-                    raise InvalidArguments('Argument gui_app must be boolean.')
             self.win_subsystem = self.validate_win_subsystem(kwargs.get('win_subsystem', 'console'))
         elif 'gui_app' in kwargs:
             raise InvalidArguments('Argument gui_app can only be used on executables.')

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -980,10 +980,6 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
     def gnu_symbol_visibility_args(self, vistype: str) -> T.List[str]:
         return []
 
-    def get_gui_app_args(self, value: bool) -> T.List[str]:
-        # Only used on Windows
-        return self.linker.get_gui_app_args(value)
-
     def get_win_subsystem_args(self, value: str) -> T.List[str]:
         # By default the dynamic linker is going to return an empty
         # array in case it either doesn't support Windows subsystems

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -451,9 +451,6 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
     def get_profile_use_args(self) -> T.List[str]:
         return ['-fprofile-use']
 
-    def get_gui_app_args(self, value: bool) -> T.List[str]:
-        return ['-mwindows' if value else '-mconsole']
-
     def compute_parameters_with_absolute_paths(self, parameter_list: T.List[str], build_dir: str) -> T.List[str]:
         for idx, i in enumerate(parameter_list):
             if i[:2] == '-I' or i[:2] == '-L':

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1807,7 +1807,6 @@ class Interpreter(InterpreterBase, HoldableObject):
         return Disabler()
 
     @FeatureNewKwargs('executable', '0.42.0', ['implib'])
-    @FeatureNewKwargs('executable', '0.56.0', ['win_subsystem'])
     @permittedKwargs(build.known_exe_kwargs)
     @typed_pos_args('executable', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.StructuredSources, build.ExtractedObjects, build.BuildTarget))
     @typed_kwargs('executable', *EXECUTABLE_KWS, allow_unknown=True)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -33,7 +33,7 @@ from ..interpreterbase import ContainerTypeInfo, InterpreterBase, KwargInfo, typ
 from ..interpreterbase import noPosargs, noKwargs, permittedKwargs, noArgsFlattening, noSecondLevelHolderResolving, unholder_return
 from ..interpreterbase import InterpreterException, InvalidArguments, InvalidCode, SubdirDoneRequest
 from ..interpreterbase import Disabler, disablerIfNotFound
-from ..interpreterbase import FeatureNew, FeatureDeprecated, FeatureBroken, FeatureNewKwargs, FeatureDeprecatedKwargs
+from ..interpreterbase import FeatureNew, FeatureDeprecated, FeatureBroken, FeatureNewKwargs
 from ..interpreterbase import ObjectHolder, ContextManagerObject
 from ..modules import ExtensionModule, ModuleObject, MutableModuleObject, NewExtensionModule, NotFoundExtensionModule
 
@@ -1808,7 +1808,6 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     @FeatureNewKwargs('executable', '0.42.0', ['implib'])
     @FeatureNewKwargs('executable', '0.56.0', ['win_subsystem'])
-    @FeatureDeprecatedKwargs('executable', '0.56.0', ['gui_app'], extra_message="Use 'win_subsystem' instead.")
     @permittedKwargs(build.known_exe_kwargs)
     @typed_pos_args('executable', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.StructuredSources, build.ExtractedObjects, build.BuildTarget))
     @typed_kwargs('executable', *EXECUTABLE_KWS, allow_unknown=True)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3280,6 +3280,18 @@ class Interpreter(InterpreterBase, HoldableObject):
                     outputs.update(o)
 
         kwargs['include_directories'] = self.extract_incdirs(kwargs)
+
+        if targetclass is build.Executable:
+            if kwargs['gui_app'] is not None:
+                if kwargs['win_subsystem'] is not None:
+                    raise InvalidArguments.from_node(
+                        'Executable got both "gui_app", and "win_subsystem" arguments, which are mutually exclusive',
+                        node=node)
+                if kwargs['gui_app']:
+                    kwargs['win_subsystem'] = 'windows'
+            if kwargs['win_subsystem'] is None:
+                kwargs['win_subsystem'] = 'console'
+
         target = targetclass(name, self.subdir, self.subproject, for_machine, srcs, struct, objs,
                              self.environment, self.compilers[for_machine], kwargs)
 

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -327,7 +327,8 @@ class _BuildTarget(_BaseBuildTarget):
 
 
 class Executable(_BuildTarget):
-    pass
+
+    gui_app: T.Optional[bool]
 
 
 class StaticLibrary(_BuildTarget):

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -329,6 +329,7 @@ class _BuildTarget(_BaseBuildTarget):
 class Executable(_BuildTarget):
 
     gui_app: T.Optional[bool]
+    win_subsystem: T.Optional[str]
 
 
 class StaticLibrary(_BuildTarget):

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -492,7 +492,9 @@ _BUILD_TARGET_KWS: T.List[KwargInfo] = [
 
 # Arguments exclusive to Executable. These are separated to make integrating
 # them into build_target easier
-_EXCLUSIVE_EXECUTABLE_KWS: T.List[KwargInfo] = []
+_EXCLUSIVE_EXECUTABLE_KWS: T.List[KwargInfo] = [
+    KwargInfo('gui_app', (bool, NoneType), deprecated='0.56.0', deprecated_message="Use 'win_subsystem' instead")
+]
 
 # The total list of arguments used by Executable
 EXECUTABLE_KWS = [

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 import os
+import re
 import typing as T
 
 from .. import compilers
@@ -490,10 +491,22 @@ _BUILD_TARGET_KWS: T.List[KwargInfo] = [
     *_ALL_TARGET_KWS,
 ]
 
+def _validate_win_subsystem(value: T.Optional[str]) -> T.Optional[str]:
+    if value is not None:
+        if re.fullmatch(r'(boot_application|console|efi_application|efi_boot_service_driver|efi_rom|efi_runtime_driver|native|posix|windows)(,\d+(\.\d+)?)?', value) is None:
+            return f'Invalid value for win_subsystem: {value}.'
+    return None
+
 # Arguments exclusive to Executable. These are separated to make integrating
 # them into build_target easier
 _EXCLUSIVE_EXECUTABLE_KWS: T.List[KwargInfo] = [
-    KwargInfo('gui_app', (bool, NoneType), deprecated='0.56.0', deprecated_message="Use 'win_subsystem' instead")
+    KwargInfo('gui_app', (bool, NoneType), deprecated='0.56.0', deprecated_message="Use 'win_subsystem' instead"),
+    KwargInfo(
+        'win_subsystem',
+        (str, NoneType),
+        convertor=lambda x: x.lower() if isinstance(x, str) else None,
+        validator=_validate_win_subsystem,
+    ),
 ]
 
 # The total list of arguments used by Executable

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -279,10 +279,6 @@ class DynamicLinker(metaclass=abc.ABCMeta):
         # Only used by the Apple linker
         return []
 
-    def get_gui_app_args(self, value: bool) -> T.List[str]:
-        # Only used by VisualStudioLikeLinkers
-        return []
-
     def get_win_subsystem_args(self, value: str) -> T.List[str]:
         # Only used if supported by the dynamic linker and
         # only when targeting Windows
@@ -1318,9 +1314,6 @@ class MSVCDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
     def get_always_args(self) -> T.List[str]:
         return self._apply_prefix(['/nologo', '/release']) + super().get_always_args()
 
-    def get_gui_app_args(self, value: bool) -> T.List[str]:
-        return self.get_win_subsystem_args("windows" if value else "console")
-
     def get_win_subsystem_args(self, value: str) -> T.List[str]:
         return self._apply_prefix([f'/SUBSYSTEM:{value.upper()}'])
 
@@ -1347,9 +1340,6 @@ class ClangClDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
 
         return super().get_output_args(outputname)
 
-    def get_gui_app_args(self, value: bool) -> T.List[str]:
-        return self.get_win_subsystem_args("windows" if value else "console")
-
     def get_win_subsystem_args(self, value: str) -> T.List[str]:
         return self._apply_prefix([f'/SUBSYSTEM:{value.upper()}'])
 
@@ -1369,9 +1359,6 @@ class XilinkDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
                  machine: str = 'x86', version: str = 'unknown version',
                  direct: bool = True):
         super().__init__(['xilink.exe'], for_machine, '', always_args, version=version)
-
-    def get_gui_app_args(self, value: bool) -> T.List[str]:
-        return self.get_win_subsystem_args("windows" if value else "console")
 
     def get_win_subsystem_args(self, value: str) -> T.List[str]:
         return self._apply_prefix([f'/SUBSYSTEM:{value.upper()}'])


### PR DESCRIPTION
This moves the handling of gui_app and win_subsystem to typed_kwargs. This obvious is an improvment in itself, but it also makes `gui_app` a purely interpreter level concept. The interpreter will simply populate the win_subsystem value based on the value of gui_app, and from the build and backend layers it doesn't exist. This makes for less code overall, and less duplication of codepaths.