### PR TITLE
rust: pass global and project C args to clang in bindgen

### DIFF
--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -236,6 +236,12 @@ class RustModule(ExtensionModule):
                 elif isinstance(s, CustomTarget):
                     depends.append(s)
 
+        clang_args.extend(state.global_args.get('c', []))
+        clang_args.extend(state.project_args.get('c', []))
+        cargs = state.get_option('args', state.subproject, lang='c')
+        assert isinstance(cargs, list), 'for mypy'
+        clang_args.extend(cargs)
+
         if self._bindgen_bin is None:
             self._bindgen_bin = state.find_program('bindgen')
 

--- a/test cases/rust/12 bindgen/meson.build
+++ b/test cases/rust/12 bindgen/meson.build
@@ -8,6 +8,9 @@ if not prog_bindgen.found()
   error('MESON_SKIP_TEST bindgen not found')
 endif
 
+add_project_arguments('-DPROJECT_ARG', language : 'c')
+add_global_arguments('-DGLOBAL_ARG', language : 'c')
+
 # This seems to happen on windows when libclang.dll is not in path or is not
 # valid. We must try to process a header file for this to work.
 #
@@ -81,3 +84,18 @@ test('generated header', rust_bin2)
 
 subdir('sub')
 subdir('dependencies')
+
+gp = rust.bindgen(
+  input : 'src/global-project.h',
+  output : 'global-project.rs',
+)
+
+gp_lib = static_library('gp_lib', 'src/global.c')
+
+gp_exe = executable(
+  'gp_exe',
+  structured_sources(['src/global.rs', gp]),
+  link_with : gp_lib,
+)
+
+test('global and project arguments', gp_exe)

--- a/test cases/rust/12 bindgen/src/global-project.h
+++ b/test cases/rust/12 bindgen/src/global-project.h
@@ -1,0 +1,10 @@
+#ifndef GLOBAL_ARG
+char * success(void);
+#endif
+#ifndef PROJECT_ARG
+char * success(void);
+#endif
+#ifndef CMD_ARG
+char * success(void);
+#endif
+int success(void);

--- a/test cases/rust/12 bindgen/src/global.c
+++ b/test cases/rust/12 bindgen/src/global.c
@@ -1,0 +1,5 @@
+#include "src/global-project.h"
+
+int success(void) {
+    return 0;
+}

--- a/test cases/rust/12 bindgen/src/global.rs
+++ b/test cases/rust/12 bindgen/src/global.rs
@@ -1,0 +1,14 @@
+// SPDX-license-identifer: Apache-2.0
+// Copyright © 2023 Intel Corporation
+
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+include!("global-project.rs");
+
+fn main() {
+    unsafe {
+        std::process::exit(success());
+    };
+}

--- a/test cases/rust/12 bindgen/test.json
+++ b/test cases/rust/12 bindgen/test.json
@@ -1,7 +1,10 @@
 {
+  "env": {
+    "CFLAGS": "-DCMD_ARG"
+  },
   "stdout": [
     {
-      "line": "test cases/rust/12 bindgen/meson.build:27: WARNING: Project targets '>= 0.63' but uses feature introduced in '1.0.0': \"rust.bindgen\" keyword argument \"include_directories\" of type array[str]."
+      "line": "test cases/rust/12 bindgen/meson.build:30: WARNING: Project targets '>= 0.63' but uses feature introduced in '1.0.0': \"rust.bindgen\" keyword argument \"include_directories\" of type array[str]."
     }
   ]
 }


### PR DESCRIPTION
This means that any arguments given project wide or globally (such as preprocessor defines) will be set.

Fixes: #12065