### PR TITLE
Add build rpaths for CMake dependencies

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -771,7 +771,7 @@ class Backend:
         srcdir = self.environment.get_source_dir()
 
         for dep in target.external_deps:
-            if dep.type_name not in {'library', 'pkgconfig'}:
+            if dep.type_name not in {'library', 'pkgconfig', 'cmake'}:
                 continue
             for libpath in dep.link_args:
                 # For all link args that are absolute paths to a library file, add RPATH args

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -787,7 +787,11 @@ class Backend:
                 # Windows doesn't support rpaths, but we use this function to
                 # emulate rpaths by setting PATH
                 # .dll is there for mingw gcc
-                if os.path.splitext(libpath)[1] not in {'.dll', '.lib', '.so', '.dylib'}:
+                # .so's may be extended with version information, e.g. libxyz.so.1.2.3
+                if not (
+                    os.path.splitext(libpath)[1] in {'.dll', '.lib', '.so', '.dylib'}
+                    or re.match(r'.+\.so(\.|$)', os.path.basename(libpath))
+                ):
                     continue
 
                 try:

--- a/test cases/unit/17 prebuilt shared/meson.build
+++ b/test cases/unit/17 prebuilt shared/meson.build
@@ -1,12 +1,16 @@
 project('prebuilt shared library', 'c')
 
-search_dir = get_option('search_dir')
-if search_dir == 'auto'
-  search_dir = meson.current_source_dir()
-endif
+if get_option('method') == 'find_library'
+  search_dir = get_option('search_dir')
+  if search_dir == 'auto'
+    search_dir = meson.current_source_dir()
+  endif
 
-cc = meson.get_compiler('c')
-shlib = cc.find_library('alexandria', dirs : search_dir)
+  cc = meson.get_compiler('c')
+  shlib = cc.find_library('alexandria', dirs : search_dir)
+else
+  shlib = dependency('alexandria', method: get_option('method'))
+endif
 
 exe = executable('patron', 'patron.c', dependencies : shlib)
 test('visitation', exe)

--- a/test cases/unit/17 prebuilt shared/meson_options.txt
+++ b/test cases/unit/17 prebuilt shared/meson_options.txt
@@ -1,1 +1,4 @@
+option('method', type : 'combo',
+       choices : ['find_library', 'pkg-config', 'cmake'],
+       value : 'find_library')
 option('search_dir', type : 'string', value : 'auto')

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1675,6 +1675,14 @@ class AllPlatformTests(BasePlatformTests):
             shared_suffix = 'so'
         return (cc, stlinker, object_suffix, shared_suffix)
 
+    def detect_prebuild_env_versioned(self):
+        (cc, stlinker, object_suffix, shared_suffix) = self.detect_prebuild_env()
+        shared_suffixes = [shared_suffix]
+        if shared_suffix == 'so':
+            # .so may have version information integrated into the filename
+            shared_suffixes += ['so.1', 'so.1.2.3', '1.so', '1.so.2.3']
+        return (cc, stlinker, object_suffix, shared_suffixes)
+
     def pbcompile(self, compiler, source, objectfile, extra_args=None):
         cmd = compiler.get_exelist()
         extra_args = extra_args or []
@@ -1797,6 +1805,90 @@ class AllPlatformTests(BasePlatformTests):
             self.init(tdir, extra_args=[f'-Dsearch_dir={d}'])
             self.build()
             self.run_tests()
