### PR TITLE
compilers: fix compiler detection when the "ccache" string is in the path

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -1034,7 +1034,7 @@ def detect_rust_compiler(env: 'Environment', for_machine: MachineChoice) -> Rust
                     extra_args['machine'] = cc.linker.machine
                 else:
                     exelist = cc.linker.exelist + cc.linker.get_always_args()
-                    if 'ccache' in exelist[0]:
+                    if os.path.basename(exelist[0]) in {'ccache', 'sccache'}:
                         del exelist[0]
                     c = exelist.pop(0)
                     compiler.extend(cls.use_linker_args(c, ''))


### PR DESCRIPTION
Currently on main with `CC=/usr/lib/ccache/bin/cc`:

```
$ ./run_project_tests.py
Meson build system 1.2.99 Project Tests
Using python 3.11.5 (main, Aug 28 2023, 20:02:58) [GCC 13.2.1 20230801] ('/usr/bin/python3')

host machine compilers

c      : [gcc]      /usr/lib/ccache/bin/cc (gcc 13.2.1 "cc (GCC) 13.2.1 20230801")
cpp    : [gcc]      /usr/lib/ccache/bin/c++ (gcc 13.2.1 "c++ (GCC) 13.2.1 20230801")
cs     : [mono]     mcs (mono 6.12.0.0)
cuda   : [not found]
cython : [cython]   cython (cython 3.0.2)
d      : [llvm]     ldc2 (llvm 1.33.0 "LDC - the LLVM D compiler (1.33.0):")
fortran: [gcc]      gfortran (gcc 13.2.1 "GNU Fortran (GCC) 13.2.1 20230801")
java   : [unknown]  javac (unknown 1.8.0)
masm   : [not found]
nasm   : [not found]
objc   : [gcc]      sccache cc (gcc 13.2.1)
objcpp : [gcc]      sccache c++ (gcc 13.2.1)
Traceback (most recent call last):
  File "/home/anubis/git/meson/./run_project_tests.py", line 1606, in <module>
    detect_system_compiler(options)
  File "/home/anubis/git/meson/./run_project_tests.py", line 1463, in detect_system_compiler
    print_compilers(env, MachineChoice.HOST)
  File "/home/anubis/git/meson/./run_project_tests.py", line 1489, in print_compilers
    comp = compiler_from_language(env, lang, machine)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/anubis/git/meson/mesonbuild/compilers/detect.py", line 112, in compiler_from_language
    return lang_map[lang](env, for_machine) if lang in lang_map else None
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/anubis/git/meson/mesonbuild/compilers/detect.py", line 1039, in detect_rust_compiler
    c = exelist.pop(0)
        ^^^^^^^^^^^^^^
IndexError: pop from empty list
```