### PR TITLE
macos: Fix test_pkgconfig_parse_libs() test on arm

### DIFF
--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -618,7 +618,8 @@ class InternalTests(unittest.TestCase):
             out = name.with_suffix('.o')
             with src.open('w', encoding='utf-8') as f:
                 f.write('int meson_foobar (void) { return 0; }')
-            subprocess.check_call(['clang', '-c', str(src), '-o', str(out)])
+            # use of x86_64 is hardcoded in run_tests.py:get_fake_env()
+            subprocess.check_call(['clang', '-c', str(src), '-o', str(out), '-arch', 'x86_64'])
             subprocess.check_call(['ar', 'csr', str(name), str(out)])
 
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
The unit test infrastructure hardcodes the architecture as x86_64. On macos, the test_pkgconfig_parse_libs() test creates a few libraries for testing using clang. This leads to the test failing on arm based macs, as darwin_get_object_archs() will skip over these libraries, which then leads to the test failing because of using -l instead of referencing the libraries by their full path.

I am not at all sure this is the best approach.

I am also somewhat confused why nobody else has encountered this? CI apparently just runs on x86_64 macs?

CC: @tristan957