### PR TITLE
Add support for dumping dependent headers in nvcc

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2451,7 +2451,11 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             # See also: https://github.com/ninja-build/ninja/pull/2275
             options['extra'] = 'restat = 1'
         rule = self.compiler_to_rule_name(compiler)
-        depargs = NinjaCommandArg.list(compiler.get_dependency_gen_args('$out', '$DEPFILE'), Quoting.none)
+        if langname == 'cuda':
+            # for cuda, we manually escape target name ($out) as $CUDA_ESCAPED_TARGET because nvcc doesn't support `-MQ` flag
+            depargs = NinjaCommandArg.list(compiler.get_dependency_gen_args('$CUDA_ESCAPED_TARGET', '$DEPFILE'), Quoting.none)
+        else:
+            depargs = NinjaCommandArg.list(compiler.get_dependency_gen_args('$out', '$DEPFILE'), Quoting.none)
         command = compiler.get_exelist()
         args = ['$ARGS'] + depargs + NinjaCommandArg.list(compiler.get_output_args('$out'), Quoting.none) + compiler.get_compile_only_args() + ['$in']
         description = f'Compiling {compiler.get_display_language()} object $out'
@@ -3006,6 +3010,28 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             element.add_orderdep(i)
         if dep_file:
             element.add_item('DEPFILE', dep_file)
+        if compiler.get_language() == 'cuda':
+            # for cuda, we manually escape target name ($out) as $CUDA_ESCAPED_TARGET because nvcc doesn't support `-MQ` flag
+            def quote_make_target(targetName: str) -> str:
+                # this escape implementation is taken from llvm
+                result = ''
+                for (i, c) in enumerate(targetName):
+                    if c in {' ', '\t'}:
+                        # Escape the preceding backslashes
+                        for j in range(i - 1, -1, -1):
+                            if targetName[j] == '\\':
+                                result += '\\'
+                            else:
+                                break
+                        # Escape the space/tab
+                        result += '\\'
+                    elif c == '$':
+                        result += '$'
+                    elif c == '#':
+                        result += '\\'
+                    result += c
+                return result
+            element.add_item('CUDA_ESCAPED_TARGET', quote_make_target(rel_obj))
         element.add_item('ARGS', commands)
 
         self.add_dependency_scanner_entries_to_element(target, compiler, element, src)

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -735,6 +735,15 @@ class CudaCompiler(Compiler):
     def get_output_args(self, target: str) -> T.List[str]:
         return ['-o', target]
 
+    def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
+        if version_compare(self.version, '>= 10.2'):
+            # According to nvcc Documentation, `-MD` option is added after 10.2
+            # Reference: [CUDA 10.1](https://docs.nvidia.com/cuda/archive/10.1/cuda-compiler-driver-nvcc/index.html#options-for-specifying-compilation-phase-generate-nonsystem-dependencies)
+            # Reference: [CUDA 10.2](https://docs.nvidia.com/cuda/archive/10.2/cuda-compiler-driver-nvcc/index.html#options-for-specifying-compilation-phase-generate-nonsystem-dependencies)
+            return ['-MD', '-MT', outtarget, '-MF', outfile]
+        else:
+            return []
+
     def get_std_exe_link_args(self) -> T.List[str]:
         return self._to_host_flags(self.host_compiler.get_std_exe_link_args(), _Phase.LINKER)
 


### PR DESCRIPTION
# Summary 

This PR mainly does following thing:

1. Add support for dumping dependent headers in nvcc
2. Add version check mentioned in [the comment](https://github.com/mesonbuild/meson/pull/11229#issuecomment-1370287546).
3. Nvcc doesn't support `-MQ` flag, so we have to manually escape cuda target name. This PR escape `$out` to `$CUDA_ESCAPED_TARGET`, so now we can just use `-MT` flag in nvcc to generate header dependencies. This is implemented according to [LLVM](https://github.com/llvm/llvm-project/blob/bbe1b06fbb7127d613cb4958e06c737967878388/clang/lib/Basic/MakeSupport.cpp#L11).

This PR supersedes #11229 and #10993, fixes #11969. It also fix some problems mentioned in comments of #11229, including

1. https://github.com/mesonbuild/meson/pull/11229#issuecomment-1369915553
2. https://github.com/mesonbuild/meson/pull/11229#issuecomment-1370308169

I have tested that this PR can work for file with space in its name using oldest ninja version (1.8.2)  that meson support. The failure case mentioned in [that comment](https://github.com/mesonbuild/meson/pull/11229#issuecomment-1370385839) is not dealt since llvm doesn't also deal with `:` in target file name, it's too strange. 

# Some discussions about dependency files generation for nvcc

Since nvcc havn't support `-MQ` yet, we have following choices to support dependency files generation using `-MT` in nvcc:

1. Wrap nvcc (#4991) and add some flags. It's very hard since we can correctly parse added flags passed to wrapper only if we can parse flags in the exactly same way as nvcc. For example, this is a failure case: compiling a file whose name is `-MQ` using the wrapper.
2. Escape target name when generating build command (This PR). It's just a workaround, but I can't think out a better way.



Closes: #11229 
Closes: #10993