### PR TITLE
clike compilers: fix cross_* functions' include

### DIFF
--- a/docs/markdown/snippets/clike_compilers_implicit_includes.md
+++ b/docs/markdown/snippets/clike_compilers_implicit_includes.md
@@ -1,0 +1,13 @@
+## Clarify of implicitly-included headers in C-like compiler checks
+
+Compiler check methods `compiler.compute_int()`, `compiler.alignment()`
+and `compiler.sizeof()` now have their implicitly-included headers
+corrected and documented.
+
+`<stdio.h>` was included unintentionally when cross-compiling, which
+is less than ideal because there is no guarantee that a standard library
+is available for the target platform. Only `<stddef.h>` is included instead.
+
+For projects that depend on the old behavior, the compiler check methods
+have an optional argument `prefix`, which can be used to specify additional
+`#include` directives.

--- a/docs/yaml/objects/compiler.yaml
+++ b/docs/yaml/objects/compiler.yaml
@@ -180,7 +180,11 @@ methods:
 
 - name: alignment
   returns: int
-  description: Returns the alignment of the specified type.
+  description: |
+    Returns the alignment of the specified type. For C-like languages,
+    For C-like languages, the header `stddef.h` and `stdio.h` are included
+    implicitly for native compilation, only `stddef.h` is included when
+    cross-compiling.
 
   posargs:
     typename:
@@ -283,6 +287,9 @@ methods:
     (defaults to -1024), `high` (defaults to 1024) and `guess` to
     specify max and min values for the search and the value to try
     first.
+    For C-like languages, the header `stddef.h` and `stdio.h` are included
+    implicitly for native compilation, only `stddef.h` is included when
+    cross-compiling.
 
   posargs:
     expr:
@@ -304,7 +311,11 @@ methods:
 
 - name: sizeof
   returns: int
-  description: returns the size of the given type (e.g. `'int'`) or -1 if the type is unknown.
+  description: |
+    returns the size of the given type (e.g. `'int'`) or -1 if the type is unknown.
+    For C-like languages, the header `stddef.h` and `stdio.h` are included
+    implicitly for native compilation, only `stddef.h` is included when
+    cross-compiling.
   kwargs_inherit: compiler._common
   posargs:
     typename:

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -502,7 +502,7 @@ class CLikeCompiler(Compiler):
                      extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]],
                      dependencies: T.Optional[T.List['Dependency']]) -> bool:
         t = f'''{prefix}
-        #include <stdio.h>
+        #include <stddef.h>
         int main(void) {{ static int a[1-2*!({expression})]; a[0]=0; return 0; }}'''
         return self.compiles(t, env, extra_args=extra_args,
                              dependencies=dependencies)[0]
@@ -563,6 +563,7 @@ class CLikeCompiler(Compiler):
         if self.is_cross:
             return self.cross_compute_int(expression, low, high, guess, prefix, env, extra_args, dependencies)
         t = f'''{prefix}
+        #include<stddef.h>
         #include<stdio.h>
         int main(void) {{
             printf("%ld\\n", (long)({expression}));
@@ -582,7 +583,7 @@ class CLikeCompiler(Compiler):
         if extra_args is None:
             extra_args = []
         t = f'''{prefix}
-        #include <stdio.h>
+        #include <stddef.h>
         int main(void) {{
             {typename} something;
             return 0;
@@ -602,6 +603,7 @@ class CLikeCompiler(Compiler):
                                   dependencies=dependencies)
             return r, False
         t = f'''{prefix}
+        #include<stddef.h>
         #include<stdio.h>
         int main(void) {{
             printf("%ld\\n", (long)(sizeof({typename})));
@@ -621,7 +623,7 @@ class CLikeCompiler(Compiler):
         if extra_args is None:
             extra_args = []
         t = f'''{prefix}
-        #include <stdio.h>
+        #include <stddef.h>
         int main(void) {{
             {typename} something;
             return 0;


### PR DESCRIPTION
A standard C library may not exist for cross-compile environments, thus the existence of <stdio.h> cannot be guaranteed. Use <stddef.h>, which comes directly from the compiler, instead.