### PR TITLE
fix regression in converting build_target kwargs to typed_kwargs

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3318,6 +3318,13 @@ class Interpreter(InterpreterBase, HoldableObject):
         # backwards compatibility anyway
         sources = [s for s in sources
                    if not isinstance(s, (build.BuildTarget, build.ExtractedObjects))]
+
+        # due to lack of type checking, these are "allowed" for legacy reasons
+        if not isinstance(kwargs['install'], bool):
+            FeatureBroken.single_use('install kwarg with non-boolean value', '1.3.0', self.subproject,
+                                     'This was never intended to work, and is essentially the same as using `install: true` regardless of value.',
+                                     node)
+
         sources = self.source_strings_to_files(sources)
         objs = kwargs['objects']
         kwargs['dependencies'] = extract_as_list(kwargs, 'dependencies')

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -573,7 +573,8 @@ _ALL_TARGET_KWS: T.List[KwargInfo] = [
     OVERRIDE_OPTIONS_KW,
     KwargInfo('build_by_default', bool, default=True, since='0.38.0'),
     KwargInfo('extra_files', ContainerTypeInfo(list, (str, File)), default=[], listify=True),
-    INSTALL_KW,
+    # Accursed. We allow this for backwards compat and warn in the interpreter.
+    KwargInfo('install', object, default=False),
     INSTALL_MODE_KW,
     KwargInfo('implicit_include_directories', bool, default=True, since='0.42.0'),
     NATIVE_KW,


### PR DESCRIPTION
We haven't actually verified that these kwargs are equal to what we had before, and should probably revert the entire series. But I have multiple reports in the wild of projects that no longer build because of `install: [true, false, get_option('foobar')]` which was always incorrect and always equal to just dropping values all over the floor and treating it the same as "bool(value) == True".

Special case this particular typed kwarg and allow it with a sternly worded warning that it was always wrong and should never ever ever be done.

Fixes: https://bugs.gentoo.org/917118
Fixes: http://qa-logs.debian.net/2023/11/11/rhythmbox_3.4.7-1_unstable_meson-exp.log

Thanks to the Gentoo Tinderbox project, and Lucas Nussbaum of the Debian project.