### PR TITLE
modules/rust: only use include and define args from global/project args

### DIFF
--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import annotations
+import itertools
 import os
 import typing as T
+
 from mesonbuild.interpreterbase.decorators import FeatureNew
 
 from . import ExtensionModule, ModuleReturnValue, ModuleInfo
@@ -237,11 +239,13 @@ class RustModule(ExtensionModule):
                 elif isinstance(s, CustomTarget):
                     depends.append(s)
 
-        clang_args.extend(state.global_args.get('c', []))
-        clang_args.extend(state.project_args.get('c', []))
+        # We only want include directories and defines, other things may not be valid
         cargs = state.get_option('args', state.subproject, lang='c')
         assert isinstance(cargs, list), 'for mypy'
         clang_args.extend(cargs)
+        for a in itertools.chain(state.global_args.get('c', []), state.project_args.get('c', []), cargs):
+            if a.startswith(('-I', '/I', '-D', '/D', '-U', '/U')):
+                clang_args.append(a)
 
         if self._bindgen_bin is None:
             self._bindgen_bin = state.find_program('bindgen')


### PR DESCRIPTION
Avoid adding args that bindgen doesn't understand by limiting the arguments we accept to -D, -U, and -I arguments