### PR TITLE
Prototype support for `--python.target-config`

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -392,6 +392,7 @@ install prefix. For example: if the install prefix is `/usr` and the
 | platlibdir        |               | Directory path              | Directory for site-specific, platform-specific files (Since 0.60.0) |
 | purelibdir        |               | Directory path              | Directory for site-specific, non-platform-specific files  (Since 0.60.0) |
 | allow_limited_api | true          | true, false                 | Disables project-wide use of the Python Limited API (Since 1.3.0) |
+| target_config     |               | File path                   | Config file for the target Python installation (Since XXX) |
 
 *Since 0.60.0* The `python.platlibdir` and `python.purelibdir` options are used
 by the python module methods `python.install_sources()` and
@@ -425,3 +426,6 @@ all.
 *Since 1.3.0* The `python.allow_limited_api` option affects whether the
 `limited_api` keyword argument of the `extension_module` method is respected.
 If set to `false`, the effect of the `limited_api` argument is disabled.
+
+*Since XXX* The `python.target_config` option allows users to provide the static
+description file for the target Python installation.

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1358,6 +1358,8 @@ BUILTIN_CORE_OPTIONS: 'MutableKeyedOptionDictType' = OrderedDict([
      BuiltinOption(UserStringOption, 'Directory for site-specific, non-platform-specific files.', '')),
     (OptionKey('allow_limited_api', module='python'),
      BuiltinOption(UserBooleanOption, 'Whether to allow use of the Python Limited API', True)),
+    (OptionKey('target_config', module='python'),
+     BuiltinOption(UserStringOption, 'Config file for the target Python installation.', '')),
 ])
 
 BUILTIN_OPTIONS = OrderedDict(chain(BUILTIN_DIR_OPTIONS.items(), BUILTIN_CORE_OPTIONS.items()))

--- a/test cases/unit/116 target config/config.toml
+++ b/test cases/unit/116 target config/config.toml
@@ -1,0 +1,7 @@
+[python]
+# inexistent version number, we set the value to this to test
+# if Meson is picking up the details from this config file
+version = '3.0.3'
+version_parts = { major = 3, minor = 0, micro = 3, releaselevel = 'final', serial = 0 }
+executable = '/usr/bin/python'
+stdlib = '/usr/lib/python3.0'

--- a/test cases/unit/116 target config/meson.build
+++ b/test cases/unit/116 target config/meson.build
@@ -1,0 +1,9 @@
+project('target config', 'c', default_options: ['python.target_config=config.toml'])
+
+py_mod = import('python')
+py = py_mod.find_installation()
+
+if py.language_version() != '3.0.3'
+  error('Wrong Python version, expecting 3.0.3 but got', py.language_version())
+endif
+

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -4853,3 +4853,8 @@ class AllPlatformTests(BasePlatformTests):
             # The first supported std should be selected
             self.setconf('-Dcpp_std=c++11,gnu++11,vc++11')
             self.assertEqual(self.getconf('cpp_std'), 'c++11')
+
+    def test_python_target_config(self):
+        testdir = os.path.join(self.unit_test_dir, '116 target config')
+        config_path = os.path.join(testdir, 'config.toml')
+        self.init(testdir, extra_args=['--python.target-config', config_path])


### PR DESCRIPTION
Early implementation prototype for the static Python installation file format proposed in https://github.com/python/cpython/pull/108483.