### PR TITLE
fix: exception during exception-handling when ast/CodeBlockNode is not set

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -522,7 +522,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         mesonlib.project_meson_versions[self.subproject] = pv
 
     def handle_meson_version_from_ast(self) -> None:
-        if not self.ast.lines:
+        if not self.ast or not self.ast.lines:
             return
         project = self.ast.lines[0]
         # first line is always project()


### PR DESCRIPTION
```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "c:\src\x\.venv\lib\site-packages\mesonbuild\mesonmain.py", line 184, in run
    return options.run_func(options)
  File "c:\src\x\.venv\lib\site-packages\mesonbuild\msetup.py", line 342, in run
    app.generate()
  File "c:\src\x\.venv\lib\site-packages\mesonbuild\msetup.py", line 171, in generate
    return self._generate(env, capture, vslite_ctx)
  File "c:\src\x\.venv\lib\site-packages\mesonbuild\msetup.py", line 193, in _generate
    intr = interpreter.Interpreter(b, user_defined_options=user_defined_options)
  File "c:\src\x\.venv\lib\site-packages\mesonbuild\interpreter\interpreter.py", line 289, in __init__
    self.load_root_meson_file()
  File "c:\src\x\.venv\lib\site-packages\mesonbuild\interpreterbase\interpreterbase.py", line 113, in load_root_meson_file
    self.handle_meson_version_from_ast()
  File "c:\src\x\.venv\lib\site-packages\mesonbuild\interpreter\interpreter.py", line 525, in handle_meson_version_from_ast
    if not self.ast.lines:
AttributeError: 'NoneType' object has no attribute 'lines'

ERROR: Unhandled python exception
```