### PR TITLE
File: Add full_path() method

### DIFF
--- a/docs/markdown/snippets/file-full-path.md
+++ b/docs/markdown/snippets/file-full-path.md
@@ -1,0 +1,7 @@
+## File object now has `full_path()` method
+
+Returns a full path pointing to the file. This is useful for printing the path
+with e.g [[message]] function for debugging purpose.
+
+**NOTE:** In most cases using the object itself will do the same job
+as this and will also allow Meson to setup dependencies correctly.

--- a/docs/yaml/objects/file.yaml
+++ b/docs/yaml/objects/file.yaml
@@ -1,3 +1,13 @@
 name: file
 long_name: File
-description: Opaque object that stores the path to an existing file
+description: Object that stores the path to an existing file
+
+methods:
+- name: full_path
+  returns: str
+  since: 1.4.0
+  description: |
+    Returns a full path pointing to the file. This is useful for printing the
+    path with e.g [[message]] function for debugging purpose.
+    **NOTE:** In most cases using the object itself will do the same job
+    as this and will also allow Meson to setup dependencies correctly.

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -701,7 +701,16 @@ class IncludeDirsHolder(ObjectHolder[build.IncludeDirs]):
     pass
 
 class FileHolder(ObjectHolder[mesonlib.File]):
-    pass
+    def __init__(self, file: mesonlib.File, interpreter: 'Interpreter'):
+        super().__init__(file, interpreter)
+        self.methods.update({'full_path': self.full_path_method,
+                             })
+
+    @noPosargs
+    @noKwargs
+    @FeatureNew('file.full_path', '1.4.0')
+    def full_path_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> str:
+        return self.held_object.absolute_path(self.env.source_dir, self.env.build_dir)
 
 class HeadersHolder(ObjectHolder[build.Headers]):
     pass

--- a/test cases/common/74 file object/meson.build
+++ b/test cases/common/74 file object/meson.build
@@ -6,3 +6,9 @@ test('fobj', executable('fobj', prog0, lib0))
 
 subdir('subdir1')
 subdir('subdir2')
+
+# Use fs.as_posix() because / operator replaces \ with / in the path, but
+# full_path() method is not doing that. This is a pretty inconsistent across all
+# Meson APIs.
+fs = import('fs')
+assert(fs.as_posix(prog0[0].full_path()) == fs.as_posix(meson.current_source_dir() / 'prog.c'))


### PR DESCRIPTION
This is needed now that str.format() is not allowing it any more. It is also more consistent with other objects that have that method as well, such as build targets.

Fixes: #12406