### PR TITLE
compilers: c: add Modern C -Werrors for GCC, Clang

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -258,6 +258,7 @@ or compiler being used:
 | c_args           |               | free-form comma-separated list           | C compile arguments to use |
 | c_link_args      |               | free-form comma-separated list           | C link arguments to use |
 | c_std            | none          | none, c89, c99, c11, c17, c18, c2x, gnu89, gnu99, gnu11, gnu17, gnu18, gnu2x | C language standard to use |
+| c_legal_code     | true          | true, false                              | Ban C dangerous constructs by default in C99 or later |
 | c_winlibs        | see below     | free-form comma-separated list           | Standard Windows libs to link against |
 | c_thread_count   | 4             | integer value ≥ 0                        | Number of threads to use with emcc when using threads |
 | cpp_args         |               | free-form comma-separated list           | C++ compile arguments to use |

--- a/docs/markdown/snippets/c-legal-code.md
+++ b/docs/markdown/snippets/c-legal-code.md
@@ -1,0 +1,16 @@
+## `c_legal_code` option introduced
+
+The new `c_legal_code` option is enabled by default. It bans
+dangerous C constructs in C99 or later to emulate newer C compiler
+defaults.
+
+For GCC, it sets the following:
+* `-Werror=implicit` (-> `-Werror=implicit-int,implicit-function-declaration`)
+* `-Werror=int-conversion`
+* `-Werror=incompatible-pointer-types`
+
+For Clang, it sets the following:
+* `-Werror=implicit` (-> `-Werror=implicit-int,implicit-function-declaration`)
+* `-Werror=int-conversion`
+* `-Werror=incompatible-pointer-types`
+* `-Wno-error=incompatible-pointer-types-discards-qualifiers` (to emulate GCC's behavior)

--- a/test cases/vala/1 basic/meson.build
+++ b/test cases/vala/1 basic/meson.build
@@ -1,5 +1,5 @@
 # Language are case unsensitive, check here that capital C works too.
-project('valatest', 'vala', 'C')
+project('valatest', 'vala', 'C', default_options: ['c_legal_code=false'])
 
 valadeps = [dependency('glib-2.0'), dependency('gobject-2.0')]
 

--- a/test cases/vala/11 generated vapi/meson.build
+++ b/test cases/vala/11 generated vapi/meson.build
@@ -1,4 +1,4 @@
-project('vapi-test', ['c', 'vala'])
+project('vapi-test', ['c', 'vala'], default_options: ['c_legal_code=false'])
 
 gnome = import('gnome')
 subdir('libfoo')

--- a/test cases/vala/14 target glib version and gresources/meson.build
+++ b/test cases/vala/14 target glib version and gresources/meson.build
@@ -1,4 +1,4 @@
-project('test glib target version and gresources', 'c', 'vala')
+project('test glib target version and gresources', 'c', 'vala', default_options: ['c_legal_code=false'])
 
 gnome = import('gnome')
 

--- a/test cases/vala/16 mixed dependence/meson.build
+++ b/test cases/vala/16 mixed dependence/meson.build
@@ -1,4 +1,4 @@
-project('mixed dependence', 'vala', 'c')
+project('mixed dependence', 'vala', 'c', default_options: ['c_legal_code=false'])
 
 cc = meson.get_compiler('c')
 

--- a/test cases/vala/17 plain consumer/meson.build
+++ b/test cases/vala/17 plain consumer/meson.build
@@ -1,4 +1,4 @@
-project('plain consumer', 'vala', 'c')
+project('plain consumer', 'vala', 'c', default_options: ['c_legal_code=false'])
 
 deps = [dependency('glib-2.0'), dependency('gobject-2.0')]
 

--- a/test cases/vala/18 vapi consumed twice/meson.build
+++ b/test cases/vala/18 vapi consumed twice/meson.build
@@ -1,4 +1,4 @@
-project('vapi consumed twice', 'vala', 'c')
+project('vapi consumed twice', 'vala', 'c', default_options: ['c_legal_code=false'])
 
 base_deps = [dependency('glib-2.0'), dependency('gobject-2.0')]
 

--- a/test cases/vala/2 multiple files/meson.build
+++ b/test cases/vala/2 multiple files/meson.build
@@ -1,5 +1,5 @@
 # adding 'c' shouldn't be required
-project('multiple files')
+project('multiple files', default_options: ['c_legal_code=false'])
 add_languages('vala')
 
 glib = dependency('glib-2.0')

--- a/test cases/vala/20 genie multiple mixed sources/meson.build
+++ b/test cases/vala/20 genie multiple mixed sources/meson.build
@@ -1,4 +1,4 @@
-project( 'Genie multiple and mixed sources', 'vala', 'c' )
+project( 'Genie multiple and mixed sources', 'vala', 'c', default_options: ['c_legal_code=false'])
 
 genie_deps = [
     dependency( 'glib-2.0' ),

--- a/test cases/vala/21 type module/meson.build
+++ b/test cases/vala/21 type module/meson.build
@@ -1,4 +1,4 @@
-project('valatest', 'c', 'vala')
+project('valatest', 'c', 'vala', default_options: ['c_legal_code=false'])
 
 glib_dep = dependency('glib-2.0')
 gobject_dep = dependency('gobject-2.0')

--- a/test cases/vala/22 same target in directories/meson.build
+++ b/test cases/vala/22 same target in directories/meson.build
@@ -1,4 +1,4 @@
-project('valatest', 'vala', 'c')
+project('valatest', 'vala', 'c', default_options: ['c_legal_code=false'])
 
 valadeps = [dependency('glib-2.0'), dependency('gobject-2.0')]
 valafiles = files(

--- a/test cases/vala/25 extract_all_objects/meson.build
+++ b/test cases/vala/25 extract_all_objects/meson.build
@@ -1,4 +1,4 @@
-project('valatest', 'vala', 'c')
+project('valatest', 'vala', 'c', default_options: ['c_legal_code=false'])
 
 valadeps = [dependency('glib-2.0'), dependency('gobject-2.0')]
 

--- a/test cases/vala/26 vala and asm/meson.build
+++ b/test cases/vala/26 vala and asm/meson.build
@@ -1,4 +1,4 @@
-project('vala and asm', 'vala', 'c')
+project('vala and asm', 'vala', 'c', default_options: ['c_legal_code=false'])
 
 cpu = host_machine.cpu_family()
 cc = meson.get_compiler('c')

--- a/test cases/vala/27 file as command line argument/meson.build
+++ b/test cases/vala/27 file as command line argument/meson.build
@@ -1,4 +1,4 @@
-project('composite', 'vala', 'c')
+project('composite', 'vala', 'c', default_options: ['c_legal_code=false'])
 gnome = import('gnome')
 deps = [
   dependency('glib-2.0', version : '>=2.38'),

--- a/test cases/vala/3 dep/meson.build
+++ b/test cases/vala/3 dep/meson.build
@@ -1,4 +1,4 @@
-project('giotest', 'vala', 'c')
+project('giotest', 'vala', 'c', default_options: ['c_legal_code=false'])
 
 glib = dependency('glib-2.0')
 gobject = dependency('gobject-2.0')

--- a/test cases/vala/4 config/meson.build
+++ b/test cases/vala/4 config/meson.build
@@ -1,4 +1,4 @@
-project('valatest', 'vala', 'c')
+project('valatest', 'vala', 'c', default_options: ['c_legal_code=false'])
 
 valac = meson.get_compiler('vala')
 # Try to find our library

--- a/test cases/vala/5 target glib/meson.build
+++ b/test cases/vala/5 target glib/meson.build
@@ -1,4 +1,4 @@
-project('valatest', 'vala', 'c')
+project('valatest', 'vala', 'c', default_options: ['c_legal_code=false'])
 
 valadeps = [dependency('glib-2.0', version : '>=2.32'), dependency('gobject-2.0')]
 

--- a/test cases/vala/6 static library/meson.build
+++ b/test cases/vala/6 static library/meson.build
@@ -1,4 +1,4 @@
-project('valastatic', 'vala', 'c')
+project('valastatic', 'vala', 'c', default_options: ['c_legal_code=false'])
 
 valadeps = [dependency('glib-2.0'), dependency('gobject-2.0')]
 

--- a/test cases/vala/7 shared library/meson.build
+++ b/test cases/vala/7 shared library/meson.build
@@ -1,4 +1,4 @@
-project('shared library', 'vala', 'c')
+project('shared library', 'vala', 'c', default_options: ['c_legal_code=false'])
 
 valadeps = [dependency('glib-2.0'), dependency('gobject-2.0')]
 


### PR DESCRIPTION
Add the following flags to error out by default via a new default-on 'Dc_legal_code' option for GCC and Clang:
* -Werror=implicit (-> -Werror=implicit-int,implicit-function-declaration)
* -Werror=int-conversion
* -Werror=incompatible-pointer-types

Implicit function declarations were removed in C99 with no deprecation period because of how dangerous they are.

Implicit conversions between integers and pointers were also never allowed in >= C89.

These were allowed by GCC and Clang until recently for compatibility reasons:
* GCC plans to make these errors by default in GCC 14
* Clang made -Werror=int-conversion a default error in Clang 15 and made the others an error in Clang 16

The reason for Meson to do this even for older compilers is straightforward:
* It'll take time for these newer versions to propagate into distributions.
* The code emitting these is broken *now*.
* Projects like PipeWire and various GNOME components are adding these flags manually to catch them already.