### PR TITLE
FAQ: MinGW UCRT are compatible with MSVC and also use libfoo.a

### DIFF
--- a/docs/markdown/FAQ.md
+++ b/docs/markdown/FAQ.md
@@ -405,6 +405,9 @@ advantages:
    not care what the extension is](https://docs.microsoft.com/en-us/cpp/build/reference/link-input-files?view=vs-2019),
    so specifying `libfoo.a` instead of `foo.lib` does not change the workflow,
    and is an improvement since it's less ambiguous.
+1. Projects built with the MinGW compiler are fully compatible with
+   MSVC as long as they use the same CRT (e.g. UCRT with MSYS2).
+   These projects also name their static libraries `libfoo.a`.
 
 If, for some reason, you really need your project to output static
 libraries of the form `foo.lib` when building with MSVC, you can set


### PR DESCRIPTION
Prior to Windows 10, libfoo.a were usually not usable with MSVC. This is not true any more since Autotools projects built with UCRT produce libfoo.a that are compatible with MSVC.

This is another reason for using that naming convention in Meson.