### PR TITLE
b_sanitize as an array, with compiler checks

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -33,22 +33,22 @@ not be relied on, since they can be absolute paths in the following cases:
 
 ### Directories
 
-| Option                               | Default value | Description |
-| ------                               | ------------- | ----------- |
-| prefix                               | see below     | Installation prefix |
-| bindir                               | bin           | Executable directory |
-| datadir                              | share         | Data file directory |
-| includedir                           | include       | Header file directory |
-| infodir                              | share/info    | Info page directory |
-| libdir                               | see below     | Library directory |
-| licensedir                           | see below     | Licenses directory (since 1.1.0)|
-| libexecdir                           | libexec       | Library executable directory |
-| localedir                            | share/locale  | Locale data directory |
-| localstatedir                        | var           | Localstate data directory |
-| mandir                               | share/man     | Manual page directory |
-| sbindir                              | sbin          | System executable directory |
-| sharedstatedir                       | com           | Architecture-independent data directory |
-| sysconfdir                           | etc           | Sysconf data directory |
+| Option         | Default value | Description                             |
+| -------------- | ------------- | --------------------------------------- |
+| prefix         | see below     | Installation prefix                     |
+| bindir         | bin           | Executable directory                    |
+| datadir        | share         | Data file directory                     |
+| includedir     | include       | Header file directory                   |
+| infodir        | share/info    | Info page directory                     |
+| libdir         | see below     | Library directory                       |
+| licensedir     | see below     | Licenses directory (since 1.1.0)        |
+| libexecdir     | libexec       | Library executable directory            |
+| localedir      | share/locale  | Locale data directory                   |
+| localstatedir  | var           | Localstate data directory               |
+| mandir         | share/man     | Manual page directory                   |
+| sbindir        | sbin          | System executable directory             |
+| sharedstatedir | com           | Architecture-independent data directory |
+| sysconfdir     | etc           | Sysconf data directory                  |
 
 
 `prefix` defaults to `C:/` on Windows, and `/usr/local` otherwise. You
@@ -141,7 +141,7 @@ from it. For example, `-Dbuildtype=debugoptimized` is the same as
 the two-way mapping:
 
 | buildtype      | debug | optimization |
-| ---------      | ----- | ------------ |
+| -------------- | ----- | ------------ |
 | plain          | false | plain        |
 | debug          | true  | 0            |
 | debugoptimized | true  | 2            |
@@ -156,7 +156,7 @@ Exact flags per warning level is compiler specific, but there is an approximativ
 table for most common compilers.
 
 | Warning level | GCC/Clang                | MSVC  |
-| ------------- | ---                      | ----  |
+| ------------- | ------------------------ | ----- |
 | 0             |                          |       |
 | 1             | -Wall                    | /W2   |
 | 2             | -Wall -Wextra            | /W3   |
@@ -207,7 +207,7 @@ The following options are available. Note that they may not be
 available on all platforms or with all compilers:
 
 | Option              | Default value        | Possible values                                               | Description                                                                    |
-|---------------------|----------------------|---------------------------------------------------------------|--------------------------------------------------------------------------------|
+| ------------------- | -------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------ |
 | b_asneeded          | true                 | true, false                                                   | Use -Wl,--as-needed when linking                                               |
 | b_bitcode           | false                | true, false                                                   | Embed Apple bitcode, see below                                                 |
 | b_colorout          | always               | auto, always, never                                           | Use colored output                                                             |
@@ -226,10 +226,17 @@ available on all platforms or with all compilers:
 | b_pie               | false                | true, false                                                   | Build position-independent executables (since 0.49.0)                          |
 | b_vscrt             | from_buildtype       | none, md, mdd, mt, mtd, from_buildtype, static_from_buildtype | VS runtime library to use (since 0.48.0) (static_from_buildtype since 0.56.0)  |
 
-The value of `b_sanitize` can be one of: `none`, `address`, `thread`,
-`undefined`, `memory`, `leak`, `address,undefined`, but note that some
-compilers might not support all of them. For example Visual Studio
-only supports the address sanitizer.
+† The default and possible values of sanitizers changed in 1.6. Before 1.6 they
+were string values, and restricted to a specific subset of values: `none`,
+`address`, `thread`, `undefined`, `memory`, `leak`, or `address,undefined`. In
+1.6 it was changed to a free form array of sanitizers, which are checked by a
+compiler and linker check. For backwards compatibility reasons
+`get_option('b_sanitize')` continues to return a string value, which is
+guaranteed to match the old string value if the array value contains the same
+values (ie, `['undefined', 'address'] == 'address,undefined`). If a value not
+allowed before 1.6 is used `b_sanitize` will return a string in undefined order.
+In 1.6 `get_option('b_sanitize', format : 2)`, will return a free form array,
+with no ordering guarantees.
 
 \* < 0 means disable, == 0 means automatic selection, > 0 sets a specific number to use
 
