### PR TITLE
wrap: catch failure to extract tarball and raise WrapException

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -569,7 +569,10 @@ class Resolver:
         if 'lead_directory_missing' in self.wrap.values:
             os.mkdir(self.dirname)
             extract_dir = self.dirname
-        shutil.unpack_archive(path, extract_dir)
+        try:
+            shutil.unpack_archive(path, extract_dir)
+        except OSError as e:
+            raise WrapException(f'failed to unpack archive with error: {str(e)}') from e
 
     def get_git(self) -> None:
         if not GIT:


### PR DESCRIPTION
This most likely happens when the source archive has files which take advantage of case sensitivity, and someone is unfortunate enough to have to work with broken operating systems that do not have the capacity to use modern technology, like the 1970s invention of case sensitive filesystems.

For example, Windows and macOS both have retrocomputing environments, where case sensitive abilities were carefully removed from modern filesystems in order to share the delights of classical computing with the masses.

On such systems, innocent tarballs fail to extract with:

```
OSError: [Errno 22] Invalid argument: 'C:\path\to\file'
```

thereby demonstrating Microsoft's unbounded and enthusiastic love for users (who are, universally, retrocomputing fans).

n.b. there is, begrudgingly, a secret option for crazy people who hate retrocomputing to enable modern 1970s computing on Windows systems. Naturally, no one with any sense would ever use this, and it is rightly left in its sensible default in for example Github Actions.

Fixes #12344