### PR TITLE
Fix typo in Cross-compilation.md

### DIFF
--- a/docs/markdown/Cross-compilation.md
+++ b/docs/markdown/Cross-compilation.md
@@ -338,7 +338,7 @@ scratch.
 ## Custom data
 
 You can store arbitrary data in `properties` and access them from your
-Meson files. As an example if you cross file has this:
+Meson files. As an example if your cross file has this:
 
 ```ini
 [properties]


### PR DESCRIPTION
This changeset fixes a typo, changing "As an example if you cross file has this:" to "As an example if your cross file has this:"