### PR TITLE
Remove `get_buildtype_args` function

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1016,11 +1016,6 @@ class Backend:
         # command-line or default_options inside project().
         commands += compiler.get_option_compile_args(copt_proxy)
 
-        # Add buildtype args: optimization level, debugging, etc.
-        buildtype = target.get_option(OptionKey('buildtype'))
-        assert isinstance(buildtype, str), 'for mypy'
-        commands += compiler.get_buildtype_args(buildtype)
-
         optimization = target.get_option(OptionKey('optimization'))
         assert isinstance(optimization, str), 'for mypy'
         commands += compiler.get_optimization_args(optimization)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1458,7 +1458,6 @@ class NinjaBackend(backends.Backend):
         return args, deps
 
     def generate_cs_target(self, target: build.BuildTarget):
-        buildtype = target.get_option(OptionKey('buildtype'))
         fname = target.get_filename()
         outname_rel = os.path.join(self.get_target_dir(target), fname)
         src_list = target.get_sources()
@@ -1466,7 +1465,6 @@ class NinjaBackend(backends.Backend):
         rel_srcs = [os.path.normpath(s.rel_to_builddir(self.build_to_src)) for s in src_list]
         deps = []
         commands = compiler.compiler_args(target.extra_args['cs'])
-        commands += compiler.get_buildtype_args(buildtype)
         commands += compiler.get_optimization_args(target.get_option(OptionKey('optimization')))
         commands += compiler.get_debug_args(target.get_option(OptionKey('debug')))
         if isinstance(target, build.Executable):
@@ -1509,7 +1507,6 @@ class NinjaBackend(backends.Backend):
 
     def determine_single_java_compile_args(self, target, compiler):
         args = []
-        args += compiler.get_buildtype_args(target.get_option(OptionKey('buildtype')))
         args += self.build.get_global_args(compiler, target.for_machine)
         args += self.build.get_project_args(compiler, target.subproject, target.for_machine)
         args += target.get_java_args()
@@ -1742,7 +1739,6 @@ class NinjaBackend(backends.Backend):
 
         args: T.List[str] = []
         args += cython.get_always_args()
-        args += cython.get_buildtype_args(target.get_option(OptionKey('buildtype')))
         args += cython.get_debug_args(target.get_option(OptionKey('debug')))
         args += cython.get_optimization_args(target.get_option(OptionKey('optimization')))
         args += cython.get_option_compile_args(target.get_options())
@@ -3379,7 +3375,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         # Add things like /NOLOGO; usually can't be overridden
         commands += linker.get_linker_always_args()
         # Add buildtype linker args: optimization level, etc.
-        commands += linker.get_buildtype_linker_args(target.get_option(OptionKey('buildtype')))
+        commands += linker.get_optimization_link_args(target.get_option(OptionKey('optimization')))
         # Add /DEBUG and the pdb filename when using MSVC
         if target.get_option(OptionKey('debug')):
             commands += self.get_link_debugfile_args(linker, target)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1126,9 +1126,8 @@ class Vs2010Backend(backends.Backend):
         return (target_args, file_args), (target_defines, file_defines), (target_inc_dirs, file_inc_dirs)
 
     @staticmethod
-    def get_build_args(compiler, buildtype: str, optimization_level: str, debug: bool, sanitize: str) -> T.List[str]:
-        build_args = compiler.get_buildtype_args(buildtype)
-        build_args += compiler.get_optimization_args(optimization_level)
+    def get_build_args(compiler, optimization_level: str, debug: bool, sanitize: str) -> T.List[str]:
+        build_args = compiler.get_optimization_args(optimization_level)
         build_args += compiler.get_debug_args(debug)
         build_args += compiler.sanitizer_compile_args(sanitize)
 
@@ -1290,7 +1289,7 @@ class Vs2010Backend(backends.Backend):
             file_args
             ) -> None:
         compiler = self._get_cl_compiler(target)
-        buildtype_link_args = compiler.get_buildtype_linker_args(self.buildtype)
+        buildtype_link_args = compiler.get_optimization_link_args(self.optimization)
 
         # Prefix to use to access the build root from the vcxproj dir
         down = self.target_to_build_root(target)
@@ -1403,10 +1402,7 @@ class Vs2010Backend(backends.Backend):
         # Linker options
         link = ET.SubElement(compiles, 'Link')
         extra_link_args = compiler.compiler_args()
-        # FIXME: Can these buildtype linker args be added as tags in the
-        # vcxproj file (similar to buildtype compiler args) instead of in
-        # AdditionalOptions?
-        extra_link_args += compiler.get_buildtype_linker_args(self.buildtype)
+        extra_link_args += compiler.get_optimization_link_args(self.optimization)
         # Generate Debug info
         if self.debug:
             self.generate_debug_information(link)
