### PR TITLE
pkgconfig: cleanups and fix define_variable type

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1143,7 +1143,7 @@ class Backend:
 
             if dep.type_name == 'pkgconfig':
                 # If by chance pkg-config knows the bin dir...
-                bindir = dep.get_pkgconfig_variable('bindir', [], default='')
+                bindir = dep.get_variable(pkgconfig='bindir', default_value='')
                 if bindir:
                     results.add(bindir)
                     continue

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -30,7 +30,6 @@ from ..mesonlib import version_compare_many
 #from ..interpreterbase import FeatureDeprecated, FeatureNew
 
 if T.TYPE_CHECKING:
-    from .._typing import ImmutableListProtocol
     from ..compilers.compilers import Compiler
     from ..environment import Environment
     from ..interpreterbase import FeatureCheckBase
@@ -38,6 +37,7 @@ if T.TYPE_CHECKING:
         CustomTarget, IncludeDirs, CustomTargetIndex, LibTypes,
         StaticLibrary, StructuredSources, ExtractedObjects, GeneratedTypes
     )
+    from ..interpreter.type_checking import PkgConfigDefineType
 
 
 class DependencyException(MesonException):
@@ -193,11 +193,6 @@ class Dependency(HoldableObject):
     def get_exe_args(self, compiler: 'Compiler') -> T.List[str]:
         return []
 
-    def get_pkgconfig_variable(self, variable_name: str,
-                               define_variable: 'ImmutableListProtocol[str]',
-                               default: T.Optional[str]) -> str:
-        raise DependencyException(f'{self.name!r} is not a pkgconfig dependency')
-
     def get_configtool_variable(self, variable_name: str) -> str:
         raise DependencyException(f'{self.name!r} is not a config-tool dependency')
 
@@ -238,7 +233,7 @@ class Dependency(HoldableObject):
     def get_variable(self, *, cmake: T.Optional[str] = None, pkgconfig: T.Optional[str] = None,
                      configtool: T.Optional[str] = None, internal: T.Optional[str] = None,
                      default_value: T.Optional[str] = None,
-                     pkgconfig_define: T.Optional[T.List[str]] = None) -> str:
+                     pkgconfig_define: PkgConfigDefineType = None) -> str:
         if default_value is not None:
             return default_value
         raise DependencyException(f'No default provided for dependency {self!r}, which is not pkg-config, cmake, or config-tool based.')
@@ -297,12 +292,6 @@ class InternalDependency(Dependency):
             return True
         return any(d.is_built() for d in self.ext_deps)
 
-    def get_pkgconfig_variable(self, variable_name: str,
-                               define_variable: 'ImmutableListProtocol[str]',
-                               default: T.Optional[str]) -> str:
-        raise DependencyException('Method "get_pkgconfig_variable()" is '
-                                  'invalid for an internal dependency')
-
     def get_configtool_variable(self, variable_name: str) -> str:
         raise DependencyException('Method "get_configtool_variable()" is '
                                   'invalid for an internal dependency')
@@ -332,7 +321,7 @@ class InternalDependency(Dependency):
     def get_variable(self, *, cmake: T.Optional[str] = None, pkgconfig: T.Optional[str] = None,
                      configtool: T.Optional[str] = None, internal: T.Optional[str] = None,
                      default_value: T.Optional[str] = None,
-                     pkgconfig_define: T.Optional[T.List[str]] = None) -> str:
+                     pkgconfig_define: PkgConfigDefineType = None) -> str:
         val = self.variables.get(internal, default_value)
         if val is not None:
             return val

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -193,9 +193,6 @@ class Dependency(HoldableObject):
     def get_exe_args(self, compiler: 'Compiler') -> T.List[str]:
         return []
 
-    def get_configtool_variable(self, variable_name: str) -> str:
-        raise DependencyException(f'{self.name!r} is not a config-tool dependency')
-
     def get_partial_dependency(self, *, compile_args: bool = False,
                                link_args: bool = False, links: bool = False,
                                includes: bool = False, sources: bool = False) -> 'Dependency':
@@ -291,10 +288,6 @@ class InternalDependency(Dependency):
         if self.sources or self.libraries or self.whole_libraries:
             return True
         return any(d.is_built() for d in self.ext_deps)
