### PR TITLE
Adding Meson-UI back on IDE-integration.md [SKIP_CI]

### DIFF
--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -424,4 +424,5 @@ schema is defined by the class structure given in
 - [Meson Syntax Highlighter](https://plugins.jetbrains.com/plugin/13269-meson-syntax-highlighter) plugin for JetBrains IDEs.
 - [vscode-meson](https://github.com/mesonbuild/vscode-meson) extension for VS Code/Codium
 - [Qt Creator](https://doc.qt.io/qtcreator/creator-project-meson.html)
+- [Meson-UI](https://github.com/dreamer-coding-555/meson-ui) Meson-UI a build GUI for Meson written with Tkinter
 - [mmeson](https://github.com/stephanlachnit/mmeson) (ccmake clone for Meson)

--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -424,5 +424,5 @@ schema is defined by the class structure given in
 - [Meson Syntax Highlighter](https://plugins.jetbrains.com/plugin/13269-meson-syntax-highlighter) plugin for JetBrains IDEs.
 - [vscode-meson](https://github.com/mesonbuild/vscode-meson) extension for VS Code/Codium
 - [Qt Creator](https://doc.qt.io/qtcreator/creator-project-meson.html)
-- [Meson-UI](https://github.com/dreamer-coding-555/meson-ui) Meson-UI a build GUI for Meson written with Tkinter
+- [Meson-UI](https://github.com/dreamer-coding-555/meson-ui) (build GUI for Meson)
 - [mmeson](https://github.com/stephanlachnit/mmeson) (ccmake clone for Meson)


### PR DESCRIPTION
Adding a rewritten version of Meson-UI into the  IDE-integration.md page.