### PR TITLE
fix bug with openssl when cmake is missing

### DIFF
--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -652,3 +652,19 @@ class CMakeDependency(ExternalDependency):
         if default_value is not None:
             return default_value
         raise DependencyException(f'Could not get cmake variable and no default provided for {self!r}')
+
+
+class CMakeDependencyFactory:
+
+    def __init__(self, name: T.Optional[str] = None, modules: T.Optional[T.List[str]] = None):
+        self.name = name
+        self.modules = modules
+
+    def __call__(self, name: str, env: Environment, kwargs: T.Dict[str, T.Any], language: T.Optional[str] = None, force_use_global_compilers: bool = False) -> CMakeDependency:
+        if self.modules:
+            kwargs['modules'] = self.modules
+        return CMakeDependency(self.name or name, env, kwargs, language, force_use_global_compilers)
+
+    @staticmethod
+    def log_tried() -> str:
+        return CMakeDependency.log_tried()

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -23,7 +23,7 @@ from .. import mesonlib
 from .. import mlog
 from .base import DependencyException, DependencyMethods
 from .base import BuiltinDependency, SystemDependency
-from .cmake import CMakeDependency
+from .cmake import CMakeDependency, CMakeDependencyFactory
 from .configtool import ConfigToolDependency
 from .detect import packages
 from .factory import DependencyFactory, factory_methods
@@ -599,19 +599,19 @@ packages['openssl'] = openssl_factory = DependencyFactory(
     'openssl',
     [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM, DependencyMethods.CMAKE],
     system_class=OpensslSystemDependency,
-    cmake_class=lambda name, env, kwargs: CMakeDependency('OpenSSL', env, dict(kwargs, modules=['OpenSSL::Crypto', 'OpenSSL::SSL'])),
+    cmake_class=CMakeDependencyFactory('OpenSSL', modules=['OpenSSL::Crypto', 'OpenSSL::SSL']),
 )
 
 packages['libcrypto'] = libcrypto_factory = DependencyFactory(
     'libcrypto',
     [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM, DependencyMethods.CMAKE],
     system_class=OpensslSystemDependency,
-    cmake_class=lambda name, env, kwargs: CMakeDependency('OpenSSL', env, dict(kwargs, modules=['OpenSSL::Crypto'])),
+    cmake_class=CMakeDependencyFactory('OpenSSL', modules=['OpenSSL::Crypto']),
 )
 
 packages['libssl'] = libssl_factory = DependencyFactory(
     'libssl',
     [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM, DependencyMethods.CMAKE],
     system_class=OpensslSystemDependency,
-    cmake_class=lambda name, env, kwargs: CMakeDependency('OpenSSL', env, dict(kwargs, modules=['OpenSSL::SSL'])),
+    cmake_class=CMakeDependencyFactory('OpenSSL', modules=['OpenSSL::SSL']),
 )

--- a/test cases/unit/117 openssl cmake bug/meson.build
+++ b/test cases/unit/117 openssl cmake bug/meson.build
@@ -1,0 +1,5 @@
+project('bug', 'cpp')
+
+# When cmake is not available,
+# this triggers the bug described in #12098
+openssl_dep = dependency('openssl')

--- a/test cases/unit/117 openssl cmake bug/nativefile.ini
+++ b/test cases/unit/117 openssl cmake bug/nativefile.ini
@@ -1,0 +1,7 @@
+[binaries]
+
+cmake = '/path/to/nothing'
+
+[built-in options]
+
+pkg_config_path = ''

--- a/unittests/platformagnostictests.py
+++ b/unittests/platformagnostictests.py
@@ -271,3 +271,10 @@ class PlatformAgnosticTests(BasePlatformTests):
         builddir = os.path.join(srcdir, '_build')
         self.change_builddir(builddir)
         self.init(srcdir, override_envvars={'MESON_PACKAGE_CACHE_DIR': os.path.join(srcdir, 'cache_dir')})
+
+    def test_cmake_openssl_not_found_bug(self):
+        """Issue #12098"""
+        testdir = os.path.join(self.unit_test_dir, '117 openssl cmake bug')
+        self.meson_native_files.append(os.path.join(testdir, 'nativefile.ini'))
+        out = self.init(testdir, allow_fail=True)
+        self.assertNotIn('Unhandled python exception', out)


### PR DESCRIPTION
Fixes #12098
Fixes #11145

DependencyFactory was returning a lambda, but it has no log_tried() function.