### PR TITLE
envconfig: read CYTHON from the environment and use it if set

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -374,6 +374,7 @@ machine](#Environment-variables-per-machine) section for details.
 | Rust          | RUSTC    | RUSTC_LD  | Before 0.54 RUST_LD*                        |
 | Vala          | VALAC    |           | Use CC_LD. Vala transpiles to C             |
 | C#            | CSC      | CSC       | The linker is the compiler                  |
+| Cython        | CYTHON   |           |                                             |
 | nasm          | NASM     |           | Uses the C linker                           |
 
 *The old environment variables are still supported, but are deprecated

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -88,6 +88,7 @@ ENV_VAR_COMPILER_MAP: T.Mapping[str, str] = {
     'c': 'CC',
     'cpp': 'CXX',
     'cs': 'CSC',
+    'cython': 'CYTHON',
     'd': 'DC',
     'fortran': 'FC',
     'objc': 'OBJC',


### PR DESCRIPTION
Add support for specifying Cython compiler using the `CYTHON` environment variable. If not set, proceed with the names hard coded for Cython. Inspired by issue #1645, which ended up with this solution being implemented for `VALAC` (https://github.com/mesonbuild/meson/commit/bc30ad6dbada192ae4ab0665c0c43781c7957ec7).

There is already [a line in the existing code](https://github.com/mesonbuild/meson/blob/master/run_project_tests.py#L1119) that reads the `CYTHON` variable, but only in test code.

Motivation: MacPorts uses versioned names (e.g., `cython-3.12`) and so does not expose `cython` or `cython3` by default (there is a command to create symlinks to `cython`/`cython3`). Its NumPy package is currently built by [patching NumPy’s bundled version of Meson](https://github.com/macports/macports-ports/blob/master/python/py-numpy/files/patch-build_cython_path.diff) to use the solution I am proposing here, and that is also where I got the idea from.

Note: I read that these environment variables are [deprecated](https://mesonbuild.com/Reference-tables.html#compiler-and-linker-selection-variables) and that environment variables in Meson generally should be “[avoided whenever possible](https://mesonbuild.com/Contributing.html#environment-variables)”, but as far as I could see there is no new solution in place yet?

Edit:
I should add that `cython-3.12` itself is a symlink to the `cython` binary, but it resides in a folder that is not on PATH. This is deliberate, so that different Python versions can live side by side.
