### PR TITLE
Fix formatting of option value

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -112,6 +112,9 @@ class UserOption(T.Generic[_T], HoldableObject):
         self.deprecated = deprecated
         self.readonly = False
 
+    def __str__(self) -> str:
+        return str(self.printable_value())
+
     def listify(self, value: T.Any) -> T.List[T.Any]:
         return [value]
 


### PR DESCRIPTION
In this pretty common use-case, it would print internal python representation for feature options: 'foo=@0@'.format(get_option('opt'))

Meson 1.3.0 already has a more comprehensive fix, this is a quick workaround for 1.2 branch.

Fixes: #12332