-
-    def get_configtool_variable(self, variable_name: str) -> str:
-        raise DependencyException('Method "get_configtool_variable()" is '
-                                  'invalid for an internal dependency')
 
     def get_partial_dependency(self, *, compile_args: bool = False,
                                link_args: bool = False, links: bool = False,

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -662,7 +662,7 @@ class BoostDependency(SystemDependency):
         try:
             boost_pc = PkgConfigDependency('boost', self.env, {'required': False})
             if boost_pc.found():
-                boost_root = boost_pc.get_pkgconfig_variable('prefix', [], None)
+                boost_root = boost_pc.get_variable(pkgconfig='prefix')
                 if boost_root:
                     roots += [Path(boost_root)]
         except DependencyException:

--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -30,6 +30,7 @@ if T.TYPE_CHECKING:
     from ..cmake import CMakeTarget
     from ..environment import Environment
     from ..envconfig import MachineInfo
+    from ..interpreter.type_checking import PkgConfigDefineType
 
 class CMakeInfo(T.NamedTuple):
     module_paths: T.List[str]
@@ -632,7 +633,7 @@ class CMakeDependency(ExternalDependency):
     def get_variable(self, *, cmake: T.Optional[str] = None, pkgconfig: T.Optional[str] = None,
                      configtool: T.Optional[str] = None, internal: T.Optional[str] = None,
                      default_value: T.Optional[str] = None,
-                     pkgconfig_define: T.Optional[T.List[str]] = None) -> str:
+                     pkgconfig_define: PkgConfigDefineType = None) -> str:
         if cmake and self.traceparser is not None:
             try:
                 v = self.traceparser.vars[cmake]

--- a/mesonbuild/dependencies/configtool.py
+++ b/mesonbuild/dependencies/configtool.py
@@ -24,6 +24,7 @@ from mesonbuild import mesonlib
 
 if T.TYPE_CHECKING:
     from ..environment import Environment
+    from ..interpreter.type_checking import PkgConfigDefineType
 
 class ConfigToolDependency(ExternalDependency):
 
@@ -171,7 +172,7 @@ class ConfigToolDependency(ExternalDependency):
     def get_variable(self, *, cmake: T.Optional[str] = None, pkgconfig: T.Optional[str] = None,
                      configtool: T.Optional[str] = None, internal: T.Optional[str] = None,
                      default_value: T.Optional[str] = None,
-                     pkgconfig_define: T.Optional[T.List[str]] = None) -> str:
+                     pkgconfig_define: PkgConfigDefineType = None) -> str:
         if configtool:
             # In the not required case '' (empty string) will be returned if the
             # variable is not found. Since '' is a valid value to return we

--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -177,7 +177,7 @@ class PkgConfigCLI(PkgConfigInterface):
 
     def _detect_pkgbin(self) -> None:
         for potential_pkgbin in find_external_program(
-                self.env, self.for_machine, 'pkgconfig', 'Pkg-config',
+                self.env, self.for_machine, 'pkg-config', 'Pkg-config',
                 self.env.default_pkgconfig, allow_default_for_cross=False):
             version_if_ok = self._check_pkgconfig(potential_pkgbin)
             if version_if_ok:

--- a/mesonbuild/dependencies/qt.py
+++ b/mesonbuild/dependencies/qt.py
@@ -198,7 +198,7 @@ class QtPkgConfigDependency(_QtBase, PkgConfigDependency, metaclass=abc.ABCMeta)
                 self.is_found = False
                 return
             if self.private_headers:
-                qt_inc_dir = mod.get_pkgconfig_variable('includedir', [], None)
+                qt_inc_dir = mod.get_variable(pkgconfig='includedir')
                 mod_private_dir = os.path.join(qt_inc_dir, 'Qt' + m)
                 if not os.path.isdir(mod_private_dir):
                     # At least some versions of homebrew don't seem to set this
@@ -220,7 +220,7 @@ class QtPkgConfigDependency(_QtBase, PkgConfigDependency, metaclass=abc.ABCMeta)
                 if arg == f'-l{debug_lib_name}' or arg.endswith(f'{debug_lib_name}.lib') or arg.endswith(f'{debug_lib_name}.a'):
                     is_debug = True
                     break
-            libdir = self.get_pkgconfig_variable('libdir', [], None)
+            libdir = self.get_variable(pkgconfig='libdir')
             if not self._link_with_qt_winmain(is_debug, libdir):
                 self.is_found = False
                 return
