### PR TITLE
Add `''` to cmake `common_paths`

### DIFF
--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -226,7 +226,7 @@ class CMakeDependency(ExternalDependency):
         module_paths = [x for x in module_paths if os.path.isdir(x)]
         archs = temp_parser.get_cmake_var('MESON_ARCH_LIST')
 
-        common_paths = ['lib', 'lib32', 'lib64', 'libx32', 'share']
+        common_paths = ['lib', 'lib32', 'lib64', 'libx32', 'share', '']
         for i in archs:
             common_paths += [os.path.join('lib', i)]
 


### PR DESCRIPTION
[PyTorch](https://github.com/pytorch/pytorch) is a project built with cmake, and provides cmake packages for applications to link with it. The cmake prefix of PyTorch can be found by running:
```bash
python -c 'import torch.utils; print(torch.utils.cmake_prefix_path)'
```
you will see something like below from the above command:
```
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/share/cmake
```
Inspecting this directory:
```
❯ tree /home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/share/cmake
/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/share/cmake
├── ATen
│   └── ATenConfig.cmake
├── Caffe2
│   ├── Caffe2Config.cmake
│   ├── Caffe2Targets.cmake
│   ├── Caffe2Targets-release.cmake
│   ├── FindCUDAToolkit.cmake
│   ├── FindCUSPARSELT.cmake
│   ├── Modules_CUDA_fix
│   │   ├── FindCUDA.cmake
│   │   ├── FindCUDNN.cmake
│   │   └── upstream
│   │       ├── CMakeInitializeConfigs.cmake
│   │       ├── FindCUDA
│   │       │   ├── make2cmake.cmake
│   │       │   ├── parse_cubin.cmake
│   │       │   ├── run_nvcc.cmake
│   │       │   └── select_compute_arch.cmake
│   │       ├── FindCUDA.cmake
│   │       ├── FindPackageHandleStandardArgs.cmake
│   │       └── FindPackageMessage.cmake
│   └── public
│       ├── cuda.cmake
│       ├── gflags.cmake
│       ├── glog.cmake
│       ├── LoadHIP.cmake
│       ├── mkl.cmake
│       ├── mkldnn.cmake
│       ├── protobuf.cmake
│       └── utils.cmake
├── Tensorpipe
│   ├── TensorpipeTargets.cmake
│   └── TensorpipeTargets-release.cmake
└── Torch
    ├── TorchConfig.cmake
    └── TorchConfigVersion.cmake

9 directories, 28 files
```
However, meson currently filters this directory out by `_preliminary_find_check`. As a result, doing
```meson
torch_dep = dependency('Torch')
```
will fail, even if you set `cmake_prefix_path` with the value returned by PyTorch.

Possibly related issues:
https://stackoverflow.com/questions/68884434/libtorch-c-meson-dependency
https://github.com/mesonbuild/meson/issues/9740
https://discuss.pytorch.org/t/libtorch-meson-build/139648