### PR TITLE
linkers: fix LLD linker response file handling

### DIFF
--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -606,6 +606,9 @@ class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
         "boot_application": "16",
     }
 
+    def get_accepts_rsp(self) -> bool:
+        return True
+
     def get_pie_args(self) -> T.List[str]:
         return ['-pie']
 
@@ -848,9 +851,6 @@ class LLVMLD64DynamicLinker(AppleDynamicLinker):
 class GnuDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, DynamicLinker):
 
     """Representation of GNU ld.bfd and ld.gold."""
-
-    def get_accepts_rsp(self) -> bool:
-        return True
 
 
 class GnuGoldDynamicLinker(GnuDynamicLinker):

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -5010,3 +5010,12 @@ class AllPlatformTests(BasePlatformTests):
             # The first supported std should be selected
             self.setconf('-Dcpp_std=c++11,gnu++11,vc++11')
             self.assertEqual(self.getconf('cpp_std'), 'c++11')
+
+    def test_rsp_support(self):
+        env = get_fake_env()
+        cc = detect_c_compiler(env, MachineChoice.HOST)
+        has_rsp = cc.linker.id in {
+            'ld.bfd', 'ld.gold', 'ld.lld', 'ld.mold', 'ld.qcld', 'ld.wasm',
+            'link', 'lld-link', 'mwldarm', 'mwldeppc', 'optlink', 'xilink',
+        }
+        self.assertEqual(cc.linker.get_accepts_rsp(), has_rsp)


### PR DESCRIPTION
When building with LLD as the linker, response files are never used.

It's because of an issue with the `LLVMDynamicLinker` class hierarchy:

```python
▸ python <<'EOF'
from mesonbuild.linkers.linkers import LLVMDynamicLinker
print(LLVMDynamicLinker(['lld'], '', '', []).get_accepts_rsp())
EOF
False
```

After correcting the base classes so GNU-like linkers all default to supporting response files:

```python
▸ python <<'EOF'
from mesonbuild.linkers.linkers import LLVMDynamicLinker
print(LLVMDynamicLinker(['lld'], '', '', []).get_accepts_rsp())
EOF
True
```

I added a test, but the CI would also need a build that actually use LLD as a linker.