### PR TITLE
Make the Requires.private line in generated .pkgconfig files reproducible

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -307,7 +307,7 @@ class DependenciesHelper:
         for name in reqs:
             vreqs = self.version_reqs.get(name, None)
             if vreqs:
-                result += [name + ' ' + self.format_vreq(vreq) for vreq in vreqs]
+                result += [name + ' ' + self.format_vreq(vreq) for vreq in sorted(vreqs)]
             else:
                 result += [name]
         return ', '.join(result)


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort, we noticed that meson was generates .pkgconfig files that are not reproducible.

For example, here is `neatvnc`'s pkgconfig file:

```
 Name: neatvnc
 Description: A Neat VNC server library
 Version: 0.7.0
-Requires.private: pixman-1, aml < 0.4.0, aml >= 0.3.0, zlib, libdrm, libturbojpeg, gnutls, nettle, hogweed, gmp, gbm, libavcodec, libavfilter, libavutil
+Requires.private: pixman-1, aml >= 0.3.0, aml < 0.4.0, zlib, libdrm, libturbojpeg, gnutls, nettle, hogweed, gmp, gbm, libavcodec, libavfilter, libavutil
 Libs: -L${libdir} -lneatvnc
 Libs.private: -lm
 Cflags: -I${includedir}
```

This is, ultimately, due to iterating over the contents of a `DefaultDict[Set]` and can thus be fixed by sorting the output immediately prior to generating the `Requires.private` string.

An alternative solution would be to place the `sorted(…)` call a few lines down:

```
return ', '.join(sorted(result))
```

However, this changes the expected ordering of the entire line and many users may be unhappy with that (alternative) change. By contrast, this commit will only enforce an ordering when there are multiple version requirements (eg. a lower and higher version range).

This was originally filed (with a slightly different patch) by myself [in the Debian bug tracker](https://bugs.debian.org/1056117).

**EDIT: Clarifying underlying `DefaultDict[Set]` data structure in comment.**