### PR TITLE
Remove shebang from rewriter.py

### DIFF
--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2016 The Meson development team
 
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
The shebang should not be in the `rewriter.py` file, because the file cannot be run:
```
$ chmod +x mesonbuild/rewriter.py
$ mesonbuild/rewriter.py
Traceback (most recent call last):
  File "/opt/src/meson/mesonbuild/rewriter.py", line 27, in <module>
    from .ast import IntrospectionInterpreter, BUILD_TARGET_FUNCTIONS, AstConditionLevel, AstIDGenerator, AstIndentationGenerator, AstPrinter
ImportError: attempted relative import with no known parent package
$
```