### PR TITLE
tests: fix java JNI test assert for jni.h existing

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -101,7 +101,6 @@ jobs:
         CPPFLAGS: "-I/usr/local/include"
         LDFLAGS: "-L/usr/local/lib"
         MESON_ARGS: --unity=${{ matrix.unity }}
-        HOMEBREW_NO_AUTO_UPDATE: 1
         CI: 1
         # These cannot evaluate anything, so we cannot set PATH or SDKROOT here
       run: |
@@ -124,13 +123,13 @@ jobs:
 
   Qt4macos:
     runs-on: macos-latest
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - env:
-        HOMEBREW_NO_AUTO_UPDATE: 1
     - run: python -m pip install -e .
     - run: brew install pkg-config ninja gcc
     - run: brew tap cartr/qt4

--- a/test cases/java/9 jni/meson.build
+++ b/test cases/java/9 jni/meson.build
@@ -17,9 +17,9 @@ java = find_program('java')
 jni_dep = dependency('jni', version : '>=1.8', modules: ['jvm', 'awt'])
 
 # Assert that the header can actually be found with the dependency.
-cc.has_header('jni.h', dependencies: [jni_dep])
+cc.has_header('jni.h', dependencies: [jni_dep], required: true)
 # Assert that the platform-specific include directory is included in the compiler arguments.
-cc.has_header('jni_md.h', dependencies: [jni_dep])
+cc.has_header('jni_md.h', dependencies: [jni_dep], required: true)
 
 # generate native headers
 subdir('src')


### PR DESCRIPTION
compiler.has_header() isn't an assert, even though the comments say it is. With `required: true` it is an actual assert.