### PR TITLE
Doc: fix type signature for add_languages.required

### DIFF
--- a/docs/yaml/functions/add_languages.yaml
+++ b/docs/yaml/functions/add_languages.yaml
@@ -36,7 +36,7 @@ varargs:
 
 kwargs:
   required:
-    type: bool
+    type: bool | feature
     default: true
     description: |
       If set to `true`, Meson will halt if any of the languages


### PR DESCRIPTION
It was listed as `bool`, but it can be a `feature` too.