### PR TITLE
pkgconfig: fix use of uninstalled libraries

### DIFF
--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -242,7 +242,7 @@ class PkgConfigCLI(PkgConfigInterface):
         if uninstalled:
             uninstalled_path = Path(self.env.get_build_dir(), 'meson-uninstalled').as_posix()
             if uninstalled_path not in extra_paths:
-                extra_paths.append(uninstalled_path)
+                extra_paths.insert(0, uninstalled_path)
         env.set('PKG_CONFIG_PATH', extra_paths)
         sysroot = self.env.properties[self.for_machine].get_sys_root()
         if sysroot:

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -1127,6 +1127,42 @@ class LinuxlikeTests(BasePlatformTests):
         pkg_config_path = env.coredata.options[OptionKey('pkg_config_path')].value
         self.assertEqual(pkg_config_path, [pkg_dir])
 
+    def test_pkgconfig_uninstalled_env_added(self):
+        '''
+        Checks that the meson-uninstalled dir is added to PKG_CONFIG_PATH
+        '''
+        testdir = os.path.join(self.unit_test_dir, '111 pkgconfig duplicate path entries')
+        meson_uninstalled_dir = os.path.join(self.builddir, 'meson-uninstalled')
+
+        env = get_fake_env(testdir, self.builddir, self.prefix)
+
+        newEnv = PkgConfigInterface.setup_env({}, env, MachineChoice.HOST, uninstalled=True)
+
+        pkg_config_path_dirs = newEnv['PKG_CONFIG_PATH'].split(os.pathsep)
+
+        self.assertEqual(len(pkg_config_path_dirs), 1)
+        self.assertEqual(pkg_config_path_dirs[0], meson_uninstalled_dir)
+
+    def test_pkgconfig_uninstalled_env_prepended(self):
+        '''
+        Checks that the meson-uninstalled dir is prepended to PKG_CONFIG_PATH
+        '''
+        testdir = os.path.join(self.unit_test_dir, '111 pkgconfig duplicate path entries')
+        meson_uninstalled_dir = os.path.join(self.builddir, 'meson-uninstalled')
+        external_pkg_config_path_dir = os.path.join('usr', 'local', 'lib', 'pkgconfig')
+
+        env = get_fake_env(testdir, self.builddir, self.prefix)
+
+        env.coredata.set_options({OptionKey('pkg_config_path'): external_pkg_config_path_dir},
+                                 subproject='')
+
+        newEnv = PkgConfigInterface.setup_env({}, env, MachineChoice.HOST, uninstalled=True)
+
+        pkg_config_path_dirs = newEnv['PKG_CONFIG_PATH'].split(os.pathsep)
+
+        self.assertEqual(pkg_config_path_dirs[0], meson_uninstalled_dir)
+        self.assertEqual(pkg_config_path_dirs[1], external_pkg_config_path_dir)
+
     @skipIfNoPkgconfig
     def test_pkgconfig_internal_libraries(self):
         '''


### PR DESCRIPTION
I suspect https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/3247 might be caused by this issue in meson.

We should prepend the path of uninstalled libraries to PKG_CONFIG_PATH so they have preference over other search paths set by the user.

Support for using uninstalled libraries was added by @xavierclaessens  in https://github.com/mesonbuild/meson/pull/10275.