### PR TITLE
Add a numpy dependency with pkg-config and configtool methods

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -653,6 +653,14 @@ The `language` keyword may used.
 
 `method` may be `auto`, `pkg-config`, `system` or `cmake`.
 
+## NumPy
+
+*(added 1.4.0)*
+
+`method` may be `auto`, `pkg-config`, or `config-tool`.
+`dependency('numpy')` supports regular use of the NumPy C API.
+Use of `numpy.f2py` for binding Fortran code isn't yet supported.
+
 ## pcap
 
 *(added 0.42.0)*

--- a/docs/markdown/snippets/numpy-custom-dependency.md
+++ b/docs/markdown/snippets/numpy-custom-dependency.md
@@ -1,0 +1,9 @@
+## New numpy custom dependency
+
+Support for `dependency('numpy')` was added, via supporting the `numpy-config` tool and
+pkg-config support, both of which are available since NumPy 2.0.0.
+
+Config-tool support is useful because it will work out of the box when
+``numpy`` is installed, while the pkg-config file is located inside python's
+site-packages, which makes it impossible to use in an out of the box manner
+without setting `PKG_CONFIG_PATH`.

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -228,6 +228,7 @@ packages.defaults.update({
     'appleframeworks': 'platform',
 
     # from python:
+    'numpy': 'python',
     'python3': 'python',
     'pybind11': 'python',
 

--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -61,6 +61,17 @@ class Pybind11ConfigToolDependency(ConfigToolDependency):
         self.compile_args = self.get_config_value(['--includes'], 'compile_args')
 
 
+class NumPyConfigToolDependency(ConfigToolDependency):
+
+    tools = ['numpy-config']
+
+    def __init__(self, name: str, environment: Environment, kwargs: T.Dict[str, T.Any]):
+        super().__init__(name, environment, kwargs)
+        if not self.is_found:
+            return
+        self.compile_args = self.get_config_value(['--cflags'], 'compile_args')
+
+
 class BasicPythonExternalProgram(ExternalProgram):
     def __init__(self, name: str, command: T.Optional[T.List[str]] = None,
                  ext_prog: T.Optional[ExternalProgram] = None):
@@ -411,4 +422,10 @@ packages['pybind11'] = pybind11_factory = DependencyFactory(
     'pybind11',
     [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.CMAKE],
     configtool_class=Pybind11ConfigToolDependency,
+)
+
+packages['numpy'] = numpy_factory = DependencyFactory(
+    'numpy',
+    [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL],
+    configtool_class=NumPyConfigToolDependency,
 )


### PR DESCRIPTION
These are being added for NumPy 2.0 (see https://github.com/numpy/numpy/pull/25570#issuecomment-1912545457). The implementation closely follows the one for the `pybind11` dependency.