### PR TITLE
Add fs.relative_to()

### DIFF
--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -224,6 +224,20 @@ fs.stem('foo/bar/baz.dll.a')  # baz.dll
    project. If the file specified by `path` is a `files()` object it
    cannot refer to a built file.
 
+### relative_to
+
+*Since 1.3.0*
+
+Return a relative filepath. In event a relative path could not be found, the
+absolute path of `to` is returned. Relative path arguments will be assumed to be
+relative to `meson.current_source_dir()`.
+
+Has the following positional arguments:
+   - to `str | file | custom_tgt | custom_idx | tgt`: end path
+   - from `str | file | custom_tgt | custom_idx | tgt`: start path
+
+returns:
+   - a string
 
 ### copyfile
 

--- a/docs/markdown/snippets/fs_relative_to.md
+++ b/docs/markdown/snippets/fs_relative_to.md
@@ -1,0 +1,17 @@
+## `fs.relative_to()`
+
+The `fs` module now has a `relative_to` method. The method will return the
+relative path from argument one to argument two, if one exists. Otherwise, the
+absolute path to argument one is returned.
+
+```meson
+assert(fs.relative_to('c:\\prefix\\lib', 'c:\\prefix\\bin') == '..\\lib')
+assert(fs.relative_to('c:\\proj1\\foo', 'd:\\proj1\\bar') == 'c:\\proj1\\foo')
+assert(fs.relative_to('prefix\\lib\\foo', 'prefix') == 'lib\\foo')
+
+assert(fs.relative_to('/prefix/lib', '/prefix/bin') == '../lib')
+assert(fs.relative_to('prefix/lib/foo', 'prefix') == 'lib/foo')
+```
+
+In addition to strings, it can handle files, custom targets, custom target
+indices, and build targets.

--- a/test cases/common/220 fs module/meson.build
+++ b/test cases/common/220 fs module/meson.build
@@ -1,4 +1,4 @@
-project('fs module test')
+project('fs module test', 'c')
 
 is_windows = build_machine.system() == 'windows'
 
@@ -138,6 +138,29 @@ assert(fs.name(f[1]) == 'meson.build', 'failed to get basename')
 assert(fs.name('foo/bar/baz.dll.a') == 'baz.dll.a', 'failed to get basename with compound suffix')
 assert(fs.stem('foo/bar/baz.dll') == 'baz', 'failed to get stem with suffix')
 assert(fs.stem('foo/bar/baz.dll.a') == 'baz.dll', 'failed to get stem with compound suffix')
+
+# relative_to
+if build_machine.system() == 'windows'
+  # strings
+  assert(fs.relative_to('c:\\prefix\\lib\\foo', 'c:\\prefix') == 'lib\\foo')
+  assert(fs.relative_to('c:\\prefix\\lib', 'c:\\prefix\\bin') == '..\\lib')
+  assert(fs.relative_to('c:\\proj1\\foo', 'd:\\proj1\\bar') == 'c:\\proj1\\foo')
+  assert(fs.relative_to('prefix\\lib\\foo', 'prefix') == 'lib\\foo')
+  assert(fs.relative_to('prefix\\lib', 'prefix\\bin') == '..\\lib')
+  assert(fs.relative_to('proj1\\foo', 'proj1\\bar') == '..\\foo')
+  assert(fs.relative_to('subdir/subdirfile.txt', meson.current_source_dir()) == 'subdir\\subdirfile.txt')
+  assert(fs.relative_to(files('meson.build'), files('subdir/meson.build')) == '..\\..\\meson.build')
+  assert(fs.relative_to(files('meson.build'), 'subdir/meson.build') == '..\\..\\meson.build')
+else
+  # strings
+  assert(fs.relative_to('/prefix/lib/foo', '/prefix') == 'lib/foo')
+  assert(fs.relative_to('/prefix/lib', '/prefix/bin') == '../lib')
+  assert(fs.relative_to('prefix/lib/foo', 'prefix') == 'lib/foo')
+  assert(fs.relative_to('prefix/lib', 'prefix/bin') == '../lib')
+  assert(fs.relative_to('subdir/subdirfile.txt', meson.current_source_dir()) == 'subdir/subdirfile.txt')
+  assert(fs.relative_to(files('meson.build'), files('subdir/meson.build')) == '../../meson.build')
+  assert(fs.relative_to(files('meson.build'), 'subdir/meson.build') == '../../meson.build')
+endif
 
 subdir('subdir')
 

