### PR TITLE
gnome: Allow generate_vapi() packages to be deps

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -33,7 +33,7 @@ from .. import interpreter
 from .. import mesonlib
 from .. import mlog
 from ..build import CustomTarget, CustomTargetIndex, Executable, GeneratedList, InvalidArguments
-from ..dependencies import Dependency, InternalDependency
+from ..dependencies import Dependency, ExternalLibrary, InternalDependency
 from ..dependencies.pkgconfig import PkgConfigDependency, PkgConfigInterface
 from ..interpreter.type_checking import DEPENDS_KW, DEPEND_FILES_KW, ENV_KW, INSTALL_DIR_KW, INSTALL_KW, NoneType, DEPENDENCY_SOURCES_KW, in_set_validator
 from ..interpreterbase import noPosargs, noKwargs, FeatureNew, FeatureDeprecated
@@ -2063,7 +2063,8 @@ class GnomeModule(ExtensionModule):
         rv = [body, header]
         return ModuleReturnValue(rv, rv)
 
-    def _extract_vapi_packages(self, state: 'ModuleState', packages: T.List[T.Union[InternalDependency, str]],
+    def _extract_vapi_packages(self, state: 'ModuleState',
+                               packages: T.List[T.Union[ExternalLibrary, InternalDependency, PkgConfigDependency, str]],
                                ) -> T.Tuple[T.List[str], T.List[VapiTarget], T.List[str], T.List[str], T.List[str]]:
         '''
         Packages are special because we need to:
@@ -2080,7 +2081,16 @@ class GnomeModule(ExtensionModule):
         vapi_args: T.List[str] = []
         remaining_args = []
         for arg in packages:
-            if isinstance(arg, InternalDependency):
+            if isinstance(arg, PkgConfigDependency):
+                vapi_args.append(f'--pkg={arg.name}')
+                vapi_packages.append(arg.name)
+                remaining_args.append(arg.name)
+            elif isinstance(arg, ExternalLibrary):
+                # We can only handle VAPI files here
+                assert arg.language == 'vala'
+                ext_vapi = arg.get_link_args('vala')[0]
+                remaining_args.append(ext_vapi)
+            elif isinstance(arg, InternalDependency):
                 targets = [t for t in arg.sources if isinstance(t, VapiTarget)]
                 for target in targets:
                     srcdir = os.path.join(state.environment.get_source_dir(),
@@ -2134,14 +2144,16 @@ class GnomeModule(ExtensionModule):
         KwargInfo('vapi_dirs', ContainerTypeInfo(list, str), listify=True, default=[]),
         KwargInfo('metadata_dirs', ContainerTypeInfo(list, str), listify=True, default=[]),
         KwargInfo('gir_dirs', ContainerTypeInfo(list, str), listify=True, default=[]),
-        KwargInfo('packages', ContainerTypeInfo(list, (str, InternalDependency)), listify=True, default=[]),
+        KwargInfo('packages', ContainerTypeInfo(list, (str, ExternalLibrary, InternalDependency, PkgConfigDependency)), listify=True, default=[]),
     )
     def generate_vapi(self, state: 'ModuleState', args: T.Tuple[str], kwargs: 'GenerateVapi') -> ModuleReturnValue:
         created_values: T.List[T.Union[Dependency, build.Data]] = []
         library = args[0]
         build_dir = os.path.join(state.environment.get_build_dir(), state.subdir)
         source_dir = os.path.join(state.environment.get_source_dir(), state.subdir)
+
         pkg_cmd, vapi_depends, vapi_packages, vapi_includes, packages = self._extract_vapi_packages(state, kwargs['packages'])
+
         cmd: T.List[T.Union[ExternalProgram, Executable, OverrideProgram, str]]
         cmd = [state.find_program('vapigen'), '--quiet', f'--library={library}', f'--directory={build_dir}']
         cmd.extend([f'--vapidir={d}' for d in kwargs['vapi_dirs']])

--- a/test cases/vala/11 generated vapi/libbar/meson.build
+++ b/test cases/vala/11 generated vapi/libbar/meson.build
@@ -27,6 +27,9 @@ libbar_gir = gnome.generate_gir(libbar,
 
 libbar_vapi = gnome.generate_vapi('bar-' + libbar_api_ver,
   sources: libbar_gir[0],
-  packages: libfoo_vapi,
+  packages: [
+    dependency('gobject-2.0'),
+    libfoo_vapi,
+  ],
   install: true,
 )

--- a/test cases/vala/11 generated vapi/libbaz/baz.c
+++ b/test cases/vala/11 generated vapi/libbaz/baz.c
@@ -1,0 +1,29 @@
+#include "baz.h"
+#include <zlib.h>
+
+struct _BazBaz
+{
+  GObject parent_instance;
+};
+
+G_DEFINE_TYPE (BazBaz, baz_baz, G_TYPE_OBJECT)
+
+static void
+baz_baz_class_init (BazBazClass *klass)
+{
+}
+
+static void
+baz_baz_init (BazBaz *self)
+{
+}
+
+/**
+ * baz_baz_return_success:
+ *
+ * Returns 0
+ */
+int baz_baz_return_zlib_version(void)
+{
+  return 0;
+}

--- a/test cases/vala/11 generated vapi/libbaz/baz.h
+++ b/test cases/vala/11 generated vapi/libbaz/baz.h
@@ -1,0 +1,9 @@
+#include <glib-object.h>
+
+#pragma once
+
+#define BAZ_TYPE_BAZ (baz_baz_get_type())
+
+G_DECLARE_FINAL_TYPE (BazBaz, baz_baz, BAZ, BAZ, GObject)
+
+int baz_baz_return_success(void);

--- a/test cases/vala/11 generated vapi/libbaz/meson.build
+++ b/test cases/vala/11 generated vapi/libbaz/meson.build
@@ -1,0 +1,26 @@
+libbaz_sources = [
+  'baz.c',
+  'baz.h',
+]
+
+libbaz = shared_library('baz', libbaz_sources,
+  install: true,
+)
+
+libbaz_api_ver = '1.0'
+
+libbaz_gir = gnome.generate_gir(libbaz,
+  sources: libbaz_sources,
+  namespace: 'Baz',
+  nsversion: libbaz_api_ver,
+  symbol_prefix: 'baz',
+  extra_args: [
+    '--c-include=baz.h',
+  ],
+)
+
+libbaz_vapi = gnome.generate_vapi('baz-' + libbaz_api_ver,
+  sources: libbaz_gir[0],
+  packages: meson.get_compiler('vala').find_library('posix'),
+  install: true,
+)

--- a/test cases/vala/11 generated vapi/main.vala
+++ b/test cases/vala/11 generated vapi/main.vala
@@ -1,5 +1,6 @@
 using Foo;
 using Bar;
+using Baz;
 
 class Main : GLib.Object {
     public static int main(string[] args) {

--- a/test cases/vala/11 generated vapi/meson.build
+++ b/test cases/vala/11 generated vapi/meson.build
@@ -3,6 +3,7 @@ project('vapi-test', ['c', 'vala'])
 gnome = import('gnome')
 subdir('libfoo')
 subdir('libbar')
+subdir('libbaz')
 
 vapiexe = executable('vapigen-test',
   'main.vala',


### PR DESCRIPTION
`gnome.generate_vapi()` allows one to specify the list of dependent packages as an list of strings (the package names). This is a bit awkward to work with in a project, as you often already have those VAPI dependencies in the form of a `find_library()` or a `dependency()` return value.

This commit allows to use both these return values to be used. For the specific logic, I basically checked what the internal `ValaCompiler` was already doing. I also extended the test for `generate_vapi()` to make sure we're not regressing on this.