@@ -1634,7 +1630,7 @@ class Vs2010Backend(backends.Backend):
         gen_hdrs += custom_hdrs
 
         compiler = self._get_cl_compiler(target)
-        build_args = Vs2010Backend.get_build_args(compiler, self.buildtype, self.optimization, self.debug, self.sanitize)
+        build_args = Vs2010Backend.get_build_args(compiler, self.optimization, self.debug, self.sanitize)
 
         assert isinstance(target, (build.Executable, build.SharedLibrary, build.StaticLibrary, build.SharedModule)), 'for mypy'
         # Prefix to use to access the build root from the vcxproj dir

--- a/mesonbuild/compilers/asm.py
+++ b/mesonbuild/compilers/asm.py
@@ -98,10 +98,6 @@ class NasmCompiler(Compiler):
         if self.info.cpu_family not in {'x86', 'x86_64'}:
             raise EnvironmentException(f'ASM compiler {self.id!r} does not support {self.info.cpu_family} CPU family')
 
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        # FIXME: Not implemented
-        return []
-
     def get_pic_args(self) -> T.List[str]:
         return []
 
@@ -185,10 +181,6 @@ class MasmCompiler(Compiler):
         if self.info.cpu_family not in {'x86', 'x86_64'}:
             raise EnvironmentException(f'ASM compiler {self.id!r} does not support {self.info.cpu_family} CPU family')
 
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        # FIXME: Not implemented
-        return []
-
     def get_pic_args(self) -> T.List[str]:
         return []
 
@@ -239,10 +231,6 @@ class MasmARMCompiler(Compiler):
     def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
         if self.info.cpu_family not in {'arm', 'aarch64'}:
             raise EnvironmentException(f'ASM compiler {self.id!r} does not support {self.info.cpu_family} CPU family')
-
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        # FIXME: Not implemented
-        return []
 
     def get_pic_args(self) -> T.List[str]:
         return []

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -190,78 +190,6 @@ class CompileCheckMode(enum.Enum):
     LINK = 'link'
 
 
-cuda_buildtype_args: T.Dict[str, T.List[str]] = {
-    'plain': [],
-    'debug': ['-g', '-G'],
-    'debugoptimized': ['-g', '-lineinfo'],
-    'release': [],
-    'minsize': [],
-    'custom': [],
-}
-
-java_buildtype_args: T.Dict[str, T.List[str]] = {
-    'plain': [],
-    'debug': ['-g'],
-    'debugoptimized': ['-g'],
-    'release': [],
-    'minsize': [],
-    'custom': [],
-}
-
-rust_buildtype_args: T.Dict[str, T.List[str]] = {
-    'plain': [],
-    'debug': [],
-    'debugoptimized': [],
-    'release': [],
-    'minsize': [],
-    'custom': [],
-}
-
-d_gdc_buildtype_args: T.Dict[str, T.List[str]] = {
-    'plain': [],
-    'debug': [],
-    'debugoptimized': ['-finline-functions'],
-    'release': ['-finline-functions'],
-    'minsize': [],
-    'custom': [],
-}
-
-d_ldc_buildtype_args: T.Dict[str, T.List[str]] = {
-    'plain': [],
-    'debug': [],
-    'debugoptimized': ['-enable-inlining', '-Hkeep-all-bodies'],
-    'release': ['-enable-inlining', '-Hkeep-all-bodies'],
-    'minsize': [],
-    'custom': [],
-}
-
-d_dmd_buildtype_args: T.Dict[str, T.List[str]] = {
-    'plain': [],
-    'debug': [],
-    'debugoptimized': ['-inline'],
-    'release': ['-inline'],
-    'minsize': [],
-    'custom': [],
-}
-
-mono_buildtype_args: T.Dict[str, T.List[str]] = {
-    'plain': [],
-    'debug': [],
-    'debugoptimized': ['-optimize+'],
-    'release': ['-optimize+'],
-    'minsize': [],
-    'custom': [],
-}
-
-swift_buildtype_args: T.Dict[str, T.List[str]] = {
-    'plain': [],
-    'debug': [],
-    'debugoptimized': [],
-    'release': [],
-    'minsize': [],
-    'custom': [],
-}
-
 gnu_winlibs = ['-lkernel32', '-luser32', '-lgdi32', '-lwinspool', '-lshell32',
                '-lole32', '-loleaut32', '-luuid', '-lcomdlg32', '-ladvapi32']
 
