### PR TITLE
Repair Xcode backend as much as possible

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -834,7 +834,7 @@ class Backend:
             fname = fname.replace(ch, '_')
         return hashed + fname
 
-    def object_filename_from_source(self, target: build.BuildTarget, source: 'FileOrString') -> str:
+    def object_filename_from_source(self, target: build.BuildTarget, source: 'FileOrString', targetdir: T.Optional[str] = None) -> str:
         assert isinstance(source, mesonlib.File)
         if isinstance(target, build.CompileTarget):
             return target.sources_map[source]
@@ -855,9 +855,8 @@ class Backend:
         elif source.is_built:
             if os.path.isabs(rel_src):
                 rel_src = rel_src[len(build_dir) + 1:]
-            targetdir = self.get_target_private_dir(target)
             # A meson- prefixed directory is reserved; hopefully no-one creates a file name with such a weird prefix.
-            gen_source = 'meson-generated_' + os.path.relpath(rel_src, targetdir)
+            gen_source = 'meson-generated_' + os.path.relpath(rel_src, self.get_target_private_dir(target))
         else:
             if os.path.isabs(rel_src):
                 # Use the absolute path directly to avoid file name conflicts
@@ -866,7 +865,10 @@ class Backend:
                 gen_source = os.path.relpath(os.path.join(build_dir, rel_src),
                                              os.path.join(self.environment.get_source_dir(), target.get_subdir()))
         machine = self.environment.machines[target.for_machine]
-        return self.canonicalize_filename(gen_source) + '.' + machine.get_object_suffix()
+        ret = self.canonicalize_filename(gen_source) + '.' + machine.get_object_suffix()
+        if targetdir is not None:
+            return os.path.join(targetdir, ret)
+        return ret
 
     def _determine_ext_objs(self, extobj: 'build.ExtractedObjects', proj_dir_to_build_root: str) -> T.List[str]:
         result: T.List[str] = []
@@ -920,8 +922,8 @@ class Backend:
                     sources.append(_src)
 
         for osrc in sources:
-            objname = self.object_filename_from_source(extobj.target, osrc)
-            objpath = os.path.join(proj_dir_to_build_root, targetdir, objname)
+            objname = self.object_filename_from_source(extobj.target, osrc, targetdir)
+            objpath = os.path.join(proj_dir_to_build_root, objname)
             result.append(objpath)
 
         return result

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1448,12 +1448,10 @@ class Vs2010Backend(backends.Backend):
                                 extra_link_args.append(path[:-len(gen_src_ext)] + '.obj')
 
                     for src in l.srclist:
-                        obj_basename = None
                         if self.environment.is_source(src):
-                            obj_basename = self.object_filename_from_source(t, src)
                             target_private_dir = self.relpath(self.get_target_private_dir(t),
                                                               self.get_target_dir(t))
-                            rel_obj = os.path.join(target_private_dir, obj_basename)
+                            rel_obj = self.object_filename_from_source(t, src, target_private_dir)
                             extra_link_args.append(rel_obj)
 
                     extra_link_args.extend(self.flatten_object_list(t))

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -230,7 +230,7 @@ class XCodeBackend(backends.Backend):
         os.makedirs(os.path.join(self.environment.get_build_dir(), dirname), exist_ok=True)
         return dirname
 
-    def object_filename_from_source(self, target: build.BuildTarget, source: mesonlib.FileOrString) -> str:
+    def object_filename_from_source(self, target: build.BuildTarget, source: mesonlib.FileOrString, targetdir: T.Optional[str] = None) -> str:
         # Xcode has the following naming scheme:
         # projectname.build/debug/prog@exe.build/Objects-normal/x86_64/func.o
         project = self.build.project_name

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -585,12 +585,15 @@ class XCodeBackend(backends.Backend):
                 elif isinstance(d, build.BuildTarget):
                     dependencies.append(self.pbx_dep_map[d.get_id()])
             for s in t.sources:
