### PR TITLE
Use posix paths in devenv's PATH variable

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1976,7 +1976,7 @@ class Backend:
             in_default_dir = t.should_install() and not t.get_install_dir()[2]
             if t.for_machine != MachineChoice.HOST or not in_default_dir:
                 continue
-            tdir = os.path.join(self.environment.get_build_dir(), self.get_target_dir(t))
+            tdir = (Path(self.environment.get_build_dir()) / self.get_target_dir(t)).as_posix()
             if isinstance(t, build.Executable):
                 # Add binaries that are going to be installed in bindir into PATH
                 # so they get used by default instead of searching on system when


### PR DESCRIPTION
Currently the devenv dumped for vscode on windows contains windows paths :
`PATH="C:\dev\tools\meson\test cases\unit\90 devenv\builddir\;C:\dev\tools\meson\test cases\unit\90 devenv\builddir\subprojects\sub"
`
which will fail when a directory start with a n for example : `c:\this\will\not\work`.

When using posix paths, vscode is happy.

- Before patch :
> dump sh/export: `PATH="C:\dev\tools\meson\test cases\unit\90 devenv\builddir\;C:\dev\tools\meson\test cases\unit\90 devenv\builddir\subprojects\sub;$PATH"`
> dump vscode: `PATH="C:\dev\tools\meson\test cases\unit\90 devenv\builddir\;C:\dev\tools\meson\test cases\unit\90 devenv\builddir\subprojects\sub"`

- After patch :
> dump sh/export: `PATH="C:/dev/tools/meson/test cases/unit/90 devenv/builddir;C:\dev\tools\meson\test cases\unit\90 devenv\builddir\subprojects\sub;$PATH"`
> dump vscode: `PATH="C:/dev/tools/meson/test cases/unit/90 devenv/builddir;C:\dev\tools\meson\test cases\unit\90 devenv\builddir\subprojects\sub"`

This is a subset that @amyspark  kindly agreed to add to #12194
