### PR TITLE
find_tool: don't assume the pkgconfig variable is a valid command

### DIFF
--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -112,7 +112,7 @@ class ModuleState:
         if dep.found() and dep.type_name == 'pkgconfig':
             value = dep.get_variable(pkgconfig=varname)
             if value:
-                return ExternalProgram(name, [value])
+                return ExternalProgram(value)
 
         # Normal program lookup
         return self.find_program(name, required=required, wanted=wanted)


### PR DESCRIPTION
ExternalProgram currently assumes that if a command is passed it exists and can be used as is. In case we extract the path from pkgconfig the path might not exist, on Windows it might be missing the ".exe" suffix.

By passing the variables as a name ExternalProgram will validate that the command exists at configure time and will fail if not, and it will try to fixup the command by appending .exe etc.

Fixes #12271