@@ -279,25 +207,11 @@ clike_optimization_args: T.Dict[str, T.List[str]] = {
     's': ['-Os'],
 }
 
-cuda_optimization_args: T.Dict[str, T.List[str]] = {
-    'plain': [],
-    '0': [],
-    'g': ['-O0'],
-    '1': ['-O1'],
-    '2': ['-O2'],
-    '3': ['-O3'],
-    's': ['-O3']
-}
-
-cuda_debug_args: T.Dict[bool, T.List[str]] = {
-    False: [],
-    True: ['-g']
-}
-
 clike_debug_args: T.Dict[bool, T.List[str]] = {
     False: [],
     True: ['-g']
 }
+
 
 MSCRT_VALS = ['none', 'md', 'mdd', 'mt', 'mtd']
 
@@ -1067,11 +981,8 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
     def bitcode_args(self) -> T.List[str]:
         return self.linker.bitcode_args()
 
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        raise EnvironmentException(f'{self.id} does not implement get_buildtype_args')
-
-    def get_buildtype_linker_args(self, buildtype: str) -> T.List[str]:
-        return self.linker.get_buildtype_args(buildtype)
+    def get_optimization_link_args(self, optimization_level: str) -> T.List[str]:
+        return self.linker.get_optimization_link_args(optimization_level)
 
     def get_soname_args(self, env: 'Environment', prefix: str, shlib_name: str,
                         suffix: str, soversion: str,

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -20,7 +20,7 @@ import typing as T
 from ..mesonlib import EnvironmentException
 from ..linkers import RSPFileSyntax
 
-from .compilers import Compiler, mono_buildtype_args
+from .compilers import Compiler
 from .mixins.islinker import BasicLinkerIsCompilerMixin
 
 if T.TYPE_CHECKING:
@@ -113,9 +113,6 @@ class CsCompiler(BasicLinkerIsCompilerMixin, Compiler):
     def needs_static_linker(self) -> bool:
         return False
 
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        return mono_buildtype_args[buildtype]
-
     def get_debug_args(self, is_debug: bool) -> T.List[str]:
         return ['-debug'] if is_debug else []
 
@@ -139,16 +136,11 @@ class VisualStudioCsCompiler(CsCompiler):
 
     id = 'csc'
 
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        res = mono_buildtype_args[buildtype]
-        if not self.info.is_windows():
-            tmp = []
-            for flag in res:
-                if flag == '-debug':
-                    flag = '-debug:portable'
-                tmp.append(flag)
-            res = tmp
-        return res
+    def get_debug_args(self, is_debug: bool) -> T.List[str]:
+        if is_debug:
+            return ['-debug'] if self.info.is_windows() else ['-debug:portable']
+        else:
+            return []
 
     def rsp_file_syntax(self) -> 'RSPFileSyntax':
         return RSPFileSyntax.MSVC

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -24,8 +24,7 @@ from ..mesonlib import (
     EnvironmentException, Popen_safe,
     is_windows, LibType, OptionKey, version_compare,
 )
-from .compilers import (Compiler, cuda_buildtype_args, cuda_optimization_args,
-                        cuda_debug_args)
+from .compilers import Compiler
 
 if T.TYPE_CHECKING:
     from .compilers import CompileCheckMode
@@ -37,6 +36,22 @@ if T.TYPE_CHECKING:
     from ..linkers.linkers import DynamicLinker
     from ..mesonlib import MachineChoice
     from ..programs import ExternalProgram
+
+
+cuda_optimization_args: T.Dict[str, T.List[str]] = {
+    'plain': [],
+    '0': ['-G'],
+    'g': ['-O0'],
+    '1': ['-O1'],
+    '2': ['-O2', '-lineinfo'],
+    '3': ['-O3'],
+    's': ['-O3']
+}
+
+cuda_debug_args: T.Dict[bool, T.List[str]] = {
+    False: [],
+    True: ['-g']
+}
 
 
 class _Phase(enum.Enum):
@@ -702,12 +717,6 @@ class CudaCompiler(Compiler):
     def get_warn_args(self, level: str) -> T.List[str]:
         return self.warn_args[level]
 
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        # nvcc doesn't support msvc's "Edit and Continue" PDB format; "downgrade" to
-        # a regular PDB to avoid cl's warning to that effect (D9025 : overriding '/ZI' with '/Zi')
-        host_args = ['/Zi' if arg == '/ZI' else arg for arg in self.host_compiler.get_buildtype_args(buildtype)]
-        return cuda_buildtype_args[buildtype] + self._to_host_flags(host_args)
-
     def get_include_args(self, path: str, is_system: bool) -> T.List[str]:
         if path == '':
             path = '.'
@@ -722,8 +731,8 @@ class CudaCompiler(Compiler):
     def get_depfile_suffix(self) -> str:
         return 'd'
 
-    def get_buildtype_linker_args(self, buildtype: str) -> T.List[str]:
-        return self._to_host_flags(self.host_compiler.get_buildtype_linker_args(buildtype), _Phase.LINKER)
+    def get_optimization_link_args(self, optimization_level: str) -> T.List[str]:
+        return self._to_host_flags(self.host_compiler.get_optimization_link_args(optimization_level), _Phase.LINKER)
 
     def build_rpath_args(self, env: 'Environment', build_dir: str, from_dir: str,
                          rpath_paths: T.Tuple[str, ...], build_rpath: str,

--- a/mesonbuild/compilers/cython.py
+++ b/mesonbuild/compilers/cython.py
@@ -54,10 +54,6 @@ class CythonCompiler(Compiler):
             if p.returncode != 0:
                 raise EnvironmentException(f'Cython compiler {self.id!r} cannot compile programs')
 
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        # Cython doesn't implement this, but Meson requires an implementation
-        return []
-
     def get_pic_args(self) -> T.List[str]:
         # We can lie here, it's fine
         return []

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -28,9 +28,6 @@ from ..mesonlib import (
 
 from . import compilers
 from .compilers import (
-    d_dmd_buildtype_args,
-    d_gdc_buildtype_args,
-    d_ldc_buildtype_args,
     clike_debug_args,
     Compiler,
     CompileCheckMode,
@@ -77,8 +74,8 @@ ldc_optimization_args: T.Dict[str, T.List[str]] = {
     '0': [],
     'g': [],
     '1': ['-O1'],
-    '2': ['-O2'],
-    '3': ['-O3'],
+    '2': ['-O2', '-enable-inlining', '-Hkeep-all-bodies'],
+    '3': ['-O3', '-enable-inlining', '-Hkeep-all-bodies'],
     's': ['-Oz'],
 }
 
@@ -87,9 +84,19 @@ dmd_optimization_args: T.Dict[str, T.List[str]] = {
     '0': [],
     'g': [],
     '1': ['-O'],
-    '2': ['-O'],
-    '3': ['-O'],
+    '2': ['-O', '-inline'],
+    '3': ['-O', '-inline'],
     's': ['-O'],
+}
+
+gdc_optimization_args: T.Dict[str, T.List[str]] = {
+    'plain': [],
+    '0': ['-O0'],
+    'g': ['-Og'],
+    '1': ['-O1'],
+    '2': ['-O2', '-finline-functions'],
+    '3': ['-O3', '-finline-functions'],
+    's': ['-Os'],
 }
 
 
@@ -171,8 +178,8 @@ class DmdLikeCompilerMixin(CompilerMixinBase):
             return []
         return ['-fPIC']
 
-    def get_buildtype_linker_args(self, buildtype: str) -> T.List[str]:
-        if buildtype != 'plain':
+    def get_optimization_link_args(self, optimization_level: str) -> T.List[str]:
+        if optimization_level != 'plain':
             return self._get_target_arch_args()
         return []
 
@@ -541,8 +548,8 @@ class DCompiler(Compiler):
 
         return res
 
-    def get_buildtype_linker_args(self, buildtype: str) -> T.List[str]:
-        if buildtype != 'plain':
+    def get_optimization_link_args(self, optimization_level: str) -> T.List[str]:
+        if optimization_level != 'plain':
             return self._get_target_arch_args()
         return []
 
@@ -707,8 +714,8 @@ class GnuDCompiler(GnuCompiler, DCompiler):
     def get_warn_args(self, level: str) -> T.List[str]:
         return self.warn_args[level]
 
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        return d_gdc_buildtype_args[buildtype]
+    def get_optimization_args(self, optimization_level: str) -> T.List[str]:
+        return gdc_optimization_args[optimization_level]
 
     def compute_parameters_with_absolute_paths(self, parameter_list: T.List[str],
                                                build_dir: str) -> T.List[str]:
@@ -774,11 +781,6 @@ class LLVMDCompiler(DmdLikeCompilerMixin, DCompiler):
             return ['-wi']
         return []
 
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        if buildtype != 'plain':
-            return self._get_target_arch_args() + d_ldc_buildtype_args[buildtype]
-        return d_ldc_buildtype_args[buildtype]
-
     def get_pic_args(self) -> T.List[str]:
         return ['-relocation-model=pic']
 
@@ -789,6 +791,8 @@ class LLVMDCompiler(DmdLikeCompilerMixin, DCompiler):
         return self._unix_args_to_native(args, self.info, self.linker.id)
 
     def get_optimization_args(self, optimization_level: str) -> T.List[str]:
+        if optimization_level != 'plain':
+            return self._get_target_arch_args() + ldc_optimization_args[optimization_level]
         return ldc_optimization_args[optimization_level]
 
     @classmethod
@@ -834,11 +838,6 @@ class DmdDCompiler(DmdLikeCompilerMixin, DCompiler):
             return ['-color=on']
         return []
 
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        if buildtype != 'plain':
-            return self._get_target_arch_args() + d_dmd_buildtype_args[buildtype]
-        return d_dmd_buildtype_args[buildtype]
-
     def get_std_exe_link_args(self) -> T.List[str]:
         if self.info.is_windows():
             # DMD links against D runtime only when main symbol is found,
@@ -880,6 +879,8 @@ class DmdDCompiler(DmdLikeCompilerMixin, DCompiler):
         return self._unix_args_to_native(args, self.info, self.linker.id)
 
     def get_optimization_args(self, optimization_level: str) -> T.List[str]:
+        if optimization_level != 'plain':
+            return self._get_target_arch_args() + dmd_optimization_args[optimization_level]
         return dmd_optimization_args[optimization_level]
 
     def can_linker_accept_rsp(self) -> bool:

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -23,9 +23,7 @@ from .compilers import (
     CompileCheckMode,
 )
 from .mixins.clike import CLikeCompiler
-from .mixins.gnu import (
-    GnuCompiler, gnulike_buildtype_args, gnu_optimization_args
-)
+from .mixins.gnu import GnuCompiler,  gnu_optimization_args
 from .mixins.intel import IntelGnuLikeCompiler, IntelVisualStudioLikeCompiler
 from .mixins.clang import ClangCompiler
 from .mixins.elbrus import ElbrusCompiler
@@ -75,9 +73,6 @@ class FortranCompiler(CLikeCompiler, Compiler):
         source_name = 'sanitycheckf.f90'
         code = 'program main; print *, "Fortran compilation is working."; end program\n'
         return self._sanity_check_impl(work_dir, environment, source_name, code)
-
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        return gnulike_buildtype_args[buildtype]
 
     def get_optimization_args(self, optimization_level: str) -> T.List[str]:
         return gnu_optimization_args[optimization_level]

--- a/mesonbuild/compilers/java.py
+++ b/mesonbuild/compilers/java.py
@@ -21,13 +21,19 @@ import textwrap
 import typing as T
 
 from ..mesonlib import EnvironmentException
-from .compilers import Compiler, java_buildtype_args
+from .compilers import Compiler
 from .mixins.islinker import BasicLinkerIsCompilerMixin
 
 if T.TYPE_CHECKING:
     from ..envconfig import MachineInfo
     from ..environment import Environment
     from ..mesonlib import MachineChoice
+
+
+java_debug_args: T.Dict[bool, T.List[str]] = {
+    False: ['-g:none'],
+    True: ['-g']
+}
 
 class JavaCompiler(BasicLinkerIsCompilerMixin, Compiler):
 
@@ -68,9 +74,6 @@ class JavaCompiler(BasicLinkerIsCompilerMixin, Compiler):
 
     def get_pch_name(self, name: str) -> str:
         return ''
-
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        return java_buildtype_args[buildtype]
 
     def compute_parameters_with_absolute_paths(self, parameter_list: T.List[str],
                                                build_dir: str) -> T.List[str]:
@@ -120,6 +123,4 @@ class JavaCompiler(BasicLinkerIsCompilerMixin, Compiler):
         return []
 
     def get_debug_args(self, is_debug: bool) -> T.List[str]:
-        if is_debug:
-            return ['-g']
-        return ['-g:none']
+        return java_debug_args[is_debug]

--- a/mesonbuild/compilers/mixins/arm.py
+++ b/mesonbuild/compilers/mixins/arm.py
@@ -34,15 +34,6 @@ else:
     # do). This gives up DRYer type checking, with no runtime impact
     Compiler = object
 
-arm_buildtype_args: T.Dict[str, T.List[str]] = {
-    'plain': [],
-    'debug': [],
-    'debugoptimized': [],
-    'release': [],
-    'minsize': [],
-    'custom': [],
-}
-
 arm_optimization_args: T.Dict[str, T.List[str]] = {
     'plain': [],
     '0': ['-O0'],
@@ -51,15 +42,6 @@ arm_optimization_args: T.Dict[str, T.List[str]] = {
     '2': [], # Compiler defaults to -O2
     '3': ['-O3', '-Otime'],
     's': ['-O3'], # Compiler defaults to -Ospace
-}
-
-armclang_buildtype_args: T.Dict[str, T.List[str]] = {
-    'plain': [],
-    'debug': [],
-    'debugoptimized': [],
-    'release': [],
-    'minsize': [],
-    'custom': [],
 }
 
 armclang_optimization_args: T.Dict[str, T.List[str]] = {
@@ -95,9 +77,6 @@ class ArmCompiler(Compiler):
     def get_pic_args(self) -> T.List[str]:
         # FIXME: Add /ropi, /rwpi, /fpic etc. qualifiers to --apcs
         return []
-
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        return arm_buildtype_args[buildtype]
 
     # Override CCompiler.get_always_args
     def get_always_args(self) -> T.List[str]:
@@ -171,9 +150,6 @@ class ArmclangCompiler(Compiler):
 
     def get_colorout_args(self, colortype: str) -> T.List[str]:
         return clang_color_args[colortype][:]
-
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        return armclang_buildtype_args[buildtype]
 
     def get_pch_suffix(self) -> str:
         return 'gch'

--- a/mesonbuild/compilers/mixins/ccrx.py
+++ b/mesonbuild/compilers/mixins/ccrx.py
@@ -31,15 +31,6 @@ else:
     # do). This gives up DRYer type checking, with no runtime impact
     Compiler = object
 
-ccrx_buildtype_args: T.Dict[str, T.List[str]] = {
-    'plain': [],
-    'debug': [],
-    'debugoptimized': [],
-    'release': [],
-    'minsize': [],
-    'custom': [],
-}
-
 ccrx_optimization_args: T.Dict[str, T.List[str]] = {
     '0': ['-optimize=0'],
     'g': ['-optimize=0'],
@@ -80,9 +71,6 @@ class CcrxCompiler(Compiler):
         # PIC support is not enabled by default for CCRX,
         # if users want to use it, they need to add the required arguments explicitly
         return []
-
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        return ccrx_buildtype_args[buildtype]
 
     def get_pch_suffix(self) -> str:
         return 'pch'

--- a/mesonbuild/compilers/mixins/compcert.py
+++ b/mesonbuild/compilers/mixins/compcert.py
@@ -30,15 +30,6 @@ else:
     # do). This gives up DRYer type checking, with no runtime impact
     Compiler = object
 
-ccomp_buildtype_args: T.Dict[str, T.List[str]] = {
-    'plain': [''],
-    'debug': ['-O0', '-g'],
-    'debugoptimized': ['-O0', '-g'],
-    'release': ['-O3'],
-    'minsize': ['-Os'],
-    'custom': ['-Obranchless'],
-}
-
 ccomp_optimization_args: T.Dict[str, T.List[str]] = {
     'plain': [],
     '0': ['-O0'],
@@ -51,7 +42,7 @@ ccomp_optimization_args: T.Dict[str, T.List[str]] = {
 
 ccomp_debug_args: T.Dict[bool, T.List[str]] = {
     False: [],
-    True: ['-g']
+    True: ['-O0', '-g']
 }
 
 # As of CompCert 20.04, these arguments should be passed to the underlying gcc linker (via -WUl,<arg>)
@@ -83,9 +74,6 @@ class CompCertCompiler(Compiler):
     def get_pic_args(self) -> T.List[str]:
         # As of now, CompCert does not support PIC
         return []
-
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        return ccomp_buildtype_args[buildtype]
 
     def get_pch_suffix(self) -> str:
         return 'pch'

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -47,15 +47,6 @@ clike_debug_args: T.Dict[bool, T.List[str]] = {
     True: ['-g'],
 }
 
-gnulike_buildtype_args: T.Dict[str, T.List[str]] = {
-    'plain': [],
-    'debug': [],
-    'debugoptimized': [],
-    'release': [],
-    'minsize': [],
-    'custom': [],
-}
-
 gnu_optimization_args: T.Dict[str, T.List[str]] = {
     'plain': [],
     '0': ['-O0'],
@@ -399,9 +390,6 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
 
     def get_pie_args(self) -> T.List[str]:
         return ['-fPIE']
-
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        return gnulike_buildtype_args[buildtype]
 
     @abc.abstractmethod
     def get_optimization_args(self, optimization_level: str) -> T.List[str]:

--- a/mesonbuild/compilers/mixins/intel.py
+++ b/mesonbuild/compilers/mixins/intel.py
@@ -50,13 +50,9 @@ class IntelGnuLikeCompiler(GnuLikeCompiler):
     minsize: -O2
     """
 
-    BUILD_ARGS: T.Dict[str, T.List[str]] = {
-        'plain': [],
-        'debug': ["-g", "-traceback"],
-        'debugoptimized': ["-g", "-traceback"],
-        'release': [],
-        'minsize': [],
-        'custom': [],
+    DEBUG_ARGS: T.Dict[bool, T.List[str]] = {
+        False: [],
+        True: ['-g', '-traceback']
     }
 
     OPTIM_ARGS: T.Dict[str, T.List[str]] = {
@@ -115,8 +111,8 @@ class IntelGnuLikeCompiler(GnuLikeCompiler):
     def get_profile_use_args(self) -> T.List[str]:
         return ['-prof-use']
 
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        return self.BUILD_ARGS[buildtype]
+    def get_debug_args(self, is_debug: bool) -> T.List[str]:
+        return self.DEBUG_ARGS[is_debug]
 
     def get_optimization_args(self, optimization_level: str) -> T.List[str]:
         return self.OPTIM_ARGS[optimization_level]
@@ -129,13 +125,9 @@ class IntelVisualStudioLikeCompiler(VisualStudioLikeCompiler):
 
     """Abstractions for ICL, the Intel compiler on Windows."""
 
-    BUILD_ARGS: T.Dict[str, T.List[str]] = {
-        'plain': [],
-        'debug': ["/Zi", "/traceback"],
-        'debugoptimized': ["/Zi", "/traceback"],
-        'release': [],
-        'minsize': [],
-        'custom': [],
+    DEBUG_ARGS: T.Dict[bool, T.List[str]] = {
+        False: [],
+        True: ['/Zi', '/traceback']
     }
 
     OPTIM_ARGS: T.Dict[str, T.List[str]] = {
@@ -175,8 +167,8 @@ class IntelVisualStudioLikeCompiler(VisualStudioLikeCompiler):
     def openmp_flags(self) -> T.List[str]:
         return ['/Qopenmp']
 
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        return self.BUILD_ARGS[buildtype]
+    def get_debug_args(self, is_debug: bool) -> T.List[str]:
+        return self.DEBUG_ARGS[is_debug]
 
     def get_optimization_args(self, optimization_level: str) -> T.List[str]:
         return self.OPTIM_ARGS[optimization_level]

--- a/mesonbuild/compilers/mixins/islinker.py
+++ b/mesonbuild/compilers/mixins/islinker.py
@@ -117,7 +117,7 @@ class BasicLinkerIsCompilerMixin(Compiler):
     def get_asneeded_args(self) -> T.List[str]:
         return []
 
-    def get_buildtype_linker_args(self, buildtype: str) -> T.List[str]:
+    def get_optimization_link_args(self, optimization_level: str) -> T.List[str]:
         return []
 
     def get_link_debugfile_name(self, targetfile: str) -> T.Optional[str]:

--- a/mesonbuild/compilers/mixins/metrowerks.py
+++ b/mesonbuild/compilers/mixins/metrowerks.py
@@ -30,15 +30,6 @@ else:
     # do). This gives up DRYer type checking, with no runtime impact
     Compiler = object
 
-mwcc_buildtype_args: T.Dict[str, T.List[str]] = {
-    'plain': [],
-    'debug': [],
-    'debugoptimized': [],
-    'release': [],
-    'minsize': [],
-    'custom': [],
-}
-
 mwccarm_instruction_set_args: T.Dict[str, T.List[str]] = {
     'generic': ['-proc', 'generic'],
     'v4': ['-proc', 'v4'],
@@ -212,9 +203,6 @@ class MetrowerksCompiler(Compiler):
 
     def get_always_args(self) -> T.List[str]:
         return ['-gccinc']
-
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        return mwcc_buildtype_args[buildtype]
 
     def get_compiler_check_args(self, mode: CompileCheckMode) -> T.List[str]:
         return []

--- a/mesonbuild/compilers/mixins/pgi.py
+++ b/mesonbuild/compilers/mixins/pgi.py
@@ -32,15 +32,6 @@ else:
     # do). This gives up DRYer type checking, with no runtime impact
     Compiler = object
 
-pgi_buildtype_args: T.Dict[str, T.List[str]] = {
-    'plain': [],
-    'debug': [],
-    'debugoptimized': [],
-    'release': [],
-    'minsize': [],
-    'custom': [],
-}
-
 
 class PGICompiler(Compiler):
 
@@ -75,9 +66,6 @@ class PGICompiler(Compiler):
 
     def openmp_flags(self) -> T.List[str]:
         return ['-mp']
-
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        return pgi_buildtype_args[buildtype]
 
     def get_optimization_args(self, optimization_level: str) -> T.List[str]:
         return clike_optimization_args[optimization_level]

--- a/mesonbuild/compilers/mixins/ti.py
+++ b/mesonbuild/compilers/mixins/ti.py
@@ -31,15 +31,6 @@ else:
     # do). This gives up DRYer type checking, with no runtime impact
     Compiler = object
 
-ti_buildtype_args: T.Dict[str, T.List[str]] = {
-    'plain': [],
-    'debug': [],
-    'debugoptimized': [],
-    'release': [],
-    'minsize': [],
-    'custom': [],
-}
-
 ti_optimization_args: T.Dict[str, T.List[str]] = {
     'plain': [],
     '0': ['-O0'],
@@ -79,9 +70,6 @@ class TICompiler(Compiler):
         # PIC support is not enabled by default for TI compilers,
         # if users want to use it, they need to add the required arguments explicitly
         return []
-
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        return ti_buildtype_args[buildtype]
 
     def get_pch_suffix(self) -> str:
         return 'pch'

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -188,9 +188,6 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
             return ['/Fe' + outputname]
         return ['/Fo' + outputname]
 
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        return []
-
     def get_debug_args(self, is_debug: bool) -> T.List[str]:
         return msvc_debug_args[is_debug]
 

--- a/mesonbuild/compilers/mixins/xc16.py
+++ b/mesonbuild/compilers/mixins/xc16.py
@@ -31,15 +31,6 @@ else:
     # do). This gives up DRYer type checking, with no runtime impact
     Compiler = object
 
-xc16_buildtype_args: T.Dict[str, T.List[str]] = {
-    'plain': [],
-    'debug': [],
-    'debugoptimized': [],
-    'release': [],
-    'minsize': [],
-    'custom': [],
-}
-
 xc16_optimization_args: T.Dict[str, T.List[str]] = {
     'plain': [],
     '0': ['-O0'],
@@ -80,9 +71,6 @@ class Xc16Compiler(Compiler):
         # PIC support is not enabled by default for xc16,
         # if users want to use it, they need to add the required arguments explicitly
         return []
-
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        return xc16_buildtype_args[buildtype]
 
     def get_pch_suffix(self) -> str:
         return 'pch'

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -20,7 +20,7 @@ import typing as T
 
 from .. import coredata
 from ..mesonlib import EnvironmentException, MesonException, Popen_safe_logged, OptionKey
-from .compilers import Compiler, rust_buildtype_args, clike_debug_args
+from .compilers import Compiler, clike_debug_args
 
 if T.TYPE_CHECKING:
     from ..coredata import MutableKeyedOptionDictType, KeyedOptionDictType
@@ -122,9 +122,6 @@ class RustCompiler(Compiler):
 
     def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
         return ['--dep-info', outfile]
-
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        return rust_buildtype_args[buildtype]
 
     def get_sysroot(self) -> str:
         cmd = self.get_exelist(ccache=False) + ['--print', 'sysroot']

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -18,7 +18,7 @@ import typing as T
 
 from ..mesonlib import EnvironmentException
 
-from .compilers import Compiler, swift_buildtype_args, clike_debug_args
+from .compilers import Compiler, clike_debug_args
 
 if T.TYPE_CHECKING:
     from ..envconfig import MachineInfo
@@ -73,9 +73,6 @@ class SwiftCompiler(Compiler):
 
     def get_warn_args(self, level: str) -> T.List[str]:
         return []
-
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        return swift_buildtype_args[buildtype]
 
     def get_std_exe_link_args(self) -> T.List[str]:
         return ['-emit-executable']

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -104,11 +104,6 @@ class ValaCompiler(Compiler):
                 msg = f'Vala compiler {self.name_string()!r} cannot compile programs'
                 raise EnvironmentException(msg)
 
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        if buildtype in {'debug', 'debugoptimized', 'minsize'}:
-            return ['--debug']
-        return []
-
     def find_library(self, libname: str, env: 'Environment', extra_dirs: T.List[str],
                      libtype: LibType = LibType.PREFER_SHARED, lib_prefix_warning: bool = True) -> T.Optional[T.List[str]]:
         if extra_dirs and isinstance(extra_dirs, str):


### PR DESCRIPTION
This is a first step to make `buildtype` a true alias of `debug` and `optimization` options.

See #10808.

Relates to:
- #11645
- #12096
- #5920
- #5814
- #8220
- #8493
- #9540
- #10487
- #12265
- #8308
- #8214
- #7194
- #11732