### PR TITLE
Revert "CI: add potential workaround for python crashes in MSYS2"

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -51,9 +51,6 @@ jobs:
             TOOLCHAIN: clang
     env:
       MESON_CI_JOBNAME: msys2-${{ matrix.NAME }}
-      # XXX: For some reason enabling jit debugging "fixes" random python crashes
-      # see https://github.com/msys2/MINGW-packages/issues/11864
-      MSYS: "winjitdebug"
 
     defaults:
       run:


### PR DESCRIPTION
This reverts commit e945f35cd72402d0d204ff10870e2a95c59b6192.

With MSYS2 udpating to Python 3.11, this should no longer be needed. See https://github.com/msys2/MINGW-packages/issues/17415#issuecomment-1606085553