### PR TITLE
Add '@INDEX@' token in generator rules

### DIFF
--- a/docs/markdown/snippets/index_token_generator.md
+++ b/docs/markdown/snippets/index_token_generator.md
@@ -1,0 +1,6 @@
+## `@INDEX@` in generator()'s args and output
+
+The `@INDEX@` special string can now be used in `generator()`'s `args` and `output` keyword arguments.
+When utilizing `generator.process()` on a list of files, `@INDEX@` will be replaced by the index of the 
+current file being processed, starting from 0. The index will be padded with leading zeroes based on the
+total number of inputs, ensuring a consistent width for easy parsing and handling.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2628,7 +2628,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             else:
                 sole_output = f'{curfile}'
             infilename = curfile.rel_to_builddir(self.build_to_src, self.get_target_private_dir(target))
-            base_args = generator.get_arglist(infilename)
+            base_args = generator.get_arglist(infilename, i, len(infilelist))
             outfiles = genlist.get_outputs_for(curfile)
             outfiles = [os.path.join(self.get_target_private_dir(target), of) for of in outfiles]
             if generator.depfile is None:

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -188,7 +188,7 @@ class Vs2010Backend(backends.Backend):
                     sole_output = ''
                 infilename = os.path.join(down, curfile.rel_to_builddir(self.build_to_src, target_private_dir))
                 deps = self.get_custom_target_depend_files(genlist, True)
-                base_args = generator.get_arglist(infilename)
+                base_args = generator.get_arglist(infilename, i, len(infilelist))
                 outfiles_rel = genlist.get_outputs_for(curfile)
                 outfiles = [os.path.join(target_private_dir, of) for of in outfiles_rel]
                 generator_output_files += outfiles

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -1246,7 +1246,7 @@ class XCodeBackend(backends.Backend):
             # and currently the build works without it.
             #infile_abs = i.absolute_path(self.environment.get_source_dir(), self.environment.get_build_dir())
             infilename = i.rel_to_builddir(self.build_to_src)
-            base_args = generator.get_arglist(infilename)
+            base_args = generator.get_arglist(infilename, i, len(infilelist))
             for o_base in genlist.get_outputs_for(i):
                 o = os.path.join(self.get_target_private_dir(t), o_base)
                 args = []

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -19,6 +19,7 @@ from functools import lru_cache
 import abc
 import hashlib
 import itertools, pathlib
+import math
 import os
 import pickle
 import re
@@ -1761,10 +1762,11 @@ class Generator(HoldableObject):
     def get_exe(self) -> T.Union['Executable', programs.ExternalProgram]:
         return self.exe
 
-    def get_base_outnames(self, inname: str) -> T.List[str]:
+    def get_base_outnames(self, inname: str, index: int, fileCount: int) -> T.List[str]:
         plainname = os.path.basename(inname)
         basename = os.path.splitext(plainname)[0]
-        bases = [x.replace('@BASENAME@', basename).replace('@PLAINNAME@', plainname) for x in self.outputs]
+        index_str = str(index).zfill(int(1 + math.log10(fileCount)))
+        bases = [x.replace('@BASENAME@', basename).replace('@PLAINNAME@', plainname).replace('@INDEX@', index_str) for x in self.outputs]
         return bases
 
     def get_dep_outname(self, inname: str) -> T.List[str]:
@@ -1774,10 +1776,11 @@ class Generator(HoldableObject):
         basename = os.path.splitext(plainname)[0]
         return self.depfile.replace('@BASENAME@', basename).replace('@PLAINNAME@', plainname)
 
-    def get_arglist(self, inname: str) -> T.List[str]:
+    def get_arglist(self, inname: str, index: int, fileCount: int) -> T.List[str]:
         plainname = os.path.basename(inname)
         basename = os.path.splitext(plainname)[0]
-        return [x.replace('@BASENAME@', basename).replace('@PLAINNAME@', plainname) for x in self.arglist]
+        index_str = str(index).zfill(int(1 + math.log10(fileCount)))
+        return [x.replace('@BASENAME@', basename).replace('@PLAINNAME@', plainname).replace('@INDEX@', index_str) for x in self.arglist]
 
     @staticmethod
     def is_parent_path(parent: str, trial: str) -> bool:
@@ -1790,7 +1793,7 @@ class Generator(HoldableObject):
                       extra_args: T.Optional[T.List[str]] = None) -> 'GeneratedList':
         output = GeneratedList(self, state.subdir, preserve_path_from, extra_args=extra_args if extra_args is not None else [])
 
