### PR TITLE
Revert "tests: skip a test that fails with new Python 3.11 from MSYS2"

### DIFF
--- a/unittests/windowstests.py
+++ b/unittests/windowstests.py
@@ -462,9 +462,6 @@ class WindowsTests(BasePlatformTests):
 
     @unittest.skipIf(is_cygwin(), "Needs visual studio")
     def test_vsenv_option(self):
-        if mesonbuild.environment.detect_msys2_arch():
-            # https://github.com/msys2-contrib/cpython-mingw/issues/141
-            raise SkipTest('mingw python fails with /bin being removed from PATH')
         if self.backend is not Backend.ninja:
             raise SkipTest('Only ninja backend is valid for test')
         env = os.environ.copy()


### PR DESCRIPTION
This reverts commit 68dce66bf9a2bcb3d23c291beb2354225a74b954.

The upstream issues https://github.com/msys2-contrib/cpython-mingw/issues/141 has been fixed now.