### PR TITLE
cpp: restore c++26 support

### DIFF
--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -55,7 +55,7 @@ if T.TYPE_CHECKING:
 else:
     CompilerMixinBase = object
 
-_ALL_STDS = ['c++98', 'c++0x', 'c++03', 'c++1y', 'c++1z', 'c++11', 'c++14', 'c++17', 'c++2a', 'c++20', 'c++23']
+_ALL_STDS = ['c++98', 'c++0x', 'c++03', 'c++1y', 'c++1z', 'c++11', 'c++14', 'c++17', 'c++2a', 'c++20', 'c++23', 'c++26']
 _ALL_STDS += [f'gnu{std[1:]}' for std in _ALL_STDS]
 _ALL_STDS += ['vc++11', 'vc++14', 'vc++17', 'vc++20', 'vc++latest', 'c++latest']
 


### PR DESCRIPTION
c++26 support was added in #11986, but regressed in #10332 because the versions now get checked against the global _ALL_STDS list, and c++26 was missing there.

Fix by adding c++26 to _ALL_STDS