### PR TITLE
vs: Manually add generated .o objects to project file

### DIFF
--- a/test cases/common/52 object generator/meson.build
+++ b/test cases/common/52 object generator/meson.build
@@ -29,6 +29,14 @@ gen2 = generator(python,
  arguments : [comp, cc, '@INPUT@', '@OUTPUT0@'])
 generated2 = gen2.process(['source3.c'])
 
-e = executable('prog', 'prog.c', generated, generated2)
+# Generate an object file ending with .o even on Windows.
+# The VS backend needs to handle .o objects differently from .obj objects.
+gen3 = generator(python,
+ output : '@BASENAME@.o',
+ arguments : [comp, cc, '@INPUT@', '@OUTPUT@'])
+
+generated3 = gen3.process(['source4.c'])
+
+e = executable('prog', 'prog.c', generated, generated2, generated3)
 
 test('objgen', e)

--- a/test cases/common/52 object generator/prog.c
+++ b/test cases/common/52 object generator/prog.c
@@ -1,7 +1,8 @@
 int func1_in_obj(void);
 int func2_in_obj(void);
 int func3_in_obj(void);
+int func4_in_obj(void);
 
 int main(void) {
-    return func1_in_obj() + func2_in_obj() + func3_in_obj();
+    return func1_in_obj() + func2_in_obj() + func3_in_obj() + func4_in_obj();
 }

--- a/test cases/common/52 object generator/source4.c
+++ b/test cases/common/52 object generator/source4.c
@@ -1,0 +1,3 @@
+int func4_in_obj(void) {
+    return 0;
+}


### PR DESCRIPTION
Fixes #12550 . Also see that issue for more discussion of the problem.

This in particular reverts commit baa6df2ce73877747c6327a0850a3eaa00e69f5f, which claimed that VS2015 automatically includes outputs from `CustomBuild` commands. As far as I could see from testing on Visual Studio versions 2022, 2015, 2013, and 2010 (stock versions of each, with no settings changed) this is not true: In the example given in the issue, all tested versions fail with the given linker error. I'm not sure what the reason for baa6df2ce73877747c6327a0850a3eaa00e69f5f was - maybe other parts of the project files were changed in the meantime that caused this behavior, or there's some additional configuration I'm missing?

Tests like `nasm/1 configure file` or `common/52 object generator` should already cover this, so I didn't add another test.
