### PR TITLE
use build target kwargs in modules

### DIFF
--- a/mesonbuild/modules/python3.py
+++ b/mesonbuild/modules/python3.py
@@ -47,14 +47,10 @@ class Python3Module(ExtensionModule):
             'sysconfig_path': self.sysconfig_path,
         })
 
-    @permittedKwargs(known_shmod_kwargs)
+    @permittedKwargs(known_shmod_kwargs - {'name_prefix', 'name_suffix'})
     @typed_pos_args('python3.extension_module', str, varargs=(str, mesonlib.File, CustomTarget, CustomTargetIndex, GeneratedList, StructuredSources, ExtractedObjects, BuildTarget))
     @typed_kwargs('python3.extension_module', *_MOD_KWARGS, allow_unknown=True)
     def extension_module(self, state: ModuleState, args: T.Tuple[str, T.List[BuildTargetSource]], kwargs: SharedModuleKW):
-        if 'name_prefix' in kwargs:
-            raise mesonlib.MesonException('Name_prefix is set automatically, specifying it is forbidden.')
-        if 'name_suffix' in kwargs:
-            raise mesonlib.MesonException('Name_suffix is set automatically, specifying it is forbidden.')
         host_system = state.host_machine.system
         if host_system == 'darwin':
             # Default suffix is 'dylib' but Python does not use it for extensions.

--- a/mesonbuild/modules/python3.py
+++ b/mesonbuild/modules/python3.py
@@ -14,12 +14,20 @@
 from __future__ import annotations
 
 import sysconfig
-from .. import mesonlib
+import typing as T
 
+from .. import mesonlib
 from . import ExtensionModule, ModuleInfo
-from ..interpreterbase import typed_pos_args, noPosargs, noKwargs, permittedKwargs
+from ..interpreter.type_checking import SHARED_MOD_KWS
+from ..interpreterbase import typed_kwargs, typed_pos_args, noPosargs, noKwargs, permittedKwargs
 from ..build import known_shmod_kwargs
 from ..programs import ExternalProgram
+
+if T.TYPE_CHECKING:
+    from ..interpreter.kwargs import SharedModule as SharedModuleKW
+
+
+_MOD_KWARGS = [k for k in SHARED_MOD_KWS if k.name not in {'name_prefix', 'name_suffix'}]
 
 
 class Python3Module(ExtensionModule):
@@ -36,7 +44,8 @@ class Python3Module(ExtensionModule):
         })
 
     @permittedKwargs(known_shmod_kwargs)
-    def extension_module(self, state, args, kwargs):
+    @typed_kwargs('python3.extension_module', *_MOD_KWARGS, allow_unknown=True)
+    def extension_module(self, state, args, kwargs: SharedModuleKW):
         if 'name_prefix' in kwargs:
             raise mesonlib.MesonException('Name_prefix is set automatically, specifying it is forbidden.')
         if 'name_suffix' in kwargs:


### PR DESCRIPTION
The python and python3 modules have methods that are thin wrappers around creating a shared module. There is some validation of these due to going through the public API. This has drawbacks of not checking the types before the wrappers poke at the arguments; that the error messages will be wrong (they'll say `shared_module` instead of `python.extension_module`; and that we have an extra function call we don't need.

This way will allow us to transparently get updates to the python modules as we add new checking to shared_module too.