@@ -242,7 +249,7 @@ used internally to pick the CRT compiler arguments for `from_buildtype` or
 option:
 
 | buildtype      | from_buildtype | static_from_buildtype |
-| --------       | -------------- | --------------------- |
+| -------------- | -------------- | --------------------- |
 | debug          | `/MDd`         | `/MTd`                |
 | debugoptimized | `/MD`          | `/MT`                 |
 | release        | `/MD`          | `/MT`                 |
@@ -380,7 +387,7 @@ option with the module's name:
 ### Pkgconfig module
 
 | Option      | Default value | Possible values | Description                                                |
-|-------------|---------------|-----------------|------------------------------------------------------------|
+| ----------- | ------------- | --------------- | ---------------------------------------------------------- |
 | relocatable | false         | true, false     | Generate the pkgconfig files as relocatable (Since 0.63.0) |
 
 *Since 0.63.0* The `pkgconfig.relocatable` option is used by the
@@ -401,13 +408,13 @@ install prefix. For example: if the install prefix is `/usr` and the
 
 ### Python module
 
-| Option            | Default value | Possible values             | Description |
-| ------            | ------------- | -----------------           | ----------- |
-| bytecompile       | 0             | integer from -1 to 2        | What bytecode optimization level to use (Since 1.2.0) |
-| install_env       | prefix        | {auto,prefix,system,venv}   | Which python environment to install to (Since 0.62.0) |
-| platlibdir        |               | Directory path              | Directory for site-specific, platform-specific files (Since 0.60.0) |
-| purelibdir        |               | Directory path              | Directory for site-specific, non-platform-specific files  (Since 0.60.0) |
-| allow_limited_api | true          | true, false                 | Disables project-wide use of the Python Limited API (Since 1.3.0) |
+| Option            | Default value | Possible values           | Description                                                              |
+| ----------------- | ------------- | ------------------------- | ------------------------------------------------------------------------ |
+| bytecompile       | 0             | integer from -1 to 2      | What bytecode optimization level to use (Since 1.2.0)                    |
+| install_env       | prefix        | {auto,prefix,system,venv} | Which python environment to install to (Since 0.62.0)                    |
+| platlibdir        |               | Directory path            | Directory for site-specific, platform-specific files (Since 0.60.0)      |
+| purelibdir        |               | Directory path            | Directory for site-specific, non-platform-specific files  (Since 0.60.0) |
+| allow_limited_api | true          | true, false               | Disables project-wide use of the Python Limited API (Since 1.3.0)        |
 
 *Since 0.60.0* The `python.platlibdir` and `python.purelibdir` options are used
 by the python module methods `python.install_sources()` and

--- a/docs/markdown/snippets/b_sanitizer_changes.md
+++ b/docs/markdown/snippets/b_sanitizer_changes.md
@@ -1,0 +1,17 @@
+## Changes to the b_sanitize option
+
+In meson <= 1.6 the b_sanitize option is a combo, which is an enumerated set of
+values. One picks one of the values as provided by that enumeration. In 1.6
+this was changed to a free array of options, and a compiler check for the
+validity of those options.
+
+This solves a number of longstanding issues such as:
+ - sanitizers may be supported by a compiler, but not on a specific platform (OpenBSD)
+ - new sanitizers are not recognized by Meson
+ - using sanitizers in different combinations
+
+In order to not break backwards compatibility, meson will continue to
+return `get_option('b_sanitize')` as a string, with a guarantee that
+`address,undefined` will remain ordered. Calling
+ `get_option('b_sanitize', format : 2)`
+returns a free form list with no ordering guarantees.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3507,7 +3507,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             commands += compilers.get_base_link_args(target.get_options(),
                                                      linker,
                                                      isinstance(target, build.SharedModule),
-                                                     self.environment.get_build_dir())
+                                                     self.environment)
         # Add -nostdlib if needed; can't be overridden
         commands += self.get_no_stdlib_link_args(target, linker)
         # Add things like /NOLOGO; usually can't be overridden

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2014-2016 The Meson development team
+# Copyright © 2023-2024 Intel Corporation
 
 from __future__ import annotations
 import copy
