### PR TITLE
compilers: cpp: wire up stdlib assertions

### DIFF
--- a/docs/markdown/snippets/cpp-debug.md
+++ b/docs/markdown/snippets/cpp-debug.md
@@ -1,0 +1,10 @@
+## `ndebug` setting now controls C++ stdlib assertions
+
+The `ndebug` setting, if disabled, now passes preprocessor defines to enable
+debugging assertions within the C++ standard library.
+
+For GCC, `-D_GLIBCXX_ASSERTIONS=1` is set.
+
+For Clang, `-D_GLIBCXX_ASSERTIONS=1` is set to cover libstdc++ usage,
+and `-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE` or
+`-D_LIBCPP_ENABLE_ASSERTIONS=1` is used depending on the Clang version.

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -293,6 +293,20 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCompiler, CPPCompiler):
             return libs
         return []
 
+    def get_assert_args(self, disable: bool) -> T.List[str]:
+        args: T.List[str] = []
+        if disable:
+            return ['-DNDEBUG']
+
+        # Clang supports both libstdc++ and libc++
+        args.append('-D_GLIBCXX_ASSERTIONS=1')
+        if version_compare(self.version, '>=18'):
+            args.append('-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE')
+        elif version_compare(self.version, '>=15'):
+            args.append('-D_LIBCPP_ENABLE_ASSERTIONS=1')
+
+        return args
+
 
 class ArmLtdClangCPPCompiler(ClangCPPCompiler):
 
@@ -461,6 +475,14 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCompiler, CPPCompiler):
                 assert isinstance(l, str)
             return libs
         return []
+
+    def get_assert_args(self, disable: bool) -> T.List[str]:
+        if disable:
+            return ['-DNDEBUG']
+
+        # XXX: This needs updating if/when GCC starts to support libc++.
+        # It currently only does so via an experimental configure arg.
+        return ['-D_GLIBCXX_ASSERTIONS=1']
 
     def get_pch_use_args(self, pch_dir: str, header: str) -> T.List[str]:
         return ['-fpch-preprocess', '-include', os.path.basename(header)]


### PR DESCRIPTION
None of the options set here affect ABI and are intended for detecting constraint violations.

For GCC, we simply need to set -D_GLIBCXX_ASSERTIONS.

For Clang, the situation is far more complicated:
* LLVM 18 uses a 'hardened mode' (https://libcxx.llvm.org/Hardening.html). There are several levels of severity available here. I've chosen _LIBCPP_HARDENING_MODE_DEBUG for now given it does the most but does not affect ABI, but we could change it to something more lightweight.

* LLVM 17 uses a similar approach to libstdc++ called '_LIBCPP_ENABLE_ASSERTIONS'

Note that LLVM 17 while in development had fully deprecated _LIBCPP_ENABLE_ASSERTIONS in favour of hardened, but changed its mind last-minute: https://discourse.llvm.org/t/rfc-hardening-in-libc/73925/4.