### PR TITLE
vala: utilize depfiles

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1723,6 +1723,8 @@ class NinjaBackend(backends.Backend):
                                     self.compiler_to_rule_name(valac),
                                     all_files + dependency_vapis)
         element.add_item('ARGS', args)
+        depfile = valac.depfile_for_object(os.path.join(self.get_target_dir(target), target.name))
+        element.add_item('DEPFILE', depfile)
         element.add_dep(extra_dep_files)
         self.add_build(element)
         self.create_target_source_introspection(target, valac, args, all_files, [])
@@ -2366,9 +2368,19 @@ class NinjaBackend(backends.Backend):
 
     def generate_vala_compile_rules(self, compiler):
         rule = self.compiler_to_rule_name(compiler)
-        command = compiler.get_exelist() + ['$ARGS', '$in']
+        command = compiler.get_exelist()
         description = 'Compiling Vala source $in'
-        self.add_rule(NinjaRule(rule, command, [], description, extra='restat = 1'))
+
+        depargs = compiler.get_dependency_gen_args('$out', '$DEPFILE')
+        depfile = '$DEPFILE' if depargs else None
+        depstyle = 'gcc' if depargs else None
+
+        args = depargs + ['$ARGS', '$in']
+
+        self.add_rule(NinjaRule(rule, command + args, [], description,
+                                depfile=depfile,
+                                deps=depstyle,
+                                extra='restat = 1'))
 
     def generate_cython_compile_rules(self, compiler: 'Compiler') -> None:
         rule = self.compiler_to_rule_name(compiler)

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -42,6 +42,14 @@ class ValaCompiler(Compiler):
     def get_optimization_args(self, optimization_level: str) -> T.List[str]:
         return []
 
+    def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
+        if version_compare(self.version, '>=0.47.2'):
+            return ['--depfile', outfile]
+        return []
+
+    def get_depfile_suffix(self) -> str:
+        return 'depfile'
+
     def get_debug_args(self, is_debug: bool) -> T.List[str]:
         return ['--debug'] if is_debug else []
 


### PR DESCRIPTION
This PR adds support for using depfiles generated by valac. Currently, it has fairly limited utility due to depfiles only referencing `.vapi` files - so the only visible behavior change it introduces currently is recompilation if vapi files referenced via `--pkg` are modified (although this is still a nice improvement). However, this change opens some future possibilities, such as:

* Replacing dependency on gresource targets added by #12418 with importing dependencies of those targets as order-only; this will require a Vala patch to write resources it utilizes to depfile but will improve parallelism a bit as well as potentially avoiding rebuilds
* Using order-only dependencies for eventual [fastapi-enabled builds](https://wiki.gnome.org/Projects/Vala/Documentation/ParallelBuilds)

Tests currently fail due to https://github.com/ninja-build/ninja/issues/2357 - I've PRed a [workaround](https://gitlab.gnome.org/GNOME/vala/-/merge_requests/361) to Vala, but that will take a while to land in distros (although a real project hitting this problem is rather improbable). Other than that, I've confirmed that depfile is successfully used.