### PR TITLE
tests: some Windows fixes with newer Python

### DIFF
--- a/mesonbuild/utils/vsenv.py
+++ b/mesonbuild/utils/vsenv.py
@@ -6,6 +6,7 @@ import json
 import pathlib
 import shutil
 import tempfile
+import locale
 
 from .. import mlog
 from .core import MesonException
@@ -93,7 +94,8 @@ def _setup_vsenv(force: bool) -> bool:
     bat_file.write(bat_contents)
     bat_file.flush()
     bat_file.close()
-    bat_output = subprocess.check_output(bat_file.name, universal_newlines=True)
+    bat_output = subprocess.check_output(bat_file.name, universal_newlines=True,
+                                         encoding=locale.getpreferredencoding(False))
     os.unlink(bat_file.name)
     bat_lines = bat_output.split('\n')
     bat_separator_seen = False

--- a/test cases/python/4 custom target depends extmodule/blaster.py
+++ b/test cases/python/4 custom target depends extmodule/blaster.py
@@ -10,6 +10,9 @@ filedir = Path(os.path.dirname(__file__)).resolve()
 if list(filedir.glob('ext/*tachyon*')):
     sys.path.insert(0, (filedir / 'ext').as_posix())
 
+if hasattr(os, 'add_dll_directory'):
+    os.add_dll_directory(filedir / 'ext' / 'lib')
+
 import tachyon
 
 parser = argparse.ArgumentParser()

--- a/test cases/python3/4 custom target depends extmodule/blaster.py
+++ b/test cases/python3/4 custom target depends extmodule/blaster.py
@@ -10,6 +10,9 @@ filedir = Path(os.path.dirname(__file__)).resolve()
 if list(filedir.glob('ext/*tachyon.*')):
     sys.path.insert(0, (filedir / 'ext').as_posix())
 
+if hasattr(os, 'add_dll_directory'):
+    os.add_dll_directory(filedir / 'ext' / 'lib')
+
 import tachyon
 
 parser = argparse.ArgumentParser()


### PR DESCRIPTION
This fixes "test_vsenv_option" with Python 3.11+ and both "4 custom target depends extmodule" on Windows with Python 3.8+. See the commits for details.

(This is required to keep MSYS2 CI green after the next Python update there)