### PR TITLE
python module: stop using distutils on sufficiently new python

### DIFF
--- a/mesonbuild/scripts/python_info.py
+++ b/mesonbuild/scripts/python_info.py
@@ -37,17 +37,29 @@ def get_distutils_paths(scheme=None, prefix=None):
 # default scheme to a custom one pointing to /usr/local and replacing
 # site-packages with dist-packages.
 # See https://github.com/mesonbuild/meson/issues/8739.
-# XXX: We should be using sysconfig, but Debian only patches distutils.
+#
+# We should be using sysconfig, but before 3.10.3, Debian only patches distutils.
+# So we may end up falling back.
 
 def get_install_paths():
-    import distutils.command.install
-    if 'deb_system' in distutils.command.install.INSTALL_SCHEMES:
-        paths = get_distutils_paths(scheme='deb_system')
-        install_paths = get_distutils_paths(scheme='deb_system', prefix='')
+    if sys.version_info >= (3, 10):
+        scheme = sysconfig.get_default_scheme()
     else:
-        paths = sysconfig.get_paths()
-        empty_vars = {'base': '', 'platbase': '', 'installed_base': ''}
-        install_paths = sysconfig.get_paths(vars=empty_vars)
+        scheme = sysconfig._get_default_scheme()
+
+    if sys.version_info >= (3, 10, 3):
+        if 'deb_system' in sysconfig.get_scheme_names():
+            scheme = 'deb_system'
+    else:
+        import distutils.command.install
+        if 'deb_system' in distutils.command.install.INSTALL_SCHEMES:
+            paths = get_distutils_paths(scheme='deb_system')
+            install_paths = get_distutils_paths(scheme='deb_system', prefix='')
+            return paths, install_paths
+
+    paths = sysconfig.get_paths(scheme=scheme)
+    empty_vars = {'base': '', 'platbase': '', 'installed_base': ''}
+    install_paths = sysconfig.get_paths(scheme=scheme, vars=empty_vars)
     return paths, install_paths
 
 def links_against_libpython():

--- a/mesonbuild/scripts/python_info.py
+++ b/mesonbuild/scripts/python_info.py
@@ -39,13 +39,16 @@ def get_distutils_paths(scheme=None, prefix=None):
 # See https://github.com/mesonbuild/meson/issues/8739.
 # XXX: We should be using sysconfig, but Debian only patches distutils.
 
-if 'deb_system' in distutils.command.install.INSTALL_SCHEMES:
-    paths = get_distutils_paths(scheme='deb_system')
-    install_paths = get_distutils_paths(scheme='deb_system', prefix='')
-else:
-    paths = sysconfig.get_paths()
-    empty_vars = {'base': '', 'platbase': '', 'installed_base': ''}
-    install_paths = sysconfig.get_paths(vars=empty_vars)
+def get_install_paths():
+    import distutils.command.install
+    if 'deb_system' in distutils.command.install.INSTALL_SCHEMES:
+        paths = get_distutils_paths(scheme='deb_system')
+        install_paths = get_distutils_paths(scheme='deb_system', prefix='')
+    else:
+        paths = sysconfig.get_paths()
+        empty_vars = {'base': '', 'platbase': '', 'installed_base': ''}
+        install_paths = sysconfig.get_paths(vars=empty_vars)
+    return paths, install_paths
 
 def links_against_libpython():
     from distutils.core import Distribution, Extension
@@ -53,42 +56,41 @@ def links_against_libpython():
     cmd.ensure_finalized()
     return bool(cmd.get_libraries(Extension('dummy', [])))
 
-variables = sysconfig.get_config_vars()
-variables.update({'base_prefix': getattr(sys, 'base_prefix', sys.prefix)})
+def main():
+    variables = sysconfig.get_config_vars()
+    variables.update({'base_prefix': getattr(sys, 'base_prefix', sys.prefix)})
+    paths, install_paths = get_install_paths()
 