-                if not isinstance(s, build.GeneratedList):
-                    continue
-                build_phases.append(self.shell_targets[(tname, generator_id)])
-                for d in s.depends:
-                    dependencies.append(self.pbx_custom_dep_map[d.get_id()])
-                generator_id += 1
+                if isinstance(s, build.GeneratedList):
+                    build_phases.append(self.shell_targets[(tname, generator_id)])
+                    for d in s.depends:
+                        dependencies.append(self.pbx_custom_dep_map[d.get_id()])
+                    generator_id += 1
+                elif isinstance(s, build.ExtractedObjects):
+                    source_target_id = self.pbx_dep_map[s.target.get_id()]
+                    if source_target_id not in dependencies:
+                        dependencies.append(source_target_id)
             build_phases.append(self.shell_targets[tname])
             aggregated_targets.append((ct_id, tname, self.buildconflistmap[tname], build_phases, dependencies))
 

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -195,6 +195,9 @@ class XCodeBackend(backends.Backend):
         self.regen_dependency_id = self.gen_id()
         self.top_level_dict = PbxDict()
         self.generator_outputs = {}
+        self.arch = self.build.environment.machines.host.cpu
+        if self.arch == 'aarch64':
+            self.arch = 'arm64'
         # In Xcode files are not accessed via their file names, but rather every one of them
         # gets an unique id. More precisely they get one unique id per target they are used
         # in. If you generate only one id per file and use them, compilation will work but the
@@ -233,11 +236,10 @@ class XCodeBackend(backends.Backend):
         project = self.build.project_name
         buildtype = self.buildtype
         tname = target.get_id()
-        arch = 'x86_64'
         if isinstance(source, mesonlib.File):
             source = source.fname
         stem = os.path.splitext(os.path.basename(source))[0]
-        obj_path = f'{project}.build/{buildtype}/{tname}.build/Objects-normal/{arch}/{stem}.o'
+        obj_path = f'{project}.build/{buildtype}/{tname}.build/Objects-normal/{self.arch}/{stem}.o'
         return obj_path
 
     def determine_swift_dep_dirs(self, target: build.BuildTarget) -> T.List[str]:
@@ -1391,7 +1393,7 @@ class XCodeBackend(backends.Backend):
             bt_dict.add_item('isa', 'XCBuildConfiguration')
             settings_dict = PbxDict()
             bt_dict.add_item('buildSettings', settings_dict)
-            settings_dict.add_item('ARCHS', '"$(NATIVE_ARCH_ACTUAL)"')
+            settings_dict.add_item('ARCHS', f'"{self.arch}"')
             settings_dict.add_item('ONLY_ACTIVE_ARCH', 'YES')
             settings_dict.add_item('SWIFT_VERSION', '5.0')
             settings_dict.add_item('SDKROOT', '"macosx"')
@@ -1435,7 +1437,7 @@ class XCodeBackend(backends.Backend):
             bt_dict.add_item('isa', 'XCBuildConfiguration')
             settings_dict = PbxDict()
             bt_dict.add_item('buildSettings', settings_dict)
-            settings_dict.add_item('ARCHS', '"$(NATIVE_ARCH_ACTUAL)"')
+            settings_dict.add_item('ARCHS', f'"{self.arch}"')
             settings_dict.add_item('ONLY_ACTIVE_ARCH', 'YES')
             settings_dict.add_item('SDKROOT', '"macosx"')
             settings_dict.add_item('SYMROOT', '"%s/build"' % self.environment.get_build_dir())


### PR DESCRIPTION
Currently, this pull request is a work-in-progress and contains some "questionable" fixes. They will be cleaned up later on.

Known issues (incomplete list):
- [x] Some projects fail to open during testing due to being "damaged", but open just fine when setup manually
- [ ] ~~Generator objects sometimes do not work~~ (will have to fix in another PR)
- [x] Extra files not supported (see #10903)
- [x] Swift modules cannot be located
- [x] Object path uses hardcoded arch 'x86_64' instead of target machine arch
- [x] Cross-compiling not supported
- [x] Swift bridging header not specified for mixed target (which Xcode supports)
- [ ] ~~Unity builds not supported~~ (will have to fix in another PR)
- [ ] ~~Specifying a header to include as C flag while using PCH causes build to fail~~ (cannot be fixed)
- [x] Xcode clean fails if anything not generated by Xcode exists in the build directory

Current limitations (on my end):
- ~~Only able to test on arm64 Mac~~ Recently obtained old x86_64 Mac to test on, so will test on both architectures
- Using latest stable version of Xcode (14.3.1 at the time of this PR) and macOS (13.5)
