### PR TITLE
do better sanity check for vs_module_defs input

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2383,7 +2383,7 @@ class SharedLibrary(BuildTarget):
             elif isinstance(path, File):
                 # When passing a generated file.
                 self.vs_module_defs = path
-            elif hasattr(path, 'get_filename'):
+            elif isinstance(path, CustomTarget):
                 # When passing output of a Custom Target
                 self.vs_module_defs = File.from_built_file(path.subdir, path.get_filename())
             else:

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -807,7 +807,7 @@ class CoreData:
                 continue
 
             oldval = self.options[key]
-            if type(oldval) != type(value):
+            if type(oldval) is not type(value):
                 self.options[key] = value
             elif oldval.choices != value.choices:
                 # If the choices have changed, use the new value, but attempt

--- a/mesonbuild/interpreterbase/baseobjects.py
+++ b/mesonbuild/interpreterbase/baseobjects.py
@@ -119,12 +119,12 @@ class InterpreterObject:
         # We use `type(...) == type(...)` here to enforce an *exact* match for comparison. We
         # don't want comparisons to be possible where `isinstance(derived_obj, type(base_obj))`
         # would pass because this comparison must never be true: `derived_obj == base_obj`
-        if type(self) != type(other):
+        if type(self) is not type(other):
             self._throw_comp_exception(other, '==')
         return self == other
 
     def op_not_equals(self, other: TYPE_var) -> bool:
-        if type(self) != type(other):
+        if type(self) is not type(other):
             self._throw_comp_exception(other, '!=')
         return self != other
 
@@ -157,12 +157,12 @@ class ObjectHolder(InterpreterObject, T.Generic[InterpreterObjectTypeVar]):
     # Override default comparison operators for the held object
     def op_equals(self, other: TYPE_var) -> bool:
         # See the comment from InterpreterObject why we are using `type()` here.
-        if type(self.held_object) != type(other):
+        if type(self.held_object) is not type(other):
             self._throw_comp_exception(other, '==')
         return self.held_object == other
 
     def op_not_equals(self, other: TYPE_var) -> bool:
-        if type(self.held_object) != type(other):
+        if type(self.held_object) is not type(other):
             self._throw_comp_exception(other, '!=')
         return self.held_object != other
 


### PR DESCRIPTION
We allow custom_target() but check for it based on hasattr, ever since the initial implementation way back in the day, in commit 66a6ea984bc43d9ac144e22cf411c16e9f911bb3. This is a bit broken because various objects might support that but still aren't supposed to work. We can actually just use isintance checks like we do immediately above, which are more accurate and avoid crashes on things that aren't even targets at all, like run_target(). Although custom_target indexes are actually targets those didn't work either.

Fixes #9648