### PR TITLE
Update Quick-guide.md

### DIFF
--- a/docs/markdown/Quick-guide.md
+++ b/docs/markdown/Quick-guide.md
@@ -35,11 +35,11 @@ generate native VS and Xcode project files.*
 Installation using package manager
 --
 
-Ubuntu:
+Ubuntu/Debian:
 
 ```console
 $ sudo apt-get install python3 python3-pip python3-setuptools \
-                       python3-wheel ninja-build
+                       python3-wheel ninja-build python3-mesonpy
 ```
 *Due to our frequent release cycle and development speed, distro packaged software may quickly become outdated.*
 


### PR DESCRIPTION
The listed apt command was missing the actual meson package. Additionally specify that the command works under Debian as well