### PR TITLE
macos: Fix test case for constructor_priority when using gcc

### DIFF
--- a/test cases/common/197 function attributes/meson.build
+++ b/test cases/common/197 function attributes/meson.build
@@ -91,6 +91,11 @@ if host_machine.system() != 'darwin'
   attributes += 'alloc_size'
 endif
 
+# gcc doesn't support constructor_priority on darwin
+if c.get_id() == 'gcc' and host_machine.system() == 'darwin'
+  expected += {'constructor_priority': false}
+endif
+
 if ['gcc', 'intel'].contains(c.get_id())
   # not supported by clang as of 5.0.0 (at least up to 6.0.1)
   attributes += 'artificial'


### PR DESCRIPTION
GCC does not support constructor_priority on macos. It's possibly not the only platform for which that is the case, but...