### PR TITLE
Document that alias_target accepts run_tgts since 0.60.0

### DIFF
--- a/docs/yaml/functions/alias_target.yaml
+++ b/docs/yaml/functions/alias_target.yaml
@@ -6,8 +6,8 @@ description: |
   targets, this integrates with the selected backend. For instance, with
   you can run it as `meson compile target_name`. This is a dummy target
   that does not execute any command, but ensures that all dependencies
-  are built. Dependencies can be any build target (e.g. return value of
-  [[executable]], [[custom_target]], etc)
+  are built. Dependencies can be any build target. Since 0.60.0, this includes
+  [[@run_tgt]].
 
 posargs:
   target_name:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2121,6 +2121,8 @@ class Interpreter(InterpreterBase, HoldableObject):
     def func_alias_target(self, node: mparser.BaseNode, args: T.Tuple[str, T.List[build.Target]],
                           kwargs: 'TYPE_kwargs') -> build.AliasTarget:
         name, deps = args
+        if any(isinstance(d, build.RunTarget) for d in deps):
+            FeatureNew.single_use('alias_target that depends on run_targets', '0.60.0', self.subproject)
         tg = build.AliasTarget(name, deps, self.subdir, self.subproject, self.environment)
         self.add_target(name, tg)
         return tg


### PR DESCRIPTION
This was accidentally changed in
982973f303e3d0431d9b79f89cdf2c8f1ee67bc0, when alias_target was changed to use typed_pos_args.