### PR TITLE
Update release frequency to match reality

### DIFF
--- a/docs/markdown/Release-procedure.md
+++ b/docs/markdown/Release-procedure.md
@@ -16,8 +16,8 @@ choose.
 # Major releases
 
 Major releases are currently in the form 0.X.0, where X is an
-increasing number. We aim to do a major release roughly once a month,
-though the schedule is not set in stone.
+increasing number. We aim to do a major release roughly once every 3 to 4
+months, though the schedule is not set in stone.
 
 Before a major release is made a stable branch will be made, and
 0.X.0-rc1 release candidate will be made. A new milestone for 0.X.0


### PR DESCRIPTION
Releases have been happening an average of once every 90 days for the past two years (since 0.60.0). If we just look at releases since 1.0.0, the average is over 100 days.

It has been 101 days since 1.2.0, and there is no 1.3.0rc yet.

Ref:

Version | Date | Days since previous release
-- | -- | --
1.2.0 | 2023-07-16 | 97
1.1.0 | 2023-04-10 | 108
1.0.0 | 2022-12-23 | 47
0.64.0 | 2022-11-06 | 126
0.63.0 | 2022-07-03 | 104
0.62.0 | 2022-03-21 | 70
0.61.0 | 2022-01-10 | 78
0.60.0 | 2021-10-24 | 98
0.59.0 | 2021-07-18 |  
