### PR TITLE
build: improve the warning for executables with the same name

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -252,6 +252,7 @@ class Build:
         self.environment = environment
         self.projects = {}
         self.targets: 'T.OrderedDict[str, T.Union[CustomTarget, BuildTarget]]' = OrderedDict()
+        self.targetnames: T.Set[T.Tuple[str, str]] = set() # Set of executable names and their subdir
         self.global_args: PerMachine[T.Dict[str, T.List[str]]] = PerMachine({}, {})
         self.global_link_args: PerMachine[T.Dict[str, T.List[str]]] = PerMachine({}, {})
         self.projects_args: PerMachine[T.Dict[str, T.Dict[str, T.List[str]]]] = PerMachine({}, {})


### PR DESCRIPTION
adb1a360b9f9edb26eda233326b1d539baeccd5b added the feature and also the usual meson-style warning to users that might be using the feature but were not targeting a new enough meson version. Well unfortunately the warning both doesn't actually work (it didn't take different directories into account) and is also really slow because it creates an O(N^2) loop for checking this.

Instead, rework this by having another dictionary that stores target names along with any ids that have the same name. When we do the check on a new target, lookup up the name in the new targetnames dictionary (should be O(1)). If we do have something, then loop through all the target ids for the key and check if the fetched target is actually an executable and has the same subdirectory. Print the warning if so. This loop here is not really avoidable, but in practice it should never bloat out to a huge value. Fixes #12404.