### PR TITLE
rust: Always inject vscrt args

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1973,13 +1973,7 @@ class NinjaBackend(backends.Backend):
         try:
             buildtype = target.get_option(OptionKey('buildtype'))
             crt = target.get_option(OptionKey('b_vscrt'))
-            is_debug = buildtype == 'debug'
-
-            if crt == 'from_buildtype':
-                crt = 'mdd' if is_debug else 'md'
-            elif crt == 'static_from_buildtype':
-                crt = 'mtd' if is_debug else 'mt'
-
+            crt = rustc.get_crt_val(crt, buildtype)
             if crt == 'mdd':
                 crt_link_args = ['-l', 'static=msvcrtd']
             elif crt == 'md':
@@ -1989,7 +1983,6 @@ class NinjaBackend(backends.Backend):
                 crt_link_args = ['-l', 'static=libcmtd']
             elif crt == 'mt':
                 crt_link_args = ['-l', 'static=libcmt']
-
         except KeyError:
             crt_args_injected = True
 

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1311,28 +1311,15 @@ class Vs2010Backend(backends.Backend):
             ET.SubElement(clconf, 'OpenMPSupport').text = 'true'
         # CRT type; debug or release
         vscrt_type = target.get_option(OptionKey('b_vscrt'))
-        if vscrt_type == 'from_buildtype':
-            if self.buildtype == 'debug':
-                ET.SubElement(type_config, 'UseDebugLibraries').text = 'true'
-                ET.SubElement(clconf, 'RuntimeLibrary').text = 'MultiThreadedDebugDLL'
-            else:
-                ET.SubElement(type_config, 'UseDebugLibraries').text = 'false'
-                ET.SubElement(clconf, 'RuntimeLibrary').text = 'MultiThreadedDLL'
-        elif vscrt_type == 'static_from_buildtype':
-            if self.buildtype == 'debug':
-                ET.SubElement(type_config, 'UseDebugLibraries').text = 'true'
-                ET.SubElement(clconf, 'RuntimeLibrary').text = 'MultiThreadedDebug'
-            else:
-                ET.SubElement(type_config, 'UseDebugLibraries').text = 'false'
-                ET.SubElement(clconf, 'RuntimeLibrary').text = 'MultiThreaded'
-        elif vscrt_type == 'mdd':
+        vscrt_val = compiler.get_crt_val(vscrt_type, self.buildtype)
+        if vscrt_val == 'mdd':
             ET.SubElement(type_config, 'UseDebugLibraries').text = 'true'
             ET.SubElement(clconf, 'RuntimeLibrary').text = 'MultiThreadedDebugDLL'
-        elif vscrt_type == 'mt':
+        elif vscrt_val == 'mt':
             # FIXME, wrong
             ET.SubElement(type_config, 'UseDebugLibraries').text = 'false'
             ET.SubElement(clconf, 'RuntimeLibrary').text = 'MultiThreaded'
-        elif vscrt_type == 'mtd':
+        elif vscrt_val == 'mtd':
             # FIXME, wrong
             ET.SubElement(type_config, 'UseDebugLibraries').text = 'true'
             ET.SubElement(clconf, 'RuntimeLibrary').text = 'MultiThreadedDebug'

--- a/mesonbuild/compilers/asm.py
+++ b/mesonbuild/compilers/asm.py
@@ -124,28 +124,7 @@ class NasmCompiler(Compiler):
     def get_crt_link_args(self, crt_val: str, buildtype: str) -> T.List[str]:
         if not self.info.is_windows():
             return []
-        if crt_val in self.crt_args:
-            return self.crt_args[crt_val]
-        assert crt_val in {'from_buildtype', 'static_from_buildtype'}
-        dbg = 'mdd'
-        rel = 'md'
-        if crt_val == 'static_from_buildtype':
-            dbg = 'mtd'
-            rel = 'mt'
-        # Match what build type flags used to do.
-        if buildtype == 'plain':
-            return []
-        elif buildtype == 'debug':
-            return self.crt_args[dbg]
-        elif buildtype == 'debugoptimized':
-            return self.crt_args[rel]
-        elif buildtype == 'release':
-            return self.crt_args[rel]
-        elif buildtype == 'minsize':
-            return self.crt_args[rel]
-        else:
-            assert buildtype == 'custom'
-            raise EnvironmentException('Requested C runtime based on buildtype, but buildtype is "custom".')
+        return self.crt_args[self.get_crt_val(crt_val, buildtype)]
 
 class YasmCompiler(NasmCompiler):
     id = 'yasm'

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -299,6 +299,8 @@ clike_debug_args: T.Dict[bool, T.List[str]] = {
     True: ['-g']
 }
 
