### PR TITLE
ci: Don't auto-update brew when installing

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,6 +44,7 @@ jobs:
         LDFLAGS: "-L/usr/local/lib"
         MESON_CI_JOBNAME: unittests-appleclang
         MESON_UNIT_TEST_BACKEND: ninja
+        HOMEBREW_NO_AUTO_UPDATE: 1
         # These cannot evaluate anything, so we cannot set PATH or SDKROOT here
       run: |
         export SDKROOT="$(xcodebuild -version -sdk macosx Path)"
@@ -77,6 +78,7 @@ jobs:
     name: ${{ matrix.NAME }}
     env:
       MESON_CI_JOBNAME: ${{ matrix.NAME }}
+        HOMEBREW_NO_AUTO_UPDATE: 1
 
     steps:
     - uses: actions/checkout@v3
@@ -99,6 +101,7 @@ jobs:
         CPPFLAGS: "-I/usr/local/include"
         LDFLAGS: "-L/usr/local/lib"
         MESON_ARGS: --unity=${{ matrix.unity }}
+        HOMEBREW_NO_AUTO_UPDATE: 1
         CI: 1
         # These cannot evaluate anything, so we cannot set PATH or SDKROOT here
       run: |
@@ -126,6 +129,8 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
+    - env:
+        HOMEBREW_NO_AUTO_UPDATE: 1
     - run: python -m pip install -e .
     - run: brew install pkg-config ninja gcc
     - run: brew tap cartr/qt4


### PR DESCRIPTION
We're getting errors that we don't care about on the CI like:

```
==> Pouring node@18--18.19.0.monterey.bottle.tar.gz
The formula built, but is not symlinked into /usr/local
Error: The `brew link` step did not complete successfully
Could not symlink lib/node_modules/npm/docs/content/commands/npm-sbom.md
Target /usr/local/lib/node_modules/npm/docs/content/commands/npm-sbom.md
already exists. You may want to remove it:
  rm '/usr/local/lib/node_modules/npm/docs/content/commands/npm-sbom.md'
```

We don't care about node, the only reason it's getting updated is because it's already installed on the image and brew is auto-updating it. So let's disable auto-update.