### PR TITLE
Fix compiler.preprocess compile_args not used

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -2029,6 +2029,9 @@ class Backend:
         commands += compiler.get_compile_only_args() + ['@INPUT@']
         commands += self.get_source_dir_include_args(target, compiler)
         commands += self.get_build_dir_include_args(target, compiler)
+        # Add per-target compile args, f.ex, `c_args : ['-DFOO']`. We set these
+        # near the end since these are supposed to override everything else.
+        commands += self.escape_extra_args(target.get_extra_args(compiler.get_language()))
         generator = build.Generator(exe, args + commands.to_native(),
                                     [output_templ], depfile='@PLAINNAME@.d',
                                     depends=depends)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2768,7 +2768,7 @@ class CompileTarget(BuildTarget):
         compilers = {compiler.get_language(): compiler}
         kwargs = {
             'build_by_default': False,
-            f'{compiler.language}_args': compile_args,
+            'language_args': {compiler.language: compile_args},
             'include_directories': include_directories,
             'dependencies': dependencies,
         }

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -18,7 +18,7 @@ from .. import mlog
 from ..compilers import SUFFIX_TO_LANG
 from ..compilers.compilers import CompileCheckMode
 from ..interpreterbase import (ObjectHolder, noPosargs, noKwargs,
-                               FeatureNew, disablerIfNotFound,
+                               FeatureNew, FeatureNewKwargs, disablerIfNotFound,
                                InterpreterException)
 from ..interpreterbase.decorators import ContainerTypeInfo, typed_kwargs, KwargInfo, typed_pos_args
 from ..mesonlib import OptionKey
@@ -853,6 +853,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
         return self.compiler.get_argument_syntax()
 
     @FeatureNew('compiler.preprocess', '0.64.0')
+    @FeatureNewKwargs('compiler.preprocess', '1.3.2', ['compile_args'], extra_message='compile_args were ignored before this version')
     @typed_pos_args('compiler.preprocess', varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList), min_varargs=1)
     @typed_kwargs(
         'compiler.preprocess',

--- a/test cases/common/259 preprocess/bar.c
+++ b/test cases/common/259 preprocess/bar.c
@@ -1,3 +1,3 @@
 int @BAR@(void) {
-    return BAR + PLOP;
+    return BAR + PLOP + BAZ;
 }

--- a/test cases/common/259 preprocess/meson.build
+++ b/test cases/common/259 preprocess/meson.build
@@ -20,7 +20,9 @@ dep = declare_dependency(compile_args: '-DPLOP=0')
 pp_files = cc.preprocess('foo.c', bar_x, 'math.c',
   output: '@PLAINNAME@.c',
   dependencies: dep,
-  depends: foo_h)
+  depends: foo_h,
+  compile_args: ['-DBAZ=0'],
+)
 
 foreach f : pp_files
   message(f.full_path())


### PR DESCRIPTION
As described in
https://github.com/mesonbuild/meson/issues/12715#issuecomment-1883448780, the compiler.preprocess function ignores compile_args. This should fix it in both ninja and visualstudio backends.