### PR TITLE
modules/rust: remove rust_crate_type for test() method

### DIFF
--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -162,6 +162,7 @@ class RustModule(ExtensionModule):
         new_target_kwargs['install'] = False
         new_target_kwargs['dependencies'] = new_target_kwargs.get('dependencies', []) + kwargs['dependencies']
         new_target_kwargs['link_with'] = new_target_kwargs.get('link_with', []) + kwargs['link_with']
+        del new_target_kwargs['rust_crate_type']
 
         lang_args = base_target.extra_args.copy()
         lang_args['rust'] = base_target.extra_args['rust'] + kwargs['rust_args'] + ['--test']

--- a/test cases/rust/9 unit tests/meson.build
+++ b/test cases/rust/9 unit tests/meson.build
@@ -36,7 +36,7 @@ exe = executable('rust_exe', ['test2.rs', 'test.rs'], build_by_default : false)
 rust = import('unstable-rust')
 rust.test('rust_test_from_exe', exe, should_fail : true)
 
-lib = static_library('rust_static', ['test.rs'], build_by_default : false)
+lib = static_library('rust_static', ['test.rs'], build_by_default : false, rust_crate_type : 'lib')
 rust.test('rust_test_from_static', lib, args: ['--skip', 'test_add_intentional_fail'])
 
 lib = shared_library('rust_shared', ['test.rs'], build_by_default : false)


### PR DESCRIPTION
This is required to test non-executable targets when they set an explicit type.