### PR TITLE
tests: Skip "withIncludeFile" for PCH on Xcode backend

### DIFF
--- a/test cases/common/13 pch/meson.build
+++ b/test cases/common/13 pch/meson.build
@@ -13,7 +13,11 @@ subdir('cpp')
 subdir('generated')
 subdir('userDefined')
 subdir('withIncludeDirectories')
-subdir('withIncludeFile')
+if meson.backend() == 'xcode'
+  warning('Xcode backend does not support forced includes. Skipping "withIncludeFile" which requires this.')
+else
+  subdir('withIncludeFile')
+endif
 
 if meson.backend() == 'xcode'
   warning('Xcode backend only supports one precompiled header per target. Skipping "mixed" which has various precompiled headers.')


### PR DESCRIPTION
Xcode always fails here because this makes the PCH not be the first included header, causing Xcode to ignore it completely. There is no way around this.