+
+    @skipIfNoPkgconfig
+    def test_prebuilt_shared_lib_pkg_config(self) -> None:
+        (cc, _, object_suffix, shared_suffixes) = self.detect_prebuild_env_versioned()
+        tdir = os.path.join(self.unit_test_dir, '17 prebuilt shared')
+        for shared_suffix in shared_suffixes:
+            with tempfile.TemporaryDirectory() as d:
+                source = os.path.join(tdir, 'alexandria.c')
+                objectfile = os.path.join(d, 'alexandria.' + object_suffix)
+                impfile = os.path.join(d, 'alexandria.lib')
+                if cc.get_argument_syntax() == 'msvc':
+                    shlibfile = os.path.join(d, 'alexandria.' + shared_suffix)
+                    linkfile = impfile  # MSVC links against the *.lib instead of the *.dll
+                elif is_cygwin():
+                    shlibfile = os.path.join(d, 'cygalexandria.' + shared_suffix)
+                    linkfile = shlibfile
+                else:
+                    shlibfile = os.path.join(d, 'libalexandria.' + shared_suffix)
+                    linkfile = shlibfile
+                # Ensure MSVC extra files end up in the directory that gets deleted
+                # at the end
+                with chdir(d):
+                    self.build_shared_lib(cc, source, objectfile, shlibfile, impfile)
+
+                with open(os.path.join(d, 'alexandria.pc'), 'w',
+                          encoding='utf-8') as f:
+                    f.write(textwrap.dedent('''
+                        Name: alexandria
+                        Description: alexandria
+                        Version: 1.0.0
+                        Libs: {}
+                        ''').format(
+                            Path(linkfile).as_posix().replace(' ', r'\ '),
+                        ))
+
+                # Run the test
+                self.init(tdir, override_envvars={'PKG_CONFIG_PATH': d},
+                        extra_args=['-Dmethod=pkg-config'])
+                self.build()
+                self.run_tests()
+
+                self.wipe()
+
+    @skip_if_no_cmake
+    def test_prebuilt_shared_lib_cmake(self) -> None:
+        (cc, _, object_suffix, shared_suffixes) = self.detect_prebuild_env_versioned()
+        tdir = os.path.join(self.unit_test_dir, '17 prebuilt shared')
+        for shared_suffix in shared_suffixes:
+            with tempfile.TemporaryDirectory() as d:
+                source = os.path.join(tdir, 'alexandria.c')
+                objectfile = os.path.join(d, 'alexandria.' + object_suffix)
+                impfile = os.path.join(d, 'alexandria.lib')
+                if cc.get_argument_syntax() == 'msvc':
+                    shlibfile = os.path.join(d, 'alexandria.' + shared_suffix)
+                    linkfile = impfile  # MSVC links against the *.lib instead of the *.dll
+                elif is_cygwin():
+                    shlibfile = os.path.join(d, 'cygalexandria.' + shared_suffix)
+                    linkfile = shlibfile
+                else:
+                    shlibfile = os.path.join(d, 'libalexandria.' + shared_suffix)
+                    linkfile = shlibfile
+                # Ensure MSVC extra files end up in the directory that gets deleted
+                # at the end
+                with chdir(d):
+                    self.build_shared_lib(cc, source, objectfile, shlibfile, impfile)
+
+                with open(os.path.join(d, 'alexandriaConfig.cmake'), 'w',
+                        encoding='utf-8') as f:
+                    f.write(textwrap.dedent('''
+                        set(alexandria_FOUND ON)
+                        set(alexandria_LIBRARIES "{}")
+                        set(alexandria_INCLUDE_DIRS "{}")
+                        ''').format(
+                            re.sub(r'([\\"])', r'\\\1', linkfile),
+                            re.sub(r'([\\"])', r'\\\1', tdir),
+                        ))
+
+                # Run the test
+                self.init(tdir, override_envvars={'CMAKE_PREFIX_PATH': d},
+                        extra_args=['-Dmethod=cmake'])
+                self.build()
+                self.run_tests()
+
+                self.wipe()
 
     def test_prebuilt_shared_lib_rpath_same_prefix(self) -> None:
         (cc, _, object_suffix, shared_suffix) = self.detect_prebuild_env()


### PR DESCRIPTION
Fixes https://github.com/mesonbuild/meson/issues/12338

This PR also extends the logic in Backend to produce build rpaths for any external *versioned* `.so`'s listed on the link line, e.g. `/path/to/libxyz.so.1.2.3`. CMake happily generates paths of this form instead of the currently supported `/path/to/libxyz.so`. The rpaths added here get removed on install, regardless of whether the `.so` was versioned or unversioned.