### PR TITLE
Fix linking custom targets from extract_all_objects in a subproject on vs backend

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -893,7 +893,7 @@ class Backend:
             if self.environment.is_source(s):
                 sources.append(s)
             elif self.environment.is_object(s):
-                result.append(s.relative_name())
+                result.append(os.path.join(proj_dir_to_build_root, s.relative_name()))
 
         # MSVC generate an object file for PCH
         if extobj.pch and self.target_uses_pch(extobj.target):

--- a/test cases/common/273 extract all custom/copy.py
+++ b/test cases/common/273 extract all custom/copy.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import sys
+import shutil
+
+shutil.copyfile(sys.argv[1], sys.argv[2])

--- a/test cases/common/273 extract all custom/custom1.c
+++ b/test cases/common/273 extract all custom/custom1.c
@@ -1,0 +1,4 @@
+int func_custom1(void)
+{
+    return 0;
+}

--- a/test cases/common/273 extract all custom/gen1.c
+++ b/test cases/common/273 extract all custom/gen1.c
@@ -1,0 +1,4 @@
+int func_gen1(void)
+{
+    return 0;
+}

--- a/test cases/common/273 extract all custom/main.c
+++ b/test cases/common/273 extract all custom/main.c
@@ -1,0 +1,25 @@
+int func_custom1(void);
+int func_custom2(void);
+int func_custom3(void);
+int func_custom4(void);
+int func_gen1(void);
+int func_gen2(void);
+int func_gen3(void);
+int func_gen4(void);
+int func_gen5(void);
+int func_gen6(void);
+
+int main(void)
+{
+    func_custom1();
+    func_custom2();
+    func_custom3();
+    func_custom4();
+    func_gen1();
+    func_gen2();
+    func_gen3();
+    func_gen4();
+    func_gen5();
+    func_gen6();
+    return 0;
+}

--- a/test cases/common/273 extract all custom/meson.build
+++ b/test cases/common/273 extract all custom/meson.build
@@ -1,0 +1,42 @@
+project('extract all custom', 'c')
+fs = import('fs')
+
+copy = find_program('copy.py')
+gen = generator(copy,
+    output : 'gen_@PLAINNAME@',
+    arguments: ['@INPUT@', '@OUTPUT@'])
+src_gen = gen.process('gen1.c', 'sub/gen2.c')
+
+i = 0
+src_custom = []
+foreach f : ['custom1.c', 'sub/custom2.c']
+    i += 1
+    src_custom += [custom_target('custom' + i.to_string(),
+        input : f,
+        output : 'gen_' + fs.name(f),
+        command : [copy, '@INPUT@', '@OUTPUT@'])
+    ]
+endforeach
+
+s1 = subproject('s1')
+sub_a = s1.get_variable('sub_a')
+sub_b = s1.get_variable('sub_b')
+subsub_a = s1.get_variable('s2').get_variable('subsub_a')
+
+# Use objects from subproject and subsubproject
+a = static_library('a', 
+    sources : [src_gen, src_custom],
+    objects : [sub_a.extract_all_objects(), subsub_a.extract_all_objects()]
+)
+e1= executable('e1',
+    sources: ['main.c'],
+    link_with : a
+)
+
+# link with lib that uses objects from subproject of subproject
+e2 = executable('e2',
+    sources : ['main.c', src_gen, src_custom],
+    link_with : [sub_b]
+)
+test('test_e1', e1)
+test('test_e2', e2)

--- a/test cases/common/273 extract all custom/sub/custom2.c
+++ b/test cases/common/273 extract all custom/sub/custom2.c
@@ -1,0 +1,4 @@
+int func_custom2(void)
+{
+    return 0;
+}

--- a/test cases/common/273 extract all custom/sub/gen2.c
+++ b/test cases/common/273 extract all custom/sub/gen2.c
@@ -1,0 +1,4 @@
+int func_gen2(void)
+{
+    return 0;
+}

--- a/test cases/common/273 extract all custom/subprojects/s1/custom3.c
+++ b/test cases/common/273 extract all custom/subprojects/s1/custom3.c
@@ -1,0 +1,4 @@
+int func_custom3(void)
+{
+    return 0;
+}

