### PR TITLE
fix regression that broke sanity checking of jar sources

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1859,10 +1859,10 @@ class Interpreter(InterpreterBase, HoldableObject):
         return self.build_library(node, args, kwargs)
 
     @permittedKwargs(build.known_jar_kwargs)
-    @typed_pos_args('jar', str, varargs=SOURCES_VARARGS)
+    @typed_pos_args('jar', str, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList, build.ExtractedObjects, build.BuildTarget))
     @typed_kwargs('jar', *JAR_KWS, allow_unknown=True)
     def func_jar(self, node: mparser.BaseNode,
-                 args: T.Tuple[str, SourcesVarargsType],
+                 args: T.Tuple[str, T.List[T.Union[str, mesonlib.File, build.GeneratedTypes]]],
                  kwargs: kwtypes.Jar) -> build.Jar:
         return self.build_target(node, args, kwargs, build.Jar)
 


### PR DESCRIPTION
In commit dd22546bdd5b7de34025437ae1360f6dd20491eb the various typed_pos_args for different BuildTarget functions was refactored into a common tuple of types.

It overlooked the fact that jar specifically does NOT accept the same types, and began to allow passing structured_sources in.