### PR TITLE
Improve error messages for invalid option values

### DIFF
--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -687,7 +687,7 @@ def interpret(subp_name: str, subdir: str, env: Environment) -> T.Tuple[mparser.
     for feature in cargo.features:
         key = OptionKey(_option_name(feature), subproject=subp_name)
         enabled = feature == 'default'
-        options[key] = coredata.UserBooleanOption(f'Cargo {feature} feature', enabled)
+        options[key] = coredata.UserBooleanOption(key.name, f'Cargo {feature} feature', enabled)
 
     ast = _create_project(cargo, build)
     ast += [build.assign(build.function('import', [build.string('rust')]), 'rust')]

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -153,12 +153,13 @@ class ClangCCompiler(_ClangCStds, ClangCompiler, CCompiler):
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
         if self.info.is_windows() or self.info.is_cygwin():
-            opts.update({
-                OptionKey('winlibs', machine=self.for_machine, lang=self.language): coredata.UserArrayOption(
-                    'Standard Win libraries to link against',
-                    gnu_winlibs,
-                ),
-            })
+            self.update_options(
+                opts,
+                self.create_option(coredata.UserArrayOption,
+                                   OptionKey('winlibs', machine=self.for_machine, lang=self.language),
+                                   'Standard Win libraries to link against',
+                                   gnu_winlibs),
+            )
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
@@ -291,12 +292,13 @@ class GnuCCompiler(GnuCompiler, CCompiler):
         assert isinstance(std_opt, coredata.UserStdOption), 'for mypy'
         std_opt.set_versions(stds, gnu=True)
         if self.info.is_windows() or self.info.is_cygwin():
-            opts.update({
-                key.evolve('winlibs'): coredata.UserArrayOption(
-                    'Standard Win libraries to link against',
-                    gnu_winlibs,
-                ),
-            })
+            self.update_options(
+                opts,
+                self.create_option(coredata.UserArrayOption,
+                                   key.evolve('winlibs'),
+                                   'Standard Win libraries to link against',
+                                   gnu_winlibs),
+            )
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
@@ -426,15 +428,16 @@ class VisualStudioLikeCCompilerMixin(CompilerMixinBase):
 
     """Shared methods that apply to MSVC-like C compilers."""
 
-    def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = super().get_options()
-        opts.update({
-            OptionKey('winlibs', machine=self.for_machine, lang=self.language): coredata.UserArrayOption(
+    def get_options(self) -> MutableKeyedOptionDictType:
+        return self.update_options(
+            super().get_options(),
+            self.create_option(
+                coredata.UserArrayOption,
+                OptionKey('winlibs', machine=self.for_machine, lang=self.language),
                 'Windows libs to link against.',
                 msvc_winlibs,
             ),
-        })
-        return opts
+        )
 
     def get_option_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         # need a TypeDict to make this work

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -9,6 +9,7 @@ import contextlib, os.path, re
 import enum
 import itertools
 import typing as T
+from dataclasses import dataclass
 from functools import lru_cache
 
 from .. import coredata
@@ -34,6 +35,7 @@ if T.TYPE_CHECKING:
 
     CompilerType = T.TypeVar('CompilerType', bound='Compiler')
     _T = T.TypeVar('_T')
+    UserOptionType = T.TypeVar('UserOptionType', bound=coredata.UserOption)
 
 """This file contains the data files of all compilers Meson knows
 about. To support a new compiler, add its information below.
@@ -206,35 +208,45 @@ clike_debug_args: T.Dict[bool, T.List[str]] = {
 
 MSCRT_VALS = ['none', 'md', 'mdd', 'mt', 'mtd']
 
-base_options: 'KeyedOptionDictType' = {
-    OptionKey('b_pch'): coredata.UserBooleanOption('Use precompiled headers', True),
-    OptionKey('b_lto'): coredata.UserBooleanOption('Use link time optimization', False),
-    OptionKey('b_lto_threads'): coredata.UserIntegerOption('Use multiple threads for Link Time Optimization', (None, None, 0)),
-    OptionKey('b_lto_mode'): coredata.UserComboOption('Select between different LTO modes.',
-                                                      ['default', 'thin'],
-                                                      'default'),
-    OptionKey('b_thinlto_cache'): coredata.UserBooleanOption('Use LLVM ThinLTO caching for faster incremental builds', False),
-    OptionKey('b_thinlto_cache_dir'): coredata.UserStringOption('Directory to store ThinLTO cache objects', ''),
-    OptionKey('b_sanitize'): coredata.UserComboOption('Code sanitizer to use',
-                                                      ['none', 'address', 'thread', 'undefined', 'memory', 'leak', 'address,undefined'],
-                                                      'none'),
-    OptionKey('b_lundef'): coredata.UserBooleanOption('Use -Wl,--no-undefined when linking', True),
-    OptionKey('b_asneeded'): coredata.UserBooleanOption('Use -Wl,--as-needed when linking', True),
-    OptionKey('b_pgo'): coredata.UserComboOption('Use profile guided optimization',
-                                                 ['off', 'generate', 'use'],
-                                                 'off'),
-    OptionKey('b_coverage'): coredata.UserBooleanOption('Enable coverage tracking.', False),
-    OptionKey('b_colorout'): coredata.UserComboOption('Use colored output',
-                                                      ['auto', 'always', 'never'],
-                                                      'always'),
-    OptionKey('b_ndebug'): coredata.UserComboOption('Disable asserts', ['true', 'false', 'if-release'], 'false'),
-    OptionKey('b_staticpic'): coredata.UserBooleanOption('Build static libraries as position independent', True),
-    OptionKey('b_pie'): coredata.UserBooleanOption('Build executables as position independent', False),
-    OptionKey('b_bitcode'): coredata.UserBooleanOption('Generate and embed bitcode (only macOS/iOS/tvOS)', False),
-    OptionKey('b_vscrt'): coredata.UserComboOption('VS run-time library type to use.',
-                                                   MSCRT_VALS + ['from_buildtype', 'static_from_buildtype'],
-                                                   'from_buildtype'),
+@dataclass
+class BaseOption(T.Generic[coredata._T, coredata._U]):
+    opt_type: T.Type[coredata._U]
+    description: str
+    default: T.Any = None
+    choices: T.Any = None
+
+    def init_option(self, name: OptionKey) -> coredata._U:
+        keywords = {'value': self.default}
+        if self.choices:
+            keywords['choices'] = self.choices
+        return self.opt_type(name.name, self.description, **keywords)
+
+BASE_OPTIONS: T.Mapping[OptionKey, BaseOption] = {
+    OptionKey('b_pch'): BaseOption(coredata.UserBooleanOption, 'Use precompiled headers', True),
+    OptionKey('b_lto'): BaseOption(coredata.UserBooleanOption, 'Use link time optimization', False),
+    OptionKey('b_lto_threads'): BaseOption(coredata.UserIntegerOption, 'Use multiple threads for Link Time Optimization', (None, None, 0)),
+    OptionKey('b_lto_mode'): BaseOption(coredata.UserComboOption, 'Select between different LTO modes.', 'default',
+                                        choices=['default', 'thin']),
+    OptionKey('b_thinlto_cache'): BaseOption(coredata.UserBooleanOption, 'Use LLVM ThinLTO caching for faster incremental builds', False),
+    OptionKey('b_thinlto_cache_dir'): BaseOption(coredata.UserStringOption, 'Directory to store ThinLTO cache objects', ''),
+    OptionKey('b_sanitize'): BaseOption(coredata.UserComboOption, 'Code sanitizer to use', 'none',
+                                        choices=['none', 'address', 'thread', 'undefined', 'memory', 'leak', 'address,undefined']),
+    OptionKey('b_lundef'): BaseOption(coredata.UserBooleanOption, 'Use -Wl,--no-undefined when linking', True),
+    OptionKey('b_asneeded'): BaseOption(coredata.UserBooleanOption, 'Use -Wl,--as-needed when linking', True),
+    OptionKey('b_pgo'): BaseOption(coredata.UserComboOption, 'Use profile guided optimization', 'off',
+                                   choices=['off', 'generate', 'use']),
+    OptionKey('b_coverage'): BaseOption(coredata.UserBooleanOption, 'Enable coverage tracking.', False),
+    OptionKey('b_colorout'): BaseOption(coredata.UserComboOption, 'Use colored output', 'always',
+                                        choices=['auto', 'always', 'never']),
+    OptionKey('b_ndebug'): BaseOption(coredata.UserComboOption, 'Disable asserts', 'false', choices=['true', 'false', 'if-release']),
+    OptionKey('b_staticpic'): BaseOption(coredata.UserBooleanOption, 'Build static libraries as position independent', True),
+    OptionKey('b_pie'): BaseOption(coredata.UserBooleanOption, 'Build executables as position independent', False),
+    OptionKey('b_bitcode'): BaseOption(coredata.UserBooleanOption, 'Generate and embed bitcode (only macOS/iOS/tvOS)', False),
+    OptionKey('b_vscrt'): BaseOption(coredata.UserComboOption, 'VS run-time library type to use.', 'from_buildtype',
+                                     choices=MSCRT_VALS + ['from_buildtype', 'static_from_buildtype']),
 }
+
+base_options: KeyedOptionDictType = {key: base_opt.init_option(key) for key, base_opt in BASE_OPTIONS.items()}
 
 def option_enabled(boptions: T.Set[OptionKey], options: 'KeyedOptionDictType',
                    option: OptionKey) -> bool:
@@ -576,6 +588,14 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         This currently means C, C++, Fortran.
         """
         return []
+
+    def create_option(self, option_type: T.Type[UserOptionType], option_key: OptionKey, *args: T.Any, **kwargs: T.Any) -> T.Tuple[OptionKey, UserOptionType]:
+        return option_key, option_type(f'{self.language}_{option_key.name}', *args, **kwargs)
+
+    @staticmethod
+    def update_options(options: MutableKeyedOptionDictType, *args: T.Tuple[OptionKey, UserOptionType]) -> MutableKeyedOptionDictType:
+        options.update(args)
+        return options
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         return {}
@@ -1327,10 +1347,12 @@ def get_global_options(lang: str,
     link_options = env.options.get(largkey, [])
 
     cargs = coredata.UserArrayOption(
+        f'{lang}_{argkey.name}',
         description + ' compiler',
         comp_options, split_args=True, allow_dups=True)
 
     largs = coredata.UserArrayOption(
+        f'{lang}_{largkey.name}',
         description + ' linker',
         link_options, split_args=True, allow_dups=True)
 

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -238,18 +238,22 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCompiler, CPPCompiler):
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = CPPCompiler.get_options(self)
         key = OptionKey('key', machine=self.for_machine, lang=self.language)
-        opts.update({
-            key.evolve('debugstl'): coredata.UserBooleanOption(
-                'STL debug mode',
-                False,
-            ),
-            key.evolve('eh'): coredata.UserComboOption(
-                'C++ exception handling type.',
-                ['none', 'default', 'a', 's', 'sc'],
-                'default',
-            ),
-            key.evolve('rtti'): coredata.UserBooleanOption('Enable RTTI', True),
-        })
+        self.update_options(
+            opts,
+            self.create_option(coredata.UserComboOption,
+                               key.evolve('eh'),
+                               'C++ exception handling type.',
+                               ['none', 'default', 'a', 's', 'sc'],
+                               'default'),
+            self.create_option(coredata.UserBooleanOption,
+                               key.evolve('rtti'),
+                               'Enable RTTI',
+                               True),
+            self.create_option(coredata.UserBooleanOption,
+                               key.evolve('debugstl'),
+                               'STL debug mode',
+                               False),
+        )
         cppstd_choices = [
             'c++98', 'c++03', 'c++11', 'c++14', 'c++17', 'c++1z', 'c++2a', 'c++20',
         ]
@@ -261,12 +265,13 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCompiler, CPPCompiler):
         assert isinstance(std_opt, coredata.UserStdOption), 'for mypy'
         std_opt.set_versions(cppstd_choices, gnu=True)
         if self.info.is_windows() or self.info.is_cygwin():
-            opts.update({
-                key.evolve('winlibs'): coredata.UserArrayOption(
-                    'Standard Win libraries to link against',
-                    gnu_winlibs,
-                ),
-            })
+            self.update_options(
+                opts,
+                self.create_option(coredata.UserArrayOption,
+                                   key.evolve('winlibs'),
+                                   'Standard Win libraries to link against',
+                                   gnu_winlibs),
+            )
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
@@ -379,13 +384,14 @@ class ArmclangCPPCompiler(ArmclangCompiler, CPPCompiler):
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = CPPCompiler.get_options(self)
         key = OptionKey('std', machine=self.for_machine, lang=self.language)
-        opts.update({
-            key.evolve('eh'): coredata.UserComboOption(
-                'C++ exception handling type.',
-                ['none', 'default', 'a', 's', 'sc'],
-                'default',
-            ),
-        })
+        self.update_options(
+            opts,
+            self.create_option(coredata.UserComboOption,
+                               key.evolve('eh'),
+                               'C++ exception handling type.',
+                               ['none', 'default', 'a', 's', 'sc'],
+                               'default'),
+        )
         std_opt = opts[key]
         assert isinstance(std_opt, coredata.UserStdOption), 'for mypy'
         std_opt.set_versions(['c++98', 'c++03', 'c++11', 'c++14', 'c++17'], gnu=True)
@@ -427,18 +433,22 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCompiler, CPPCompiler):
     def get_options(self) -> 'MutableKeyedOptionDictType':
         key = OptionKey('std', machine=self.for_machine, lang=self.language)
         opts = CPPCompiler.get_options(self)
