### PR TITLE
gnome: use the devenv to run g-ir-scanner

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -957,6 +957,7 @@ class GnomeModule(ExtensionModule):
             scan_command: T.Sequence[T.Union['FileOrString', Executable, ExternalProgram, OverrideProgram]],
             generated_files: T.Sequence[T.Union[str, mesonlib.File, CustomTarget, CustomTargetIndex, GeneratedList]],
             depends: T.Sequence[T.Union['FileOrString', build.BuildTarget, 'build.GeneratedTypes', build.StructuredSources]],
+            devenv: mesonlib.EnvironmentVariables,
             kwargs: T.Dict[str, T.Any]) -> GirTarget:
         install = kwargs['install_gir']
         if install is None:
@@ -978,6 +979,7 @@ class GnomeModule(ExtensionModule):
         cc_exelist = state.environment.coredata.compilers.host['c'].get_exelist()
         run_env.set('CC', [quote_arg(x) for x in cc_exelist], ' ')
         run_env.merge(kwargs['env'])
+        run_env.merge(devenv)
 
         return GirTarget(
             girfile,
@@ -1211,7 +1213,7 @@ class GnomeModule(ExtensionModule):
         generated_files = [f for f in libsources if isinstance(f, (GeneratedList, CustomTarget, CustomTargetIndex))]
 
         scan_target = self._make_gir_target(
-            state, girfile, scan_command, generated_files, depends,
+            state, girfile, scan_command, generated_files, depends, self.interpreter.backend.get_devenv(),
             # We have to cast here because mypy can't figure this out
             T.cast('T.Dict[str, T.Any]', kwargs))
 


### PR DESCRIPTION
This attempts to fix #1181 by using the `devenv` to run g-ir-scanner. This will set the correct `LD_LIBRARY_PATH` for uninstalled libraries so that the runtime linker uses these ones over the system ones.
