### PR TITLE
build.py: improve BuildTarget error message

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1346,8 +1346,8 @@ class BuildTarget(Target):
                     self.process_sourcelist(dep.get_sources())
                 self.add_deps(dep.ext_deps)
             elif isinstance(dep, BuildTarget):
-                raise InvalidArguments('''Tried to use a build target as a dependency.
-You probably should put it in link_with instead.''')
+                raise InvalidArguments(f'Tried to use a build target {dep.name} as a dependency of target {self.name}.\n'
+                                       'You probably should put it in link_with instead.')
             else:
                 # This is a bit of a hack. We do not want Build to know anything
                 # about the interpreter so we can't import it and use isinstance.


### PR DESCRIPTION
Improve the error message when a build target is assigned as dependency of another build target, which allows to better pinpoint where the issue lies on.

In the example that follow, modules/meson.build:294 is in a for loop creating library targets from an array of dictionary, and doesn't point to the location where interop_sw_plugin is assigned with vlc_opengl:

Before:

    modules/meson.build:294:17: ERROR: Tried to use a build target as a dependency.
    You probably should put it in link_with instead.

After:

    modules/meson.build:294:17: ERROR: Tried to use a build target vlc_opengl as a dependency of target interop_sw_plugin.
    You probably should put it in link_with instead.

It would probably be best to directly pinpoint where the assignment was made but it's probably harder so start simple by saying what is concerned by the error.