### PR TITLE
Shader program compilation support

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -253,23 +253,26 @@ The following options are available. They can be set by passing
 the possible values they can take will depend on the target platform
 or compiler being used:
 
-| Option           | Default value | Possible values                          | Description |
-| ------           | ------------- | ---------------                          | ----------- |
-| c_args           |               | free-form comma-separated list           | C compile arguments to use |
-| c_link_args      |               | free-form comma-separated list           | C link arguments to use |
-| c_std            | none          | none, c89, c99, c11, c17, c18, c2x, gnu89, gnu99, gnu11, gnu17, gnu18, gnu2x | C language standard to use |
-| c_winlibs        | see below     | free-form comma-separated list           | Standard Windows libs to link against |
-| c_thread_count   | 4             | integer value ≥ 0                        | Number of threads to use with emcc when using threads |
-| cpp_args         |               | free-form comma-separated list           | C++ compile arguments to use |
-| cpp_link_args    |               | free-form comma-separated list           | C++ link arguments to use |
-| cpp_std          | none          | none, c++98, c++03, c++11, c++14, c++17, c++20 <br/>c++2a, c++1z, gnu++03, gnu++11, gnu++14, gnu++17, gnu++1z, <br/> gnu++2a, gnu++20, vc++14, vc++17, vc++20, vc++latest | C++ language standard to use |
-| cpp_debugstl     | false         | true, false                              | C++ STL debug mode |
-| cpp_eh           | default       | none, default, a, s, sc                  | C++ exception handling type |
-| cpp_rtti         | true          | true, false                              | Whether to enable RTTI (runtime type identification) |
-| cpp_thread_count | 4             | integer value ≥ 0                        | Number of threads to use with emcc when using threads |
-| cpp_winlibs      | see below     | free-form comma-separated list           | Standard Windows libs to link against |
-| fortran_std      | none          | [none, legacy, f95, f2003, f2008, f2018] | Fortran language standard to use |
-| cuda_ccbindir    |               | filesystem path                          | CUDA non-default toolchain directory to use (-ccbin) *(Added in 0.57.1)* |
+| Option           | Default value | Possible values                                                                                                                                                           | Description                                                              |
+|------------------|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
+| c_args           |               | free-form comma-separated list                                                                                                                                            | C compile arguments to use                                               |
+| c_link_args      |               | free-form comma-separated list                                                                                                                                            | C link arguments to use                                                  |
+| c_std            | none          | none, c89, c99, c11, c17, c18, c2x, gnu89, gnu99, gnu11, gnu17, gnu18, gnu2x                                                                                              | C language standard to use                                               |
+| c_winlibs        | see below     | free-form comma-separated list                                                                                                                                            | Standard Windows libs to link against                                    |
+| c_thread_count   | 4             | integer value ≥ 0                                                                                                                                                         | Number of threads to use with emcc when using threads                    |
+| cpp_args         |               | free-form comma-separated list                                                                                                                                            | C++ compile arguments to use                                             |
+| cpp_link_args    |               | free-form comma-separated list                                                                                                                                            | C++ link arguments to use                                                |
+| cpp_std          | none          | none, c++98, c++03, c++11, c++14, c++17, c++20 <br/>c++2a, c++1z, gnu++03, gnu++11, gnu++14, gnu++17, gnu++1z, <br/> gnu++2a, gnu++20, vc++14, vc++17, vc++20, vc++latest | C++ language standard to use                                             |
+| cpp_debugstl     | false         | true, false                                                                                                                                                               | C++ STL debug mode                                                       |
+| cpp_eh           | default       | none, default, a, s, sc                                                                                                                                                   | C++ exception handling type                                              |
+| cpp_rtti         | true          | true, false                                                                                                                                                               | Whether to enable RTTI (runtime type identification)                     |
+| cpp_thread_count | 4             | integer value ≥ 0                                                                                                                                                         | Number of threads to use with emcc when using threads                    |
+| cpp_winlibs      | see below     | free-form comma-separated list                                                                                                                                            | Standard Windows libs to link against                                    |
+| fortran_std      | none          | [none, legacy, f95, f2003, f2008, f2018]                                                                                                                                  | Fortran language standard to use                                         |
+| cuda_ccbindir    |               | filesystem path                                                                                                                                                           | CUDA non-default toolchain directory to use (-ccbin) *(Added in 0.57.1)* |
+| glsl_std         |               | concatenation of version and profile, e.g. 310es, 450core, etc.                                                                                                           | Version and profile for GLSL shaders                                     |
+| glsl_target_env  |               | vulkan, vulkan1.0, vulkan1.1, vulkan1.2, vulkan1.3, opengl, opengl4.5                                                                                                     | Target execution environment for GLSL shaders                            |
+| glsl_target_spv  |               | spv1.0, spv1.1, spv1.2, spv1.3, spv1.4, spv1.5, spv1.6                                                                                                                    | SPIR-V output version for GLSL shaders                                   |
 
 The default values of `c_winlibs` and `cpp_winlibs` are in
 compiler-specific argument forms, but the libraries are: kernel32,

