### PR TITLE
tests: skip a test that fails with new Python 3.11 from MSYS2

### DIFF
--- a/unittests/windowstests.py
+++ b/unittests/windowstests.py
@@ -462,6 +462,9 @@ class WindowsTests(BasePlatformTests):
 
     @unittest.skipIf(is_cygwin(), "Needs visual studio")
     def test_vsenv_option(self):
+        if mesonbuild.environment.detect_msys2_arch():
+            # https://github.com/msys2-contrib/cpython-mingw/issues/141
+            raise SkipTest('mingw python fails with /bin being removed from PATH')
         if self.backend is not Backend.ninja:
             raise SkipTest('Only ninja backend is valid for test')
         env = os.environ.copy()


### PR DESCRIPTION
For some (atm unknown) reason mingw Python fails to load some modules when MSYS2 is removed from PATH, like in this test.

Skip for now to make the test suite pass again. Once https://github.com/msys2-contrib/cpython-mingw/issues/141 is fixed this can be reverted.