### PR TITLE
Hack resolve_cmake_trace_targets to fix pytorch

### DIFF
--- a/mesonbuild/cmake/tracetargets.py
+++ b/mesonbuild/cmake/tracetargets.py
@@ -39,7 +39,17 @@ def resolve_cmake_trace_targets(target_name: str,
 
     processed_targets: T.List[str] = []
     while len(targets) > 0:
-        curr = targets.pop(0)
+        def maybe_unwrap(x: str) -> str:
+            # Unwrap things like:
+            # -Wl,--no-as-needed,"/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so" -Wl,--as-needed
+            # TODO: This is a hack, we should really be parsing the arguments properly
+            prefix = '-Wl,--no-as-needed,"'
+            suffix = '" -Wl,--as-needed'
+            if x.startswith(prefix) and x.endswith(suffix):
+                return x[len(prefix):-len(suffix)]
+            return x
+
+        curr = maybe_unwrap(targets.pop(0))
 
         # Skip already processed targets
         if curr in processed_targets:


### PR DESCRIPTION
The cmake traces of pytorch contains things like:
```
-Wl,--no-as-needed,"/home/gaoxiang/.virtualenvs/nvfuser/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so" -Wl,--as-needed
```
which is not correctly handled by meson yet.

This PR adds a hack to workaround it.

I totally understand that this is not a robust solution, but this does make things work.

Considering that PyTorch is a very widely used library, I think it is worthy to have such hack.