### PR TITLE
cmake: improve heuristics for static LLVM detection

### DIFF
--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -379,7 +379,7 @@ class CMakeDependency(ExternalDependency):
             cmake_opts += ['-DARCHS={}'.format(';'.join(self.cmakeinfo.archs))]
             cmake_opts += [f'-DVERSION={package_version}']
             cmake_opts += ['-DCOMPS={}'.format(';'.join([x[0] for x in comp_mapped]))]
-            cmake_opts += [f'-DSTATIC={self.static}']
+            cmake_opts += ['-DSTATIC={}'.format('ON' if self.static else 'OFF')]
             cmake_opts += args
             cmake_opts += self.traceparser.trace_args()
             cmake_opts += toolchain.get_cmake_args()

--- a/mesonbuild/dependencies/data/CMakeListsLLVM.txt
+++ b/mesonbuild/dependencies/data/CMakeListsLLVM.txt
@@ -85,7 +85,7 @@ if(LLVM_FOUND)
   elseif(NOT LLVM_MESON_DYLIB)
     # Use LLVMSupport to check if static targets exist
     set(static_tg FALSE)
-    is_static(LLVMSupport static_tg)
+    is_static(LLVMCore static_tg)
     if(static_tg)
       set(PACKAGE_FOUND TRUE)
     endif(static_tg)

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -329,7 +329,7 @@ class LLVMDependencyConfigTool(ConfigToolDependency):
 
         Old versions of LLVM bring an extra level of insanity with them.
         llvm-config will provide the correct arguments for static linking, but
-        not for shared-linnking, we have to figure those out ourselves, because
+        not for shared-linking, we have to figure those out ourselves, because
         of course we do.
         """
         if self.static:
@@ -413,7 +413,7 @@ class LLVMDependencyCMake(CMakeDependency):
         if not self.is_found:
             return
 
-        #CMake will return not found due to not defined LLVM_DYLIB_COMPONENTS
+        # CMake will return not found due to not defined LLVM_DYLIB_COMPONENTS
         if not self.static and version_compare(self.version, '< 7.0') and self.llvm_modules:
             mlog.warning('Before version 7.0 cmake does not export modules for dynamic linking, cannot check required modules')
             return


### PR DESCRIPTION
In https://github.com/mesonbuild/meson/commit/89146e84c9eab649d3847af101d61047cac45765, a heuristic was introduced where
if libLLVMSupport is available as a static library, LLVM itself is assumed
to be availble as a static library as a whole.

This is unfortunately not the case at least on Gentoo and Arch Linux, where
a subsequent llvm-config call yields:
```
$ /usr/lib/llvm/17/bin/llvm-config --libfiles --link-static
llvm-config: error: missing: /usr/lib/llvm/17/lib64/libLLVMTargetParser.a
llvm-config: error: missing: /usr/lib/llvm/17/lib64/libLLVMBinaryFormat.a
llvm-config: error: missing: /usr/lib/llvm/17/lib64/libLLVMBitstreamReader.a
llvm-config: error: missing: /usr/lib/llvm/17/lib64/libLLVMRemarks.a
[...]
```

On Gentoo, where LLVM's static libraries are not included, we still have:
```
$ equery f llvm:17 | grep -i lib64/.*.a$
/usr/lib/llvm/17/lib64/libLLVMDemangle.a
/usr/lib/llvm/17/lib64/libLLVMSupport.a
/usr/lib/llvm/17/lib64/libLLVMTableGen.a
/usr/lib/llvm/17/lib64/libLLVMTestingAnnotations.a
/usr/lib/llvm/17/lib64/libLLVMTestingSupport.a
/usr/lib/llvm/17/lib64/libllvm_gtest.a
/usr/lib/llvm/17/lib64/libllvm_gtest_main.a
```

Therefore, testing for libLLVMSupport is insufficient. We now try libLLVMCore
instead, as that appears to only be installed when LLVM truly has static libraries
available. libLLVMCore is handled as a LLVM component which gives us some guarantee
this is supposed to be happening and not a fluke.

(Specifically, LLVM's llvm/lib/Support/CMakeLists.txt pays 0 attention to
-DLLVM_BUILD_LLVM_DYLIB and -DLLVM_LINK_LLVM_DYLIB, and is hence only affected
by -DBUILD_SHARED_LIBS, which LLVM upstream say is only to be used for development.

Therefore, with -DBUILD_SHARED_LIBS=OFF (as is recommended/the default) and
-DLLVM_BUILD_LLVM_DYLIB=ON, you will get a static libLLVMSupport, without it
indicating anything about the rest of your configuration.)

Closes: https://github.com/mesonbuild/meson/issues/12323
Fixes: https://github.com/mesonbuild/meson/commit/89146e84c9eab649d3847af101d61047cac45765
Signed-off-by: Sam James <sam@gentoo.org>