### PR TITLE
fix variable substitution for devenv for vscode 

### DIFF
--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -395,4 +395,7 @@ format should be used. There are currently 3 formats supported:
 - `vscode`: Same as `sh` but without `$VAR` substitution because they do not
   seems to be properly supported by vscode.
 
+*Since 1.4.0* `--dump-format=vscode` now performs correct substitution
+using `VAR=/prepend:${env:VAR}:/append`
+
 {{ devenv_arguments.inc }}

--- a/mesonbuild/mdevenv.py
+++ b/mesonbuild/mdevenv.py
@@ -64,10 +64,14 @@ def get_env(b: build.Build, dump_fmt: T.Optional[str]) -> T.Tuple[T.Dict[str, st
         extra_env.set('QEMU_LD_PREFIX', [sysroot])
 
     env = {} if dump_fmt else os.environ.copy()
-    default_fmt = '${0}' if dump_fmt in {'sh', 'export'} else None
+    default_fmt = {
+        'vscode': '${{env:{0}}}',
+        'sh': '${0}',
+        'export': '${0}',
+    }
     varnames = set()
     for i in itertools.chain(b.devenv, {extra_env}):
-        env = i.get_env(env, default_fmt)
+        env = i.get_env(env, default_fmt.get(dump_fmt))
         varnames |= i.get_names()
 
     reduce_winepath(env)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -52,6 +52,11 @@ from unittests.windowstests import WindowsTests
 from unittests.platformagnostictests import PlatformAgnosticTests
 
 def unset_envs():
+    # Suppress warnings that can interfer with captured outputs
+    os.environ['PYDEVD_DISABLE_FILE_VALIDATION'] = '1'
+    if sys.version_info >= (3, 10):
+        os.environ['PYTHONWARNINGS'] = 'ignore::EncodingWarning:platform'
+
     # For unit tests we must fully control all command lines
     # so that there are no unexpected changes coming from the
     # environment, for example when doing a package build.

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -4284,7 +4284,7 @@ class AllPlatformTests(BasePlatformTests):
 
         cmd = self.meson_command + ['devenv', '-C', self.builddir, '--dump', '--dump-format', 'vscode']
         o = self._run(cmd)
-        expected = os.pathsep.join(['/prefix', '/suffix'])
+        expected = os.pathsep.join(['/prefix', '${env:TEST_C}', '/suffix'])
         self.assertIn(f'TEST_C="{expected}"', o)
         self.assertNotIn('export', o)
 


### PR DESCRIPTION
cc @xclaesse 

meson devenv was previously dropping the system PATH. The correct way to
handle this is to use `${env:PATH}` for substitution.

See:
https://code.visualstudio.com/docs/editor/variables-reference#_environment-variables