### PR TITLE
macos: Skip as-needed test, the linker is too smart

### DIFF
--- a/test cases/common/173 as-needed/meson.build
+++ b/test cases/common/173 as-needed/meson.build
@@ -11,3 +11,10 @@ libB = library('B', 'libB.cpp', link_with : libA)
 
 main_exe = executable('C', 'main.cpp', link_with : [libA, libB])
 test('main test', main_exe)
+
+# Since Sonoma / Xcode 15 the macos linker considers the dependency via the
+# initializer sufficient to pull in the other other library. There's no good
+# way to detect the linker version here, so just skip the on macos.
+if host_machine.system() == 'darwin'
+    error('MESON_SKIP_TEST: the macos linker is too smart for this test')
+endif


### PR DESCRIPTION
The new linker in Sonoma / Xcode 15 considers the dependency via the initializer sufficient to pull in the library. The man page now notes:
  The linker never dead strips initialization and termination routines.
  They are considered "roots" of the dead strip graph.

I could not find a good way to skip only if the linker version is new enough. Before long everyone will be using the new linker anyway...