### PR TITLE
fix bug where all Java builds & tests fail to run SanityCheck

### DIFF
--- a/mesonbuild/compilers/java.py
+++ b/mesonbuild/compilers/java.py
@@ -100,7 +100,7 @@ class JavaCompiler(BasicLinkerIsCompilerMixin, Compiler):
             raise EnvironmentException(f'Java compiler {self.name_string()} cannot compile programs.')
         runner = shutil.which(self.javarunner)
         if runner:
-            cmdlist = [runner, obj]
+            cmdlist = [runner, '-cp', '.', obj]
             pe = subprocess.Popen(cmdlist, cwd=work_dir)
             pe.wait()
             if pe.returncode != 0:


### PR DESCRIPTION
Needed a classpath set in the current working directory. This was on a Zulu build of OpenJDK 11.0.17 on a macOS ARM machine.

The errors folks might encounter:

- Error: Could not find or load main class SanityCheck 
- Caused by: java.lang.ClassNotFoundException: SanityCheck