### PR TITLE
nasm tests: skip asm language test on Solaris & illumos

### DIFF
--- a/test cases/nasm/2 asm language/meson.build
+++ b/test cases/nasm/2 asm language/meson.build
@@ -7,6 +7,8 @@ endif
 
 if host_machine.system() == 'windows'
   error('MESON_SKIP_TEST: this test asm is not made for Windows')
+elif host_machine.system() == 'sunos'
+  error('MESON_SKIP_TEST: this test asm is not made for Solaris or illumos')
 endif
 
 if meson.backend().startswith('vs')


### PR DESCRIPTION
The code in this test to make Linux system calls is not compatible with the SunOS kernel system call conventions.

Without this change, the test fails when running "ninja test":

```
[0/1] Running all tests.
1/2 hello                  FAIL            0.37s   killed by signal 11 SIGSEGV
>>> MALLOC_PERTURB_=122 '/export/alanc/git/github/meson/test cases/nasm/2 asm language/builddir/hello'

2/2 hello_w_threads        FAIL            0.37s   killed by signal 11 SIGSEGV
>>> MALLOC_PERTURB_=201 '/export/alanc/git/github/meson/test cases/nasm/2 asm language/builddir/hello_w_threads'


Summary of Failures:

1/2 hello           FAIL            0.37s   killed by signal 11 SIGSEGV
2/2 hello_w_threads FAIL            0.37s   killed by signal 11 SIGSEGV
```
