### PR TITLE
docs: fix bindgen_clang_arguments example

### DIFF
--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -103,7 +103,7 @@ were never turned on by Meson.
 
 ```ini
 [properties]
-bindgen_clang_arguments = ['--target', 'x86_64-linux-gnu']
+bindgen_clang_arguments = ['-target', 'x86_64-linux-gnu']
 ```
 
 ### proc_macro()


### PR DESCRIPTION
> error: unsupported option '--target'; did you mean '-target'?