### PR TITLE
scan-build: Exclude subprojects from scan-build report

### DIFF
--- a/docs/markdown/snippets/subprojects_excluded_from_scanbuild.md
+++ b/docs/markdown/snippets/subprojects_excluded_from_scanbuild.md
@@ -1,0 +1,4 @@
+## Subprojects excluded from scan-build reports
+
+The `scan-build` target, created when using the `ninja` backend with `scan-build`
+present, now excludes bugs found in subprojects from its final report.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3587,7 +3587,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         if 'scan-build' in self.all_outputs:
             return
         cmd = self.environment.get_build_command() + \
-            ['--internal', 'scanbuild', self.environment.source_dir, self.environment.build_dir] + \
+            ['--internal', 'scanbuild', self.environment.source_dir, self.environment.build_dir, self.build.get_subproject_dir()] + \
             self.environment.get_build_command() + self.get_user_option_args()
         elem = self.create_phony_target('scan-build', 'CUSTOM_COMMAND', 'PHONY')
         elem.add_item('COMMAND', cmd)

--- a/mesonbuild/scripts/scanbuild.py
+++ b/mesonbuild/scripts/scanbuild.py
@@ -24,12 +24,12 @@ import typing as T
 from ast import literal_eval
 import os
 
-def scanbuild(exelist: T.List[str], srcdir: Path, blddir: Path, privdir: Path, logdir: Path, args: T.List[str]) -> int:
+def scanbuild(exelist: T.List[str], srcdir: Path, blddir: Path, privdir: Path, logdir: Path, subprojdir: Path, args: T.List[str]) -> int:
     # In case of problems leave the temp directory around
     # so it can be debugged.
     scandir = tempfile.mkdtemp(dir=str(privdir))
     meson_cmd = exelist + args
-    build_cmd = exelist + ['-o', str(logdir)] + detect_ninja() + ['-C', scandir]
+    build_cmd = exelist + ['--exclude', str(subprojdir), '-o', str(logdir)] + detect_ninja() + ['-C', scandir]
     rc = subprocess.call(meson_cmd + [str(srcdir), scandir])
     if rc != 0:
         return rc
@@ -41,8 +41,9 @@ def scanbuild(exelist: T.List[str], srcdir: Path, blddir: Path, privdir: Path, l
 def run(args: T.List[str]) -> int:
     srcdir = Path(args[0])
     bldpath = Path(args[1])
+    subprojdir = srcdir / Path(args[2])
     blddir = args[1]
-    meson_cmd = args[2:]
+    meson_cmd = args[3:]
     privdir = bldpath / 'meson-private'
     logdir = bldpath / 'meson-logs' / 'scanbuild'
     shutil.rmtree(str(logdir), ignore_errors=True)
@@ -63,4 +64,4 @@ def run(args: T.List[str]) -> int:
         print('Could not execute scan-build "%s"' % ' '.join(exelist))
         return 1
 
-    return scanbuild(exelist, srcdir, bldpath, privdir, logdir, meson_cmd)
+    return scanbuild(exelist, srcdir, bldpath, privdir, logdir, subprojdir, meson_cmd)


### PR DESCRIPTION
When a user invokes the `scan-build` target that Meson generates, bugs found by `scan-build` in subprojects are included in the resulting report. This commit modifies the invocation of `scan-build` in order to exclude all bugs that are found inside subprojects from the final report.

### Motivation

I would like to be able to use Meson's `scan-build` target in a continuous integration workflow to notify of any newly added code that the static analyser considers to be a possible bug.

In order to do this I would like to invoke the `scan-build` and raise an error if a report exists after ninja exits, `scan-build`'s default behaviour being to not create a report if no bugs were found. For trivially small projects this works well, but for anything which uses subprojects, this doesn't work so well as `scan-build` will report any bugs it finds in the subprojects in its report, causing it to be present when ninja exits.

The simplest solution that I could imagine was to exclude subprojects from the report, something `scan-build` explicitly supports in its command-line interface with the `--exclude <PATH>` option. 

Excluding subprojects aligns the behaviour of the `scan-build` target with that of the `coverage` target which also explicitly excludes code in subprojects from its coverage report (except when a subproject has an explicit gcovr config).

Feedback very welcome!
