### PR TITLE
docs: Use common conventions for shared libs

### DIFF
--- a/docs/markdown/Build-targets.md
+++ b/docs/markdown/Build-targets.md
@@ -36,7 +36,7 @@ ignored if the library is configured as static at the compile time.
 
 ```meson
 project('shared lib', 'c')
-library('mylib', 'source.c', version : '1.2.3', soversion : '0')
+library('mylib', 'source.c', version : '1.2.3', soversion : '1')
 ```
 
 It is common to build a library and then an executable that links


### PR DESCRIPTION
Use common conventions for documentation of shared library version and soversion. In general, the numeric version part is expected to be first component of version, so suggest this in the example code.