### PR TITLE
rust: Add `--extern proc_macro` in `rust.proc_macro() not in cargo tr…

### DIFF
--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright © 2022-2023 Intel Corporation
+# Copyright © 2022-2024 Intel Corporation
 
 """Interpreter for converting Cargo Toml definitions to Meson AST
 
@@ -418,7 +418,6 @@ def _create_lib(cargo: Manifest, build: builder.Builder, crate_type: manifest.CR
 
     lib: mparser.BaseNode
     if cargo.lib.proc_macro or crate_type == 'proc-macro':
-        kwargs['rust_args'] = build.array([build.string('--extern'), build.string('proc_macro')])
         lib = build.method('proc_macro', build.identifier('rust'), posargs, kwargs)
     else:
         if crate_type in {'lib', 'rlib', 'staticlib'}:

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright © 2020-2023 Intel Corporation
+# Copyright © 2020-2024 Intel Corporation
 
 from __future__ import annotations
 import itertools
@@ -283,6 +283,7 @@ class RustModule(ExtensionModule):
     def proc_macro(self, state: ModuleState, args: T.Tuple[str, SourcesVarargsType], kwargs: _kwargs.SharedLibrary) -> SharedLibrary:
         kwargs['native'] = True  # type: ignore
         kwargs['rust_crate_type'] = 'proc-macro'  # type: ignore
+        kwargs['rust_args'] = kwargs['rust_args'] + ['--extern', 'proc_macro']
         target = state._interpreter.build_target(state.current_node, args, kwargs, SharedLibrary)
         return target
 


### PR DESCRIPTION
…anslation

Cargo does this by default, so it's reasonable that we do the same.

Fixes: #12758