### PR TITLE
compilers: pass cross information to ldc2

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -1151,6 +1151,7 @@ def detect_d_compiler(env: 'Environment', for_machine: MachineChoice) -> Compile
 
             return cls(
                 exelist, version, for_machine, info, arch,
+                exe_wrapper=exe_wrap, is_cross=is_cross,
                 full_version=full_version, linker=linker, version_output=out)
         elif 'gdc' in out:
             cls = d.GnuDCompiler


### PR DESCRIPTION
ldc2 supports cross compilation with -mtriplet flag.

Unless I missed the proper way to do cross compilation, this change fix this cross file:

```
[binaries]
d = ['ldc2', '-mtriple=aarch64-linux-gnu']
```