-        for e in files:
+        for index, e in enumerate(files):
             if isinstance(e, CustomTarget):
                 output.depends.add(e)
             if isinstance(e, CustomTargetIndex):
@@ -1814,9 +1817,8 @@ class Generator(HoldableObject):
                     if not self.is_parent_path(preserve_path_from, abs_f):
                         raise InvalidArguments('generator.process: When using preserve_path_from, all input files must be in a subdirectory of the given dir.')
                 f = FileMaybeInTargetPrivateDir(f)
-                output.add_file(f, state)
+                output.add_file(f, state, index, len(files))
         return output
-
 
 @dataclass(eq=False)
 class GeneratedList(HoldableObject):
@@ -1859,9 +1861,9 @@ class GeneratedList(HoldableObject):
             result.append(os.path.join(path_segment, of))
         return result
 
-    def add_file(self, newfile: FileMaybeInTargetPrivateDir, state: T.Union['Interpreter', 'ModuleState']) -> None:
+    def add_file(self, newfile: FileMaybeInTargetPrivateDir, state: T.Union['Interpreter', 'ModuleState'], index: int, fileCount: int) -> None:
         self.infilelist.append(newfile)
-        outfiles = self.generator.get_base_outnames(newfile.fname)
+        outfiles = self.generator.get_base_outnames(newfile.fname, index, fileCount)
         if self.preserve_path_from:
             outfiles = self.add_preserved_path_segment(newfile, outfiles, state)
         self.outfilelist += outfiles

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2149,8 +2149,8 @@ class Interpreter(InterpreterBase, HoldableObject):
                        args: T.Tuple[T.Union[build.Executable, ExternalProgram]],
                        kwargs: 'kwtypes.FuncGenerator') -> build.Generator:
         for rule in kwargs['output']:
-            if '@BASENAME@' not in rule and '@PLAINNAME@' not in rule:
-                raise InvalidArguments('Every element of "output" must contain @BASENAME@ or @PLAINNAME@.')
+            if '@BASENAME@' not in rule and '@PLAINNAME@' not in rule and '@INDEX@' not in rule:
+                raise InvalidArguments('Every element of "output" must contain @BASENAME@, @PLAINNAME@ or @INDEX@')
             if has_path_sep(rule):
                 raise InvalidArguments('"output" must not contain a directory separator.')
         if len(kwargs['output']) > 1:


### PR DESCRIPTION
Currently, the name of a generator's output must be constructed from the input file's name (with or without extension). This is somewhat limiting, as one may need outputs to be named something completely unrelated.

For instance, assume I have the following .json files in a directory, which contain data about some classes for a game:

```
alligator.json
bird.json
cat.json
dog.json
eagle.json
fox.json
giraffe.json
```

I want to process these files with a `generator()` to generate some .bin files, which will then become inputs for a `custom_target()` that combines them into a compressed archive. Furthermore, the binaries need to be in the following order in the archive:

```
cat
alligator
fox
bird
eagle
dog
giraffe
```

The archiver tool copies the order of the binaries in the target's private directory, so to ensure the binaries are packaged in the correct order, the outputs should be named by index (`cat.json` should be converted to 0000.bin, `alligator.json` to 0001.bin, and so on). Currently, the only way of doing this, afaik, would be to rename the json files themselves by index. This isn't great, as it makes it hard to locate the json for a specific animal in the source tree (especially when there are many more such files) 

Enter the `@INDEX@` token. This token, which can be used in a generator's `output:` and `args:` kwargs, will be replaced by the index of the file being processed by the generator. I can now do this:

```meson
json_inputs = files(
    cat.json,
    alligator.json,
    fox.json,
    bird.json,
    eagle.json,
    dog.json,
    giraffe.json
)

json2bin_gen = generator(converter_exe,
    args: [...],
    output: '@INDEX@' + '.bin'
)

archive = custom_target('archive',
    input: json2bin_gen.process(json_inputs)
   ...
)
```

And in archive.p, the binaries for the animals will be named by index, while the json files can still be named by animal, which improves data organization in the source tree.

Now, given a large enough collection of files, the output names should be padded with 0s to ensure correct ordering (otherwise, the file system will place e.g. 11.bin before 2.bin). That's why `@INDEX:<padding>@` will do just that.