### PR TITLE
Stop using the removed `importlib.resources.path` on Python >=3.13

### DIFF
--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import functools, json, os, textwrap
 from pathlib import Path
+import sys
 import typing as T
 
 from .. import mesonlib, mlog
@@ -112,8 +113,13 @@ class BasicPythonExternalProgram(ExternalProgram):
         # Sanity check, we expect to have something that at least quacks in tune
 
         import importlib.resources
+        if sys.version_info >= (3, 13):
+            traversable = importlib.resources.files('mesonbuild.scripts').joinpath('python_info.py')
+            context_mgr = importlib.resources.as_file(traversable)
+        else:
+            context_mgr = importlib.resources.path('mesonbuild.scripts', 'python_info.py')
 
-        with importlib.resources.path('mesonbuild.scripts', 'python_info.py') as f:
+        with context_mgr as f:
             cmd = self.get_command() + [str(f)]
             env = os.environ.copy()
             env['SETUPTOOLS_USE_DISTUTILS'] = 'stdlib'

--- a/mesonbuild/mesondata.py
+++ b/mesonbuild/mesondata.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import importlib.resources
 from pathlib import PurePosixPath, Path
+import sys
 import typing as T
 
 if T.TYPE_CHECKING:
@@ -27,10 +28,12 @@ class DataFile:
 
     def write_once(self, path: Path) -> None:
         if not path.exists():
-            data = importlib.resources.read_text( # [ignore encoding] it's on the next lines, Mr. Lint
-                    ('mesonbuild' / self.path.parent).as_posix().replace('/', '.'),
-                    self.path.name,
-                    encoding='utf-8')
+
+            package = ('mesonbuild' / self.path.parent).as_posix().replace('/', '.')
+            if sys.version_info >= (3, 13):
+                data = importlib.resources.files(package).joinpath(self.path.name).read_text(encoding='utf-8')
+            else:
+                data = importlib.resources.read_text(package, self.path.name, encoding='utf-8')
             path.write_text(data, encoding='utf-8')
 
     def write_to_private(self, env: 'Environment') -> Path:

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
-import copy, json, os, shutil, re
+import copy, json, os, shutil, re, sys
 import typing as T
 
 from . import ExtensionModule, ModuleInfo
@@ -407,7 +407,10 @@ class PythonModule(ExtensionModule):
         import importlib.resources
         pycompile = os.path.join(self.interpreter.environment.get_scratch_dir(), 'pycompile.py')
         with open(pycompile, 'wb') as f:
-            f.write(importlib.resources.read_binary('mesonbuild.scripts', 'pycompile.py'))
+            if sys.version_info >= (3, 13):
+                f.write(importlib.resources.files('mesonbuild.scripts').joinpath('pycompile.py').read_bytes())
+            else:
+                f.write(importlib.resources.read_binary('mesonbuild.scripts', 'pycompile.py'))
 
         for i in self.installations.values():
             if isinstance(i, PythonExternalProgram) and i.run_bytecompile[i.info['version']]:


### PR DESCRIPTION
Closes gh-12401

I've tested that `run_project_tests.py` is happy when changing `if sys.version_info >= (3, 13):` to `(3, 9)` instead, but decided to only change this for Python 3.13 and up to be conservative and because I saw in the CPython commit log for `importlib.resources` that `as_file` leaked a file descriptor until less than a year ago.