### PR TITLE
use host gobject-introspection-1.0.pc for looking up g-ir-scanner

### DIFF
--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -81,7 +81,7 @@ class ModuleState:
                                                    wanted=wanted, silent=silent, for_machine=for_machine)
 
     def find_tool(self, name: str, depname: str, varname: str, required: bool = True,
-                  wanted: T.Optional[str] = None) -> T.Union['build.Executable', ExternalProgram, 'OverrideProgram']:
+                  wanted: T.Optional[str] = None, native: bool = True) -> T.Union['build.Executable', ExternalProgram, 'OverrideProgram']:
         # Look in overrides in case it's built as subproject
         progobj = self._interpreter.program_from_overrides([name], [])
         if progobj is not None:
@@ -93,7 +93,7 @@ class ModuleState:
             return ExternalProgram.from_entry(name, prog_list)
 
         # Check if pkgconfig has a variable
-        dep = self.dependency(depname, native=True, required=False, wanted=wanted)
+        dep = self.dependency(depname, native=native, required=False, wanted=wanted)
         if dep.found() and dep.type_name == 'pkgconfig':
             value = dep.get_variable(pkgconfig=varname)
             if value:

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -317,7 +317,7 @@ class GnomeModule(ExtensionModule):
         }
         depname = tool_map[tool]
         varname = tool.replace('-', '_')
-        return state.find_tool(tool, depname, varname)
+        return state.find_tool(tool, depname, varname, native=depname != "gobject-introspection-1.0")
 
     @typed_kwargs(
         'gnome.post_install',


### PR DESCRIPTION
When cross compiling, native (build architecture) g-ir-scanner by itself is unable to produce GIR XML files for the host architecture. Some distributions, like Debian, allow running foreign (host architecture) g-ir-scanner in a qemu-user wrapper to produce the correct GIR XML files during cross compilation via /usr/bin/<triplet>-g-ir-scanner. Unfortunately, meson looks up the gobject-introspection-1.0 dependency with native set to true. Hence, it does not pick up the host triplet but the build triplet here and that doesn't go well. We need to change the native argument to false here.

This patch is from https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1060838 and I'm submitting with with consent of its author @helmutg (as recorded in the git commit Author field). Using qemu-user around g-ir-scanner to support cross-compilation of projects using gobject-introspection is a technique that is also used by PtxDist, Yocto and Void Linux.

Other remarks to consider were made by @smcv in above Debian bug report. I'm filing this MR to broaden its audience for more input and comments.

Thank you!