### PR TITLE
Autogenerate Xcode projects by the detected version

### DIFF
--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -1271,7 +1271,7 @@ class XCodeBackend(backends.Backend):
         project_dict.add_item('buildStyles', style_arr)
         for name, idval in self.buildstylemap.items():
             style_arr.add_item(idval, name)
-        project_dict.add_item('compatibilityVersion', '"Xcode 3.2"')
+        project_dict.add_item('compatibilityVersion', f'"{self.xcodeversion}"')
         project_dict.add_item('hasScannedForEncodings', 0)
         project_dict.add_item('mainGroup', self.maingroup_id)
         project_dict.add_item('projectDirPath', '"' + self.environment.get_source_dir() + '"')
@@ -1870,7 +1870,7 @@ class XCodeBackend(backends.Backend):
     def generate_prefix(self, pbxdict: PbxDict) -> PbxDict:
         pbxdict.add_item('archiveVersion', '1')
         pbxdict.add_item('classes', PbxDict())
-        pbxdict.add_item('objectVersion', '46')
+        pbxdict.add_item('objectVersion', self.objversion)
         objects_dict = PbxDict()
         pbxdict.add_item('objects', objects_dict)
 

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -296,7 +296,8 @@ class XCodeBackend(backends.Backend):
         self.build_targets = self.build.get_build_targets()
         self.custom_targets = self.build.get_custom_targets()
         self.generate_filemap()
-        self.generate_buildstylemap()
+        if self.objversion < 50:
+            self.generate_buildstylemap()
         self.generate_build_phase_map()
         self.generate_build_configuration_map()
         self.generate_build_configurationlist_map()
@@ -328,9 +329,10 @@ class XCodeBackend(backends.Backend):
         self.generate_pbx_build_rule(objects_dict)
         objects_dict.add_comment(PbxComment('End PBXBuildRule section'))
         objects_dict.add_comment(PbxComment('Begin PBXBuildStyle section'))
-        self.generate_pbx_build_style(objects_dict)
-        objects_dict.add_comment(PbxComment('End PBXBuildStyle section'))
-        objects_dict.add_comment(PbxComment('Begin PBXContainerItemProxy section'))
+        if self.objversion < 50:
+            self.generate_pbx_build_style(objects_dict)
+            objects_dict.add_comment(PbxComment('End PBXBuildStyle section'))
+            objects_dict.add_comment(PbxComment('Begin PBXContainerItemProxy section'))
         self.generate_pbx_container_item_proxy(objects_dict)
         objects_dict.add_comment(PbxComment('End PBXContainerItemProxy section'))
         objects_dict.add_comment(PbxComment('Begin PBXFileReference section'))
@@ -758,8 +760,8 @@ class XCodeBackend(backends.Backend):
             odict.add_item('isa', 'PBXBuildFile')
             odict.add_item('fileRef', ref_id)
 
+    # This is skipped if Xcode 9 or above is installed, as PBXBuildStyle was removed on that version.
     def generate_pbx_build_style(self, objects_dict: PbxDict) -> None:
-        # FIXME: Xcode 9 and later does not uses PBXBuildStyle and it gets removed. Maybe we can remove this part.
         for name, idval in self.buildstylemap.items():
             styledict = PbxDict()
             objects_dict.add_item(idval, styledict, name)
@@ -1267,10 +1269,11 @@ class XCodeBackend(backends.Backend):
         attr_dict.add_item('BuildIndependentTargetsInParallel', 'YES')
         project_dict.add_item('buildConfigurationList', self.project_conflist, f'Build configuration list for PBXProject "{self.build.project_name}"')
         project_dict.add_item('buildSettings', PbxDict())
-        style_arr = PbxArray()
-        project_dict.add_item('buildStyles', style_arr)
-        for name, idval in self.buildstylemap.items():
-            style_arr.add_item(idval, name)
+        if self.objversion < 50:
+            style_arr = PbxArray()
+            project_dict.add_item('buildStyles', style_arr)
+            for name, idval in self.buildstylemap.items():
+                style_arr.add_item(idval, name)
         project_dict.add_item('compatibilityVersion', f'"{self.xcodeversion}"')
         project_dict.add_item('hasScannedForEncodings', 0)
         project_dict.add_item('mainGroup', self.maingroup_id)


### PR DESCRIPTION
This pull request enables Meson to detect the installed version of Xcode and generate project files for that version, rather than just assume it's Xcode 3.2. This will enable us to finely adjust how the project files are generated. As an example, Xcode 9 eliminated `PBXBuildStyle`, so we can skip generating that for Xcode 9 and newer.

This also addresses a mostly benign issue in Xcode 15, where project formats older than Xcode 12 do not appear as options.