### PR TITLE
tests: fix broken promises with linker scripts

### DIFF
--- a/test cases/linuxlike/3 linker script/meson.build
+++ b/test cases/linuxlike/3 linker script/meson.build
@@ -22,7 +22,7 @@ m = configure_file(
   output : 'bob-conf.map',
   configuration : conf,
 )
-vflag = '-Wl,--version-script,@0@'.format(m)
+vflag = '-Wl,--version-script,@0@'.format(meson.current_build_dir() / 'bob-conf.map')
 
 l = shared_library('bob-conf', 'bob.c', link_args : vflag, link_depends : m)
 e = executable('prog-conf', 'prog.c', link_with : l)
@@ -41,14 +41,6 @@ vflag = '-Wl,--version-script,@0@'.format(m.full_path())
 
 l = shared_library('bob-ct', ['bob.c', m], link_args : vflag, link_depends : m)
 e = executable('prog-ct', 'prog.c', link_with : l)
-test('core', e)
-
-# File
-mapfile = files('bob.map')
-vflag = '-Wl,--version-script,@0@/@1@'.format(meson.current_source_dir(), mapfile[0])
-
-l = shared_library('bob-files', 'bob.c', link_args : vflag, link_depends : mapfile)
-e = executable('prog-files', 'prog.c', link_with : l)
 test('core', e)
 
 subdir('sub')


### PR DESCRIPTION
This has never, ever, ever worked. You can get away with it a tiny, tiny bit, iff you magically assume several things about both internal implementations, as well as the project source layout and builddir location.

This can be witnessed by the way using files() was mercilessly tortured through joining the undefined stringified format value of the file to the current source dir... because it didn't actually *work*, the stringified value isn't an absolute path or a builddir-relative one, but it works as long as you do it from the root meson.build file.

Furthermore, this triggers a deprecation warning if you do it. And using it for files() is frivolous, the "static map file" case was correct all along.

Fix the configure_file case to demonstrate the same painful hoops we must jump through to get custom_target outputs to work correctly.

Fixes #12259