@@ -228,7 +228,7 @@ class QtPkgConfigDependency(_QtBase, PkgConfigDependency, metaclass=abc.ABCMeta)
         self.bindir = self.get_pkgconfig_host_bins(self)
         if not self.bindir:
             # If exec_prefix is not defined, the pkg-config file is broken
-            prefix = self.get_pkgconfig_variable('exec_prefix', [], None)
+            prefix = self.get_variable(pkgconfig='exec_prefix')
             if prefix:
                 self.bindir = os.path.join(prefix, 'bin')
 
@@ -422,7 +422,7 @@ class Qt4PkgConfigDependency(QtPkgConfigDependency):
         applications = ['moc', 'uic', 'rcc', 'lupdate', 'lrelease']
         for application in applications:
             try:
-                return os.path.dirname(core.get_pkgconfig_variable(f'{application}_location', [], None))
+                return os.path.dirname(core.get_variable(pkgconfig=f'{application}_location'))
             except mesonlib.MesonException:
                 pass
         return None
@@ -439,7 +439,7 @@ class Qt5PkgConfigDependency(QtPkgConfigDependency):
 
     @staticmethod
     def get_pkgconfig_host_bins(core: PkgConfigDependency) -> str:
-        return core.get_pkgconfig_variable('host_bins', [], None)
+        return core.get_variable(pkgconfig='host_bins')
 
     @staticmethod
     def get_pkgconfig_host_libexecs(core: PkgConfigDependency) -> str:
@@ -460,12 +460,12 @@ class Qt6PkgConfigDependency(Qt6WinMainMixin, QtPkgConfigDependency):
 
     @staticmethod
     def get_pkgconfig_host_bins(core: PkgConfigDependency) -> str:
-        return core.get_pkgconfig_variable('bindir', [], None)
+        return core.get_variable(pkgconfig='bindir')
 
     @staticmethod
     def get_pkgconfig_host_libexecs(core: PkgConfigDependency) -> str:
         # Qt6 pkg-config for Qt defines libexecdir from 6.3+
-        return core.get_pkgconfig_variable('libexecdir', [], None)
+        return core.get_variable(pkgconfig='libexecdir')
 
     def get_private_includes(self, mod_inc_dir: str, module: str) -> T.List[str]:
         return _qt_get_private_includes(mod_inc_dir, module, self.version)

--- a/mesonbuild/dependencies/scalapack.py
+++ b/mesonbuild/dependencies/scalapack.py
@@ -148,5 +148,5 @@ class MKLPkgConfigDependency(PkgConfigDependency):
             # gfortran doesn't appear to look in system paths for INCLUDE files,
             # so don't allow pkg-config to suppress -I flags for system paths
             allow_system = True
