### PR TITLE
macos: Fix path in test to be Sonoma compatible

### DIFF
--- a/unittests/darwintests.py
+++ b/unittests/darwintests.py
@@ -151,5 +151,5 @@ class DarwinTests(BasePlatformTests):
 
     def test_darwin_get_object_archs(self):
         from mesonbuild.mesonlib import darwin_get_object_archs
-        archs = darwin_get_object_archs('/System/Library/CoreServices/Encodings/libSymbolConverter.dylib')
+        archs = darwin_get_object_archs('/bin/cat')
         self.assertEqual(archs, ['x86_64', 'aarch64'])


### PR DESCRIPTION
The path tested prior does not exist anymore in Sonoma. It seems less likely that 'cp' will be removed.

CC: @tristan957 