### PR TITLE
Fix / CMake custom targets can output directories, not just files

### DIFF
--- a/mesonbuild/scripts/cmake_run_ctgt.py
+++ b/mesonbuild/scripts/cmake_run_ctgt.py
@@ -95,7 +95,10 @@ def run(argsv: T.List[str]) -> int:
         if do_copy:
             if expected.exists():
                 expected.unlink()
-            shutil.copyfile(str(generated), str(expected))
+            if generated.is_dir():
+                shutil.copytree(str(generated), str(expected))
+            else :
+                shutil.copyfile(str(generated), str(expected))
 
     return 0
 


### PR DESCRIPTION
# Issue

CMake custom targets can output directories, not just files. They must be copied recursively by the meson CMake handler.

Example: [libwebsockets](https://github.com/warmcat/libwebsockets) uses the `cmake -E copy_directory` command:

https://github.com/warmcat/libwebsockets/blob/2631f825d0b8ed665f7f209e544a1a71a0820072/CMakeLists.txt#L1095-L1096

# Problem

This fails meson `cmake_run_ctgt` when libwebsocket is used as CMake subproject: 

```
FAILED: subprojects/libwebsockets_cmake/lws_config.h subprojects/libwebsockets_cmake/libwebsockets subprojects/libwebsockets_cmake/libwebsockets.h 
/usr/bin/meson --internal cmake_run_ctgt -o subprojects/libwebsockets_cmake/lws_config.h subprojects/libwebsockets_cmake/libwebsockets subprojects/libwebsockets_cmake/libwebsockets.h -O /home/markus/workspace/v_erp/v_platform/builddir_debug/subprojects/libwebsockets_cmake/__CMake_build/include/lws_config.h /home/markus/workspace/v_erp/v_platform/builddir_debug/subprojects/libwebsockets_cmake/__CMake_build/include/libwebsockets /home/markus/workspace/v_erp/v_platform/builddir_debug/subprojects/libwebsockets_cmake/__CMake_build/include/libwebsockets.h -d /home/markus/workspace/v_erp/v_platform/builddir_debug/subprojects/libwebsockets_cmake/__CMake_build /usr/bin/cmake -E copy /home/markus/workspace/v_erp/v_platform/subprojects/libwebsockets_cmake/include/libwebsockets.h /home/markus/workspace/v_erp/v_platform/builddir_debug/subprojects/libwebsockets_cmake/__CMake_build/include/libwebsockets.h ';;;' /usr/bin/cmake -E copy_directory /home/markus/workspace/v_erp/v_platform/subprojects/libwebsockets_cmake/include/libwebsockets/ /home/markus/workspace/v_erp/v_platform/builddir_debug/subprojects/libwebsockets_cmake/__CMake_build/include/libwebsockets ';;;' /usr/bin/cmake -E copy /home/markus/workspace/v_erp/v_platform/builddir_debug/subprojects/libwebsockets_cmake/__CMake_build/lws_config.h /home/markus/workspace/v_erp/v_platform/builddir_debug/subprojects/libwebsockets_cmake/__CMake_build/include/lws_config.h ';;;'
Traceback (most recent call last):
  File "/usr/bin/meson", line 40, in <module>
    sys.exit(mesonmain.main())
             ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/mesonbuild/mesonmain.py", line 294, in main
    return run(sys.argv[1:], launcher)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/mesonbuild/mesonmain.py", line 282, in run
    return run_script_command(args[1], args[2:])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/mesonbuild/mesonmain.py", line 223, in run_script_command
    return module.run(script_args)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/mesonbuild/scripts/cmake_run_ctgt.py", line 98, in run
    shutil.copyfile(str(generated), str(expected))
  File "/usr/lib/python3.11/shutil.py", line 256, in copyfile
    with open(src, 'rb') as fsrc:
         ^^^^^^^^^^^^^^^
IsADirectoryError: [Errno 21] Is a directory: '/home/markus/workspace/v_erp/v_platform/builddir_debug/subprojects/libwebsockets_cmake/__CMake_build/include/libwebsockets'
ninja: build stopped: subcommand failed.
```

https://github.com/mesonbuild/meson/blob/35d89301a908a42b9fe1284dd616cffabdfc45aa/mesonbuild/scripts/cmake_run_ctgt.py#L95-L98


See also #12655 