### PR TITLE
dependencies: fix crash in Qt if private_headers dir not found

### DIFF
--- a/mesonbuild/dependencies/qt.py
+++ b/mesonbuild/dependencies/qt.py
@@ -53,7 +53,7 @@ def _qt_get_private_includes(mod_inc_dir: str, module: str, mod_version: str) ->
 
     private_dir = os.path.join(mod_inc_dir, mod_version)
     # fallback, let's try to find a directory with the latest version
-    if not os.path.exists(private_dir):
+    if os.path.isdir(mod_inc_dir) and not os.path.exists(private_dir):
         dirs = [filename for filename in os.listdir(mod_inc_dir)
                 if os.path.isdir(os.path.join(mod_inc_dir, filename))]
 


### PR DESCRIPTION
You cannot listdir() a directory that doesn't exist. This header directory may not exist if suitable devel packages in distros with split devel packages, aren't installed.

In theory we could raise a suitable error here. But it would be inconsistent -- we don't otherwise validate that the Qt include directories exist, usually just assuming they do because the dependency was found. And this is niche code inside a non-default special kwarg. At least for pkg-config, it's probably a bug in the distro if pkg-config files exist but the headers don't. The qmake status is less clear.

Avoiding a crash means that at the very least, if those headers are in fact directly used by the project, an obvious compiler error occurs instead of a noisy meson traceback.

Fixes #12214