### PR TITLE
Add support for dumping dependent headers in nvcc

### DIFF
--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -735,6 +735,15 @@ class CudaCompiler(Compiler):
     def get_output_args(self, target: str) -> T.List[str]:
         return ['-o', target]
 
+    def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
+        if version_compare(self.version, '>= 10.2'):
+            # According to nvcc Documentation, `-MD` option is added after 10.2
+            # Reference: [CUDA 10.1](https://docs.nvidia.com/cuda/archive/10.1/cuda-compiler-driver-nvcc/index.html#options-for-specifying-compilation-phase-generate-nonsystem-dependencies)
+            # Reference: [CUDA 10.2](https://docs.nvidia.com/cuda/archive/10.2/cuda-compiler-driver-nvcc/index.html#options-for-specifying-compilation-phase-generate-nonsystem-dependencies)
+            return ['-MD', '-MT', outtarget, '-MF', outfile]
+        else:
+            return []
+
     def get_std_exe_link_args(self) -> T.List[str]:
         return self._to_host_flags(self.host_compiler.get_std_exe_link_args(), _Phase.LINKER)
 


### PR DESCRIPTION
This PR mainly does following thing:

1. Add support for dumping dependent headers in nvcc
2. Add version check mentioned in [the comment](https://github.com/mesonbuild/meson/pull/11229#issuecomment-1370287546).
3. Since nvcc doesn't support `-MQ` option, this PR first escapes the `outFile` then passes it to `-MT`. This is implemented according to [LLVM](https://github.com/llvm/llvm-project/blob/bbe1b06fbb7127d613cb4958e06c737967878388/clang/lib/Basic/MakeSupport.cpp#L11).

This PR supersedes #11229 and #10993, fixes #11969. It also fix some problem mentioned in comments of #11229, including

1. https://github.com/mesonbuild/meson/pull/11229#issuecomment-1369915553
2. https://github.com/mesonbuild/meson/pull/11229#issuecomment-1370308169

The failure case mentioned in [that comment](https://github.com/mesonbuild/meson/pull/11229#issuecomment-1370385839) is not dealt since llvm doesn't also deal with `:` in target file name, it's too strange. 