### PR TITLE
Fix visibility attribute support check for GCC on Windows

### DIFF
--- a/mesonbuild/compilers/c_function_attributes.py
+++ b/mesonbuild/compilers/c_function_attributes.py
@@ -103,17 +103,17 @@ C_FUNC_ATTRIBUTES = {
     'vector_size':
         '__attribute__((vector_size(32))); int foo(void) { return 0; }',
     'visibility': '''
-        int foo_def(void) __attribute__((visibility("default")));
-        int foo_hid(void) __attribute__((visibility("hidden")));
-        int foo_int(void) __attribute__((visibility("internal")));''',
+        int foo_def(void) __attribute__((visibility("default"))); int foo_def(void) { return 0; }
+        int foo_hid(void) __attribute__((visibility("hidden"))); int foo_hid(void) { return 0; }
+        int foo_int(void) __attribute__((visibility("internal"))); int foo_int(void) { return 0; }''',
     'visibility:default':
-        'int foo(void) __attribute__((visibility("default")));',
+        'int foo(void) __attribute__((visibility("default"))); int foo(void) { return 0; }',
     'visibility:hidden':
-        'int foo(void) __attribute__((visibility("hidden")));',
+        'int foo(void) __attribute__((visibility("hidden"))); int foo(void) { return 0; }',
     'visibility:internal':
-        'int foo(void) __attribute__((visibility("internal")));',
+        'int foo(void) __attribute__((visibility("internal"))); int foo(void) { return 0; }',
     'visibility:protected':
-        'int foo(void) __attribute__((visibility("protected")));',
+        'int foo(void) __attribute__((visibility("protected"))); int foo(void) { return 0; }',
     'warning':
         'int foo(void) __attribute__((warning("")));',
     'warn_unused_result':

--- a/test cases/common/197 function attributes/meson.build
+++ b/test cases/common/197 function attributes/meson.build
@@ -23,7 +23,8 @@ if c.get_id() == 'pgi'
   error('MESON_SKIP_TEST: PGI supports its own set of features, will need a separate list for PGI to test it.')
 endif
 
-expected_result = not ['msvc', 'clang-cl', 'intel-cl'].contains(c.get_id())
+expected = {}
+expected_default = not ['msvc', 'clang-cl', 'intel-cl'].contains(c.get_id())
 
 # Q: Why is ifunc not in this list or any of the below lists?
 # A: It's too damn hard to figure out if you actually support it, since it
@@ -56,7 +57,23 @@ attributes = [
   'vector_size',
   'warn_unused_result',
   'weak',
+  'dllexport',
+  'dllimport',
 ]
+
+expected += {
+  'dllexport': ['windows', 'cygwin'].contains(host_machine.system()),
+  'dllimport': ['windows', 'cygwin'].contains(host_machine.system()),
+}
+
+if c.get_id() == 'gcc' and ['windows', 'cygwin'].contains(host_machine.system())
+  expected += {
+    'visibility': false,
+    'visibility:hidden': false,
+    'visibility:internal': false,
+    'visibility:protected': false,
+  }
+endif
 
 if c.get_id() != 'intel'
   # not supported by icc as of 19.0.0
@@ -67,6 +84,10 @@ endif
 if host_machine.system() != 'darwin'
   attributes += 'alias'
   attributes += 'visibility'
+  attributes += 'visibility:default'
+  attributes += 'visibility:hidden'
+  attributes += 'visibility:internal'
+  attributes += 'visibility:protected'
   attributes += 'alloc_size'
 endif
 
@@ -94,24 +115,18 @@ endif
 if get_option('mode') == 'single'
   foreach a : attributes
     x = c.has_function_attribute(a)
+    expected_result = expected.get(a, expected_default)
     assert(x == expected_result, '@0@: @1@'.format(c.get_id(), a))
     x = cpp.has_function_attribute(a)
     assert(x == expected_result, '@0@: @1@'.format(cpp.get_id(), a))
   endforeach
-
-  win_expect = ['windows', 'cygwin'].contains(host_machine.system())
-  foreach a : ['dllexport', 'dllimport']
-    assert(c.has_function_attribute(a) == win_expect,
-          '@0@: @1@'.format(c.get_id(), a))
-    assert(cpp.has_function_attribute(a) == win_expect,
-          '@0@: @1@'.format(cpp.get_id(), a))
-  endforeach
 else
-  if not ['msvc', 'clang-cl', 'intel-cl'].contains(c.get_id())
-    multi_expected = attributes
-  else
-    multi_expected = []
-  endif
+  multi_expected = []
+  foreach a : attributes
+    if expected.get(a, expected_default)
+      multi_expected += a
+    endif
+  endforeach
 
   multi_check = c.get_supported_function_attributes(attributes)
   assert(multi_check == multi_expected, 'get_supported_function_arguments works (C)')


### PR DESCRIPTION
`has_function_attribute()` depends on `-Wattributes` being emitted when an attribute is not supported by the compiler. In case of GCC on Window (at least) there is no warning in case the attribute is used on a declaration. Only once there is also a function definition does it emit a warning like:

```
a.c: In function ‘foo’:
a.c:8:1: warning: visibility attribute not supported in this configuration; ignored [-Wattributes]
    8 | }
```

To fix this add a dummy function definition to all visibility compiler checks in meson.

The tests in "197 function attributes" only checked for positive return result on non-msvc compilers, except one special case for dllexport/dllimport. Refactor the tests a bit so one can specify also a negative expected result, and add tests for all visibility attribute variants.