### PR TITLE
dependencies/llvm: strip default include dirs also for config-tool version

### DIFF
--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -232,6 +232,7 @@ class LLVMDependencyConfigTool(ConfigToolDependency):
 
         cargs = mesonlib.OrderedSet(self.get_config_value(['--cppflags'], 'compile_args'))
         self.compile_args = list(cargs.difference(self.__cpp_blacklist))
+        self.compile_args = strip_system_includedirs(environment, self.for_machine, self.compile_args)
 
         if version_compare(self.version, '>= 3.9'):
             self._set_new_link_args(environment)


### PR DESCRIPTION
This should have been done in my earlier fix, but kinda forgot to test and fix it there as well.

See https://github.com/mesonbuild/meson/pull/11733 for the discussion.

Fixes: 8284be813 ("dependencies/llvm: strip default include dirs")