-        cflags = self.pkgconfig.cflags(self.name, allow_system, define_variable=['prefix', self.__mklroot.as_posix()])
+        cflags = self.pkgconfig.cflags(self.name, allow_system, define_variable=('prefix', self.__mklroot.as_posix()))
         self.compile_args = self._convert_mingw_paths(cflags)

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -133,7 +133,6 @@ ENV_VAR_TOOL_MAP: T.Mapping[str, str] = {
     # Other tools
     'cmake': 'CMAKE',
     'qmake': 'QMAKE',
-    'pkgconfig': 'PKG_CONFIG',
     'pkg-config': 'PKG_CONFIG',
     'make': 'MAKE',
     'vapigen': 'VAPIGEN',
@@ -403,6 +402,11 @@ class BinaryTable:
                 if not isinstance(command, (list, str)):
                     raise mesonlib.MesonException(
                         f'Invalid type {command!r} for entry {name!r} in cross file')
+                if name == 'pkgconfig':
+                    if 'pkg-config' in binaries:
+                        raise mesonlib.MesonException('Both pkgconfig and pkg-config entries in machine file.')
+                    mlog.deprecation('"pkgconfig" entry is deprecated and should be replaced by "pkg-config"')
+                    name = 'pkg-config'
                 self.binaries[name] = mesonlib.listify(command)
 
     @staticmethod

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -506,7 +506,13 @@ class DependencyHolder(ObjectHolder[Dependency]):
     @noKwargs
     @typed_pos_args('dependency.get_config_tool_variable', str)
     def configtool_method(self, args: T.Tuple[str], kwargs: TYPE_kwargs) -> str:
-        return self.held_object.get_configtool_variable(args[0])
+        from ..dependencies.configtool import ConfigToolDependency
+        if not isinstance(self.held_object, ConfigToolDependency):
+            raise InvalidArguments(f'{self.held_object.get_name()!r} is not a config-tool dependency')
+        return self.held_object.get_variable(
+            configtool=args[0],
+            default_value='',
+        )
 
     @FeatureNew('dependency.partial_dependency', '0.46.0')
     @noPosargs

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -16,7 +16,7 @@ from ..dependencies.base import Dependency
 from ..mesonlib import EnvironmentVariables, MachineChoice, File, FileMode, FileOrString, OptionKey
 from ..modules.cmake import CMakeSubprojectOptions
 from ..programs import ExternalProgram
-
+from .type_checking import PkgConfigDefineType
 
 class FuncAddProjectArgs(TypedDict):
 
@@ -256,7 +256,7 @@ class FeatureOptionRequire(TypedDict):
 class DependencyPkgConfigVar(TypedDict):
 
     default: T.Optional[str]
-    define_variable: T.List[str]
+    define_variable: PkgConfigDefineType
 
 
 class DependencyGetVariable(TypedDict):
@@ -266,7 +266,7 @@ class DependencyGetVariable(TypedDict):
     configtool: T.Optional[str]
     internal: T.Optional[str]
     default_value: T.Optional[str]
-    pkgconfig_define: T.List[str]
+    pkgconfig_define: PkgConfigDefineType
 
 
 class ConfigurationDataSet(TypedDict):

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -29,6 +29,7 @@ if T.TYPE_CHECKING:
     from ..mesonlib import EnvInitValueType
 
     _FullEnvInitValueType = T.Union[EnvironmentVariables, T.List[str], T.List[T.List[str]], EnvInitValueType, str, None]
+    PkgConfigDefineType = T.Optional[T.Tuple[str, str]]
 
 
 def in_set_validator(choices: T.Set[str]) -> T.Callable[[str], T.Optional[str]]:
@@ -648,3 +649,11 @@ BUILD_TARGET_KWS = [
         }
     )
 ]
+
+PKGCONFIG_DEFINE_KW: KwargInfo = KwargInfo(
+    'pkgconfig_define',
+    ContainerTypeInfo(list, str, pairs=True),
+    default=[],
+    validator=lambda x: 'must be of length 2 or empty' if len(x) not in {0, 2} else None,
+    convertor=lambda x: tuple(x) if x else None
+)

--- a/mesonbuild/mdevenv.py
+++ b/mesonbuild/mdevenv.py
@@ -85,7 +85,7 @@ def bash_completion_files(b: build.Build, install_data: 'InstallData') -> T.List
         datadir = b.environment.coredata.get_option(OptionKey('datadir'))
         assert isinstance(datadir, str), 'for mypy'
         datadir_abs = os.path.join(prefix, datadir)
-        completionsdir = dep.get_variable(pkgconfig='completionsdir', pkgconfig_define=['datadir', datadir_abs])
+        completionsdir = dep.get_variable(pkgconfig='completionsdir', pkgconfig_define=('datadir', datadir_abs))
         assert isinstance(completionsdir, str), 'for mypy'
         completionsdir_path = Path(completionsdir)
         for f in install_data.data:

--- a/mesonbuild/modules/external_project.py
+++ b/mesonbuild/modules/external_project.py
@@ -24,7 +24,7 @@ from .. import mlog, build
 from ..compilers.compilers import CFLAGS_MAPPING
 from ..envconfig import ENV_VAR_PROG_MAP
 from ..dependencies import InternalDependency
-from ..dependencies.pkgconfig import PkgConfigCLI
+from ..dependencies.pkgconfig import PkgConfigInterface
 from ..interpreterbase import FeatureNew
 from ..interpreter.type_checking import ENV_KW, DEPENDS_KW
 from ..interpreterbase.decorators import ContainerTypeInfo, KwargInfo, typed_kwargs, typed_pos_args
@@ -40,6 +40,7 @@ if T.TYPE_CHECKING:
     from ..interpreter import Interpreter
     from ..interpreterbase import TYPE_var
     from ..mesonlib import EnvironmentVariables
+    from ..utils.core import EnvironOrDict
 
     class Dependency(TypedDict):
 
@@ -144,7 +145,7 @@ class ExternalProject(NewExtensionModule):
         # Set common env variables like CFLAGS, CC, etc.
         link_exelist: T.List[str] = []
         link_args: T.List[str] = []
