### PR TITLE
ninjabackend: Use cleaner rule name

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2178,7 +2178,7 @@ class NinjaBackend(backends.Backend):
 
     @classmethod
     def compiler_to_rule_name(cls, compiler: Compiler) -> str:
-        return cls.get_compiler_rule_name(compiler.get_language(), compiler.for_machine, compiler.mode)
+        return cls.get_compiler_rule_name(compiler.get_language(), compiler.for_machine, compiler.mode.name)
 
     @classmethod
     def compiler_to_pch_rule_name(cls, compiler: Compiler) -> str:


### PR DESCRIPTION
Compiler.mode is an enum but get_compiler_rule_name() type annotation expects a string. f-string convert it to `CompileCheckMode.COMPILE` which is pretty ugly, we were expecting simply `COMPILE`.

This renames all ninja rules from something like
`c_CompileCheckMode.COMPILE` to `c_COMPILE`.