### PR TITLE
include_directories: Always add both source and build dirs

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -389,7 +389,7 @@ class IncludeDirs(HoldableObject):
     def get_extra_build_dirs(self) -> T.List[str]:
         return self.extra_build_dirs
 
-    def to_string_list(self, sourcedir: str, builddir: T.Optional[str] = None) -> T.List[str]:
+    def to_string_list(self, sourcedir: str, builddir: str) -> T.List[str]:
         """Convert IncludeDirs object to a list of strings.
 
         :param sourcedir: The absolute source directory
@@ -400,8 +400,7 @@ class IncludeDirs(HoldableObject):
         strlist: T.List[str] = []
         for idir in self.incdirs:
             strlist.append(os.path.join(sourcedir, self.curdir, idir))
-            if builddir:
-                strlist.append(os.path.join(builddir, self.curdir, idir))
+            strlist.append(os.path.join(builddir, self.curdir, idir))
         return strlist
 
 @dataclass(eq=False)

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -257,7 +257,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
                         mode: CompileCheckMode = CompileCheckMode.LINK) -> T.List[str]:
         args: T.List[str] = []
         for i in kwargs['include_directories']:
-            for idir in i.to_string_list(self.environment.get_source_dir()):
+            for idir in i.to_string_list(self.environment.get_source_dir(), self.environment.get_build_dir()):
                 args.extend(self.compiler.get_include_args(idir, False))
         if not kwargs['no_builtin_args']:
             opts = self.environment.coredata.options

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -412,7 +412,7 @@ def list_deps(coredata: cdata.CoreData, backend: backends.Backend) -> T.List[T.D
             'version': d.get_version(),
             'compile_args': d.get_compile_args(),
             'link_args': d.get_link_args(),
-            'include_directories': [i for idirs in d.get_include_dirs() for i in idirs.to_string_list(backend.source_dir)],
+            'include_directories': [i for idirs in d.get_include_dirs() for i in idirs.to_string_list(backend.source_dir, backend.build_dir)],
             'sources': [f for s in d.get_sources() for f in _src_to_str(s)],
             'extra_files': [f for s in d.get_extra_files() for f in _src_to_str(s)],
             'dependencies': [e.name for e in d.ext_deps],

--- a/test cases/common/28 try compile/meson.build
+++ b/test cases/common/28 try compile/meson.build
@@ -12,8 +12,21 @@ warncode = '''#warning This is a warning
 int main(void) { return 0; }
 '''
 
+configure_file(
+  input: 'foo.h.in',
+  output: 'foo.h',
+  configuration: {},
+)
+
+header_code = '#include "foo.h"'
+
 foreach lang : ['c', 'cpp']
   compiler = meson.get_compiler(lang)
+
+  assert(not compiler.compiles(header_code, name: 'Should not include . by default'))
+  assert(compiler.compiles(header_code, name: 'Should include builddir',
+    include_directories: include_directories('.'),
+  ))
 
   if compiler.compiles(code, name : 'code should succeed') == false
     error('Compiler ' + compiler.get_id() + ' is fail.')


### PR DESCRIPTION
Compiler checks were not adding build dir side, which prevents using headers generated with configure_file().