### PR TITLE
Use HOMEBREW_PREFIX for searching if it's set

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1377,6 +1377,11 @@ BUILTIN_DIR_NOPREFIX_OPTIONS: T.Dict[OptionKey, T.Dict[str, str]] = {
     OptionKey('purelibdir', module='python'): {},
 }
 
+if 'HOMEBREW_PREFIX' in os.environ:
+    homebrew_prefix = os.environ['HOMEBREW_PREFIX']
+    BUILTIN_DIR_NOPREFIX_OPTIONS[OptionKey('localstatedir')][homebrew_prefix] = homebrew_prefix
+    BUILTIN_DIR_NOPREFIX_OPTIONS[OptionKey('sharedstatedir')][homebrew_prefix] = homebrew_prefix + '/lib'
+
 FORBIDDEN_TARGET_NAMES = frozenset({
     'clean',
     'clean-ctlist',

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import os
 import re
 import dataclasses
 import functools
@@ -701,6 +702,10 @@ class BoostDependency(SystemDependency):
             tmp += [Path('/usr/local/opt/boost')]
             tmp += [Path('/usr/local')]
             tmp += [Path('/usr')]
+
+            if "HOMEBREW_PREFIX" in os.environ:
+                tmp += [Path(os.environ["HOMEBREW_PREFIX"])]
+                tmp += [Path(os.environ["HOMEBREW_PREFIX"] + "/opt/boost")]
 
             # Cleanup paths
             tmp = [x for x in tmp if x.is_dir()]

--- a/mesonbuild/dependencies/cuda.py
+++ b/mesonbuild/dependencies/cuda.py
@@ -58,6 +58,11 @@ class CudaDependency(SystemDependency):
                     req_modules += ['rt', 'pthread', 'dl']
             self.requested_modules = req_modules + self.requested_modules
 
+        if 'HOMEBREW_PREFIX' in os.environ:
+            self.local_path = os.environ['HOMEBREW_PREFIX']
+        else:
+            self.local_path = '/usr/local'
+
         (self.cuda_path, self.version, self.is_found) = self._detect_cuda_path_and_version()
         if not self.is_found:
             return
@@ -116,7 +121,7 @@ class CudaDependency(SystemDependency):
             return (defaults[0][0], defaults[0][1], True)
 
         platform_msg = 'set the CUDA_PATH environment variable' if self._is_windows() \
-            else 'set the CUDA_PATH environment variable/create the \'/usr/local/cuda\' symbolic link'
+            else f'set the CUDA_PATH environment variable/create the \'{self.local_path}/cuda\' symbolic link'
         msg = f'Please specify the desired CUDA Toolkit version (e.g. dependency(\'cuda\', version : \'>=10.1\')) or {platform_msg} to point to the location of your desired version.'
         return self._report_dependency_error(msg, (None, None, False))
 
@@ -130,7 +135,7 @@ class CudaDependency(SystemDependency):
         mlog.debug(f'Search paths: {paths}')
 
         if nvcc_version and defaults:
-            default_src = f"the {self.env_var} environment variable" if self.env_var else "the \'/usr/local/cuda\' symbolic link"
+            default_src = f"the {self.env_var} environment variable" if self.env_var else f"the \'{self.local_path}/cuda\' symbolic link"
             nvcc_warning = 'The default CUDA Toolkit as designated by {} ({}) doesn\'t match the current nvcc version {} and will be ignored.'.format(default_src, os.path.realpath(defaults[0][0]), nvcc_version)
         else:
             nvcc_warning = None
@@ -164,7 +169,7 @@ class CudaDependency(SystemDependency):
 
     def _cuda_paths_nix(self) -> T.List[T.Tuple[str, bool]]:
         # include /usr/local/cuda default only if no env_var was found
-        pattern = '/usr/local/cuda-*' if self.env_var else '/usr/local/cuda*'
+        pattern = f'{self.local_path}/cuda-*' if self.env_var else f'{self.local_path}/cuda*'
         return [(path, os.path.basename(path) == 'cuda') for path in glob.iglob(pattern)]
 
     toolkit_version_regex = re.compile(r'^CUDA Version\s+(.*)$')

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -1051,6 +1051,8 @@ def default_prefix() -> str:
         return 'c:/'
     if is_haiku():
         return '/boot/system/non-packaged'
+    if 'HOMEBREW_PREFIX' in os.environ:
+        return os.environ['HOMEBREW_PREFIX']
     return '/usr/local'
 
 


### PR DESCRIPTION
Fixes https://github.com/mesonbuild/meson-python/issues/462

Currently Homebrew patches meson to replace usage of /usr/local with /opt/homebrew. This patch set does a cleaner job and should allow meson-python to work correctly on M1/M2 macs.