-        opts.update({
-            key.evolve('eh'): coredata.UserComboOption(
-                'C++ exception handling type.',
-                ['none', 'default', 'a', 's', 'sc'],
-                'default',
-            ),
-            key.evolve('rtti'): coredata.UserBooleanOption('Enable RTTI', True),
-            key.evolve('debugstl'): coredata.UserBooleanOption(
-                'STL debug mode',
-                False,
-            )
-        })
+        self.update_options(
+            opts,
+            self.create_option(coredata.UserComboOption,
+                               key.evolve('eh'),
+                               'C++ exception handling type.',
+                               ['none', 'default', 'a', 's', 'sc'],
+                               'default'),
+            self.create_option(coredata.UserBooleanOption,
+                               key.evolve('rtti'),
+                               'Enable RTTI',
+                               True),
+            self.create_option(coredata.UserBooleanOption,
+                               key.evolve('debugstl'),
+                               'STL debug mode',
+                               False),
+        )
         cppstd_choices = [
             'c++98', 'c++03', 'c++11', 'c++14', 'c++17', 'c++1z',
             'c++2a', 'c++20',
@@ -451,12 +461,13 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCompiler, CPPCompiler):
         assert isinstance(std_opt, coredata.UserStdOption), 'for mypy'
         std_opt.set_versions(cppstd_choices, gnu=True)
         if self.info.is_windows() or self.info.is_cygwin():
