### PR TITLE
unittest: Fix clang-tidy-fix

### DIFF
--- a/test cases/unit/68 clang-tidy/cttest_fixed.cpp
+++ b/test cases/unit/68 clang-tidy/cttest_fixed.cpp
@@ -1,0 +1,7 @@
+#include<cstdio>
+
+int main(int, char**) {
+  bool intbool = true;
+  printf("Intbool is %d\n", (int)intbool);
+  return 0;
+}

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -42,7 +42,7 @@ from mesonbuild.mesonlib import (
     is_sunos, windows_proof_rmtree, python_command, version_compare, split_args, quote_arg,
     relpath, is_linux, git, search_version, do_conf_file, do_conf_str, default_prefix,
     MesonException, EnvironmentException, OptionKey,
-    windows_proof_rm, quiet_git
+    windows_proof_rm
 )
 from mesonbuild.programs import ExternalProgram
 
@@ -3030,7 +3030,6 @@ class AllPlatformTests(BasePlatformTests):
         self.assertNotIn(dummydir, out)
 
     @skipIfNoExecutable('clang-tidy')
-    @unittest.skipIf(not is_git_repo(), 'Skipping because this is not in git repo')
     def test_clang_tidy_fix(self):
         if self.backend is not Backend.ninja:
             raise SkipTest(f'Clang-tidy is for now only supported on Ninja, not {self.backend.name}')
@@ -3039,15 +3038,27 @@ class AllPlatformTests(BasePlatformTests):
         if is_osx():
             raise SkipTest('Apple ships a broken clang-tidy that chokes on -pipe.')
         testdir = os.path.join(self.unit_test_dir, '68 clang-tidy')
+
+        # Ensure that test project is in git even when running meson from tarball.
+        srcdir = os.path.join(self.builddir, 'src')
+        shutil.copytree(testdir, srcdir)
+        git_init(srcdir)
+        testdir = srcdir
+        self.new_builddir()
+
         dummydir = os.path.join(testdir, 'dummydir.h')
+        testfile = os.path.join(testdir, 'cttest.cpp')
+        fixedfile = os.path.join(testdir, 'cttest_fixed.cpp')
         self.init(testdir, override_envvars={'CXX': 'c++'})
+        # Make sure test files are different
+        self.assertNotEqual(Path(testfile).read_text(encoding='utf-8'),
+                            Path(fixedfile).read_text(encoding='utf-8'))
         out = self.run_target('clang-tidy-fix')
         self.assertIn('cttest.cpp:4:20', out)
         self.assertNotIn(dummydir, out)
-        ret = quiet_git(['diff', '--exit-code', 'test cases/unit/68 clang-tidy/cttest.cpp'], '.')
-        self.assertFalse(ret[0])
-        # Restore the file
-        quiet_git(['checkout', '--', 'test cases/unit/68 clang-tidy/cttest.cpp'], '.')
+        # Make sure the test file is fixed
+        self.assertEqual(Path(testfile).read_text(encoding='utf-8'),
+                         Path(fixedfile).read_text(encoding='utf-8'))
 
     def test_identity_cross(self):
         testdir = os.path.join(self.unit_test_dir, '69 cross')

--- a/unittests/helpers.py
+++ b/unittests/helpers.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from mesonbuild.compilers import detect_c_compiler, compiler_from_language
 from mesonbuild.mesonlib import (
     MachineChoice, is_osx, is_cygwin, EnvironmentException, OptionKey, MachineChoice,
-    OrderedSet, quiet_git
+    OrderedSet
 )
 from run_tests import get_fake_env
 
@@ -134,9 +134,6 @@ def is_tarball():
     if not os.path.isdir('docs'):
         return True
     return False
-
-def is_git_repo():
-    return quiet_git(['branch'], '.')[0]
 
 @contextmanager
 def chdir(path: str):


### PR DESCRIPTION
The unittest case for `clang-tidy-fix` checks if the whole project is in git or not, and skips if not.

Fix this by creating a temporary git repo, copy the test files and run the tests, following how `clang-format` does.

It also reverts some help code introduced in the previous test.

Tested: Verify the test case passes.