### PR TITLE
Fix intellisense errors in genvslite projects

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1118,7 +1118,7 @@ class Vs2010Backend(backends.Backend):
     # and include paths, e.g. -
     #    '..\\some\\dir\\include;../../some/other/dir;'
     # and finally any remaining compiler options, e.g. -
-    #    '/MDd;/W2;/std:c++17;/Od/Zi'
+    #    '/MDd /W2 /std:c++17 /Od/Zi'
     @staticmethod
     def _extract_nmake_fields(captured_build_args: list[str]) -> T.Tuple[str, str, str]:
         include_dir_options = [
@@ -1131,7 +1131,7 @@ class Vs2010Backend(backends.Backend):
         ]
 
         defs = ''
-        paths = ''
+        paths = '$(VC_IncludePath);$(WindowsSDK_IncludePath);'
         additional_opts = ''
         for arg in captured_build_args:
             if arg.startswith(('-D', '/D')):
@@ -1141,7 +1141,7 @@ class Vs2010Backend(backends.Backend):
                 if opt_match:
                     paths += arg[len(opt_match):] + ';'
                 elif arg.startswith(('-', '/')):
-                    additional_opts += arg + ';'
+                    additional_opts += arg + ' '
         return (defs, paths, additional_opts)
 
     @staticmethod


### PR DESCRIPTION
This pull request fixes two separate issues related to the "genvslite" option. These issues don't affect compilation, but prevent intellisense correctly parsing code in the generated project files, arguably the main incentive to generate VS projects in this form in the first place.

To reproduce the issues, do the following:
1. Download and extract [MesonIntellisense.zip](https://github.com/mesonbuild/meson/files/13782183/MesonIntellisense.zip)
2. From the extracted folder, run the following command: `meson.exe setup --genvslite vs2022 "VSProject"`
3. Open "VSProject_vs\TestIntellisense.sln" in Visual Studio
4. Open the "main.cpp" file

You should now see several intellisense errors (red squiggles) like this:
![image](https://github.com/mesonbuild/meson/assets/22307782/9ba83952-ef06-44ed-842b-0c58b836272a)

Both of the issues relate to the options that appear in the generated "NMake" project settings under the "Intellisense" section:
![image](https://github.com/mesonbuild/meson/assets/22307782/b85efe4f-f6bf-429b-ab6b-69b2d189256c)

The first issue is the "Additional Options" field. Currently, meson separates arguments with a semicolon. This is the correct form for other fields here like the defines and include search paths, but the additional compiler options field is a simple string, not a list, and needs to have options separated by spaces in order to be recognised. The visible result of this is that the `/std:c++20` flag isn't recognised, so the nested namespace definition (C++17 feature) isn't accepted.

The second issue relates to include paths. Standard include paths need to be added to resolve STL and platform headers, these are not added implicitly for NMake project types. This is simply resolved by prepending "$(VC_IncludePath);$(WindowsSDK_IncludePath);" to the include search paths, which will be resolved within VS for Intellisense. Neither of these changes affect compilation. The end result after these changes looks like this:
![image](https://github.com/mesonbuild/meson/assets/22307782/c6486dd8-785c-4784-89c6-6c587569e0de)