### PR TITLE
gnome.compile_schemas(): fail on incorrect schemas

### DIFF
--- a/docs/markdown/snippets/glib-compile-schemas-strict.md
+++ b/docs/markdown/snippets/glib-compile-schemas-strict.md
@@ -1,0 +1,3 @@
+## `gnome.compile_schemas()` now fails on incorrect schemas
+
+Build will now fail if a schema XML file isn't correct.

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1232,7 +1232,7 @@ class GnomeModule(ExtensionModule):
         srcdir = os.path.join(state.build_to_src, state.subdir)
         outdir = state.subdir
 
-        cmd: T.List[T.Union['ToolType', str]] = [self._find_tool(state, 'glib-compile-schemas'), '--targetdir', outdir, srcdir]
+        cmd: T.List[T.Union['ToolType', str]] = [self._find_tool(state, 'glib-compile-schemas'), '--strict', '--targetdir', outdir, srcdir]
         if state.subdir == '':
             targetname = 'gsettings-compile'
         else:

--- a/test cases/failing build/6 glib-compile-schemas strict/meson.build
+++ b/test cases/failing build/6 glib-compile-schemas strict/meson.build
@@ -1,0 +1,3 @@
+project('bad gsettings schema')
+
+import('gnome').compile_schemas(depend_files: 'bad.gschema.xml')


### PR DESCRIPTION
When a schema file isn't correct, build should fail.

Fixes #10802