### PR TITLE
Fix: LLVM tool detection

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -630,7 +630,8 @@ class NinjaBackend(backends.Backend):
             key = OptionKey('b_coverage')
             if (key in self.environment.coredata.options and
                     self.environment.coredata.options[key].value):
-                gcovr_exe, gcovr_version, lcov_exe, lcov_version, genhtml_exe, _ = environment.find_coverage_tools()
+                gcovr_exe, gcovr_version, lcov_exe, lcov_version, genhtml_exe, llvm_cov_exe = environment.find_coverage_tools(self.environment.coredata)
+                mlog.debug(f'Using {gcovr_exe} ({gcovr_version}), {lcov_exe} and {llvm_cov_exe} for code coverage')
                 if gcovr_exe or (lcov_exe and genhtml_exe):
                     self.add_build_comment(NinjaComment('Coverage rules'))
                     self.generate_coverage_rules(gcovr_exe, gcovr_version)

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -171,7 +171,11 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
             trials = [defaults['gcc_static_linker']] + default_linkers
         elif compiler.id == 'clang':
             # Use llvm-ar if available; needed for LTO
-            trials = [defaults['clang_static_linker']] + default_linkers
+            llvm_ar = defaults['clang_static_linker']
+            # Extract the version major of the compiler to use as a suffix
+            suffix = compiler.version.split('.')[0]
+            # Prefer suffixed llvm-ar first, then unsuffixed then the defaults
+            trials = [[f'{llvm_ar[0]}-{suffix}'], llvm_ar] + default_linkers
         elif compiler.language == 'd':
             # Prefer static linkers over linkers used by D compilers
             if is_windows():

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -72,8 +72,7 @@ def _get_env_var(for_machine: MachineChoice, is_cross: bool, var_name: str) -> T
     return value
 
 
-def detect_gcovr(min_version: str = '3.3', log: bool = False):
-    gcovr_exe = 'gcovr'
+def detect_gcovr(gcovr_exe: str = 'gcovr', min_version: str = '3.3', log: bool = False):
     try:
         p, found = Popen_safe([gcovr_exe, '--version'])[0:2]
     except (FileNotFoundError, PermissionError):
@@ -86,8 +85,7 @@ def detect_gcovr(min_version: str = '3.3', log: bool = False):
         return gcovr_exe, found
     return None, None
 
-def detect_lcov(log: bool = False):
-    lcov_exe = 'lcov'
+def detect_lcov(lcov_exe: str = 'lcov', log: bool = False):
     try:
         p, found = Popen_safe([lcov_exe, '--version'])[0:2]
     except (FileNotFoundError, PermissionError):
@@ -107,16 +105,19 @@ def detect_llvm_cov():
             return tool
     return None
 
-def find_coverage_tools() -> T.Tuple[T.Optional[str], T.Optional[str], T.Optional[str], T.Optional[str], T.Optional[str], T.Optional[str]]:
+def detect_lcov_genhtml(lcov_exe: str = 'lcov', genhtml_exe: str = 'genhtml'):
+    lcov_exe, lcov_version = detect_lcov(lcov_exe)
+    if not mesonlib.exe_exists([genhtml_exe, '--version']):
+        genhtml_exe = None
+
+    return lcov_exe, lcov_version, genhtml_exe
+
+def find_coverage_tools(coredata: coredata.CoreData) -> T.Tuple[T.Optional[str], T.Optional[str], T.Optional[str], T.Optional[str], T.Optional[str], T.Optional[str]]:
     gcovr_exe, gcovr_version = detect_gcovr()
 
     llvm_cov_exe = detect_llvm_cov()
 
-    lcov_exe, lcov_version = detect_lcov()
-    genhtml_exe = 'genhtml'
-
-    if not mesonlib.exe_exists([genhtml_exe, '--version']):
-        genhtml_exe = None
+    lcov_exe, lcov_version, genhtml_exe = detect_lcov_genhtml()
 
     return gcovr_exe, gcovr_version, lcov_exe, lcov_version, genhtml_exe, llvm_cov_exe
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -188,6 +188,7 @@ def get_llvm_tool_names(tool: str) -> T.List[str]:
     # unless it becomes a stable release.
     suffixes = [
         '', # base (no suffix)
+        '-18',  '18',
         '-17',  '17',
         '-16',  '16',
         '-15',  '15',

--- a/mesonbuild/scripts/coverage.py
+++ b/mesonbuild/scripts/coverage.py
@@ -8,11 +8,19 @@ from mesonbuild import environment, mesonlib
 import argparse, re, sys, os, subprocess, pathlib, stat
 import typing as T
 
-def coverage(outputs: T.List[str], source_root: str, subproject_root: str, build_root: str, log_dir: str, use_llvm_cov: bool) -> int:
+def coverage(outputs: T.List[str], source_root: str, subproject_root: str, build_root: str, log_dir: str, use_llvm_cov: bool,
+             gcovr_exe: str, llvm_cov_exe: str) -> int:
     outfiles = []
     exitcode = 0
 
-    (gcovr_exe, gcovr_version, lcov_exe, lcov_version, genhtml_exe, llvm_cov_exe) = environment.find_coverage_tools()
+    if gcovr_exe == '':
+        gcovr_exe = None
+    else:
+        gcovr_exe, gcovr_version = environment.detect_gcovr(gcovr_exe)
+    if llvm_cov_exe == '' or not mesonlib.exe_exists([llvm_cov_exe, '--version']):
+        llvm_cov_exe = None
+
+    lcov_exe, lcov_version, genhtml_exe = environment.detect_lcov_genhtml()
 
     # load config files for tools if available in the source tree
     # - lcov requires manually specifying a per-project config
@@ -186,8 +194,12 @@ def run(args: T.List[str]) -> int:
                         const='sonarqube', help='generate Sonarqube Xml report')
     parser.add_argument('--html', dest='outputs', action='append_const',
                         const='html', help='generate Html report')
-    parser.add_argument('--use_llvm_cov', action='store_true',
+    parser.add_argument('--use-llvm-cov', action='store_true',
                         help='use llvm-cov')
+    parser.add_argument('--gcovr', action='store', default='',
+                        help='The gcovr executable to use if specified')
+    parser.add_argument('--llvm-cov', action='store', default='',
+                        help='The llvm-cov executable to use if specified')
     parser.add_argument('source_root')
     parser.add_argument('subproject_root')
     parser.add_argument('build_root')
@@ -195,7 +207,8 @@ def run(args: T.List[str]) -> int:
     options = parser.parse_args(args)
     return coverage(options.outputs, options.source_root,
                     options.subproject_root, options.build_root,
-                    options.log_dir, options.use_llvm_cov)
+                    options.log_dir, options.use_llvm_cov,
+                    options.gcovr, options.llvm_cov)
 
 if __name__ == '__main__':
     sys.exit(run(sys.argv[1:]))


### PR DESCRIPTION
In this PR, we attempt to implement the logic devised in issue #12145 and fix how Meson detects and uses LLVM tooling when Clang is picked as compiler.

This addresses Clang/LLVM 17 and 18 being a thing now for the get_llvm_tool_names hard-coded list. Plus it makes it so Meson does its best that if a specific suffixed Clang has been chosen, that it will also pick to use a matching specifically suffixed llvm-ar and llvm-cov rather than being able to pick older tools and configuring a broken build directory.

the GCOV environment variable is still ignored with this PR, which is still a problem, but that can be solved separately. Fixes #12145