### PR TITLE
Fix KeyError in Python module

### DIFF
--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -74,6 +74,7 @@ class PythonExternalProgram(BasicPythonExternalProgram):
         if ret:
             self.platlib = self._get_path(state, 'platlib')
             self.purelib = self._get_path(state, 'purelib')
+            self.run_bytecompile.setdefault(self.info['version'], False)
         return ret
 
     def _get_path(self, state: T.Optional['ModuleState'], key: str) -> str:
@@ -544,7 +545,6 @@ class PythonModule(ExtensionModule):
             assert isinstance(python, PythonExternalProgram), 'for mypy'
             python = copy.copy(python)
             python.pure = kwargs['pure']
-            python.run_bytecompile.setdefault(python.info['version'], False)
             return python
 
         raise mesonlib.MesonBugException('Unreachable code was reached (PythonModule.find_installation).')

--- a/test cases/python/5 modules kwarg/meson.build
+++ b/test cases/python/5 modules kwarg/meson.build
@@ -1,7 +1,19 @@
-project('python kwarg')
+project('python kwarg',
+    default_options: [
+        'python.bytecompile=-1',
+        'python.purelibdir=/pure',
+    ]
+)
 
 py = import('python')
-prog_python = py.find_installation('python3', modules : ['os', 'sys', 're'])
+prog_python = py.find_installation('python3', modules : ['os', 'sys', 're'], pure: true)
 assert(prog_python.found() == true, 'python not found when should be')
+
+# In meson 1.2 - 1.3.2, there was a bug when a python installation
+# with a different version did not have a module, and we try to install
+# something with another python version...
+py.find_installation('python3.7', modules: ['notamodule'], required: false)
+prog_python.install_sources('a.py')
+
 prog_python = py.find_installation('python3', modules : ['thisbetternotexistmod'], required : false)
 assert(prog_python.found() == false, 'python not found but reported as found')

--- a/test cases/python/5 modules kwarg/test.json
+++ b/test cases/python/5 modules kwarg/test.json
@@ -1,0 +1,5 @@
+{
+    "installed": [
+        { "type": "python_file", "file": "pure/a.py"}
+    ]
+}


### PR DESCRIPTION
0e7fb07f915b7a2b04df209fbacd92aca19c87af introduced a subtile bug in the Python module.
If a python version is found, but is missing a required module,
it is added to the list of python installations, but the
`run_bytecompile` attribute for that version was not initialized.
Therefore, if any other python version added something to install, it
was raising a KeyError when trying to read the `run_bytecompile`
attribute for the python version with missing module.


Stack trace:

```
Traceback (most recent call last):
  File "<HIDDEN PATH>\mesonbuild\mesonmain.py", line 194, in run
    return options.run_func(options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<HIDDEN PATH>\mesonbuild\msetup.py", line 358, in run
    app.generate()
  File "<HIDDEN PATH>\mesonbuild\msetup.py", line 181, in generate
    return self._generate(env, capture, vslite_ctx)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<HIDDEN PATH>\mesonbuild\msetup.py", line 243, in _generate
    self.finalize_postconf_hooks(b, intr)
  File "<HIDDEN PATH>\mesonbuild\msetup.py", line 311, in finalize_postconf_hooks
    mod.postconf_hook(b)
  File "<HIDDEN PATH>\mesonbuild\modules\python.py", line 430, in postconf_hook
    b.install_scripts.extend(self._get_install_scripts())
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<HIDDEN PATH>\mesonbuild\modules\python.py", line 413, in _get_install_scripts
    if isinstance(i, PythonExternalProgram) and i.run_bytecompile[i.info['version']]:
                                                ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
KeyError: '3.8'
```