### PR TITLE
fix broken type annotation imports being ignored

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - run: python -m pip install mypy types-PyYAML
+    - run: python -m pip install mypy coverage types-PyYAML types-tqdm types-chevron
     - run: python run_mypy.py --allver
       env:
         PYTHONUNBUFFERED: 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - run: python -m pip install mypy coverage types-PyYAML types-tqdm types-chevron
+    - run: python -m pip install mypy coverage strictyaml types-PyYAML types-tqdm types-chevron
     - run: python run_mypy.py --allver
       env:
         PYTHONUNBUFFERED: 1

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -2,7 +2,7 @@
 strict_optional               = False
 show_error_context            = False
 show_column_numbers           = True
-ignore_missing_imports        = True
+ignore_missing_imports        = False
 implicit_reexport             = False
 
 follow_imports                = silent

--- a/docs/refman/loaderyaml.py
+++ b/docs/refman/loaderyaml.py
@@ -41,7 +41,7 @@ class Template:
 
 class StrictTemplate(Template):
     def __init__(self) -> None:
-        from strictyaml import Map, MapPattern, Optional, Str, Seq, Int, Bool, EmptyList, OrValidator
+        from strictyaml import Map, MapPattern, Optional, Str, Seq, Int, Bool, EmptyList, OrValidator # type: ignore[import-untyped]
 
         d_named_object = {
             'name': Str(),

--- a/mesonbuild/compilers/mixins/compcert.py
+++ b/mesonbuild/compilers/mixins/compcert.py
@@ -20,7 +20,7 @@ import re
 import typing as T
 
 if T.TYPE_CHECKING:
-    from envconfig import MachineInfo
+    from ...envconfig import MachineInfo
     from ...environment import Environment
     from ...compilers.compilers import Compiler
 else:

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -30,7 +30,7 @@ if T.TYPE_CHECKING:
     from ..compilers import Compiler, RunResult
     from ..interpreterbase import TYPE_var, TYPE_kwargs
     from .kwargs import ExtractRequired, ExtractSearchDirs
-    from .interpreter.interpreter import SourceOutputs
+    from .interpreter import SourceOutputs
     from ..mlog import TV_LoggableList
 
     from typing_extensions import TypedDict, Literal
@@ -856,7 +856,8 @@ class CompilerHolder(ObjectHolder['Compiler']):
     )
     def preprocess_method(self, args: T.Tuple[T.List['mesonlib.FileOrString']], kwargs: 'PreprocessKW') -> T.List[build.CustomTargetIndex]:
         compiler = self.compiler.get_preprocessor()
-        sources: 'SourceOutputs' = self.interpreter.source_strings_to_files(args[0])
+        _sources: T.List[mesonlib.File] = self.interpreter.source_strings_to_files(args[0])
+        sources = T.cast('T.List[SourceOutputs]', _sources)
         if any(isinstance(s, (build.CustomTarget, build.CustomTargetIndex, build.GeneratedList)) for s in sources):
             FeatureNew.single_use('compiler.preprocess with generated sources', '1.1.0', self.subproject,
                                   location=self.current_node)

--- a/mesonbuild/mdevenv.py
+++ b/mesonbuild/mdevenv.py
@@ -5,6 +5,7 @@ import argparse
 import tempfile
 import shutil
 import itertools
+import typing as T
 
 from pathlib import Path
 from . import build, minstall
@@ -12,9 +13,9 @@ from .mesonlib import (EnvironmentVariables, MesonException, is_windows, setup_v
                        get_wine_shortpath, MachineChoice)
 from . import mlog
 
-import typing as T
+
 if T.TYPE_CHECKING:
-    from .backends import InstallData
+    from .backend.backends import InstallData
 
 POWERSHELL_EXES = {'pwsh.exe', 'powershell.exe'}
 

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -69,7 +69,8 @@ modules = [
     'mesonbuild/mtest.py',
     'mesonbuild/optinterpreter.py',
     'mesonbuild/programs.py',
-
+]
+additional = [
     'run_mypy.py',
     'run_project_tests.py',
     'run_single_test.py',
@@ -115,23 +116,29 @@ def main() -> int:
         print('\x1bc', end='', flush=True)
 
     to_check = [] # type: T.List[str]
+    additional_to_check = [] # type: T.List[str]
     if opts.files:
         for f in opts.files:
             if f in modules:
                 to_check.append(f)
             elif any(f.startswith(i) for i in modules):
                 to_check.append(f)
+            elif f in additional:
+                additional_to_check.append(f)
+            elif any(f.startswith(i) for i in additional):
+                additional_to_check.append(f)
             else:
                 if not opts.quiet:
                     print(f'skipping {f!r} because it is not yet typed')
     else:
         to_check.extend(modules)
+        additional_to_check.extend(additional)
 
     if to_check:
         command = [opts.mypy] if opts.mypy else [sys.executable, '-m', 'mypy']
         if not opts.quiet:
             print('Running mypy (this can take some time) ...')
-        retcode = subprocess.run(command + args + to_check, cwd=root).returncode
+        retcode = subprocess.run(command + args + to_check + additional_to_check, cwd=root).returncode
         if opts.allver and retcode == 0:
             for minor in range(7, sys.version_info[1]):
                 if not opts.quiet:


### PR DESCRIPTION
If an annotation could not be resolved, it's classified as a "missing import" and our configuration ignored it:

```
Skipping analyzing "mesonbuild.backends": module is installed, but missing library stubs or py.typed marker
```

As far as mypy is concerned, this library may or may not exist, but it doesn't have any typing information at all (may need to be installed first).

We ignored this because of our docs/ and tools/ thirdparty dependencies, but we really should not. It is trivial to install them, and then enforce that this "just works".

By enforcing it, we also make sure typos get caught.