### PR TITLE
Compilers: pass -Werror to the linker with b_lto

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -324,6 +324,9 @@ def get_base_link_args(options: 'KeyedOptionDictType', linker: 'Compiler',
     args: T.List[str] = []
     try:
         if options[OptionKey('b_lto')].value:
+            if options[OptionKey('werror')].value:
+                args.extend(linker.get_werror_args())
+
             thinlto_cache_dir = None
             if get_option_value(options, OptionKey('b_thinlto_cache'), False):
                 thinlto_cache_dir = get_option_value(options, OptionKey('b_thinlto_cache_dir'), '')


### PR DESCRIPTION
With LTO, the linker will re-execute the compiler and various warnings may be emitted. We must therefore pass -Werror to the linker as well when -Werror is enabled to capture these. This is only required / useful with LTO.

Closes: https://github.com/mesonbuild/meson/issues/7360