### PR TITLE
cpp: use -nostlib++ instead of -nostlib for custom cpp_stdlib

### DIFF
--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -93,6 +93,9 @@ class CPPCompiler(CLikeCompiler, Compiler):
     def get_no_stdinc_args(self) -> T.List[str]:
         return ['-nostdinc++']
 
+    def get_no_stdlib_link_args(self) -> T.List[str]:
+        return ['-nostdlib++']
+
     def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
         code = 'class breakCCompiler;int main(void) { return 0; }\n'
         return self._sanity_check_impl(work_dir, environment, 'sanitycheckcpp.cc', code)


### PR DESCRIPTION
Notes: 
- this is my first contribution, I am not really a compiler person so I hope I got this right.

The <lang>_stdlib can be used in cross files to use a custom standard library for a given language.

When cpp_stdlib is used in a cross file, meson passes
* -nostdinc++ to the compiler
* -nostlib to the linker

According to [1] (gcc) and [2] (clang), we should pass -nostlib++ to the linker when we don't want to link to the standard C++ library. Currently, we pass -nostlib.

Fix this by implementing a C++ specific get_no_stdlib_link_args() function.

[1] https://gcc.gnu.org/onlinedocs/gcc/Link-Options.html#index-nostdlib_002b_002b
[2] https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-nostdlib
Signed-off-by: Mattijs Korpershoek <mkorpershoek@baylibre.com>