### PR TITLE
`meson wrap install` multiple projects

### DIFF
--- a/docs/markdown/Using-wraptool.md
+++ b/docs/markdown/Using-wraptool.md
@@ -64,7 +64,12 @@ the install command.
     Installed libjpeg branch 9a revision 2
 
 Now you can issue a `subproject('libjpeg')` in your `meson.build` file
-to use it.
+to use it. Since *1.12.0* you may also specify multiple dependencies to install.
+
+    $ meson wrap install cairo pango harfbuzz
+    Installed cairo version 1.18.0 revision 1
+    Installed pango version 1.51.0 revision 2
+    Installed harfbuzz version 8.3.1 revision 1
 
 To check if your projects are up to date you can issue the `status` command.
 

--- a/docs/markdown/snippets/meson_wrap_install_multiple.md
+++ b/docs/markdown/snippets/meson_wrap_install_multiple.md
@@ -1,0 +1,6 @@
+## Multiple positional arguments for `meson wrap install`
+
+Previously `meson wrap install` only accepted a single wrap name to install.
+This limitation has now been lifted, and it is now possible to specify
+multiple wrap names for installation. The exit code will be non-zero
+if *any* of the wraps fail to install.

--- a/mesonbuild/wrap/wraptool.py
+++ b/mesonbuild/wrap/wraptool.py
@@ -36,7 +36,7 @@ def add_arguments(parser: 'argparse.ArgumentParser') -> None:
     p = subparsers.add_parser('install', help='install the specified project')
     p.add_argument('--allow-insecure', default=False, action='store_true',
                    help='Allow insecure server connections.')
-    p.add_argument('name')
+    p.add_argument('name', nargs='+')
     p.set_defaults(wrap_func=install)
 
     p = msubprojects.add_wrap_update_parser(subparsers)
@@ -87,21 +87,35 @@ def get_latest_version(name: str, allow_insecure: bool) -> T.Tuple[str, str]:
     version, revision = latest_version.rsplit('-', 1)
     return version, revision
 
-def install(options: 'argparse.Namespace') -> None:
-    name = options.name
+def install_one(name: str, allow_insecure: bool) -> None:
     subproject_dir_name = mesonlib.get_subproject_dir()
-    if subproject_dir_name is None or not os.path.isdir(subproject_dir_name):
-        raise SystemExit('Subprojects dir not found. Run this script in your source root directory.')
     if os.path.isdir(os.path.join(subproject_dir_name, name)):
         raise SystemExit('Subproject directory for this project already exists.')
     wrapfile = os.path.join(subproject_dir_name, name + '.wrap')
     if os.path.exists(wrapfile):
-        raise SystemExit('Wrap file already exists.')
-    (version, revision) = get_latest_version(name, options.allow_insecure)
-    url = open_wrapdburl(f'https://wrapdb.mesonbuild.com/v2/{name}_{version}-{revision}/{name}.wrap', options.allow_insecure, True, True)
+        raise SystemExit(f'Wrap file for {name} already exists.')
+    (version, revision) = get_latest_version(name, allow_insecure)
+    url = open_wrapdburl(f'https://wrapdb.mesonbuild.com/v2/{name}_{version}-{revision}/{name}.wrap', allow_insecure, True, True)
     with open(wrapfile, 'wb') as f:
         f.write(read_and_decompress(url))
     print(f'Installed {name} version {version} revision {revision}')
+
+def install(options: 'argparse.Namespace') -> None:
+    subproject_dir_name = mesonlib.get_subproject_dir()
+    if subproject_dir_name is None or not os.path.isdir(subproject_dir_name):
+        raise SystemExit('Subprojects dir not found. Run this script in your source root directory.')
+
+    failed = 0
+
+    for name in dict.fromkeys(options.name):
+        try:
+            install_one(name, options.allow_insecure)
+        except WrapException as e:
+            print(str(e), file=sys.stderr)
+            failed += 1
+
+    if failed > 0:
+        raise SystemExit(1)
 
 def get_current_version(wrapfile: str) -> T.Tuple[str, str, str, str, T.Optional[str]]:
     cp = configparser.ConfigParser(interpolation=None)


### PR DESCRIPTION
```
Previously, `meson wrap install` took only one argument, so installing
multiple projects needed multiple invocations, which is not too convenient.
So add support for installing multiple projects.
```
