### PR TITLE
temp disable pylint falsepositive on dub.py

### DIFF
--- a/mesonbuild/dependencies/dub.py
+++ b/mesonbuild/dependencies/dub.py
@@ -53,7 +53,7 @@ class DubDependency(ExternalDependency):
             self.is_found = False
             return
 
-        (self.dubbin, dubver) = DubDependency.class_dubbin
+        (self.dubbin, dubver) = DubDependency.class_dubbin  # pylint: disable=unpacking-non-sequence
 
         assert isinstance(self.dubbin, ExternalProgram)
 


### PR DESCRIPTION
This was introduced by pylint 3.0.0.
See https://github.com/pylint-dev/pylint/issues/9095.