### PR TITLE
Fix test failure on Darwin on a case-sensitive fs

### DIFF
--- a/test cases/osx/5 extra frameworks/meson.build
+++ b/test cases/osx/5 extra frameworks/meson.build
@@ -7,7 +7,7 @@ dep_main = dependency('Foundation')
 assert(dep_main.type_name() == 'extraframeworks', 'type_name is ' + dep_main.type_name())
 
 # https://github.com/mesonbuild/meson/issues/10002
-ldap_dep = dependency('ldap', method : 'extraframework')
+ldap_dep = dependency('LDAP', method : 'extraframework')
 assert(ldap_dep.type_name() == 'extraframeworks', 'type_name is ' + ldap_dep.type_name())
 
 stlib = static_library('stat', 'stat.c', install : true, dependencies: [opengl_dep, ldap_dep])


### PR DESCRIPTION
This was encountered while looking into an issue with https://github.com/NixOS/nixpkgs/pull/268583.

I run my Nix store on case-sensitive APFS, so the test fails due to trying to link `-framework ldap` instead of `-framework LDAP`.