### PR TITLE
fix UnboundLocalError if guess_win_linker fails in detect_fortran_compiler

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -769,6 +769,7 @@ def detect_fortran_compiler(env: 'Environment', for_machine: MachineChoice) -> C
 
             if 'flang' in out or 'clang' in out:
                 cls = fortran.FlangFortranCompiler
+                linker = None
                 if 'windows' in out or env.machines[for_machine].is_windows():
                     # If we're in a MINGW context this actually will use a gnu
                     # style ld, but for flang on "real" windows we'll use


### PR DESCRIPTION
In #12305 I unfortunately introduced a bug - if `guess_win_linker` didn't produce a result, then the code would try to do `if linker is None` on a variable that hadn't been set yet. Set the value before so that the variable always exists.