### PR TITLE
CMake-subproject fortran fix: Compile inner libraries with dependencies and capitalized F suffixes

### DIFF
--- a/mesonbuild/cmake/common.py
+++ b/mesonbuild/cmake/common.py
@@ -198,6 +198,8 @@ class CMakeTarget:
         self.type: str = data.get('type', 'EXECUTABLE')
         # self.is_generator_provided: bool = data.get('isGeneratorProvided', False)
         self.files: T.List[CMakeFileGroup] = []
+        self.id: str = data.get('id')
+        self.dependencies: T.List[str] = data.get('dependencies', [])
 
         for i in data.get('fileGroups', []):
             self.files += [CMakeFileGroup(i)]

--- a/mesonbuild/cmake/fileapi.py
+++ b/mesonbuild/cmake/fileapi.py
@@ -152,10 +152,9 @@ class CMakeFileAPI:
                 if i['role'] == 'flags':
                     link_flags += [i['fragment']]
 
-            # TODO The `dependencies` entry is new in the file API.
-            #      maybe we can make use of that in addition to the
-            #      implicit dependency detection
             tgt_data = {
+                'id': tgt.get('id'),
+                'dependencies': [dep['id'] for dep in tgt.get('dependencies', [])],
                 'artifacts': [Path(x.get('path', '')) for x in tgt.get('artifacts', [])],
                 'sourceDirectory': src_dir,
                 'buildDirectory': bld_dir,

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -85,6 +85,7 @@ blacklist_compiler_flags = [
     '/RTC1', '/RTCc', '/RTCs', '/RTCu',
     '/Z7', '/Zi', '/ZI',
 ]
+blacklist_fortran_opts_startswith = ['-J']
 
 blacklist_link_flags = [
     '/machine:x64', '/machine:x86', '/machine:arm', '/machine:ebc',
@@ -443,8 +444,13 @@ class ConverterTarget:
                 return False
             return True
 
+        def check_fortran_opt(flag: str) -> bool:
+            return not any(flag.startswith(black) for black in blacklist_fortran_opts_startswith)
+
         self.link_libraries = [x for x in self.link_libraries if x.lower() not in blacklist_link_libs]
         self.link_flags = [x for x in self.link_flags if check_flag(x)]
+        if 'fortran' in self.compile_opts:
+            self.compile_opts['fortran'] = [opt for opt in self.compile_opts['fortran'] if check_fortran_opt(opt)]
 
         # Handle OSX frameworks
         def handle_frameworks(flags: T.List[str]) -> T.List[str]:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -43,6 +43,13 @@ header_suffixes = {'h', 'hh', 'hpp', 'hxx', 'H', 'ipp', 'moc', 'vapi', 'di'}
 obj_suffixes = {'o', 'obj', 'res'}
 # To the emscripten compiler, .js files are libraries
 lib_suffixes = {'a', 'lib', 'dll', 'dll.a', 'dylib', 'so', 'js'}
+# Fortran suffixes
+# f90, f95, f03, f08 are for free-form fortran ('f90' recommended)
+# f, for, ftn, fpp are for fixed-form fortran ('f' or 'for' recommended)
+fortran_suffixes: T.Tuple[str, ...] = ('f90', 'f95', 'f03', 'f08', 'f', 'for', 'ftn', 'fpp')
+# Fortran suffixes are generally case-insensitive. Upper- and lowercased suffixes
+# commonly exist mixed up together in the same projects.
+fortran_suffixes = fortran_suffixes + tuple(suffix.upper() for suffix in fortran_suffixes)
 # Mapping of language to suffixes of files that should always be in that language
 # This means we can't include .h headers here since they could be C, C++, ObjC, etc.
 # First suffix is the language's default.
@@ -50,9 +57,7 @@ lang_suffixes = {
     'c': ('c',),
     'cpp': ('cpp', 'cc', 'cxx', 'c++', 'hh', 'hpp', 'ipp', 'hxx', 'ino', 'ixx', 'C'),
     'cuda': ('cu',),
-    # f90, f95, f03, f08 are for free-form fortran ('f90' recommended)
-    # f, for, ftn, fpp are for fixed-form fortran ('f' or 'for' recommended)
-    'fortran': ('f90', 'f95', 'f03', 'f08', 'f', 'for', 'ftn', 'fpp'),
+    'fortran': fortran_suffixes,
     'd': ('d', 'di'),
     'objc': ('m',),
     'objcpp': ('mm',),

--- a/test cases/cmake/28 fortran modules/empty.c
+++ b/test cases/cmake/28 fortran modules/empty.c
@@ -1,0 +1,5 @@
+// This is a placeholder source file to work around "no sources" warnings for the intermediate lib workaround.
+// Lack of sources seems to also cause an issue on Windows CI with vs/ninja.
+int placeholder(void) {
+    return 42;
+}

--- a/test cases/cmake/28 fortran modules/main.c
+++ b/test cases/cmake/28 fortran modules/main.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include <mylib.h>
+int main(void) {
+    int x = 1;
+    int y = c_lib_function(x);
+    printf("%d -> %d", x, y);
+    return 0;
+}

--- a/test cases/cmake/28 fortran modules/meson.build
+++ b/test cases/cmake/28 fortran modules/meson.build
@@ -1,0 +1,49 @@
+# While this top-level project is all C, what we really want to test for is
+# correct handling of the cmake-based fortran subproject, and to be able to
+# create "wrapping" libraries and executables in the main project.
+project('fortran modules')
+
+if not add_languages('c', required: false)
+  error('MESON_SKIP_TEST: C language not available.')
+endif
+if not add_languages('fortran', required: false)
+  error('MESON_SKIP_TEST: Fortran language not available.')
+endif
+
+cm = import('cmake')
+
+sub_pro = cm.subproject('fortproj')
+sub_sta = sub_pro.dependency('fortproj')
+
+# 1. build exe linked with static library.
+lib_sta = static_library(
+    'stalib',
+    'mylib.c',
+    dependencies: [sub_sta],
+    install: true,
+)
+exe_sta = executable('exe_sta', files('main.c', 'mylib.h'), link_with: lib_sta)
+test('test_sta', exe_sta)
+
+# 2. build exe linked with dynamic library.
+# Use workaround with intermediate static lib from https://github.com/mesonbuild/meson/issues/10764
+intermediate_static_lib = static_library(
+    'fortproj_intermediate',
+    'empty.c',
+    dependencies: sub_sta,
+    pic: true,
+    install: false
+)
+intermediate_dependency = declare_dependency(
+    link_with: intermediate_static_lib,
+    include_directories: sub_pro.include_directories('fortproj')
+)
+lib_dyn = shared_library(
+    'dynlib',
+    'mylib.c',
+    name_prefix: '',  # to avoid battling meson's test framework too hard
+    dependencies: [intermediate_dependency],
+    install: true,
+)
+exe_dyn = executable('exe_dyn', files('main.c', 'mylib.h'), link_with: lib_dyn)
+test('test_dyn', exe_dyn)

--- a/test cases/cmake/28 fortran modules/mylib.c
+++ b/test cases/cmake/28 fortran modules/mylib.c
@@ -1,0 +1,17 @@
+#if defined _WIN32 || defined __CYGWIN__
+  #define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+extern void layers_of_calculations(int* input, int* output);
+
+int DLL_PUBLIC c_lib_function(int input) {
+    int output;
+    layers_of_calculations(&input, &output);
+    return output;
+}

--- a/test cases/cmake/28 fortran modules/mylib.h
+++ b/test cases/cmake/28 fortran modules/mylib.h
@@ -1,0 +1,1 @@
+int c_lib_function(int input);

--- a/test cases/cmake/28 fortran modules/subprojects/fortproj/CMakeLists.txt
+++ b/test cases/cmake/28 fortran modules/subprojects/fortproj/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.17)
+
+project(
+    FORTPROJ
+    LANGUAGES Fortran
+)
+
+add_subdirectory("libinnercalc")
+
+set(sources "fortproj.f90")
+add_library(fortproj STATIC "${sources}")
+target_link_libraries(fortproj PUBLIC ${PROJECT_NAME}-libinnercalc)
+target_include_directories(fortproj
+    PUBLIC
+    "${CMAKE_CURRENT_BINARY_DIR}"
+)
+
+add_executable(test "test.f90")
+target_link_libraries(test
+  PRIVATE
+  fortproj
+)
+add_test(NAME "test" COMMAND test)

--- a/test cases/cmake/28 fortran modules/subprojects/fortproj/fortproj.f90
+++ b/test cases/cmake/28 fortran modules/subprojects/fortproj/fortproj.f90
@@ -1,0 +1,13 @@
+module fortproj
+    use, intrinsic :: iso_c_binding
+    use innercalc, only: do_calculation
+    implicit none
+    public
+    contains
+    subroutine layers_of_calculations(input, output) bind(c)
+        integer, intent(in) :: input
+        integer, intent(out) :: output
+        call do_calculation(input, output)
+        output = output + 10
+    end subroutine
+end module

--- a/test cases/cmake/28 fortran modules/subprojects/fortproj/libinnercalc/CMakeLists.txt
+++ b/test cases/cmake/28 fortran modules/subprojects/fortproj/libinnercalc/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_library(
+  ${PROJECT_NAME}-libinnercalc
+  STATIC
+  
+  innercalc.f90
+  collections.F90
+  )
+
+target_include_directories(
+  ${PROJECT_NAME}-libinnercalc
+  INTERFACE "${CMAKE_CURRENT_BINARY_DIR}")

--- a/test cases/cmake/28 fortran modules/subprojects/fortproj/libinnercalc/collections.F90
+++ b/test cases/cmake/28 fortran modules/subprojects/fortproj/libinnercalc/collections.F90
@@ -1,0 +1,23 @@
+! This file has a capitalized .F90 file suffix. The only point is to challenge the assumption that
+! file suffixes are lowercase. In Fortran projects it's quite common to see a mixture of upper
+! and lower case file suffixes. Meson should not care, either.
+module collections
+    implicit none
+    public
+    contains
+    subroutine collection_lookup(index, output)
+        integer, intent(in) :: index
+        integer, intent(out) :: output
+        if (index == 0) then
+            output = 1
+        else if (index == 1) then
+            output = 3
+        else if (index == 2) then
+            output = 37
+        else if (index == 4) then
+            output = 42
+        else
+            output = 100
+        endif
+    end subroutine
+end module collections

--- a/test cases/cmake/28 fortran modules/subprojects/fortproj/libinnercalc/innercalc.f90
+++ b/test cases/cmake/28 fortran modules/subprojects/fortproj/libinnercalc/innercalc.f90
@@ -1,0 +1,13 @@
+module innercalc
+    use collections, only: collection_lookup
+    implicit none
+    public
+    contains
+    subroutine do_calculation(number, output)
+        integer, intent(in) :: number
+        integer, intent(out) :: output
+        output = number
+        call collection_lookup(number, output)
+        output = 2 * (output + 3)
+    end subroutine
+end module innercalc

--- a/test cases/cmake/28 fortran modules/subprojects/fortproj/test.f90
+++ b/test cases/cmake/28 fortran modules/subprojects/fortproj/test.f90
@@ -1,0 +1,8 @@
+program test
+    use fortproj, only: layers_of_calculations
+    implicit none
+    integer :: input, output
+    input = 1
+    call layers_of_calculations(input, output)
+    print*,output
+end program

--- a/test cases/cmake/28 fortran modules/test.json
+++ b/test cases/cmake/28 fortran modules/test.json
@@ -1,0 +1,8 @@
+{
+    "installed": [
+        {"type": "file", "file": "usr/lib/libstalib.a"},
+        {"type": "implib", "file": "usr/lib/dynlib"},
+        {"type": "expr", "file": "usr/lib/dynlib?so"},
+        {"type": "pdb", "file": "usr/bin/dynlib"}
+    ]
+}


### PR DESCRIPTION
This PR fixes #9946.

I added a cmake subproject test with fortran sources that wouldn't compile before. I then added three fixes to enable this test to build (in separate commits, but let me know if squashing or reordering is in order, or if they should come in separate PRs even):

1. The list of suffixes for fortran in `compilers.py` had to include capitalized ones. I didn't actually trace exactly through which methods this affected the ninja build file, I just realized that it did. As an alternative to this, the methods in the file could be adjusted to be case-insensitive, but then it would also apply for other languages, which might not be intentional (e.g. 'c' vs 'C' is actually case sensitive, so that approach might not be easy).
2. Cmake outputs a `-J` compile flag, but this conflicts with what meson outputs. So now cmake has this flag blacklisted (along with many others, although this is fortran-specific).
3. I added some code to propagate Cmake dependencies specified in the FileAPI json file into the generated meson file (ie. targets' `_dep` variables are listed under dependants' `dependencies: [..]`. This was necessary to have the private dir of a target listed as an include dir of a dependant, since fortran requires this (to see the .mod files).