-            opts.update({
-                key.evolve('winlibs'): coredata.UserArrayOption(
-                    'Standard Win libraries to link against',
-                    gnu_winlibs,
-                ),
-            })
+            self.update_options(
+                opts,
+                self.create_option(coredata.UserArrayOption,
+                                   key.evolve('winlibs'),
+                                   'Standard Win libraries to link against',
+                                   gnu_winlibs),
+            )
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
@@ -551,17 +562,18 @@ class ElbrusCPPCompiler(ElbrusCompiler, CPPCompiler):
             cpp_stds += ['c++20']
 
         key = OptionKey('std', machine=self.for_machine, lang=self.language)
-        opts.update({
-            key.evolve('eh'): coredata.UserComboOption(
-                'C++ exception handling type.',
-                ['none', 'default', 'a', 's', 'sc'],
-                'default',
-            ),
-            key.evolve('debugstl'): coredata.UserBooleanOption(
-                'STL debug mode',
-                False,
-            ),
-        })
+        self.update_options(
+            opts,
+            self.create_option(coredata.UserComboOption,
+                               key.evolve('eh'),
+                               'C++ exception handling type.',
+                               ['none', 'default', 'a', 's', 'sc'],
+                               'default'),
+            self.create_option(coredata.UserBooleanOption,
+                               key.evolve('debugstl'),
+                               'STL debug mode',
+                               False),
+        )
         std_opt = opts[key]
         assert isinstance(std_opt, coredata.UserStdOption), 'for mypy'
         std_opt.set_versions(cpp_stds, gnu=True)
