### PR TITLE
CI fixes for macOS

### DIFF
--- a/mesonbuild/dependencies/hdf5.py
+++ b/mesonbuild/dependencies/hdf5.py
@@ -122,13 +122,20 @@ class HDF5ConfigToolDependency(ConfigToolDependency):
         # and then without -c to get the link arguments.
         args = self.get_config_value(['-show', '-c'], 'args')[1:]
         args += self.get_config_value(['-show', '-noshlib' if self.static else '-shlib'], 'args')[1:]
+        found = False
         for arg in args:
             if arg.startswith(('-I', '-f', '-D')) or arg == '-pthread':
                 self.compile_args.append(arg)
             elif arg.startswith(('-L', '-l', '-Wl')):
                 self.link_args.append(arg)
+                found = True
             elif Path(arg).is_file():
                 self.link_args.append(arg)
+                found = True
+
+        # cmake h5cc is broken
+        if not found:
+            raise DependencyException('HDF5 was built with cmake instead of autotools, and h5cc is broken.')
 
     def _sanitize_version(self, ver: str) -> str:
         v = re.search(r'\s*HDF5 Version: (\d+\.\d+\.\d+)', ver)

--- a/test cases/common/219 include_type dependency/meson.build
+++ b/test cases/common/219 include_type dependency/meson.build
@@ -1,6 +1,7 @@
 project(
   'dependency include_type',
   ['c', 'cpp'],
+  default_options: ['cpp_std=c++11'],
 )
 
 dep = dependency('zlib', method: 'pkg-config', required : false)

--- a/test cases/frameworks/25 hdf5/test.json
+++ b/test cases/frameworks/25 hdf5/test.json
@@ -2,8 +2,8 @@
   "matrix": {
     "options": {
       "method": [
-        { "val": "pkg-config", "skip_on_jobname": ["macos"] },
-        { "val": "config-tool" }
+        { "val": "pkg-config" },
+        { "val": "config-tool", "skip_on_jobname": ["macos"] }
       ]
     }
   },


### PR DESCRIPTION
- hdf5 tests:
  - dependencies: detect when it is bad
  - CI: mark as not-found and skipped for macOS
- test that uses boost, needs to require a suitable `$CXX -std`