### PR TITLE
Add missing FeatureNew for meson.add_dist_script

### DIFF
--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -188,6 +188,7 @@ class MesonMain(MesonInterpreterObject):
         varargs=(str, mesonlib.File, ExternalProgram)
     )
     @noKwargs
+    @FeatureNew('meson.add_dist_script', '0.48.0')
     def add_dist_script_method(
             self,
             args: T.Tuple[T.Union[str, mesonlib.File, ExternalProgram],


### PR DESCRIPTION
Per the docs, it is available since 0.48.0. Notify about this at runtime too.

Fixes #12773