### PR TITLE
Allow cpp_std=c++23 with gcc-11.

### DIFF
--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -426,7 +426,7 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCompiler, CPPCompiler):
             'c++98', 'c++03', 'c++11', 'c++14', 'c++17', 'c++1z',
             'c++2a', 'c++20',
         ]
-        if version_compare(self.version, '>=12.2.0'):
+        if version_compare(self.version, '>=11.0.0'):
             cppstd_choices.append('c++23')
         if version_compare(self.version, '>=14.0.0'):
             cppstd_choices.append('c++26')

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -520,10 +520,10 @@ class LinuxlikeTests(BasePlatformTests):
                      compiler.get_id() == 'gcc' and version_compare(compiler.version, '>=10.0.0'))
         has_cpp2b = (compiler.get_id() not in {'clang', 'gcc'} or
                      compiler.get_id() == 'clang' and _clang_at_least(compiler, '>=12.0.0', None) or
-                     compiler.get_id() == 'gcc' and version_compare(compiler.version, '>=12.2.0'))
+                     compiler.get_id() == 'gcc' and version_compare(compiler.version, '>=11.0.0'))
         has_cpp23 = (compiler.get_id() not in {'clang', 'gcc'} or
                      compiler.get_id() == 'clang' and _clang_at_least(compiler, '>=17.0.0', None) or
-                     compiler.get_id() == 'gcc' and version_compare(compiler.version, '>=12.2.0'))
+                     compiler.get_id() == 'gcc' and version_compare(compiler.version, '>=11.0.0'))
         has_cpp26 = (compiler.get_id() not in {'clang', 'gcc'} or
                      compiler.get_id() == 'clang' and _clang_at_least(compiler, '>=17.0.0', None) or
                      compiler.get_id() == 'gcc' and version_compare(compiler.version, '>=14.0.0'))


### PR DESCRIPTION
This PR allows using `cpp_std=c++23` with gcc-11 as per issue #12291.

Currently meson requires GCC version `>=12.2.0` for `cpp_std=c++23`.  However, this seems incorrect, as `gcc-11` also supports `-std=c++23`.  Obvious c++23 support isn't complete in gcc-11, but it isn't complete in gcc-12 either.

The commit adding support for `-std=c++23` was done in January 2021, several months before the gcc-11 release, so `11.0.0` seems fine.
- https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=78739c2df788ee5c868d998a6333d453317d8711

In GCC-11, three new features are enabled by this flag:
- https://gcc.gnu.org/projects/cxx-status.html
- Literal Suffix for (signed) size_t 
- Make () more optional for lambdas 
- Allow Duplicate Attributes 