### PR TITLE
Use os.path.normpath to make paths prettier

### DIFF
--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -429,7 +429,7 @@ class File(HoldableObject):
         absdir = srcdir
         if self.is_built:
             absdir = builddir
-        return os.path.join(absdir, self.relative_name())
+        return os.path.normpath(os.path.join(absdir, self.relative_name()))
 
     @property
     def suffix(self) -> str:


### PR DESCRIPTION
# Minimal Example:

meson.build:
```meson
project('hello', 'c')
subdir('subdir')
```
subdir/meson.build:
```meson
executable('hello', '../hello.c')
```

# Old behaviour:
```
$ meson setup build
...
$ meson introspect build --targets | python -m json.tool | grep hello.c
                    "/home/volker/Documents/mesoncases/resolve/subdir/../hello.c"
```

# New Behaviour:

```
$ meson setup build
...
$ meson introspect build --targets | python -m json.tool | grep hello.c
                    "/home/volker/Documents/mesoncases/resolve/hello.c"
```

Notice how "subdir/.." got removed