### PR TITLE
Suggest fix in MesonVersionMismatchException

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -91,7 +91,8 @@ class MesonVersionMismatchException(MesonException):
     '''Build directory generated with Meson version is incompatible with current version'''
     def __init__(self, old_version: str, current_version: str) -> None:
         super().__init__(f'Build directory has been generated with Meson version {old_version}, '
-                         f'which is incompatible with the current version {current_version}.')
+                         f'which is incompatible with the current version {current_version}. '
+                         f'Consider reconfiguring the directory with meson setup --reconfigure.')
         self.old_version = old_version
         self.current_version = current_version
 


### PR DESCRIPTION
Every time I update meson, I spend about 20 minutes on frustrated googling to figure out how to update my build directory to work with the new version. I'm forgetful, okay? Ease this pain point by suggesting a potential fix in the error message.