### PR TITLE
Always use posix paths when retrieving link name

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -358,16 +358,16 @@ class Backend:
             # In AIX, if we archive .so, the blibpath must link to archived shared library otherwise to the .so file.
             if mesonlib.is_aix() and target.aix_so_archive:
                 link_lib = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*', '.a', link_lib.replace('.so', '.a'))
-            return os.path.join(self.get_target_dir(target), link_lib)
+            return Path(self.get_target_dir(target), link_lib).as_posix()
         elif isinstance(target, build.StaticLibrary):
-            return os.path.join(self.get_target_dir(target), target.get_filename())
+            return Path(self.get_target_dir(target), target.get_filename()).as_posix()
         elif isinstance(target, (build.CustomTarget, build.CustomTargetIndex)):
             if not target.is_linkable_target():
                 raise MesonException(f'Tried to link against custom target "{target.name}", which is not linkable.')
-            return os.path.join(self.get_target_dir(target), target.get_filename())
+            return Path(self.get_target_dir(target), target.get_filename()).as_posix()
         elif isinstance(target, build.Executable):
             if target.import_filename:
-                return os.path.join(self.get_target_dir(target), target.get_import_filename())
+                return Path(self.get_target_dir(target), target.get_import_filename()).as_posix()
             else:
                 return None
         raise AssertionError(f'BUG: Tried to link to {target!r} which is not linkable')


### PR DESCRIPTION
This commit modifies the get_target_filename_for_linking function to always return POSIX-style paths, even on Windows systems. This is necessary because the Ninja generator can have issues with Windows-style paths when using the `/WHOLEARCHIVE:` flag.

This is consistent with the syntax accepted by the cl and clang-cl compilers, as documented in the Microsoft documentation: https: //learn.microsoft.com/en-us/cpp/build/reference/cl-filename-syntax?view=msvc-170

Fixes: 12534