--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -5,47 +5,48 @@
 These are return values of the `get_id` (Compiler family) and
 `get_argument_syntax` (Argument syntax) method in a compiler object.
 
-| Value     | Compiler family                  | Argument syntax |
-| -----     | ---------------                  | --------------- |
-| arm       | ARM compiler                     |                 |
-| armclang  | ARMCLANG compiler                |                 |
-| ccomp     | The CompCert formally-verified C compiler |        |
-| ccrx      | Renesas RX Family C/C++ compiler |                 |
-| clang     | The Clang compiler               | gcc             |
-| clang-cl  | The Clang compiler (MSVC compatible driver) | msvc |
-| dmd       | D lang reference compiler        |                 |
-| emscripten| Emscripten WASM compiler         |                 |
-| flang     | Flang Fortran compiler           |                 |
-| g95       | The G95 Fortran compiler         |                 |
-| gcc       | The GNU Compiler Collection      | gcc             |
-| intel     | Intel compiler (Linux and Mac)   | gcc             |
-| intel-cl  | Intel compiler (Windows)         | msvc            |
-| intel-llvm    | Intel oneAPI LLVM-based compiler            |                 |
-| intel-llvm-cl | Intel oneAPI LLVM-based compiler (Windows)  | msvc            |
-| lcc       | Elbrus C/C++/Fortran Compiler    |                 |
-| llvm      | LLVM-based compiler (Swift, D)   |                 |
-| mono      | Xamarin C# compiler              |                 |
-| mwccarm   | Metrowerks C/C++ compiler for Embedded ARM         |                 |
-| mwcceppc  | Metrowerks C/C++ compiler for Embedded PowerPC     |                 |
-| msvc      | Microsoft Visual Studio          | msvc            |
-| nagfor    | The NAG Fortran compiler         |                 |
-| nvidia_hpc| NVidia HPC SDK compilers         |                 |
-| open64    | The Open64 Fortran Compiler      |                 |
-| pathscale | The Pathscale Fortran compiler   |                 |
-| pgi       | Portland PGI C/C++/Fortran compilers |             |
-| rustc     | Rust compiler                    |                 |
-| sun       | Sun Fortran compiler             |                 |
-| c2000     | Texas Instruments C/C++ Compiler (C2000) |                 |
-| ti        | Texas Instruments C/C++ Compiler |                 |
-| valac     | Vala compiler                    |                 |
-| xc16      | Microchip XC16 C compiler        |                 |
-| cython    | The Cython compiler              |                 |
-| nasm      | The NASM compiler (Since 0.64.0) |                 |
-| yasm      | The YASM compiler (Since 0.64.0) |                 |
-| ml        | Microsoft Macro Assembler for x86 and x86_64 (Since 0.64.0) | msvc |
-| armasm    | Microsoft Macro Assembler for ARM and AARCH64 (Since 0.64.0) | |
-| mwasmarm        | Metrowerks Assembler for Embedded ARM | |
-| mwasmeppc       | Metrowerks Assembler for Embedded PowerPC | |
+| Value         | Compiler family                                              | Argument syntax |
+|---------------|--------------------------------------------------------------|-----------------|
+| arm           | ARM compiler                                                 |                 |
+| armclang      | ARMCLANG compiler                                            |                 |
+| ccomp         | The CompCert formally-verified C compiler                    |                 |
+| ccrx          | Renesas RX Family C/C++ compiler                             |                 |
+| clang         | The Clang compiler                                           | gcc             |
+| clang-cl      | The Clang compiler (MSVC compatible driver)                  | msvc            |
+| dmd           | D lang reference compiler                                    |                 |
+| emscripten    | Emscripten WASM compiler                                     |                 |
+| flang         | Flang Fortran compiler                                       |                 |
+| g95           | The G95 Fortran compiler                                     |                 |
+| gcc           | The GNU Compiler Collection                                  | gcc             |
+| intel         | Intel compiler (Linux and Mac)                               | gcc             |
+| intel-cl      | Intel compiler (Windows)                                     | msvc            |
+| intel-llvm    | Intel oneAPI LLVM-based compiler                             |                 |
+| intel-llvm-cl | Intel oneAPI LLVM-based compiler (Windows)                   | msvc            |
+| lcc           | Elbrus C/C++/Fortran Compiler                                |                 |
+| llvm          | LLVM-based compiler (Swift, D)                               |                 |
+| mono          | Xamarin C# compiler                                          |                 |
+| mwccarm       | Metrowerks C/C++ compiler for Embedded ARM                   |                 |
+| mwcceppc      | Metrowerks C/C++ compiler for Embedded PowerPC               |                 |
+| msvc          | Microsoft Visual Studio                                      | msvc            |
+| nagfor        | The NAG Fortran compiler                                     |                 |
+| nvidia_hpc    | NVidia HPC SDK compilers                                     |                 |
+| open64        | The Open64 Fortran Compiler                                  |                 |
+| pathscale     | The Pathscale Fortran compiler                               |                 |
+| pgi           | Portland PGI C/C++/Fortran compilers                         |                 |
+| rustc         | Rust compiler                                                |                 |
+| sun           | Sun Fortran compiler                                         |                 |
+| c2000         | Texas Instruments C/C++ Compiler (C2000)                     |                 |
+| ti            | Texas Instruments C/C++ Compiler                             |                 |
+| valac         | Vala compiler                                                |                 |
+| xc16          | Microchip XC16 C compiler                                    |                 |
+| cython        | The Cython compiler                                          |                 |
+| nasm          | The NASM compiler (Since 0.64.0)                             |                 |
+| yasm          | The YASM compiler (Since 0.64.0)                             |                 |
+| ml            | Microsoft Macro Assembler for x86 and x86_64 (Since 0.64.0)  | msvc            |
+| armasm        | Microsoft Macro Assembler for ARM and AARCH64 (Since 0.64.0) |                 |
+| mwasmarm      | Metrowerks Assembler for Embedded ARM                        |                 |
+| mwasmeppc     | Metrowerks Assembler for Embedded PowerPC                    |                 |
+| glslc         | GLSL Compiler                                                |                 |
 
 ## Linker ids
 
