### PR TITLE
respect build_by_default and install flags

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1400,6 +1400,15 @@ class Backend:
                 result[name] = b
         return result
 
+    def get_install_targets(self) -> 'T.OrderedDict[str, T.Union[build.BuildTarget, build.CustomTarget]]':
+        result: 'T.OrderedDict[str, T.Union[build.BuildTarget, build.CustomTarget]]' = OrderedDict()
+        # Get all install targets, this is distinct from build_by_default targets
+        # as there may be targets that are installed but not built by default
+        for name, b in self.build.get_targets().items():
+            if b.install:
+                result[name] = b
+        return result
+
     def get_testlike_targets(self, benchmark: bool = False) -> T.OrderedDict[str, T.Union[build.BuildTarget, build.CustomTarget]]:
         result: T.OrderedDict[str, T.Union[build.BuildTarget, build.CustomTarget]] = OrderedDict()
         targets = self.build.get_benchmarks() if benchmark else self.build.get_tests()

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1261,7 +1261,7 @@ class NinjaBackend(backends.Backend):
     def generate_install(self):
         self.create_install_data_files()
         elem = self.create_phony_target('install', 'CUSTOM_COMMAND', 'PHONY')
-        elem.add_dep('all')
+        elem.add_dep('all_install')
         elem.add_item('DESC', 'Installing files.')
         elem.add_item('COMMAND', self.environment.get_build_command() + ['install', '--no-rebuild'])
         elem.add_item('pool', 'console')
@@ -3642,6 +3642,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
     def generate_ending(self) -> None:
         for targ, deps in [
                 ('all', self.get_build_by_default_targets()),
+                ('all_install', self.get_install_targets()),
                 ('meson-test-prereq', self.get_testlike_targets()),
                 ('meson-benchmark-prereq', self.get_testlike_targets(True))]:
             targetlist = []

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1261,7 +1261,7 @@ class NinjaBackend(backends.Backend):
     def generate_install(self):
         self.create_install_data_files()
         elem = self.create_phony_target('install', 'CUSTOM_COMMAND', 'PHONY')
-        elem.add_dep('all_install')
+        elem.add_dep('all-install')
         elem.add_item('DESC', 'Installing files.')
         elem.add_item('COMMAND', self.environment.get_build_command() + ['install', '--no-rebuild'])
         elem.add_item('pool', 'console')
@@ -3642,7 +3642,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
     def generate_ending(self) -> None:
         for targ, deps in [
                 ('all', self.get_build_by_default_targets()),
-                ('all_install', self.get_install_targets()),
+                ('all-install', self.get_install_targets()),
                 ('meson-test-prereq', self.get_testlike_targets()),
                 ('meson-benchmark-prereq', self.get_testlike_targets(True))]:
             targetlist = []

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -642,11 +642,10 @@ class Target(HoldableObject, metaclass=abc.ABCMeta):
             self.build_by_default = kwargs['build_by_default']
             if not isinstance(self.build_by_default, bool):
                 raise InvalidArguments('build_by_default must be a boolean value.')
-
-        if not self.build_by_default and kwargs.get('install', False):
+        else:
             # For backward compatibility, if build_by_default is not explicitly
             # set, use the value of 'install' if it's enabled.
-            self.build_by_default = True
+            self.build_by_default = kwargs.get('install', False)
 
         self.set_option_overrides(self.parse_overrides(kwargs))
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2582,7 +2582,7 @@ class CustomTarget(Target, CustomTargetBase, CommandBase):
             outputs, get_filenames_templates_dict(
                 get_sources_string_names(sources, backend),
                 []))
-        self.build_by_default = build_by_default if build_by_default is not None else install
+        self.build_by_default = build_by_default or False
         self.capture = capture
         self.console = console
         self.depend_files = list(depend_files or [])

--- a/test cases/common/202 custom target build by default/test.json
+++ b/test cases/common/202 custom target build by default/test.json
@@ -1,5 +1,7 @@
 {
   "installed": [
-
+    { "type": "file", "file": "usr/share/doc/testpkgname/html/a.txt" },
+    { "type": "file", "file": "usr/share/doc/testpkgname/html/b.txt" },
+    { "type": "file", "file": "usr/share/doc/testpkgname/html/c.txt" }
   ]
 }

--- a/test cases/common/273 install build by default/checkexists.py
+++ b/test cases/common/273 install build by default/checkexists.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+import os.path, sys
+
+invert = False
+for path in sys.argv[1:]:
+    if path == '--not':
+        invert = True
+    elif not os.path.exists(path) ^ invert:
+        sys.exit(1)

--- a/test cases/common/273 install build by default/hello.c
+++ b/test cases/common/273 install build by default/hello.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+int main(void) {
+    puts("Hello, world!");
+}

--- a/test cases/common/273 install build by default/meson.build
+++ b/test cases/common/273 install build by default/meson.build
@@ -1,0 +1,19 @@
+project('install build by default target', 'c')
+
+py3_mod = import('python3')
+py3 = py3_mod.find_python()
+checkexists = files('checkexists.py')
+
+hello = executable('hello', 'hello.c',
+    build_by_default : false,
+    install : true
+)
+
+hello_output = join_paths(meson.build_root(), 'hello')
+
+if host_machine.system() == 'windows'
+  hello_output += '.exe'
+endif
+
+test('check-build-by-default', py3,
+    args : [checkexists, '--not', hello_output])

--- a/test cases/common/273 install build by default/test.json
+++ b/test cases/common/273 install build by default/test.json
@@ -1,0 +1,5 @@
+{
+    "installed": [
+        { "type": "exe", "file": "usr/bin/hello" }
+    ]
+}


### PR DESCRIPTION
This fixes #12751 and #12530.

Added a new `all-install` rule that contains all the targets that are to be installed, this way installing builds required targets and the default rule doesnt pick up on them