### PR TITLE
gnome module: fix invalid find_tool variable contents causing crash

### DIFF
--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -112,7 +112,12 @@ class ModuleState:
         if dep.found() and dep.type_name == 'pkgconfig':
             value = dep.get_variable(pkgconfig=varname)
             if value:
-                return ExternalProgram(value)
+                progobj = ExternalProgram(value)
+                if not progobj.found():
+                    msg = (f'Dependency {depname!r} tool variable {varname!r} contains erroneous value: {value!r}\n\n'
+                           'This is a distributor issue -- please report it to your {depname} provider.')
+                    raise mesonlib.MesonException(msg)
+                return progobj
 
         # Normal program lookup
         return self.find_program(name, required=required, wanted=wanted)


### PR DESCRIPTION
If a tool that is looked up in a .pc file is supposed to be there and has a pkg-config variable entry, but the value is incorrect, we can't actually use it.

Since commit ab3d02066c91974922948f8b8b0fc944875d1a90 we actually do run the ExternalProgram search procedure on it though -- which caused it to go wonky and return a None if it doesn't exist, instead of containing a path to a program that does not exist and fails at build time. This is better in the case where searching helps resolve .exe file extensions -- and worse in the case where patches to the dependency means nothing we do is ever enough to actually find what is expected, since now we crash.

Raise an explicit error in such a case, pointing out that the dependency itself is broken and needs a distributor-side resolution.

Fixes #12412