### PR TITLE
release notes: fix snippet for "fill:" argument

### DIFF
--- a/docs/markdown/snippets/int_to_string_fill.md
+++ b/docs/markdown/snippets/int_to_string_fill.md
@@ -6,10 +6,10 @@ string representation of the integer with leading zeroes:
 ```meson
 n = 4
 message(n.to_string())
-message(n.to_string(length: 3))
+message(n.to_string(fill: 3))
 
 n = -4
-message(n.to_string(length: 3))
+message(n.to_string(fill: 3))
 ```
 
 OUTPUT:


### PR DESCRIPTION
The release notes were using the older spelling "length". Replace it with the spelling that was actually committed.