### PR TITLE
get_llvm_tool_names: add llvm 17

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -157,6 +157,7 @@ def get_llvm_tool_names(tool: str) -> T.List[str]:
     # unless it becomes a stable release.
     suffixes = [
         '', # base (no suffix)
+        '-17',  '17',
         '-16',  '16',
         '-15',  '15',
         '-14',  '14',


### PR DESCRIPTION
this fixes the "frameworks: 15 llvm" tests with llvm 17