### PR TITLE
Install files in deterministic order

### DIFF
--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -483,6 +483,8 @@ class Installer:
         else:
             exclude_files = exclude_dirs = set()
         for root, dirs, files in os.walk(src_dir):
+            dirs.sort()
+            files.sort()
             assert os.path.isabs(root)
             for d in dirs[:]:
                 abs_src = os.path.join(root, d)


### PR DESCRIPTION
It might not matter much, but it makes for nicer builddir-diffs without variations in `install-log.txt`

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).