### PR TITLE
external_project.py: fix --host value

### DIFF
--- a/mesonbuild/modules/external_project.py
+++ b/mesonbuild/modules/external_project.py
@@ -136,8 +136,9 @@ class ExternalProject(NewExtensionModule):
         configure_cmd += self._format_options(self.configure_options, d)
 
         if self.env.is_cross_build():
-            host = '{}-{}-{}'.format(self.host_machine.cpu_family,
-                                     self.build_machine.system,
+            host = '{}-{}-{}'.format(self.host_machine.cpu,
+                                     'pc' if self.host_machine.cpu_family in {"x86", "x86_64"}
+                                     else 'unknown',
                                      self.host_machine.system)
             d = [('HOST', None, host)]
             configure_cmd += self._format_options(self.cross_configure_options, d)


### PR DESCRIPTION
Currently in cross-compilation mode the --host is set to x86-linux-linux, which results in an error.
Use x86-unknown-linux instead.

Fixes #12608