### PR TITLE
coredata: fix compiler base option recognized as "Unknown options" on an already configured directory.

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -950,6 +950,7 @@ class CoreData:
         return dirty
 
     def set_options(self, options: T.Dict[OptionKey, T.Any], subproject: str = '', first_invocation: bool = False) -> bool:
+        from .compilers import base_options
         dirty = False
         if not self.is_cross_build():
             options = {k: v for k, v in options.items() if k.machine is not MachineChoice.BUILD}
@@ -969,6 +970,8 @@ class CoreData:
             elif k in self.options:
                 dirty |= self.set_option(k, v, first_invocation)
             elif k.machine != MachineChoice.BUILD and k.type != OptionType.COMPILER:
+                if k.type == OptionType.BASE and k.as_root() in base_options:
+                    continue
                 unknown_options.append(k)
         if unknown_options:
             unknown_options_str = ', '.join(sorted(str(s) for s in unknown_options))


### PR DESCRIPTION

Fix error:
`ERROR: Unknown options: "b_lto"`

cmd line:

> meson setup --prefix C:\code\dev\yyyy\venv --pkg-config-path C:\vcpkg\installed\x64-windows\lib\pkgconfig;C:\code\dev\yyyy\venv\Lib\pkgconfig --buildtype release --debug -Db_lto=true --bindir=Scripts --libdir=Lib --includedir=Include -Db_vscrt=md --backend=vs2022 -Dtests=false C:\code\dev\yyyy\external\pkgconf external\pkgconf\builddir