### PR TITLE
backend: fix checking dep instance for xcode

### DIFF
--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -456,7 +456,7 @@ class XCodeBackend(backends.Backend):
         self.native_frameworks_fileref = {}
         for t in self.build_targets.values():
             for dep in t.get_external_deps():
-                if isinstance(dep, dependencies.AppleFrameworks):
+                if isinstance(dep, dependencies.platform.AppleFrameworks):
                     for f in dep.frameworks:
                         self.native_frameworks[f] = self.gen_id()
                         self.native_frameworks_fileref[f] = self.gen_id()
@@ -598,7 +598,7 @@ class XCodeBackend(backends.Backend):
     def generate_pbx_build_file(self, objects_dict):
         for tname, t in self.build_targets.items():
             for dep in t.get_external_deps():
-                if isinstance(dep, dependencies.AppleFrameworks):
+                if isinstance(dep, dependencies.platform.AppleFrameworks):
                     for f in dep.frameworks:
                         fw_dict = PbxDict()
                         fwkey = self.native_frameworks[f]
@@ -708,7 +708,7 @@ class XCodeBackend(backends.Backend):
     def generate_pbx_file_reference(self, objects_dict):
         for tname, t in self.build_targets.items():
             for dep in t.get_external_deps():
-                if isinstance(dep, dependencies.AppleFrameworks):
+                if isinstance(dep, dependencies.platform.AppleFrameworks):
                     for f in dep.frameworks:
                         fw_dict = PbxDict()
                         framework_fileref = self.native_frameworks_fileref[f]
@@ -868,7 +868,7 @@ class XCodeBackend(backends.Backend):
             file_list = PbxArray()
             bt_dict.add_item('files', file_list)
             for dep in t.get_external_deps():
-                if isinstance(dep, dependencies.AppleFrameworks):
+                if isinstance(dep, dependencies.platform.AppleFrameworks):
                     for f in dep.frameworks:
                         file_list.add_item(self.native_frameworks[f], f'{f}.framework in Frameworks')
             bt_dict.add_item('runOnlyForDeploymentPostprocessing', 0)
@@ -916,7 +916,7 @@ class XCodeBackend(backends.Backend):
 
         for t in self.build_targets.values():
             for dep in t.get_external_deps():
-                if isinstance(dep, dependencies.AppleFrameworks):
+                if isinstance(dep, dependencies.platform.AppleFrameworks):
                     for f in dep.frameworks:
                         frameworks_children.add_item(self.native_frameworks_fileref[f], f)
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/opt/homebrew/lib/python3.11/site-packages/mesonbuild/mesonmain.py", line 194, in run
    return options.run_func(options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/mesonbuild/msetup.py", line 358, in run
    app.generate()
  File "/opt/homebrew/lib/python3.11/site-packages/mesonbuild/msetup.py", line 183, in generate
    return self._generate(env, capture, vslite_ctx)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/mesonbuild/msetup.py", line 253, in _generate
    captured_compile_args = intr.backend.generate(capture, vslite_ctx)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/mesonbuild/backend/xcodebackend.py", line 276, in generate
    self.generate_native_frameworks_map()
  File "/opt/homebrew/lib/python3.11/site-packages/mesonbuild/backend/xcodebackend.py", line 459, in generate_native_frameworks_map
    if isinstance(dep, dependencies.AppleFrameworks):
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'mesonbuild.dependencies' has no attribute 'AppleFrameworks'
```