### PR TITLE
Replace deprecated GTK flag

### DIFF
--- a/docs/markdown/Tutorial.md
+++ b/docs/markdown/Tutorial.md
@@ -141,7 +141,7 @@ int main(int argc, char **argv)
   GtkApplication *app;
   int status;
 
-  app = gtk_application_new(NULL, G_APPLICATION_FLAGS_NONE);
+  app = gtk_application_new(NULL, G_APPLICATION_DEFAULT_FLAGS);
   g_signal_connect(app, "activate", G_CALLBACK(activate), NULL);
   status = g_application_run(G_APPLICATION(app), argc, argv);
   g_object_unref(app);


### PR DESCRIPTION
Before you would get a deprecation warning on compile:
```
warning: ‘G_APPLICATION_FLAGS_NONE’ is deprecated: Use 'G_APPLICATION_DEFAULT_FLAGS' instead [-Wdeprecated-declarations]
```

And now it's fixed!

Would you by any chance be interested in me updating `Tutorial.md` to GTK4?