-if sys.version_info < (3, 0):
-    suffix = variables.get('SO')
-elif sys.version_info < (3, 8, 7):
-    # https://bugs.python.org/issue?@action=redirect&bpo=39825
-    from distutils.sysconfig import get_config_var
-    suffix = get_config_var('EXT_SUFFIX')
-else:
-    suffix = variables.get('EXT_SUFFIX')
+    if sys.version_info < (3, 0):
+        suffix = variables.get('SO')
+    elif sys.version_info < (3, 8, 7):
+        # https://bugs.python.org/issue?@action=redirect&bpo=39825
+        from distutils.sysconfig import get_config_var
+        suffix = get_config_var('EXT_SUFFIX')
+    else:
+        suffix = variables.get('EXT_SUFFIX')
 
-limited_api_suffix = None
-if sys.version_info >= (3, 2):
-    try:
-        from importlib.machinery import EXTENSION_SUFFIXES
-        limited_api_suffix = EXTENSION_SUFFIXES[1]
-    except Exception:
-        pass
+    limited_api_suffix = None
+    if sys.version_info >= (3, 2):
+        try:
+            from importlib.machinery import EXTENSION_SUFFIXES
+            limited_api_suffix = EXTENSION_SUFFIXES[1]
+        except Exception:
+            pass
 
-# pypy supports modules targetting the limited api but
-# does not use a special suffix to distinguish them:
-# https://doc.pypy.org/en/latest/cpython_differences.html#permitted-abi-tags-in-extensions
-if '__pypy__' in sys.builtin_module_names:
-    limited_api_suffix = suffix
+    return {
+      'variables': variables,
+      'paths': paths,
+      'sysconfig_paths': sysconfig.get_paths(),
+      'install_paths': install_paths,
+      'version': sysconfig.get_python_version(),
+      'platform': sysconfig.get_platform(),
+      'is_pypy': '__pypy__' in sys.builtin_module_names,
+      'is_venv': sys.prefix != variables['base_prefix'],
+      'link_libpython': links_against_libpython(),
+      'suffix': suffix,
+      'limited_api_suffix': limited_api_suffix,
+    }
 
-print(json.dumps({
-  'variables': variables,
-  'paths': paths,
-  'sysconfig_paths': sysconfig.get_paths(),
-  'install_paths': install_paths,
-  'version': sysconfig.get_python_version(),
-  'platform': sysconfig.get_platform(),
-  'is_pypy': '__pypy__' in sys.builtin_module_names,
-  'is_venv': sys.prefix != variables['base_prefix'],
-  'link_libpython': links_against_libpython(),
-  'suffix': suffix,
-  'limited_api_suffix': limited_api_suffix,
-}))
+if __name__ == '__main__':
+    print(json.dumps(main()))

--- a/mesonbuild/scripts/python_info.py
+++ b/mesonbuild/scripts/python_info.py
@@ -13,7 +13,6 @@ if sys.path[0].endswith('scripts'):
     del sys.path[0]
 
 import json, os, sysconfig
-import distutils.command.install
 
 def get_distutils_paths(scheme=None, prefix=None):
     import distutils.dist
@@ -63,10 +62,15 @@ def get_install_paths():
     return paths, install_paths
 
 def links_against_libpython():
-    from distutils.core import Distribution, Extension
-    cmd = Distribution().get_command_obj('build_ext')
-    cmd.ensure_finalized()
-    return bool(cmd.get_libraries(Extension('dummy', [])))
+    # on versions supporting python-embed.pc, this is the non-embed lib
+    if sys.version_info >= (3, 12):
+        variables = sysconfig.get_config_vars()
+        return bool(variables.get('LIBPYTHON', True))
+    else:
+        from distutils.core import Distribution, Extension
+        cmd = Distribution().get_command_obj('build_ext')
+        cmd.ensure_finalized()
+        return bool(cmd.get_libraries(Extension('dummy', [])))
 
 def main():
     variables = sysconfig.get_config_vars()


### PR DESCRIPTION
This is a rebase of #11133 on current master. @eli-schwartz I took the freedom of updating this PR of yours that haven't seen activity since quite a while. With the Python 3.12 release approaching it makes sense to push this across the finish line sooner rather than later.