### PR TITLE
add punctuation mark to make log more understandable

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -414,7 +414,7 @@ class ExternalDependency(Dependency, HasNativeKwarg):
                 self.is_found = False
                 found_msg: mlog.TV_LoggableList = []
                 found_msg += ['Dependency', mlog.bold(self.name), 'found:']
-                found_msg += [mlog.red('NO'), 'unknown version, but need:', self.version_reqs]
+                found_msg += [str(mlog.red('NO')) + '.', 'Unknown version, but need:', self.version_reqs]
                 mlog.log(*found_msg)
 
                 if self.required:
@@ -426,8 +426,8 @@ class ExternalDependency(Dependency, HasNativeKwarg):
                     version_compare_many(self.version, self.version_reqs)
                 if not self.is_found:
                     found_msg = ['Dependency', mlog.bold(self.name), 'found:']
-                    found_msg += [mlog.red('NO'),
-                                  'found', mlog.normal_cyan(self.version), 'but need:',
+                    found_msg += [str(mlog.red('NO')) + '.',
+                                  'Found', mlog.normal_cyan(self.version), 'but need:',
                                   mlog.bold(', '.join([f"'{e}'" for e in not_found]))]
                     if found:
                         found_msg += ['; matched:',


### PR DESCRIPTION
Some meson log as following is confusible :
```Dependency glib-2.0 found: NO found 2.76.4 but need: '>=2.79.0'```


This PR modifies some meson log with adding a punctuation and makes prompt information more understandable.
Could U please help to review it?