### PR TITLE
Improve rust.bindgen's handling of of C++

### DIFF
--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -63,6 +63,7 @@ It takes the following keyword arguments
 - `args`: a list of string arguments to pass to `bindgen` untouched.
 - `dependencies`: a list of `Dependency` objects to pass to the underlying clang call (*since 1.0.0*)
 - `language`: A literal string value of `c` or `cpp`. When set this will force bindgen to treat a source as the given language. Defaults to checking based on the input file extension. *(since 1.4.0)*
+- `bindgen_version`: a list of string version values. When set the found bindgen binary must conform to these constraints. *(since 1.4.0)*
 
 ```meson
 rust = import('unstable-rust')

--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -3,7 +3,7 @@ short-description: Rust language integration module
 authors:
     - name: Dylan Baker
       email: dylan@pnwbakers.com
-      years: [2020, 2021, 2022]
+      years: [2020, 2021, 2022, 2024]
 ...
 
 # Rust module
@@ -62,6 +62,7 @@ It takes the following keyword arguments
 - `c_args`: a list of string arguments to pass to clang untouched
 - `args`: a list of string arguments to pass to `bindgen` untouched.
 - `dependencies`: a list of `Dependency` objects to pass to the underlying clang call (*since 1.0.0*)
+- `language`: A literal string value of `c` or `cpp`. When set this will force bindgen to treat a source as the given language. Defaults to checking based on the input file extension. *(since 1.4.0)*
 
 ```meson
 rust = import('unstable-rust')

--- a/docs/markdown/snippets/rust-bindgen-cpp.md
+++ b/docs/markdown/snippets/rust-bindgen-cpp.md
@@ -1,0 +1,6 @@
+## Bindgen will now use Meson's hueristic for what is a C++ header
+
+Bindgen natively assumes that a file with the extension `.cpp` is a C++ header,
+but that everything else is a C header. Meson has a whole list of extensions it
+considers to be C++, and now will automatically look for those extensions and
+set bindgen to treat those as C++

--- a/docs/markdown/snippets/rust-bindgen-language.md
+++ b/docs/markdown/snippets/rust-bindgen-language.md
@@ -1,0 +1,5 @@
+## Overriding bindgen language setting
+
+Even though Meson will now tell bindgen to do the right thing in most cases,
+there may still be cases where Meson does not have the intended behavior,
+specifically with headers with a `.h` suffix, but are C++ headers.