--- a/test cases/common/220 fs module/subdir/btgt.c
+++ b/test cases/common/220 fs module/subdir/btgt.c
@@ -1,0 +1,5 @@
+int
+main(void)
+{
+    return 0;
+}

--- a/test cases/common/220 fs module/subdir/meson.build
+++ b/test cases/common/220 fs module/subdir/meson.build
@@ -4,3 +4,53 @@ assert(fs.is_samepath(meson.project_source_root(), '..'), 'is_samepath not detec
 assert(fs.is_samepath(meson.project_build_root(), meson.current_build_dir() / '..'), 'is_samepath not detecting same directory')
 
 assert(fs.is_samepath(subdirfiles[0], 'subdirfile.txt'), 'is_samepath not detecting same directory when using File and str')
+
+# More relative_to to test subdir/builddir components
+
+python3 = find_program('python3')
+build_to_src = fs.relative_to(meson.current_source_dir(), meson.current_build_dir())
+src_to_build = fs.relative_to(meson.current_build_dir(), meson.current_source_dir())
+
+btgt = executable('btgt', 'btgt.c')
+ctgt = custom_target(
+  'copied-files',
+  command: [
+    python3,
+    '-c',
+    'import shutil; shutil.copyfile("@INPUT0@", "@OUTPUT0@"); shutil.copyfile("@INPUT1@", "@OUTPUT1@")'
+  ],
+  input: [
+    'subdirfile.txt',
+    'meson.build',
+  ],
+  output: [
+    'subdirfile.txt',
+    'meson.build',
+  ],
+)
+
+if build_machine.system() == 'windows'
+  # Test that CustomTarget works
+  assert(fs.relative_to('subdirfile.txt', ctgt) == '..\\@0@\\subdirfile.txt'.format(build_to_src))
+  assert(fs.relative_to(ctgt, 'subdirfile.txt') == '..\\@0@\\subdirfile.txt'.format(src_to_build))
+  # Test that CustomTargetIndex works
+  assert(fs.relative_to('meson.build', ctgt[1]) == '..\\@0@\\meson.build'.format(build_to_src))
+  assert(fs.relative_to(ctgt[1], 'meson.build') == '..\\@0@\\meson.build'.format(src_to_build))
+  # Test that BuildTarget works
+  assert(fs.relative_to('subdirfile.txt', btgt) == '..\\@0@\\subdirfile.txt'.format(build_to_src))
+  assert(fs.relative_to(btgt, 'subdirfile.txt') == '..\\@0@\\btgt.exe'.format(src_to_build))
+else
+  # Test that CustomTarget works
+  assert(fs.relative_to('subdirfile.txt', ctgt) == '../@0@/subdirfile.txt'.format(build_to_src))
+  assert(fs.relative_to(ctgt, 'subdirfile.txt') == '../@0@/subdirfile.txt'.format(src_to_build))
+  # Test that CustomTargetIndex works
+  assert(fs.relative_to('meson.build', ctgt[1]) == '../@0@/meson.build'.format(build_to_src))
+  assert(fs.relative_to(ctgt[1], 'meson.build') == '../@0@/meson.build'.format(src_to_build))
+  # Test that BuildTarget works
+  assert(fs.relative_to('subdirfile.txt', btgt) == '../@0@/subdirfile.txt'.format(build_to_src))
+  if host_machine.system() == 'windows'
+    assert(fs.relative_to(btgt, 'subdirfile.txt') == '../@0@/btgt.exe'.format(src_to_build))
+  else
+    assert(fs.relative_to(btgt, 'subdirfile.txt') == '../@0@/btgt'.format(src_to_build))
+  endif
+endif


### PR DESCRIPTION
Returns a relative path from arg 2 to arg 1 similar to os.path.relpath().

Closes: https://github.com/mesonbuild/meson/pull/7908