@@ -629,15 +641,22 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
             g_stds += ['gnu++2a']
 
         key = OptionKey('std', machine=self.for_machine, lang=self.language)
-        opts.update({
-            key.evolve('eh'): coredata.UserComboOption(
-                'C++ exception handling type.',
-                ['none', 'default', 'a', 's', 'sc'],
-                'default',
-            ),
-            key.evolve('rtti'): coredata.UserBooleanOption('Enable RTTI', True),
-            key.evolve('debugstl'): coredata.UserBooleanOption('STL debug mode', False),
-        })
+        self.update_options(
+            opts,
+            self.create_option(coredata.UserComboOption,
+                               key.evolve('eh'),
+                               'C++ exception handling type.',
+                               ['none', 'default', 'a', 's', 'sc'],
+                               'default'),
+            self.create_option(coredata.UserBooleanOption,
+                               key.evolve('rtti'),
+                               'Enable RTTI',
+                               True),
+            self.create_option(coredata.UserBooleanOption,
+                               key.evolve('debugstl'),
+                               'STL debug mode',
+                               False),
+        )
         std_opt = opts[key]
         assert isinstance(std_opt, coredata.UserStdOption), 'for mypy'
         std_opt.set_versions(c_stds + g_stds)
@@ -695,18 +714,22 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
 
     def _get_options_impl(self, opts: 'MutableKeyedOptionDictType', cpp_stds: T.List[str]) -> 'MutableKeyedOptionDictType':
         key = OptionKey('std', machine=self.for_machine, lang=self.language)
