### PR TITLE
clang: use gcc syntax to enable diagnostics color

### DIFF
--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -31,9 +31,9 @@ if T.TYPE_CHECKING:
     from ...dependencies import Dependency  # noqa: F401
 
 clang_color_args: T.Dict[str, T.List[str]] = {
-    'auto': ['-fcolor-diagnostics'],
-    'always': ['-fcolor-diagnostics'],
-    'never': ['-fno-color-diagnostics'],
+    'auto': ['-fdiagnostics-color=auto'],
+    'always': ['-fdiagnostics-color=always'],
+    'never': ['-fdiagnostics-color=never'],
 }
 
 clang_optimization_args: T.Dict[str, T.List[str]] = {


### PR DESCRIPTION
Clang supports the same arguments as GCC [since version 3.3.0](https://github.com/llvm/llvm-project/commit/7e2da79efaf866cd6a0142d154aea371714f3fea) from 10 years ago.

It's not properly documented, like quite a few other options... but it works well!  It's also the only way to explicitly pass "auto" as you can see [here](https://github.com/llvm/llvm-project/blob/729b55ef5e7aff33fb1d191c5ef576bbda03b801/clang/lib/Frontend/CompilerInvocation.cpp#L2162).  Currently meson treats "auto" as the same thing as "always" with clang.

If someone was explicitly asking meson for "auto" (the default is "always") and then using ninja (which pipes the output), they will lose the colors after this patch.  But I think this is an acceptable breakage, and we should implement the correct behavior for everyone from now on.