### PR TITLE
cmake: Fix blunt target filtering skipping GENERATED dependencies

### DIFF
--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -362,7 +362,15 @@ class ConverterTarget:
             supported += list(lang_suffixes[i])
         supported = [f'.{x}' for x in supported]
         self.sources = [x for x in self.sources if any(x.name.endswith(y) for y in supported)]
-        self.generated_raw = [x for x in self.generated_raw if any(x.name.endswith(y) for y in supported)]
+        # Don't filter unsupported files from generated_raw because they
+        # can be GENERATED dependencies for other targets.
+        # See: https://github.com/mesonbuild/meson/issues/11607
+        # However, the dummy CMake rule files for Visual Studio still
+        # need to be filtered out. They don't exist (because the project was
+        # not generated at this time) but the fileapi will still
+        # report them on Windows.
+        # See: https://stackoverflow.com/a/41816323
+        self.generated_raw = [x for x in self.generated_raw if not x.name.endswith('.rule')]
 
         # Make paths relative
         def rel_path(x: Path, is_header: bool, is_generated: bool) -> T.Optional[Path]:

--- a/test cases/cmake/8 custom command/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/CMakeLists.txt
@@ -46,9 +46,12 @@ add_custom_command(
   DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/cpyBase.hpp.in"
 )
 
+# Slight tuning to the file extension (it's still a C++ header)
+# checks that file extensions are not considered for the purposes
+# of target dependencies
 add_custom_command(
-  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cpyBase.hpp"
-  COMMAND mycpy cpyBase.hpp.something                        cpyBase.hpp
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cpyBase.txt"
+  COMMAND mycpy cpyBase.hpp.something                        cpyBase.txt
   DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/cpyBase.hpp.something"
 )
 
@@ -127,7 +130,7 @@ add_custom_command(
 )
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/cpyTest/some")
 
-add_library(cmModLib SHARED cmMod.cpp genTest.cpp cpyBase.cpp cpyBase.hpp cpyNext.cpp cpyNext.hpp cpyTest.cpp cpyTest.hpp cpyTest2.hpp cpyTest3.hpp cpyTest/some/directory/cpyTest5.hpp)
+add_library(cmModLib SHARED cmMod.cpp genTest.cpp cpyBase.cpp cpyBase.txt cpyNext.cpp cpyNext.hpp cpyTest.cpp cpyTest.hpp cpyTest2.hpp cpyTest3.hpp cpyTest/some/directory/cpyTest5.hpp)
 include(GenerateExportHeader)
 generate_export_header(cmModLib)
 

--- a/test cases/cmake/8 custom command/subprojects/cmMod/cmMod.cpp
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/cmMod.cpp
@@ -1,6 +1,6 @@
 #include "cmMod.hpp"
 #include "genTest.hpp"
-#include "cpyBase.hpp"
+#include "cpyBase.txt"
 #include "cpyNext.hpp"
 #include "cpyTest.hpp"
 #include "cmModLib.hpp"

--- a/test cases/cmake/8 custom command/subprojects/cmMod/cpyBase.cpp.am
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/cpyBase.cpp.am
@@ -1,4 +1,4 @@
-#include "cpyBase.hpp"
+#include "cpyBase.txt"
 
 std::string getStrCpy() {
   return "Hello Copied File";


### PR DESCRIPTION
GENERATED files can be used as dependencies for other targets, so it's misguided (at best) to filter them with a blunt whitelist.

However, there does exist an extension that needs to be skipped: on Windows + MSVC, CMake will by default try to generate a Visual Studio project, and there dependencies with no inputs are instead tied to a dummy .rule input file which is created by the generation step. The fileapi will still report those, so it will cause Meson to bail out when it realises there's no such file in the build tree.

Fixes #11607