### PR TITLE
Added support for Texas Instruments C6000 compiler.

### DIFF
--- a/cross/ti-c6000.txt
+++ b/cross/ti-c6000.txt
@@ -1,0 +1,22 @@
+# Cross file tested on Texas Instruments C6000 compiler (bare metal DSP devices)
+# This file assumes that path to the Texas Instruments C6000 toolchain is added
+# to the environment(PATH) variable.
+
+[host_machine]
+system = 'c6000'
+cpu_family = 'c6000'
+cpu = 'c64x'
+endian = 'little'
+
+[binaries]
+c = 'cl6x'
+cpp = 'cl6x'
+ar = 'ar6x'
+strip = 'strip6x'
+nm = 'nm6x'
+as = 'asm6x'
+
+[properties]
+needs_exe_wrapper = true
+has_function_printf = true
+bits = 32

--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -37,6 +37,7 @@ These are return values of the `get_id` (Compiler family) and
 | rustc     | Rust compiler                    |                 |
 | sun       | Sun Fortran compiler             |                 |
 | c2000     | Texas Instruments C/C++ Compiler (C2000) |                 |
+| c6000     | Texas Instruments C/C++ Compiler (C6000) |                 |
 | ti        | Texas Instruments C/C++ Compiler |                 |
 | valac     | Vala compiler                    |                 |
 | xc16      | Microchip XC16 C compiler        |                 |
@@ -70,6 +71,7 @@ These are return values of the `get_linker_id` method in a compiler object.
 | xc16-ar    | The Microchip linker, used with XC16 only   |
 | ar2000     | The Texas Instruments linker, used with C2000 only |
 | ti-ar      | The Texas Instruments linker |
+| ar6000     | The Texas Instruments linker, used with C6000 only |
 | armlink    | The ARM linker (arm and armclang compilers) |
 | pgi        | Portland/Nvidia PGI                         |
 | nvlink     | Nvidia Linker used with cuda                |
@@ -104,6 +106,7 @@ set in the cross file.
 | arm                 | 32 bit ARM processor     |
 | avr                 | Atmel AVR processor      |
 | c2000               | 32 bit C2000 processor   |
+| c6000               | 32 bit C6000 processor   |
 | csky                | 32 bit CSky processor    |
 | dspic               | 16 bit Microchip dsPIC   |
 | e2k                 | MCST Elbrus processor    |

--- a/docs/markdown/snippets/ti_c6000_compiler_support.md
+++ b/docs/markdown/snippets/ti_c6000_compiler_support.md
@@ -1,0 +1,4 @@
+## Support for Texas Instruments C6000 C/C++ compiler
+
+Meson now supports the TI C6000 C/C++ compiler use for the C6000 cpu family.
+The example cross file is available in `cross/ti-c6000.txt`.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1978,8 +1978,8 @@ class Executable(BuildTarget):
                 self.suffix = 'abs'
             elif ('c' in self.compilers and self.compilers['c'].get_id().startswith('xc16')):
                 self.suffix = 'elf'
-            elif ('c' in self.compilers and self.compilers['c'].get_id() in {'ti', 'c2000'} or
-                  'cpp' in self.compilers and self.compilers['cpp'].get_id() in {'ti', 'c2000'}):
+            elif ('c' in self.compilers and self.compilers['c'].get_id() in {'ti', 'c2000', 'c6000'} or
+                  'cpp' in self.compilers and self.compilers['cpp'].get_id() in {'ti', 'c2000', 'c6000'}):
                 self.suffix = 'out'
             elif ('c' in self.compilers and self.compilers['c'].get_id() in {'mwccarm', 'mwcceppc'} or
                   'cpp' in self.compilers and self.compilers['cpp'].get_id() in {'mwccarm', 'mwcceppc'}):

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -735,6 +735,9 @@ class C2000CCompiler(TICCompiler):
     # Required for backwards compat with projects created before ti-cgt support existed
     id = 'c2000'
 
+class C6000CCompiler(TICCompiler):
+    id = 'c6000'
+
 class MetrowerksCCompilerARM(MetrowerksCompiler, CCompiler):
     id = 'mwccarm'
 

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -960,6 +960,9 @@ class C2000CPPCompiler(TICPPCompiler):
     # Required for backwards compat with projects created before ti-cgt support existed
     id = 'c2000'
 
+class C6000CPPCompiler(TICPPCompiler):
+    id = 'c6000'
+
 class MetrowerksCPPCompilerARM(MetrowerksCompiler, CPPCompiler):
     id = 'mwccarm'
 

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -198,6 +198,8 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
 
         if any(os.path.basename(x) in {'lib', 'lib.exe', 'llvm-lib', 'llvm-lib.exe', 'xilib', 'xilib.exe'} for x in linker):
             arg = '/?'
+        elif linker_name in {'ar2000', 'ar2000.exe', 'ar430', 'ar430.exe', 'armar', 'armar.exe', 'ar6x', 'ar6x.exe'}:
+            arg = '?'
         else:
             arg = '--version'
         try:
@@ -231,6 +233,9 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
                 return linkers.C2000Linker(linker)
             else:
                 return linkers.TILinker(linker)
