### PR TITLE
Fix ninja cannot find the library when libraries contain symlinks.

### DIFF
--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -470,9 +470,12 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
             # which is wrong and breaks things. Store everything, just to be sure.
             pobj = pathlib.Path(p)
             if pobj.exists():
-                resolved = pobj.resolve().as_posix()
-                if resolved not in result:
-                    result.append(resolved)
+                try:
+                    resolved = pobj.resolve(True).as_posix()
+                    if resolved not in result:
+                        result.append(resolved)
+                except FileNotFoundError:
+                    pass
                 unresolved = pobj.as_posix()
                 if unresolved not in result:
                     result.append(unresolved)

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -469,16 +469,13 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
             # paths under /lib would be considered not a "system path",
             # which is wrong and breaks things. Store everything, just to be sure.
             pobj = pathlib.Path(p)
-            unresolved = pobj.as_posix()
             if pobj.exists():
+                resolved = pobj.resolve().as_posix()
+                if resolved not in result:
+                    result.append(resolved)
+                unresolved = pobj.as_posix()
                 if unresolved not in result:
                     result.append(unresolved)
-                try:
-                    resolved = pathlib.Path(p).resolve().as_posix()
-                    if resolved not in result:
-                        result.append(resolved)
-                except FileNotFoundError:
-                    pass
         return result
 
     def get_compiler_dirs(self, env: 'Environment', name: str) -> T.List[str]:


### PR DESCRIPTION
If there're weird symlinks in the system like Fedora RISC-V
/lib64/lp64d -> /lib64
and glibc is installed to /lib64/lp64d

When calling cxx.find_library, it will first search for /lib64/lp64d/../lib64/lp64d/
https://github.com/mesonbuild/meson/blob/2fbc7b5ce3aced483b196dd10ca9eee1713b7494/mesonbuild/compilers/mixins/clike.py#L205
https://github.com/mesonbuild/meson/blob/2fbc7b5ce3aced483b196dd10ca9eee1713b7494/mesonbuild/compilers/mixins/gnu.py#L475
Then generate linkargs ['/lib64/lp64d/../lib64/lp64d/libbz2.so']
which will cause ninja build fail: https://github.com/ninja-build/ninja/issues/1330

Here is a simple example
```
meson.build：
project('my_project', 'c')
c_compiler = meson.get_compiler('c')
bzip2_dep = c_compiler.find_library(
      'bz2',
      dirs: '/usr/lib',
)
executable('main', 'main.c', dependencies: bzip2_dep)

main.c：
int main(){return 0;}
```

```
sh-5.2# meson setup build
The Meson build system
Version: 1.3.1
Source dir: /test
Build dir: /test/build
Build type: native build
Project name: my_project
Project version: undefined
C compiler for the host machine: cc (gcc 13.2.1 "cc (GCC) 13.2.1 20231011 (Red Hat 13.2.1-4)")
C linker for the host machine: cc ld.bfd 2.41-14
Host machine cpu family: riscv64
Host machine cpu: riscv64
linkargs ['/lib64/lp64d/../lib64/lp64d/libbz2.so']
Library bz2 found: YES
Build targets in project: 1

Found ninja-1.11.1 at /usr/bin/ninja
sh-5.2# ninja -C build/
ninja: Entering directory `build/'
ninja: error: '/lib64/lib64/lp64d/libbz2.so', needed by 'main', missing and no known rule to make it
```

According to the commit history, the issue was introduced in [this commit](https://github.com/mesonbuild/meson/commit/c658427a0614ba05cdc8a155c05cd67649c5b0ee) that inserts the unresolved variable to paths to avoid systemd test fail.
I don't know if the workaround mentioned above is still required now, so I temporarily adjusted the priority in my patch for compatibility.

CC: @rwmjones @davidlt