### PR TITLE
Metrowerks toolchain improvements

### DIFF
--- a/cross/metrowerks-arm.txt
+++ b/cross/metrowerks-arm.txt
@@ -2,12 +2,6 @@
 # toolchain is added to the environment(PATH) variable, so that
 # Meson can find the binaries while building.
 
-# You should also do one of the following to ensure Meson can
-# locate the .lcf linker script:
-# - Add the cross directory to PATH as well
-# - Edit c_link_args and cpp_link_args with the full
-#   path to the .lcf file on your machine
-
 [binaries]
 c = 'mwccarm'
 c_ld = 'mwldarm'
@@ -18,11 +12,12 @@ as = 'mwasmarm'
 
 [built-in options]
 c_args = ['-lang', 'c99', '-D_NITRO', '-nosyspath']
-c_link_args = 'metrowerks.lcf'
+c_link_args = '@DIRNAME@/metrowerks.lcf'
 cpp_args = ['-lang', 'c++', '-D_NITRO', '-nosyspath']
-cpp_link_args = 'metrowerks.lcf'
+cpp_link_args = '@DIRNAME@/metrowerks.lcf'
 
 [host_machine]
 system = 'bare metal'
+cpu = 'arm'
 cpu_family = 'arm'
 endian = 'little'

--- a/cross/metrowerks-eppc.txt
+++ b/cross/metrowerks-eppc.txt
@@ -2,12 +2,6 @@
 # of choice is added to the environment(PATH) variable, so that
 # Meson can find the binaries while building.
 
-# You should also do one of the following to ensure Meson can
-# locate the .lcf linker script:
-# - Add the cross directory to PATH as well
-# - Edit c_link_args and cpp_link_args with the full
-#   path to the lcf file on your machine
-
 [binaries]
 c = 'mwcceppc'
 c_ld = 'mwldeppc'
@@ -18,11 +12,12 @@ as = 'mwasmeppc'
 
 [built-in options]
 c_args = ['-lang', 'c99', '-nosyspath']
-c_link_args = 'metrowerks.lcf'
+c_link_args = '@DIRNAME@/metrowerks.lcf'
 cpp_args = ['-lang', 'c++', '-nosyspath']
-cpp_link_args = 'metrowerks.lcf'
+cpp_link_args = '@DIRNAME@/metrowerks.lcf'
 
 [host_machine]
 system = 'bare metal'
+cpu = 'ppc'
 cpu_family = 'ppc'
 endian = 'little'

--- a/mesonbuild/compilers/asm.py
+++ b/mesonbuild/compilers/asm.py
@@ -318,6 +318,9 @@ class MetrowerksAsmCompilerARM(MetrowerksAsmCompiler):
 
     def get_instruction_set_args(self, instruction_set: str) -> T.Optional[T.List[str]]:
         return mwasmarm_instruction_set_args.get(instruction_set, None)
+    
+    def get_optimization_args(self, optimization_level: str) -> T.List[str]:
+        return []
 
     def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
         if self.info.cpu_family not in {'arm'}:
@@ -329,6 +332,9 @@ class MetrowerksAsmCompilerEmbeddedPowerPC(MetrowerksAsmCompiler):
 
     def get_instruction_set_args(self, instruction_set: str) -> T.Optional[T.List[str]]:
         return mwasmeppc_instruction_set_args.get(instruction_set, None)
+    
+    def get_optimization_args(self, optimization_level: str) -> T.List[str]:
+        return []
 
     def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
         if self.info.cpu_family not in {'ppc'}:

--- a/mesonbuild/compilers/mixins/metrowerks.py
+++ b/mesonbuild/compilers/mixins/metrowerks.py
@@ -32,10 +32,10 @@ else:
 
 mwcc_buildtype_args: T.Dict[str, T.List[str]] = {
     'plain': [],
-    'debug': ['-g'],
-    'debugoptimized': ['-g', '-O4'],
-    'release': ['-O4,p'],
-    'minsize': ['-Os'],
+    'debug': [],
+    'debugoptimized': [],
+    'release': [],
+    'minsize': [],
     'custom': [],
 }
 
@@ -173,7 +173,7 @@ mwcc_optimization_args: T.Dict[str, T.List[str]] = {
     'g': ['-Op'],
     '1': ['-O1'],
     '2': ['-O2'],
-    '3': ['-O3'],
+    '3': ['-O4,p'],
     's': ['-Os']
 }
 


### PR DESCRIPTION
Just a few fixes and improvements:

- Removed duplicate arguments across `mwcc_optimization_args` and `mwcc_buildtype_args`, which made any build other than plain or custom broken without manually setting opt-level to 0. This is no longer the case.
- The Metrowerks Assembler does not support optimization arguments, but was receiving them because it inherits from the MetrowerksCompiler mixin. For now, I just decided to override `get_optimization_args`  in `MetrowerksAssembler` so that it returns a blank list.
- The Metrowerks toolchain files in `cross/` now take advantage of the newly introduced '@DIRNAME@' feature in machine files to point to the Metrowerks linker script.