### PR TITLE
ninja backend: fix the automatic restat of outputs when reconfiguring

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -664,9 +664,9 @@ class NinjaBackend(backends.Backend):
         os.replace(tempfilename, outfilename)
         mlog.cmd_ci_include(outfilename)  # For CI debugging
         # Refresh Ninja's caches. https://github.com/ninja-build/ninja/pull/1685
-        if mesonlib.version_compare(self.ninja_version, '>=1.10.0') and os.path.exists('.ninja_deps'):
-            subprocess.call(self.ninja_command + ['-t', 'restat'])
-            subprocess.call(self.ninja_command + ['-t', 'cleandead'])
+        if mesonlib.version_compare(self.ninja_version, '>=1.10.0') and os.path.exists(os.path.join(self.environment.build_dir, '.ninja_log')):
+            subprocess.call(self.ninja_command + ['-t', 'restat'], cwd=self.environment.build_dir)
+            subprocess.call(self.ninja_command + ['-t', 'cleandead'], cwd=self.environment.build_dir)
         self.generate_compdb()
         self.generate_rust_project_json()
 


### PR DESCRIPTION
The most notable problem this causes is that when running `meson setup --reconfigure` the build.ninja file is erroneously seen as out of date, so ninja immediately tries to regenerate it again as it didn't see the file get updated.

There are two problems.

The first problem is that we looked for the wrong file. Ninja creates a few internal files, and one of them is the one we care about: `.ninja_log`, which contains stat'ed timestamps for build outputs to aid in checking when things are out of date. But the thing we actually checked for is `.ninja_deps`, a file that contains a compressed database of depfile outputs. If the latter exists, then the former surely exists too.

Checking for the wrong file meant that we would restat outputs, but only when some build edges were previously built that had depfile outputs.

The second problem is that we checked for this in os.getcwd() instead of the configured build directory. This very easily fails to be correct, except when reconfigure is triggered directly by ninja itself, in which case we didn't need the restat to begin with.

/cc @bruchar1 @tristan957 