@@ -204,7 +205,7 @@ These are the parameter names for passing language specific arguments
 to your build target.
 
 | Language      | compiler name | linker name       |
-| ------------- | ------------- | ----------------- |
+|---------------|---------------|-------------------|
 | C             | c_args        | c_link_args       |
 | C++           | cpp_args      | cpp_link_args     |
 | C#            | cs_args       | cs_link_args      |
@@ -218,6 +219,7 @@ to your build target.
 | Cython        | cython_args   | cython_link_args  |
 | NASM          | nasm_args     | N/A               |
 | MASM          | masm_args     | N/A               |
+| GLSL          | glsl_args     |                   |
 
 All these `<lang>_*` options are specified per machine. See in
 [specifying options per

--- a/docs/markdown/Shaders.md
+++ b/docs/markdown/Shaders.md
@@ -1,0 +1,14 @@
+---
+title: Shaders
+short-description: Compiling shader programs
+...
+
+# Compiling shader programs
+
+Meson has support for compiling shaders written in GLSL. This is done through the shader() function:
+
+```meson
+project('shader_example', 'glsl')
+
+shader('example_shader_program', 'example.vert')
+```

--- a/docs/markdown/snippets/shader_support.md
+++ b/docs/markdown/snippets/shader_support.md
@@ -1,0 +1,12 @@
+## Shader language support
+
+Added support for shader program compilation. This includes
+the GLSL language, glslc compiler, and the new shader() function.
+Also adds the options `glsl_target_env`, `glsl_target_spv` and `glsl_std`
+to default_options to control different aspects of the GLSL compiler.
+
+```meson
+project('shaders', 'glsl')
+
+shader('example', 'example.vert')
+```

--- a/docs/sitemap.txt
+++ b/docs/sitemap.txt
@@ -64,6 +64,7 @@ index.md
 		D.md
 		Cython.md
 		Rust.md
+		Shaders.md
 		IDE-integration.md
 		Custom-build-targets.md
 		Build-system-converters.md

--- a/docs/yaml/functions/build_target.yaml
+++ b/docs/yaml/functions/build_target.yaml
@@ -13,6 +13,7 @@ description: |
   - `both_libraries` (see [[both_libraries]])
   - `library` (see [[library]])
   - `jar` (see [[jar]])*
+  - 'shader' (see [[shader]])
 
   This declaration:
 

--- a/docs/yaml/functions/project.yaml
+++ b/docs/yaml/functions/project.yaml
@@ -24,7 +24,7 @@ description: |
 
   Supported values for languages are `c`, `cpp` (for `C++`), `cuda`,
   `cython`, `d`, `objc`, `objcpp`, `fortran`, `java`, `cs` (for `C#`),
-  `vala` and `rust`.
+  `vala`, `rust` and `glsl`.
 
 posargs:
   project_name:

--- a/docs/yaml/functions/shader.yaml
+++ b/docs/yaml/functions/shader.yaml
@@ -1,0 +1,9 @@
+name: shader
+returns: shader
+
+description: |
+  Build a shader program from the specified GLSL source files.
+
+posargs_inherit: _build_target_base
+varargs_inherit: _build_target_base
+kwargs_inherit: _build_target_base

--- a/docs/yaml/objects/shader.yaml
+++ b/docs/yaml/objects/shader.yaml
@@ -1,0 +1,4 @@
+name: shader
+long_name: Shader build target
+description: A shader build target
+extends: build_tgt

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -73,6 +73,7 @@ lang_suffixes = {
     'cython': ('pyx', ),
     'nasm': ('asm',),
     'masm': ('masm',),
+    'glsl': ('vert', 'frag', 'geom', 'tesc', 'tese', 'comp', 'rgen', 'rint', 'rahit', 'rchit', 'rmiss', '.rcall'),
 }
 all_languages = lang_suffixes.keys()
 c_cpp_suffixes = {'h'}

--- a/mesonbuild/compilers/shader.py
+++ b/mesonbuild/compilers/shader.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import typing as T
+
+from .. import coredata
+
+from .compilers import Compiler
+from .mixins.islinker import BasicLinkerIsCompilerMixin
+from ..mesonlib import EnvironmentException, OptionKey
+
+if T.TYPE_CHECKING:
+    from ..envconfig import MachineInfo
+    from ..environment import Environment
+    from ..mesonlib import MachineChoice
+    from ..coredata import KeyedOptionDictType, UserComboOption, MutableKeyedOptionDictType
+
+glslc_optimization_args: T.Dict[str, T.List[str]] = {
+    'plain': [],
+    '0': ['-O0'],
+    'g': ['-O'],
+    '1': ['-O'],
+    '2': ['-O'],
+    '3': ['-O'],
+    's': ['-Os'],
+}
+
+glslc_buildtype_args: T.Dict[str, T.List[str]] = {
+    'plain': [],
+    'debug': ['-g'],
+    'debugoptimized': ['-g', '-O'],
+    'release': ['-O'],
+    'minsize': ['-Os'],
+    'custom': [],
+}
+
+
+class GlslcCompiler(BasicLinkerIsCompilerMixin, Compiler):
+    id = 'glslc'
+    language = 'glsl'
+
+    def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, info: 'MachineInfo'):
+        super().__init__([], exelist, version, for_machine, info)
+
+    def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
+        code = '#version 450\nvoid main() {}'
+        with self.cached_compile(code, environment.coredata) as p:
+            if p.returncode != 0:
+                raise EnvironmentException(f'Cython compiler {self.id!r} cannot compile programs')
+
+    def compute_parameters_with_absolute_paths(self, parameter_list: T.List[str],
+                                               build_dir: str) -> T.List[str]:
+        return parameter_list
+
+    def needs_static_linker(self) -> bool:
+        return False
+
+    def get_output_args(self, outputname: str) -> T.List[str]:
+        return ['-o', outputname]
+
+    def get_optimization_args(self, optimization_level: str) -> T.List[str]:
+        return glslc_optimization_args[optimization_level]
+
+    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
+        return glslc_buildtype_args[buildtype]
+
+    def get_debug_args(self, is_debug: bool) -> T.List[str]:
+        if is_debug:
+            return ['-g']
+        return []
+
+    def get_no_optimization_args(self) -> T.List[str]:
+        return ['-O0']
+
+    def get_werror_args(self) -> T.List[str]:
+        return ['-Werror']
+
+    def get_no_warn_args(self) -> T.List[str]:
+        return ['-w']
+
+    def get_preprocess_only_args(self) -> T.List[str]:
+        return ['-E']
+
+    def get_compile_only_args(self) -> T.List[str]:
+        return ['-c']
+
+    def get_include_args(self, path: str, is_system: bool) -> T.List[str]:
+        return ['-I', path]
+
+    def get_depfile_suffix(self) -> str:
+        return ''
+
+    def get_options(self) -> 'MutableKeyedOptionDictType':
+        opts = super().get_options()
+        target_env_key = OptionKey('target_env', lang=self.language)
+        target_spv_key = OptionKey('target_spv', lang=self.language)
+        std_key = OptionKey('std', lang=self.language)
+        target_env_choices = ['', 'vulkan', 'vulkan1.0', 'vulkan1.1', 'vulkan1.2', 'vulkan1.3', 'opengl',
+                              'opengl4.5']
+        target_spv_choices = ['', 'spv1.0', 'spv1.1', 'spv1.2', 'spv1.3', 'spv1.4', 'spv1.5', 'spv1.6']
+        std_choices = ['', '150core', '150es', '150compatibility', '330core', '330es', '330compatibility',
+                       '400core', '400es', '400compatibility', '410core', '410es', '410compatibility',
+                       '420core', '420es', '420compatibility', '430core', '430es', '430compatibility',
+                       '440core', '440es', '440compatibility', '450core', '450es', '450compatibility',
+                       '460core', '460es', '460compatibility']
+        opts.update({
+            target_env_key: coredata.UserComboOption('Target execution environment for GLSL shaders',
+                                                     target_env_choices, ''),
+            target_spv_key: coredata.UserComboOption('SPIR-V output version for GLSL shaders', target_spv_choices, ''),
+            std_key: coredata.UserComboOption('Version and profile for GLSL shaders', std_choices, ''),
+        })
+        return opts
+
+    def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+        target_env_key = OptionKey('target_env', lang=self.language)
+        target_spv_key = OptionKey('target_spv', lang=self.language)
+        std_key = OptionKey('std', lang=self.language)
+
+        target_env = options[target_env_key].value
+        target_spv = options[target_spv_key].value
+        std = options[std_key].value
+
+        args = []
+
+        if isinstance(target_env, str) and target_env != '':
+            args.append(f'--target-env={target_env}')
+        if isinstance(target_spv, str) and target_spv != '':
+            args.append(f'--target-spv={target_spv}')
+        if isinstance(std, str) and std != '':
+            args.append(f'--std={std}')
+
+        return args

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -961,6 +961,9 @@ class SharedModuleHolder(BuildTargetHolder[build.SharedModule]):
 class JarHolder(BuildTargetHolder[build.Jar]):
     pass
 
