### PR TITLE
Use windows_proof_rmtree for CMakeFiles

### DIFF
--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -12,7 +12,6 @@ from pathlib import Path
 import functools
 import re
 import os
-import shutil
 import textwrap
 import typing as T
 

--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -16,6 +16,8 @@ import shutil
 import textwrap
 import typing as T
 
+from ..utils.universal import windows_proof_rmtree
+
 if T.TYPE_CHECKING:
     from ..cmake import CMakeTarget
     from ..environment import Environment
@@ -574,7 +576,7 @@ class CMakeDependency(ExternalDependency):
         cmake_files = build_dir / 'CMakeFiles'
         if cmake_cache.exists():
             cmake_cache.unlink()
-        shutil.rmtree(cmake_files.as_posix(), ignore_errors=True)
+        windows_proof_rmtree(cmake_files.absolute().as_posix())
 
         # Insert language parameters into the CMakeLists.txt and write new CMakeLists.txt
         cmake_txt = importlib.resources.read_text('mesonbuild.dependencies.data', cmake_file, encoding = 'utf-8')


### PR DESCRIPTION
In scipy/scipy#19855, I was experiencing Windows CI build failures with logs like the following:
```
SciPy 1.13.0.dev0

  User defined options
    Native files: D:\a\scipy\scipy\.mesonpy-rct2q19y\meson-python-native-file.ini
    buildtype   : release
    b_ndebug    : if-release
    b_vscrt     : md
    use-pythran : false

Found ninja.EXE-1.11.1.git.kitware.jobserver-1 at C:\hostedtoolcache\windows\Python\3.11.7\x64\Scripts\ninja.EXE
+ meson dist --allow-dirty --no-tests --formats gztar
WARNING: Repository has uncommitted changes that will not be included in the dist tarball
Created D:\a\scipy\scipy\.mesonpy-rct2q19y\meson-dist\SciPy-1.13.0.dev0.tar.gz
Traceback (most recent call last):
  File "C:\hostedtoolcache\windows\Python\3.11.7\x64\Lib\shutil.py", line 624, in _rmtree_unsafe
    os.rmdir(path)
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: '.\\.mesonpy-rct2q19y\\meson-private\\cmake_scipy-openblas\\CMakeFiles\\CMakeScratch\\TryCompile-cewmca'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\hostedtoolcache\windows\Python\3.11.7\x64\Lib\tempfile.py", line 878, in onerror
    _os.unlink(path)
PermissionError: [WinError 5] Access is denied: '.\\.mesonpy-rct2q19y\\meson-private\\cmake_scipy-openblas\\CMakeFiles\\CMakeScratch\\TryCompile-cewmca'
```
The logs then alternate between the two functions thousands of times until reaching a recursion depth error.

As noted in the docstring for `windows_proof_rmtree`, it is occasionally possible for a delete to fail on Windows due to external programs holding a file open. Since that might be the case here, I changed what I think might be the offending line to use `windows_proof_rmtree` instead of `shutil.rmtree`.
