### PR TITLE
fix another regression in converting build_target kwargs to typed_kwargs

### DIFF
--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -554,11 +554,8 @@ def _objects_validator(vals: T.List[ObjectTypes]) -> T.Optional[str]:
     non_objects: T.List[str] = []
 
     for val in vals:
-        if isinstance(val, ExtractedObjects):
+        if isinstance(val, (str, File, ExtractedObjects)):
             continue
-        elif isinstance(val, (str, File)):
-            if not compilers.is_object(val):
-                non_objects.append(str(val))
         else:
             non_objects.extend(o for o in val.get_outputs() if not compilers.is_object(o))
 


### PR DESCRIPTION
This time we have a case where people are passing non-objects by using them as str | File, which we never warned about and silently accepted. If it was passed via custom_target outputs we *would* error out, interestingly enough. At the backend layer, we just pass them directly to the linker... which is valid, if we misdetected what's a valid linker input or people just used funny names. In particular, the mingw toolchain allows passing a *.def file directly, and some people are doing that.

If we do want to allow this, we should do it consistently. For now, just follow the current theme of what's expected, but do so by warning instead of fatally erroring, for cases where users were able to do it in the past.