### PR TITLE
Fix rebuilding whole project when test has no deps

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -2131,6 +2131,10 @@ def rebuild_deps(ninja: T.List[str], wd: str, tests: T.List[TestSerialisation]) 
             depends.update(d)
             targets.update(intro_targets[d])
 
+    if not targets:
+        mlog.log('No test dependencies to build')
+        return True
+
     ret = subprocess.run(ninja + ['-C', wd] + sorted(targets)).returncode
     if ret != 0:
         print(f'Could not rebuild {wd}')

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -2135,7 +2135,7 @@ def rebuild_deps(ninja: T.List[str], wd: str, tests: T.List[TestSerialisation]) 
         mlog.log('No test dependencies to build')
         return True
 
-    ret = subprocess.run(ninja + ['-C', wd] + sorted(targets)).returncode
+    ret = subprocess.run(ninja + ['-C', wd] + targets).returncode
     if ret != 0:
         print(f'Could not rebuild {wd}')
         return False


### PR DESCRIPTION
When a test had no build deps, meson was calling `ninja` with no
targets, resulting in building the whole project. `ninja` invocation is
now skipped when there are no build target.