### PR TITLE
Stop using MachineInfo Interpreter objects when the raw objects are available

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -225,10 +225,10 @@ class Vs2010Backend(backends.Backend):
         # Check for (currently) unexpected capture arg use cases -
         if capture:
             raise MesonBugException('We do not expect any vs backend to generate with \'capture = True\'')
-        target_machine = self.interpreter.builtin['target_machine'].cpu_family_method(None, None)
+        target_machine = self.environment.machines.target.cpu_family
         if target_machine in {'64', 'x86_64'}:
             # amd64 or x86_64
-            target_system = self.interpreter.builtin['target_machine'].system_method(None, None)
+            target_system = self.environment.machines.target.system
             if detect_microsoft_gdk(target_system):
                 self.platform = target_system
             else:
@@ -237,7 +237,7 @@ class Vs2010Backend(backends.Backend):
             # x86
             self.platform = 'Win32'
         elif target_machine in {'aarch64', 'arm64'}:
-            target_cpu = self.interpreter.builtin['target_machine'].cpu_method(None, None)
+            target_cpu = self.environment.machines.target.cpu
             if target_cpu == 'arm64ec':
                 self.platform = 'arm64ec'
             else:
@@ -247,7 +247,7 @@ class Vs2010Backend(backends.Backend):
         else:
             raise MesonException('Unsupported Visual Studio platform: ' + target_machine)
 
-        build_machine = self.interpreter.builtin['build_machine'].cpu_family_method(None, None)
+        build_machine = self.environment.machines.build.cpu_family
         if build_machine in {'64', 'x86_64'}:
             # amd64 or x86_64
             self.build_platform = 'x64'
@@ -255,7 +255,7 @@ class Vs2010Backend(backends.Backend):
             # x86
             self.build_platform = 'Win32'
         elif build_machine in {'aarch64', 'arm64'}:
-            target_cpu = self.interpreter.builtin['build_machine'].cpu_method(None, None)
+            target_cpu = self.environment.machines.build.cpu
             if target_cpu == 'arm64ec':
                 self.build_platform = 'arm64ec'
             else:

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -225,27 +225,27 @@ class Vs2010Backend(backends.Backend):
         # Check for (currently) unexpected capture arg use cases -
         if capture:
             raise MesonBugException('We do not expect any vs backend to generate with \'capture = True\'')
-        target_machine = self.environment.machines.target.cpu_family
-        if target_machine in {'64', 'x86_64'}:
+        host_machine = self.environment.machines.host.cpu_family
+        if host_machine in {'64', 'x86_64'}:
             # amd64 or x86_64
-            target_system = self.environment.machines.target.system
+            target_system = self.environment.machines.host.system
             if detect_microsoft_gdk(target_system):
                 self.platform = target_system
             else:
                 self.platform = 'x64'
-        elif target_machine == 'x86':
+        elif host_machine == 'x86':
             # x86
             self.platform = 'Win32'
-        elif target_machine in {'aarch64', 'arm64'}:
-            target_cpu = self.environment.machines.target.cpu
+        elif host_machine in {'aarch64', 'arm64'}:
+            target_cpu = self.environment.machines.host.cpu
             if target_cpu == 'arm64ec':
                 self.platform = 'arm64ec'
             else:
                 self.platform = 'arm64'
-        elif 'arm' in target_machine.lower():
+        elif 'arm' in host_machine.lower():
             self.platform = 'ARM'
         else:
-            raise MesonException('Unsupported Visual Studio platform: ' + target_machine)
+            raise MesonException('Unsupported Visual Studio platform: ' + host_machine)
 
         build_machine = self.environment.machines.build.cpu_family
         if build_machine in {'64', 'x86_64'}:

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -16,7 +16,6 @@ from ..programs import ExternalProgram
 if T.TYPE_CHECKING:
     from ..interpreter import Interpreter
     from ..interpreter.interpreter import ProgramVersionFunc
-    from ..interpreter.interpreterobjects import MachineHolder
     from ..interpreterbase import TYPE_var, TYPE_kwargs
     from ..programs import OverrideProgram
     from ..wrap import WrapMode
@@ -52,9 +51,6 @@ class ModuleState:
         self.man = interpreter.build.get_man()
         self.global_args = interpreter.build.global_args.host
         self.project_args = interpreter.build.projects_args.host.get(interpreter.subproject, {})
-        self.build_machine = T.cast('MachineHolder', interpreter.builtin['build_machine']).held_object
-        self.host_machine = T.cast('MachineHolder', interpreter.builtin['host_machine']).held_object
-        self.target_machine = T.cast('MachineHolder', interpreter.builtin['target_machine']).held_object
         self.current_node = interpreter.current_node
 
     def get_include_args(self, include_dirs: T.Iterable[T.Union[str, build.IncludeDirs]], prefix: str = '-I') -> T.List[str]:

