### PR TITLE
use typed_kwargs for vs_module_defs

### DIFF
--- a/docs/markdown/snippets/executable_vs_module_defs.md
+++ b/docs/markdown/snippets/executable_vs_module_defs.md
@@ -1,0 +1,4 @@
+## Executable gains vs_module_defs keyword
+
+This allows using a .def file to control which functions an [[executable]] will
+expose to a [[shared_module]].

--- a/docs/markdown/snippets/vs_module_defs_customtargetindex.md
+++ b/docs/markdown/snippets/vs_module_defs_customtargetindex.md
@@ -1,0 +1,8 @@
+## vs_module_defs keyword now supports indexes of custom_target
+
+This means you can do something like:
+```meson
+defs = custom_target('generate_module_defs', ...)
+shared_library('lib1', vs_module_defs : defs[0])
+shared_library('lib2', vs_module_defs : defs[2])
+```

--- a/docs/yaml/functions/executable.yaml
+++ b/docs/yaml/functions/executable.yaml
@@ -44,3 +44,13 @@ kwargs:
     type: bool
     since: 0.49.0
     description: Build a position-independent executable.
+
+  vs_module_defs:
+    type: str | file | custom_tgt | custom_idx
+    since: 1.3.0
+    description: |
+      Specify a Microsoft module definition file for controlling symbol exports,
+      etc., on platforms where that is possible (e.g. Windows).
+
+      This can be used to expose which functions a shared_module loaded by an
+      executable will be allowed to use.

--- a/docs/yaml/functions/shared_library.yaml
+++ b/docs/yaml/functions/shared_library.yaml
@@ -45,6 +45,8 @@ kwargs:
       Specify a Microsoft module definition file for controlling symbol exports,
       etc., on platforms where that is possible (e.g. Windows).
 
+      *(Since 1.3.0)* [[@custom_idx]] are supported
+
   rust_abi:
     type: str
     since: 1.3.0

--- a/docs/yaml/functions/shared_module.yaml
+++ b/docs/yaml/functions/shared_module.yaml
@@ -40,6 +40,8 @@ kwargs:
       Specify a Microsoft module definition file for controlling symbol exports,
       etc., on platforms where that is possible (e.g. Windows).
 
+      *(Since 1.3.0)* [[@custom_idx]] are supported
+
   rust_abi:
     type: str
     since: 1.3.0

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3248,6 +3248,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 commands += linker.gen_import_library_args(self.get_import_filename(target))
             if target.pie:
                 commands += linker.get_pie_link_args()
+            if target.vs_module_defs and hasattr(linker, 'gen_vs_module_defs_args'):
+                commands += linker.gen_vs_module_defs_args(target.vs_module_defs.rel_to_builddir(self.build_to_src))
         elif isinstance(target, build.SharedLibrary):
             if isinstance(target, build.SharedModule):
                 commands += linker.get_std_shared_module_link_args(target.get_options())

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1530,7 +1530,7 @@ class Vs2010Backend(backends.Backend):
             # DLLs built with MSVC always have an import library except when
             # they're data-only DLLs, but we don't support those yet.
             ET.SubElement(link, 'ImportLibrary').text = target.get_import_filename()
-        if isinstance(target, build.SharedLibrary):
+        if isinstance(target, (build.SharedLibrary, build.Executable)):
             # Add module definitions file, if provided
             if target.vs_module_defs:
                 relpath = os.path.join(down, target.vs_module_defs.rel_to_builddir(self.build_to_src))

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2333,13 +2333,13 @@ class SharedLibrary(BuildTarget):
             elif isinstance(path, File):
                 # When passing a generated file.
                 self.vs_module_defs = path
-            elif isinstance(path, CustomTarget):
+            elif isinstance(path, (CustomTarget, CustomTargetIndex)):
                 # When passing output of a Custom Target
-                self.vs_module_defs = File.from_built_file(path.subdir, path.get_filename())
+                self.vs_module_defs = File.from_built_file(path.get_subdir(), path.get_filename())
             else:
                 raise InvalidArguments(
                     'Shared library vs_module_defs must be either a string, '
-                    'a file object or a Custom Target')
+                    'a file object, a Custom Target, or a Custom Target Index')
             self.process_link_depends(path)
 
         rust_abi = kwargs.get('rust_abi')

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2323,7 +2323,7 @@ class SharedLibrary(BuildTarget):
                 self.darwin_versions = (self.soversion, self.soversion)
 
         # Visual Studio module-definitions file
-        if 'vs_module_defs' in kwargs:
+        if kwargs.get('vs_module_defs') is not None:
             path = kwargs['vs_module_defs']
             if isinstance(path, str):
                 if os.path.isabs(path):

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -353,7 +353,7 @@ class _SharedLibMixin(TypedDict):
     darwin_versions: T.Optional[T.Tuple[str, str]]
     soversion: T.Optional[str]
     version: T.Optional[str]
-    vs_module_defs: T.Optional[T.Union[str, File, build.CustomTarget]]
+    vs_module_defs: T.Optional[T.Union[str, File, build.CustomTarget, build.CustomTargetIndex]]
 
 
 class SharedLibrary(_BuildTarget, _SharedLibMixin, _LibraryMixin):
@@ -362,7 +362,7 @@ class SharedLibrary(_BuildTarget, _SharedLibMixin, _LibraryMixin):
 
 class SharedModule(_BuildTarget, _LibraryMixin):
 
-    vs_module_defs: T.Optional[T.Union[str, File, build.CustomTarget]]
+    vs_module_defs: T.Optional[T.Union[str, File, build.CustomTarget, build.CustomTargetIndex]]
 
 
 class Library(_BuildTarget, _SharedLibMixin, _LibraryMixin):

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -353,6 +353,7 @@ class _SharedLibMixin(TypedDict):
     darwin_versions: T.Optional[T.Tuple[str, str]]
     soversion: T.Optional[str]
     version: T.Optional[str]
