### PR TITLE
rust: Add transitive dependencies to ninja rules

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1877,10 +1877,7 @@ class NinjaBackend(backends.Backend):
         self.generate_generator_list_rules(target)
 
         # dependencies need to cause a relink, they're not just for ordering
-        deps = [
-            os.path.join(t.subdir, t.get_filename())
-            for t in itertools.chain(target.link_targets, target.link_whole_targets)
-        ]
+        deps: T.List[str] = []
 
         # Dependencies for rust-project.json
         project_deps: T.List[RustDep] = []
@@ -1983,6 +1980,7 @@ class NinjaBackend(backends.Backend):
         target_deps = target.get_dependencies()
         for d in target_deps:
             linkdirs.add(d.subdir)
+            deps.append(self.get_dependency_filename(d))
             if d.uses_rust_abi():
                 if d not in itertools.chain(target.link_targets, target.link_whole_targets):
                     # Indirect Rust ABI dependency, we only need its path in linkdirs.

--- a/test cases/rust/21 transitive dependencies/app.rs
+++ b/test cases/rust/21 transitive dependencies/app.rs
@@ -1,0 +1,9 @@
+extern "C" {
+    fn static2() -> i32;
+}
+
+fn main() {
+    unsafe {
+        static2();
+    }
+}

--- a/test cases/rust/21 transitive dependencies/meson.build
+++ b/test cases/rust/21 transitive dependencies/meson.build
@@ -27,3 +27,11 @@ exe = executable('footest', 'foo.c',
 test('footest', exe)
 
 subdir('diamond')
+
+# The ninja rule for libstatic2.a does not depend on libstatic1.a because it
+# only need static2.c.o to create the archive. That means that the ninja rule
+# for app must depend on both, otherwise libstatic1.a won't be built and linking
+# will fail.
+static1 = static_library('static1', 'static1.c', build_by_default: false)
+static2 = static_library('static2', 'static2.c', link_with: static1)
+exe = executable('app', 'app.rs', link_with: static2)

--- a/test cases/rust/21 transitive dependencies/static1.c
+++ b/test cases/rust/21 transitive dependencies/static1.c
@@ -1,0 +1,5 @@
+int static1(void);
+
+int static1(void){
+    return 1;
+}

--- a/test cases/rust/21 transitive dependencies/static2.c
+++ b/test cases/rust/21 transitive dependencies/static2.c
@@ -1,0 +1,7 @@
+int static1(void);
+int static2(void);
+
+int static2(void)
+{
+    return 1 + static1();
+}


### PR DESCRIPTION
In the case r1 -> s1 -> s2 where s1 and s2 are uninstalled C static libraries, the libs1.a rule does not depend on libs2.a. That means that r1 rule must depend on both s1 and s2.