### PR TITLE
add devenv to introspection data

### DIFF
--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -198,6 +198,9 @@ Display basic information about a configured project in `builddir`:
 meson introspect builddir --projectinfo
 ```
 
+*(since 1.4.0)* `--devenv` was added.
+
+
 ### install
 
 *(since 0.47.0)*

--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -32,17 +32,18 @@ to be the last file written.
 
 The `meson-info` directory should contain the following files:
 
-| File                           | Description                                                                   |
-| ------------------------------ | ----------------------------------------------------------------------------- |
-| `intro-benchmarks.json`        | Lists all benchmarks                                                          |
-| `intro-buildoptions.json`      | Contains a full list of Meson configuration options for the project           |
-| `intro-buildsystem_files.json` | Full list of all Meson build files                                            |
-| `intro-dependencies.json`      | Lists all dependencies used in the project                                    |
-| `intro-installed.json`         | Contains mapping of files to their installed location                         |
-| `intro-install_plan.json`      | Dictionary of data types with the source files and their installation details |
-| `intro-projectinfo.json`       | Stores basic information about the project (name, version, etc.)              |
-| `intro-targets.json`           | Full list of all build targets                                                |
-| `intro-tests.json`             | Lists all tests with instructions how to run them                             |
+| File                           | Description                                                                             |
+| ------------------------------ | --------------------------------------------------------------------------------------- |
+| `intro-benchmarks.json`        | Lists all benchmarks                                                                    |
+| `intro-buildoptions.json`      | Contains a full list of Meson configuration options for the project                     |
+| `intro-buildsystem_files.json` | Full list of all Meson build files                                                      |
+| `intro-dependencies.json`      | Lists all dependencies used in the project                                              |
+| `intro-devenv.json`            | Dictionary of environment variable to run executable in build directory (*since 1.4.0*) |
+| `intro-installed.json`         | Contains mapping of files to their installed location                                   |
+| `intro-install_plan.json`      | Dictionary of data types with the source files and their installation details           |
+| `intro-projectinfo.json`       | Stores basic information about the project (name, version, etc.)                        |
+| `intro-targets.json`           | Full list of all build targets                                                          |
+| `intro-tests.json`             | Lists all tests with instructions how to run them                                       |
 
 The content of the JSON files is further specified in the remainder of
 this document.

--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -37,13 +37,16 @@ The `meson-info` directory should contain the following files:
 | `intro-benchmarks.json`        | Lists all benchmarks                                                                    |
 | `intro-buildoptions.json`      | Contains a full list of Meson configuration options for the project                     |
 | `intro-buildsystem_files.json` | Full list of all Meson build files                                                      |
+| `intro-compilers.json`         | List of compilers, for each machine                                                     |
 | `intro-dependencies.json`      | Lists all dependencies used in the project                                              |
 | `intro-devenv.json`            | Dictionary of environment variable to run executable in build directory (*since 1.4.0*) |
 | `intro-installed.json`         | Contains mapping of files to their installed location                                   |
 | `intro-install_plan.json`      | Dictionary of data types with the source files and their installation details           |
+| `intro-machines.json`          | Details of architecture for each machine (host, build, target)                          |
 | `intro-projectinfo.json`       | Stores basic information about the project (name, version, etc.)                        |
 | `intro-targets.json`           | Full list of all build targets                                                          |
 | `intro-tests.json`             | Lists all tests with instructions how to run them                                       |
+| `meson-info.json`              | Meson version, directories, and list of introspection files                             |
 
 The content of the JSON files is further specified in the remainder of
 this document.

--- a/docs/markdown/snippets/mintro_devenv.md
+++ b/docs/markdown/snippets/mintro_devenv.md
@@ -1,0 +1,9 @@
+## Added devenv to introspection data
+
+Introspection data now contains environment variables defined in devenv.
+
+This allows external tools to use that information to launch executables
+from the build directory without the need to call `meson devenv`.
+
+As a side effect, it also mades it possible to dump `devenv` in `json` format,
+using `meson introspect --devenv`.

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -29,7 +29,7 @@ from pathlib import Path, PurePath
 import sys
 import typing as T
 
-from . import build, mesonlib, coredata as cdata
+from . import build, mesonlib, mdevenv, coredata as cdata
 from .ast import IntrospectionInterpreter, BUILD_TARGET_FUNCTIONS, AstConditionLevel, AstIDGenerator, AstIndentationGenerator, AstJSONPrinter
 from .backend import backends
 from .dependencies import Dependency
@@ -81,6 +81,7 @@ def get_meson_introspection_types(coredata: T.Optional[cdata.CoreData] = None,
         ('buildsystem_files', IntroCommand('List files that make up the build system', func=lambda: list_buildsystem_files(builddata, interpreter))),
         ('compilers', IntroCommand('List used compilers', func=lambda: list_compilers(coredata))),
         ('dependencies', IntroCommand('List external dependencies', func=lambda: list_deps(coredata, backend), no_bd=list_deps_from_source)),
+        ('devenv', IntroCommand('List environment variables required to run project from the build directory', func=lambda: dump_devenv(builddata))),
         ('scan_dependencies', IntroCommand('Scan for dependencies used in the meson.build file', no_bd=list_deps_from_source)),
         ('installed', IntroCommand('List all installed files and directories', func=lambda: list_installed(installdata))),
         ('install_plan', IntroCommand('List all installed files and directories with their details', func=lambda: list_install_plan(installdata))),
@@ -433,6 +434,10 @@ def list_deps(coredata: cdata.CoreData, backend: backends.Backend) -> T.List[T.D
                     result[d.name] = _create_result(d, varname)
 
     return list(result.values())
+
+def dump_devenv(builddata: build.Build) -> T.Dict[str, str]:
+    env, varnames = mdevenv.get_env(builddata, None)
+    return {varname: env[varname] for varname in varnames}
 
 def get_test_list(testdata: T.List[backends.TestSerialisation]) -> T.List[T.Dict[str, T.Union[str, int, T.List[str], T.Dict[str, str]]]]:
     result: T.List[T.Dict[str, T.Union[str, int, T.List[str], T.Dict[str, str]]]] = []


### PR DESCRIPTION
This is to allow external tools to run executables using meson devenv,
without the need of wrapping it with the meson command.