### PR TITLE
Support `meson dist` when getting project versions from VCS

### DIFF
--- a/docs/markdown/Creating-releases.md
+++ b/docs/markdown/Creating-releases.md
@@ -86,3 +86,30 @@ meson setup builddir
 meson dist -C builddir
 ```
 This produces `builddir/meson-dist/mysubproject-1.0.tar.xz` tarball.
+
+## Cement a version obtained from VCS
+
+*Since 1.4.0* the `meson dist` command enables rewriting the build
+configuration of the distribution tarball. This is needed when the
+configuration depends on metadata from revision control such as in the
+following example.
+
+`meson.build`:
+```meson
+project('tig', 'c',
+  version : run_command('version.sh', 'get-vcs').stdout.strip())
+
+meson.add_dist_script('version.sh', 'set-dist', meson.project_version())
+```
+`version.sh`:
+```sh
+#!/bin/sh
+
+if [ "$1" = "get-vcs" ]; then
+  git -C "$MESON_SOURCE_ROOT" describe --always --dirty
+elif [ "$1" = "set-dist" ]; then
+  $MESONREWRITE --sourcedir="$MESON_PROJECT_DIST_ROOT" kwargs set project / version "$2"
+else
+  exit 1
+fi
+```

--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -85,6 +85,7 @@ For languages that don't have separate dynamic linkers such as C# and Java, the
 | Value               | Comment                         |
 | -----               | -------                         |
 | MESONINTROSPECT     | Command to run to run the introspection command, may be of the form `python /path/to/meson introspect`, user is responsible for splitting the path if necessary. |
+| MESONREWRITE        | Command to run to run the rewriting command, only set when running `dist` scripts |
 | MESON_BUILD_ROOT    | Absolute path to the build dir  |
 | MESON_DIST_ROOT     | Points to the root of the staging directory, only set when running `dist` scripts |
 | MESON_SOURCE_ROOT   | Absolute path to the source dir |

--- a/docs/yaml/builtins/meson.yaml
+++ b/docs/yaml/builtins/meson.yaml
@@ -32,6 +32,17 @@ methods:
       scripts, but for subproject scripts they have the path to the root of the
       subproject appended, usually `subprojects/<subproject-name>`.
 
+      *(since 1.4.0)* The `MESONREWRITE` environment variable contains the path
+      to the rewrite command that corresponds to the `meson` executable that
+      was used to configure the build. (This might be a different path than the
+      first executable found in `PATH`.) It can be used to remove or replace
+      any [[run_command]] that depends on the revision control system from the
+      build configuration. Note that the value will contain many parts. For
+      example, it may be `python3 /path/to/meson.py introspect`. The user is
+      responsible for splitting the string to an array if needed by splitting
+      lexically like a UNIX shell would. If your script uses Python,
+      `shlex.split()` is the easiest correct way to do this.
+
     posargs:
       script_name:
         type: str | file | external_program

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from glob import glob
 from pathlib import Path
 from mesonbuild.environment import detect_ninja
-from mesonbuild.mesonlib import (MesonException, RealPathAction, quiet_git,
+from mesonbuild.mesonlib import (MesonException, RealPathAction, get_meson_command, quiet_git,
                                  windows_proof_rmtree, setup_vsenv, OptionKey)
 from mesonbuild.msetup import add_arguments as msetup_argparse
 from mesonbuild.wrap import wrap
@@ -327,9 +327,6 @@ def run(options: argparse.Namespace) -> int:
     b = build.load(options.wd)
     need_vsenv = T.cast('bool', b.environment.coredata.get_option(OptionKey('vsenv')))
     setup_vsenv(need_vsenv)
-    # This import must be load delayed, otherwise it will get the default
-    # value of None.
-    from mesonbuild.mesonlib import get_meson_command
     src_root = b.environment.source_dir
     bld_root = b.environment.build_dir
     priv_dir = os.path.join(bld_root, 'meson-private')

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -20,7 +20,7 @@ import typing as T
 from dataclasses import dataclass
 from glob import glob
 from pathlib import Path
-from mesonbuild.environment import detect_ninja
+from mesonbuild.environment import Environment, detect_ninja
 from mesonbuild.mesonlib import (MesonException, RealPathAction, get_meson_command, quiet_git,
                                  windows_proof_rmtree, setup_vsenv, OptionKey)
 from mesonbuild.msetup import add_arguments as msetup_argparse
@@ -102,10 +102,12 @@ class Dist(metaclass=abc.ABCMeta):
 
     def run_dist_scripts(self) -> None:
         assert os.path.isabs(self.distdir)
-        env = {}
-        env['MESON_DIST_ROOT'] = self.distdir
-        env['MESON_SOURCE_ROOT'] = self.src_root
-        env['MESON_BUILD_ROOT'] = self.bld_root
+        mesonrewrite = Environment.get_build_command() + ['rewrite']
+        env = {'MESON_DIST_ROOT': self.distdir,
+               'MESON_SOURCE_ROOT': self.src_root,
+               'MESON_BUILD_ROOT': self.bld_root,
+               'MESONREWRITE': ' '.join(shlex.quote(x) for x in mesonrewrite),
+               }
         for d in self.dist_scripts:
             if d.subproject and d.subproject not in self.subprojects:
                 continue

--- a/test cases/unit/35 dist script/subprojects/sub/dist-script.py
+++ b/test cases/unit/35 dist script/subprojects/sub/dist-script.py
@@ -2,11 +2,18 @@
 
 import os
 import pathlib
+import shlex
+import subprocess
 import sys
 
 assert sys.argv[1] == 'success'
 
 source_root = pathlib.Path(os.environ['MESON_PROJECT_DIST_ROOT'])
+mesonrewrite = shlex.split(os.environ['MESONREWRITE'])
+rewrite_cmd = ['kwargs', 'set', 'project', '/', 'version', 'release']
+
+subprocess.run([*mesonrewrite, '-s', source_root, *rewrite_cmd], check=True)
+
 modfile = source_root / 'prog.c'
 with modfile.open('w') as f:
     f.write('int main(){return 0;}')

--- a/test cases/unit/35 dist script/subprojects/sub/meson.build
+++ b/test cases/unit/35 dist script/subprojects/sub/meson.build
@@ -1,4 +1,5 @@
-project('sub', 'c')
+project('sub', 'c',
+  version : 'vcs')
 
 if get_option('broken_dist_script')
   # Make sure we can add a dist script in a subproject, but it won't be run
@@ -8,4 +9,7 @@ else
   # The dist script replace prog.c with something that actually build.
   meson.add_dist_script('dist-script.py', 'success')
   executable('prog', 'prog.c')
+
+  versiontest = find_program('version-test.py')
+  test('dist version replacement', versiontest, args : meson.project_version())
 endif

--- a/test cases/unit/35 dist script/subprojects/sub/version-test.py
+++ b/test cases/unit/35 dist script/subprojects/sub/version-test.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+from sys import argv
+
+assert argv[1] == 'release'


### PR DESCRIPTION
Together with #12782, this allows versioning via git (#688) as follows.

`meson.build`:
```meson
project('tig', 'c',
  version : run_command('version.sh', 'get_vcs').stdout.strip())
meson.add_dist_script('version.sh', 'set_dist', meson.project_version())
```
`version.sh`:
```sh
#!/bin/sh
if [ "$1" = "get_vcs" ]; then
  git -C "$MESON_SOURCE_ROOT" describe --always --dirty
elif [ "$1" = "set_dist" ]; then
  $MESONREWRITE --sourcedir="$MESON_PROJECT_DIST_ROOT" kwargs set project / version "$2"
else
  exit 1
fi
```

Without #12782, the rewriting will not work, so that one needs to be merged before the current pull request.