### PR TITLE
Fix building with clang-cl on 32-bit Windows

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -278,7 +278,7 @@ def detect_windows_arch(compilers: CompilersDict) -> str:
     for compiler in compilers.values():
         if compiler.id == 'msvc' and (compiler.target in {'x86', '80x86'}):
             return 'x86'
-        if compiler.id == 'clang-cl' and compiler.target == 'x86':
+        if compiler.id == 'clang-cl' and (compiler.target in {'x86', 'i686'}):
             return 'x86'
         if compiler.id == 'gcc' and compiler.has_builtin_define('__i386__'):
             return 'x86'


### PR DESCRIPTION
Fixes building scikit-image 0.22.0 for Python 3.11.6, 32-bit, with clang-cl 16.0.6 (required by pythran). Apparently `compiler.target` is `i686` for that compiler.

```
----------------------------------------------------------------------
-- Set vc17-win32 build environment

**********************************************************************
** Visual Studio 2022 Developer Command Prompt v17.7.5
** Copyright (c) 2022 Microsoft Corporation
**********************************************************************
[vcvarsall.bat] Environment initialized for: 'x64_x86'
info: using existing install for 'stable-i686-pc-windows-msvc'
info: default toolchain set to 'stable-i686-pc-windows-msvc'

  stable-i686-pc-windows-msvc unchanged - rustc 1.72.1 (d5c2e9c34 2023-09-13)

Processing d:\build\scikit-image\scikit_image-0.22.0
  Running command Preparing metadata (pyproject.toml)
  + meson setup D:\Build\scikit-image\scikit_image-0.22.0 D:\Build\scikit-image\scikit_image-0.22.0\.mesonpy-_e4dkyk3 -Dbuildtype=release -Db_ndebug=if-release -Db_vscrt=md --native-file=D:\Build\scikit-image\scikit_image-0.22.0\.mesonpy-_e4dkyk3\meson-python-native-file.ini
  The Meson build system
  Version: 1.2.2
  Source dir: D:\Build\scikit-image\scikit_image-0.22.0
  Build dir: D:\Build\scikit-image\scikit_image-0.22.0\.mesonpy-_e4dkyk3
  Build type: native build
  Project name: scikit-image
  Project version: 0.22.0
  C compiler for the host machine: clang-cl (clang-cl 16.0.6)
  C linker for the host machine: lld-link lld-link 16.0.6
  C++ compiler for the host machine: clang-cl (clang-cl 16.0.6)
  C++ linker for the host machine: lld-link lld-link 16.0.6
  Host machine cpu family: x86_64
  Host machine cpu: x86_64
  Compiler for C supports arguments -Wno-unused-function: YES
  Library m found: NO
  Checking if "-Wl,--version-script" : links: NO
  Program cython found: YES (X:\Python311-x32\Scripts\cython.EXE)
  Program pythran found: YES (X:\Python311-x32\Scripts\pythran.EXE)
  Program skimage/_build_utils/copyfiles.py found: YES (python D:\Build\scikit-image\scikit_image-0.22.0\skimage/_build_utils/copyfiles.py)
  Program python found: YES (X:\Python311-x32\python.exe)
  Need python for x86_64, but found x86
  Run-time dependency python found: NO (tried sysconfig)

  D:\Build\scikit-image\scikit_image-0.22.0\meson.build:69:14: ERROR: Python dependency not found

  A full log can be found at D:\Build\scikit-image\scikit_image-0.22.0\.mesonpy-_e4dkyk3\meson-logs\meson-log.txt
  error: subprocess-exited-with-error

  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> See above for output.

  note: This error originates from a subprocess, and is likely not a problem with pip.
  full command: 'X:\Python311-x32\python.exe' 'X:\Python311-x32\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py' prepare_metadata_for_build_wheel 'C:\Users\gohlke\AppData\Local\Temp\tmpyoacdg_b'
  cwd: D:\Build\scikit-image\scikit_image-0.22.0
  Preparing metadata (pyproject.toml) ... error
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
Build failed!
```