--- a/test cases/common/273 extract all custom/subprojects/s1/gen3.c
+++ b/test cases/common/273 extract all custom/subprojects/s1/gen3.c
@@ -1,0 +1,4 @@
+int func_gen3(void)
+{
+    return 0;
+}

--- a/test cases/common/273 extract all custom/subprojects/s1/meson.build
+++ b/test cases/common/273 extract all custom/subprojects/s1/meson.build
@@ -1,0 +1,26 @@
+project('subproj', 'c')
+
+fs = import('fs')
+copy = find_program('../../copy.py')
+
+i = 2
+src_custom = []
+foreach f : ['custom3.c', 'sub/custom4.c']
+    i += 1
+    src_custom += [custom_target('custom' + i.to_string(),
+        input : f,
+        output : 'gen_' + fs.name(f),
+        command : [copy, '@INPUT@', '@OUTPUT@'])
+    ]
+endforeach
+
+gen = generator(copy,
+    output : 'gen_@PLAINNAME@',
+    arguments: ['@INPUT@', '@OUTPUT@'])
+src_gen = gen.process('gen3.c', 'sub/gen4.c')
+
+s2 = subproject('s2')
+subsub_a = s2.get_variable('subsub_a')
+
+sub_a = static_library('sub_a', sources : [src_custom, src_gen])
+sub_b = static_library('sub_b', objects : [sub_a.extract_all_objects(), subsub_a.extract_all_objects()])

--- a/test cases/common/273 extract all custom/subprojects/s1/sub/custom4.c
+++ b/test cases/common/273 extract all custom/subprojects/s1/sub/custom4.c
@@ -1,0 +1,4 @@
+int func_custom4(void)
+{
+    return 0;
+}

--- a/test cases/common/273 extract all custom/subprojects/s1/sub/gen4.c
+++ b/test cases/common/273 extract all custom/subprojects/s1/sub/gen4.c
@@ -1,0 +1,4 @@
+int func_gen4(void)
+{
+    return 0;
+}

--- a/test cases/common/273 extract all custom/subprojects/s1/subprojects/s2/gen5.c
+++ b/test cases/common/273 extract all custom/subprojects/s1/subprojects/s2/gen5.c
@@ -1,0 +1,4 @@
+int func_gen5(void)
+{
+    return 0;
+}

--- a/test cases/common/273 extract all custom/subprojects/s1/subprojects/s2/meson.build
+++ b/test cases/common/273 extract all custom/subprojects/s1/subprojects/s2/meson.build
@@ -1,0 +1,11 @@
+project('subproj', 'c')
+
+fs = import('fs')
+copy = find_program('../../../../copy.py')
+
+gen = generator(copy,
+    output : 'gen_@PLAINNAME@',
+    arguments: ['@INPUT@', '@OUTPUT@'])
+src_gen = gen.process('gen5.c', 'sub/gen6.c')
+
+subsub_a = static_library('subsub_a', sources : [src_gen])

--- a/test cases/common/273 extract all custom/subprojects/s1/subprojects/s2/sub/gen6.c
+++ b/test cases/common/273 extract all custom/subprojects/s1/subprojects/s2/sub/gen6.c
@@ -1,0 +1,4 @@
+int func_gen6(void)
+{
+    return 0;
+}


### PR DESCRIPTION
Fixes #8020

The actual bug was in `_determine_ext_objs` in `backends.py`, but that function is only called with a nonempty `proj_dir_to_build_root` in the VS backend. (So this also will not change behavior for ninja or any other backends.)

An alternative fix would be making `_determine_ext_objs` not take a `proj_dir_to_build_root` parameter at all and instead only adjusting the paths after calling it by changing this line
https://github.com/mesonbuild/meson/blob/85e4ee5b54c334d4104e6c3b2f3fda11cd9b2dd6/mesonbuild/backend/backends.py#L509
to
```py
obj_list.extend([os.path.join(proj_dir_to_build_root, p) for p in self._determine_ext_objs(obj)]) 
```

The added test case is taken from #8211 .