### PR TITLE
Major rewrite of the rewriter and the static introspection tool

### DIFF
--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -65,6 +65,16 @@ if T.TYPE_CHECKING:
 _T = T.TypeVar('_T')
 _V = T.TypeVar('_V')
 
+# `IntrospectionDependency` is to the `IntrospectionInterpreter` what `Dependency` is to the normal `Interpreter`.
+@dataclass
+class IntrospectionDependency(MesonInterpreterObject):
+    name: str
+    required: T.Union[bool]
+    version: T.List[str]
+    has_fallback: bool
+    conditional: bool
+    node: FunctionNode
+
 # `IntrospectionBuildTarget` is to the `IntrospectionInterpreter` what `BuildTarget` is to the normal `Interpreter`.
 @dataclass
 class IntrospectionBuildTarget(MesonInterpreterObject):

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -185,7 +185,6 @@ class AstInterpreter(InterpreterBase):
         self.dataflow_dag = DataflowDAG()
         self.funcvals: T.Dict[BaseNode, T.Any] = {}
         self.tainted = False
-        self.assign_vals: T.Dict[str, T.Any] = {}
         self.funcs.update({'project': self.func_do_nothing,
                            'test': self.func_do_nothing,
                            'benchmark': self.func_do_nothing,
@@ -642,9 +641,9 @@ class AstInterpreter(InterpreterBase):
 
     def assignment(self, node: AssignmentNode) -> None:
         assert isinstance(node, AssignmentNode)
+        self.evaluate_statement(node.value)
         self.cur_assignments[node.var_name.value].append((self.nesting.copy(), node.value))
         self.all_assignment_nodes[node.var_name.value].append(node)
-        self.assign_vals[node.var_name.value] = self.evaluate_statement(node.value) # Evaluate the value just in case
 
     def evaluate_plusassign(self, node: PlusAssignmentNode) -> None:
         assert isinstance(node, PlusAssignmentNode)
@@ -660,8 +659,6 @@ class AstInterpreter(InterpreterBase):
 
         self.dataflow_dag.add_edge(lhs, newval)
         self.dataflow_dag.add_edge(node.value, newval)
-
-        self.assign_vals[node.var_name.value] = self.evaluate_statement(node.value)
 
     def func_set_variable(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> None:
         assert isinstance(node, FunctionNode)

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -54,9 +54,10 @@ from ..mparser import (
 )
 
 if T.TYPE_CHECKING:
+    from pathlib import Path
     from .visitor import AstVisitor
     from ..interpreter import Interpreter
-    from ..interpreterbase import SubProject, TYPE_nkwargs, TYPE_var, TYPE_nvar
+    from ..interpreterbase import SubProject, TYPE_var, TYPE_nvar
     from ..mparser import (
         AndNode,
         ComparisonNode,
@@ -246,10 +247,10 @@ class AstInterpreter(InterpreterBase):
                            'debug': self.func_do_nothing,
                            })
 
-    def _unholder_args(self, args: _T, kwargs: _V) -> T.Tuple[_T, _V]:
+    def _unholder_args(self, args: T.Any, kwargs: T.Any) -> T.Tuple[T.Any, T.Any]:
         return args, kwargs
 
-    def _holderify(self, res: _T) -> _T:
+    def _holderify(self, res: T.Any) -> T.Any:
         return res
 
     def func_do_nothing(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> UnknownValue:
@@ -340,13 +341,13 @@ class AstInterpreter(InterpreterBase):
                 args: mparser.ArgumentNode,
                 key_resolver: T.Callable[[mparser.BaseNode], str] = default_resolve_key,
                 duplicate_key_error: T.Optional[str] = None,
-            ) -> T.Tuple[T.List[TYPE_var], TYPE_nkwargs]:
+            ) -> T.Tuple[T.List[T.Any], T.Any]:
         for arg in args.arguments:
             self.evaluate_statement(arg)
         for value in args.kwargs.values():
             self.evaluate_statement(value)
         if isinstance(args, ArgumentNode):
-            kwargs: T.Dict[str, TYPE_var] = {}
+            kwargs = {}
             for key, val in args.kwargs.items():
                 kwargs[key_resolver(key)] = val
             if args.incorrect_order():
@@ -496,9 +497,6 @@ class AstInterpreter(InterpreterBase):
             return UnknownValue()
         assert ret is not None
         return ret
-
-    def get_variable(self, varname: str) -> int:
-        return 0
 
     # The function `node_to_runtime_value` takes a node of the ast as an
     # argument and tries to return the same thing that would be passed to e.g.

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -96,6 +96,7 @@ class AstInterpreter(InterpreterBase):
     def __init__(self, source_root: str, subdir: str, subproject: SubProject, subproject_dir: str, env: environment.Environment, visitors: T.Optional[T.List[AstVisitor]] = None):
         super().__init__(source_root, subdir, subproject, subproject_dir, env)
         self.visitors = visitors if visitors is not None else []
+        self.nesting: T.List[int] = []
         self.assignments: T.Dict[str, BaseNode] = {}
         self.assign_vals: T.Dict[str, T.Any] = {}
         self.reverse_assignment: T.Dict[str, BaseNode] = {}
@@ -283,10 +284,13 @@ class AstInterpreter(InterpreterBase):
             pass
 
     def evaluate_if(self, node: IfClauseNode) -> None:
+        self.nesting.append(0)
         for i in node.ifs:
             self.evaluate_codeblock(i.block)
+            self.nesting[-1] += 1
         if not isinstance(node.elseblock, EmptyNode):
             self.evaluate_codeblock(node.elseblock.block)
+        self.nesting.pop()
 
     def get_variable(self, varname: str) -> int:
         return 0

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -8,11 +8,13 @@ from __future__ import annotations
 import os
 import sys
 import typing as T
+from dataclasses import dataclass
 
 from .. import mparser, mesonlib
 from .. import environment
 
 from ..interpreterbase import (
+    MesonInterpreterObject,
     InterpreterBase,
     InvalidArguments,
     BreakRequest,
@@ -57,11 +59,28 @@ if T.TYPE_CHECKING:
         OrNode,
         TestCaseClauseNode,
         UMinusNode,
+        FunctionNode,
     )
 
 _T = T.TypeVar('_T')
 _V = T.TypeVar('_V')
 
+# `IntrospectionBuildTarget` is to the `IntrospectionInterpreter` what `BuildTarget` is to the normal `Interpreter`.
+@dataclass
+class IntrospectionBuildTarget(MesonInterpreterObject):
+    name: str
+    machine: str
+    id: str
+    typename: str
+    defined_in: str
+    subdir: str
+    build_by_default: bool
+    installed: bool
+    outputs: T.List[str]
+    source_nodes: T.List[BaseNode]
+    extra_files: T.List[BaseNode]
+    kwargs: T.Dict[str, TYPE_var]
+    node: FunctionNode
 
 class AstInterpreter(InterpreterBase):
     def __init__(self, source_root: str, subdir: str, subproject: SubProject, subproject_dir: str, env: environment.Environment, visitors: T.Optional[T.List[AstVisitor]] = None):

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -13,7 +13,6 @@ from .. import mparser, mesonlib
 from .. import environment
 
 from ..interpreterbase import (
-    MesonInterpreterObject,
     InterpreterBase,
     InvalidArguments,
     BreakRequest,
@@ -59,27 +58,6 @@ if T.TYPE_CHECKING:
         TestCaseClauseNode,
         UMinusNode,
     )
-
-class DontCareObject(MesonInterpreterObject):
-    pass
-
-class MockExecutable(MesonInterpreterObject):
-    pass
-
-class MockStaticLibrary(MesonInterpreterObject):
-    pass
-
-class MockSharedLibrary(MesonInterpreterObject):
-    pass
-
-class MockCustomTarget(MesonInterpreterObject):
-    pass
-
-class MockRunTarget(MesonInterpreterObject):
-    pass
-
-ADD_SOURCE = 0
-REMOVE_SOURCE = 1
 
 _T = T.TypeVar('_T')
 _V = T.TypeVar('_V')
@@ -231,9 +209,6 @@ class AstInterpreter(InterpreterBase):
 
     def evaluate_indexing(self, node: IndexNode) -> int:
         return 0
-
-    def unknown_function_called(self, func_name: str) -> None:
-        pass
 
     def reduce_arguments(
                 self,

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -49,7 +49,7 @@ from ..mparser import (
 if T.TYPE_CHECKING:
     from .visitor import AstVisitor
     from ..interpreter import Interpreter
-    from ..interpreterbase import SubProject, TYPE_nkwargs, TYPE_var
+    from ..interpreterbase import SubProject, TYPE_nkwargs, TYPE_var, TYPE_nvar
     from ..mparser import (
         AndNode,
         ComparisonNode,
@@ -387,7 +387,7 @@ class AstInterpreter(InterpreterBase):
 
         return result
 
-    def flatten_args(self, args_raw: T.Union[TYPE_var, T.Sequence[TYPE_var]], include_unknown_args: bool = False, id_loop_detect: T.Optional[T.List[str]] = None) -> T.List[TYPE_var]:
+    def flatten_args(self, args_raw: T.Union[TYPE_nvar, T.Sequence[TYPE_nvar]], include_unknown_args: bool = False, id_loop_detect: T.Optional[T.List[str]] = None) -> T.List[TYPE_var]:
         # Make sure we are always dealing with lists
         if isinstance(args_raw, list):
             args = args_raw

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -157,7 +157,7 @@ class IntrospectionInterpreter(AstInterpreter):
         except (mesonlib.MesonException, RuntimeError):
             pass
 
-    def func_add_languages(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> None:
+    def func_add_languages(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> UnknownValue:
         kwargs = self.flatten_kwargs(kwargs)
         required = kwargs.get('required', True)
         assert isinstance(required, (bool, options.UserFeatureOption, UnknownValue)), 'for mypy'
@@ -169,6 +169,7 @@ class IntrospectionInterpreter(AstInterpreter):
         else:
             for for_machine in [MachineChoice.BUILD, MachineChoice.HOST]:
                 self._add_languages(args, required, for_machine)
+        return UnknownValue()
 
     def _add_languages(self, raw_langs: T.List[TYPE_var], required: T.Union[bool, UnknownValue], for_machine: MachineChoice) -> None:
         langs: T.List[str] = []
@@ -197,12 +198,12 @@ class IntrospectionInterpreter(AstInterpreter):
                         options[k] = v
                     self.coredata.add_compiler_options(options, lang, for_machine, self.environment, self.subproject)
 
-    def func_dependency(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> None:
+    def func_dependency(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> T.Optional[IntrospectionDependency]:
         assert isinstance(node, FunctionNode)
         args = self.flatten_args(args)
         kwargs = self.flatten_kwargs(kwargs)
         if not args:
-            return
+            return None
         name = args[0]
         assert isinstance(name, (str, UnknownValue))
         has_fallback = 'fallback' in kwargs
@@ -222,6 +223,7 @@ class IntrospectionInterpreter(AstInterpreter):
             conditional=node.condition_level > 0,
             node=node)
         self.dependencies += [newdep]
+        return newdep
 
     def build_target(self, node: BaseNode, args: T.List[TYPE_var], kwargs_raw: T.Dict[str, TYPE_var], targetclass: T.Type[BuildTarget]) -> T.Union[IntrospectionBuildTarget, UnknownValue]:
         assert isinstance(node, FunctionNode)

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -44,8 +44,11 @@ class IntrospectionHelper:
         return NotImplemented
 
 class IntrospectionInterpreter(AstInterpreter):
-    # Interpreter to detect the options without a build directory
-    # Most of the code is stolen from interpreter.Interpreter
+    # If you run `meson setup ...` the `Interpreter`-class walks over the AST.
+    # If you run `meson rewrite ...` and `meson introspect meson.build ...`,
+    # the `AstInterpreter`-class walks over the AST.
+    # Works without a build directory.
+    # Most of the code is stolen from interpreter.Interpreter .
     def __init__(self,
                  source_root: str,
                  subdir: str,

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -22,7 +22,6 @@ from .interpreter import AstInterpreter, IntrospectionBuildTarget, Introspection
 if T.TYPE_CHECKING:
     from ..build import BuildTarget
     from ..interpreterbase import TYPE_var
-    from ..options import OptionDict
     from .visitor import AstVisitor
 
 
@@ -64,7 +63,6 @@ class IntrospectionInterpreter(AstInterpreter):
 
         self.cross_file = cross_file
         self.backend = backend
-        self.default_options = {OptionKey('backend'): self.backend}
         self.project_data: T.Dict[str, T.Any] = {}
         self.targets: T.List[IntrospectionBuildTarget] = []
         self.dependencies: T.List[IntrospectionDependency] = []
@@ -127,24 +125,6 @@ class IntrospectionInterpreter(AstInterpreter):
         self.project_data = {'descriptive_name': proj_name, 'version': proj_vers, 'license': proj_license, 'license_files': proj_license_files}
 
         self._load_option_file()
-
-        def_opts = self.flatten_args(kwargs.get('default_options', []))
-        _project_default_options = mesonlib.stringlistify(def_opts)
-        self.project_default_options = create_options_dict(_project_default_options, self.subproject)
-        self.default_options.update(self.project_default_options)
-        if self.environment.first_invocation or (self.subproject != '' and self.subproject not in self.coredata.initialized_subprojects):
-            if self.subproject == '':
-                self.coredata.optstore.initialize_from_top_level_project_call(
-                    T.cast('OptionDict', self.project_default_options),
-                    {},  # TODO: not handled by this Interpreter.
-                    self.environment.options)
-            else:
-                self.coredata.optstore.initialize_from_subproject_call(
-                    self.subproject,
-                    {},  # TODO: this isn't handled by the introspection interpreter...
-                    T.cast('OptionDict', self.project_default_options),
-                    {})  # TODO: this isn't handled by the introspection interpreter...
-                self.coredata.initialized_subprojects.add(self.subproject)
 
         if not self.is_subproject() and 'subproject_dir' in kwargs:
             spdirname = kwargs['subproject_dir']

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -17,7 +17,7 @@ from ..interpreterbase import InvalidArguments, SubProject
 from ..mesonlib import MachineChoice
 from ..options import OptionKey
 from ..mparser import BaseNode, ArithmeticNode, ArrayNode, ElementaryNode, IdNode, FunctionNode, StringNode
-from .interpreter import AstInterpreter, IntrospectionBuildTarget
+from .interpreter import AstInterpreter, IntrospectionBuildTarget, IntrospectionDependency
 
 if T.TYPE_CHECKING:
     from ..build import BuildTarget
@@ -67,7 +67,7 @@ class IntrospectionInterpreter(AstInterpreter):
         self.default_options = {OptionKey('backend'): self.backend}
         self.project_data: T.Dict[str, T.Any] = {}
         self.targets: T.List[IntrospectionBuildTarget] = []
-        self.dependencies: T.List[T.Dict[str, T.Any]] = []
+        self.dependencies: T.List[IntrospectionDependency] = []
         self.project_node: BaseNode = None
 
         self.funcs.update({
@@ -231,14 +231,14 @@ class IntrospectionInterpreter(AstInterpreter):
             required = required.value
         if not isinstance(required, bool):
             required = False
-        self.dependencies += [{
-            'name': name,
-            'required': required,
-            'version': version,
-            'has_fallback': has_fallback,
-            'conditional': node.condition_level > 0,
-            'node': node
-        }]
+        newdep = IntrospectionDependency(
+            name=name,
+            required=required,
+            version=version,
+            has_fallback=has_fallback,
+            conditional=node.condition_level > 0,
+            node=node)
+        self.dependencies += [newdep]
 
     def build_target(self, node: BaseNode, args: T.List[TYPE_var], kwargs_raw: T.Dict[str, TYPE_var], targetclass: T.Type[BuildTarget]) -> IntrospectionBuildTarget:
         args = self.flatten_args(args)

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -17,7 +17,7 @@ from ..interpreterbase import InvalidArguments, SubProject
 from ..mesonlib import MachineChoice
 from ..options import OptionKey
 from ..mparser import BaseNode, ArithmeticNode, ArrayNode, ElementaryNode, IdNode, FunctionNode, StringNode
-from .interpreter import AstInterpreter
+from .interpreter import AstInterpreter, IntrospectionBuildTarget
 
 if T.TYPE_CHECKING:
     from ..build import BuildTarget
@@ -66,7 +66,7 @@ class IntrospectionInterpreter(AstInterpreter):
         self.backend = backend
         self.default_options = {OptionKey('backend'): self.backend}
         self.project_data: T.Dict[str, T.Any] = {}
-        self.targets: T.List[T.Dict[str, T.Any]] = []
+        self.targets: T.List[IntrospectionBuildTarget] = []
         self.dependencies: T.List[T.Dict[str, T.Any]] = []
         self.project_node: BaseNode = None
 
@@ -240,7 +240,7 @@ class IntrospectionInterpreter(AstInterpreter):
             'node': node
         }]
 
-    def build_target(self, node: BaseNode, args: T.List[TYPE_var], kwargs_raw: T.Dict[str, TYPE_var], targetclass: T.Type[BuildTarget]) -> T.Optional[T.Dict[str, T.Any]]:
+    def build_target(self, node: BaseNode, args: T.List[TYPE_var], kwargs_raw: T.Dict[str, TYPE_var], targetclass: T.Type[BuildTarget]) -> IntrospectionBuildTarget:
         args = self.flatten_args(args)
         if not args or not isinstance(args[0], str):
             return None
@@ -305,26 +305,25 @@ class IntrospectionInterpreter(AstInterpreter):
                              self.environment, self.coredata.compilers[for_machine], kwargs_reduced)
         target.process_compilers_late()
 
-        new_target = {
-            'name': target.get_basename(),
-            'machine': target.for_machine.get_lower_case_name(),
-            'id': target.get_id(),
-            'type': target.get_typename(),
-            'defined_in': os.path.normpath(os.path.join(self.source_root, self.subdir, environment.build_filename)),
-            'subdir': self.subdir,
-            'build_by_default': target.build_by_default,
-            'installed': target.should_install(),
-            'outputs': target.get_outputs(),
-            'sources': source_nodes,
-            'extra_files': extraf_nodes,
-            'kwargs': kwargs,
-            'node': node,
-        }
+        new_target = IntrospectionBuildTarget(
+            name=target.get_basename(),
+            machine=target.for_machine.get_lower_case_name(),
+            id=target.get_id(),
+            typename=target.get_typename(),
+            defined_in=os.path.normpath(os.path.join(self.source_root, self.subdir, environment.build_filename)),
+            subdir=self.subdir,
+            build_by_default=target.build_by_default,
+            installed=target.should_install(),
+            outputs=target.get_outputs(),
+            source_nodes=source_nodes,
+            extra_files=extraf_nodes,
+            kwargs=kwargs,
+            node=node)
 
         self.targets += [new_target]
         return new_target
 
-    def build_library(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> T.Optional[T.Dict[str, T.Any]]:
+    def build_library(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> IntrospectionBuildTarget:
         default_library = self.coredata.optstore.get_value_for(OptionKey('default_library'))
         if default_library == 'shared':
             return self.build_target(node, args, kwargs, SharedLibrary)
@@ -334,28 +333,28 @@ class IntrospectionInterpreter(AstInterpreter):
             return self.build_target(node, args, kwargs, SharedLibrary)
         return None
 
-    def func_executable(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> T.Optional[T.Dict[str, T.Any]]:
+    def func_executable(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> IntrospectionBuildTarget:
         return self.build_target(node, args, kwargs, Executable)
 
-    def func_static_lib(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> T.Optional[T.Dict[str, T.Any]]:
+    def func_static_lib(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> IntrospectionBuildTarget:
         return self.build_target(node, args, kwargs, StaticLibrary)
 
-    def func_shared_lib(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> T.Optional[T.Dict[str, T.Any]]:
+    def func_shared_lib(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> IntrospectionBuildTarget:
         return self.build_target(node, args, kwargs, SharedLibrary)
 
-    def func_both_lib(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> T.Optional[T.Dict[str, T.Any]]:
+    def func_both_lib(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> IntrospectionBuildTarget:
         return self.build_target(node, args, kwargs, SharedLibrary)
 
-    def func_shared_module(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> T.Optional[T.Dict[str, T.Any]]:
+    def func_shared_module(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> IntrospectionBuildTarget:
         return self.build_target(node, args, kwargs, SharedModule)
 
-    def func_library(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> T.Optional[T.Dict[str, T.Any]]:
+    def func_library(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> IntrospectionBuildTarget:
         return self.build_library(node, args, kwargs)
 
-    def func_jar(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> T.Optional[T.Dict[str, T.Any]]:
+    def func_jar(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> IntrospectionBuildTarget:
         return self.build_target(node, args, kwargs, Jar)
 
-    def func_build_target(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> T.Optional[T.Dict[str, T.Any]]:
+    def func_build_target(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> IntrospectionBuildTarget:
         if 'target_type' not in kwargs:
             return None
         target_type = kwargs.pop('target_type')

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -290,7 +290,7 @@ class IntrospectionInterpreter(AstInterpreter):
         extraf_nodes = traverse_nodes(extra_queue)
 
         # Make sure nothing can crash when creating the build class
-        kwargs_reduced = {k: v for k, v in kwargs.items() if k in targetclass.known_kwargs and k in {'install', 'build_by_default', 'build_always'}}
+        kwargs_reduced = {k: v for k, v in kwargs.items() if k in targetclass.known_kwargs and k in {'install', 'build_by_default', 'build_always', 'name_prefix'}}
         kwargs_reduced = {k: v.value if isinstance(v, ElementaryNode) else v for k, v in kwargs_reduced.items()}
         kwargs_reduced = {k: v for k, v in kwargs_reduced.items() if not isinstance(v, BaseNode)}
         for_machine = MachineChoice.BUILD if kwargs.get('native', False) else MachineChoice.HOST

--- a/mesonbuild/ast/printer.py
+++ b/mesonbuild/ast/printer.py
@@ -7,10 +7,42 @@ from __future__ import annotations
 
 from .. import mparser
 from .visitor import AstVisitor, FullAstVisitor
+from ..mesonlib import MesonBugException
 
 import re
 import typing as T
 
+
+# Also known as "order of operations" or "binding power".
+# This is the counterpart to Parser.e1, Parser.e2, Parser.e3, Parser.e4, Parser.e5, Parser.e6, Parser.e7, Parser.e8, Parser.e9, Parser.e10
+def precedence_level(node: mparser.BaseNode) -> int:
+    if isinstance(node, (mparser.PlusAssignmentNode, mparser.AssignmentNode, mparser.TernaryNode)):
+        return 1
+    elif isinstance(node, mparser.OrNode):
+        return 2
+    elif isinstance(node, mparser.AndNode):
+        return 3
+    elif isinstance(node, mparser.ComparisonNode):
+        return 4
+    elif isinstance(node, mparser.ArithmeticNode):
+        if node.operation in {'add', 'sub'}:
+            return 5
+        elif node.operation in {'mod', 'mul', 'div'}:
+            return 6
+    elif isinstance(node, (mparser.NotNode, mparser.UMinusNode)):
+        return 7
+    elif isinstance(node, mparser.FunctionNode):
+        return 8
+    elif isinstance(node, (mparser.ArrayNode, mparser.DictNode)):
+        return 9
+    elif isinstance(node, (mparser.BooleanNode, mparser.IdNode, mparser.NumberNode, mparser.StringNode, mparser.EmptyNode)):
+        return 10
+    elif isinstance(node, mparser.ParenthesizedNode):
+        # Parenthesize have the highest binding power, but since the AstPrinter
+        # ignores ParanthesizedNode, the binding power of the inner node is
+        # relevant.
+        return precedence_level(node.inner)
+    raise MesonBugException('Unhandled node type')
 
 class AstPrinter(AstVisitor):
     escape_trans: T.Dict[int, str] = str.maketrans({'\\': '\\\\', "'": "\'"})
@@ -110,11 +142,21 @@ class AstPrinter(AstVisitor):
         node.lineno = self.curr_line or node.lineno
         node.right.accept(self)
 
+    def maybe_parentheses(self, outer: mparser.BaseNode, inner: mparser.BaseNode, parens: bool) -> None:
+        if parens:
+            self.append('(', inner)
+        inner.accept(self)
+        if parens:
+            self.append(')', inner)
+
     def visit_ArithmeticNode(self, node: mparser.ArithmeticNode) -> None:
-        node.left.accept(self)
+        prec = precedence_level(node)
+        prec_left = precedence_level(node.left)
+        prec_right = precedence_level(node.right)
+        self.maybe_parentheses(node, node.left, prec > prec_left)
         self.append_padded(node.operator.value, node)
         node.lineno = self.curr_line or node.lineno
-        node.right.accept(self)
+        self.maybe_parentheses(node, node.right, prec > prec_right or (prec == prec_right and node.operation in {'sub', 'div', 'mod'}))
 
     def visit_NotNode(self, node: mparser.NotNode) -> None:
         node.lineno = self.curr_line or node.lineno

--- a/mesonbuild/ast/printer.py
+++ b/mesonbuild/ast/printer.py
@@ -13,6 +13,8 @@ import typing as T
 
 
 class AstPrinter(AstVisitor):
+    escape_trans: T.Dict[int, str] = str.maketrans({'\\': '\\\\', "'": "\'"})
+
     def __init__(self, indent: int = 2, arg_newline_cutoff: int = 5, update_ast_line_nos: bool = False):
         self.result = ''
         self.indent = indent
@@ -57,7 +59,7 @@ class AstPrinter(AstVisitor):
         node.lineno = self.curr_line or node.lineno
 
     def escape(self, val: str) -> str:
-        return val.replace('\\', '\\\\').replace("'", "\'")
+        return val.translate(self.escape_trans)
 
     def visit_StringNode(self, node: mparser.StringNode) -> None:
         assert isinstance(node.value, str)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -33,7 +33,7 @@ from .compilers import (
     is_header, is_object, is_source, clink_langs, sort_clink, all_languages,
     is_known_suffix, detect_static_linker
 )
-from .interpreterbase import FeatureNew, FeatureDeprecated
+from .interpreterbase import FeatureNew, FeatureDeprecated, UnknownValue
 
 if T.TYPE_CHECKING:
     from typing_extensions import Literal, TypedDict
@@ -648,7 +648,7 @@ class Target(HoldableObject, metaclass=abc.ABCMeta):
     def process_kwargs_base(self, kwargs: T.Dict[str, T.Any]) -> None:
         if 'build_by_default' in kwargs:
             self.build_by_default = kwargs['build_by_default']
-            if not isinstance(self.build_by_default, bool):
+            if not isinstance(self.build_by_default, (bool, UnknownValue)):
                 raise InvalidArguments('build_by_default must be a boolean value.')
 
         if not self.build_by_default and kwargs.get('install', False):

--- a/mesonbuild/interpreterbase/__init__.py
+++ b/mesonbuild/interpreterbase/__init__.py
@@ -59,6 +59,8 @@ __all__ = [
     'TYPE_HoldableTypes',
 
     'HoldableTypes',
+
+    'UnknownValue',
 ]
 
 from .baseobjects import (
@@ -81,6 +83,8 @@ from .baseobjects import (
     SubProject,
 
     HoldableTypes,
+
+    UnknownValue,
 )
 
 from .decorators import (

--- a/mesonbuild/interpreterbase/baseobjects.py
+++ b/mesonbuild/interpreterbase/baseobjects.py
@@ -121,6 +121,12 @@ class MesonInterpreterObject(InterpreterObject):
 class MutableInterpreterObject:
     ''' Dummy class to mark the object type as mutable '''
 
+class UnknownValue(MesonInterpreterObject):
+    '''This class is only used for the rewriter/static introspection tool and
+    indicates that a value cannot be determined statically, either because of
+    limitations in our code or because the value differs from machine to
+    machine.'''
+
 HoldableTypes = (HoldableObject, int, bool, str, list, dict)
 TYPE_HoldableTypes = T.Union[TYPE_var, HoldableObject]
 InterpreterObjectTypeVar = T.TypeVar('InterpreterObjectTypeVar', bound=TYPE_HoldableTypes)

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -31,6 +31,12 @@ if T.TYPE_CHECKING:
 
     from .interpreter import Interpreter
 
+class IntrospectionEncoder(json.JSONEncoder):
+    def default(self, obj: T.Any) -> T.Any:
+        if isinstance(obj, UnknownValue):
+            return 'unknown'
+        return json.JSONEncoder.default(self, obj)
+
 def get_meson_info_file(info_dir: str) -> str:
     return os.path.join(info_dir, 'meson-info.json')
 
@@ -492,12 +498,12 @@ def print_results(options: argparse.Namespace, results: T.Sequence[T.Tuple[str, 
         return 1
     elif len(results) == 1 and not options.force_dict:
         # Make to keep the existing output format for a single option
-        print(json.dumps(results[0][1], indent=indent))
+        print(json.dumps(results[0][1], indent=indent, cls=IntrospectionEncoder))
     else:
         out = {}
         for i in results:
             out[i[0]] = i[1]
-        print(json.dumps(out, indent=indent))
+        print(json.dumps(out, indent=indent, cls=IntrospectionEncoder))
     return 0
 
 def get_infodir(builddir: T.Optional[str] = None) -> str:

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -191,25 +191,25 @@ def list_targets_from_source(intr: IntrospectionInterpreter) -> T.List[T.Dict[st
                     res += [Path(j.value)]
                 elif isinstance(j, str):
                     res += [Path(j)]
-        res = [root_dir / i['subdir'] / x for x in res]
+        res = [root_dir / i.subdir / x for x in res]
         res = [x.resolve() for x in res]
         return res
 
     for i in intr.targets:
-        sources = nodes_to_paths(i['sources'])
-        extra_f = nodes_to_paths(i['extra_files'])
-        outdir = get_target_dir(intr.coredata, i['subdir'])
+        sources = nodes_to_paths(i.source_nodes)
+        extra_f = nodes_to_paths(i.extra_files)
+        outdir = get_target_dir(intr.coredata, i.subdir)
 
         tlist += [{
-            'name': i['name'],
-            'id': i['id'],
-            'type': i['type'],
-            'defined_in': i['defined_in'],
-            'filename': [os.path.join(outdir, x) for x in i['outputs']],
-            'build_by_default': i['build_by_default'],
+            'name': i.name,
+            'id': i.id,
+            'type': i.typename,
+            'defined_in': i.defined_in,
+            'filename': [os.path.join(outdir, x) for x in i.outputs],
+            'build_by_default': i.build_by_default,
             'target_sources': [{
                 'language': 'unknown',
-                'machine': i['machine'],
+                'machine': i.machine,
                 'compiler': [],
                 'parameters': [],
                 'sources': [str(x) for x in sources],
@@ -218,7 +218,7 @@ def list_targets_from_source(intr: IntrospectionInterpreter) -> T.List[T.Dict[st
             'depends': [],
             'extra_files': [str(x) for x in extra_f],
             'subproject': None, # Subprojects are not supported
-            'installed': i['installed']
+            'installed': i.installed
         }]
 
     return tlist

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -380,17 +380,16 @@ def list_compilers(coredata: cdata.CoreData) -> T.Dict[str, T.Dict[str, T.Dict[s
             }
     return compilers
 
-def list_deps_from_source(intr: IntrospectionInterpreter) -> T.List[T.Dict[str, T.Union[str, bool]]]:
-    result: T.List[T.Dict[str, T.Union[str, bool]]] = []
+def list_deps_from_source(intr: IntrospectionInterpreter) -> T.List[T.Dict[str, T.Union[str, bool, T.List[str]]]]:
+    result: T.List[T.Dict[str, T.Union[str, bool, T.List[str]]]] = []
     for i in intr.dependencies:
-        keys = [
-            'name',
-            'required',
-            'version',
-            'has_fallback',
-            'conditional',
-        ]
-        result += [{k: v for k, v in i.items() if k in keys}]
+        result += [{
+            'name': i.name,
+            'required': i.required,
+            'version': i.version,
+            'has_fallback': i.has_fallback,
+            'conditional': i.conditional,
+        }]
     return result
 
 def list_deps(coredata: cdata.CoreData, backend: backends.Backend) -> T.List[T.Dict[str, T.Union[str, T.List[str]]]]:

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -54,7 +54,7 @@ class IntroCommand:
 
 def get_meson_introspection_types(coredata: T.Optional[cdata.CoreData] = None,
                                   builddata: T.Optional[build.Build] = None,
-                                  backend: T.Optional[backends.Backend] = None) -> 'T.Mapping[str, IntroCommand]':
+                                  backend: T.Optional[backends.Backend] = None) -> T.Mapping[str, IntroCommand]:
     if backend and builddata:
         benchmarkdata = backend.create_test_serialisation(builddata.get_benchmarks())
         testdata = backend.create_test_serialisation(builddata.get_tests())
@@ -546,10 +546,11 @@ def run(options: argparse.Namespace) -> int:
         datadir = os.path.join(options.builddir, datadir)
     indent = 4 if options.indent else None
     results: T.List[T.Tuple[str, T.Union[dict, T.List[T.Any]]]] = []
-    sourcedir = '.' if options.builddir == 'meson.build' else options.builddir[:-11]
     intro_types = get_meson_introspection_types()
 
-    if 'meson.build' in [os.path.basename(options.builddir), options.builddir]:
+    # TODO: This if clause is undocumented.
+    if os.path.basename(options.builddir) == environment.build_filename:
+        sourcedir = '.' if options.builddir == environment.build_filename else options.builddir[:-len(environment.build_filename)]
         # Make sure that log entries in other parts of meson don't interfere with the JSON output
         with redirect_stdout(sys.stderr):
             backend = backends.get_backend_from_name(options.backend)

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -24,7 +24,7 @@ from .ast import IntrospectionInterpreter, BUILD_TARGET_FUNCTIONS, AstConditionL
 from .backend import backends
 from .dependencies import Dependency
 from . import environment
-from .interpreterbase import ObjectHolder
+from .interpreterbase import ObjectHolder, UnknownValue
 from .options import OptionKey
 from .mparser import FunctionNode, ArrayNode, ArgumentNode, StringNode
 
@@ -380,8 +380,8 @@ def list_compilers(coredata: cdata.CoreData) -> T.Dict[str, T.Dict[str, T.Dict[s
             }
     return compilers
 
-def list_deps_from_source(intr: IntrospectionInterpreter) -> T.List[T.Dict[str, T.Union[str, bool, T.List[str]]]]:
-    result: T.List[T.Dict[str, T.Union[str, bool, T.List[str]]]] = []
+def list_deps_from_source(intr: IntrospectionInterpreter) -> T.List[T.Dict[str, T.Union[str, bool, T.List[str], UnknownValue]]]:
+    result: T.List[T.Dict[str, T.Union[str, bool, T.List[str], UnknownValue]]] = []
     for i in intr.dependencies:
         result += [{
             'name': i.name,

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -369,6 +369,13 @@ class ArgumentNode(BaseNode):
             mlog.warning('This will be an error in Meson 2.0.')
         self.kwargs[name] = value
 
+    def get_kwarg_or_default(self, name: str, default: BaseNode) -> BaseNode:
+        for k, v in self.kwargs.items():
+            assert isinstance(k, IdNode)
+            if k.value == name:
+                return v
+        return default
+
     def set_kwarg_no_check(self, name: BaseNode, value: BaseNode) -> None:
         self.kwargs[name] = value
 

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -201,7 +201,7 @@ class Lexer:
                         lines = value.split('\n')
                         if len(lines) > 1:
                             lineno += len(lines) - 1
-                            line_start = mo.end() - len(lines[-1])
+                            line_start = mo.end() - len(lines[-1]) - 3
                     elif tid == 'eol_cont':
                         lineno += 1
                         line_start = loc

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -11,13 +11,15 @@ from __future__ import annotations
 
 from .ast import IntrospectionInterpreter, BUILD_TARGET_FUNCTIONS, AstConditionLevel, AstIDGenerator, AstIndentationGenerator, AstPrinter
 from .ast.interpreter import IntrospectionBuildTarget, IntrospectionDependency, _symbol
-from .interpreterbase import TV_func
-from mesonbuild.mesonlib import MesonException, setup_vsenv
+from .interpreterbase import UnknownValue, TV_func
+from .interpreterbase.helpers import flatten
+from mesonbuild.mesonlib import MesonException, setup_vsenv, relpath
 from . import mlog, environment
 from functools import wraps
-from .mparser import Token, ArrayNode, ArgumentNode, AssignmentNode, BaseNode, StringNode, BooleanNode, ElementaryNode, IdNode, FunctionNode, PlusAssignmentNode
-import json, os, re, sys
+from .mparser import Token, ArrayNode, ArgumentNode, ArithmeticNode, AssignmentNode, BaseNode, StringNode, BooleanNode, ElementaryNode, IdNode, FunctionNode, PlusAssignmentNode
+import json, os, re, sys, codecs
 import typing as T
+from pathlib import Path
 
 if T.TYPE_CHECKING:
     import argparse
@@ -633,6 +635,166 @@ class Rewriter:
                     return ass
         return None
 
+    def affects_no_other_targets(self, candidate: BaseNode) -> bool:
+        affected = self.interpreter.dataflow_dag.reachable({candidate}, False)
+        affected_targets = [x for x in affected if isinstance(x, FunctionNode) and x.func_name.value in BUILD_TARGET_FUNCTIONS]
+        return len(affected_targets) == 1
+
+    def get_relto(self, target_node: BaseNode, node: BaseNode) -> Path:
+        cwd = Path(os.getcwd())
+        all_paths = self.interpreter.dataflow_dag.find_all_paths(node, target_node)
+        # len(all_paths) == 0 would imply that data does not flow from node to
+        # target_node. This would imply that adding sources to node would not
+        # add the source to the target.
+        assert all_paths
+        if len(all_paths) > 1:
+            return None
+        return (cwd / next(x for x in all_paths[0] if isinstance(x, FunctionNode)).filename).parent
+
+    def add_src_or_extra(self, op: str, target: IntrospectionBuildTarget, newfiles: T.List[str], to_sort_nodes: T.List[T.Union[FunctionNode, ArrayNode]]) -> None:
+        assert op in {'src_add', 'extra_files_add'}
+
+        if op == 'src_add':
+            old: T.Set[T.Union[BaseNode, UnknownValue]] = set(target.source_nodes)
+        elif op == 'extra_files_add':
+            if target.extra_files is None:
+                old = set()
+            else:
+                old = {target.extra_files}
+            tgt_function: FunctionNode = target.node
+
+        cwd = Path(os.getcwd())
+        target_dir_abs = cwd / os.path.dirname(target.node.filename)
+        source_root_abs = cwd / self.interpreter.source_root
+
+        candidates1 = self.interpreter.dataflow_dag.reachable(old, True)
+        # A node is a member of the set `candidates1` exactly if data from this node
+        # flow into one of the `dest` nodes. We assume that this implies that if we
+        # add `foo.c` to this node, then 'foo.c' will be added to one of these
+        # nodes. This assumption is not always true:
+        # ar = ['a.c', 'b.c']
+        # srcs = ar[1]
+        # executable('name', srcs)
+        # Data flows from `ar` to `srcs`, but if we add 'foo.c':
+        # ar = ['a.c', 'b.c', 'foo.c']
+        # srcs = ar[1]
+        # executable('name', srcs)
+        # this does not add 'foo.c' to `srcs`. This is a known bug/limitation of
+        # the meson rewriter that could be fixed by replacing `reachable` with a
+        # more advanced analysis. But this is a lot of work and I think e.g.
+        # `srcs = ar[1]` is rare in real-world projects, so I will just leave
+        # this for now.
+
+        candidates2 = {x for x in candidates1 if isinstance(x, (FunctionNode, ArrayNode))}
+
+        # If we have this meson.build file:
+        # shared = ['shared.c']
+        # executable('foo', shared + ['foo.c'])
+        # executable('bar', shared + ['bar.c'])
+        # and we are tasked with adding 'new.c' to 'foo', we should do e.g this:
+        # shared = ['shared.c']
+        # executable('foo', shared + ['foo.c', 'new.c'])
+        # executable('bar', shared + ['bar.c'])
+        # but never this:
+        # shared = ['shared.c', 'new.c']
+        # executable('foo', shared + ['foo.c'])
+        # executable('bar', shared + ['bar.c'])
+        # We do this by removing the `['shared.c']`-node from `candidates2`.
+        candidates2 = {x for x in candidates2 if self.affects_no_other_targets(x)}
+
+        def path_contains_unknowns(candidate: BaseNode) -> bool:
+            all_paths = self.interpreter.dataflow_dag.find_all_paths(candidate, target.node)
+            for path in all_paths:
+                for el in path:
+                    if isinstance(el, UnknownValue):
+                        return True
+            return False
+
+        candidates2 = {x for x in candidates2 if not path_contains_unknowns(x)}
+
+        candidates2 = {x for x in candidates2 if self.get_relto(target.node, x) is not None}
+
+        chosen: T.Union[FunctionNode, ArrayNode] = None
+        new_kwarg_flag = False
+        if len(candidates2) > 0:
+            # So that files(['a', 'b']) gets modified to files(['a', 'b', 'c']) instead of files(['a', 'b'], 'c')
+            if len({x for x in candidates2 if isinstance(x, ArrayNode)}) > 0:
+                candidates2 = {x for x in candidates2 if isinstance(x, ArrayNode)}
+
+            # We choose one more or less arbitrary candidate
+            chosen = min(candidates2, key=lambda x: (x.lineno, x.colno))
+        elif op == 'src_add':
+            chosen = target.node
+        elif op == 'extra_files_add':
+            chosen = ArrayNode(_symbol('['), ArgumentNode(Token('', tgt_function.filename, 0, 0, 0, None, '[]')), _symbol(']'))
+
+            # this is fundamentally error prone
+            self.interpreter.dataflow_dag.add_edge(chosen, target.node)
+
+            extra_files_idnode = IdNode(Token('string', tgt_function.filename, 0, 0, 0, None, 'extra_files'))
+            if tgt_function not in self.modified_nodes:
+                self.modified_nodes += [tgt_function]
+            new_extra_files_node: BaseNode
+            if target.node.args.get_kwarg_or_default('extra_files', None) is None:
+                # Target has no extra_files kwarg, create one
+                new_kwarg_flag = True
+                new_extra_files_node = chosen
+            else:
+                new_kwarg_flag = True
+                old_extra_files = target.node.args.get_kwarg_or_default('extra_files', None)
+                target.node.args.kwargs = {k: v for k, v in target.node.args.kwargs.items() if not (isinstance(k, IdNode) and k.value == 'extra_files')}
+                new_extra_files_node = ArithmeticNode('add', old_extra_files, _symbol('+'), chosen)
+
+            tgt_function.args.kwargs[extra_files_idnode] = new_extra_files_node
+
+        newfiles_relto = self.get_relto(target.node, chosen)
+        old_src_list: T.List[T.Any] = flatten([self.interpreter.node_to_runtime_value(sn) for sn in old])
+
+        if op == 'src_add':
+            name = 'Source'
+        elif op == 'extra_files_add':
+            name = 'Extra file'
+        # Generate the new String nodes
+        to_append = []
+        added = []
+
+        old_src_list = [(target_dir_abs / x).resolve() if isinstance(x, str) else x.to_abs_path(source_root_abs) for x in old_src_list if not isinstance(x, UnknownValue)]
+        for _newf in sorted(set(newfiles)):
+            newf = Path(_newf)
+            if os.path.isabs(newf):
+                newf = Path(newf)
+            else:
+                newf = source_root_abs / newf
+            if newf in old_src_list:
+                mlog.log('  -- ', name, mlog.green(str(newf)), 'is already defined for the target --> skipping')
+                continue
+
+            mlog.log('  -- Adding ', name.lower(), mlog.green(str(newf)), 'at',
+                     mlog.yellow(f'{chosen.filename}:{chosen.lineno}'))
+            added.append(newf)
+            mocktarget = self.interpreter.funcvals[target.node]
+            assert isinstance(mocktarget, IntrospectionBuildTarget)
+            # print("adding ", str(newf), 'to', mocktarget.name) todo: should we write something to stderr?
+
+            path = relpath(newf, newfiles_relto)
+            path = codecs.encode(path, 'unicode_escape').decode() # Because the StringNode constructor does the inverse
+            token = Token('string', chosen.filename, 0, 0, 0, None, path)
+            to_append += [StringNode(token)]
+
+        assert isinstance(chosen, (FunctionNode, ArrayNode))
+        arg_node = chosen.args
+        # Append to the AST at the right place
+        arg_node.arguments += to_append
+
+        # Mark the node as modified
+        if chosen not in to_sort_nodes:
+            to_sort_nodes += [chosen]
+        # If the extra_files array is newly created, i.e. if new_kwarg_flag is
+        # True, don't mark it as its parent function node already is, otherwise
+        # this would cause double modification.
+        if chosen not in self.modified_nodes and not new_kwarg_flag:
+            self.modified_nodes += [chosen]
+
     # Utility function to get a list of the sources from a node
     def arg_list_from_node(self, n: BaseNode) -> T.List[BaseNode]:
         args = []
@@ -646,18 +808,26 @@ class Rewriter:
             args = n.arguments
         return args
 
-    def rm_src_or_extra(self, op: str, target: IntrospectionBuildTarget, to_be_removed: T.List[str], to_sort_nodes: T.List[ArgumentNode]) -> None:
+    def rm_src_or_extra(self, op: str, target: IntrospectionBuildTarget, to_be_removed: T.List[str], to_sort_nodes: T.List[T.Union[FunctionNode, ArrayNode]]) -> None:
+        assert op in {'src_rm', 'extra_files_rm'}
+        cwd = Path(os.getcwd())
+        source_root_abs = cwd / self.interpreter.source_root
+
         # Helper to find the exact string node and its parent
-        def find_node(src: str) -> T.Tuple[BaseNode, StringNode]:
+        def find_node(src: str) -> T.Tuple[T.Optional[BaseNode], T.Optional[StringNode]]:
             if op == 'src_rm':
-                nodes = target.source_nodes
+                nodes = self.interpreter.dataflow_dag.reachable(set(target.source_nodes), True).union({target.node})
             elif op == 'extra_files_rm':
-                nodes = target.extra_files
+                nodes = self.interpreter.dataflow_dag.reachable({target.extra_files}, True)
             for i in nodes:
-                for j in self.arg_list_from_node(i):
-                    if isinstance(j, StringNode):
-                        if j.value == src:
-                            return i, j
+                if isinstance(i, UnknownValue):
+                    continue
+                relto = self.get_relto(target.node, i)
+                if relto is not None:
+                    for j in self.arg_list_from_node(i):
+                        if isinstance(j, StringNode):
+                            if os.path.normpath(relto / j.value) == os.path.normpath(source_root_abs / src):
+                                return i, j
             return None, None
 
         if op == 'src_rm':
@@ -671,22 +841,22 @@ class Rewriter:
             if root is None:
                 mlog.warning('  -- Unable to find', name, mlog.green(i), 'in the target')
                 continue
+            if not self.affects_no_other_targets(string_node):
+                mlog.warning('  -- Removing the', name, mlog.green(i), 'is too compilicated')
+                continue
 
-            arg_node = None
-            if isinstance(root, (FunctionNode, ArrayNode)):
-                arg_node = root.args
-            elif isinstance(root, ArgumentNode):
-                arg_node = root
-            assert arg_node is not None
+            if not isinstance(root, (FunctionNode, ArrayNode)):
+                raise NotImplementedError # I'm lazy
 
             # Remove the found string node from the argument list
+            arg_node = root.args
             mlog.log('  -- Removing', name, mlog.green(i), 'from',
                      mlog.yellow(f'{string_node.filename}:{string_node.lineno}'))
             arg_node.arguments.remove(string_node)
 
             # Mark the node as modified
-            if arg_node not in to_sort_nodes and not isinstance(root, FunctionNode):
-                to_sort_nodes += [arg_node]
+            if root not in to_sort_nodes:
+                to_sort_nodes += [root]
             if root not in self.modified_nodes:
                 self.modified_nodes += [root]
 
@@ -711,106 +881,10 @@ class Rewriter:
         if target is not None:
             cmd['sources'] = [rel_source(x) for x in cmd['sources']]
 
-        to_sort_nodes = []
+        to_sort_nodes: T.List[T.Union[FunctionNode, ArrayNode]] = []
 
-        if cmd['operation'] == 'src_add':
-            node = None
-            if target.source_nodes:
-                node = target.source_nodes[0]
-            else:
-                node = target.node
-            assert node is not None
-
-            # Generate the current source list
-            src_list = []
-            for src_node in target.source_nodes:
-                for j in self.arg_list_from_node(src_node):
-                    if isinstance(j, StringNode):
-                        src_list += [j.value]
-
-            # Generate the new String nodes
-            to_append = []
-            for i in sorted(set(cmd['sources'])):
-                if i in src_list:
-                    mlog.log('  -- Source', mlog.green(i), 'is already defined for the target --> skipping')
-                    continue
-                mlog.log('  -- Adding source', mlog.green(i), 'at',
-                         mlog.yellow(f'{node.filename}:{node.lineno}'))
-                token = Token('string', node.filename, 0, 0, 0, None, i)
-                to_append += [StringNode(token)]
-
-            # Append to the AST at the right place
-            arg_node = None
-            if isinstance(node, (FunctionNode, ArrayNode)):
-                arg_node = node.args
-            elif isinstance(node, ArgumentNode):
-                arg_node = node
-            assert arg_node is not None
-            arg_node.arguments += to_append
-
-            # Mark the node as modified
-            if arg_node not in to_sort_nodes and not isinstance(node, FunctionNode):
-                to_sort_nodes += [arg_node]
-            if node not in self.modified_nodes:
-                self.modified_nodes += [node]
-
-        elif cmd['operation'] == 'extra_files_add':
-            tgt_function: FunctionNode = target.node
-            mark_array = True
-            try:
-                node = target.extra_files[0]
-            except IndexError:
-                # Specifying `extra_files` with a list that flattens to empty gives an empty
-                # target.extra_files list, account for that.
-                try:
-                    extra_files_key = next(k for k in tgt_function.args.kwargs.keys() if isinstance(k, IdNode) and k.value == 'extra_files')
-                    node = tgt_function.args.kwargs[extra_files_key]
-                except StopIteration:
-                    # Target has no extra_files kwarg, create one
-                    node = ArrayNode(_symbol('['), ArgumentNode(Token('', tgt_function.filename, 0, 0, 0, None, '[]')), _symbol(']'))
-                    tgt_function.args.kwargs[IdNode(Token('string', tgt_function.filename, 0, 0, 0, None, 'extra_files'))] = node
-                    mark_array = False
-                    if tgt_function not in self.modified_nodes:
-                        self.modified_nodes += [tgt_function]
-                target.extra_files = [node]
-            if isinstance(node, IdNode):
-                cv = self.interpreter.get_cur_value(node.value)
-                assert isinstance(cv, BaseNode)
-                node = cv
-                target.extra_files = [node]
-            if not isinstance(node, ArrayNode):
-                mlog.error('Target', mlog.bold(cmd['target']), 'extra_files argument must be a list', *self.on_error())
-                return self.handle_error()
-
-            # Generate the current extra files list
-            extra_files_list = []
-            for i in target.extra_files:
-                for j in self.arg_list_from_node(i):
-                    if isinstance(j, StringNode):
-                        extra_files_list += [j.value]
-
-            # Generate the new String nodes
-            to_append = []
-            for i in sorted(set(cmd['sources'])):
-                if i in extra_files_list:
-                    mlog.log('  -- Extra file', mlog.green(i), 'is already defined for the target --> skipping')
-                    continue
-                mlog.log('  -- Adding extra file', mlog.green(i), 'at',
-                         mlog.yellow(f'{node.filename}:{node.lineno}'))
-                token = Token('string', node.filename, 0, 0, 0, None, i)
-                to_append += [StringNode(token)]
-
-            # Append to the AST at the right place
-            arg_node = node.args
-            arg_node.arguments += to_append
-
-            # Mark the node as modified
-            if arg_node not in to_sort_nodes:
-                to_sort_nodes += [arg_node]
-            # If the extra_files array is newly created, don't mark it as its parent function node already is,
-            # otherwise this would cause double modification.
-            if mark_array and node not in self.modified_nodes:
-                self.modified_nodes += [node]
+        if cmd['operation'] in {'src_add', 'extra_files_add'}:
+            self.add_src_or_extra(cmd['operation'], target, cmd['sources'], to_sort_nodes)
 
         elif cmd['operation'] in {'src_rm', 'extra_files_rm'}:
             self.rm_src_or_extra(cmd['operation'], target, cmd['sources'], to_sort_nodes)
@@ -823,7 +897,7 @@ class Rewriter:
             id_base = re.sub(r'[- ]', '_', cmd['target'])
             target_id = id_base + '_exe' if cmd['target_type'] == 'executable' else '_lib'
             source_id = id_base + '_sources'
-            filename = os.path.join(cmd['subdir'], environment.build_filename)
+            filename = os.path.join(os.getcwd(), self.interpreter.source_root, cmd['subdir'], environment.build_filename)
 
             # Build src list
             src_arg_node = ArgumentNode(Token('string', filename, 0, 0, 0, None, ''))
@@ -857,16 +931,16 @@ class Rewriter:
 
         elif cmd['operation'] == 'info':
             # T.List all sources in the target
-            src_list = []
-            for i in target.source_nodes:
-                for j in self.arg_list_from_node(i):
-                    if isinstance(j, StringNode):
-                        src_list += [j.value]
-            extra_files_list = []
-            for i in target.extra_files:
-                for j in self.arg_list_from_node(i):
-                    if isinstance(j, StringNode):
-                        extra_files_list += [j.value]
+
+            cwd = Path(os.getcwd())
+            source_root_abs = cwd / self.interpreter.source_root
+
+            src_list = self.interpreter.nodes_to_pretty_filelist(source_root_abs, target.subdir, target.source_nodes)
+            extra_files_list = self.interpreter.nodes_to_pretty_filelist(source_root_abs, target.subdir, [target.extra_files] if target.extra_files else [])
+
+            src_list = ['unknown' if isinstance(x, UnknownValue) else relpath(x, source_root_abs) for x in src_list]
+            extra_files_list = ['unknown' if isinstance(x, UnknownValue) else relpath(x, source_root_abs) for x in extra_files_list]
+
             test_data = {
                 'name': target.name,
                 'sources': src_list,
@@ -885,10 +959,16 @@ class Rewriter:
             def path_sorter(key: str) -> T.List[T.Tuple[bool, T.List[T.Union[int, str]]]]:
                 return [(key.count('/') <= idx, alphanum_key(x)) for idx, x in enumerate(key.split('/'))]
 
-            unknown = [x for x in i.arguments if not isinstance(x, StringNode)]
-            sources = [x for x in i.arguments if isinstance(x, StringNode)]
+            if isinstance(i, FunctionNode) and i.func_name.value in BUILD_TARGET_FUNCTIONS:
+                src_args = i.args.arguments[1:]
+                target_name = [i.args.arguments[0]]
+            else:
+                src_args = i.args.arguments
+                target_name = []
+            unknown: T.List[BaseNode] = [x for x in src_args if not isinstance(x, StringNode)]
+            sources: T.List[StringNode] = [x for x in src_args if isinstance(x, StringNode)]
             sources = sorted(sources, key=lambda x: path_sorter(x.value))
-            i.arguments = unknown + T.cast(T.List[BaseNode], sources)
+            i.args.arguments = target_name + unknown + T.cast(T.List[BaseNode], sources)
 
     def process(self, cmd: T.Dict[str, T.Any]) -> None:
         if 'type' not in cmd:
@@ -931,7 +1011,7 @@ class Rewriter:
         for i in str_list:
             if i['file'] in files:
                 continue
-            fpath = os.path.realpath(os.path.join(self.sourcedir, T.cast(str, i['file'])))
+            fpath = os.path.realpath(T.cast(str, i['file']))
             fdata = ''
             # Create an empty file if it does not exist
             if not os.path.exists(fpath):
@@ -1077,12 +1157,22 @@ def run(options: argparse.Namespace) -> int:
         if not isinstance(commands, list):
             raise TypeError('Command is not a list')
 
-        for i in commands:
-            if not isinstance(i, object):
+        for i, cmd in enumerate(commands):
+            if not isinstance(cmd, object):
                 raise TypeError('Command is not an object')
-            rewriter.process(i)
+            rewriter.process(cmd)
+            rewriter.apply_changes()
 
-        rewriter.apply_changes()
+            if i == len(commands) - 1: # Improves the performance, is not necessary for correctness.
+                break
+
+            rewriter.modified_nodes = []
+            rewriter.to_remove_nodes = []
+            rewriter.to_add_nodes = []
+            # The AST changed, so we need to update every information that was derived from the AST
+            rewriter.interpreter = IntrospectionInterpreter(rewriter.sourcedir, '', rewriter.interpreter.backend, visitors = [AstIDGenerator(), AstIndentationGenerator(), AstConditionLevel()])
+            rewriter.analyze_meson()
+
         rewriter.print_info()
         return 0
     except Exception as e:

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -17,6 +17,7 @@ from mesonbuild.mesonlib import MesonException, setup_vsenv, relpath
 from . import mlog, environment
 from functools import wraps
 from .mparser import Token, ArrayNode, ArgumentNode, ArithmeticNode, AssignmentNode, BaseNode, StringNode, BooleanNode, ElementaryNode, IdNode, FunctionNode, PlusAssignmentNode
+from .mintro import IntrospectionEncoder
 import json, os, re, sys, codecs
 import typing as T
 from pathlib import Path
@@ -399,7 +400,7 @@ class Rewriter:
     def print_info(self) -> None:
         if self.info_dump is None:
             return
-        sys.stdout.write(json.dumps(self.info_dump, indent=2))
+        sys.stdout.write(json.dumps(self.info_dump, indent=2, cls=IntrospectionEncoder))
 
     def on_error(self) -> T.Tuple[AnsiDecorator, AnsiDecorator]:
         if self.skip_errors:

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -618,11 +618,11 @@ class Rewriter:
         if num_changed > 0 and node not in self.modified_nodes:
             self.modified_nodes += [node]
 
-    def find_assignment_node(self, node: BaseNode) -> AssignmentNode:
-        if node.ast_id and node.ast_id in self.interpreter.reverse_assignment:
-            ret = self.interpreter.reverse_assignment[node.ast_id]
-            assert isinstance(ret, AssignmentNode)
-            return ret
+    def find_assignment_node(self, node: BaseNode) -> T.Optional[AssignmentNode]:
+        for k, v in self.interpreter.all_assignment_nodes.items():
+            for ass in v:
+                if ass.value == node:
+                    return ass
         return None
 
     @RequiredKeys(rewriter_keys['target'])

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -10,6 +10,7 @@
 from __future__ import annotations
 
 from .ast import IntrospectionInterpreter, BUILD_TARGET_FUNCTIONS, AstConditionLevel, AstIDGenerator, AstIndentationGenerator, AstPrinter
+from .ast.interpreter import IntrospectionDependency
 from mesonbuild.mesonlib import MesonException, setup_vsenv
 from . import mlog, environment
 from functools import wraps
@@ -427,10 +428,10 @@ class Rewriter:
 
         return tgt
 
-    def find_dependency(self, dependency: str):
+    def find_dependency(self, dependency: str) -> T.Optional[IntrospectionDependency]:
         def check_list(name: str):
             for i in self.interpreter.dependencies:
-                if name == i['name']:
+                if name == i.name:
                     return i
             return None
 
@@ -521,9 +522,9 @@ class Rewriter:
                 node = tmp_tgt.node
                 arg_node = node.args
         elif cmd['function'] == 'dependency':
-            tmp = self.find_dependency(cmd['id'])
-            if tmp:
-                node = tmp['node']
+            tmp_dep = self.find_dependency(cmd['id'])
+            if tmp_dep:
+                node = tmp_dep.node
                 arg_node = node.args
         if not node:
             mlog.error('Unable to find the function node')

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -456,7 +456,7 @@ class Rewriter:
             node = self.interpreter.get_cur_value(dependency)
             if isinstance(node, FunctionNode):
                 if node.func_name.value == 'dependency':
-                    name = self.interpreter.flatten_args(node.args)[0]
+                    name = self.interpreter.node_to_runtime_value(node.args.arguments[0])
                     assert isinstance(name, str)
                     dep = check_list(name)
 

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -83,6 +83,7 @@ modules = [
     'mesonbuild/optinterpreter.py',
     'mesonbuild/options.py',
     'mesonbuild/programs.py',
+    'mesonbuild/rewriter.py',
 ]
 additional = [
     'run_mypy.py',

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -13,7 +13,7 @@ from mesonbuild.mesonlib import version_compare
 
 modules = [
     # fully typed submodules
-    # 'mesonbuild/ast/',
+    'mesonbuild/ast/',
     'mesonbuild/cargo/',
     'mesonbuild/cmake/',
     'mesonbuild/compilers/',
@@ -26,10 +26,6 @@ modules = [
     'mesonbuild/wrap/',
 
     # specific files
-    'mesonbuild/ast/introspection.py',
-    'mesonbuild/ast/printer.py',
-    'mesonbuild/ast/postprocess.py',
-    'mesonbuild/ast/visitor.py',
     'mesonbuild/arglist.py',
     'mesonbuild/backend/backends.py',
     'mesonbuild/backend/nonebackend.py',

--- a/test cases/rewrite/1 basic/addSrc.json
+++ b/test cases/rewrite/1 basic/addSrc.json
@@ -43,6 +43,24 @@
   },
   {
     "type": "target",
+    "target": "trivialprog10",
+    "operation": "src_add",
+    "sources": ["fileA.cpp", "fileB.cpp", "a1.cpp"]
+  },
+  {
+    "type": "target",
+    "target": "trivialprog11",
+    "operation": "src_add",
+    "sources": ["fileA.cpp", "a1.cpp"]
+  },
+  {
+    "type": "target",
+    "target": "trivialprog12",
+    "operation": "src_add",
+    "sources": ["fileA.cpp", "fileB.cpp", "a1.cpp"]
+  },
+  {
+    "type": "target",
     "target": "trivialprog0",
     "operation": "info"
   },
@@ -89,6 +107,26 @@
   {
     "type": "target",
     "target": "trivialprog9",
+    "operation": "info"
+  },
+  {
+    "type": "target",
+    "target": "trivialprog10",
+    "operation": "info"
+  },
+  {
+    "type": "target",
+    "target": "trivialprog11",
+    "operation": "info"
+  },
+  {
+    "type": "target",
+    "target": "trivialprog12",
+    "operation": "info"
+  },
+  {
+    "type": "target",
+    "target": "rightName",
     "operation": "info"
   }
 ]

--- a/test cases/rewrite/1 basic/addTgt.json
+++ b/test cases/rewrite/1 basic/addTgt.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "target",
-    "target": "trivialprog10",
+    "target": "trivialprog13",
     "operation": "target_add",
     "sources": ["new1.cpp", "new2.cpp"],
     "target_type": "shared_library"

--- a/test cases/rewrite/1 basic/expected_dag.txt
+++ b/test cases/rewrite/1 basic/expected_dag.txt
@@ -1,0 +1,83 @@
+Data flowing to FunctionNode(1:0):
+    StringNode(1:8)
+    StringNode(1:23)
+Data flowing to ArrayNode(3:7):
+    StringNode(3:8)
+    StringNode(3:20)
+Data flowing to FunctionNode(4:7):
+    ArrayNode(4:13)
+Data flowing to ArrayNode(4:13):
+    StringNode(4:14)
+    StringNode(4:27)
+Data flowing to IdNode(5:7):
+    ArrayNode(3:7)
+Data flowing to ArrayNode(6:7):
+    IdNode(6:8)
+Data flowing to IdNode(6:8):
+    IdNode(5:7)
+Data flowing to FunctionNode(10:7):
+    StringNode(10:18)
+    ArithmeticNode(10:34)
+Data flowing to ArithmeticNode(10:34):
+    IdNode(10:34)
+    IdNode(10:41)
+Data flowing to IdNode(10:34):
+    ArrayNode(3:7)
+Data flowing to IdNode(10:41):
+    FunctionNode(4:7)
+Data flowing to FunctionNode(11:7):
+    StringNode(11:18)
+    IdNode(11:34)
+Data flowing to IdNode(11:34):
+    ArrayNode(3:7)
+Data flowing to FunctionNode(12:7):
+    StringNode(12:18)
+    ArrayNode(12:34)
+Data flowing to ArrayNode(12:34):
+    IdNode(12:35)
+Data flowing to IdNode(12:35):
+    FunctionNode(4:7)
+Data flowing to FunctionNode(13:7):
+    StringNode(13:18)
+    ArrayNode(13:34)
+Data flowing to ArrayNode(13:34):
+    StringNode(13:35)
+    StringNode(13:47)
+Data flowing to FunctionNode(14:7):
+    StringNode(14:18)
+    ArrayNode(14:34)
+Data flowing to ArrayNode(14:34):
+    StringNode(14:35)
+    ArrayNode(14:47)
+Data flowing to ArrayNode(14:47):
+    StringNode(14:48)
+Data flowing to FunctionNode(15:7):
+    StringNode(15:18)
+    ArrayNode(15:34)
+Data flowing to ArrayNode(15:34):
+    IdNode(15:35)
+    StringNode(15:41)
+Data flowing to IdNode(15:35):
+    FunctionNode(4:7)
+Data flowing to FunctionNode(16:7):
+    StringNode(16:18)
+    StringNode(16:34)
+    StringNode(16:46)
+Data flowing to FunctionNode(17:7):
+    StringNode(17:18)
+    StringNode(17:34)
+    IdNode(17:47)
+    StringNode(17:53)
+Data flowing to IdNode(17:47):
+    ArrayNode(3:7)
+Data flowing to FunctionNode(18:7):
+    StringNode(18:18)
+    IdNode(18:34)
+Data flowing to IdNode(18:34):
+    IdNode(5:7)
+Data flowing to FunctionNode(19:0):
+    StringNode(19:11)
+    IdNode(19:27)
+Data flowing to IdNode(19:27):
+    ArrayNode(6:7)
+

--- a/test cases/rewrite/1 basic/expected_dag.txt
+++ b/test cases/rewrite/1 basic/expected_dag.txt
@@ -15,69 +15,115 @@ Data flowing to ArrayNode(6:7):
     IdNode(6:8)
 Data flowing to IdNode(6:8):
     IdNode(5:7)
+Data flowing to ArithmeticNode(7:7):
+    ArrayNode(7:7)
+    ArrayNode(8:8)
+Data flowing to ArrayNode(7:7):
+    StringNode(7:8)
+    StringNode(7:20)
+Data flowing to ArrayNode(8:8):
+    StringNode(8:9)
+Data flowing to ArrayNode(9:7):
+    StringNode(9:8)
+    StringNode(9:20)
 Data flowing to FunctionNode(10:7):
-    StringNode(10:18)
-    ArithmeticNode(10:34)
-Data flowing to ArithmeticNode(10:34):
-    IdNode(10:34)
-    IdNode(10:41)
-Data flowing to IdNode(10:34):
+    IdNode(10:13)
+Data flowing to IdNode(10:13):
+    ArrayNode(9:7)
+Data flowing to ArrayNode(11:7):
+    StringNode(11:8)
+    StringNode(11:20)
+Data flowing to IdNode(12:7):
+    ArrayNode(11:7)
+Data flowing to ArrayNode(13:7):
+    StringNode(13:8)
+    StringNode(13:21)
+Data flowing to FunctionNode(15:13):
+    StringNode(14:7)
+    StringNode(15:26)
+Data flowing to FunctionNode(20:7):
+    StringNode(20:18)
+    ArithmeticNode(20:34)
+Data flowing to ArithmeticNode(20:34):
+    IdNode(20:34)
+    IdNode(20:41)
+Data flowing to IdNode(20:34):
     ArrayNode(3:7)
-Data flowing to IdNode(10:41):
+Data flowing to IdNode(20:41):
     FunctionNode(4:7)
-Data flowing to FunctionNode(11:7):
-    StringNode(11:18)
-    IdNode(11:34)
-Data flowing to IdNode(11:34):
+Data flowing to FunctionNode(21:7):
+    StringNode(21:18)
+    IdNode(21:34)
+Data flowing to IdNode(21:34):
     ArrayNode(3:7)
-Data flowing to FunctionNode(12:7):
-    StringNode(12:18)
-    ArrayNode(12:34)
-Data flowing to ArrayNode(12:34):
-    IdNode(12:35)
-Data flowing to IdNode(12:35):
+Data flowing to FunctionNode(22:7):
+    StringNode(22:18)
+    ArrayNode(22:34)
+Data flowing to ArrayNode(22:34):
+    IdNode(22:35)
+Data flowing to IdNode(22:35):
     FunctionNode(4:7)
-Data flowing to FunctionNode(13:7):
-    StringNode(13:18)
-    ArrayNode(13:34)
-Data flowing to ArrayNode(13:34):
-    StringNode(13:35)
-    StringNode(13:47)
-Data flowing to FunctionNode(14:7):
-    StringNode(14:18)
-    ArrayNode(14:34)
-Data flowing to ArrayNode(14:34):
-    StringNode(14:35)
-    ArrayNode(14:47)
-Data flowing to ArrayNode(14:47):
-    StringNode(14:48)
-Data flowing to FunctionNode(15:7):
-    StringNode(15:18)
-    ArrayNode(15:34)
-Data flowing to ArrayNode(15:34):
-    IdNode(15:35)
-    StringNode(15:41)
-Data flowing to IdNode(15:35):
+Data flowing to FunctionNode(23:7):
+    StringNode(23:18)
+    ArrayNode(23:34)
+Data flowing to ArrayNode(23:34):
+    StringNode(23:35)
+    StringNode(23:47)
+Data flowing to FunctionNode(24:7):
+    StringNode(24:18)
+    ArrayNode(24:34)
+Data flowing to ArrayNode(24:34):
+    StringNode(24:35)
+    ArrayNode(24:47)
+Data flowing to ArrayNode(24:47):
+    StringNode(24:48)
+Data flowing to FunctionNode(25:7):
+    StringNode(25:18)
+    ArrayNode(25:34)
+Data flowing to ArrayNode(25:34):
+    IdNode(25:35)
+    StringNode(25:41)
+Data flowing to IdNode(25:35):
     FunctionNode(4:7)
-Data flowing to FunctionNode(16:7):
-    StringNode(16:18)
-    StringNode(16:34)
-    StringNode(16:46)
-Data flowing to FunctionNode(17:7):
-    StringNode(17:18)
-    StringNode(17:34)
-    IdNode(17:47)
-    StringNode(17:53)
-Data flowing to IdNode(17:47):
+Data flowing to FunctionNode(26:7):
+    StringNode(26:18)
+    StringNode(26:34)
+    StringNode(26:46)
+Data flowing to FunctionNode(27:7):
+    StringNode(27:18)
+    StringNode(27:34)
+    FunctionNode(27:47)
+    StringNode(27:69)
+Data flowing to FunctionNode(27:47):
     ArrayNode(3:7)
-Data flowing to FunctionNode(18:7):
-    StringNode(18:18)
-    IdNode(18:34)
-Data flowing to IdNode(18:34):
+    StringNode(27:60)
+Data flowing to FunctionNode(28:7):
+    StringNode(28:18)
+    IdNode(28:34)
+Data flowing to IdNode(28:34):
     IdNode(5:7)
-Data flowing to FunctionNode(19:0):
-    StringNode(19:11)
-    IdNode(19:27)
-Data flowing to IdNode(19:27):
+Data flowing to FunctionNode(29:0):
+    StringNode(29:11)
+    IdNode(29:27)
+Data flowing to IdNode(29:27):
     ArrayNode(6:7)
-
+Data flowing to FunctionNode(30:0):
+    StringNode(30:11)
+    IdNode(30:28)
+Data flowing to IdNode(30:28):
+    ArithmeticNode(7:7)
+Data flowing to FunctionNode(31:0):
+    StringNode(31:11)
+    IdNode(31:28)
+Data flowing to IdNode(31:28):
+    FunctionNode(10:7)
+Data flowing to FunctionNode(32:0):
+    StringNode(32:11)
+    IdNode(32:28)
+Data flowing to IdNode(32:28):
+    IdNode(12:7)
+Data flowing to FunctionNode(33:0):
+    IdNode(33:11)
+    StringNode(33:23)
+Data flowing to IdNode(33:11):
+    FunctionNode(15:13)

--- a/test cases/rewrite/1 basic/info.json
+++ b/test cases/rewrite/1 basic/info.json
@@ -53,5 +53,25 @@
     "type": "target",
     "target": "trivialprog10",
     "operation": "info"
+  },
+  {
+    "type": "target",
+    "target": "trivialprog11",
+    "operation": "info"
+  },
+  {
+    "type": "target",
+    "target": "trivialprog12",
+    "operation": "info"
+  },
+  {
+    "type": "target",
+    "target": "trivialprog13",
+    "operation": "info"
+  },
+  {
+    "type": "target",
+    "target": "rightName",
+    "operation": "info"
   }
 ]

--- a/test cases/rewrite/1 basic/meson.build
+++ b/test cases/rewrite/1 basic/meson.build
@@ -4,6 +4,16 @@ src1 = ['main.cpp', 'fileA.cpp']
 src2 = files(['fileB.cpp', 'fileC.cpp'])
 src3 = src1
 src4 = [src3]
+src5 = ['main.cpp', 'fileA.cpp']
+src5 += ['fileB.cpp']
+src6 = ['main.cpp', 'fileA.cpp']
+src6 = files(src6)
+src7 = ['main.cpp', 'fileA.cpp']
+src8 = src7
+src7 = ['fileB.cpp', 'fileC.cpp']
+name = 'rightName'
+trickyName = get_variable('name')
+name = 'wrongName'
 
 # Magic comment
 
@@ -14,6 +24,10 @@ exe3 = executable('trivialprog3', ['main.cpp', 'fileA.cpp'])
 exe4 = executable('trivialprog4', ['main.cpp', ['fileA.cpp']])
 exe5 = executable('trivialprog5', [src2, 'main.cpp'])
 exe6 = executable('trivialprog6', 'main.cpp', 'fileA.cpp')
-exe7 = executable('trivialprog7', 'fileB.cpp', src1, 'fileC.cpp')
+exe7 = executable('trivialprog7', 'fileB.cpp', get_variable('src1'), 'fileC.cpp')
 exe8 = executable('trivialprog8', src3)
 executable('trivialprog9', src4)
+executable('trivialprog10', src5)
+executable('trivialprog11', src6)
+executable('trivialprog12', src8)
+executable(trickyName, 'main.cpp')

--- a/test cases/rewrite/1 basic/rmSrc.json
+++ b/test cases/rewrite/1 basic/rmSrc.json
@@ -1,12 +1,6 @@
 [
   {
     "type": "target",
-    "target": "trivialprog1",
-    "operation": "src_rm",
-    "sources": ["fileA.cpp"]
-  },
-  {
-    "type": "target",
     "target": "trivialprog3",
     "operation": "src_rm",
     "sources": ["fileA.cpp"]
@@ -21,7 +15,7 @@
     "type": "target",
     "target": "trivialprog5",
     "operation": "src_rm",
-    "sources": ["fileB.cpp"]
+    "sources": ["main.cpp"]
   },
   {
     "type": "target",
@@ -34,6 +28,18 @@
     "target": "trivialprog7",
     "operation": "src_rm",
     "sources": ["fileB.cpp"]
+  },
+  {
+    "type": "target",
+    "target": "trivialprog10",
+    "operation": "src_rm",
+    "sources": ["fileA.cpp", "fileB.cpp"]
+  },
+  {
+    "type": "target",
+    "target": "trivialprog11",
+    "operation": "src_rm",
+    "sources": ["fileA.cpp"]
   },
   {
     "type": "target",
@@ -83,6 +89,26 @@
   {
     "type": "target",
     "target": "trivialprog9",
+    "operation": "info"
+  },
+  {
+    "type": "target",
+    "target": "trivialprog10",
+    "operation": "info"
+  },
+  {
+    "type": "target",
+    "target": "trivialprog11",
+    "operation": "info"
+  },
+  {
+    "type": "target",
+    "target": "trivialprog12",
+    "operation": "info"
+  },
+  {
+    "type": "target",
+    "target": "rightName",
     "operation": "info"
   }
 ]

--- a/test cases/rewrite/1 basic/rmTgt.json
+++ b/test cases/rewrite/1 basic/rmTgt.json
@@ -13,5 +13,10 @@
     "type": "target",
     "target": "trivialprog9",
     "operation": "target_rm"
+  },
+  {
+    "type": "target",
+    "target": "rightName",
+    "operation": "target_rm"
   }
 ]

--- a/test cases/rewrite/7 tricky dataflow/addSrc.json
+++ b/test cases/rewrite/7 tricky dataflow/addSrc.json
@@ -1,0 +1,72 @@
+[
+    {
+        "type": "target",
+        "target": "tgt1",
+        "operation": "src_add",
+        "sources": [
+            "new.c"
+        ]
+    },
+    {
+        "type": "target",
+        "target": "tgt2",
+        "operation": "src_add",
+        "sources": [
+            "new.c"
+        ]
+    },
+    {
+        "type": "target",
+        "target": "tgt3",
+        "operation": "src_add",
+        "sources": [
+            "new.c"
+        ]
+    },
+    {
+        "type": "target",
+        "target": "tgt5",
+        "operation": "src_add",
+        "sources": [
+            "new.c"
+        ]
+    },
+    {
+        "type": "target",
+        "target": "tgt6",
+        "operation": "src_add",
+        "sources": [
+            "new.c"
+        ]
+    },
+    {
+        "type": "target",
+        "target": "tgt1",
+        "operation": "info"
+    },
+    {
+        "type": "target",
+        "target": "tgt2",
+        "operation": "info"
+    },
+    {
+        "type": "target",
+        "target": "tgt3",
+        "operation": "info"
+    },
+    {
+        "type": "target",
+        "target": "tgt4",
+        "operation": "info"
+    },
+    {
+        "type": "target",
+        "target": "tgt5",
+        "operation": "info"
+    },
+    {
+        "type": "target",
+        "target": "tgt6",
+        "operation": "info"
+    }
+]

--- a/test cases/rewrite/7 tricky dataflow/info.json
+++ b/test cases/rewrite/7 tricky dataflow/info.json
@@ -1,0 +1,32 @@
+[
+    {
+        "type": "target",
+        "target": "tgt1",
+        "operation": "info"
+    },
+    {
+        "type": "target",
+        "target": "tgt2",
+        "operation": "info"
+    },
+    {
+        "type": "target",
+        "target": "tgt3",
+        "operation": "info"
+    },
+    {
+        "type": "target",
+        "target": "tgt4",
+        "operation": "info"
+    },
+    {
+        "type": "target",
+        "target": "tgt5",
+        "operation": "info"
+    },
+    {
+        "type": "target",
+        "target": "tgt6",
+        "operation": "info"
+    }
+]

--- a/test cases/rewrite/7 tricky dataflow/meson.build
+++ b/test cases/rewrite/7 tricky dataflow/meson.build
@@ -1,0 +1,35 @@
+project('rewrite tricky dataflow', 'c')
+
+# Adding a file to `begin` will add this file to the sources of `tgt1`, but
+# not to any other target. But a buggy rewriter might think that adding a file
+# to `begin` will also add this file to `end` and will refuse to add a file to
+# `begin`.
+begin = ['foo.c']
+tgt1 = library('tgt1', begin)
+distraction = executable('distraction', link_with: tgt1)
+
+
+tgt2_srcs = ['foo.c']
+if meson.host_machine().system() == 'windows' # Some condition that cannot be known statically
+    tgt2_srcs += ['bar.c']
+endif
+executable('tgt2', tgt2_srcs)
+
+
+tgt34_srcs = ['foo.c']
+executable('tgt3', tgt34_srcs)
+if meson.host_machine().system() == 'windows'
+    tgt34_srcs += ['bar.c']
+endif
+executable('tgt4', tgt34_srcs)
+
+
+dont_add_here_5 = ['foo.c']
+ct = custom_target('ct', output: 'out.c', input: dont_add_here_5, command: ['placeholder', '@INPUT@', '@OUTPUT@'])
+executable('tgt5', ct)
+
+
+dont_add_here_6 = ['foo.c']
+gen = generator(find_program('cp'), output: '@BASENAME@_copy.c', arguments: ['@INPUT@', '@OUTPUT@'])
+generated = gen.process(dont_add_here_6)
+executable('tgt6', generated)

--- a/test cases/unit/120 rewrite/meson.build
+++ b/test cases/unit/120 rewrite/meson.build
@@ -62,6 +62,7 @@ cppcoro = declare_dependency(
 )
 
 
+cpp_compiler = meson.get_compiler('cpp')
 if get_option('unicode')  #if comment
 #if comment 2
   mfc=cpp_compiler.find_library(get_option('debug')?'mfc140ud':'mfc140u')
@@ -79,6 +80,10 @@ assert(not (3 in [1, 2]), '''3 shouldn't be in [1, 2]''')
 
 assert('b' in ['a', 'b'], ''''b' should be in ['a', 'b']''')
 assert('c' not in ['a', 'b'], ''''c' shouldn't be in ['a', 'b']''')
+
+exe1 = 'exe1'
+exe2 = 'exe2'
+exe3 = 'exe3'
 
 assert(exe1 in [exe1, exe2], ''''exe1 should be in [exe1, exe2]''')
 assert(exe3 not in [exe1, exe2], ''''exe3 shouldn't be in [exe1, exe2]''')

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -3612,6 +3612,8 @@ class AllPlatformTests(BasePlatformTests):
         # Account for differences in output
         res_wb = [i for i in res_wb if i['type'] != 'custom']
         for i in res_wb:
+            if i['id'] == 'test1@exe':
+                i['build_by_default'] = 'unknown'
             i['filename'] = [os.path.relpath(x, self.builddir) for x in i['filename']]
             for k in ('install_filename', 'dependencies', 'win_subsystem'):
                 if k in i:
@@ -3730,7 +3732,7 @@ class AllPlatformTests(BasePlatformTests):
             },
             {
                 'name': 'bugDep1',
-                'required': True,
+                'required': 'unknown',
                 'version': [],
                 'has_fallback': False,
                 'conditional': False

--- a/unittests/rewritetests.py
+++ b/unittests/rewritetests.py
@@ -73,6 +73,10 @@ class RewriterTests(BasePlatformTests):
                 'trivialprog7@exe': {'name': 'trivialprog7', 'sources': ['fileB.cpp', 'fileC.cpp', 'main.cpp', 'fileA.cpp'], 'extra_files': []},
                 'trivialprog8@exe': {'name': 'trivialprog8', 'sources': ['main.cpp', 'fileA.cpp'], 'extra_files': []},
                 'trivialprog9@exe': {'name': 'trivialprog9', 'sources': ['main.cpp', 'fileA.cpp'], 'extra_files': []},
+                'trivialprog10@exe': {'name': 'trivialprog10', 'sources': ['main.cpp', 'fileA.cpp', 'fileB.cpp'], 'extra_files': []},
+                'trivialprog11@exe': {'name': 'trivialprog11', 'sources': ['main.cpp', 'fileA.cpp'], 'extra_files': []},
+                'trivialprog12@exe': {'name': 'trivialprog12', 'sources': ['main.cpp', 'fileA.cpp'], 'extra_files': []},
+                'rightName@exe': {'name': 'rightName', 'sources': ['main.cpp'], 'extra_files': []},
             }
         }
         self.assertEqualIgnoreOrder(out, expected)
@@ -82,16 +86,20 @@ class RewriterTests(BasePlatformTests):
         out = self.rewrite(self.builddir, os.path.join(self.builddir, 'addSrc.json'))
         expected = {
             'target': {
-                'trivialprog0@exe': {'name': 'trivialprog0', 'sources': ['a1.cpp', 'a2.cpp', 'a6.cpp', 'fileA.cpp', 'main.cpp', 'a7.cpp', 'fileB.cpp', 'fileC.cpp'], 'extra_files': []},
-                'trivialprog1@exe': {'name': 'trivialprog1', 'sources': ['a1.cpp', 'a2.cpp', 'a6.cpp', 'fileA.cpp', 'main.cpp'], 'extra_files': []},
-                'trivialprog2@exe': {'name': 'trivialprog2', 'sources': ['a7.cpp', 'fileB.cpp', 'fileC.cpp'], 'extra_files': []},
+                'trivialprog0@exe': {'name': 'trivialprog0', 'sources': ['main.cpp', 'fileA.cpp', 'fileB.cpp', 'fileC.cpp'], 'extra_files': []},
+                'trivialprog1@exe': {'name': 'trivialprog1', 'sources': ['main.cpp', 'fileA.cpp', 'a1.cpp', 'a2.cpp'], 'extra_files': []},
+                'trivialprog2@exe': {'name': 'trivialprog2', 'sources': ['fileB.cpp', 'fileC.cpp', 'a7.cpp'], 'extra_files': []},
                 'trivialprog3@exe': {'name': 'trivialprog3', 'sources': ['a5.cpp', 'fileA.cpp', 'main.cpp'], 'extra_files': []},
-                'trivialprog4@exe': {'name': 'trivialprog4', 'sources': ['a5.cpp', 'main.cpp', 'fileA.cpp'], 'extra_files': []},
-                'trivialprog5@exe': {'name': 'trivialprog5', 'sources': ['a3.cpp', 'main.cpp', 'a7.cpp', 'fileB.cpp', 'fileC.cpp'], 'extra_files': []},
+                'trivialprog4@exe': {'name': 'trivialprog4', 'sources': ['main.cpp', 'a5.cpp', 'fileA.cpp'], 'extra_files': []},
+                'trivialprog5@exe': {'name': 'trivialprog5', 'sources': ['fileB.cpp', 'fileC.cpp', 'a3.cpp', 'main.cpp'], 'extra_files': []},
                 'trivialprog6@exe': {'name': 'trivialprog6', 'sources': ['main.cpp', 'fileA.cpp', 'a4.cpp'], 'extra_files': []},
-                'trivialprog7@exe': {'name': 'trivialprog7', 'sources': ['fileB.cpp', 'fileC.cpp', 'a1.cpp', 'a2.cpp', 'a6.cpp', 'fileA.cpp', 'main.cpp'], 'extra_files': []},
-                'trivialprog8@exe': {'name': 'trivialprog8', 'sources': ['a1.cpp', 'a2.cpp', 'a6.cpp', 'fileA.cpp', 'main.cpp'], 'extra_files': []},
-                'trivialprog9@exe': {'name': 'trivialprog9', 'sources': ['a1.cpp', 'a2.cpp', 'a6.cpp', 'fileA.cpp', 'main.cpp'], 'extra_files': []},
+                'trivialprog7@exe': {'name': 'trivialprog7', 'sources': ['fileB.cpp', 'fileC.cpp', 'fileA.cpp', 'main.cpp'], 'extra_files': []},
+                'trivialprog8@exe': {'name': 'trivialprog8', 'sources': ['main.cpp', 'fileA.cpp'], 'extra_files': []},
+                'trivialprog9@exe': {'name': 'trivialprog9', 'sources': ['main.cpp', 'fileA.cpp', 'a1.cpp', 'a6.cpp' ], 'extra_files': []},
+                'trivialprog10@exe': {'name': 'trivialprog10', 'sources': ['main.cpp', 'fileA.cpp', 'fileB.cpp', 'a1.cpp'], 'extra_files': []},
+                'trivialprog11@exe': {'name': 'trivialprog11', 'sources': ['a1.cpp', 'fileA.cpp', 'main.cpp'], 'extra_files': []},
+                'trivialprog12@exe': {'name': 'trivialprog12', 'sources': ['a1.cpp', 'fileA.cpp', 'fileB.cpp', 'main.cpp'], 'extra_files': []},
+                'rightName@exe': {'name': 'rightName', 'sources': ['main.cpp'], 'extra_files': []},
             }
         }
         self.assertEqualIgnoreOrder(out, expected)
@@ -107,7 +115,7 @@ class RewriterTests(BasePlatformTests):
         inf = json.dumps([{"type": "target", "target": "trivialprog1", "operation": "info"}])
         self.rewrite(self.builddir, add)
         out = self.rewrite(self.builddir, inf)
-        expected = {'target': {'trivialprog1@exe': {'name': 'trivialprog1', 'sources': ['a1.cpp', 'a2.cpp', 'a6.cpp', 'fileA.cpp', 'main.cpp'], 'extra_files': []}}}
+        expected = {'target': {'trivialprog1@exe': {'name': 'trivialprog1', 'sources': ['main.cpp', 'fileA.cpp', 'a1.cpp', 'a2.cpp', 'a6.cpp'], 'extra_files': []}}}
         self.assertDictEqual(out, expected)
 
     def test_target_remove_sources(self):
@@ -115,16 +123,20 @@ class RewriterTests(BasePlatformTests):
         out = self.rewrite(self.builddir, os.path.join(self.builddir, 'rmSrc.json'))
         expected = {
             'target': {
-                'trivialprog0@exe': {'name': 'trivialprog0', 'sources': ['main.cpp', 'fileC.cpp'], 'extra_files': []},
-                'trivialprog1@exe': {'name': 'trivialprog1', 'sources': ['main.cpp'], 'extra_files': []},
-                'trivialprog2@exe': {'name': 'trivialprog2', 'sources': ['fileC.cpp'], 'extra_files': []},
+                'trivialprog0@exe': {'name': 'trivialprog0', 'sources': ['main.cpp', 'fileA.cpp', 'fileB.cpp', 'fileC.cpp'], 'extra_files': []},
+                'trivialprog1@exe': {'name': 'trivialprog1', 'sources': ['main.cpp', 'fileA.cpp'], 'extra_files': []},
+                'trivialprog2@exe': {'name': 'trivialprog2', 'sources': ['fileB.cpp', 'fileC.cpp'], 'extra_files': []},
                 'trivialprog3@exe': {'name': 'trivialprog3', 'sources': ['main.cpp'], 'extra_files': []},
                 'trivialprog4@exe': {'name': 'trivialprog4', 'sources': ['main.cpp'], 'extra_files': []},
-                'trivialprog5@exe': {'name': 'trivialprog5', 'sources': ['main.cpp', 'fileC.cpp'], 'extra_files': []},
+                'trivialprog5@exe': {'name': 'trivialprog5', 'sources': ['fileB.cpp', 'fileC.cpp'], 'extra_files': []},
                 'trivialprog6@exe': {'name': 'trivialprog6', 'sources': ['main.cpp'], 'extra_files': []},
-                'trivialprog7@exe': {'name': 'trivialprog7', 'sources': ['fileC.cpp', 'main.cpp'], 'extra_files': []},
-                'trivialprog8@exe': {'name': 'trivialprog8', 'sources': ['main.cpp'], 'extra_files': []},
-                'trivialprog9@exe': {'name': 'trivialprog9', 'sources': ['main.cpp'], 'extra_files': []},
+                'trivialprog7@exe': {'name': 'trivialprog7', 'sources': ['fileC.cpp', 'main.cpp', 'fileA.cpp'], 'extra_files': []},
+                'trivialprog8@exe': {'name': 'trivialprog8', 'sources': ['main.cpp', 'fileA.cpp'], 'extra_files': []},
+                'trivialprog9@exe': {'name': 'trivialprog9', 'sources': ['main.cpp', 'fileA.cpp'], 'extra_files': []},
+                'trivialprog10@exe': {'name': 'trivialprog10', 'sources': ['main.cpp'], 'extra_files': []},
+                'trivialprog11@exe': {'name': 'trivialprog11', 'sources': ['main.cpp'], 'extra_files': []},
+                'trivialprog12@exe': {'name': 'trivialprog12', 'sources': ['main.cpp', 'fileA.cpp'], 'extra_files': []},
+                'rightName@exe': {'name': 'rightName', 'sources': ['main.cpp'], 'extra_files': []},
             }
         }
         self.assertEqualIgnoreOrder(out, expected)
@@ -136,7 +148,7 @@ class RewriterTests(BasePlatformTests):
     def test_target_subdir(self):
         self.prime('2 subdirs')
         out = self.rewrite(self.builddir, os.path.join(self.builddir, 'addSrc.json'))
-        expected = {'name': 'something', 'sources': ['first.c', 'second.c', 'third.c'], 'extra_files': []}
+        expected = {'name': 'something', 'sources': ['third.c', f'sub2{os.path.sep}first.c', f'sub2{os.path.sep}second.c'], 'extra_files': []}
         self.assertDictEqual(list(out['target'].values())[0], expected)
 
         # Check the written file
@@ -157,6 +169,9 @@ class RewriterTests(BasePlatformTests):
                 'trivialprog6@exe': {'name': 'trivialprog6', 'sources': ['main.cpp', 'fileA.cpp'], 'extra_files': []},
                 'trivialprog7@exe': {'name': 'trivialprog7', 'sources': ['fileB.cpp', 'fileC.cpp', 'main.cpp', 'fileA.cpp'], 'extra_files': []},
                 'trivialprog8@exe': {'name': 'trivialprog8', 'sources': ['main.cpp', 'fileA.cpp'], 'extra_files': []},
+                'trivialprog10@exe': {'name': 'trivialprog10', 'sources': ['main.cpp', 'fileA.cpp', 'fileB.cpp'], 'extra_files': []},
+                'trivialprog11@exe': {'name': 'trivialprog11', 'sources': ['main.cpp', 'fileA.cpp'], 'extra_files': []},
+                'trivialprog12@exe': {'name': 'trivialprog12', 'sources': ['main.cpp', 'fileA.cpp'], 'extra_files': []},
             }
         }
         self.assertEqualIgnoreOrder(out, expected)
@@ -178,7 +193,11 @@ class RewriterTests(BasePlatformTests):
                 'trivialprog7@exe': {'name': 'trivialprog7', 'sources': ['fileB.cpp', 'fileC.cpp', 'main.cpp', 'fileA.cpp'], 'extra_files': []},
                 'trivialprog8@exe': {'name': 'trivialprog8', 'sources': ['main.cpp', 'fileA.cpp'], 'extra_files': []},
                 'trivialprog9@exe': {'name': 'trivialprog9', 'sources': ['main.cpp', 'fileA.cpp'], 'extra_files': []},
-                'trivialprog10@sha': {'name': 'trivialprog10', 'sources': ['new1.cpp', 'new2.cpp'], 'extra_files': []},
+                'trivialprog10@exe': {'name': 'trivialprog10', 'sources': ['main.cpp', 'fileA.cpp', 'fileB.cpp'], 'extra_files': []},
+                'trivialprog11@exe': {'name': 'trivialprog11', 'sources': ['main.cpp', 'fileA.cpp'], 'extra_files': []},
+                'trivialprog12@exe': {'name': 'trivialprog12', 'sources': ['main.cpp', 'fileA.cpp'], 'extra_files': []},
+                'trivialprog13@sha': {'name': 'trivialprog13', 'sources': ['new1.cpp', 'new2.cpp'], 'extra_files': []},
+                'rightName@exe': {'name': 'rightName', 'sources': ['main.cpp'], 'extra_files': []},
             }
         }
         self.assertEqualIgnoreOrder(out, expected)
@@ -193,7 +212,7 @@ class RewriterTests(BasePlatformTests):
         self.prime('2 subdirs')
         self.rewrite(self.builddir, os.path.join(self.builddir, 'addTgt.json'))
         out = self.rewrite(self.builddir, os.path.join(self.builddir, 'info.json'))
-        expected = {'name': 'something', 'sources': ['first.c', 'second.c'], 'extra_files': []}
+        expected = {'name': 'something', 'sources': [f'sub2{os.path.sep}first.c', f'sub2{os.path.sep}second.c'], 'extra_files': []}
         self.assertDictEqual(out['target']['94b671c@@something@exe'], expected)
 
     def test_target_source_sorting(self):
@@ -240,16 +259,23 @@ class RewriterTests(BasePlatformTests):
                 }
             }
         }
+        for k1, v1 in expected.items():
+            for k2, v2 in v1.items():
+                for k3, v3 in v2.items():
+                    if isinstance(v3, list):
+                        for i in range(len(v3)):
+                            v3[i] = v3[i].replace('/', os.path.sep)
         self.assertDictEqual(out, expected)
 
     def test_target_same_name_skip(self):
         self.prime('4 same name targets')
         out = self.rewrite(self.builddir, os.path.join(self.builddir, 'addSrc.json'))
         out = self.rewrite(self.builddir, os.path.join(self.builddir, 'info.json'))
-        expected = {'name': 'myExe', 'sources': ['main.cpp'], 'extra_files': []}
+        expected1 = {'name': 'myExe', 'sources': ['main.cpp'], 'extra_files': []}
+        expected2 = {'name': 'myExe', 'sources': [f'sub1{os.path.sep}main.cpp'], 'extra_files': []}
         self.assertEqual(len(out['target']), 2)
-        for val in out['target'].values():
-            self.assertDictEqual(expected, val)
+        self.assertDictEqual(expected1, out['target']['myExe@exe'])
+        self.assertDictEqual(expected2, out['target']['9a11041@@myExe@exe'])
 
     def test_kwargs_info(self):
         self.prime('3 kwargs')
@@ -359,14 +385,14 @@ class RewriterTests(BasePlatformTests):
         out = self.rewrite(self.builddir, os.path.join(self.builddir, 'addExtraFiles.json'))
         expected = {
             'target': {
-                'trivialprog0@exe': {'name': 'trivialprog0', 'sources': ['main.cpp'], 'extra_files': ['a1.hpp', 'a2.hpp', 'a6.hpp', 'fileA.hpp', 'main.hpp', 'a7.hpp', 'fileB.hpp', 'fileC.hpp']},
-                'trivialprog1@exe': {'name': 'trivialprog1', 'sources': ['main.cpp'], 'extra_files': ['a1.hpp', 'a2.hpp', 'a6.hpp', 'fileA.hpp', 'main.hpp']},
+                'trivialprog0@exe': {'name': 'trivialprog0', 'sources': ['main.cpp'], 'extra_files': ['fileA.hpp', 'main.hpp', 'fileB.hpp', 'fileC.hpp']},
+                'trivialprog1@exe': {'name': 'trivialprog1', 'sources': ['main.cpp'], 'extra_files': ['a1.hpp', 'a2.hpp', 'fileA.hpp', 'main.hpp']},
                 'trivialprog2@exe': {'name': 'trivialprog2', 'sources': ['main.cpp'], 'extra_files': ['a7.hpp', 'fileB.hpp', 'fileC.hpp']},
                 'trivialprog3@exe': {'name': 'trivialprog3', 'sources': ['main.cpp'], 'extra_files': ['a5.hpp', 'fileA.hpp', 'main.hpp']},
                 'trivialprog4@exe': {'name': 'trivialprog4', 'sources': ['main.cpp'], 'extra_files': ['a5.hpp', 'main.hpp', 'fileA.hpp']},
-                'trivialprog5@exe': {'name': 'trivialprog5', 'sources': ['main.cpp'], 'extra_files': ['a3.hpp', 'main.hpp', 'a7.hpp', 'fileB.hpp', 'fileC.hpp']},
-                'trivialprog6@exe': {'name': 'trivialprog6', 'sources': ['main.cpp'], 'extra_files': ['a1.hpp', 'a2.hpp', 'a6.hpp', 'fileA.hpp', 'main.hpp']},
-                'trivialprog7@exe': {'name': 'trivialprog7', 'sources': ['main.cpp'], 'extra_files': ['a1.hpp', 'a2.hpp', 'a6.hpp', 'fileA.hpp', 'main.hpp']},
+                'trivialprog5@exe': {'name': 'trivialprog5', 'sources': ['main.cpp'], 'extra_files': ['a3.hpp', 'main.hpp', 'fileB.hpp', 'fileC.hpp']},
+                'trivialprog6@exe': {'name': 'trivialprog6', 'sources': ['main.cpp'], 'extra_files': ['fileA.hpp', 'main.hpp']},
+                'trivialprog7@exe': {'name': 'trivialprog7', 'sources': ['main.cpp'], 'extra_files': ['a1.hpp', 'a6.hpp', 'fileA.hpp', 'main.hpp']},
                 'trivialprog8@exe': {'name': 'trivialprog8', 'sources': ['main.cpp'], 'extra_files': ['a2.hpp', 'a7.hpp']},
                 'trivialprog9@exe': {'name': 'trivialprog9', 'sources': ['main.cpp'], 'extra_files': ['a8.hpp', 'a9.hpp']},
                 'trivialprog10@exe': {'name': 'trivialprog10', 'sources': ['main.cpp'], 'extra_files': ['a1.hpp', 'a4.hpp']},
@@ -383,14 +409,14 @@ class RewriterTests(BasePlatformTests):
         out = self.rewrite(self.builddir, os.path.join(self.builddir, 'rmExtraFiles.json'))
         expected = {
             'target': {
-                'trivialprog0@exe': {'name': 'trivialprog0', 'sources': ['main.cpp'], 'extra_files': ['main.hpp', 'fileC.hpp']},
-                'trivialprog1@exe': {'name': 'trivialprog1', 'sources': ['main.cpp'], 'extra_files': ['main.hpp']},
-                'trivialprog2@exe': {'name': 'trivialprog2', 'sources': ['main.cpp'], 'extra_files': ['fileC.hpp']},
+                'trivialprog0@exe': {'name': 'trivialprog0', 'sources': ['main.cpp'], 'extra_files': ['main.hpp', 'fileA.hpp', 'fileB.hpp', 'fileC.hpp']},
+                'trivialprog1@exe': {'name': 'trivialprog1', 'sources': ['main.cpp'], 'extra_files': ['main.hpp', 'fileA.hpp']},
+                'trivialprog2@exe': {'name': 'trivialprog2', 'sources': ['main.cpp'], 'extra_files': ['fileB.hpp', 'fileC.hpp']},
                 'trivialprog3@exe': {'name': 'trivialprog3', 'sources': ['main.cpp'], 'extra_files': ['main.hpp']},
                 'trivialprog4@exe': {'name': 'trivialprog4', 'sources': ['main.cpp'], 'extra_files': ['main.hpp']},
-                'trivialprog5@exe': {'name': 'trivialprog5', 'sources': ['main.cpp'], 'extra_files': ['main.hpp', 'fileC.hpp']},
-                'trivialprog6@exe': {'name': 'trivialprog6', 'sources': ['main.cpp'], 'extra_files': ['main.hpp']},
-                'trivialprog7@exe': {'name': 'trivialprog7', 'sources': ['main.cpp'], 'extra_files': ['main.hpp']},
+                'trivialprog5@exe': {'name': 'trivialprog5', 'sources': ['main.cpp'], 'extra_files': ['fileB.hpp', 'fileC.hpp', 'main.hpp']},
+                'trivialprog6@exe': {'name': 'trivialprog6', 'sources': ['main.cpp'], 'extra_files': ['main.hpp', 'fileA.hpp']},
+                'trivialprog7@exe': {'name': 'trivialprog7', 'sources': ['main.cpp'], 'extra_files': ['main.hpp', 'fileA.hpp']},
                 'trivialprog8@exe': {'name': 'trivialprog8', 'sources': ['main.cpp'], 'extra_files': []},
                 'trivialprog9@exe': {'name': 'trivialprog9', 'sources': ['main.cpp'], 'extra_files': []},
                 'trivialprog10@exe': {'name': 'trivialprog10', 'sources': ['main.cpp'], 'extra_files': []},
@@ -400,7 +426,26 @@ class RewriterTests(BasePlatformTests):
 
         # Check the written file
         out = self.rewrite(self.builddir, os.path.join(self.builddir, 'info.json'))
-        self.assertDictEqual(out, expected)
+        self.assertEqualIgnoreOrder(out, expected)
+
+    def test_tricky_dataflow(self):
+        self.prime('7 tricky dataflow')
+        out = self.rewrite(self.builddir, os.path.join(self.builddir, 'addSrc.json'))
+        expected = {
+            'target': {
+                'tgt1@sha': {'name': 'tgt1', 'sources': ['foo.c', 'new.c'], 'extra_files': []},
+                'tgt2@exe': {'name': 'tgt2', 'sources': ['new.c', 'unknown'], 'extra_files': []},
+                'tgt3@exe': {'name': 'tgt3', 'sources': ['foo.c', 'new.c'], 'extra_files': []},
+                'tgt4@exe': {'name': 'tgt4', 'sources': ['unknown'], 'extra_files': []},
+                'tgt5@exe': {'name': 'tgt5', 'sources': ['unknown', 'new.c'], 'extra_files': []},
+                'tgt6@exe': {'name': 'tgt6', 'sources': ['unknown', 'new.c'], 'extra_files': []},
+            }
+        }
+        self.assertEqualIgnoreOrder(out, expected)
+
+        # Check the written file
+        out = self.rewrite(self.builddir, os.path.join(self.builddir, 'info.json'))
+        self.assertEqualIgnoreOrder(out, expected)
 
     def test_raw_printer_is_idempotent(self):
         test_path = Path(self.unit_test_dir, '120 rewrite')
@@ -437,7 +482,7 @@ class RewriterTests(BasePlatformTests):
     # Asserts that AstInterpreter.dataflow_dag is what it should be
     def test_dataflow_dag(self):
         test_path = Path(self.rewrite_test_dir, '1 basic')
-        interpreter = IntrospectionInterpreter(test_path, '', 'ninja', visitors = [AstIDGenerator()])
+        interpreter = IntrospectionInterpreter(test_path, '', 'ninja')
         interpreter.analyze()
 
         def sortkey(node):

--- a/unittests/rewritetests.py
+++ b/unittests/rewritetests.py
@@ -46,6 +46,18 @@ class RewriterTests(BasePlatformTests):
             args = [args]
         return self.rewrite_raw(directory, ['command'] + args)
 
+    # The rewriter sorts the sources alphabetically, but this is very unstable
+    # and buggy, so we do not test it.
+    def assertEqualIgnoreOrder(self, a, b):
+        def deepsort(x):
+            if isinstance(x, list):
+                return sorted(deepsort(el) for el in x)
+            elif isinstance(x, dict):
+                return {k: deepsort(v) for k,v in x.items()}
+            else:
+                return x
+        self.assertDictEqual(deepsort(a), deepsort(b))
+
     def test_target_source_list(self):
         self.prime('1 basic')
         out = self.rewrite(self.builddir, os.path.join(self.builddir, 'info.json'))
@@ -63,7 +75,7 @@ class RewriterTests(BasePlatformTests):
                 'trivialprog9@exe': {'name': 'trivialprog9', 'sources': ['main.cpp', 'fileA.cpp'], 'extra_files': []},
             }
         }
-        self.assertDictEqual(out, expected)
+        self.assertEqualIgnoreOrder(out, expected)
 
     def test_target_add_sources(self):
         self.prime('1 basic')
@@ -82,11 +94,11 @@ class RewriterTests(BasePlatformTests):
                 'trivialprog9@exe': {'name': 'trivialprog9', 'sources': ['a1.cpp', 'a2.cpp', 'a6.cpp', 'fileA.cpp', 'main.cpp'], 'extra_files': []},
             }
         }
-        self.assertDictEqual(out, expected)
+        self.assertEqualIgnoreOrder(out, expected)
 
         # Check the written file
         out = self.rewrite(self.builddir, os.path.join(self.builddir, 'info.json'))
-        self.assertDictEqual(out, expected)
+        self.assertEqualIgnoreOrder(out, expected)
 
     def test_target_add_sources_abs(self):
         self.prime('1 basic')
@@ -115,11 +127,11 @@ class RewriterTests(BasePlatformTests):
                 'trivialprog9@exe': {'name': 'trivialprog9', 'sources': ['main.cpp'], 'extra_files': []},
             }
         }
-        self.assertDictEqual(out, expected)
+        self.assertEqualIgnoreOrder(out, expected)
 
         # Check the written file
         out = self.rewrite(self.builddir, os.path.join(self.builddir, 'info.json'))
-        self.assertDictEqual(out, expected)
+        self.assertEqualIgnoreOrder(out, expected)
 
     def test_target_subdir(self):
         self.prime('2 subdirs')
@@ -147,7 +159,7 @@ class RewriterTests(BasePlatformTests):
                 'trivialprog8@exe': {'name': 'trivialprog8', 'sources': ['main.cpp', 'fileA.cpp'], 'extra_files': []},
             }
         }
-        self.assertDictEqual(out, expected)
+        self.assertEqualIgnoreOrder(out, expected)
 
     def test_target_add(self):
         self.prime('1 basic')
@@ -169,7 +181,7 @@ class RewriterTests(BasePlatformTests):
                 'trivialprog10@sha': {'name': 'trivialprog10', 'sources': ['new1.cpp', 'new2.cpp'], 'extra_files': []},
             }
         }
-        self.assertDictEqual(out, expected)
+        self.assertEqualIgnoreOrder(out, expected)
 
     def test_target_remove_subdir(self):
         self.prime('2 subdirs')
@@ -360,11 +372,11 @@ class RewriterTests(BasePlatformTests):
                 'trivialprog10@exe': {'name': 'trivialprog10', 'sources': ['main.cpp'], 'extra_files': ['a1.hpp', 'a4.hpp']},
             }
         }
-        self.assertDictEqual(out, expected)
+        self.assertEqualIgnoreOrder(out, expected)
 
         # Check the written file
         out = self.rewrite(self.builddir, os.path.join(self.builddir, 'info.json'))
-        self.assertDictEqual(out, expected)
+        self.assertEqualIgnoreOrder(out, expected)
 
     def test_target_remove_extra_files(self):
         self.prime('6 extra_files')
@@ -384,7 +396,7 @@ class RewriterTests(BasePlatformTests):
                 'trivialprog10@exe': {'name': 'trivialprog10', 'sources': ['main.cpp'], 'extra_files': []},
             }
         }
-        self.assertDictEqual(out, expected)
+        self.assertEqualIgnoreOrder(out, expected)
 
         # Check the written file
         out = self.rewrite(self.builddir, os.path.join(self.builddir, 'info.json'))


### PR DESCRIPTION
The rewriter and the static introspection tool used to be very broken, now it is *less* broken.

The most important changes are:

1. We now have `class UnknownValue` for more explicit handling of situations that are too complex/impossible.
2. If you write
```
var = 'foo'
name = var
var = 'bar'
executable(name, 'foo.c')
```
the tool now knows that the name of the executable is `foo` and not `bar`. See `dataflow_dag` and `node_to_runtime_value` for details on how we do this.

To test my work I wrote a script that:
1. `git clone`'s a couple of big projects using meson (e.g. systemd).
3. Checks if the outputs of `meson introspect meson.build --targets` and `meson introspect build_folder --targets` are not contradicting each other.
4. Checks if the output of `meson introspect meson.build --targets` is the same for two different versions of meson (the one we want to test and a known good version).
5. Iterates over all targets that are found using  `meson introspect meson.build --targets` and checks if
```
meson rewrite target tgt add rewrite_test_source.c
meson rewrite target tgt add rewrite_test_source.c
meson introspect meson.build --targets
meson rewrite target tgt rm rewrite_test_source.c
meson introspect meson.build --targets
```
does not crash and produces the expected output.

I think this script is very useful (it found a ton of bugs), but I do not know where to put it, so it currently only exists on my machine. It is too slow (1 hour iirc, haven't measured) to run it in the CI pipeline. [In the docs](https://mesonbuild.com/Users.html) you write
```
All the software on this list is tested for regressions before release
```
Is this testing (partially) automated? If so, could we merge my script with it?


@bruchar1 @kcgen Afaik you are one of the few people using the rewriter/static introspection tool in production. Could you test your usecases and voice your opinion?

@eli-schwartz You promised me this in a mail:

> I would be willing to review the resulting PRs with the intent of
checking that the results "seem to work" and not getting bogged down in
nitty-gritty details. 🙂 I agree that it's relatively obscure
functionality that doesn't always work and the priority should be,
essentially, treating it as brand new code.
