### PR TITLE
Fix crash for cargo wrap files with [target] sections without dependencies

### DIFF
--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -292,7 +292,7 @@ def _convert_manifest(raw_manifest: manifest.Manifest, subdir: str, path: str = 
         [Benchmark(**_fixup_raw_mappings(b)) for b in raw_manifest.get('bench', {})],
         [Example(**_fixup_raw_mappings(b)) for b in raw_manifest.get('example', {})],
         raw_manifest.get('features', {}),
-        {k: {k2: Dependency.from_raw(v2) for k2, v2 in v['dependencies'].items()}
+        {k: {k2: Dependency.from_raw(v2) for k2, v2 in v.get('dependencies', {}).items()}
          for k, v in raw_manifest.get('target', {}).items()},
         subdir,
         path,


### PR DESCRIPTION
Previously, creating a meson wrap with "method=cargo" for https://github.com/sunfishcode/is-terminal would cause meson to crash, because `is-terminal`'s Cargo.toml contains a `[target]` section without dependencies.

 Instead, we now fall back to an empty list in case of no specified dependencies (like everywhere else in "_convert_manifest")

The relevant wrap file looks like this:
```ini
[wrap-file]
directory = is-terminal-0.4.9
source_url = https://crates.io/api/v1/crates/is-terminal/0.4.9/download
source_filename = is-terminal-0.4.9.tar.gz
source_hash = cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b
method = cargo
```

Note: First time contributor, i didn't find any documentation about commit message style and such, can amend if necessary