### PR TITLE
CI misc updates

### DIFF
--- a/ci/ciimage/build.py
+++ b/ci/ciimage/build.py
@@ -143,13 +143,14 @@ class ImageTester(BuilderBase):
         shutil.copytree(
             self.meson_root,
             self.temp_dir / 'meson',
+            symlinks=True,
             ignore=shutil.ignore_patterns(
                 '.git',
                 '*_cache',
                 '__pycache__',
                 # 'work area',
                 self.temp_dir.name,
-            )
+            ),
         )
 
     def do_test(self, tty: bool = False) -> None:

--- a/ci/ciimage/common.sh
+++ b/ci/ciimage/common.sh
@@ -39,11 +39,11 @@ dub_fetch() {
 }
 
 install_minimal_python_packages() {
-  rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED
+  rm -f /usr/lib*/python3.*/EXTERNALLY-MANAGED
   python3 -m pip install "${base_python_pkgs[@]}" $*
 }
 
 install_python_packages() {
-  rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED
+  rm -f /usr/lib*/python3.*/EXTERNALLY-MANAGED
   python3 -m pip install "${base_python_pkgs[@]}" "${python_pkgs[@]}" $*
 }

--- a/ci/ciimage/opensuse/install.sh
+++ b/ci/ciimage/opensuse/install.sh
@@ -9,7 +9,7 @@ pkgs=(
   ninja make git autoconf automake patch libjpeg-devel
   elfutils gcc gcc-c++ gcc-fortran gcc-objc gcc-obj-c++ vala rust bison flex curl lcov
   mono-core gtkmm3-devel gtest gmock protobuf-devel wxGTK3-3_2-devel gobject-introspection-devel
-  itstool gtk3-devel java-20-openjdk-devel gtk-doc llvm-devel clang-devel libSDL2-devel graphviz-devel zlib-devel zlib-devel-static
+  itstool gtk3-devel java-17-openjdk-devel gtk-doc llvm-devel clang-devel libSDL2-devel graphviz-devel zlib-devel zlib-devel-static
   #hdf5-devel netcdf-devel libscalapack2-openmpi3-devel libscalapack2-gnu-openmpi3-hpc-devel openmpi3-devel
   doxygen vulkan-devel vulkan-validationlayers openssh mercurial gtk-sharp3-complete gtk-sharp2-complete libpcap-devel libgpgme-devel
   libqt5-qtbase-devel libqt5-qttools-devel libqt5-linguist libqt5-qtbase-private-headers-devel


### PR DESCRIPTION
The eternal quest to get CI images periodically updating. This doesn't actually fix anything, but it does make the image builders get a bit further before erroring: in particular, the opensuse image now successfully builds, so we can see where the self-tests fail.

- CI: install an older java on opensuse
- CI: fix broken ciimage builder script failing to correctly copy meson
- CI: fix the fix for python actually being mildly useful