### PR TITLE
Add default_options argument to find_program()

### DIFF
--- a/docs/markdown/snippets/find_program_default_options.md
+++ b/docs/markdown/snippets/find_program_default_options.md
@@ -1,0 +1,4 @@
+## find_program() now supports the 'default_options' argument
+
+In a similar fashion as dependency(), find_program() now also allows you to set default 
+options for the subproject that gets built in case of a fallback.

--- a/docs/yaml/functions/find_program.yaml
+++ b/docs/yaml/functions/find_program.yaml
@@ -113,3 +113,13 @@ kwargs:
     type: list[str]
     since: 0.53.0
     description: extra list of absolute paths where to look for program names.
+
+  default_options:
+    type: list[str] | dict[str | bool | int | list[str]]
+    since: 1.3.0
+    description: |
+      An array of default option values
+      that override those set in the subproject's `meson.options`
+      (like `default_options` in [[project]], they only have
+      effect when Meson is run for the first time, and command line
+      arguments override any default options in build files)

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -232,6 +232,7 @@ class Summary(TypedDict):
 
 class FindProgram(ExtractRequired, ExtractSearchDirs):
 
+    default_options: T.Dict[OptionKey, T.Union[str, int, bool, T.List[str]]]
     native: MachineChoice
     version: T.List[str]
 

--- a/test cases/common/265 default_options in find_program/meson.build
+++ b/test cases/common/265 default_options in find_program/meson.build
@@ -1,0 +1,5 @@
+project('test default_options in find_program')
+
+dummy_exe = find_program('dummy', default_options: ['subproject_option=true'])
+
+test('test_dummy', dummy_exe)

--- a/test cases/common/265 default_options in find_program/subprojects/dummy.wrap
+++ b/test cases/common/265 default_options in find_program/subprojects/dummy.wrap
@@ -1,0 +1,5 @@
+[wrap-file]
+directory = dummy
+
+[provide]
+program_names = dummy

--- a/test cases/common/265 default_options in find_program/subprojects/dummy/dummy.c
+++ b/test cases/common/265 default_options in find_program/subprojects/dummy/dummy.c
@@ -1,0 +1,3 @@
+int main(void) {
+    return 0;
+}

--- a/test cases/common/265 default_options in find_program/subprojects/dummy/meson.build
+++ b/test cases/common/265 default_options in find_program/subprojects/dummy/meson.build
@@ -1,0 +1,6 @@
+project('dummy', 'c')
+
+if get_option('subproject_option')
+    dummy_exe = executable('dummy', 'dummy.c')
+    meson.override_find_program('dummy', dummy_exe)
+endif

--- a/test cases/common/265 default_options in find_program/subprojects/dummy/meson_options.txt
+++ b/test cases/common/265 default_options in find_program/subprojects/dummy/meson_options.txt
@@ -1,0 +1,1 @@
+option('subproject_option', type: 'boolean', value: false)


### PR DESCRIPTION
This PR adds a `default_options` argument to `find_program()`. It allows users to pass options to the subproject in case of a fallback , in a similar fashion as the argument of the same name in `dependency()`. If this feature is acceptable, I will proceed to write a test for it.