### PR TITLE
rewriter: don't output target info to stderr

### DIFF
--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -385,7 +385,7 @@ class Rewriter:
     def print_info(self):
         if self.info_dump is None:
             return
-        sys.stderr.write(json.dumps(self.info_dump, indent=2))
+        sys.stdout.write(json.dumps(self.info_dump, indent=2))
 
     def on_error(self):
         if self.skip_errors:
@@ -1044,6 +1044,7 @@ cli_type_map = {
 }
 
 def run(options):
+    mlog.redirect(True)
     if not options.verbose:
         mlog.set_quiet()
 

--- a/unittests/rewritetests.py
+++ b/unittests/rewritetests.py
@@ -34,12 +34,12 @@ class RewriterTests(BasePlatformTests):
         print('STDERR:')
         print(p.stderr)
         if p.returncode != 0:
-            if 'MESON_SKIP_TEST' in p.stdout:
+            if 'MESON_SKIP_TEST' in p.stderr:
                 raise unittest.SkipTest('Project requested skipping.')
-            raise subprocess.CalledProcessError(p.returncode, command, output=p.stdout)
-        if not p.stderr:
+            raise subprocess.CalledProcessError(p.returncode, command, output=p.stderr)
+        if not p.stdout:
             return {}
-        return json.loads(p.stderr)
+        return json.loads(p.stdout)
 
     def rewrite(self, directory, args):
         if isinstance(args, str):


### PR DESCRIPTION
Send the info to stdout, where it belongs.