+        if 'Texas Instruments Incorporated' in out:
+            if 'ar6000' in linker_name:
+                return linkers.C6000Linker(linker)
         if out.startswith('The CompCert'):
             return linkers.CompCertLinker(linker)
         if out.strip().startswith('Metrowerks') or out.strip().startswith('Freescale'):
@@ -308,7 +313,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
             arg = '--version'
         elif 'ccomp' in compiler_name:
             arg = '-version'
-        elif compiler_name in {'cl2000', 'cl2000.exe', 'cl430', 'cl430.exe', 'armcl', 'armcl.exe'}:
+        elif compiler_name in {'cl2000', 'cl2000.exe', 'cl430', 'cl430.exe', 'armcl', 'armcl.exe', 'cl6x', 'cl6x.exe'}:
             # TI compiler
             arg = '-version'
         elif compiler_name in {'icl', 'icl.exe'}:
@@ -428,6 +433,24 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
             return cls(
                 compiler, version, for_machine, is_cross, info, target,
                 exe_wrap, linker=linker)
+
+        # must be detected here before clang because TI compilers contain 'clang' in their output and so that they can be detected as 'clang'
+        ti_compilers = {
+           'TMS320C2000 C/C++': (c.C2000CCompiler, cpp.C2000CPPCompiler, linkers.C2000DynamicLinker),
+           'TMS320C6x C/C++': (c.C6000CCompiler, cpp.C6000CPPCompiler, linkers.C6000DynamicLinker),
+           'TI ARM C/C++ Compiler': (c.TICCompiler, cpp.TICPPCompiler, linkers.TIDynamicLinker),
+           'MSP430 C/C++': (c.TICCompiler, cpp.TICPPCompiler, linkers.TIDynamicLinker)
+        }
+        for indentifier, compiler_classes in ti_compilers.items():
+            if indentifier in out:
+                cls = compiler_classes[0] if lang == 'c' else compiler_classes[1]
+                lnk = compiler_classes[2]
+                env.coredata.add_lang_args(cls.language, cls, for_machine, env)
+                linker = lnk(compiler, for_machine, version=version)
+                return cls(
+                    ccache, compiler, version, for_machine, is_cross, info,
+                    exe_wrap, full_version=full_version, linker=linker)
+
         if 'clang' in out or 'Clang' in out:
             linker = None
 
@@ -525,19 +548,6 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
             return cls(
                 ccache, compiler, version, for_machine, is_cross, info,
                 exe_wrap, full_version=full_version, linker=l)
-        if 'TMS320C2000 C/C++' in out or 'MSP430 C/C++' in out or 'TI ARM C/C++ Compiler' in out:
-            if 'TMS320C2000 C/C++' in out:
-                cls = c.C2000CCompiler if lang == 'c' else cpp.C2000CPPCompiler
-                lnk = linkers.C2000DynamicLinker
-            else:
-                cls = c.TICCompiler if lang == 'c' else cpp.TICPPCompiler
-                lnk = linkers.TIDynamicLinker
-
-            env.coredata.add_lang_args(cls.language, cls, for_machine, env)
-            linker = lnk(compiler, for_machine, version=version)
-            return cls(
-                ccache, compiler, version, for_machine, is_cross, info,
-                exe_wrap, full_version=full_version, linker=linker)
         if 'ARM' in out and not ('Metrowerks' in out or 'Freescale' in out):
             cls = c.ArmCCompiler if lang == 'c' else cpp.ArmCPPCompiler
             env.coredata.add_lang_args(cls.language, cls, for_machine, env)

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -1051,6 +1051,10 @@ class CLikeCompiler(Compiler):
         elif env.machines[self.for_machine].is_cygwin():
             shlibext = ['dll', 'dll.a']
             prefixes = ['cyg'] + prefixes
+        elif self.id.lower() == 'c6000' or self.id.lower() == 'ti':
+            # TI C6000 compiler can use both extensions for static or dynamic libs.
+            stlibext = ['a', 'lib']
+            shlibext = ['dll', 'so']
         else:
             # Linux/BSDs
             shlibext = ['so']

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -34,6 +34,7 @@ known_cpu_families = (
     'arm',
     'avr',
     'c2000',
+    'c6000',
     'csky',
     'dspic',
     'e2k',

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -492,6 +492,9 @@ class C2000Linker(TILinker):
     # Required for backwards compat with projects created before ti-cgt support existed
     id = 'ar2000'
 
+class C6000Linker(TILinker):
+    id = 'ar6000'
+
 
 class AIXArLinker(ArLikeLinker, StaticLinker):
     id = 'aixar'
@@ -1093,6 +1096,9 @@ class TIDynamicLinker(DynamicLinker):
 class C2000DynamicLinker(TIDynamicLinker):
     # Required for backwards compat with projects created before ti-cgt support existed
     id = 'cl2000'
+
+class C6000DynamicLinker(TIDynamicLinker):
+    id = 'cl6000'
 
 
 class ArmDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):


### PR DESCRIPTION
Created new compiler and linker classes:

- C6000CCompiler
- C6000CPPCompiler
- C6000Linker
- C6000DynamicLinker

It was necessary the compiler  can detect both extension for static libs (*.a, *.lib) and for dynamic libs (*.dll, *.so) => added function is_baremetal()

Added new cpu family 'c6000' into known_cpu_families for which the C6000 compiler is used (https://www.ti.com/tool/C6000-CGT)
