### PR TITLE
Add malloc debug support on macOS

### DIFF
--- a/docs/markdown/Unit-tests.md
+++ b/docs/markdown/Unit-tests.md
@@ -38,6 +38,8 @@ set to a random value between 1..255. This can help find memory leaks on
 configurations using glibc, including with non-GCC compilers. This feature
 can be disabled as discussed in [[test]].
 
+TODO: document MallocPreScribble MallocScribble here
+
 ### ASAN_OPTIONS and UBSAN_OPTIONS
 
 By default, the environment variables `ASAN_OPTIONS` and `UBSAN_OPTIONS` are

--- a/docs/yaml/functions/benchmark.yaml
+++ b/docs/yaml/functions/benchmark.yaml
@@ -6,7 +6,7 @@ description: |
   except for:
 
   * benchmark() has no `is_parallel` keyword because benchmarks are not run in parallel
-  * benchmark() does not automatically add the `MALLOC_PERTURB_` environment variable
+  * benchmark() does not automatically add the `MALLOC_PERTURB_` environment variable (or equivalent on other platforms)
 
   Defined tests can be run in a backend-agnostic way by calling
   `meson test` inside the build dir, or by using backend-specific

--- a/docs/yaml/functions/test.yaml
+++ b/docs/yaml/functions/test.yaml
@@ -33,6 +33,8 @@ description: |
   test(..., env: nomalloc, ...)
   ```
 
+  TODO: MallocPreScribble/MallocScribble
+
   By default, the environment variables `ASAN_OPTIONS` and `UBSAN_OPTIONS` are
   set to enable aborting on detected violations and to give a backtrace. To suppress
   this, `ASAN_OPTIONS` and `UBSAN_OPTIONS` can be set in the environment.

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1403,8 +1403,14 @@ class SingleTestRunner:
         # it ourselves. We do this unconditionally for regular tests
         # because it is extremely useful to have.
         # Setting MALLOC_PERTURB_="0" will completely disable this feature.
-        if ('MALLOC_PERTURB_' not in env or not env['MALLOC_PERTURB_']) and not options.benchmark:
-            env['MALLOC_PERTURB_'] = str(random.randint(1, 255))
+        # XXX update comment above
+        if not options.benchmark:
+            if 'MALLOC_PERTURB_' not in env or not env['MALLOC_PERTURB_']:
+                env['MALLOC_PERTURB_'] = str(random.randint(1, 255))
+            if 'MallocPreScribble' not in env:
+                env['MallocPreScribble'] = '1'
+            if 'MallocScribble' not in env:
+                env['MallocScribble'] = '1'
 
         # Sanitizers do not default to aborting on error. This is counter to
         # expectations when using -Db_sanitize and has led to confusion in the wild


### PR DESCRIPTION
Set MallocPreScribble and MallocScribble environment variables when running tests.  These have an effect on macOS that is similar to the existing support for MALLOC_PERTURB_ with glibc.

TODO: missing documentation updates

Upstream documentation: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/malloc.3.html

Questions:
* Should this code be gated by some kind of `is_darwin`? The existing code wasn't gated by "is-linux" or "is-glibc", so I didn't put anything either.
* A little flaw is that you can't disable this by setting like `MallocScribble=0`, because the OS just checks for "set", not the value. I suppose we could catch that special value in meson and then forcibly unset the variable. Maybe all of this would be cleaner as a build option or something more formal like that.