### PR TITLE
msubprojects: Fix conditions around rebase on update

### DIFF
--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -231,7 +231,9 @@ class Runner:
         try:
             self.git_output(['-c', 'rebase.autoStash=true', 'rebase', 'FETCH_HEAD'])
         except GitException as e:
-            self.log('  -> Could not rebase', mlog.bold(self.repo_dir), 'onto', mlog.bold(revision))
+            self.git_output(['-c', 'rebase.autoStash=true', 'rebase', '--abort'])
+            self.log('  -> Could not rebase', mlog.bold(self.repo_dir), 'onto', mlog.bold(revision),
+                     '-- aborted')
             self.log(mlog.red(e.output))
             self.log(mlog.red(str(e)))
             return False

--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -287,6 +287,19 @@ class Runner:
             success = self.git_rebase(revision)
         return success
 
+    def git_branch_has_upstream(self, urls: set) -> bool:
+        cmd = ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}']
+        ret, upstream = quiet_git(cmd, self.repo_dir)
+        if not ret:
+            return False
+        try:
+            remote = upstream.split('/', maxsplit=1)[0]
+        except IndexError:
+            return False
+        cmd = ['remote', 'get-url', remote]
+        ret, remote_url = quiet_git(cmd, self.repo_dir)
+        return remote_url.strip() in urls
+
     def update_git(self) -> bool:
         options = T.cast('UpdateArguments', self.options)
         if not os.path.exists(os.path.join(self.repo_dir, '.git')):
@@ -378,12 +391,16 @@ class Runner:
                 success = self.git_rebase(revision)
         else:
             # We are in another branch, either the user created their own branch and
-            # we should rebase it, or revision changed in the wrap file and we need
-            # to checkout the new branch.
+            # we should rebase it, or revision changed in the wrap file (we
+            # know this when the current branch has an upstream) and we need to
+            # checkout the new branch.
             if options.reset:
                 success = self.git_checkout_and_reset(revision)
             else:
-                success = self.git_rebase(revision)
+                if self.git_branch_has_upstream({url, push_url}):
+                    success = self.git_checkout_and_rebase(revision)
+                else:
+                    success = self.git_rebase(revision)
         if success:
             self.update_git_done()
         return success


### PR DESCRIPTION
1. Abort the rebase if there's conflicts on update
2. Don't rebase if the branch is already tracking upstream, just checkout and update