### PR TITLE
Only convert boolean values for cmake formats

### DIFF
--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -1210,7 +1210,7 @@ def do_replacement(regex: T.Pattern[str], line: str,
                 var, _ = confdata.get(varname)
                 if isinstance(var, str):
                     var_str = var
-                elif isinstance(var, bool):
+                elif variable_format.startswith("cmake") and isinstance(var, bool):
                     var_str = str(int(var))
                 elif isinstance(var, int):
                     var_str = str(var)


### PR DESCRIPTION
This caused a regression with mesondefine where
  `conf_data.set("FOO", true)`
turned into
  `#define FOO 1`
instead of
  `#define FOO`