### PR TITLE
clike: Deduplicate rpath linker flags

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2022 The Meson development team
+# Copyright 2012-2023 The Meson development team
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ class CLikeCompilerArgs(arglist.CompilerArgs):
 
     # NOTE: not thorough. A list of potential corner cases can be found in
     # https://github.com/mesonbuild/meson/pull/4593#pullrequestreview-182016038
-    dedup1_prefixes = ('-l', '-Wl,-l', '-Wl,--export-dynamic')
+    dedup1_prefixes = ('-l', '-Wl,-l', '-Wl,--export-dynamic', '-Wl,-rpath')
     dedup1_suffixes = ('.lib', '.dll', '.so', '.dylib', '.a')
     dedup1_args = ('-c', '-S', '-E', '-pipe', '-pthread')
 


### PR DESCRIPTION
**[why]**
On Apple clang 15.0.0 linker (i.e. `ld64 1015.7`) giving the same rpath multiple times raises a warning:
```
ld: warning: duplicate -rpath '/local/lib' ignored
```
This can frequently happen when linking several dependencies that all have that rpath in e.g. pkgconfig.

**[how]**
Deduplicate all rpath arguments.

**[note]**
I'm not sure how the code handles --start/end-group, but for rpath that should not make any difference as that is not bound to a group.