### PR TITLE
wrap: default values for netrc are empty string from python 3.11

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -656,7 +656,7 @@ class Resolver:
             return None
 
         login, account, password = self.netrc.authenticators(netloc)
-        if account is not None:
+        if account:
             login = account
 
         return login, password


### PR DESCRIPTION
From python 3.11 [1]:

> The entry in the netrc file no longer needs to contain all tokens.  The missing
> tokens' value default to an empty string.  All the tokens and their values now
> can contain arbitrary characters, like whitespace and non-ASCII characters.
> If the login name is anonymous, it won't trigger the security check.

[1] https://github.com/python/cpython/commit/15409c720be0503131713e3d3abc1acd0da07378