### PR TITLE
CPU family support 'sw_64' and remove the compile warning 

### DIFF
--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -68,6 +68,7 @@ known_cpu_families = (
     'sh4',
     'sparc',
     'sparc64',
+    'sw_64',
     'wasm32',
     'wasm64',
     'x86',
@@ -86,6 +87,7 @@ CPU_FAMILIES_64_BIT = [
     'riscv64',
     's390x',
     'sparc64',
+    'sw_64',
     'wasm64',
     'x86_64',
 ]


### PR DESCRIPTION
CPU family support 'sw_64' and remove the compile warning :
"WARNING: Unknown CPU family 'sw_64', please report this at https://github.com/mesonbuild/meson/issues/new with the output of uname -a and cat /proc/cpuinfo"

uname -a:
Linux localhost.localdomain 4.19.90-52.27 https://github.com/mesonbuild/meson/issues/1 SMP Fri Sep 29 10:19:44 CST 2023 sw_64 sw_64 sw_64 GNU/Linux

cpuinfo:
processor : 0
vendor_id : sunway
cpu family : 6
model : 49
model name : SW3231 CPU @ 2.40GHz
cpu variation : 3
cpu revision : 2
cpu MHz : 2400.00
cache size : 65536 KB
physical id : 0
bogomips : 4800.00
flags : fpu simd vpn upn cpuid
page size : 8192
cache_alignment : 128
address sizes : 48 bits physical, 53 bits virtual