### PR TITLE
compilers: cpp: wire up debugstl for Clang

### DIFF
--- a/docs/markdown/snippets/cpp-stldebug.md
+++ b/docs/markdown/snippets/cpp-stldebug.md
@@ -1,0 +1,4 @@
+## `stldebug` gains Clang support
+
+For Clang, we now pass `-D_GLIBCXX_DEBUG=1` if `debugstl` is enabled, and
+we also pass `-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG`.


### PR DESCRIPTION
compilers: cpp: wire up stdlib_stl for Clang

For Clang, we now pass -D_GLIBCXX_DEBUG=1 if debugstl is enabled, and
we also pass -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG.

Per https://discourse.llvm.org/t/building-a-program-with-d-libcpp-debug-1-against-a-libc-that-is-not-itself-built-with-that-define/59176/3,
we can't use _LIBCPP_DEBUG for older Clang versions as it's unreliable unless
libc++ was built with it.

We choose MODE_DEBUG for stldebug while building with assertions will do
MODE_EXTENSIVE.