+class ShaderHolder(BuildTargetHolder[build.Shader]):
+    pass
+
 class CustomTargetIndexHolder(ObjectHolder[build.CustomTargetIndex]):
     def __init__(self, target: build.CustomTargetIndex, interp: 'Interpreter'):
         super().__init__(target, interp)

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -370,6 +370,10 @@ class Jar(_BaseBuildTarget):
     java_resources: T.Optional[build.StructuredSources]
 
 
+class Shader(_BaseBuildTarget):
+    pass
+
+
 class FuncDeclareDependency(TypedDict):
 
     compile_args: T.List[str]

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -612,6 +612,16 @@ JAR_KWS = [
     *_EXCLUSIVE_JAR_KWS,
 ]
 
+# Arguments exclusive to Shader. These are separated to make integrating
+# them into build_target easier
+_EXCLUSIVE_SHADER_KWS: T.List[KwargInfo] = []
+
+# The total list of arguments used by JAR
+SHADER_KWS = [
+    *_ALL_TARGET_KWS,
+    *_EXCLUSIVE_SHADER_KWS,
+]
+
 # Arguments used by both_library and library
 LIBRARY_KWS = [
     *_BUILD_TARGET_KWS,

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -86,7 +86,8 @@ if T.TYPE_CHECKING:
 ALL_TESTS = ['cmake', 'common', 'native', 'warning-meson', 'failing-meson', 'failing-build', 'failing-test',
              'keyval', 'platform-osx', 'platform-windows', 'platform-linux',
              'java', 'C#', 'vala', 'cython', 'rust', 'd', 'objective c', 'objective c++',
-             'fortran', 'swift', 'cuda', 'python3', 'python', 'fpga', 'frameworks', 'nasm', 'wasm', 'wayland'
+             'fortran', 'swift', 'cuda', 'python3', 'python', 'fpga', 'frameworks', 'nasm', 'wasm', 'wayland',
+             'shader'
              ]
 
 
@@ -1133,6 +1134,7 @@ def detect_tests_to_run(only: T.Dict[str, T.List[str]], use_tmp: bool) -> T.List
         TestCategory('nasm', 'nasm'),
         TestCategory('wasm', 'wasm', shutil.which('emcc') is None or backend is not Backend.ninja),
         TestCategory('wayland', 'wayland', should_skip_wayland()),
+        TestCategory('shader', 'shader'),
     ]
 
     categories = [t.category for t in all_tests]

--- a/test cases/shader/1 basic/basic.vert
+++ b/test cases/shader/1 basic/basic.vert
@@ -1,0 +1,7 @@
+#version 450
+
+layout(location = 0) in vec3 pos;
+
+void main() {
+    gl_Position = vec4(pos, 0.0);
+}

--- a/test cases/shader/1 basic/meson.build
+++ b/test cases/shader/1 basic/meson.build
@@ -1,0 +1,6 @@
+project('shader_test_1_basic', 'glsl')
+
+shader('basic',
+  'basic.vert',
+  install: true,
+  install_dir: get_option('bindir'))

--- a/test cases/shader/1 basic/test.json
+++ b/test cases/shader/1 basic/test.json
@@ -1,0 +1,5 @@
+{
+  "installed": [
+    {"type": "file", "file": "usr/bin/basic.spv"}
+  ]
+}


### PR DESCRIPTION
Decided to implement this because in my project I have a lot shaders to compile in a lot of places, and I would have to write my own build system specifically for shaders. It would be better to just have another command for this. #7071 asked for this to be done with executable() or library() but a shader is neither of those and i couldn't figure out how to make that work, so this introduces a new function, shader().

I've only implemented GLSL and glslc, but other languages and compilers should be easy to implement.
