### PR TITLE
gnome: Fix crash in gtkdoc and generate_gir in C++ projects

### DIFF
--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -167,6 +167,8 @@ class ModuleState:
             else:
                 yield self._interpreter.build_incdir_object([d])
 
+    def add_language(self, lang: str, for_machine: MachineChoice) -> None:
+        self._interpreter.add_languages([lang], True, for_machine)
 
 class ModuleObject(HoldableObject):
     """Base class for all objects returned by modules

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1113,6 +1113,9 @@ class GnomeModule(ExtensionModule):
     )
     def generate_gir(self, state: 'ModuleState', args: T.Tuple[T.List[T.Union[Executable, build.SharedLibrary, build.StaticLibrary]]],
                      kwargs: 'GenerateGir') -> ModuleReturnValue:
+        # Ensure we have a C compiler even in C++ projects.
+        state.add_language('c', MachineChoice.HOST)
+
         girtargets = [self._unwrap_gir_target(arg, state) for arg in args[0]]
         if len(girtargets) > 1 and any(isinstance(el, Executable) for el in girtargets):
             raise MesonException('generate_gir only accepts a single argument when one of the arguments is an executable')
@@ -1429,6 +1432,9 @@ class GnomeModule(ExtensionModule):
         command = state.environment.get_build_command()
 
         namespace = kwargs['namespace']
+
+        # Ensure we have a C compiler even in C++ projects.
+        state.add_language('c', MachineChoice.HOST)
 
         def abs_filenames(files: T.Iterable['FileOrString']) -> T.Iterator[str]:
             for f in files:

--- a/test cases/frameworks/36 gtkdoc cpp/foo-docs.xml
+++ b/test cases/frameworks/36 gtkdoc cpp/foo-docs.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!DOCTYPE book PUBLIC '-//OASIS//DTD DocBook XML V4.5//EN'
+                      'http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd' [
+<!ENTITY % local.common.attrib "xmlns:xi  CDATA  #FIXED 'http://www.w3.org/2003/XInclude'">
+<!ENTITY version SYSTEM "version.xml">
+]>
+<book id="index" xmlns:xi="http://www.w3.org/2003/XInclude">
+  <bookinfo>
+    <title>Foo Reference Manual</title>
+  </bookinfo>
+
+  <chapter id="foo">
+    <title>GLib Core Application Support</title>
+    <xi:include href="xml/foo.xml" />
+  </chapter>
+</book>

--- a/test cases/frameworks/36 gtkdoc cpp/foo.cpp
+++ b/test cases/frameworks/36 gtkdoc cpp/foo.cpp
@@ -1,0 +1,5 @@
+#include "foo.h"
+
+int foo_do_something(void) {
+    return 42;
+}

--- a/test cases/frameworks/36 gtkdoc cpp/foo.h
+++ b/test cases/frameworks/36 gtkdoc cpp/foo.h
@@ -1,0 +1,1 @@
+int foo_do_something(void);

--- a/test cases/frameworks/36 gtkdoc cpp/meson.build
+++ b/test cases/frameworks/36 gtkdoc cpp/meson.build
@@ -1,0 +1,13 @@
+project('gnome module without C', 'cpp')
+
+gtkdoc = find_program('gtkdoc-scan', required: false)
+if not gtkdoc.found()
+  error('MESON_SKIP_TEST gtkdoc not found.')
+endif
+
+gnome = import('gnome')
+
+lib = library('foo++', 'foo.cpp')
+gnome.gtkdoc('foo',
+  src_dir: '.',
+  main_xml : 'foo-docs.xml',)

--- a/test cases/frameworks/36 gtkdoc cpp/test.json
+++ b/test cases/frameworks/36 gtkdoc cpp/test.json
@@ -1,0 +1,17 @@
+{
+  "installed": [
+    {"type": "file", "file": "usr/share/gtk-doc/html/foo/up-insensitive.png"},
+    {"type": "file", "file": "usr/share/gtk-doc/html/foo/home.png"},
+    {"type": "file", "file": "usr/share/gtk-doc/html/foo/foo.html"},
+    {"type": "file", "file": "usr/share/gtk-doc/html/foo/foo-foo.html"},
+    {"type": "file", "file": "usr/share/gtk-doc/html/foo/style.css"},
+    {"type": "file", "file": "usr/share/gtk-doc/html/foo/index.html"},
+    {"type": "file", "file": "usr/share/gtk-doc/html/foo/foo.devhelp2"},
+    {"type": "file", "file": "usr/share/gtk-doc/html/foo/left.png"},
+    {"type": "file", "file": "usr/share/gtk-doc/html/foo/left-insensitive.png"},
+    {"type": "file", "file": "usr/share/gtk-doc/html/foo/right-insensitive.png"},
+    {"type": "file", "file": "usr/share/gtk-doc/html/foo/up.png"},
+    {"type": "file", "file": "usr/share/gtk-doc/html/foo/right.png"}
+  ],
+  "skip_on_jobname": ["azure", "msys2"]
+}

--- a/test cases/frameworks/37 gir cpp/foo.cpp
+++ b/test cases/frameworks/37 gir cpp/foo.cpp
@@ -1,0 +1,5 @@
+#include "foo.h"
+
+int foo_do_something(void) {
+    return 42;
+}

--- a/test cases/frameworks/37 gir cpp/foo.h
+++ b/test cases/frameworks/37 gir cpp/foo.h
@@ -1,0 +1,1 @@
+int foo_do_something(void);

--- a/test cases/frameworks/37 gir cpp/meson.build
+++ b/test cases/frameworks/37 gir cpp/meson.build
@@ -1,0 +1,16 @@
+project('gnome module without C', 'cpp')
+
+gi = dependency('gobject-introspection-1.0', required: false)
+if not gi.found()
+  error('MESON_SKIP_TEST gobject-introspection not found.')
+endif
+
+gnome = import('gnome')
+
+lib = library('foo++', 'foo.cpp')
+gnome.generate_gir(
+  lib,
+  sources: ['foo.cpp', 'foo.h'],
+  namespace: 'foo',
+  nsversion: meson.project_version(),
+)

--- a/test cases/frameworks/37 gir cpp/test.json
+++ b/test cases/frameworks/37 gir cpp/test.json
@@ -1,0 +1,3 @@
+{
+  "skip_on_jobname": ["azure", "macos", "msys2"]
+}


### PR DESCRIPTION
gtkdoc() and generate_gir() methods assumes there is a C compiler, but pure C++ projects might not add it explicitly.

Fixes: #12162