+    vs_module_defs: T.Optional[T.Union[str, File, build.CustomTarget]]
 
 
 class SharedLibrary(_BuildTarget, _SharedLibMixin, _LibraryMixin):
@@ -360,7 +361,8 @@ class SharedLibrary(_BuildTarget, _SharedLibMixin, _LibraryMixin):
 
 
 class SharedModule(_BuildTarget, _LibraryMixin):
-    pass
+
+    vs_module_defs: T.Optional[T.Union[str, File, build.CustomTarget]]
 
 
 class Library(_BuildTarget, _SharedLibMixin, _LibraryMixin):

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -341,6 +341,7 @@ class _LibraryMixin(TypedDict):
 class Executable(_BuildTarget):
 
     gui_app: T.Optional[bool]
+    vs_module_defs: T.Optional[T.Union[str, File, build.CustomTarget, build.CustomTargetIndex]]
     win_subsystem: T.Optional[str]
 
 

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -601,6 +601,7 @@ _EXCLUSIVE_EXECUTABLE_KWS: T.List[KwargInfo] = [
 EXECUTABLE_KWS = [
     *_BUILD_TARGET_KWS,
     *_EXCLUSIVE_EXECUTABLE_KWS,
+    _VS_MODULE_DEFS_KW.evolve(since='1.3.0', since_values=None),
 ]
 
 # Arguments exclusive to library types

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -513,9 +513,10 @@ RUST_ABI_KW: KwargInfo[T.Union[str, None]] = KwargInfo(
     since='1.3.0',
     validator=in_set_validator({'rust', 'c'}))
 
-_VS_MODULE_DEFS_KW: KwargInfo[T.Optional[T.Union[str, File, CustomTarget]]] = KwargInfo(
+_VS_MODULE_DEFS_KW: KwargInfo[T.Optional[T.Union[str, File, CustomTarget, CustomTargetIndex]]] = KwargInfo(
     'vs_module_defs',
-    (str, File, CustomTarget, NoneType),
+    (str, File, CustomTarget, CustomTargetIndex, NoneType),
+    since_values={CustomTargetIndex: '1.3.0'}
 )
 
 # Applies to all build_target like classes

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -513,6 +513,11 @@ RUST_ABI_KW: KwargInfo[T.Union[str, None]] = KwargInfo(
     since='1.3.0',
     validator=in_set_validator({'rust', 'c'}))
 
+_VS_MODULE_DEFS_KW: KwargInfo[T.Optional[T.Union[str, File, CustomTarget]]] = KwargInfo(
+    'vs_module_defs',
+    (str, File, CustomTarget, NoneType),
+)
+
 # Applies to all build_target like classes
 _ALL_TARGET_KWS: T.List[KwargInfo] = [
     OVERRIDE_OPTIONS_KW,
@@ -626,6 +631,7 @@ SHARED_LIB_KWS = [
     *_BUILD_TARGET_KWS,
     *_EXCLUSIVE_SHARED_LIB_KWS,
     *_EXCLUSIVE_LIB_KWS,
+    _VS_MODULE_DEFS_KW,
 ]
 
 # Arguments exclusive to SharedModule. These are separated to make integrating
@@ -637,6 +643,7 @@ SHARED_MOD_KWS = [
     *_BUILD_TARGET_KWS,
     *_EXCLUSIVE_SHARED_MOD_KWS,
     *_EXCLUSIVE_LIB_KWS,
+    _VS_MODULE_DEFS_KW,
 ]
 
 # Arguments exclusive to JAR. These are separated to make integrating
@@ -659,6 +666,7 @@ LIBRARY_KWS = [
     *_EXCLUSIVE_SHARED_LIB_KWS,
     *_EXCLUSIVE_SHARED_MOD_KWS,
     *_EXCLUSIVE_STATIC_LIB_KWS,
+    _VS_MODULE_DEFS_KW,
 ]
 
 # Arguments used by build_Target

--- a/test cases/windows/10 vs module defs generated custom target/subdir/meson.build
+++ b/test cases/windows/10 vs module defs generated custom target/subdir/meson.build
@@ -5,3 +5,5 @@ def_file = custom_target('gen_def',
         output: 'somedll.def')
 
 shlib = shared_library('somedll', 'somedll.c', vs_module_defs: def_file)
+
+shared_library('somedll2', 'somedll.c', vs_module_defs: def_file[0])

--- a/test cases/windows/9 vs module defs generated/exe.def
+++ b/test cases/windows/9 vs module defs generated/exe.def
@@ -1,0 +1,2 @@
+EXPORTS
+    exefunc

--- a/test cases/windows/9 vs module defs generated/meson.build
+++ b/test cases/windows/9 vs module defs generated/meson.build
@@ -1,5 +1,5 @@
 project('generated_dll_module_defs', 'c')
 
 subdir('subdir')
-exe = executable('prog', 'prog.c', link_with : shlib)
+exe = executable('prog', 'prog.c', link_with : shlib, vs_module_defs : 'exe.def')
 test('runtest', exe)

--- a/test cases/windows/9 vs module defs generated/prog.c
+++ b/test cases/windows/9 vs module defs generated/prog.c
@@ -1,5 +1,9 @@
 int somedllfunc(void);
 
+int exefunc(void) {
+    return 42;
+}
+
 int main(void) {
-    return somedllfunc() == 42 ? 0 : 1;
+    return somedllfunc() == exefunc() ? 0 : 1;
 }


### PR DESCRIPTION
@tristan957 had mentioned this was needed for Executables as well, but I haven't written a test case or doc changes for that yet.