--- a/mesonbuild/modules/cuda.py
+++ b/mesonbuild/modules/cuda.py
@@ -82,7 +82,7 @@ class CudaModule(NewExtensionModule):
         driver_version = 'unknown'
         for d in driver_version_table:
             if version_compare(cuda_version, d['cuda_version']):
-                driver_version = d.get(state.host_machine.system, d['linux'])
+                driver_version = d.get(state.environment.machines.host.system, d['linux'])
                 break
 
         return driver_version

--- a/mesonbuild/modules/external_project.py
+++ b/mesonbuild/modules/external_project.py
@@ -65,8 +65,6 @@ class ExternalProject(NewExtensionModule):
         self.project_version = state.project_version
         self.subproject = state.subproject
         self.env = state.environment
-        self.build_machine = state.build_machine
-        self.host_machine = state.host_machine
         self.configure_command = configure_command
         self.configure_options = configure_options
         self.cross_configure_options = cross_configure_options
@@ -126,10 +124,10 @@ class ExternalProject(NewExtensionModule):
         configure_cmd += self._format_options(self.configure_options, d)
 
         if self.env.is_cross_build():
-            host = '{}-{}-{}'.format(self.host_machine.cpu,
-                                     'pc' if self.host_machine.cpu_family in {"x86", "x86_64"}
+            host = '{}-{}-{}'.format(state.environment.machines.host.cpu,
+                                     'pc' if state.environment.machines.host.cpu_family in {"x86", "x86_64"}
                                      else 'unknown',
-                                     self.host_machine.system)
+                                     state.environment.machines.host.system)
             d = [('HOST', None, host)]
             configure_cmd += self._format_options(self.cross_configure_options, d)
 

--- a/mesonbuild/modules/python3.py
+++ b/mesonbuild/modules/python3.py
@@ -41,7 +41,7 @@ class Python3Module(ExtensionModule):
     @typed_pos_args('python3.extension_module', str, varargs=(str, mesonlib.File, CustomTarget, CustomTargetIndex, GeneratedList, StructuredSources, ExtractedObjects, BuildTarget))
     @typed_kwargs('python3.extension_module', *_MOD_KWARGS, allow_unknown=True)
     def extension_module(self, state: ModuleState, args: T.Tuple[str, T.List[BuildTargetSource]], kwargs: SharedModuleKW):
-        host_system = state.host_machine.system
+        host_system = state.environment.machines.host.system
         if host_system == 'darwin':
             # Default suffix is 'dylib' but Python does not use it for extensions.
             suffix = 'so'

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -196,18 +196,12 @@ class MesonApp:
         # even to write `T.Callable[[*mlog.TV_Loggable], None]`
         logger_fun = T.cast('T.Callable[[mlog.TV_Loggable, mlog.TV_Loggable], None]',
                             (mlog.log if env.is_cross_build() else mlog.debug))
-        build_machine = intr.builtin['build_machine']
-        host_machine = intr.builtin['host_machine']
-        target_machine = intr.builtin['target_machine']
-        assert isinstance(build_machine, interpreter.MachineHolder)
-        assert isinstance(host_machine, interpreter.MachineHolder)
-        assert isinstance(target_machine, interpreter.MachineHolder)
-        logger_fun('Build machine cpu family:', mlog.bold(build_machine.cpu_family_method([], {})))
-        logger_fun('Build machine cpu:', mlog.bold(build_machine.cpu_method([], {})))
-        mlog.log('Host machine cpu family:', mlog.bold(host_machine.cpu_family_method([], {})))
-        mlog.log('Host machine cpu:', mlog.bold(host_machine.cpu_method([], {})))
-        logger_fun('Target machine cpu family:', mlog.bold(target_machine.cpu_family_method([], {})))
-        logger_fun('Target machine cpu:', mlog.bold(target_machine.cpu_method([], {})))
+        logger_fun('Build machine cpu family:', mlog.bold(env.machines.build.cpu_family))
+        logger_fun('Build machine cpu:', mlog.bold(env.machines.build.cpu))
+        mlog.log('Host machine cpu family:', mlog.bold(env.machines.host.cpu_family))
+        mlog.log('Host machine cpu:', mlog.bold(env.machines.host.cpu))
+        logger_fun('Target machine cpu family:', mlog.bold(env.machines.target.cpu_family))
+        logger_fun('Target machine cpu:', mlog.bold(env.machines.target.cpu))
         try:
             if self.options.profile:
                 fname = os.path.join(self.build_dir, 'meson-logs', 'profile-interpreter.log')


### PR DESCRIPTION
Also fix the vs backend to use the host machine instead of the target machine, since that's more correct.