### PR TITLE
Remove XML filter from testlog.{json,txt} and std streams

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -869,10 +869,10 @@ class JunitBuilder(TestLogger):
                     et.SubElement(testcase, 'system-out').text = subtest.explanation
             if test.stdo:
                 out = et.SubElement(suite, 'system-out')
-                out.text = test.stdo.rstrip()
+                out.text = replace_unencodable_xml_chars(test.stdo.rstrip())
             if test.stde:
                 err = et.SubElement(suite, 'system-err')
-                err.text = test.stde.rstrip()
+                err.text = replace_unencodable_xml_chars(test.stde.rstrip())
         else:
             if test.project not in self.suites:
                 suite = self.suites[test.project] = et.Element(
@@ -895,10 +895,10 @@ class JunitBuilder(TestLogger):
                 suite.attrib['failures'] = str(int(suite.attrib['failures']) + 1)
             if test.stdo:
                 out = et.SubElement(testcase, 'system-out')
-                out.text = test.stdo.rstrip()
+                out.text = replace_unencodable_xml_chars(test.stdo.rstrip())
             if test.stde:
                 err = et.SubElement(testcase, 'system-err')
-                err.text = test.stde.rstrip()
+                err.text = replace_unencodable_xml_chars(test.stde.rstrip())
 
     async def finish(self, harness: 'TestHarness') -> None:
         """Calculate total test counts and write out the xml result."""
@@ -1182,9 +1182,9 @@ def decode(stream: T.Union[None, bytes]) -> str:
     if stream is None:
         return ''
     try:
-        return replace_unencodable_xml_chars(stream.decode('utf-8'))
+        return stream.decode('utf-8')
     except UnicodeDecodeError:
-        return replace_unencodable_xml_chars(stream.decode('iso-8859-1', errors='ignore'))
+        return stream.decode('iso-8859-1', errors='ignore')
 
 async def read_decode(reader: asyncio.StreamReader,
                       queue: T.Optional['asyncio.Queue[T.Optional[str]]'],

--- a/test cases/unit/110 replace unencodable xml chars/meson.build
+++ b/test cases/unit/110 replace unencodable xml chars/meson.build
@@ -1,4 +1,4 @@
 project('replace unencodable xml chars')
 
 test_script = find_program('script.py')
-test('main', test_script)
+test('main', test_script, verbose: true)

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -463,9 +463,8 @@ class AllPlatformTests(BasePlatformTests):
 
         valid_string = base_string_valid + repr(invalid_string)[1:-1] + base_string_valid
         invalid_string = base_string_invalid + invalid_string + base_string_invalid
-        broken_xml_stream = invalid_string.encode()
-        decoded_broken_stream = mtest.decode(broken_xml_stream)
-        self.assertEqual(decoded_broken_stream, valid_string)
+        fixed_string = mtest.replace_unencodable_xml_chars(invalid_string)
+        self.assertEqual(fixed_string, valid_string)
 
     def test_replace_unencodable_xml_chars_unit(self):
         '''
@@ -477,9 +476,16 @@ class AllPlatformTests(BasePlatformTests):
             raise SkipTest('xmllint not installed')
         testdir = os.path.join(self.unit_test_dir, '110 replace unencodable xml chars')
         self.init(testdir)
-        self.run_tests()
+        tests_command_output = self.run_tests()
         junit_xml_logs = Path(self.logdir, 'testlog.junit.xml')
         subprocess.run(['xmllint', junit_xml_logs], check=True)
+        # Ensure command output and JSON / text logs are not mangled.
+        raw_output_sample = '\x00\x01\x02\x03\x04\x05\x06\x07\x08\x0b'
+        assert raw_output_sample in tests_command_output
+        text_log = Path(self.logdir, 'testlog.txt').read_text()
+        assert raw_output_sample in text_log
+        json_log = json.loads(Path(self.logdir, 'testlog.json').read_bytes())
+        assert raw_output_sample in json_log['stdout']
 
     def test_run_target_files_path(self):
         '''


### PR DESCRIPTION
This was an unintended consequence of the original patch in #11977.