### PR TITLE
Re-enable "11 runpath rpath ldlibrarypath"

### DIFF
--- a/test cases/linuxlike/11 runpath rpath ldlibrarypath/main.c
+++ b/test cases/linuxlike/11 runpath rpath ldlibrarypath/main.c
@@ -2,7 +2,7 @@
 
 int some_symbol (void);
 
-int main () {
+int main (void) {
   int ret = some_symbol ();
   if (ret == 1)
     return 0;

--- a/test cases/linuxlike/11 runpath rpath ldlibrarypath/meson.build
+++ b/test cases/linuxlike/11 runpath rpath ldlibrarypath/meson.build
@@ -1,7 +1,5 @@
 project('runpath rpath ldlibrarypath', 'c')
 
-error('MESON_SKIP_TEST test disabled due to bug #1635.')
-
 libsrc = files('lib.c')
 
 subdir('lib1')


### PR DESCRIPTION
The bug it was blocked on was fixed in
a0514a7c4183a9e42d436865087d2f887d658d54.