### PR TITLE
completions: bash: added a bunch of missing completion options.

### DIFF
--- a/data/shell-completions/bash/meson
+++ b/data/shell-completions/bash/meson
@@ -168,6 +168,55 @@ _meson_compgen_options() {
   return 0
 }
 
+_meson_common_setup_configure_longopts=(
+  help
+  prefix
+  bindir
+  datadir
+  includedir
+  infodir
+  libdir
+  licensedir
+  libexecdir
+  localedir
+  localstatedir
+  mandir
+  sbindir
+  sharedstatedir
+  sysconfdir
+  auto-features
+  backend
+  genvslite
+  buildtype
+  debug
+  default-library
+  errorlogs
+  install-umask
+  layout
+  optimization
+  prefer-static
+  stdsplit
+  strip
+  unity
+  unity-size
+  warnlevel
+  werror
+  wrap-mode
+  force-fallback-for
+  vsenv
+  pkgconfig.relocatable
+  python.bytecompile
+  python.install-env
+  python.platlibdir
+  python.purelibdir
+  python.allow-limited-api
+  pkg-config-path
+  build.pkg-config-path
+  cmake-prefix-path
+  build.cmake-prefix-path
+  clearcache
+)
+
 _meson-setup() {
   shortopts=(
     h
@@ -175,53 +224,10 @@ _meson-setup() {
     v
   )
 
-  # backend-startup-project is currently VS backend only.
-
   longopts=(
-    help
-    prefix
-    bindir
-    datadir
-    includedir
-    infodir
-    libdir
-    libexecdir
-    licensedir
-    localedir
-    localstatedir
-    mandir
-    sbindir
-    sharedstatedir
-    sysconfdir
-    auto-features
-    backend
-    buildtype
-    debug
-    default-library
-    errorlogs
-    install-umask
-    layout
-    optimization
-    prefer-static
-    stdsplit
-    strip
-    unity
-    unity-size
-    warnlevel
-    werror
-    wrap-mode
-    force-fallback-for
-    pkgconfig.relocatable
-    python.install-env
-    python.platlibdir
-    python.purelibdir
-    pkg-config-path
-    build.pkg-config-path
-    cmake-prefix-path
-    build.cmake-prefix-path
+    ${_meson_common_setup_configure_longopts[@]}
     native-file
     cross-file
-    vsenv
     version
     fatal-meson-warnings
     reconfigure
@@ -266,49 +272,7 @@ _meson-configure() {
   )
 
   longopts=(
-    help
-    prefix
-    bindir
-    datadir
-    includedir
-    infodir
-    libdir
-    libexecdir
-    licensedir
-    localedir
-    localstatedir
-    mandir
-    sbindir
-    sharedstatedir
-    sysconfdir
-    auto-features
-    backend
-    buildtype
-    debug
-    default-library
-    errorlogs
-    install-umask
-    layout
-    optimization
-    prefer-static
-    stdsplit
-    strip
-    unity
-    unity-size
-    warnlevel
-    werror
-    wrap-mode
-    force-fallback-for
-    backend-startup-project
-    pkgconfig.relocatable
-    python.install-env
-    python.platlibdir
-    python.purelibdir
-    pkg-config-path
-    build.pkg-config-path
-    cmake-prefix-path
-    build.cmake-prefix-path
-    clearcache
+    ${_meson_common_setup_configure_longopts[@]}
     no-pager
   )
 

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1332,6 +1332,7 @@ class BuiltinOption(T.Generic[_T, _U]):
 
 # Update `docs/markdown/Builtin-options.md` after changing the options below
 # Also update mesonlib._BUILTIN_NAMES. See the comment there for why this is required.
+# Please also update completion scripts in $MESONSRC/data/shell-completions/
 BUILTIN_DIR_OPTIONS: 'MutableKeyedOptionDictType' = OrderedDict([
     (OptionKey('prefix'),          BuiltinOption(UserStringOption, 'Installation prefix', default_prefix())),
     (OptionKey('bindir'),          BuiltinOption(UserStringOption, 'Executable directory', 'bin')),

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -271,6 +271,8 @@ def get_parsed_args_xcode(options: 'argparse.Namespace', builddir: Path) -> T.Tu
     cmd += options.xcode_args
     return cmd, None
 
+# Note: when adding arguments, please also add them to the completion
+# scripts in $MESONSRC/data/shell-completions/
 def add_arguments(parser: 'argparse.ArgumentParser') -> None:
     """Add compile specific arguments."""
     parser.add_argument(

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -35,6 +35,8 @@ if T.TYPE_CHECKING:
     # cannot be TV_Loggable, because non-ansidecorators do direct string concat
     LOGLINE = T.Union[str, mlog.AnsiDecorator]
 
+# Note: when adding arguments, please also add them to the completion
+# scripts in $MESONSRC/data/shell-completions/
 def add_arguments(parser: 'argparse.ArgumentParser') -> None:
     coredata.register_builtin_arguments(parser)
     parser.add_argument('builddir', nargs='?', default='.')

--- a/mesonbuild/mdevenv.py
+++ b/mesonbuild/mdevenv.py
@@ -18,6 +18,8 @@ if T.TYPE_CHECKING:
 
 POWERSHELL_EXES = {'pwsh.exe', 'powershell.exe'}
 
+# Note: when adding arguments, please also add them to the completion
+# scripts in $MESONSRC/data/shell-completions/
 def add_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('-C', dest='builddir', type=Path, default='.',
                         help='Path to build directory')

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -48,6 +48,8 @@ archive_extension = {'gztar': '.tar.gz',
                      'xztar': '.tar.xz',
                      'zip': '.zip'}
 
+# Note: when adding arguments, please also add them to the completion
+# scripts in $MESONSRC/data/shell-completions/
 def add_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('-C', dest='wd', action=RealPathAction,
                         help='directory to cd into before running')

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -153,6 +153,8 @@ def autodetect_options(options: Arguments, sample: bool = False) -> None:
             raise SystemExit("Can't autodetect language, please specify it with -l.")
         print("Detected language: " + options.language)
 
+# Note: when adding arguments, please also add them to the completion
+# scripts in $MESONSRC/data/shell-completions/
 def add_arguments(parser: 'argparse.ArgumentParser') -> None:
     '''
     Here we add args for that the user can passed when making a new

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -70,6 +70,8 @@ build definitions so that it will not break when the change happens.'''
 
 selinux_updates: T.List[str] = []
 
+# Note: when adding arguments, please also add them to the completion
+# scripts in $MESONSRC/data/shell-completions/
 def add_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('-C', dest='wd', action=RealPathAction,
                         help='directory to cd into before running')

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -91,6 +91,8 @@ def get_meson_introspection_types(coredata: T.Optional[cdata.CoreData] = None,
         ('tests', IntroCommand('List all unit tests', func=lambda: list_tests(testdata))),
     ])
 
+# Note: when adding arguments, please also add them to the completion
+# scripts in $MESONSRC/data/shell-completions/
 def add_arguments(parser: argparse.ArgumentParser) -> None:
     intro_types = get_meson_introspection_types()
     for key, val in intro_types.items():

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -31,6 +31,8 @@ syntax: glob
 '''
 
 
+# Note: when adding arguments, please also add them to the completion
+# scripts in $MESONSRC/data/shell-completions/
 def add_arguments(parser: argparse.ArgumentParser) -> None:
     coredata.register_builtin_arguments(parser)
     parser.add_argument('--native-file',

--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -633,6 +633,8 @@ def add_wrap_update_parser(subparsers: 'SubParsers') -> argparse.ArgumentParser:
     p.set_defaults(pre_func=Runner.pre_update_wrapdb)
     return p
 
+# Note: when adding arguments, please also add them to the completion
+# scripts in $MESONSRC/data/shell-completions/
 def add_arguments(parser: argparse.ArgumentParser) -> None:
     subparsers = parser.add_subparsers(title='Commands', dest='command')
     subparsers.required = True

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -124,6 +124,8 @@ def determine_worker_count() -> int:
             num_workers = 1
     return num_workers
 
+# Note: when adding arguments, please also add them to the completion
+# scripts in $MESONSRC/data/shell-completions/
 def add_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('--maxfail', default=0, type=int,
                         help='Number of failing tests before aborting the '

--- a/mesonbuild/munstable_coredata.py
+++ b/mesonbuild/munstable_coredata.py
@@ -21,6 +21,8 @@ import os.path
 import pprint
 import textwrap
 
+# Note: when adding arguments, please also add them to the completion
+# scripts in $MESONSRC/data/shell-completions/
 def add_arguments(parser):
     parser.add_argument('--all', action='store_true', dest='all', default=False,
                         help='Show data not used by current backend.')

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -38,6 +38,8 @@ if T.TYPE_CHECKING:
 class RewriterException(MesonException):
     pass
 
+# Note: when adding arguments, please also add them to the completion
+# scripts in $MESONSRC/data/shell-completions/
 def add_arguments(parser, formatter=None):
     parser.add_argument('-s', '--sourcedir', type=str, default='.', metavar='SRCDIR', help='Path to source directory.')
     parser.add_argument('-V', '--verbose', action='store_true', default=False, help='Enable verbose output')

--- a/mesonbuild/scripts/env2mfile.py
+++ b/mesonbuild/scripts/env2mfile.py
@@ -31,6 +31,8 @@ def has_for_build() -> bool:
             return True
     return False
 
+# Note: when adding arguments, please also add them to the completion
+# scripts in $MESONSRC/data/shell-completions/
 def add_arguments(parser: 'argparse.ArgumentParser') -> None:
     parser.add_argument('--debarch', default=None,
                         help='The dpkg architecture to generate.')

--- a/mesonbuild/wrap/wraptool.py
+++ b/mesonbuild/wrap/wraptool.py
@@ -28,6 +28,8 @@ from .. import mesonlib, msubprojects
 if T.TYPE_CHECKING:
     import argparse
 
+# Note: when adding arguments, please also add them to the completion
+# scripts in $MESONSRC/data/shell-completions/
 def add_arguments(parser: 'argparse.ArgumentParser') -> None:
     subparsers = parser.add_subparsers(title='Commands', dest='command')
     subparsers.required = True


### PR DESCRIPTION
#11422 was merged but 7 months old, so here's bash support for options added since then that can hopefully go in before the next release.

Perhaps a comment in `coredata.py` (or wherever best) alongside

```
# Update `docs/markdown/Builtin-options.md` after changing the options below
# Also update mesonlib._BUILTIN_NAMES. See the comment there for why this is required.
```

about updating shell completion helpers might help keep things synced?

Thanks

