### PR TITLE
Cache get_default_include_dirs for E2K

### DIFF
--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 """Abstractions for the Elbrus family of compilers."""
 
+import functools
 import os
 import typing as T
 import subprocess
@@ -59,6 +60,7 @@ class ElbrusCompiler(GnuLikeCompiler):
                 return [os.path.realpath(p) for p in libstr.split(':')]
         return []
 
+    @functools.lru_cache(maxsize=None)
     def get_default_include_dirs(self) -> T.List[str]:
         os_env = os.environ.copy()
         os_env['LC_ALL'] = 'C'


### PR DESCRIPTION
Meson will spawn around ~700 child processes without caching to get default include dirs for my project.

```
# Before
$ time ~/dev/meson/meson.py setup build
...
real    0m26,988s
user    0m18,299s
sys     0m9,251s

# After
$ time ~/dev/meson/meson.py setup build
...
real    0m6,774s
user    0m5,367s
sys     0m1,497s
```