### PR TITLE
Support -j as a shorthand for --num-processes

### DIFF
--- a/docs/markdown/snippets/shorthand_argument_for_mtest_num_processes.md
+++ b/docs/markdown/snippets/shorthand_argument_for_mtest_num_processes.md
@@ -1,0 +1,4 @@
+## `-j` shorthand for `--num-processes`
+
+`-j` now means the same thing as `--num-processes`. It was inconsistently
+supported only in some subcommands. Now you may use it everywhere

--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -638,7 +638,7 @@ def add_common_arguments(p: argparse.ArgumentParser) -> None:
                    help='Path to source directory')
     p.add_argument('--types', default='',
                    help=f'Comma-separated list of subproject types. Supported types are: {ALL_TYPES_STRING} (default: all)')
-    p.add_argument('--num-processes', default=None, type=int,
+    p.add_argument('-j', '--num-processes', default=None, type=int,
                    help='How many parallel processes to use (Since 0.59.0).')
     p.add_argument('--allow-insecure', default=False, action='store_true',
                    help='Allow insecure server connections.')

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -157,7 +157,7 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
                         help="Run benchmarks instead of tests.")
     parser.add_argument('--logbase', default='testlog',
                         help="Base name for log file.")
-    parser.add_argument('--num-processes', default=determine_worker_count(), type=int,
+    parser.add_argument('-j', '--num-processes', default=determine_worker_count(), type=int,
                         help='How many parallel processes to use.')
     parser.add_argument('-v', '--verbose', default=False, action='store_true',
                         help='Do not redirect stdout and stderr')


### PR DESCRIPTION
We already use -j to support parallelism in meson compile. So let's add the same for meson test and subprojects.