### PR TITLE
rust: fix linking static executables

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1998,7 +1998,7 @@ class NinjaBackend(backends.Backend):
             # "-l" argument and does not rely on platform specific dynamic linker.
             lib = self.get_target_filename_for_linking(d)
             link_whole = d in target.link_whole_targets
-            if isinstance(target, build.StaticLibrary):
+            if isinstance(target, build.StaticLibrary) or (isinstance(target, build.Executable) and rustc.get_crt_static()):
                 static = isinstance(d, build.StaticLibrary)
                 libname = os.path.basename(lib) if verbatim else d.name
                 _link_library(libname, static, bundle=link_whole)

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import functools
 import subprocess, os.path
 import textwrap
 import re
@@ -117,6 +118,12 @@ class RustCompiler(Compiler):
         cmd = self.get_exelist(ccache=False) + ['--print', 'sysroot']
         p, stdo, stde = Popen_safe_logged(cmd)
         return stdo.split('\n', maxsplit=1)[0]
+
+    @functools.lru_cache(maxsize=None)
+    def get_crt_static(self) -> bool:
+        cmd = self.get_exelist(ccache=False) + ['--print', 'cfg']
+        p, stdo, stde = Popen_safe_logged(cmd)
+        return bool(re.search('^target_feature="crt-static"$', stdo, re.MULTILINE))
 
     def get_debug_args(self, is_debug: bool) -> T.List[str]:
         return clike_debug_args[is_debug]

--- a/test cases/rust/23 crt-static/lib.c
+++ b/test cases/rust/23 crt-static/lib.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+void test_function(void)
+{
+    puts("Hello, world!");
+}

--- a/test cases/rust/23 crt-static/main.rs
+++ b/test cases/rust/23 crt-static/main.rs
@@ -1,0 +1,9 @@
+extern "C" {
+    fn test_function();
+}
+
+pub fn main() {
+    unsafe {
+        test_function();
+    }
+}

--- a/test cases/rust/23 crt-static/meson.build
+++ b/test cases/rust/23 crt-static/meson.build
@@ -1,0 +1,9 @@
+project('rustprog', 'c')
+
+if not add_languages('rust', required : false)
+  error('MESON_SKIP_TEST crt-static doesn\'t work')
+endif
+
+c_lib = static_library('lib', 'lib.c')
+
+executable('main', 'main.rs', link_with : c_lib)

--- a/test cases/rust/23 crt-static/test.json
+++ b/test cases/rust/23 crt-static/test.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "RUSTC": "rustc -C target-feature=+crt-static"
+  }
+}


### PR DESCRIPTION
For the same reason as for static libraries, we have to use -l when generating static executables.

Fixes: https://github.com/mesonbuild/meson/issues/12585

---

I wasn't sure how to test this, because we'd have to skip the tests if it's not possible to build static executables, and I don't know how to do that from a test case.