### PR TITLE
Add linker detection for older Darwin linkers

### DIFF
--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -186,16 +186,16 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
 
         linker = linkers.LLVMDynamicLinker(compiler, for_machine, comp_class.LINKER_PREFIX, override, version=v)
     # first might be apple clang, second is for real gcc, the third is icc
-    elif e.endswith('(use -v to see invocation)\n') or 'macosx_version' in e or 'ld: unknown option:' in e:
+    elif e.endswith('(use -v to see invocation)\n') or 'macosx_version' in e or ': unknown option:' in e or ': unknown flag:' in e:
         if isinstance(comp_class.LINKER_PREFIX, str):
             cmd = compiler + [comp_class.LINKER_PREFIX + '-v'] + extra_args
         else:
             cmd = compiler + comp_class.LINKER_PREFIX + ['-v'] + extra_args
         _, newo, newerr = Popen_safe_logged(cmd, msg='Detecting Apple linker via')
 
-        for line in newerr.split('\n'):
-            if 'PROJECT:ld' in line or 'PROJECT:dyld' in line:
-                v = line.split('-')[1]
+        for word in (newo + '\n' + newerr).split():
+            if 'PROJECT:ld' in word or 'PROJECT:dyld' in word or 'cctools-' in word:
+                v = word.split('-')[1]
                 break
         else:
             __failed_to_detect_linker(compiler, check_args, o, e)


### PR DESCRIPTION
This PR makes a couple of slight tweaks to the linker detection, which allows it to detect `ld` and `ld64` from Tiger and Leopard.

The only risk in this PR is the addition of the `or ': unknown flag:' in e` predicate to the Apple case of the if/elif structure:

Because this is a chain of if/elif, if any of the linkers from the proceeding elif cases (GNU, Solaris, AIX) happen to produce `: unknown flag:` in their error output, they will now erroneously get caught by the Apple case.

I unfortunately don't have a Solaris or AIX box handy, so while I think this chance is very small, I can't actually be 100% certain.