-        self.run_env = os.environ.copy()
+        self.run_env: EnvironOrDict = os.environ.copy()
         for lang, compiler in self.env.coredata.compilers[MachineChoice.HOST].items():
             if any(lang not in i for i in (ENV_VAR_PROG_MAP, CFLAGS_MAPPING)):
                 continue
@@ -165,8 +166,8 @@ class ExternalProject(NewExtensionModule):
         self.run_env['LDFLAGS'] = self._quote_and_join(link_args)
 
         self.run_env = self.user_env.get_env(self.run_env)
-        self.run_env = PkgConfigCLI.setup_env(self.run_env, self.env, MachineChoice.HOST,
-                                              uninstalled=True)
+        self.run_env = PkgConfigInterface.setup_env(self.run_env, self.env, MachineChoice.HOST,
+                                                    uninstalled=True)
 
         self.build_dir.mkdir(parents=True, exist_ok=True)
         self._run('configure', configure_cmd, workdir)

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -34,7 +34,7 @@ from .. import mesonlib
 from .. import mlog
 from ..build import CustomTarget, CustomTargetIndex, Executable, GeneratedList, InvalidArguments
 from ..dependencies import Dependency, InternalDependency
-from ..dependencies.pkgconfig import PkgConfigDependency, PkgConfigCLI
+from ..dependencies.pkgconfig import PkgConfigDependency, PkgConfigInterface
 from ..interpreter.type_checking import DEPENDS_KW, DEPEND_FILES_KW, ENV_KW, INSTALL_DIR_KW, INSTALL_KW, NoneType, SOURCES_KW, in_set_validator
 from ..interpreterbase import noPosargs, noKwargs, FeatureNew, FeatureDeprecated
 from ..interpreterbase import typed_kwargs, KwargInfo, ContainerTypeInfo
@@ -980,7 +980,7 @@ class GnomeModule(ExtensionModule):
         # -uninstalled.pc files Meson generated. It also must respect pkgconfig
         # settings user could have set in machine file, like PKG_CONFIG_LIBDIR,
         # SYSROOT, etc.
-        run_env = PkgConfigCLI.get_env(state.environment, MachineChoice.HOST, uninstalled=True)
+        run_env = PkgConfigInterface.get_env(state.environment, MachineChoice.HOST, uninstalled=True)
         # g-ir-scanner uses Python's distutils to find the compiler, which uses 'CC'
         cc_exelist = state.environment.coredata.compilers.host['c'].get_exelist()
         run_env.set('CC', [quote_arg(x) for x in cc_exelist], ' ')

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -26,7 +26,7 @@ from .. import dependencies
 from .. import mesonlib
 from .. import mlog
 from ..coredata import BUILTIN_DIR_OPTIONS
-from ..dependencies.pkgconfig import PkgConfigDependency, PkgConfigCLI
+from ..dependencies.pkgconfig import PkgConfigDependency, PkgConfigInterface
 from ..interpreter.type_checking import D_MODULE_VERSIONS_KW, INSTALL_DIR_KW, VARIABLES_KW, NoneType
 from ..interpreterbase import FeatureNew, FeatureDeprecated
 from ..interpreterbase.decorators import ContainerTypeInfo, KwargInfo, typed_kwargs, typed_pos_args
@@ -741,7 +741,7 @@ class PkgConfigModule(NewExtensionModule):
                     self._metadata[lib.get_id()] = MetaData(
                         filebase, name, state.current_node)
         if self.devenv is None:
-            self.devenv = PkgConfigCLI.get_env(state.environment, mesonlib.MachineChoice.HOST, uninstalled=True)
+            self.devenv = PkgConfigInterface.get_env(state.environment, mesonlib.MachineChoice.HOST, uninstalled=True)
         return ModuleReturnValue(res, [res])
 
 

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -524,6 +524,10 @@ class PerMachine(T.Generic[_T]):
             unfreeze.host = None
         return unfreeze
 
+    def assign(self, build: _T, host: _T) -> None:
+        self.build = build
+        self.host = host
+
     def __repr__(self) -> str:
         return f'PerMachine({self.build!r}, {self.host!r})'
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -36,7 +36,7 @@ import typing as T
 
 from mesonbuild.compilers.c import CCompiler
 from mesonbuild.compilers.detect import detect_c_compiler
-from mesonbuild.dependencies.pkgconfig import PkgConfigCLI
+from mesonbuild.dependencies.pkgconfig import PkgConfigInterface
 from mesonbuild import mesonlib
 from mesonbuild import mesonmain
 from mesonbuild import mtest
