### PR TITLE
vsenv: check the version of vswhere and raise an error if it is too old

### DIFF
--- a/mesonbuild/utils/vsenv.py
+++ b/mesonbuild/utils/vsenv.py
@@ -10,7 +10,7 @@ import locale
 
 from .. import mlog
 from .core import MesonException
-from .universal import is_windows, windows_detect_native_arch
+from .universal import is_windows, search_version, version_compare, windows_detect_native_arch
 
 
 __all__ = [
@@ -56,6 +56,10 @@ def _setup_vsenv(force: bool) -> bool:
     bat_locator_bin = pathlib.Path(root, 'Microsoft Visual Studio/Installer/vswhere.exe')
     if not bat_locator_bin.exists():
         raise MesonException(f'Could not find {bat_locator_bin}')
+    ver = search_version(subprocess.check_output(str(bat_locator_bin), text=True))
+    if not version_compare(ver, '>=3.0.2'):
+        raise MesonException(f'{bat_locator_bin} is too old. Found {ver} but need: 3.0.2')
+
     bat_json = subprocess.check_output(
         [
             str(bat_locator_bin),

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -39,6 +39,7 @@ modules = [
     'mesonbuild/utils/core.py',
     'mesonbuild/utils/platform.py',
     'mesonbuild/utils/universal.py',
+    'mesonbuild/utils/vsenv.py',
     'mesonbuild/mconf.py',
     'mesonbuild/mdist.py',
     'mesonbuild/minit.py',


### PR DESCRIPTION
Per #10799 at least 3.0.2 is needed for the -utf8 option to both exist and work.

See #12687