--- a/docs/markdown/snippets/rust-bindgen-std.md
+++ b/docs/markdown/snippets/rust-bindgen-std.md
@@ -1,0 +1,3 @@
+## Bindgen now uses the same C/C++ as the project as a whole
+
+Which is very important for C++ bindings.

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -48,7 +48,7 @@ lib_suffixes = {'a', 'lib', 'dll', 'dll.a', 'dylib', 'so', 'js'}
 # First suffix is the language's default.
 lang_suffixes = {
     'c': ('c',),
-    'cpp': ('cpp', 'cc', 'cxx', 'c++', 'hh', 'hpp', 'ipp', 'hxx', 'ino', 'ixx', 'C'),
+    'cpp': ('cpp', 'cc', 'cxx', 'c++', 'hh', 'hpp', 'ipp', 'hxx', 'ino', 'ixx', 'C', 'H'),
     'cuda': ('cu',),
     # f90, f95, f03, f08 are for free-form fortran ('f90' recommended)
     # f, for, ftn, fpp are for fixed-form fortran ('f' or 'for' recommended)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2012-2021 The Meson development team
-# Copyright © 2023 Intel Corporation
+# Copyright © 2023-2024 Intel Corporation
 
 from __future__ import annotations
 

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -73,7 +73,7 @@ class ModuleState:
     def find_program(self, prog: T.Union[mesonlib.FileOrString, T.List[mesonlib.FileOrString]],
                      required: bool = True,
                      version_func: T.Optional[ProgramVersionFunc] = None,
-                     wanted: T.Optional[str] = None, silent: bool = False,
+                     wanted: T.Union[str, T.List[str]] = '', silent: bool = False,
                      for_machine: MachineChoice = MachineChoice.HOST) -> T.Union[ExternalProgram, build.Executable, OverrideProgram]:
         if not isinstance(prog, list):
             prog = [prog]

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -268,6 +268,23 @@ class RustModule(ExtensionModule):
         if language == 'cpp':
             clang_args.extend(['-x', 'c++'])
 
+        # Add the C++ standard to the clang arguments. Attempt to translate VS
+        # extension versions into the nearest standard version
+        std = state.get_option('std', lang=language)
+        assert isinstance(std, str), 'for mypy'
+        if std.startswith('vc++'):
+            if std.endswith('latest'):
+                mlog.warning('Attempting to translate vc++latest into a clang compatible version.',
+                             'Currently this is hardcoded for c++20', once=True, fatal=False)
+                std = 'c++20'
+            else:
+                mlog.debug('The current C++ standard is a Visual Studio extension version.',
+                           'bindgen will use a the nearest C++ standard instead')
+                std = std[1:]
+
+        if std != 'none':
+            clang_args.append(f'-std={std}')
+
         cmd = self._bindgen_bin.get_command() + \
             [
                 '@INPUT@', '--output',

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -48,6 +48,7 @@ if T.TYPE_CHECKING:
         output: str
         dependencies: T.List[T.Union[Dependency, ExternalLibrary]]
         language: T.Optional[Literal['c', 'cpp']]
+        bindgen_version: T.List[str]
 
 
 class RustModule(ExtensionModule):
@@ -192,6 +193,7 @@ class RustModule(ExtensionModule):
             required=True,
         ),
         KwargInfo('language', (str, NoneType), since='1.4.0', validator=in_set_validator({'c', 'cpp'})),
+        KwargInfo('bindgen_version', ContainerTypeInfo(list, str), default=[], listify=True, since='1.4.0'),
         INCLUDE_DIRECTORIES.evolve(since_values={ContainerTypeInfo(list, str): '1.0.0'}),
         OUTPUT_KW,
         DEPENDENCIES_KW.evolve(since='1.0.0'),
@@ -236,7 +238,7 @@ class RustModule(ExtensionModule):
                     depends.append(s)
 
         if self._bindgen_bin is None:
-            self._bindgen_bin = state.find_program('bindgen')
+            self._bindgen_bin = state.find_program('bindgen', wanted=kwargs['bindgen_version'])
 
         name: str
         if isinstance(header, File):

--- a/test cases/rust/12 bindgen/cpp/meson.build
+++ b/test cases/rust/12 bindgen/cpp/meson.build
@@ -1,0 +1,19 @@
+# SPDX-license-identifer: Apache-2.0
+# Copyright © 2021-2023 Intel Corporation
+
+fs = import('fs')
+
+cpp_header = fs.copyfile('../src/header.hpp', 'cpp_header.h')
+
+cpp_bind_override = rust.bindgen(
+  input : cpp_header,
+  output : 'generated-cpp.rs',
+  language : 'cpp',
+)
+
+cpp_exe2 = executable(
+  'cpp_exe2',
+  structured_sources(['../src/cpp.rs', cpp_bind_override]),
+  link_with : cpp_lib,
+)
+test('cpp-forced', cpp_exe2)

--- a/test cases/rust/12 bindgen/meson.build
+++ b/test cases/rust/12 bindgen/meson.build
@@ -1,7 +1,11 @@
 # SPDX-license-identifer: Apache-2.0
-# Copyright © 2021-2022 Intel Corporation
+# Copyright © 2021-2024 Intel Corporation
 
-project('rustmod bindgen', ['c', 'cpp', 'rust'], meson_version : '>= 0.63')
+project(
+  'rustmod bindgen',
+  ['c', 'cpp', 'rust'],
+  meson_version : '>= 0.63',
+  default_options : ['cpp_std=c++17'])
 
 prog_bindgen = find_program('bindgen', required : false)
 if not prog_bindgen.found()

--- a/test cases/rust/12 bindgen/meson.build
+++ b/test cases/rust/12 bindgen/meson.build
@@ -32,12 +32,17 @@ if result.returncode() != 0
   error('MESON_SKIP_TEST bindgen does not seem to work')
 endif
 
+rust = import('unstable-rust')
+
+# Check version, this case is obviously impossible
+testcase expect_error('Program \'bindgen\' not found or not executable')
+  rust.bindgen(input : 'include/other.h', output : 'other.rs', bindgen_version : ['< 0.1', '> 10000'])
+endtestcase
+
 # This is to test the include_directories argument to bindgen
 inc = include_directories('include')
 
 c_lib = static_library('clib', 'src/source.c', include_directories : inc)
-
-rust = import('unstable-rust')
 
 gen = rust.bindgen(
   input : 'src/header.h',

--- a/test cases/rust/12 bindgen/meson.build
+++ b/test cases/rust/12 bindgen/meson.build
@@ -1,7 +1,7 @@
 # SPDX-license-identifer: Apache-2.0
 # Copyright © 2021-2022 Intel Corporation
 
-project('rustmod bindgen', ['c', 'rust'], meson_version : '>= 0.63')
+project('rustmod bindgen', ['c', 'cpp', 'rust'], meson_version : '>= 0.63')
 
 prog_bindgen = find_program('bindgen', required : false)
 if not prog_bindgen.found()
@@ -107,3 +107,17 @@ gp_exe = executable(
 )
 
 test('global and project arguments', gp_exe)
+
+cpp_lib = static_library('cpplib', 'src/impl.cpp')
+
+cpp_bind = rust.bindgen(
+  input : 'src/header.hpp',
+  output : 'generated-cpp.rs',
+)
+
+cpp_exe = executable(
+  'cpp_exe',
+  structured_sources(['src/cpp.rs', cpp_bind]),
+  link_with : cpp_lib,
+)
+test('cpp', cpp_exe)

--- a/test cases/rust/12 bindgen/src/cpp.rs
+++ b/test cases/rust/12 bindgen/src/cpp.rs
@@ -1,0 +1,19 @@
+// SPDX-license-identifer: Apache-2.0
+// Copyright © 2023 Intel Corporation
+
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+include!("generated-cpp.rs");
+
+fn main() {
+    let mut instance = std::mem::MaybeUninit::<MyClass>::uninit();
+    let val: i32;
+    unsafe {
+        MyClass_MyClass(instance.as_mut_ptr());
+        val = instance.assume_init_mut().method();
+    }
+    let success = val == 7;
+    std::process::exit(!success as i32);
+}

--- a/test cases/rust/12 bindgen/src/header.hpp
+++ b/test cases/rust/12 bindgen/src/header.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+class MyClass {
+  public:
+    MyClass();
+    int method() const;
+  private:
+    int val;
+};

--- a/test cases/rust/12 bindgen/src/impl.cpp
+++ b/test cases/rust/12 bindgen/src/impl.cpp
@@ -1,0 +1,7 @@
+#include "header.hpp"
+
+MyClass::MyClass() : val{7} {};
+
+int MyClass::method() const {
+    return val;
+}

--- a/test cases/rust/12 bindgen/test.json
+++ b/test cases/rust/12 bindgen/test.json
@@ -4,7 +4,7 @@
   },
   "stdout": [
     {
-      "line": "test cases/rust/12 bindgen/meson.build:38: WARNING: Project targets '>= 0.63' but uses feature introduced in '1.0.0': \"rust.bindgen\" keyword argument \"include_directories\" of type array[str]."
+      "line": "test cases/rust/12 bindgen/meson.build:42: WARNING: Project targets '>= 0.63' but uses feature introduced in '1.0.0': \"rust.bindgen\" keyword argument \"include_directories\" of type array[str]."
     }
   ]
 }

--- a/test cases/rust/12 bindgen/test.json
+++ b/test cases/rust/12 bindgen/test.json
@@ -4,7 +4,7 @@
   },
   "stdout": [
     {
-      "line": "test cases/rust/12 bindgen/meson.build:42: WARNING: Project targets '>= 0.63' but uses feature introduced in '1.0.0': \"rust.bindgen\" keyword argument \"include_directories\" of type array[str]."
+      "line": "test cases/rust/12 bindgen/meson.build:47: WARNING: Project targets '>= 0.63' but uses feature introduced in '1.0.0': \"rust.bindgen\" keyword argument \"include_directories\" of type array[str]."
     }
   ]
 }


### PR DESCRIPTION
This has 3 distinct changes wrapped up into one smallish PR:
 - Meson will check the header extension against it's own heuristic for whether a header is C or C++ instead of relying on bindgen, which only supports `.hpp`
 - Meson will add the appropriate C or C++ standard to the clang invocation
 - The internal finder for bindgen has it's version constraint arguments exposed.