### PR TITLE
Add clang-tidy-fix target

### DIFF
--- a/docs/markdown/snippets/meson_clang_tidy_fix.md
+++ b/docs/markdown/snippets/meson_clang_tidy_fix.md
@@ -1,0 +1,9 @@
+## clang-tidy-fix target
+
+If `clang-tidy` is installed and the project's source root contains a
+`.clang-tidy` (or `_clang-tidy`) file, Meson will automatically define
+a `clang-tidy-fix` target that runs `run-clang-tidy` tool with `-fix`
+option to apply the changes found by clang-tidy to the source code.
+
+If you have defined your own `clang-tidy-fix` target, Meson will not
+generate its own target.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3659,6 +3659,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         if not shutil.which('clang-tidy'):
             return
         self.generate_clangtool('tidy')
+        self.generate_clangtool('tidy', 'fix')
 
     def generate_tags(self, tool: str, target_name: str) -> None:
         import shutil

--- a/mesonbuild/scripts/clangtidy.py
+++ b/mesonbuild/scripts/clangtidy.py
@@ -23,8 +23,12 @@ import typing as T
 def run_clang_tidy(fname: Path, builddir: Path) -> subprocess.CompletedProcess:
     return subprocess.run(['clang-tidy', '-p', str(builddir), str(fname)])
 
+def run_clang_tidy_fix(fname: Path, builddir: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(['run-clang-tidy', '-fix', '-format', '-quiet', '-p', str(builddir), str(fname)])
+
 def run(args: T.List[str]) -> int:
     parser = argparse.ArgumentParser()
+    parser.add_argument('--fix', action='store_true')
     parser.add_argument('sourcedir')
     parser.add_argument('builddir')
     options = parser.parse_args(args)
@@ -32,4 +36,5 @@ def run(args: T.List[str]) -> int:
     srcdir = Path(options.sourcedir)
     builddir = Path(options.builddir)
 
-    return run_tool('clang-tidy', srcdir, builddir, run_clang_tidy, builddir)
+    run_func = run_clang_tidy_fix if options.fix else run_clang_tidy
+    return run_tool('clang-tidy', srcdir, builddir, run_func, builddir)

--- a/unittests/helpers.py
+++ b/unittests/helpers.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from mesonbuild.compilers import detect_c_compiler, compiler_from_language
 from mesonbuild.mesonlib import (
     MachineChoice, is_osx, is_cygwin, EnvironmentException, OptionKey, MachineChoice,
-    OrderedSet
+    OrderedSet, quiet_git
 )
 from run_tests import get_fake_env
 
@@ -134,6 +134,9 @@ def is_tarball():
     if not os.path.isdir('docs'):
         return True
     return False
+
+def is_git_repo():
+    return quiet_git(['branch'], '.')[0]
 
 @contextmanager
 def chdir(path: str):


### PR DESCRIPTION
Add the `clang-tidy-fix` target to apply clang-tidy fixes to the source code.
This is done by calling `run-clang-tidy` with `-fix` argument.