### PR TITLE
fix openmp dependency for clang-cl

### DIFF
--- a/test cases/common/184 openmp/meson.build
+++ b/test cases/common/184 openmp/meson.build
@@ -10,8 +10,8 @@ endif
 if cc.get_id() == 'msvc' and cc.version().version_compare('<17')
   error('MESON_SKIP_TEST msvc is too old to support OpenMP.')
 endif
-if cc.get_id() == 'clang-cl'
-  error('MESON_SKIP_TEST clang-cl does not support OpenMP.')
+if cc.get_id() == 'clang-cl' and cc.version().version_compare('<10.0.0')
+  error('MESON_SKIP_TEST clang-cl is too old to support OpenMP.')
 endif
 if cc.get_id() == 'clang' and host_machine.system() == 'windows'
   error('MESON_SKIP_TEST Windows clang does not support OpenMP.')


### PR DESCRIPTION
Resolves issue https://github.com/mesonbuild/meson/issues/5298

I do know that this fix resolves the referenced issue for clang-cl 17.0.6 on windows (https://github.com/peter-urban/demonstrate-meson-openmp/actions/runs/7474295927/job/20340150365)

However, I am struggling with the test cases (test cases/common/184 openmp/meson.build)
- I am not 100% sure that i made the correct change to activate openmp testing for clang-cl
- I do not know which is the minimum clang-cl version that works now

Hints and comments welcome 