### PR TITLE
windows: shorten .res output name to basename.res

### DIFF
--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -183,7 +183,7 @@ class WindowsModule(ExtensionModule):
             # Path separators are not allowed in target names
             name = name.replace('/', '_').replace('\\', '_').replace(':', '_')
             name_formatted = name_formatted.replace('/', '_').replace('\\', '_').replace(':', '_')
-            output = f'{name}_@BASENAME@.{suffix}'
+            output = f'@BASENAME@.{suffix}'
             command: T.List[T.Union[str, ExternalProgram]] = []
             command.append(rescomp)
             command.extend(res_args)


### PR DESCRIPTION
Before this commit .res output file name is flattenned from input .rc file name and it's path. I.e. given that project has .rc file in some subfolder:
```
  some/path/to/file.rc
```
Generated .res file name will be:
```
  some_path_to_file.rc_@BASENAME@.res
```

This commit shortens .res output file name to just `@BASENAME@.res` which seems to be enough.

This helps with the build issue for some projects that output .res can't be created due to legacy Windows limitation on supporting file names only shorter than 260. Unfortunately issue with .res is not cured even with enabling long file support in Windows - build still fails.