### PR TITLE
fs configure_file_list function

### DIFF
--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -264,3 +264,32 @@ returns:
 ```meson
 copy = fs.copyfile('input-file', 'output-file')
 ```
+
+### configure_file_list
+
+*Since 1.7.0*
+
+Write paths from a list of files to a configuration file, which can be used as
+an argument to a command. The result file is generated at build time and 
+updated when any input file is updated.
+
+Has the following positional arguments:
+   - name `str`: name of the resulting file
+   - sources `str | file | custom_tgt | custom_idx | build_tgt`: file paths to
+     write to the result file
+
+Has the following keyword arguments:
+   - quote `bool`: if `true`, add quote and escape chars to the file paths
+     (default `false`)
+   - separator `str`: characters used to separate the paths (default `\n`)
+   - end `str`: characters to put at the end of the file (default `\n`)
+   - relative_paths `bool`: if `true`, write relative paths, if `false`, write
+     absolute paths (default: `false`)
+
+returns:
+   - a [[custom_target]] object
+
+```meson
+src_files = files(...)
+file_list = fs.configure_file_list('filelist.txt', src_files)
+```

--- a/docs/markdown/snippets/fs_configure_file_list.md
+++ b/docs/markdown/snippets/fs_configure_file_list.md
@@ -1,0 +1,7 @@
+## `fs.configure_file_list()`
+
+This function produces, at build time, a file containing the list of files given
+as argument. It is used when a command uses, as argument, a file containing the
+list of files to process. One usecase is to provide `xgettext` with the list of
+files to process, from the list of source files, when this list is too long to
+be provided to the command line as individual files.

--- a/test cases/common/220 fs module/meson.build
+++ b/test cases/common/220 fs module/meson.build
@@ -191,6 +191,21 @@ subdir('subdir')
 
 subproject('subbie')
 
+
+# configure_file_list
+test_file_list = find_program('testfilelist.py')
+cfl = fs.configure_file_list(
+  'fl.txt',
+  'meson.build',
+  subdirfiles,
+  [btgt, ctgt],
+)
+test(
+  'fs.configure_file_list',
+  test_file_list,
+  args: cfl,
+)
+
 testcase expect_error('File notfound does not exist.')
   fs.read('notfound')
 endtestcase

--- a/test cases/common/220 fs module/testfilelist.py
+++ b/test cases/common/220 fs module/testfilelist.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import sys
+from pathlib import Path
+
+input_file = Path(sys.argv[-1])
+if not input_file.exists():
+    sys.exit('Input file not found')
+
+with input_file.open('r', encoding='utf-8') as f:
+    for line in f:
+        line = line.strip()
+        if not Path(line).exists():
+            sys.exit(f'File {line} not found')
+
+sys.exit(0)


### PR DESCRIPTION
This is a new attempt to achieve the same goal as what I tried in #11822 , but in a simpler way.

This function produces, at build time, a file containing the list of files given as argument. It is used when a command uses, as argument, a file containing the list of files to process. One usecase is to provide to `xgettext` the list of files to process, from the list of source files, when this list is too long to be provided to the command line as individual files.