-        opts.update({
-            key.evolve('eh'): coredata.UserComboOption(
-                'C++ exception handling type.',
-                ['none', 'default', 'a', 's', 'sc'],
-                'default',
-            ),
-            key.evolve('rtti'): coredata.UserBooleanOption('Enable RTTI', True),
-            key.evolve('winlibs'): coredata.UserArrayOption(
-                'Windows libs to link against.',
-                msvc_winlibs,
-            ),
-        })
+        self.update_options(
+            opts,
+            self.create_option(coredata.UserComboOption,
+                               key.evolve('eh'),
+                               'C++ exception handling type.',
+                               ['none', 'default', 'a', 's', 'sc'],
+                               'default'),
+            self.create_option(coredata.UserBooleanOption,
+                               key.evolve('rtti'),
+                               'Enable RTTI',
+                               True),
+            self.create_option(coredata.UserArrayOption,
+                               key.evolve('winlibs'),
+                               'Windows libs to link against.',
+                               msvc_winlibs),
+        )
         std_opt = opts[key]
         assert isinstance(std_opt, coredata.UserStdOption), 'for mypy'
         std_opt.set_versions(cpp_stds)

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -632,10 +632,6 @@ class CudaCompiler(Compiler):
     _CPP20_VERSION = '>=12.0'
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = super().get_options()
-        std_key = OptionKey('std', machine=self.for_machine, lang=self.language)
-        ccbindir_key = OptionKey('ccbindir', machine=self.for_machine, lang=self.language)
-
         cpp_stds = ['none', 'c++03', 'c++11']
         if version_compare(self.version, self._CPP14_VERSION):
             cpp_stds += ['c++14']
@@ -644,13 +640,18 @@ class CudaCompiler(Compiler):
         if version_compare(self.version, self._CPP20_VERSION):
             cpp_stds += ['c++20']
 
