### PR TITLE
itstool.py: Prepend call to itstool with sys.executable

### DIFF
--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 from os import path
+import shlex
 import typing as T
 
 from . import ExtensionModule, ModuleReturnValue, ModuleInfo
@@ -360,11 +361,14 @@ class I18nModule(ExtensionModule):
         command: T.List[T.Union[str, build.BuildTarget, build.CustomTarget,
                                 build.CustomTargetIndex, 'ExternalProgram', mesonlib.File]] = []
         command.extend(state.environment.get_build_command())
+
+        itstool_cmd = self.tools['itstool'].get_command()
+        # TODO: python 3.8 can use shlex.join()
         command.extend([
             '--internal', 'itstool', 'join',
             '-i', '@INPUT@',
             '-o', '@OUTPUT@',
-            '--itstool=' + self.tools['itstool'].get_path(),
+            '--itstool=' + ' '.join(shlex.quote(c) for c in itstool_cmd),
         ])
         if its_files:
             for fname in its_files:

--- a/mesonbuild/scripts/itstool.py
+++ b/mesonbuild/scripts/itstool.py
@@ -17,6 +17,7 @@ import os
 import argparse
 import subprocess
 import tempfile
+import shlex
 import shutil
 import typing as T
 
@@ -56,7 +57,7 @@ def run_join(build_dir: str, itstool: str, its_files: T.List[str], mo_files: T.L
             shutil.copy(mo_file, tmp_mo_fname)
             locale_mo_files.append(tmp_mo_fname)
 
-        cmd = [itstool]
+        cmd = shlex.split(itstool)
         if its_files:
             for fname in its_files:
                 cmd.extend(['-i', fname])


### PR DESCRIPTION
Hi,

This PR attempts to make calling `itstool` work on environments where shebang lines are not directly supported, by prepending the `itstool` call with `sys.executable`.

This was found while attempting to add `clang-cl` build support for appstream.

With blessings, thank you!