@@ -272,7 +273,7 @@ class Vs2010Backend(backends.Backend):
         try:
             self.sanitize = self.environment.coredata.get_option(OptionKey('b_sanitize'))
         except MesonException:
-            self.sanitize = 'none'
+            self.sanitize = []
         sln_filename = os.path.join(self.environment.get_build_dir(), self.build.project_name + '.sln')
         projlist = self.generate_projects(vslite_ctx)
         self.gen_testproj()

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2012-2017 The Meson development team
+# Copyright © 2024 Intel Corporation
 
 from __future__ import annotations
 
@@ -16,10 +17,9 @@ from ..mesonlib import (
     is_windows, LibType, version_compare
 )
 from ..options import OptionKey
-from .compilers import Compiler
+from .compilers import Compiler, CompileCheckMode
 
 if T.TYPE_CHECKING:
-    from .compilers import CompileCheckMode
     from ..build import BuildTarget
     from ..coredata import MutableKeyedOptionDictType, KeyedOptionDictType
     from ..dependencies import Dependency
@@ -813,3 +813,13 @@ class CudaCompiler(Compiler):
 
     def get_assert_args(self, disable: bool, env: 'Environment') -> T.List[str]:
         return self.host_compiler.get_assert_args(disable, env)
+
+    def has_multi_arguments(self, args: T.List[str], env: Environment) -> T.Tuple[bool, bool]:
+        args = self._to_host_flags(args)
+        return self.compiles(
+            'int main(void) { return 0; }', env, extra_args=args, mode=CompileCheckMode.COMPILE)
+
+    def has_multi_link_arguments(self, args: T.List[str], env: Environment) -> T.Tuple[bool, bool]:
+        args = self._to_host_flags(self.linker.fatal_warnings() + args, phase=Phase.LINKER)
+        return self.compiles(
+            'int main(void) { return 0; }', env, extra_args=args, mode=CompileCheckMode.LINK)

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2012-2017 The Meson development team
-# Copyright © 2024 Intel Corporation
+# Copyright © 2023-2024 Intel Corporation
 
 from __future__ import annotations
 
@@ -707,10 +707,10 @@ class CudaCompiler(Compiler):
         # return self._to_host_flags(self.host_compiler.get_optimization_args(optimization_level))
         return cuda_optimization_args[optimization_level]
 
-    def sanitizer_compile_args(self, value: str) -> T.List[str]:
+    def sanitizer_compile_args(self, value: T.List[str]) -> T.List[str]:
         return self._to_host_flags(self.host_compiler.sanitizer_compile_args(value))
 
-    def sanitizer_link_args(self, value: str) -> T.List[str]:
+    def sanitizer_link_args(self, value: T.List[str]) -> T.List[str]:
         return self._to_host_flags(self.host_compiler.sanitizer_link_args(value))
 
     def get_debug_args(self, is_debug: bool) -> T.List[str]:

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019-2022 The meson development team
+# Copyright © 2023 Intel Corporation
 
 from __future__ import annotations
 
@@ -496,11 +497,11 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
         # for their specific arguments
         return ['-flto']
 
-    def sanitizer_compile_args(self, value: str) -> T.List[str]:
-        if value == 'none':
-            return []
-        args = ['-fsanitize=' + value]
-        if 'address' in value:  # for -fsanitize=address,undefined
+    def sanitizer_compile_args(self, value: T.List[str]) -> T.List[str]:
+        if not value:
+            return value
+        args = ['-fsanitize=' + ','.join(value)]
+        if 'address' in value:
             args.append('-fno-omit-frame-pointer')
         return args
 

--- a/mesonbuild/compilers/mixins/islinker.py
+++ b/mesonbuild/compilers/mixins/islinker.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
+# Copyright © 2023 Intel Corporation
 
 from __future__ import annotations
 
