### PR TITLE
Use -idirafter when adding Apple framework include paths

### DIFF
--- a/mesonbuild/dependencies/framework.py
+++ b/mesonbuild/dependencies/framework.py
@@ -76,7 +76,7 @@ class ExtraFrameworkDependency(ExternalDependency):
             # https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPFrameworks/Tasks/IncludingFrameworks.html
             incdir = self._get_framework_include_path(framework_path)
             if incdir:
-                self.compile_args += ['-I' + incdir]
+                self.compile_args += ['-idirafter' + incdir]
             self.is_found = True
             return
 

--- a/test cases/osx/5 extra frameworks/meson.build
+++ b/test cases/osx/5 extra frameworks/meson.build
@@ -1,10 +1,14 @@
 project('xcode extra framework test', 'c')
 
-dep_libs = dependency('OpenGL', method : 'extraframework')
-assert(dep_libs.type_name() == 'extraframeworks', 'type_name is ' + dep_libs.type_name())
+opengl_dep = dependency('OpenGL', method : 'extraframework')
+assert(opengl_dep.type_name() == 'extraframeworks', 'type_name is ' + opengl_dep.type_name())
 
 dep_main = dependency('Foundation')
 assert(dep_main.type_name() == 'extraframeworks', 'type_name is ' + dep_main.type_name())
 
-stlib = static_library('stat', 'stat.c', install : true, dependencies: dep_libs)
+# https://github.com/mesonbuild/meson/issues/10002
+ldap_dep = dependency('ldap', method : 'extraframework')
+assert(ldap_dep.type_name() == 'extraframeworks', 'type_name is ' + ldap_dep.type_name())
+
+stlib = static_library('stat', 'stat.c', install : true, dependencies: [opengl_dep, ldap_dep])
 exe = executable('prog', 'prog.c', install : true, dependencies: dep_main)

--- a/test cases/osx/5 extra frameworks/stat.c
+++ b/test cases/osx/5 extra frameworks/stat.c
@@ -1,1 +1,4 @@
+// https://github.com/mesonbuild/meson/issues/10002
+#include <ldap.h>
+
 int func(void) { return 933; }


### PR DESCRIPTION
System headers will continue to "preempt" the framework headers. This should allow both <GStreamer/gst/gst.h> and <gst/gst.h>

Fixes: #10002 