### PR TITLE
meson/rust: wrap `bindgen`s `wrap-static-fns` functionality

### DIFF
--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -57,6 +57,9 @@ It takes the following keyword arguments
 - `input`: a list of Files, Strings, or CustomTargets. The first element is
   the header bindgen will parse, additional elements are dependencies.
 - `output`: the name of the output rust file
+- `output_inline_wrapper`: the name of the optional output c file containing
+  wrappers for static inline function. This requires `bindgen-0.65` or
+  newer (*since 1.3.0*).
 - `include_directories`: A list of `include_directories` or `string` objects,
   these are passed to clang as `-I` arguments *(string since 1.0.0)*
 - `c_args`: a list of string arguments to pass to clang untouched

--- a/test cases/rust/12 bindgen/meson.build
+++ b/test cases/rust/12 bindgen/meson.build
@@ -99,6 +99,34 @@ rust_bin2 = executable(
 
 test('generated header', rust_bin2)
 
+if prog_bindgen.version().version_compare('>= 0.65')
+  # Test generating a static inline wrapper
+  gen3 = rust.bindgen(
+    input : 'src/header3.h',
+    output : 'header3.rs',
+    output_inline_wrapper : 'header3.c',
+    include_directories : 'include',
+  )
+  c_inline_wrapper = static_library('c_wrapper', gen3[1])
+
+  f = configure_file(
+    input : 'src/main3.rs',
+    output : 'main3.rs',
+    copy : true,
+  )
+
+  rust_bin3 = executable(
+    'rust_bin3',
+    [f, gen3[0]],
+    link_with : [
+      c_lib,
+      c_inline_wrapper,
+    ],
+  )
+
+  test('static inline wrapper', rust_bin3)
+endif
+
 subdir('sub')
 subdir('dependencies')
 

--- a/test cases/rust/12 bindgen/src/header3.h
+++ b/test cases/rust/12 bindgen/src/header3.h
@@ -1,0 +1,12 @@
+// SPDX-license-identifer: Apache-2.0
+// Copyright © 2023 Red Hat, Inc
+
+#pragma once
+
+#include "other.h"
+
+int32_t add(const int32_t, const int32_t);
+
+static inline int32_t sub(const int32_t a, const int32_t b) {
+   return a - b;
+}

--- a/test cases/rust/12 bindgen/src/main3.rs
+++ b/test cases/rust/12 bindgen/src/main3.rs
@@ -1,0 +1,14 @@
+// SPDX-license-identifer: Apache-2.0
+// Copyright © 2023 Red Hat, Inc
+
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+include!("header3.rs");
+
+fn main() {
+    unsafe {
+        std::process::exit(add(0, sub(0, 0)));
+    };
+}


### PR DESCRIPTION
This way the `rust.bindgen` can generate a second output being a C file, which contains wrapper functions for static inline ones.

This output file can then be compiled via C targets.