### PR TITLE
vs2010backend: fix incompatibility with custom manifests

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -693,6 +693,8 @@ class Vs2010Backend(backends.Backend):
             if target_ext:
                 ET.SubElement(direlem, 'TargetExt').text = target_ext
 
+            ET.SubElement(direlem, 'EmbedManifest').text = 'false'
+
         return (root, type_config)
 
     def gen_run_target_vcxproj(self, target: build.RunTarget, ofname: str, guid: str) -> None:


### PR DESCRIPTION

<details> 
<summary>Given this relatively simple setup</summary>

The code attempts to create a file named `zß水🍌` with standard C++ APIs (which use the ANSI variants of Win32 APIs), then checks whether it succeeded by using the Wide variant of a Win32 API. There is sufficient variation in the filename to not be covered by a single codepage, so unless the ANSI variants operate in the UTF-8 codepage, the check will fail. In more recent versions of Windows 10, [this can be requested in the application manifest](https://learn.microsoft.com/en-us/windows/apps/design/globalizing/use-utf8-code-page), which this setup also attempts, and, using the VS backend and current release versions of Meson, fails to do.

<ul>
<li><details> 
<summary><code>embed-manifest-test.cpp</code></summary>

```cpp
#include <Windows.h>
#include <string>
#include <fstream>

static std::wstring WinWiden(const std::string &source)
{
        int buffer_size = MultiByteToWideChar(CP_UTF8, 0, source.c_str(), source.size(), nullptr, 0);
        if (!buffer_size)
        {
                return L"";
        }
        std::wstring output(buffer_size, 0);
        if (!MultiByteToWideChar(CP_UTF8, 0, source.c_str(), source.size(), &output[0], buffer_size))
        {
                return L"";
        }
        return output;
}

int main()
{
        std::string path = "\x7a\xc3\x9f\xe6\xb0\xb4\xf0\x9f\x8d\x8c"; // zß水🍌 in utf-8
        {
                std::ofstream f(path);
        }
        if (GetFileAttributesA(path.c_str()) == INVALID_FILE_ATTRIBUTES)
        {
                return 2;
        }
        if (GetFileAttributesW(WinWiden(path).c_str()) == INVALID_FILE_ATTRIBUTES)
        {
                return 1;
        }
        return 0;
}
```

</details></li>

<li><details> 
<summary><code>embed-manifest-test.rc</code></summary>

```
#include <ntdef.h>
#include <winuser.h>

CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "winutf8.xml"
```

</details></li>

<li><details> 
<summary><code>meson.build</code></summary>

```meson
project('embed-manifest-test', 'cpp', default_options: [ 'cpp_std=c++17' ])

executable(
        'embed-manifest-test',
        sources: [
                import('windows').compile_resources(
                        'embed-manifest-test.rc',
                        depend_files: 'winutf8.xml',
                ),
                'embed-manifest-test.cpp',
        ],
)
```

</details></li>

<li><details> 
<summary><code>winutf8.xml</code></summary>

```xml
<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
        <assemblyIdentity name="." version="6.0.0.0"/>
        <application>
                <windowsSettings>
                        <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
                </windowsSettings>
        </application>
</assembly>
```

</details></li>
</ul>

</details>

and the following setup and compile commands
```sh
meson --backend=vs setup build
cd build && meson compile
```

the linking step fails with the following errors:
```
CVTRES : fatal error CVT1100: duplicate resource.  type:MANIFEST, name:1, language:0x0409
LINK : fatal error LNK1123: failure during conversion to COFF: file invalid or corrupt
```

due to the reason explained in the commit message:

> EmbedManifest seems to default to true, which creates a default manifest based on other parameters (likewise defaults) and makes it impossible to supply your own with CREATEPROCESS_MANIFEST_RESOURCE_ID.

This has been tested with fairly vanilla installs of VS2017 and VS2022; results may vary depending on toolset, I'm not entirely sure, but I don't think the default for this setting would change. Again, as per the commit message:

> There is value to being able to do this [supply your own manifest] and no value to the default one, so this should be disabled.

So this PR disables it.