### PR TITLE
Vala: fixes to gresource handling

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1709,16 +1709,21 @@ class NinjaBackend(backends.Backend):
                 # Install GIR to default location if requested by user
                 if len(target.install_dir) > 3 and target.install_dir[3] is True:
                     target.install_dir[3] = os.path.join(self.environment.get_datadir(), 'gir-1.0')
-        # Detect gresources and add --gresources arguments for each
+        # Detect gresources and add --gresources/--gresourcesdir arguments for each
+        gres_dirs = []
         for gensrc in other_src[1].values():
             if isinstance(gensrc, modules.GResourceTarget):
                 gres_xml, = self.get_custom_target_sources(gensrc)
                 args += ['--gresources=' + gres_xml]
+                for source_dir in gensrc.source_dirs:
+                    gres_dirs += [os.path.join(self.get_target_dir(gensrc), source_dir)]
                 # Ensure that resources are built before vala sources
                 # This is required since vala code using [GtkTemplate] effectively depends on .ui files
                 # GResourceHeaderTarget is not suitable due to lacking depfile
                 gres_c, = gensrc.get_outputs()
-                extra_dep_files.append(os.path.join(self.get_target_dir(gensrc), gres_c))
+                extra_dep_files += [os.path.join(self.get_target_dir(gensrc), gres_c)]
+        for gres_dir in OrderedSet(gres_dirs):
+            args += [f'--gresourcesdir={gres_dir}']
         dependency_vapis = self.determine_dep_vapis(target)
         extra_dep_files += dependency_vapis
         extra_dep_files.extend(self.get_target_depend_files(target))

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1714,6 +1714,11 @@ class NinjaBackend(backends.Backend):
             if isinstance(gensrc, modules.GResourceTarget):
                 gres_xml, = self.get_custom_target_sources(gensrc)
                 args += ['--gresources=' + gres_xml]
+                # Ensure that resources are built before vala sources
+                # This is required since vala code using [GtkTemplate] effectively depends on .ui files
+                # GResourceHeaderTarget is not suitable due to lacking depfile
+                gres_c, = gensrc.get_outputs()
+                extra_dep_files.append(os.path.join(self.get_target_dir(gensrc), gres_c))
         dependency_vapis = self.determine_dep_vapis(target)
         extra_dep_files += dependency_vapis
         extra_dep_files.extend(self.get_target_depend_files(target))

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -264,7 +264,7 @@ class ModuleReturnValue:
         self.new_objects: T.List[T.Union['TYPE_var', 'mesonlib.ExecutableSerialisation']] = new_objects
 
 class GResourceTarget(build.CustomTarget):
-    pass
+    source_dirs: T.List[str] = []
 
 class GResourceHeaderTarget(build.CustomTarget):
     pass

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -518,6 +518,7 @@ class GnomeModule(ExtensionModule):
             install_dir=[kwargs['install_dir']] if kwargs['install_dir'] else [],
             install_tag=['runtime'],
         )
+        target_c.source_dirs = source_dirs
 
         if gresource: # Only one target for .gresource files
             return ModuleReturnValue(target_c, [target_c])

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -459,7 +459,10 @@ class GnomeModule(ExtensionModule):
         # Always include current directory, but after paths set by user
         source_dirs.append(os.path.join(state.build_to_src, state.subdir))
 
-        for source_dir in OrderedSet(source_dirs):
+        # Clean up duplicate directories
+        source_dirs = list(OrderedSet(os.path.normpath(dir) for dir in source_dirs))
+
+        for source_dir in source_dirs:
             cmd += ['--sourcedir', source_dir]
 
         if kwargs['c_name']:

--- a/test cases/vala/28 generated ui file/TestBox.ui.in
+++ b/test cases/vala/28 generated ui file/TestBox.ui.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk" version="4.0"/>
+  <requires lib="gtk" version="3.0"/>
   <template class="TestBox" parent="GtkBox">
   </template>
 </interface>

--- a/test cases/vala/28 generated ui file/TestBox.ui.in
+++ b/test cases/vala/28 generated ui file/TestBox.ui.in
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk" version="4.0"/>
+  <template class="TestBox" parent="GtkBox">
+  </template>
+</interface>

--- a/test cases/vala/28 generated ui file/meson.build
+++ b/test cases/vala/28 generated ui file/meson.build
@@ -1,0 +1,34 @@
+project('demo', 'c', 'vala')
+
+gnome = import('gnome', required: false)
+
+if not gnome.found()
+  error('MESON_SKIP_TEST: gnome module not supported')
+endif
+
+deps = [
+  dependency('glib-2.0', version : '>=2.50'),
+  dependency('gobject-2.0'),
+  dependency('gtk4'),
+]
+
+ui_tgt = custom_target(
+  input: 'TestBox.ui.in',
+  output:  'TestBox.ui',
+  command: [find_program('cat')],
+  feed: true,
+  capture: true,
+)
+
+resources = gnome.compile_resources('test-resources',
+  'test.gresource.xml',
+  c_name: 'test_res',
+  dependencies: ui_tgt,
+)
+
+executable(
+  'demo',
+  'test.vala',
+  resources,
+  dependencies: deps,
+)

--- a/test cases/vala/28 generated ui file/meson.build
+++ b/test cases/vala/28 generated ui file/meson.build
@@ -9,7 +9,7 @@ endif
 deps = [
   dependency('glib-2.0', version : '>=2.50'),
   dependency('gobject-2.0'),
-  dependency('gtk4'),
+  dependency('gtk+-3.0'),
 ]
 
 ui_tgt = custom_target(

--- a/test cases/vala/28 generated ui file/test.gresource.xml
+++ b/test cases/vala/28 generated ui file/test.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/com/mesonbuild/test">
+    <file>TestBox.ui</file>
+  </gresource>
+</gresources>

--- a/test cases/vala/28 generated ui file/test.vala
+++ b/test cases/vala/28 generated ui file/test.vala
@@ -1,0 +1,7 @@
+[GtkTemplate (ui = "/com/mesonbuild/test/TestBox.ui")]
+class TestBox: Gtk.Box {
+}
+
+int main() {
+    return 0;
+}


### PR DESCRIPTION
Fixes #12417.

Introduces two primary changes:

* Makes Vala targets depend on gresources compiled alongside them. The reason behind this is that valac may use same files as resource compiler, which it does for `.ui` files. This leads to race condition if `.ui` files are generated as part of the build and `valac` is invoked before they are (or `.c`/`.o` target is built directly instead of whole executable) and does not cause vala recompilation if `.ui` files are changed.
* Automatically passes `--gresourcesdir` to valac. I consider this to be a bugfix as well rather than a feature since passing of both `--gresources` to valac and `--source` to `glib-compile-resources` was already automated and only led to failure in specific cases.

I'm not 100% happy with how `source_dirs` is set in `GResourceTarget`, but it seems like doing it the right way would require some refactoring and I don't quite feel like I'm up to that.

P.S.: A possible alternative to depending directly on resources target is to import its explicit dependencies and make `valac` generate a depfile by passing `--depfile` to it (reusing depfile of resources is not viable since there may be multiple of them). However, I doubt this would be very beneficial in practice and have not checked if generated depfile even includes `.ui` resources.