### PR TITLE
Fix coverage with lcov 2.0 and uncovered subprojects

### DIFF
--- a/mesonbuild/scripts/coverage.py
+++ b/mesonbuild/scripts/coverage.py
@@ -145,6 +145,7 @@ def coverage(outputs: T.List[str], source_root: str, subproject_root: str, build
                                    '--remove', covinfo,
                                    *lcov_subpoject_exclude,
                                    *lcov_exe_rc_branch_coverage,
+                                   '--ignore-errors', 'unused',
                                    '--output-file', covinfo] + lcov_config)
             subprocess.check_call([genhtml_exe,
                                    '--prefix', build_root,


### PR DESCRIPTION
Version 2.0 of lcov triggers an error when an exclude pattern is unused.  This can happen when the project has subprojects, but no code in them ends up covered:

    lcov: ERROR: 'exclude' pattern '/[...]/subprojects/*' is unused.
             (use "lcov --ignore-errors unused ..." to bypass this error)

So, simply do as it says.  Unused patterns doesn't seem problematic (or even interesting) here, so I don't think there's any risk in simply turning this off, which matches what happened with earlier versions of lcov anyway.