### PR TITLE
Qt documentation updates

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -679,7 +679,7 @@ but dependency tries `pkg-config` first.
 
 `method` may be `auto`, `extraframework`, `pkg-config` or `sysconfig`
 
-## Qt4 & Qt5
+## Qt
 
 Meson has native Qt support. Its usage is best demonstrated with an
 example.

--- a/docs/markdown/Qt6-module.md
+++ b/docs/markdown/Qt6-module.md
@@ -19,7 +19,7 @@ It takes no positional arguments, and the following keyword arguments:
     A list of sources to be transpiled. Required, must have at least one source<br/>
     *New in 0.60.0*: support for custom_target, custom_target_index, and generator_output.
   - `extra_args` string[]: Extra arguments to pass directly to `qt-rcc`
-  - `method` string: The method to use to detect qt, see [[dependency]]
+  - `method` string: The method to use to detect Qt, see [[dependency]]
 
 ## compile_ui
 
@@ -32,7 +32,7 @@ It takes no positional arguments, and the following keyword arguments:
     A list of sources to be transpiled. Required, must have at least one source<br/>
     *New in 0.60.0*: support for custom_target, custom_target_index, and generator_output.
   - `extra_args` string[]: Extra arguments to pass directly to `qt-uic`
-  - `method` string: The method to use to detect qt, see [[dependency]]
+  - `method` string: The method to use to detect Qt, see [[dependency]]
 
 ## compile_moc
 
@@ -49,7 +49,7 @@ It takes no positional arguments, and the following keyword arguments:
      A list of headers to be transpiled into .cpp files<br/>
     *New in 0.60.0*: support for custom_target, custom_target_index, and generator_output.
   - `extra_args` string[]: Extra arguments to pass directly to `qt-moc`
-  - `method` string: The method to use to detect qt, see [[dependency]]
+  - `method` string: The method to use to detect Qt, see [[dependency]]
   - `dependencies`: dependency objects whose include directories are used by moc.
   - `include_directories` (string | IncludeDirectory)[]: A list of `include_directory()`
     objects used when transpiling the .moc files
@@ -134,7 +134,7 @@ This method takes the following keyword arguments:
 - `required` bool | FeatureOption: by default, `required` is set to `false`. If `required` is set to
   `true` or an enabled [`feature`](Build-options.md#features) and some tools are
   missing Meson will abort.
-- `method` string: The method to use to detect qt, see [[dependency]]
+- `method` string: The method to use to detect Qt, see [[dependency]]
 
 ## Dependencies
 

--- a/docs/markdown/Qt6-module.md
+++ b/docs/markdown/Qt6-module.md
@@ -138,7 +138,7 @@ This method takes the following keyword arguments:
 
 ## Dependencies
 
-See [Qt dependencies](Dependencies.md#qt4-qt5)
+See [Qt dependencies](Dependencies.md#qt)
 
 The 'modules' argument is used to include Qt modules in the project.
 See the Qt documentation for the [list of

--- a/docs/markdown/Qt6-module.md
+++ b/docs/markdown/Qt6-module.md
@@ -2,8 +2,14 @@
 
 *New in Meson 0.57.0*
 
-The Qt6 module provides tools to automatically deal with the various
+The Qt6 module provides methods to automatically deal with the various
 tools and steps required for Qt.
+
+<div class="alert alert-warning">
+<strong>Warning:</strong> before version 0.63.0 Meson would fail to find
+Qt 6.1 or later due to the Qt tools having moved to the libexec subdirectory,
+and tool names being suffixed with only the Qt major version number e.g. qmake6.
+</div>
 
 ## compile_resources
 

--- a/docs/markdown/_include_qt_base.md
+++ b/docs/markdown/_include_qt_base.md
@@ -128,7 +128,7 @@ This method takes the following keyword arguments:
 
 ## Dependencies
 
-See [Qt dependencies](Dependencies.md#qt4-qt5)
+See [Qt dependencies](Dependencies.md#qt)
 
 The 'modules' argument is used to include Qt modules in the project.
 See the Qt documentation for the [list of

--- a/docs/markdown/_include_qt_base.md
+++ b/docs/markdown/_include_qt_base.md
@@ -81,7 +81,9 @@ This method takes the following keyword arguments:
 
 It returns an array of targets and sources to pass to a compilation target.
 
-## compile_translations (since v0.44.0)
+## compile_translations
+
+*since 0.44.0*
 
 This method generates the necessary targets to build translation files with
 lrelease, it takes no positional arguments, and the following keyword arguments:

--- a/docs/markdown/_include_qt_base.md
+++ b/docs/markdown/_include_qt_base.md
@@ -12,7 +12,7 @@ It takes no positional arguments, and the following keyword arguments:
     A list of sources to be transpiled. Required, must have at least one source
     *New in 0.60.0*: support for custom_target, custom_target_index, and generator_output.
   - `extra_args` string[]: Extra arguments to pass directly to `qt-rcc`
-  - `method` string: The method to use to detect qt, see `dependency()` for more
+  - `method` string: The method to use to detect Qt, see `dependency()` for more
     information.
 
 ## compile_ui
@@ -26,7 +26,7 @@ It takes no positional arguments, and the following keyword arguments:
     A list of sources to be transpiled. Required, must have at least one source
     *New in 0.60.0*: support for custom_target, custom_target_index, and generator_output.
   - `extra_args` string[]: Extra arguments to pass directly to `qt-uic`
-  - `method` string: The method to use to detect qt, see `dependency()` for more
+  - `method` string: The method to use to detect Qt, see `dependency()` for more
     information.
 
 ## compile_moc
@@ -44,7 +44,7 @@ It takes no positional arguments, and the following keyword arguments:
      A list of headers to be transpiled into .cpp files
     *New in 0.60.0*: support for custom_target, custom_target_index, and generator_output.
   - `extra_args` string[]: Extra arguments to pass directly to `qt-moc`
-  - `method` string: The method to use to detect qt, see `dependency()` for more
+  - `method` string: The method to use to detect Qt, see `dependency()` for more
     information.
   - `dependencies`: dependency objects whose include directories are used by moc.
   - `include_directories` (string | IncludeDirectory)[]: A list of `include_directory()`


### PR DESCRIPTION
Some suggestions after learning to use the Qt6 module for the first time. I think making it clear that `0.63.0` is the effective minimum version for Qt6 would be helpful.