-        opts.update({
-            std_key:      coredata.UserComboOption('C++ language standard to use with CUDA',
-                                                   cpp_stds, 'none'),
-            ccbindir_key: coredata.UserStringOption('CUDA non-default toolchain directory to use (-ccbin)',
-                                                    ''),
-        })
-        return opts
+        return self.update_options(
+            super().get_options(),
+            self.create_option(coredata.UserComboOption,
+                               OptionKey('std', machine=self.for_machine, lang=self.language),
+                               'C++ language standard to use with CUDA',
+                               cpp_stds,
+                               'none'),
+            self.create_option(coredata.UserStringOption,
+                               OptionKey('ccbindir', machine=self.for_machine, lang=self.language),
+                               'CUDA non-default toolchain directory to use (-ccbin)',
+                               ''),
+        )
 
     def _to_host_compiler_options(self, options: 'KeyedOptionDictType') -> 'KeyedOptionDictType':
         """

--- a/mesonbuild/compilers/cython.py
+++ b/mesonbuild/compilers/cython.py
@@ -67,20 +67,19 @@ class CythonCompiler(Compiler):
         return new
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = super().get_options()
-        opts.update({
-            OptionKey('version', machine=self.for_machine, lang=self.language): coredata.UserComboOption(
-                'Python version to target',
-                ['2', '3'],
-                '3',
-            ),
-            OptionKey('language', machine=self.for_machine, lang=self.language): coredata.UserComboOption(
-                'Output C or C++ files',
-                ['c', 'cpp'],
-                'c',
-            )
-        })
-        return opts
+        return self.update_options(
+            super().get_options(),
+            self.create_option(coredata.UserComboOption,
+                               OptionKey('version', machine=self.for_machine, lang=self.language),
+                               'Python version to target',
+                               ['2', '3'],
+                               '3'),
+            self.create_option(coredata.UserComboOption,
+                               OptionKey('language', machine=self.for_machine, lang=self.language),
+                               'Output C or C++ files',
+                               ['c', 'cpp'],
+                               'c'),
+        )
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args: T.List[str] = []

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -113,16 +113,14 @@ class FortranCompiler(CLikeCompiler, Compiler):
         return self._has_multi_link_arguments(args, env, 'stop; end program')
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = super().get_options()
-        key = OptionKey('std', machine=self.for_machine, lang=self.language)
-        opts.update({
-            key: coredata.UserComboOption(
-                'Fortran language standard to use',
-                ['none'],
-                'none',
-            ),
-        })
-        return opts
+        return self.update_options(
+            super().get_options(),
+            self.create_option(coredata.UserComboOption,
+                               OptionKey('std', machine=self.for_machine, lang=self.language),
+                               'Fortran language standard to use',
+                               ['none'],
+                               'none'),
+        )
 
 
 class GnuFortranCompiler(GnuCompiler, FortranCompiler):

--- a/mesonbuild/compilers/mixins/emscripten.py
+++ b/mesonbuild/compilers/mixins/emscripten.py
@@ -55,17 +55,16 @@ class EmscriptenMixin(Compiler):
             args.append(f'-sPTHREAD_POOL_SIZE={count}')
         return args
 
-    def get_options(self) -> 'coredata.MutableKeyedOptionDictType':
-        opts = super().get_options()
-        key = OptionKey('thread_count', machine=self.for_machine, lang=self.language)
-        opts.update({
-            key: coredata.UserIntegerOption(
+    def get_options(self) -> coredata.MutableKeyedOptionDictType:
+        return self.update_options(
+            super().get_options(),
+            self.create_option(
+                coredata.UserIntegerOption,
+                OptionKey('thread_count', machine=self.for_machine, lang=self.language),
                 'Number of threads to use in web assembly, set to 0 to disable',
                 (0, None, 4),  # Default was picked at random
             ),
-        })
-
-        return opts
+        )
 
     @classmethod
     def native_args_to_unix(cls, args: T.List[str]) -> T.List[str]:

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -82,15 +82,14 @@ class ClangObjCCompiler(ClangCompiler, ObjCCompiler):
                           'everything': ['-Weverything']}
 
     def get_options(self) -> 'coredata.MutableKeyedOptionDictType':
-        opts = super().get_options()
-        opts.update({
-            OptionKey('std', machine=self.for_machine, lang='c'): coredata.UserComboOption(
-                'C language standard to use',
-                ['none', 'c89', 'c99', 'c11', 'c17', 'gnu89', 'gnu99', 'gnu11', 'gnu17'],
-                'none',
-            )
-        })
-        return opts
+        return self.update_options(
+            super().get_options(),
+            self.create_option(coredata.UserComboOption,
+                               OptionKey('std', machine=self.for_machine, lang='c'),
+                               'C language standard to use',
+                               ['none', 'c89', 'c99', 'c11', 'c17', 'gnu89', 'gnu99', 'gnu11', 'gnu17'],
+                               'none'),
+        )
 
     def get_option_compile_args(self, options: 'coredata.KeyedOptionDictType') -> T.List[str]:
         args = []

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -81,18 +81,17 @@ class ClangObjCPPCompiler(ClangCompiler, ObjCPPCompiler):
                           '3': default_warn_args + ['-Wextra', '-Wpedantic'],
                           'everything': ['-Weverything']}
 
-    def get_options(self) -> 'coredata.MutableKeyedOptionDictType':
-        opts = super().get_options()
-        opts.update({
-            OptionKey('std', machine=self.for_machine, lang='cpp'): coredata.UserComboOption(
-                'C++ language standard to use',
-                ['none', 'c++98', 'c++11', 'c++14', 'c++17', 'c++20', 'c++2b',
-                 'gnu++98', 'gnu++11', 'gnu++14', 'gnu++17', 'gnu++20',
-                 'gnu++2b'],
-                'none',
-            )
-        })
-        return opts
+    def get_options(self) -> coredata.MutableKeyedOptionDictType:
+        return self.update_options(
+            super().get_options(),
+            self.create_option(coredata.UserComboOption,
+                               OptionKey('std', machine=self.for_machine, lang='cpp'),
+                               'C++ language standard to use',
+                               ['none', 'c++98', 'c++11', 'c++14', 'c++17', 'c++20', 'c++2b',
+                                'gnu++98', 'gnu++11', 'gnu++14', 'gnu++17', 'gnu++20',
+                                'gnu++2b'],
+                               'none'),
+        )
 
     def get_option_compile_args(self, options: 'coredata.KeyedOptionDictType') -> T.List[str]:
         args = []

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -154,15 +154,12 @@ class RustCompiler(Compiler):
     # C compiler for dynamic linking, as such we invoke the C compiler's
     # use_linker_args method instead.
 
-    def get_options(self) -> 'MutableKeyedOptionDictType':
-        key = OptionKey('std', machine=self.for_machine, lang=self.language)
-        return {
-            key: coredata.UserComboOption(
-                'Rust edition to use',
-                ['none', '2015', '2018', '2021'],
-                'none',
-            ),
-        }
+    def get_options(self) -> MutableKeyedOptionDictType:
+        return dict((self.create_option(coredata.UserComboOption,
+                                        OptionKey('std', machine=self.for_machine, lang=self.language),
+                                        'Rust edition to use',
+                                        ['none', '2015', '2018', '2021'],
+                                        'none'),))
 
     def get_dependency_compile_args(self, dep: 'Dependency') -> T.List[str]:
         # Rust doesn't have dependency compile arguments so simply return

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -16,16 +16,15 @@ from pathlib import Path
 
 from . import mlog
 from . import mesonlib
-from .mesonlib import MesonException, RealPathAction, join_args, setup_vsenv
+from .mesonlib import MesonException, RealPathAction, join_args, listify_array_value, setup_vsenv
 from mesonbuild.environment import detect_ninja
-from mesonbuild.coredata import UserArrayOption
 from mesonbuild import build
 
 if T.TYPE_CHECKING:
     import argparse
 
 def array_arg(value: str) -> T.List[str]:
-    return UserArrayOption.listify_value(value)
+    return listify_array_value(value)
 
 def validate_builddir(builddir: Path) -> None:
     if not (builddir / 'meson-private' / 'coredata.dat').is_file():

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -196,7 +196,7 @@ class OptionInterpreter:
         n_kwargs = {k: v for k, v in kwargs.items()
                     if k not in {'type', 'description', 'deprecated', 'yield'}}
 
-        opt = parser(description, (kwargs['yield'], kwargs['deprecated']), n_kwargs)
+        opt = parser(opt_name, description, (kwargs['yield'], kwargs['deprecated']), n_kwargs)
         if key in self.options:
             mlog.deprecation(f'Option {opt_name} already exists.')
         self.options[key] = opt
@@ -205,8 +205,8 @@ class OptionInterpreter:
         'string option',
         KwargInfo('value', str, default=''),
     )
-    def string_parser(self, description: str, args: T.Tuple[bool, _DEPRECATED_ARGS], kwargs: StringArgs) -> coredata.UserOption:
-        return coredata.UserStringOption(description, kwargs['value'], *args)
+    def string_parser(self, name: str, description: str, args: T.Tuple[bool, _DEPRECATED_ARGS], kwargs: StringArgs) -> coredata.UserOption:
+        return coredata.UserStringOption(name, description, kwargs['value'], *args)
 
     @typed_kwargs(
         'boolean option',
@@ -218,20 +218,20 @@ class OptionInterpreter:
             deprecated_values={str: ('1.1.0', 'use a boolean, not a string')},
         ),
     )
-    def boolean_parser(self, description: str, args: T.Tuple[bool, _DEPRECATED_ARGS], kwargs: BooleanArgs) -> coredata.UserOption:
-        return coredata.UserBooleanOption(description, kwargs['value'], *args)
+    def boolean_parser(self, name: str, description: str, args: T.Tuple[bool, _DEPRECATED_ARGS], kwargs: BooleanArgs) -> coredata.UserOption:
+        return coredata.UserBooleanOption(name, description, kwargs['value'], *args)
 
     @typed_kwargs(
         'combo option',
         KwargInfo('value', (str, NoneType)),
         KwargInfo('choices', ContainerTypeInfo(list, str, allow_empty=False), required=True),
     )
-    def combo_parser(self, description: str, args: T.Tuple[bool, _DEPRECATED_ARGS], kwargs: ComboArgs) -> coredata.UserOption:
+    def combo_parser(self, name: str, description: str, args: T.Tuple[bool, _DEPRECATED_ARGS], kwargs: ComboArgs) -> coredata.UserOption:
         choices = kwargs['choices']
         value = kwargs['value']
         if value is None:
             value = kwargs['choices'][0]
-        return coredata.UserComboOption(description, choices, value, *args)
+        return coredata.UserComboOption(name, description, choices, value, *args)
 
     @typed_kwargs(
         'integer option',
@@ -245,17 +245,17 @@ class OptionInterpreter:
         KwargInfo('min', (int, NoneType)),
         KwargInfo('max', (int, NoneType)),
     )
-    def integer_parser(self, description: str, args: T.Tuple[bool, _DEPRECATED_ARGS], kwargs: IntegerArgs) -> coredata.UserOption:
+    def integer_parser(self, name: str, description: str, args: T.Tuple[bool, _DEPRECATED_ARGS], kwargs: IntegerArgs) -> coredata.UserOption:
         value = kwargs['value']
         inttuple = (kwargs['min'], kwargs['max'], value)
-        return coredata.UserIntegerOption(description, inttuple, *args)
+        return coredata.UserIntegerOption(name, description, inttuple, *args)
 
     @typed_kwargs(
         'string array option',
         KwargInfo('value', (ContainerTypeInfo(list, str), str, NoneType)),
         KwargInfo('choices', ContainerTypeInfo(list, str), default=[]),
     )
-    def string_array_parser(self, description: str, args: T.Tuple[bool, _DEPRECATED_ARGS], kwargs: StringArrayArgs) -> coredata.UserOption:
+    def string_array_parser(self, name: str, description: str, args: T.Tuple[bool, _DEPRECATED_ARGS], kwargs: StringArrayArgs) -> coredata.UserOption:
         choices = kwargs['choices']
         value = kwargs['value'] if kwargs['value'] is not None else choices
         if isinstance(value, str):
@@ -263,7 +263,7 @@ class OptionInterpreter:
                 FeatureDeprecated('String value for array option', '1.3.0').use(self.subproject)
             else:
                 raise mesonlib.MesonException('Value does not define an array: ' + value)
-        return coredata.UserArrayOption(description, value,
+        return coredata.UserArrayOption(name, description, value,
                                         choices=choices,
                                         yielding=args[0],
                                         deprecated=args[1])
@@ -272,5 +272,5 @@ class OptionInterpreter:
         'feature option',
         KwargInfo('value', str, default='auto', validator=in_set_validator({'auto', 'enabled', 'disabled'})),
     )
-    def feature_parser(self, description: str, args: T.Tuple[bool, _DEPRECATED_ARGS], kwargs: FeatureArgs) -> coredata.UserOption:
-        return coredata.UserFeatureOption(description, kwargs['value'], *args)
+    def feature_parser(self, name: str, description: str, args: T.Tuple[bool, _DEPRECATED_ARGS], kwargs: FeatureArgs) -> coredata.UserOption:
+        return coredata.UserFeatureOption(name, description, kwargs['value'], *args)

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 from pathlib import Path
 import argparse
+import ast
 import enum
 import sys
 import stat
@@ -129,6 +130,7 @@ __all__ = [
     'iter_regexin_iter',
     'join_args',
     'listify',
+    'listify_array_value',
     'partition',
     'path_is_in_root',
     'pickle_load',
@@ -1435,6 +1437,26 @@ def listify(item: T.Any, flatten: bool = True) -> T.List[T.Any]:
             result.append(i)
     return result
 
+def listify_array_value(value: T.Union[str, T.List[str]], shlex_split_args: bool = False) -> T.List[str]:
+    if isinstance(value, str):
+        if value.startswith('['):
+            try:
+                newvalue = ast.literal_eval(value)
+            except ValueError:
+                raise MesonException(f'malformed value {value}')
+        elif value == '':
+            newvalue = []
+        else:
+            if shlex_split_args:
+                newvalue = split_args(value)
+            else:
+                newvalue = [v.strip() for v in value.split(',')]
+    elif isinstance(value, list):
+        newvalue = value
+    else:
+        raise MesonException(f'"{value}" should be a string array, but it is not')
+    assert isinstance(newvalue, list)
+    return newvalue
 
 def extract_as_list(dict_object: T.Dict[_T, _U], key: _T, pop: bool = False) -> T.List[_U]:
     '''

--- a/test cases/failing/98 number in combo/test.json
+++ b/test cases/failing/98 number in combo/test.json
@@ -1,5 +1,5 @@
 {
   "stdout": [
-    { "line": "test cases/failing/98 number in combo/meson.build:1:0: ERROR: Value \"1\" (of type \"number\") for combo option \"Optimization level\" is not one of the choices. Possible choices are (as string): \"plain\", \"0\", \"g\", \"1\", \"2\", \"3\", \"s\"." }
+    { "line": "test cases/failing/98 number in combo/meson.build:1:0: ERROR: Value \"1\" (of type \"number\") for option \"optimization\" is not one of the choices. Possible choices are (as string): \"plain\", \"0\", \"g\", \"1\", \"2\", \"3\", \"s\"." }
   ]
 }

--- a/test cases/failing/99 bool in combo/test.json
+++ b/test cases/failing/99 bool in combo/test.json
@@ -1,5 +1,5 @@
 {
   "stdout": [
-    { "line": "test cases/failing/99 bool in combo/meson.build:1:0: ERROR: Value \"True\" (of type \"boolean\") for combo option \"opt\" is not one of the choices. Possible choices are (as string): \"true\", \"false\"." }
+    { "line": "test cases/failing/99 bool in combo/meson.build:1:0: ERROR: Value \"True\" (of type \"boolean\") for option \"opt\" is not one of the choices. Possible choices are (as string): \"true\", \"false\"." }
   ]
 }


### PR DESCRIPTION
By adding the option name to UserOption object, it is now possible to
display the name of the affected option when the given option value is
not valid.

Fixes https://github.com/mesonbuild/meson/issues/12635