### PR TITLE
docs/dependency: fix type of version kwarg

### DIFF
--- a/docs/yaml/functions/dependency.yaml
+++ b/docs/yaml/functions/dependency.yaml
@@ -179,7 +179,7 @@ kwargs:
       subproject if it was not set explicitly in `default_options` keyword argument.
 
   version:
-    type: str
+    type: list[str] | str
     since: 0.37.0
     description: |
       Specifies the required version,


### PR DESCRIPTION
In the description both types are used.