### PR TITLE
use typed_kwargs for exclusive SharedLibrary keyword arguments

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2138,7 +2138,7 @@ class SharedLibrary(BuildTarget):
             environment: environment.Environment,
             compilers: T.Dict[str, 'Compiler'],
             kwargs):
-        self.soversion = None
+        self.soversion: T.Optional[str] = None
         self.ltversion: T.Optional[str] = None
         # Max length 2, first element is compatibility_version, second is current_version
         self.darwin_versions = []
@@ -2351,14 +2351,8 @@ class SharedLibrary(BuildTarget):
         if not self.environment.machines[self.for_machine].is_android():
             # Shared library version
             self.ltversion = T.cast('T.Optional[str]', kwargs.get('version'))
-            # Try to extract/deduce the soversion
-            if 'soversion' in kwargs:
-                self.soversion = kwargs['soversion']
-                if isinstance(self.soversion, int):
-                    self.soversion = str(self.soversion)
-                if not isinstance(self.soversion, str):
-                    raise InvalidArguments('Shared library soversion is not a string or integer.')
-            elif self.ltversion:
+            self.soversion = T.cast('T.Optional[str]', kwargs.get('soversion'))
+            if self.soversion is None and self.ltversion is not None:
                 # library version is defined, get the soversion from that
                 # We replicate what Autotools does here and take the first
                 # number of the version by default.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2139,7 +2139,7 @@ class SharedLibrary(BuildTarget):
             compilers: T.Dict[str, 'Compiler'],
             kwargs):
         self.soversion = None
-        self.ltversion = None
+        self.ltversion: T.Optional[str] = None
         # Max length 2, first element is compatibility_version, second is current_version
         self.darwin_versions = []
         self.vs_module_defs = None
@@ -2350,12 +2350,7 @@ class SharedLibrary(BuildTarget):
 
         if not self.environment.machines[self.for_machine].is_android():
             # Shared library version
-            if 'version' in kwargs:
-                self.ltversion = kwargs['version']
-                if not isinstance(self.ltversion, str):
-                    raise InvalidArguments('Shared library version needs to be a string, not ' + type(self.ltversion).__name__)
-                if not re.fullmatch(r'[0-9]+(\.[0-9]+){0,2}', self.ltversion):
-                    raise InvalidArguments(f'Invalid Shared library version "{self.ltversion}". Must be of the form X.Y.Z where all three are numbers. Y and Z are optional.')
+            self.ltversion = T.cast('T.Optional[str]', kwargs.get('version'))
             # Try to extract/deduce the soversion
             if 'soversion' in kwargs:
                 self.soversion = kwargs['soversion']

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -340,6 +340,7 @@ class StaticLibrary(_BuildTarget):
 
 class _SharedLibMixin(TypedDict):
 
+    soversion: T.Optional[str]
     version: T.Optional[str]
 
 

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -338,7 +338,12 @@ class StaticLibrary(_BuildTarget):
     pass
 
 
-class SharedLibrary(_BuildTarget):
+class _SharedLibMixin(TypedDict):
+
+    version: T.Optional[str]
+
+
+class SharedLibrary(_BuildTarget, _SharedLibMixin):
     pass
 
 
@@ -346,7 +351,7 @@ class SharedModule(_BuildTarget):
     pass
 
 
-class Library(_BuildTarget):
+class Library(_BuildTarget, _SharedLibMixin):
 
     """For library, both_library, and as a base for build_target"""
 

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -340,6 +340,7 @@ class StaticLibrary(_BuildTarget):
 
 class _SharedLibMixin(TypedDict):
 
+    darwin_versions: T.Optional[T.Tuple[str, str]]
     soversion: T.Optional[str]
     version: T.Optional[str]
 

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -119,6 +119,13 @@ def _lower_strlist(input: T.List[str]) -> T.List[str]:
     return [i.lower() for i in input]
 
 
+def _validate_shlib_version(val: T.Optional[str]) -> T.Optional[str]:
+    if val is not None and not re.fullmatch(r'[0-9]+(\.[0-9]+){0,2}', val):
+        return (f'Invalid Shared library version "{val}". '
+                'Must be of the form X.Y.Z where all three are numbers. Y and Z are optional.')
+    return None
+
+
 def variables_validator(contents: T.Union[str, T.List[str], T.Dict[str, str]]) -> T.Optional[str]:
     if isinstance(contents, str):
         contents = [contents]
@@ -527,7 +534,9 @@ STATIC_LIB_KWS = [
 
 # Arguments exclusive to SharedLibrary. These are separated to make integrating
 # them into build_target easier
-_EXCLUSIVE_SHARED_LIB_KWS: T.List[KwargInfo] = []
+_EXCLUSIVE_SHARED_LIB_KWS: T.List[KwargInfo] = [
+    KwargInfo('version', (str, NoneType), validator=_validate_shlib_version)
+]
 
 # The total list of arguments used by SharedLibrary
 SHARED_LIB_KWS = [

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -535,6 +535,7 @@ STATIC_LIB_KWS = [
 # Arguments exclusive to SharedLibrary. These are separated to make integrating
 # them into build_target easier
 _EXCLUSIVE_SHARED_LIB_KWS: T.List[KwargInfo] = [
+    KwargInfo('soversion', (str, int, NoneType), convertor=lambda x: str(x) if x is not None else None),
     KwargInfo('version', (str, NoneType), validator=_validate_shlib_version)
 ]
 


### PR DESCRIPTION
A set of nice, simple cleanups to use typed_kwargs for shared_library exclusive keyword arguments.