@@ -161,6 +161,8 @@ def get_fake_env(sdir='', bdir=None, prefix='', opts=None):
     env = Environment(sdir, bdir, opts)
     env.coredata.options[OptionKey('args', lang='c')] = FakeCompilerOptions()
     env.machines.host.cpu_family = 'x86_64' # Used on macOS inside find_library
+    # Invalidate cache when using a different Environment object.
+    clear_meson_configure_class_caches()
     return env
 
 def get_convincing_fake_env_and_cc(bdir, prefix):
@@ -309,11 +311,10 @@ def run_mtest_inprocess(commandlist: T.List[str]) -> T.Tuple[int, str, str]:
     return returncode, out.getvalue()
 
 def clear_meson_configure_class_caches() -> None:
-    CCompiler.find_library_cache = {}
-    CCompiler.find_framework_cache = {}
-    PkgConfigCLI.pkgbin_cache = {}
-    PkgConfigCLI.class_pkgbin = mesonlib.PerMachine(None, None)
-    mesonlib.project_meson_versions = collections.defaultdict(str)
+    CCompiler.find_library_cache.clear()
+    CCompiler.find_framework_cache.clear()
+    PkgConfigInterface.class_impl.assign(False, False)
+    mesonlib.project_meson_versions.clear()
 
 def run_configure_inprocess(commandlist: T.List[str], env: T.Optional[T.Dict[str, str]] = None, catch_exception: bool = False) -> T.Tuple[int, str, str]:
     stderr = StringIO()

--- a/test cases/unit/114 empty project/expected_mods.json
+++ b/test cases/unit/114 empty project/expected_mods.json
@@ -188,7 +188,6 @@
       "mesonbuild.dependencies",
       "mesonbuild.dependencies.base",
       "mesonbuild.dependencies.detect",
-      "mesonbuild.dependencies.pkgconfig",
       "mesonbuild.depfile",
       "mesonbuild.envconfig",
       "mesonbuild.environment",

--- a/test cases/unit/114 empty project/expected_mods.json
+++ b/test cases/unit/114 empty project/expected_mods.json
@@ -188,6 +188,7 @@
       "mesonbuild.dependencies",
       "mesonbuild.dependencies.base",
       "mesonbuild.dependencies.detect",
+      "mesonbuild.dependencies.pkgconfig",
       "mesonbuild.depfile",
       "mesonbuild.envconfig",
       "mesonbuild.environment",

--- a/unittests/failuretests.py
+++ b/unittests/failuretests.py
@@ -247,7 +247,7 @@ class FailureTests(BasePlatformTests):
         dep = declare_dependency(dependencies : zlib_dep)
         dep.get_configtool_variable('foo')
         '''
-        self.assertMesonRaises(code, "Method.*configtool.*is invalid.*internal")
+        self.assertMesonRaises(code, ".* is not a config-tool dependency")
 
     def test_objc_cpp_detection(self):
         '''

--- a/unittests/failuretests.py
+++ b/unittests/failuretests.py
@@ -242,7 +242,7 @@ class FailureTests(BasePlatformTests):
         dep = declare_dependency(dependencies : zlib_dep)
         dep.get_pkgconfig_variable('foo')
         '''
-        self.assertMesonRaises(code, "Method.*pkgconfig.*is invalid.*internal")
+        self.assertMesonRaises(code, ".*is not a pkgconfig dependency")
         code = '''zlib_dep = dependency('zlib', required : false)
         dep = declare_dependency(dependencies : zlib_dep)
         dep.get_configtool_variable('foo')

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -174,7 +174,7 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertEqual(libhello_nolib.get_variable(pkgconfig='foo'), 'bar')
         self.assertEqual(libhello_nolib.get_variable(pkgconfig='prefix'), self.prefix)
         impl = libhello_nolib.pkgconfig
-        if not isinstance(impl, PkgConfigCLI) or version_compare(PkgConfigCLI.check_pkgconfig(env, impl.pkgbin),">=0.29.1"):
+        if not isinstance(impl, PkgConfigCLI) or version_compare(impl.pkgbin_version, ">=0.29.1"):
             self.assertEqual(libhello_nolib.get_variable(pkgconfig='escaped_var'), r'hello\ world')
         self.assertEqual(libhello_nolib.get_variable(pkgconfig='unescaped_var'), 'hello world')
 

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -45,7 +45,7 @@ from mesonbuild.compilers.c import AppleClangCCompiler
 from mesonbuild.compilers.cpp import AppleClangCPPCompiler
 from mesonbuild.compilers.objc import AppleClangObjCCompiler
 from mesonbuild.compilers.objcpp import AppleClangObjCPPCompiler