@@ -36,7 +37,7 @@ class BasicLinkerIsCompilerMixin(Compiler):
     functionality itself.
     """
 
-    def sanitizer_link_args(self, value: str) -> T.List[str]:
+    def sanitizer_link_args(self, value: T.List[str]) -> T.List[str]:
         return []
 
     def get_lto_link_args(self, *, threads: int = 0, mode: str = 'default',

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The meson development team
+# Copyright © 2023 Intel Corporation
 
 from __future__ import annotations
 
@@ -166,12 +167,10 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
     def get_no_optimization_args(self) -> T.List[str]:
         return ['/Od', '/Oi-']
 
-    def sanitizer_compile_args(self, value: str) -> T.List[str]:
-        if value == 'none':
-            return []
-        if value != 'address':
-            raise mesonlib.MesonException('VS only supports address sanitizer at the moment.')
-        return ['/fsanitize=address']
+    def sanitizer_compile_args(self, value: T.List[str]) -> T.List[str]:
+        if not value:
+            return value
+        return [f'/fsanitize={",".join(value)}']
 
     def get_output_args(self, outputname: str) -> T.List[str]:
         if self.mode == 'PREPROCESSOR':

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2012-2022 The Meson development team
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 
@@ -12,7 +13,7 @@ import typing as T
 from .. import options
 from ..mesonlib import EnvironmentException, MesonException, Popen_safe_logged
 from ..options import OptionKey
-from .compilers import Compiler, clike_debug_args
+from .compilers import Compiler, CompileCheckMode, clike_debug_args
 
 if T.TYPE_CHECKING:
     from ..coredata import MutableKeyedOptionDictType, KeyedOptionDictType
@@ -300,6 +301,14 @@ class RustCompiler(Compiler):
             return []
 
         return exelist + args
+
+    def has_multi_arguments(self, args: T.List[str], env: 'Environment') -> T.Tuple[bool, bool]:
+        return self.compiles('fn main { std::process::exit(0) };\n', env, extra_args=args, mode=CompileCheckMode.COMPILE)
+
+    def has_multi_link_arguments(self, args: T.List[str], env: 'Environment') -> T.Tuple[bool, bool]:
+        args = self.linker.fatal_warnings() + args
+        return self.compiles(
+            'fn main { std::process::exit(0) };\n', env, extra_args=args, mode=CompileCheckMode.LINK)
 
 
 class ClippyRustCompiler(RustCompiler):

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright © 2021 The Meson Developers
-# Copyright © 2021-2024 Intel Corporation
+# Copyright 2021 The Meson Developers
+# Copyright © 2021-2025 Intel Corporation
 from __future__ import annotations
 
 """Keyword Argument type annotations."""
@@ -482,3 +482,8 @@ class FuncDeclareDependency(TypedDict):
     sources: T.List[T.Union[FileOrString, build.GeneratedTypes]]
     variables: T.Dict[str, str]
     version: T.Optional[str]
+
+
+class FuncGetOption(TypedDict):
+
+    format: int

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright © 2021 Intel Corporation
+# Copyright © 2021-2024 Intel Corporation
 
 """Helpers for strict type checking."""
 

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2012-2022 The Meson development team
+# Copyright © 2023 Intel Corporation
 
 from __future__ import annotations
 
@@ -216,7 +217,7 @@ class DynamicLinker(metaclass=abc.ABCMeta):
     def get_thinlto_cache_args(self, path: str) -> T.List[str]:
         return []
 
-    def sanitizer_args(self, value: str) -> T.List[str]:
+    def sanitizer_args(self, value: T.List[str]) -> T.List[str]:
         return []
 
     def get_asneeded_args(self) -> T.List[str]:
@@ -592,6 +593,9 @@ class PosixDynamicLinkerMixin(DynamicLinkerBase):
     def get_search_args(self, dirname: str) -> T.List[str]:
         return ['-L' + dirname]
 
+    def sanitizer_args(self, value: T.List[str]) -> T.List[str]:
+        return []
+
 
 class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
 
@@ -647,10 +651,10 @@ class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
     def get_lto_args(self) -> T.List[str]:
         return ['-flto']
 
-    def sanitizer_args(self, value: str) -> T.List[str]:
-        if value == 'none':
-            return []
-        return ['-fsanitize=' + value]
+    def sanitizer_args(self, value: T.List[str]) -> T.List[str]:
+        if not value:
+            return value
+        return [f'-fsanitize={",".join(value)}']
 
     def get_coverage_args(self) -> T.List[str]:
         return ['--coverage']
@@ -802,10 +806,10 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
     def get_coverage_args(self) -> T.List[str]:
         return ['--coverage']
 
-    def sanitizer_args(self, value: str) -> T.List[str]:
-        if value == 'none':
-            return []
-        return ['-fsanitize=' + value]
+    def sanitizer_args(self, value: T.List[str]) -> T.List[str]:
+        if not value:
+            return value
+        return [f'-fsanitize={",".join(value)}']
 
     def no_undefined_args(self) -> T.List[str]:
         # We used to emit -undefined,error, but starting with Xcode 15 /

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2015-2016 The Meson development team
+# Copyright © 2023-2024 Intel Corporation
 
 '''This module provides helper functions for Gnome/GLib related
 functionality such as gobject-introspection, gresources and gtk-doc'''
@@ -911,8 +912,8 @@ class GnomeModule(ExtensionModule):
                 cflags += state.project_args[lang]
             if OptionKey('b_sanitize') in compiler.base_options:
                 sanitize = state.environment.coredata.optstore.get_value('b_sanitize')
+                assert isinstance(sanitize, list), 'for mypy'
                 cflags += compiler.sanitizer_compile_args(sanitize)
-                sanitize = sanitize.split(',')
                 # These must be first in ldflags
                 if 'address' in sanitize:
                     internal_ldflags += ['-lasan']

--- a/test cases/linuxlike/16 sanitizers/meson.build
+++ b/test cases/linuxlike/16 sanitizers/meson.build
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2023-2024 Intel Corporation
+
+project('sanitizer', 'c', meson_version : '>= 1.6')
+
+assert(get_option('b_sanitize') == 'address,undefined', 'order of address + undefined is not correct')
+
+array = get_option('b_sanitize', format : 2)
+assert(',' not in array)
+assert(array == ['address', 'undefined'] or array == ['undefined', 'address'])

--- a/test cases/linuxlike/16 sanitizers/test.json
+++ b/test cases/linuxlike/16 sanitizers/test.json
@@ -1,0 +1,10 @@
+{
+  "matrix": {
+    "options": {
+      "b_sanitize": [
+        { "val": ["undefined", "address"] },
+        { "val": ["address", "undefined"] }
+      ]
+    }
+  }
+}

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016-2021 The Meson development team
+# Copyright © 2023-2024 Intel Corporation
 
 import subprocess
 import re
@@ -2750,7 +2751,7 @@ class AllPlatformTests(BasePlatformTests):
             obj = mesonbuild.coredata.load(self.builddir)
             self.assertEqual(obj.optstore.get_value('bindir'), 'bar')
             self.assertEqual(obj.optstore.get_value('buildtype'), 'release')
-            self.assertEqual(obj.optstore.get_value('b_sanitize'), 'thread')
+            self.assertEqual(obj.optstore.get_value('b_sanitize'), ['thread'])
             self.assertEqual(obj.optstore.get_value(OptionKey('c_args')), ['-Dbar'])
             self.setconf(['--bindir=bar', '--bindir=foo',
                           '-Dbuildtype=release', '-Dbuildtype=plain',
@@ -2759,7 +2760,7 @@ class AllPlatformTests(BasePlatformTests):
             obj = mesonbuild.coredata.load(self.builddir)
             self.assertEqual(obj.optstore.get_value('bindir'), 'foo')
             self.assertEqual(obj.optstore.get_value('buildtype'), 'plain')
-            self.assertEqual(obj.optstore.get_value('b_sanitize'), 'address')
+            self.assertEqual(obj.optstore.get_value('b_sanitize'), ['address'])
             self.assertEqual(obj.optstore.get_value(OptionKey('c_args')), ['-Dfoo'])
             self.wipe()
         except KeyError:


### PR DESCRIPTION
The current state of Meson's sanitizer support is that we have a hardcoded set of of string values that can be chosen from. There's several problems with this:

1) some of those values don't work on some platforms, or specific versions of platforms, or on specific compilers on specific platforms. This makes it more than a  simple "GCC has X, MSVC does not" issue. We really need to do a compiler/linker check
2) We don't support all of the possible values that a compiler might, and updates to Meson are required to udpate the list of supported values

To solve all of this I've moved to doing a compiler check for sanitizer arguments, rather than using a hardcoded list. This makes configuration slightly slower when using sanitizers, but much more robust.

Second, I've moved from a string argument to an array. Because we currently support either a single string or `address,undefined` we can do this transparently on the command line, the value of `address,undefined` is a valid array argument, as are single strings. So the command line of `-Db_sanitize=...` this is a 100% backwards compatible change. This simplifies things considerably as we don't have to deal with deprecations and collisions. In the Meson DSL, `get_option('b_sanitize')` has retained its current behavior of returning a string, with a guarantee that and order of `address,undefined` will always return `address,undefined`. If there are new values the value will be `','.join(opts)` with no order guarantees. A new `get_option('b_sanitizers')` will return an array of sanitizers with no ordering guarantees. This keeps things relatively simple, but also provides backwards compatibility guarantees.