### PR TITLE
Differentiate message between dynamic linker and archiver

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -197,7 +197,7 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
         else:
             arg = '--version'
         try:
-            p, out, err = Popen_safe_logged(linker + [arg], msg='Detecting linker via')
+            p, out, err = Popen_safe_logged(linker + [arg], msg='Detecting archiver via')
         except OSError as e:
             popen_exceptions[join_args(linker + [arg])] = e
             continue


### PR DESCRIPTION
Currently both print `Detecting linker via`, which can be confusing. Clarifying this by printing "archiver" instead of "linker" for the static linker/archiver