### PR TITLE
Use typed_kwargs for exclusive executable args

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1938,10 +1938,6 @@ class Executable(BuildTarget):
         self.implib = kwargs.get('implib')
         if not isinstance(self.implib, (bool, str, type(None))):
             raise InvalidArguments('"export_dynamic" keyword argument must be a boolean or string')
-        if self.implib:
-            self.export_dynamic = True
-        if self.export_dynamic and self.implib is False:
-            raise InvalidArguments('"implib" keyword argument must not be false for if "export_dynamic" is true')
         # Only linkwithable if using export_dynamic
         self.is_linkwithable = self.export_dynamic
         # Remember that this exe was returned by `find_program()` through an override

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1806,7 +1806,6 @@ class Interpreter(InterpreterBase, HoldableObject):
     def func_disabler(self, node, args, kwargs):
         return Disabler()
 
-    @FeatureNewKwargs('executable', '0.42.0', ['implib'])
     @permittedKwargs(build.known_exe_kwargs)
     @typed_pos_args('executable', str, varargs=SOURCES_VARARGS)
     @typed_kwargs('executable', *EXECUTABLE_KWS, allow_unknown=True)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3327,6 +3327,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         kwargs['include_directories'] = self.extract_incdirs(kwargs)
 
         if targetclass is build.Executable:
+            kwargs = T.cast('kwtypes.Executable', kwargs)
             if kwargs['gui_app'] is not None:
                 if kwargs['win_subsystem'] is not None:
                     raise InvalidArguments.from_node(
@@ -3336,6 +3337,21 @@ class Interpreter(InterpreterBase, HoldableObject):
                     kwargs['win_subsystem'] = 'windows'
             if kwargs['win_subsystem'] is None:
                 kwargs['win_subsystem'] = 'console'
+
+            if kwargs['implib']:
+                if kwargs['export_dynamic'] is False:
+                    FeatureDeprecated.single_use('implib overrides explict export_dynamic off', '1.3.0', self.subprojct,
+                                                 'Do not set ths if want export_dynamic disabled if implib is enabled',
+                                                 location=node)
+                kwargs['export_dynamic'] = True
+            elif kwargs['export_dynamic']:
+                if kwargs['implib'] is False:
+                    raise InvalidArguments('"implib" keyword" must not be false if "export_dynamic" is set and not false.')
+                kwargs['implib'] = True
+            if kwargs['export_dynamic'] is None:
+                kwargs['export_dynamic'] = False
+            if kwargs['implib'] is None:
+                kwargs['implib'] = False
 
         target = targetclass(name, self.subdir, self.subproject, for_machine, srcs, struct, objs,
                              self.environment, self.compilers[for_machine], kwargs)

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -342,6 +342,7 @@ class Executable(_BuildTarget):
 
     export_dynamic: bool
     gui_app: T.Optional[bool]
+    pie: T.Optional[bool]
     vs_module_defs: T.Optional[T.Union[str, File, build.CustomTarget, build.CustomTargetIndex]]
     win_subsystem: T.Optional[str]
 

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -340,7 +340,7 @@ class _LibraryMixin(TypedDict):
 
 class Executable(_BuildTarget):
 
-    export_dynamic: bool
+    export_dynamic: T.Optional[bool]
     gui_app: T.Optional[bool]
     implib: T.Optional[T.Union[str, bool]]
     pie: T.Optional[bool]

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -342,6 +342,7 @@ class Executable(_BuildTarget):
 
     export_dynamic: bool
     gui_app: T.Optional[bool]
+    implib: T.Optional[T.Union[str, bool]]
     pie: T.Optional[bool]
     vs_module_defs: T.Optional[T.Union[str, File, build.CustomTarget, build.CustomTargetIndex]]
     win_subsystem: T.Optional[str]

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -340,6 +340,7 @@ class _LibraryMixin(TypedDict):
 
 class Executable(_BuildTarget):
 
+    export_dynamic: bool
     gui_app: T.Optional[bool]
     vs_module_defs: T.Optional[T.Union[str, File, build.CustomTarget, build.CustomTargetIndex]]
     win_subsystem: T.Optional[str]

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -588,6 +588,7 @@ _DARWIN_VERSIONS_KW: KwargInfo[T.List[T.Union[str, int]]] = KwargInfo(
 # Arguments exclusive to Executable. These are separated to make integrating
 # them into build_target easier
 _EXCLUSIVE_EXECUTABLE_KWS: T.List[KwargInfo] = [
+    KwargInfo('export_dynamic', bool, default=False, since='0.45.0'),
     KwargInfo('gui_app', (bool, NoneType), deprecated='0.56.0', deprecated_message="Use 'win_subsystem' instead"),
     KwargInfo(
         'win_subsystem',

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -590,6 +590,7 @@ _DARWIN_VERSIONS_KW: KwargInfo[T.List[T.Union[str, int]]] = KwargInfo(
 _EXCLUSIVE_EXECUTABLE_KWS: T.List[KwargInfo] = [
     KwargInfo('export_dynamic', bool, default=False, since='0.45.0'),
     KwargInfo('gui_app', (bool, NoneType), deprecated='0.56.0', deprecated_message="Use 'win_subsystem' instead"),
+    KwargInfo('pie', (bool, NoneType)),
     KwargInfo(
         'win_subsystem',
         (str, NoneType),

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -590,6 +590,7 @@ _DARWIN_VERSIONS_KW: KwargInfo[T.List[T.Union[str, int]]] = KwargInfo(
 _EXCLUSIVE_EXECUTABLE_KWS: T.List[KwargInfo] = [
     KwargInfo('export_dynamic', bool, default=False, since='0.45.0'),
     KwargInfo('gui_app', (bool, NoneType), deprecated='0.56.0', deprecated_message="Use 'win_subsystem' instead"),
+    KwargInfo('implib', (bool, str, NoneType), since='0.42.0'),
     KwargInfo('pie', (bool, NoneType)),
     KwargInfo(
         'win_subsystem',

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -588,7 +588,7 @@ _DARWIN_VERSIONS_KW: KwargInfo[T.List[T.Union[str, int]]] = KwargInfo(
 # Arguments exclusive to Executable. These are separated to make integrating
 # them into build_target easier
 _EXCLUSIVE_EXECUTABLE_KWS: T.List[KwargInfo] = [
-    KwargInfo('export_dynamic', bool, default=False, since='0.45.0'),
+    KwargInfo('export_dynamic', (bool, NoneType), since='0.45.0'),
     KwargInfo('gui_app', (bool, NoneType), deprecated='0.56.0', deprecated_message="Use 'win_subsystem' instead"),
     KwargInfo('implib', (bool, str, NoneType), since='0.42.0'),
     KwargInfo('pie', (bool, NoneType)),


### PR DESCRIPTION
This gets all of the executable exclusive keyword arguments ported to typed_kwargs