### PR TITLE
Fix macos.yml and add a yamllint job to lint.yml

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -78,7 +78,7 @@ jobs:
     name: ${{ matrix.NAME }}
     env:
       MESON_CI_JOBNAME: ${{ matrix.NAME }}
-        HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
A .yamllint file is created for the lint.yml job, which can also be used on the command line
e.g. to find the problem without the macos.yml commit:

```
$ yamllint .github/workflows/
.github/workflows/macos.yml
  81:32     error    syntax error: mapping values are not allowed here (syntax)
```