+MSCRT_VALS = ['none', 'md', 'mdd', 'mt', 'mtd']
+
 base_options: 'KeyedOptionDictType' = {
     OptionKey('b_pch'): coredata.UserBooleanOption('Use precompiled headers', True),
     OptionKey('b_lto'): coredata.UserBooleanOption('Use link time optimization', False),
@@ -325,7 +327,7 @@ base_options: 'KeyedOptionDictType' = {
     OptionKey('b_pie'): coredata.UserBooleanOption('Build executables as position independent', False),
     OptionKey('b_bitcode'): coredata.UserBooleanOption('Generate and embed bitcode (only macOS/iOS/tvOS)', False),
     OptionKey('b_vscrt'): coredata.UserComboOption('VS run-time library type to use.',
-                                                   ['none', 'md', 'mdd', 'mt', 'mtd', 'from_buildtype', 'static_from_buildtype'],
+                                                   MSCRT_VALS + ['from_buildtype', 'static_from_buildtype'],
                                                    'from_buildtype'),
 }
 
@@ -1104,6 +1106,28 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         :return: A list of string arguments for this compiler
         """
         return []
+
+    def get_crt_val(self, crt_val: str, buildtype: str) -> str:
+        if crt_val in MSCRT_VALS:
+            return crt_val
+        assert crt_val in {'from_buildtype', 'static_from_buildtype'}
+
+        dbg = 'mdd'
+        rel = 'md'
+        if crt_val == 'static_from_buildtype':
+            dbg = 'mtd'
+            rel = 'mt'
+
+        # Match what build type flags used to do.
+        if buildtype == 'plain':
+            return 'none'
+        elif buildtype == 'debug':
+            return dbg
+        elif buildtype in {'debugoptimized', 'release', 'minsize'}:
+            return rel
+        else:
+            assert buildtype == 'custom'
+            raise EnvironmentException('Requested C runtime based on buildtype, but buildtype is "custom".')
 
     def get_crt_compile_args(self, crt_val: str, buildtype: str) -> T.List[str]:
         raise EnvironmentException('This compiler does not support Windows CRT selection')

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -379,31 +379,7 @@ class DmdLikeCompilerMixin(CompilerMixinBase):
     def _get_crt_args(self, crt_val: str, buildtype: str) -> T.List[str]:
         if not self.info.is_windows():
             return []
-
-        if crt_val in self.mscrt_args:
-            return self.mscrt_args[crt_val]
-        assert crt_val in {'from_buildtype', 'static_from_buildtype'}
-
-        dbg = 'mdd'
-        rel = 'md'
-        if crt_val == 'static_from_buildtype':
-            dbg = 'mtd'
-            rel = 'mt'
-
-        # Match what build type flags used to do.
-        if buildtype == 'plain':
-            return []
-        elif buildtype == 'debug':
-            return self.mscrt_args[dbg]
-        elif buildtype == 'debugoptimized':
-            return self.mscrt_args[rel]
-        elif buildtype == 'release':
-            return self.mscrt_args[rel]
-        elif buildtype == 'minsize':
-            return self.mscrt_args[rel]
-        else:
-            assert buildtype == 'custom'
-            raise EnvironmentException('Requested C runtime based on buildtype, but buildtype is "custom".')
+        return self.mscrt_args[self.get_crt_val(crt_val, buildtype)]
 
     def get_soname_args(self, env: 'Environment', prefix: str, shlib_name: str,
                         suffix: str, soversion: str,

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -366,28 +366,8 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
         return os.environ['INCLUDE'].split(os.pathsep)
 
     def get_crt_compile_args(self, crt_val: str, buildtype: str) -> T.List[str]:
-        if crt_val in self.crt_args:
-            return self.crt_args[crt_val]
-        assert crt_val in {'from_buildtype', 'static_from_buildtype'}
-        dbg = 'mdd'
-        rel = 'md'
-        if crt_val == 'static_from_buildtype':
-            dbg = 'mtd'
-            rel = 'mt'
-        # Match what build type flags used to do.
-        if buildtype == 'plain':
-            return []
-        elif buildtype == 'debug':
-            return self.crt_args[dbg]
-        elif buildtype == 'debugoptimized':
-            return self.crt_args[rel]
-        elif buildtype == 'release':
-            return self.crt_args[rel]
-        elif buildtype == 'minsize':
-            return self.crt_args[rel]
-        else:
-            assert buildtype == 'custom'
-            raise mesonlib.EnvironmentException('Requested C runtime based on buildtype, but buildtype is "custom".')
+        crt_val = self.get_crt_val(crt_val, buildtype)
+        return self.crt_args[crt_val]
 
     def has_func_attribute(self, name: str, env: 'Environment') -> T.Tuple[bool, bool]:
         # MSVC doesn't have __attribute__ like Clang and GCC do, so just return


### PR DESCRIPTION
    Rustc assumes "md" by default, but we should always respect Meson
    options. Building some targets with different vscrt makes them fail to
    link together. This is also what other compilers does.
