### PR TITLE
python module: Respect PATH when python is not given in machine file

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,9 +33,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - run: |
-        export PATH="$HOME/Library/Python/3.9/bin:$PATH"
-        /usr/bin/python3 -m pip install --upgrade pip
-        /usr/bin/python3 -m pip install pytest pytest-xdist pytest-subtests fastjsonschema
+        export PATH="$HOME/Library/Python/3.9/bin:/Applications/Xcode.app/Contents/Developer/usr/bin:$PATH"
+        python3 -m pip install --upgrade pip
+        python3 -m pip install pytest pytest-xdist pytest-subtests fastjsonschema
     - run: brew install pkg-config ninja llvm qt@5
     - env:
         CPPFLAGS: "-I/opt/homebrew/include"
@@ -46,9 +46,9 @@ jobs:
         # These cannot evaluate anything, so we cannot set PATH or SDKROOT here
       run: |
         export SDKROOT="$(xcodebuild -version -sdk macosx Path)"
-        export PATH="$HOME/Library/Python/3.9/bin:$HOME/tools:/opt/homebrew/opt/qt@5/bin:/opt/homebrew/opt/llvm/bin:$PATH"
+        export PATH="$HOME/Library/Python/3.9/bin:/Applications/Xcode.app/Contents/Developer/usr/bin:$HOME/tools:/opt/homebrew/opt/qt@5/bin:/opt/homebrew/opt/llvm/bin:$PATH"
         export PKG_CONFIG_PATH="/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/Current/lib/pkgconfig:/opt/homebrew/opt/qt@5/lib/pkgconfig:$PKG_CONFIG_PATH"
-        /usr/bin/python3 ./run_unittests.py
+        python3 ./run_unittests.py
 
 
   project-tests-appleclang:

--- a/.github/workflows/os_comp.yml
+++ b/.github/workflows/os_comp.yml
@@ -87,7 +87,8 @@ jobs:
       run: |
         source /ci/env_vars.sh
         export MESON_CI_JOBNAME=$MESON_CI_JOBNAME_UPDATE
-        pypy3 run_tests.py
+        echo -e "[binaries]\npython = '/usr/bin/pypy3'" > /tmp/native.ini
+        pypy3 run_tests.py -- --native-file /tmp/native.ini
 
   ubuntu-rolling:
     name: 'Ubuntu Rolling'

--- a/docs/markdown/Python-module.md
+++ b/docs/markdown/Python-module.md
@@ -34,7 +34,8 @@ pymod.find_installation(name_or_path, ...)
 Find a python installation matching `name_or_path`.
 
 That argument is optional, if not provided then the returned python
-installation will be the one used to run Meson.
+installation will be the one found in the `PATH` as `python3` or the one used
+to run Meson.
 
 If provided, it can be:
 

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -471,7 +471,9 @@ class PythonModule(ExtensionModule):
         build_config = self.interpreter.environment.coredata.optstore.get_value_for(OptionKey('python.build_config'))
 
         if not name_or_path:
-            python = PythonExternalProgram('python3', mesonlib.python_command, build_config_path=build_config)
+            python = PythonExternalProgram('python3', build_config_path=build_config)
+            if not python.found():
+                python = PythonExternalProgram('python3', mesonlib.python_command, build_config_path=build_config)
         else:
             tmp_python = ExternalProgram.from_entry(display_name, name_or_path)
             python = PythonExternalProgram(display_name, ext_prog=tmp_python, build_config_path=build_config)

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -393,7 +393,7 @@ class PythonModule(ExtensionModule):
 
     def __init__(self, interpreter: 'Interpreter') -> None:
         super().__init__(interpreter)
-        self.installations: T.Dict[str, MaybePythonProg] = {}
+        self.installations: T.Dict[(str, str), MaybePythonProg] = {}
         self.methods.update({
             'find_installation': self.find_installation,
         })
@@ -533,10 +533,10 @@ class PythonModule(ExtensionModule):
             mlog.log('Program', name_or_path or 'python', 'found:', mlog.red('NO'), '(disabled by:', mlog.bold(feature), ')')
             return NonExistingExternalProgram()
 
-        python = self.installations.get(name_or_path)
+        python = self.installations.get((display_name, name_or_path))
         if not python:
             python = self._find_installation_impl(state, display_name, name_or_path, required)
-            self.installations[name_or_path] = python
+            self.installations[(display_name, name_or_path)] = python
 
         want_modules = kwargs['modules']
         found_modules: T.List[str] = []

--- a/test cases/frameworks/1 boost/meson.build
+++ b/test cases/frameworks/1 boost/meson.build
@@ -25,6 +25,11 @@ require_bp = host_machine.system() in ['linux', 'darwin']
 pymod = import('python')
 python2 = pymod.find_installation('python2', required: false                           , disabler: true)
 python3 = pymod.find_installation('python3', required: require_bp , disabler: true)
+
+if python3.has_variable('implementation') and python3.get_variable('implementation') == 'PyPy'
+  error('MESON_SKIP_TEST boost does not support PyPy.')
+endif
+
 python2dep = python2.dependency(required: false                           , embed: true, disabler: true)
 python3dep = python3.dependency(required: require_bp, embed: true, disabler: true)
 

--- a/test cases/frameworks/1 boost/test.json
+++ b/test cases/frameworks/1 boost/test.json
@@ -18,5 +18,5 @@
       { "static": "false", "b_vscrt": "mtd" }
     ]
   },
-  "expect_skip_on_jobname": ["azure", "msys2", "windows"]
+  "expect_skip_on_jobname": ["azure", "msys2", "pypy", "windows"]
 }


### PR DESCRIPTION
We should only fall back to the Python interpreter running Meson itself if `python3` is not found in the PATH.

See [Gentoo bug #912051](https://bugs.gentoo.org/912051).