### PR TITLE
compilers: avoid -Wunused-value compiler warning in CLikeCompiler.has_members()

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -885,7 +885,7 @@ class CLikeCompiler(Compiler):
                  dependencies: T.Optional[T.List['Dependency']] = None) -> T.Tuple[bool, bool]:
         t = f'''{prefix}
         void bar(void) {{
-            sizeof({typename});
+            (void) sizeof({typename});
         }}'''
         return self.compiles(t, env, extra_args=extra_args,
                              dependencies=dependencies)

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -870,11 +870,12 @@ class CLikeCompiler(Compiler):
         if extra_args is None:
             extra_args = []
         # Create code that accesses all members
-        members = ''.join(f'foo.{member};\n' for member in membernames)
+        members = ''.join(f'(void) ( foo.{member} );\n' for member in membernames)
         t = f'''{prefix}
         void bar(void) {{
             {typename} foo;
             {members}
+            (void) foo;
         }}'''
         return self.compiles(t, env, extra_args=extra_args,
                              dependencies=dependencies)


### PR DESCRIPTION
Otherwise, `CFLAGS='-Wall -Werror' meson build` can fail detection:
```
          void bar(void) {
              struct stat foo;
              foo.st_mtim.tv_nsec;

          }
  -----------
  Command line: `cc ./project/build/meson-private/tmpqz_gi65d/testfile.c -o ./project/build/meson-private/tmpqz_gi65d/output.obj -c -O3 -Werror -Wall -D_FILE_OFFSET_BITS=64 -O0 -std=gnu99` -> 1
  stderr:
  ./project/build/meson-private/tmpqz_gi65d/testfile.c: In function 'bar':
  ./project/build/meson-private/tmpqz_gi65d/testfile.c:45:24: error: statement with no effect [-Werror=unused-value]
     45 |             foo.st_mtim.tv_nsec;
        |             ~~~~~~~~~~~^~~~~~~~
  cc1: all warnings being treated as errors
```