### PR TITLE
machine file: Fix parenthesized expressions

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1097,6 +1097,8 @@ class MachineFileParser():
             return node.value
         elif isinstance(node, mparser.NumberNode):
             return node.value
+        elif isinstance(node, mparser.ParenthesizedNode):
+            return self._evaluate_statement(node.inner)
         elif isinstance(node, mparser.ArrayNode):
             # TODO: This is where recursive types would come in handy
             return [self._evaluate_statement(arg) for arg in node.args.arguments]

--- a/test cases/common/222 native prop/nativefile.ini
+++ b/test cases/common/222 native prop/nativefile.ini
@@ -1,3 +1,4 @@
 [properties]
 astring = 'mystring'
 anarray = ['one', 'two']
+withparentheses = ('anotherstring')  # Ensure parentheses can be parsed


### PR DESCRIPTION
79ed2415e9a5 didn't get this one. I'm not familiar enough with the codebase to be sure that this is the only instance of a missing handling of ParenthesizedNode; someone with more insight may want to look into it. Regardless:

<details>
<summary>meson.build</summary>

```meson
project('a', 'c')
```

</details>

<details>
<summary>a.ini</summary>

```ini
[constants]
foo = ('b' + 'ar')
```

</details>

Before: dies an early death without even printing version info
```
$ meson setup --cross-file=a.ini build

ERROR: Malformed value in machine file variable 'foo': Unsupported node type.
```

After: works fine
```
$ meson setup --cross-file=a.ini build
The Meson build system
Version: 1.3.99
...
```