-from mesonbuild.dependencies.pkgconfig import PkgConfigDependency, PkgConfigCLI
+from mesonbuild.dependencies.pkgconfig import PkgConfigDependency, PkgConfigCLI, PkgConfigInterface
 import mesonbuild.modules.pkgconfig
 
 PKG_CONFIG = os.environ.get('PKG_CONFIG', 'pkg-config')
@@ -1169,7 +1169,7 @@ class LinuxlikeTests(BasePlatformTests):
 
         # Regression test: This used to modify the value of `pkg_config_path`
         # option, adding the meson-uninstalled directory to it.
-        PkgConfigCLI.setup_env({}, env, MachineChoice.HOST, uninstalled=True)
+        PkgConfigInterface.setup_env({}, env, MachineChoice.HOST, uninstalled=True)
 
         pkg_config_path = env.coredata.options[OptionKey('pkg_config_path')].value
         self.assertEqual(pkg_config_path, [pkg_dir])

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -164,19 +164,19 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertTrue(foo_dep.found())
         self.assertEqual(foo_dep.get_version(), '1.0')
         self.assertIn('-lfoo', foo_dep.get_link_args())
-        self.assertEqual(foo_dep.get_pkgconfig_variable('foo', [], None), 'bar')
-        self.assertPathEqual(foo_dep.get_pkgconfig_variable('datadir', [], None), '/usr/data')
+        self.assertEqual(foo_dep.get_variable(pkgconfig='foo'), 'bar')
+        self.assertPathEqual(foo_dep.get_variable(pkgconfig='datadir'), '/usr/data')
 
         libhello_nolib = PkgConfigDependency('libhello_nolib', env, kwargs)
         self.assertTrue(libhello_nolib.found())
         self.assertEqual(libhello_nolib.get_link_args(), [])
         self.assertEqual(libhello_nolib.get_compile_args(), [])
-        self.assertEqual(libhello_nolib.get_pkgconfig_variable('foo', [], None), 'bar')
-        self.assertEqual(libhello_nolib.get_pkgconfig_variable('prefix', [], None), self.prefix)
+        self.assertEqual(libhello_nolib.get_variable(pkgconfig='foo'), 'bar')
+        self.assertEqual(libhello_nolib.get_variable(pkgconfig='prefix'), self.prefix)
         impl = libhello_nolib.pkgconfig
         if not isinstance(impl, PkgConfigCLI) or version_compare(PkgConfigCLI.check_pkgconfig(env, impl.pkgbin),">=0.29.1"):
-            self.assertEqual(libhello_nolib.get_pkgconfig_variable('escaped_var', [], None), r'hello\ world')
-        self.assertEqual(libhello_nolib.get_pkgconfig_variable('unescaped_var', [], None), 'hello world')
+            self.assertEqual(libhello_nolib.get_variable(pkgconfig='escaped_var'), r'hello\ world')
+        self.assertEqual(libhello_nolib.get_variable(pkgconfig='unescaped_var'), 'hello world')
 
         cc = detect_c_compiler(env, MachineChoice.HOST)
         if cc.get_id() in {'gcc', 'clang'}:


### PR DESCRIPTION
-    pkgconfig: Set PKG_CONFIG in env for devenv and g-ir-scanner

-    pkgconfig: Deprecate "pkgconfig" in favor of "pkg-config" in [binaries]

-    pkgconfig: Restore logging of pkg-config version
    
    While at it, make more methods private by storing the version found on
    the instance. That avoids having to call check_pkgconfig() as static
    method from unittests.

-    pkgconfig: Use lru_cache instead of caching command lines

-    pkgconfig: Cache the implementation instance

-    Remove get_configtool_variable()
    
    This also makes it more consistent with get_pkgconfig_variable() which
    always return empty value instead of failing when the variable does not
    exist. Linking that to self.required makes no sense and was never
    documented any way.

-    Remove get_pkgconfig_variable()
    
    Make sure that pkgconfig_define is a pair of strings and not a list with
    more than 2 strings.
