### PR TITLE
Fix detection of ifunc attribute on clang++

### DIFF
--- a/mesonbuild/compilers/c_function_attributes.py
+++ b/mesonbuild/compilers/c_function_attributes.py
@@ -137,7 +137,7 @@ CXX_FUNC_ATTRIBUTES = {
     'ifunc':
         ('extern "C" {'
          'int my_foo(void) { return 0; }'
-         'static int (*resolve_foo(void))(void) { return my_foo; }'
+         'int (*resolve_foo(void))(void) { return my_foo; }'
          '}'
          'int foo(void) __attribute__((ifunc("resolve_foo")));'),
 }


### PR DESCRIPTION
clang++ seems to require the resolver function to have external linkage, so the test code that was used was failing even though clang does support the attribute.

Closes #12413.