### PR TITLE
Adding CLion to the list of the existing IDE integrations

### DIFF
--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -418,11 +418,12 @@ schema is defined by the class structure given in
 
 # Existing integrations
 
+- [CLion](https://www.jetbrains.com/clion/)
+- [Eclipse CDT](https://www.eclipse.org/cdt/)
 - [Gnome Builder](https://wiki.gnome.org/Apps/Builder)
 - [KDevelop](https://www.kdevelop.org)
-- [Eclipse CDT](https://www.eclipse.org/cdt/)
-- [Meson Syntax Highlighter](https://plugins.jetbrains.com/plugin/13269-meson-syntax-highlighter) plugin for JetBrains IDEs.
-- [vscode-meson](https://github.com/mesonbuild/vscode-meson) extension for VS Code/Codium
-- [Qt Creator](https://doc.qt.io/qtcreator/creator-project-meson.html)
+- [Meson Syntax Highlighter](https://plugins.jetbrains.com/plugin/13269-meson-syntax-highlighter) 3rd party plugin for JetBrains IDEs.
 - [Meson-UI](https://github.com/dreamer-coding-555/meson-ui) (build GUI for Meson)
 - [mmeson](https://github.com/stephanlachnit/mmeson) (ccmake clone for Meson)
+- [Qt Creator](https://doc.qt.io/qtcreator/creator-project-meson.html) 
+- [vscode-meson](https://github.com/mesonbuild/vscode-meson) extension for VS Code/Codium


### PR DESCRIPTION
Please consider the following changes to Documentation -> IDE integration -> Existing integrations:

- Added CLion to the list of integrations (https://www.jetbrains.com/help/clion/meson.html).
- Added "3rd party" to the Meson Syntax Highlighter plugin to indicate that it doesn't come from JetBrains.
- Sorted the list alphabetically.

Thank you!