### PR TITLE
Fix DUB dependencies (with cache description)

### DIFF
--- a/mesonbuild/modules/dlang.py
+++ b/mesonbuild/modules/dlang.py
@@ -28,8 +28,8 @@ class DlangModule(ExtensionModule):
         })
 
     def _init_dub(self, state):
-        if DlangModule.class_dubbin is None:
-            self.dubbin = DubDependency.class_dubbin
+        if DlangModule.class_dubbin is None and DubDependency.class_dubbin is not None:
+            self.dubbin = DubDependency.class_dubbin[0]
             DlangModule.class_dubbin = self.dubbin
         else:
             self.dubbin = DlangModule.class_dubbin

--- a/test cases/d/11 dub/meson.build
+++ b/test cases/d/11 dub/meson.build
@@ -1,10 +1,13 @@
 project('dub-example', 'd')
 
-error('MESON_SKIP_TEST: Dub support is broken at the moment (#11773)')
-
 dub_exe = find_program('dub', required : false)
 if not dub_exe.found()
   error('MESON_SKIP_TEST: Dub not found')
+endif
+
+dub_ver = dub_exe.version()
+if dub_ver.version_compare('>1.31.1') and dub_ver.version_compare('<1.35.0')
+  error('MESON_SKIP_TEST: Incompatible Dub version ' + dub_ver)
 endif
 
 urld_dep = dependency('urld', method: 'dub')

--- a/test cases/d/14 dub with deps/meson.build
+++ b/test cases/d/14 dub with deps/meson.build
@@ -1,10 +1,13 @@
 project('dub-with-deps-example', ['d'])
 
-error('MESON_SKIP_TEST: Dub support is broken at the moment (#11773)')
-
 dub_exe = find_program('dub', required : false)
 if not dub_exe.found()
     error('MESON_SKIP_TEST: Dub not found')
+endif
+
+dub_ver = dub_exe.version()
+if dub_ver.version_compare('>1.31.1') and dub_ver.version_compare('<1.35.0')
+  error('MESON_SKIP_TEST: Incompatible Dub version')
 endif
 
 if meson.get_compiler('d').get_id() == 'gcc'


### PR DESCRIPTION
Two PR has been merged into DUB which will help to use DUB packages with Meson:
 - dlang/dub#2644
   - add the `dub describe` output the path of the built library in Dub's cache
 - dlang/dub#2647
   - add `dub build --deep` switch to build a complete tree of static libraries

`dub build --deep` will build exactly the same libraries (same build-id) as the packages returned by `dub describe`.
So for a complex dependency tree (e.g. `vibe-d`), a single command (entered by the user) will build all the needed sub-libraries, and then meson will be able to find them all in a single shot.

This PR fixes #11773 and supersedes #11798