### PR TITLE
Add support for padding zeroes in int.to_string() method

### DIFF
--- a/docs/markdown/snippets/int_to_string_fill.md
+++ b/docs/markdown/snippets/int_to_string_fill.md
@@ -1,0 +1,20 @@
+## Added 'fill' kwarg to int.to_string()
+
+int.to_string() now accepts a `fill` argument. This allows you to pad the
+string representation of the integer with leading zeroes:
+
+```meson
+n = 4
+message(n.to_string())
+message(n.to_string(length: 3))
+
+n = -4
+message(n.to_string(length: 3))
+```
+
+OUTPUT:
+```meson
+4
+004
+-04
+```

--- a/docs/yaml/elementary/int.yml
+++ b/docs/yaml/elementary/int.yml
@@ -14,3 +14,15 @@ methods:
 - name: to_string
   returns: str
   description: Returns the value of the number as a string.
+
+  optargs:
+    fill:
+      type: int
+      description: |
+        Left fill the string with zeros until it reaches the length
+        specified by this argument. A leading negative sign counts towards
+        the length, and is handled by inserting the padding after the `-`
+        character rather than before. The original string is returned if the
+        value provided is less than or equal to the former's length.
+
+

--- a/mesonbuild/interpreter/primitives/integer.py
+++ b/mesonbuild/interpreter/primitives/integer.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from ...interpreterbase import (
-    FeatureBroken, InvalidArguments, MesonOperator, ObjectHolder,
-    noKwargs, noPosargs, typed_operator,
+    FeatureBroken, InvalidArguments, MesonOperator, ObjectHolder, KwargInfo,
+    noKwargs, noPosargs, typed_operator, typed_kwargs
 )
 
 import typing as T
@@ -65,10 +65,13 @@ class IntegerHolder(ObjectHolder[int]):
     def is_odd_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> bool:
         return self.held_object % 2 != 0
 
-    @noKwargs
+    @typed_kwargs(
+        'to_string',
+        KwargInfo('fill', int, default=0, since='1.3.0')
+    )
     @noPosargs
-    def to_string_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> str:
-        return str(self.held_object)
+    def to_string_method(self, args: T.List[TYPE_var], kwargs: T.Dict[str, T.Any]) -> str:
+        return str(self.held_object).zfill(kwargs['fill'])
 
     @typed_operator(MesonOperator.DIV, int)
     def op_div(self, other: int) -> int:

--- a/test cases/common/270 int_to_str_fill/meson.build
+++ b/test cases/common/270 int_to_str_fill/meson.build
@@ -1,0 +1,9 @@
+project('test_fill_in_int_to_string')
+
+n = 4
+assert(n.to_string() == '4')
+assert(n.to_string(fill: 3) == '004')
+assert(n.to_string(fill: -3) == '4')
+
+n = -4
+assert(n.to_string(fill: 3) == '-04')


### PR DESCRIPTION
As per title, this PR implements being able to convert an int to a string padded with leading zeroes. Very simple functionality, just a kwarg for int.to_string(). If you are on board with it, I'll proceed with editing the docs.