### PR TITLE
modules/pkgconfig: Don't insert None into devenv list

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -391,7 +391,8 @@ class PkgConfigModule(NewExtensionModule):
         })
 
     def postconf_hook(self, b: build.Build) -> None:
-        b.devenv.append(self.devenv)
+        if self.devenv is not None:
+            b.devenv.append(self.devenv)
 
     def _get_lname(self, l: T.Union[build.SharedLibrary, build.StaticLibrary, build.CustomTarget, build.CustomTargetIndex],
                    msg: str, pcfile: str) -> str:

--- a/test cases/unit/90 devenv/meson.build
+++ b/test cases/unit/90 devenv/meson.build
@@ -20,3 +20,6 @@ env = environment({'TEST_C': ['/prefix']}, method: 'prepend')
 meson.add_devenv(env)
 env = environment({'TEST_C': ['/suffix']}, method: 'append')
 meson.add_devenv(env)
+
+# Reproducer for https://github.com/mesonbuild/meson/issues/12032
+pkgconf = import('pkgconfig')


### PR DESCRIPTION
When the pkgconfig module is imported, but not used, it will insert None on the end of the devenv list. This list is not expected to contain None, and causes Meson to crash. This can happen in complex build setups (reported from mesa), where pkgconfig is only used in some configurations

Fixes: #12032