### PR TITLE
Use isort, take 2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,3 +52,13 @@ jobs:
         PYTHONUNBUFFERED: 1
         TERM: xterm-color
         MYPY_FORCE_COLOR: 1
+
+  isort:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: python -m pip install isort
+      - run: isort --color --check-only mesonbuild unittests

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,6 @@
+[settings]
+py_version=37
+line_length=100
+use_parentheses=True
+multi_line_output=5
+add_imports=from __future__ import annotations

--- a/mesonbuild/_pathlib.py
+++ b/mesonbuild/_pathlib.py
@@ -20,8 +20,8 @@
 '''
 from __future__ import annotations
 
-import pathlib
 import os
+import pathlib
 import platform
 
 __all__ = [

--- a/mesonbuild/_typing.py
+++ b/mesonbuild/_typing.py
@@ -7,6 +7,8 @@
 Holds typing helper classes, such as the ImmutableProtocol classes
 """
 
+from __future__ import annotations
+
 import typing
 
 # We can change this to typing when we require python 3.8

--- a/mesonbuild/_typing.py
+++ b/mesonbuild/_typing.py
@@ -7,15 +7,15 @@
 Holds typing helper classes, such as the ImmutableProtocol classes
 """
 
-__all__ = [
-    'Protocol',
-    'ImmutableListProtocol'
-]
-
 import typing
 
 # We can change this to typing when we require python 3.8
 from typing_extensions import Protocol
+
+__all__ = [
+    'Protocol',
+    'ImmutableListProtocol'
+]
 
 
 T = typing.TypeVar('T')

--- a/mesonbuild/arglist.py
+++ b/mesonbuild/arglist.py
@@ -4,16 +4,16 @@
 
 from __future__ import annotations
 
-from functools import lru_cache
 import collections
 import enum
 import os
 import re
 import typing as T
+from functools import lru_cache
 
 if T.TYPE_CHECKING:
-    from .linkers.linkers import StaticLinker
     from .compilers import Compiler
+    from .linkers.linkers import StaticLinker
 
 # execinfo is a compiler lib on BSD
 UNIXY_COMPILER_INTERNAL_LIBS = ['m', 'c', 'pthread', 'dl', 'rt', 'execinfo']

--- a/mesonbuild/ast/__init__.py
+++ b/mesonbuild/ast/__init__.py
@@ -3,11 +3,13 @@
 
 """Provides interface to maintain `from ast import ...`"""
 
+from __future__ import annotations
+
 from .interpreter import AstInterpreter
-from .introspection import IntrospectionInterpreter, BUILD_TARGET_FUNCTIONS
-from .visitor import AstVisitor
+from .introspection import BUILD_TARGET_FUNCTIONS, IntrospectionInterpreter
 from .postprocess import AstConditionLevel, AstIDGenerator, AstIndentationGenerator
-from .printer import AstPrinter, AstJSONPrinter
+from .printer import AstJSONPrinter, AstPrinter
+from .visitor import AstVisitor
 
 __all__ = [
     'AstConditionLevel',

--- a/mesonbuild/ast/__init__.py
+++ b/mesonbuild/ast/__init__.py
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
 
-# This class contains the basic functionality needed to run any interpreter
-# or an interpreter-based tool.
+"""Provides interface to maintain `from ast import ...`"""
 
 from .interpreter import AstInterpreter
 from .introspection import IntrospectionInterpreter, BUILD_TARGET_FUNCTIONS

--- a/mesonbuild/ast/__init__.py
+++ b/mesonbuild/ast/__init__.py
@@ -4,6 +4,12 @@
 # This class contains the basic functionality needed to run any interpreter
 # or an interpreter-based tool.
 
+from .interpreter import AstInterpreter
+from .introspection import IntrospectionInterpreter, BUILD_TARGET_FUNCTIONS
+from .visitor import AstVisitor
+from .postprocess import AstConditionLevel, AstIDGenerator, AstIndentationGenerator
+from .printer import AstPrinter, AstJSONPrinter
+
 __all__ = [
     'AstConditionLevel',
     'AstInterpreter',
@@ -15,9 +21,3 @@ __all__ = [
     'IntrospectionInterpreter',
     'BUILD_TARGET_FUNCTIONS',
 ]
-
-from .interpreter import AstInterpreter
-from .introspection import IntrospectionInterpreter, BUILD_TARGET_FUNCTIONS
-from .visitor import AstVisitor
-from .postprocess import AstConditionLevel, AstIDGenerator, AstIndentationGenerator
-from .printer import AstPrinter, AstJSONPrinter

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -7,56 +7,24 @@ import os
 import sys
 import typing as T
 
-from .. import mparser, mesonlib
-from .. import environment
-
+from .. import environment, mesonlib, mparser
+from ..interpreter import ArrayHolder, BooleanHolder, DictHolder, IntegerHolder, StringHolder
 from ..interpreterbase import (
-    MesonInterpreterObject,
-    InterpreterBase,
-    InvalidArguments,
-    BreakRequest,
-    ContinueRequest,
-    Disabler,
-    default_resolve_key,
+    BreakRequest, ContinueRequest, Disabler, InterpreterBase, InvalidArguments,
+    MesonInterpreterObject, default_resolve_key
 )
-
-from ..interpreter import (
-    StringHolder,
-    BooleanHolder,
-    IntegerHolder,
-    ArrayHolder,
-    DictHolder,
-)
-
 from ..mparser import (
-    ArgumentNode,
-    ArithmeticNode,
-    ArrayNode,
-    AssignmentNode,
-    BaseNode,
-    ElementaryNode,
-    EmptyNode,
-    IdNode,
-    MethodNode,
-    NotNode,
-    PlusAssignmentNode,
-    TernaryNode,
-    TestCaseClauseNode,
+    ArgumentNode, ArithmeticNode, ArrayNode, AssignmentNode, BaseNode, ElementaryNode, EmptyNode,
+    IdNode, MethodNode, NotNode, PlusAssignmentNode, TernaryNode, TestCaseClauseNode
 )
 
 if T.TYPE_CHECKING:
-    from .visitor import AstVisitor
     from ..interpreter import Interpreter
     from ..interpreterbase import SubProject, TYPE_nkwargs, TYPE_var
     from ..mparser import (
-        AndNode,
-        ComparisonNode,
-        ForeachClauseNode,
-        IfClauseNode,
-        IndexNode,
-        OrNode,
-        UMinusNode,
+        AndNode, ComparisonNode, ForeachClauseNode, IfClauseNode, IndexNode, OrNode, UMinusNode
     )
+    from .visitor import AstVisitor
 
 class DontCareObject(MesonInterpreterObject):
     pass

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016 The Meson development team
 
-# This class contains the basic functionality needed to run any interpreter
-# or an interpreter-based tool.
 from __future__ import annotations
 
 import os

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2018 The Meson development team
 
-# This class contains the basic functionality needed to run any interpreter
-# or an interpreter-based tool
-
 from __future__ import annotations
 import argparse
 import copy

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -2,18 +2,22 @@
 # Copyright 2018 The Meson development team
 
 from __future__ import annotations
+
 import argparse
 import copy
 import os
 import typing as T
 
-from .. import compilers, environment, mesonlib, optinterpreter
+from .. import compilers
 from .. import coredata as cdata
+from .. import environment, mesonlib, optinterpreter
 from ..build import Executable, Jar, SharedLibrary, SharedModule, StaticLibrary
 from ..compilers import detect_compiler_for
 from ..interpreterbase import InvalidArguments, SubProject
 from ..mesonlib import MachineChoice, OptionKey
-from ..mparser import BaseNode, ArithmeticNode, ArrayNode, ElementaryNode, IdNode, FunctionNode, BaseStringNode
+from ..mparser import (
+    ArithmeticNode, ArrayNode, BaseNode, BaseStringNode, ElementaryNode, FunctionNode, IdNode
+)
 from .interpreter import AstInterpreter
 
 if T.TYPE_CHECKING:

--- a/mesonbuild/ast/postprocess.py
+++ b/mesonbuild/ast/postprocess.py
@@ -3,8 +3,9 @@
 
 from __future__ import annotations
 
-from .visitor import AstVisitor
 import typing as T
+
+from .visitor import AstVisitor
 
 if T.TYPE_CHECKING:
     from .. import mparser

--- a/mesonbuild/ast/postprocess.py
+++ b/mesonbuild/ast/postprocess.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
 
-# This class contains the basic functionality needed to run any interpreter
-# or an interpreter-based tool
 from __future__ import annotations
 
 from .visitor import AstVisitor

--- a/mesonbuild/ast/printer.py
+++ b/mesonbuild/ast/printer.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
 
-# This class contains the basic functionality needed to run any interpreter
-# or an interpreter-based tool
 from __future__ import annotations
 
 from .. import mparser

--- a/mesonbuild/ast/printer.py
+++ b/mesonbuild/ast/printer.py
@@ -3,12 +3,12 @@
 
 from __future__ import annotations
 
-from .. import mparser
-from .visitor import AstVisitor
-
-from itertools import zip_longest
 import re
 import typing as T
+from itertools import zip_longest
+
+from .. import mparser
+from .visitor import AstVisitor
 
 arithmic_map = {
     'add': '+',

--- a/mesonbuild/ast/visitor.py
+++ b/mesonbuild/ast/visitor.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
 
-# This class contains the basic functionality needed to run any interpreter
-# or an interpreter-based tool
 from __future__ import annotations
 
 import typing as T

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -255,8 +255,6 @@ def get_genvslite_backend(genvsname: str, build: T.Optional[build.Build] = None,
         return vs2022backend.Vs2022Backend(build, interpreter, gen_lite = True)
     return None
 
-# This class contains the basic functionality that is needed by all backends.
-# Feel free to move stuff in and out of it as you see fit.
 class Backend:
 
     environment: T.Optional['Environment']

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -3,13 +3,9 @@
 
 from __future__ import annotations
 
-from collections import OrderedDict
-from dataclasses import dataclass, InitVar
-from functools import lru_cache
-from itertools import chain
-from pathlib import Path
 import copy
 import enum
+import hashlib
 import json
 import os
 import pickle
@@ -17,20 +13,22 @@ import re
 import shlex
 import shutil
 import typing as T
-import hashlib
+from collections import OrderedDict
+from dataclasses import InitVar, dataclass
+from functools import lru_cache
+from itertools import chain
+from pathlib import Path
 
-from .. import build
-from .. import dependencies
-from .. import programs
-from .. import mesonlib
-from .. import mlog
+from .. import build, dependencies, mesonlib, mlog, programs
 from ..compilers import LANGUAGES_USING_LDFLAGS, detect
 from ..mesonlib import (
-    File, MachineChoice, MesonException, OrderedSet,
-    ExecutableSerialisation, classify_unity_sources, OptionKey
+    ExecutableSerialisation, File, MachineChoice, MesonException, OptionKey, OrderedSet,
+    classify_unity_sources
 )
 
 if T.TYPE_CHECKING:
+    from typing_extensions import TypedDict
+
     from .._typing import ImmutableListProtocol
     from ..arglist import CompilerArgs
     from ..compilers import Compiler
@@ -38,8 +36,6 @@ if T.TYPE_CHECKING:
     from ..interpreter import Interpreter, Test
     from ..linkers.linkers import StaticLinker
     from ..mesonlib import FileMode, FileOrString
-
-    from typing_extensions import TypedDict
 
     _ALL_SOURCES_TYPE = T.List[T.Union[File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList]]
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3,12 +3,6 @@
 
 from __future__ import annotations
 
-from collections import OrderedDict
-from dataclasses import dataclass
-from enum import Enum, unique
-from functools import lru_cache
-from pathlib import PurePath, Path
-from textwrap import dedent
 import itertools
 import json
 import os
@@ -16,33 +10,34 @@ import pickle
 import re
 import subprocess
 import typing as T
+from collections import OrderedDict
+from dataclasses import dataclass
+from enum import Enum, unique
+from functools import lru_cache
+from pathlib import Path, PurePath
+from textwrap import dedent
 
-from . import backends
-from .. import modules
-from .. import environment, mesonlib
-from .. import build
-from .. import mlog
-from .. import compilers
+from .. import build, compilers, environment, mesonlib, mlog, modules
 from ..arglist import CompilerArgs
+from ..build import GeneratedList, InvalidArguments
 from ..compilers import Compiler
 from ..linkers import ArLikeLinker, RSPFileSyntax
 from ..mesonlib import (
-    File, LibType, MachineChoice, MesonBugException, MesonException, OrderedSet, PerMachine,
-    ProgressBar, quote_arg
+    File, LibType, MachineChoice, MesonBugException, MesonException, OptionKey, OrderedSet,
+    PerMachine, ProgressBar, get_compiler_for_source, has_path_sep, quote_arg
 )
-from ..mesonlib import get_compiler_for_source, has_path_sep, OptionKey
+from . import backends
 from .backends import CleanTrees
-from ..build import GeneratedList, InvalidArguments
 
 if T.TYPE_CHECKING:
     from typing_extensions import Literal
 
     from .._typing import ImmutableListProtocol
     from ..build import ExtractedObjects, LibTypes
-    from ..interpreter import Interpreter
-    from ..linkers.linkers import DynamicLinker, StaticLinker
     from ..compilers.cs import CsCompiler
     from ..compilers.fortran import FortranCompiler
+    from ..interpreter import Interpreter
+    from ..linkers.linkers import DynamicLinker, StaticLinker
 
     CommandArgOrStr = T.List[T.Union['NinjaCommandArg', str]]
     RUST_EDITIONS = Literal['2015', '2018', '2021']

--- a/mesonbuild/backend/nonebackend.py
+++ b/mesonbuild/backend/nonebackend.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-from .backends import Backend
 from .. import mlog
 from ..mesonlib import MesonBugException
+from .backends import Backend
 
 
 class NoneBackend(Backend):

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -2,27 +2,25 @@
 # Copyright 2014-2016 The Meson development team
 
 from __future__ import annotations
+
 import copy
 import itertools
 import os
+import re
+import typing as T
+import uuid
 import xml.dom.minidom
 import xml.etree.ElementTree as ET
-import uuid
-import typing as T
-from pathlib import Path, PurePath, PureWindowsPath
-import re
 from collections import Counter
+from pathlib import Path, PurePath, PureWindowsPath
 
-from . import backends
-from .. import build
-from .. import mlog
-from .. import compilers
-from .. import mesonlib
-from ..mesonlib import (
-    File, MesonBugException, MesonException, replace_if_different, OptionKey, version_compare, MachineChoice
-)
+from .. import build, compilers, coredata, mesonlib, mlog
 from ..environment import Environment, build_filename
-from .. import coredata
+from ..mesonlib import (
+    File, MachineChoice, MesonBugException, MesonException, OptionKey, replace_if_different,
+    version_compare
+)
+from . import backends
 
 if T.TYPE_CHECKING:
     from ..arglist import CompilerArgs

--- a/mesonbuild/backend/vs2012backend.py
+++ b/mesonbuild/backend/vs2012backend.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 import typing as T
 
-from .vs2010backend import Vs2010Backend
 from ..mesonlib import MesonException
+from .vs2010backend import Vs2010Backend
 
 if T.TYPE_CHECKING:
     from ..build import Build

--- a/mesonbuild/backend/vs2013backend.py
+++ b/mesonbuild/backend/vs2013backend.py
@@ -3,9 +3,10 @@
 
 from __future__ import annotations
 
-from .vs2010backend import Vs2010Backend
-from ..mesonlib import MesonException
 import typing as T
+
+from ..mesonlib import MesonException
+from .vs2010backend import Vs2010Backend
 
 if T.TYPE_CHECKING:
     from ..build import Build

--- a/mesonbuild/backend/vs2015backend.py
+++ b/mesonbuild/backend/vs2015backend.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 import typing as T
 
-from .vs2010backend import Vs2010Backend
 from ..mesonlib import MesonException
+from .vs2010backend import Vs2010Backend
 
 if T.TYPE_CHECKING:
     from ..build import Build

--- a/mesonbuild/backend/vs2017backend.py
+++ b/mesonbuild/backend/vs2017backend.py
@@ -7,8 +7,8 @@ import os
 import typing as T
 import xml.etree.ElementTree as ET
 
-from .vs2010backend import Vs2010Backend
 from ..mesonlib import MesonException
+from .vs2010backend import Vs2010Backend
 
 if T.TYPE_CHECKING:
     from ..build import Build

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -3,14 +3,15 @@
 
 from __future__ import annotations
 
-import functools, uuid, os, operator
+import functools
+import operator
+import os
 import typing as T
+import uuid
 
-from . import backends
-from .. import build
-from .. import mesonlib
-from .. import mlog
+from .. import build, mesonlib, mlog
 from ..mesonlib import MesonBugException, MesonException, OptionKey
+from . import backends
 
 if T.TYPE_CHECKING:
     from ..interpreter import Interpreter

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2,35 +2,32 @@
 # Copyright 2012-2017 The Meson development team
 
 from __future__ import annotations
-from collections import defaultdict, OrderedDict
-from dataclasses import dataclass, field, InitVar
-from functools import lru_cache
+
 import abc
 import hashlib
-import itertools, pathlib
+import itertools
 import os
+import pathlib
 import pickle
 import re
 import textwrap
 import typing as T
+from collections import OrderedDict, defaultdict
+from dataclasses import InitVar, dataclass, field
+from functools import lru_cache
 
-from . import coredata
-from . import dependencies
-from . import mlog
-from . import programs
-from .mesonlib import (
-    HoldableObject, SecondLevelHolder,
-    File, MesonException, MachineChoice, PerMachine, OrderedSet, listify,
-    extract_as_list, typeslistify, stringlistify, classify_unity_sources,
-    get_filenames_templates_dict, substitute_values, has_path_sep,
-    OptionKey, PerMachineDefaultable,
-    MesonBugException, EnvironmentVariables, pickle_load,
-)
+from . import coredata, dependencies, mlog, programs
 from .compilers import (
-    is_header, is_object, is_source, clink_langs, sort_clink, all_languages,
-    is_known_suffix, detect_static_linker
+    all_languages, clink_langs, detect_static_linker, is_header, is_known_suffix, is_object,
+    is_source, sort_clink
 )
-from .interpreterbase import FeatureNew, FeatureDeprecated
+from .interpreterbase import FeatureDeprecated, FeatureNew
+from .mesonlib import (
+    EnvironmentVariables, File, HoldableObject, MachineChoice, MesonBugException, MesonException,
+    OptionKey, OrderedSet, PerMachine, PerMachineDefaultable, SecondLevelHolder,
+    classify_unity_sources, extract_as_list, get_filenames_templates_dict, has_path_sep, listify,
+    pickle_load, stringlistify, substitute_values, typeslistify
+)
 
 if T.TYPE_CHECKING:
     from typing_extensions import Literal, TypedDict
@@ -39,7 +36,7 @@ if T.TYPE_CHECKING:
     from ._typing import ImmutableListProtocol
     from .backend.backends import Backend
     from .compilers import Compiler
-    from .interpreter.interpreter import SourceOutputs, Interpreter
+    from .interpreter.interpreter import Interpreter, SourceOutputs
     from .interpreter.interpreterobjects import Test
     from .interpreterbase import SubProject
     from .linkers.linkers import StaticLinker

--- a/mesonbuild/cargo/__init__.py
+++ b/mesonbuild/cargo/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __all__ = [
     'interpret'
 ]

--- a/mesonbuild/cargo/builder.py
+++ b/mesonbuild/cargo/builder.py
@@ -8,6 +8,7 @@ build descriptions easier.
 """
 
 from __future__ import annotations
+
 import dataclasses
 import typing as T
 

--- a/mesonbuild/cargo/cfg.py
+++ b/mesonbuild/cargo/cfg.py
@@ -20,15 +20,15 @@ so you could have examples like:
 """
 
 from __future__ import annotations
+
 import dataclasses
 import enum
 import functools
 import typing as T
 
-
-from . import builder
 from .. import mparser
 from ..mesonlib import MesonBugException
+from . import builder
 
 if T.TYPE_CHECKING:
     _T = T.TypeVar('_T')

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -10,6 +10,7 @@ port will be required.
 """
 
 from __future__ import annotations
+
 import dataclasses
 import glob
 import importlib
@@ -19,16 +20,15 @@ import os
 import shutil
 import typing as T
 
-from . import builder
-from . import version
 from ..mesonlib import MesonException, Popen_safe
+from . import builder, version
 
 if T.TYPE_CHECKING:
     from types import ModuleType
 
-    from . import manifest
     from .. import mparser
     from ..environment import Environment
+    from . import manifest
 
 # tomllib is present in python 3.11, before that it is a pypi module called tomli,
 # we try to import tomllib, then tomli,

--- a/mesonbuild/cargo/manifest.py
+++ b/mesonbuild/cargo/manifest.py
@@ -4,9 +4,10 @@
 """Type definitions for cargo manifest files."""
 
 from __future__ import annotations
+
 import typing as T
 
-from typing_extensions import Literal, TypedDict, Required
+from typing_extensions import Literal, Required, TypedDict
 
 EDITION = Literal['2015', '2018', '2021']
 CRATE_TYPE = Literal['bin', 'lib', 'dylib', 'staticlib', 'cdylib', 'rlib', 'proc-macro']

--- a/mesonbuild/cargo/version.py
+++ b/mesonbuild/cargo/version.py
@@ -4,6 +4,7 @@
 """Convert Cargo versions into Meson compatible ones."""
 
 from __future__ import annotations
+
 import typing as T
 
 

--- a/mesonbuild/cmake/__init__.py
+++ b/mesonbuild/cmake/__init__.py
@@ -1,10 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
 
-from .common import CMakeException, TargetOptions, cmake_defines_to_args, language_map, check_cmake_args, cmake_is_debug
+from __future__ import annotations
+
+from .common import (
+    CMakeException, TargetOptions, check_cmake_args, cmake_defines_to_args, cmake_is_debug,
+    language_map
+)
 from .executor import CMakeExecutor
 from .interpreter import CMakeInterpreter
-from .toolchain import CMakeToolchain, CMakeExecScope
+from .toolchain import CMakeExecScope, CMakeToolchain
 from .traceparser import CMakeTarget, CMakeTraceParser
 from .tracetargets import resolve_cmake_trace_targets
 

--- a/mesonbuild/cmake/__init__.py
+++ b/mesonbuild/cmake/__init__.py
@@ -4,6 +4,13 @@
 # This class contains the basic functionality needed to run any interpreter
 # or an interpreter-based tool.
 
+from .common import CMakeException, TargetOptions, cmake_defines_to_args, language_map, check_cmake_args, cmake_is_debug
+from .executor import CMakeExecutor
+from .interpreter import CMakeInterpreter
+from .toolchain import CMakeToolchain, CMakeExecScope
+from .traceparser import CMakeTarget, CMakeTraceParser
+from .tracetargets import resolve_cmake_trace_targets
+
 __all__ = [
     'CMakeExecutor',
     'CMakeExecScope',
@@ -19,10 +26,3 @@ __all__ = [
     'cmake_is_debug',
     'resolve_cmake_trace_targets',
 ]
-
-from .common import CMakeException, TargetOptions, cmake_defines_to_args, language_map, check_cmake_args, cmake_is_debug
-from .executor import CMakeExecutor
-from .interpreter import CMakeInterpreter
-from .toolchain import CMakeToolchain, CMakeExecScope
-from .traceparser import CMakeTarget, CMakeTraceParser
-from .tracetargets import resolve_cmake_trace_targets

--- a/mesonbuild/cmake/__init__.py
+++ b/mesonbuild/cmake/__init__.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
 
-# This class contains the basic functionality needed to run any interpreter
-# or an interpreter-based tool.
-
 from .common import CMakeException, TargetOptions, cmake_defines_to_args, language_map, check_cmake_args, cmake_is_debug
 from .executor import CMakeExecutor
 from .interpreter import CMakeInterpreter

--- a/mesonbuild/cmake/common.py
+++ b/mesonbuild/cmake/common.py
@@ -3,10 +3,11 @@
 
 from __future__ import annotations
 
-from ..mesonlib import MesonException, OptionKey
-from .. import mlog
-from pathlib import Path
 import typing as T
+from pathlib import Path
+
+from .. import mlog
+from ..mesonlib import MesonException, OptionKey
 
 if T.TYPE_CHECKING:
     from ..environment import Environment

--- a/mesonbuild/cmake/executor.py
+++ b/mesonbuild/cmake/executor.py
@@ -3,15 +3,15 @@
 
 from __future__ import annotations
 
-import subprocess as S
-from threading import Thread
-import typing as T
-import re
 import os
+import re
+import subprocess as S
+import typing as T
+from threading import Thread
 
 from .. import mlog
-from ..mesonlib import PerMachine, Popen_safe, version_compare, is_windows, OptionKey
-from ..programs import find_external_program, NonExistingExternalProgram
+from ..mesonlib import OptionKey, PerMachine, Popen_safe, is_windows, version_compare
+from ..programs import NonExistingExternalProgram, find_external_program
 
 if T.TYPE_CHECKING:
     from pathlib import Path

--- a/mesonbuild/cmake/fileapi.py
+++ b/mesonbuild/cmake/fileapi.py
@@ -3,12 +3,13 @@
 
 from __future__ import annotations
 
-from .common import CMakeException, CMakeBuildFile, CMakeConfiguration
-import typing as T
-from .. import mlog
-from pathlib import Path
 import json
 import re
+import typing as T
+from pathlib import Path
+
+from .. import mlog
+from .common import CMakeBuildFile, CMakeConfiguration, CMakeException
 
 STRIP_KEYS = ['cmake', 'reply', 'backtrace', 'backtraceGraph', 'version']
 

--- a/mesonbuild/cmake/generator.py
+++ b/mesonbuild/cmake/generator.py
@@ -3,13 +3,13 @@
 
 from __future__ import annotations
 
-from .. import mesonlib
-from .. import mlog
-from .common import cmake_is_debug
 import typing as T
 
+from .. import mesonlib, mlog
+from .common import cmake_is_debug
+
 if T.TYPE_CHECKING:
-    from .traceparser import CMakeTraceParser, CMakeTarget
+    from .traceparser import CMakeTarget, CMakeTraceParser
 
 def parse_generator_expressions(
             raw: str,

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -3,48 +3,41 @@
 
 from __future__ import annotations
 
+import re
+import typing as T
 from functools import lru_cache
 from os import environ
 from pathlib import Path
-import re
-import typing as T
 
-from .common import CMakeException, CMakeTarget, language_map, cmake_get_generator_args, check_cmake_args
-from .fileapi import CMakeFileAPI
+from .. import mesonlib, mlog
+from ..compilers.compilers import (
+    assembler_suffixes, header_suffixes, is_header, lang_suffixes, lib_suffixes, obj_suffixes
+)
+from ..coredata import FORBIDDEN_TARGET_NAMES
+from ..mesondata import DataFile
+from ..mesonlib import (
+    MachineChoice, OptionKey, OrderedSet, path_is_in_root, relative_to_if_possible
+)
+from ..mparser import (
+    ArgumentNode, ArrayNode, AssignmentNode, BaseNode, BooleanNode, CodeBlockNode, FunctionNode,
+    IdNode, IndexNode, MethodNode, NumberNode, StringNode, SymbolNode, Token
+)
+from ..programs import ExternalProgram
+from .common import (
+    CMakeException, CMakeTarget, check_cmake_args, cmake_get_generator_args, language_map
+)
 from .executor import CMakeExecutor
-from .toolchain import CMakeToolchain, CMakeExecScope
+from .fileapi import CMakeFileAPI
+from .toolchain import CMakeExecScope, CMakeToolchain
 from .traceparser import CMakeTraceParser
 from .tracetargets import resolve_cmake_trace_targets
-from .. import mlog, mesonlib
-from ..mesonlib import MachineChoice, OrderedSet, path_is_in_root, relative_to_if_possible, OptionKey
-from ..mesondata import DataFile
-from ..compilers.compilers import assembler_suffixes, lang_suffixes, header_suffixes, obj_suffixes, lib_suffixes, is_header
-from ..programs import ExternalProgram
-from ..coredata import FORBIDDEN_TARGET_NAMES
-from ..mparser import (
-    Token,
-    BaseNode,
-    CodeBlockNode,
-    FunctionNode,
-    ArrayNode,
-    ArgumentNode,
-    AssignmentNode,
-    BooleanNode,
-    StringNode,
-    IdNode,
-    IndexNode,
-    MethodNode,
-    NumberNode,
-    SymbolNode,
-)
-
 
 if T.TYPE_CHECKING:
-    from .common import CMakeConfiguration, TargetOptions
-    from .traceparser import CMakeGeneratorTarget
     from .._typing import ImmutableListProtocol
     from ..backend.backends import Backend
     from ..environment import Environment
+    from .common import CMakeConfiguration, TargetOptions
+    from .traceparser import CMakeGeneratorTarget
 
     TYPE_mixed = T.Union[str, int, bool, Path, BaseNode]
     TYPE_mixed_list = T.Union[TYPE_mixed, T.Sequence[TYPE_mixed]]

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
 
-# This class contains the basic functionality needed to run any interpreter
-# or an interpreter-based tool.
 from __future__ import annotations
 
 from functools import lru_cache

--- a/mesonbuild/cmake/toolchain.py
+++ b/mesonbuild/cmake/toolchain.py
@@ -3,22 +3,22 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-from .traceparser import CMakeTraceParser
-from ..envconfig import CMakeSkipCompilerTest
-from .common import language_map, cmake_get_generator_args
-from .. import mlog
-
 import shutil
 import typing as T
 from enum import Enum
+from pathlib import Path
 from textwrap import dedent
 
+from .. import mlog
+from ..envconfig import CMakeSkipCompilerTest
+from .common import cmake_get_generator_args, language_map
+from .traceparser import CMakeTraceParser
+
 if T.TYPE_CHECKING:
-    from .executor import CMakeExecutor
-    from ..environment import Environment
     from ..compilers import Compiler
+    from ..environment import Environment
     from ..mesonlib import MachineChoice
+    from .executor import CMakeExecutor
 
 class CMakeExecScope(Enum):
     SUBPROJECT = 'subproject'

--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -3,17 +3,17 @@
 
 from __future__ import annotations
 
-from .common import CMakeException
-from .generator import parse_generator_expressions
+import json
+import re
+import textwrap
+import typing as T
+from functools import lru_cache
+from pathlib import Path
+
 from .. import mlog
 from ..mesonlib import version_compare
-
-import typing as T
-from pathlib import Path
-from functools import lru_cache
-import re
-import json
-import textwrap
+from .common import CMakeException
+from .generator import parse_generator_expressions
 
 if T.TYPE_CHECKING:
     from ..environment import Environment

--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
 
-# This class contains the basic functionality needed to run any interpreter
-# or an interpreter-based tool.
 from __future__ import annotations
 
 from .common import CMakeException

--- a/mesonbuild/cmake/tracetargets.py
+++ b/mesonbuild/cmake/tracetargets.py
@@ -2,18 +2,18 @@
 # Copyright 2021 The Meson development team
 from __future__ import annotations
 
-from .common import cmake_is_debug
-from .. import mlog
-
-from pathlib import Path
 import re
 import typing as T
+from pathlib import Path
+
+from .. import mlog
+from .common import cmake_is_debug
 
 if T.TYPE_CHECKING:
-    from .traceparser import CMakeTraceParser
-    from ..environment import Environment
     from ..compilers import Compiler
     from ..dependencies import MissingCompiler
+    from ..environment import Environment
+    from .traceparser import CMakeTraceParser
 
 class ResolvedTarget:
     def __init__(self) -> None:

--- a/mesonbuild/compilers/__init__.py
+++ b/mesonbuild/compilers/__init__.py
@@ -2,48 +2,7 @@
 # Copyright 2017 The Meson development team
 
 # Public symbols for compilers sub-package when using 'from . import compilers'
-__all__ = [
-    'Compiler',
-    'RunResult',
 
-    'all_languages',
-    'base_options',
-    'clib_langs',
-    'clink_langs',
-    'c_suffixes',
-    'cpp_suffixes',
-    'get_base_compile_args',
-    'get_base_link_args',
-    'is_assembly',
-    'is_header',
-    'is_library',
-    'is_llvm_ir',
-    'is_object',
-    'is_source',
-    'is_known_suffix',
-    'lang_suffixes',
-    'LANGUAGES_USING_LDFLAGS',
-    'sort_clink',
-    'SUFFIX_TO_LANG',
-
-    'compiler_from_language',
-    'detect_compiler_for',
-    'detect_static_linker',
-    'detect_c_compiler',
-    'detect_cpp_compiler',
-    'detect_cuda_compiler',
-    'detect_fortran_compiler',
-    'detect_objc_compiler',
-    'detect_objcpp_compiler',
-    'detect_java_compiler',
-    'detect_cs_compiler',
-    'detect_vala_compiler',
-    'detect_rust_compiler',
-    'detect_d_compiler',
-    'detect_swift_compiler',
-]
-
-# Bring symbols from each module into compilers sub-package namespace
 from .compilers import (
     Compiler,
     RunResult,
@@ -84,3 +43,44 @@ from .detect import (
     detect_d_compiler,
     detect_swift_compiler,
 )
+
+__all__ = [
+    'Compiler',
+    'RunResult',
+
+    'all_languages',
+    'base_options',
+    'clib_langs',
+    'clink_langs',
+    'c_suffixes',
+    'cpp_suffixes',
+    'get_base_compile_args',
+    'get_base_link_args',
+    'is_assembly',
+    'is_header',
+    'is_library',
+    'is_llvm_ir',
+    'is_object',
+    'is_source',
+    'is_known_suffix',
+    'lang_suffixes',
+    'LANGUAGES_USING_LDFLAGS',
+    'sort_clink',
+    'SUFFIX_TO_LANG',
+
+    'compiler_from_language',
+    'detect_compiler_for',
+    'detect_static_linker',
+    'detect_c_compiler',
+    'detect_cpp_compiler',
+    'detect_cuda_compiler',
+    'detect_fortran_compiler',
+    'detect_objc_compiler',
+    'detect_objcpp_compiler',
+    'detect_java_compiler',
+    'detect_cs_compiler',
+    'detect_vala_compiler',
+    'detect_rust_compiler',
+    'detect_d_compiler',
+    'detect_swift_compiler',
+]

--- a/mesonbuild/compilers/__init__.py
+++ b/mesonbuild/compilers/__init__.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2017 The Meson development team
 
-# Public symbols for compilers sub-package when using 'from . import compilers'
+"""Public symbols for compilers sub-package when using 'from . import compilers'"""
+
 
 from .compilers import (
     Compiler,

--- a/mesonbuild/compilers/__init__.py
+++ b/mesonbuild/compilers/__init__.py
@@ -4,45 +4,19 @@
 """Public symbols for compilers sub-package when using 'from . import compilers'"""
 
 
+from __future__ import annotations
+
 from .compilers import (
-    Compiler,
-    RunResult,
-    all_languages,
-    base_options,
-    clib_langs,
-    clink_langs,
-    c_suffixes,
-    cpp_suffixes,
-    get_base_compile_args,
-    get_base_link_args,
-    is_header,
-    is_source,
-    is_assembly,
-    is_llvm_ir,
-    is_object,
-    is_library,
-    is_known_suffix,
-    lang_suffixes,
-    LANGUAGES_USING_LDFLAGS,
-    sort_clink,
-    SUFFIX_TO_LANG,
+    LANGUAGES_USING_LDFLAGS, SUFFIX_TO_LANG, Compiler, RunResult, all_languages, base_options,
+    c_suffixes, clib_langs, clink_langs, cpp_suffixes, get_base_compile_args, get_base_link_args,
+    is_assembly, is_header, is_known_suffix, is_library, is_llvm_ir, is_object, is_source,
+    lang_suffixes, sort_clink
 )
 from .detect import (
-    compiler_from_language,
-    detect_compiler_for,
-    detect_static_linker,
-    detect_c_compiler,
-    detect_cpp_compiler,
-    detect_cuda_compiler,
-    detect_objc_compiler,
-    detect_objcpp_compiler,
-    detect_fortran_compiler,
-    detect_java_compiler,
-    detect_cs_compiler,
-    detect_vala_compiler,
-    detect_rust_compiler,
-    detect_d_compiler,
-    detect_swift_compiler,
+    compiler_from_language, detect_c_compiler, detect_compiler_for, detect_cpp_compiler,
+    detect_cs_compiler, detect_cuda_compiler, detect_d_compiler, detect_fortran_compiler,
+    detect_java_compiler, detect_objc_compiler, detect_objcpp_compiler, detect_rust_compiler,
+    detect_static_linker, detect_swift_compiler, detect_vala_compiler
 )
 
 __all__ = [

--- a/mesonbuild/compilers/asm.py
+++ b/mesonbuild/compilers/asm.py
@@ -5,13 +5,15 @@ import typing as T
 
 from ..mesonlib import EnvironmentException, OptionKey, get_meson_command
 from .compilers import Compiler
-from .mixins.metrowerks import MetrowerksCompiler, mwasmarm_instruction_set_args, mwasmeppc_instruction_set_args
+from .mixins.metrowerks import (
+    MetrowerksCompiler, mwasmarm_instruction_set_args, mwasmeppc_instruction_set_args
+)
 
 if T.TYPE_CHECKING:
+    from ..envconfig import MachineInfo
     from ..environment import Environment
     from ..linkers.linkers import DynamicLinker
     from ..mesonlib import MachineChoice
-    from ..envconfig import MachineInfo
 
 nasm_optimization_args: T.Dict[str, T.List[str]] = {
     'plain': [],

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -6,34 +6,29 @@ from __future__ import annotations
 import os.path
 import typing as T
 
-from .. import coredata
-from .. import mlog
-from ..mesonlib import MesonException, version_compare, OptionKey
+from .. import coredata, mlog
+from ..mesonlib import MesonException, OptionKey, version_compare
 from .c_function_attributes import C_FUNC_ATTRIBUTES
-from .mixins.clike import CLikeCompiler
+from .compilers import Compiler, gnu_winlibs, msvc_winlibs
+from .mixins.arm import ArmclangCompiler, ArmCompiler
 from .mixins.ccrx import CcrxCompiler
-from .mixins.xc16 import Xc16Compiler
-from .mixins.compcert import CompCertCompiler
-from .mixins.ti import TICompiler
-from .mixins.arm import ArmCompiler, ArmclangCompiler
-from .mixins.visualstudio import MSVCCompiler, ClangClCompiler
-from .mixins.gnu import GnuCompiler
-from .mixins.gnu import gnu_common_warning_args, gnu_c_warning_args
-from .mixins.intel import IntelGnuLikeCompiler, IntelVisualStudioLikeCompiler
 from .mixins.clang import ClangCompiler
+from .mixins.clike import CLikeCompiler
+from .mixins.compcert import CompCertCompiler
 from .mixins.elbrus import ElbrusCompiler
-from .mixins.pgi import PGICompiler
 from .mixins.emscripten import EmscriptenMixin
-from .mixins.metrowerks import MetrowerksCompiler
-from .mixins.metrowerks import mwccarm_instruction_set_args, mwcceppc_instruction_set_args
-from .compilers import (
-    gnu_winlibs,
-    msvc_winlibs,
-    Compiler,
+from .mixins.gnu import GnuCompiler, gnu_c_warning_args, gnu_common_warning_args
+from .mixins.intel import IntelGnuLikeCompiler, IntelVisualStudioLikeCompiler
+from .mixins.metrowerks import (
+    MetrowerksCompiler, mwccarm_instruction_set_args, mwcceppc_instruction_set_args
 )
+from .mixins.pgi import PGICompiler
+from .mixins.ti import TICompiler
+from .mixins.visualstudio import ClangClCompiler, MSVCCompiler
+from .mixins.xc16 import Xc16Compiler
 
 if T.TYPE_CHECKING:
-    from ..coredata import MutableKeyedOptionDictType, KeyedOptionDictType
+    from ..coredata import KeyedOptionDictType, MutableKeyedOptionDictType
     from ..dependencies import Dependency
     from ..envconfig import MachineInfo
     from ..environment import Environment

--- a/mesonbuild/compilers/c_function_attributes.py
+++ b/mesonbuild/compilers/c_function_attributes.py
@@ -10,6 +10,8 @@
 #   warranty.
 #
 
+from __future__ import annotations
+
 C_FUNC_ATTRIBUTES = {
     'alias': '''
         int foo(void) { return 0; }

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -5,32 +5,30 @@
 from __future__ import annotations
 
 import abc
-import contextlib, os.path, re
+import contextlib
 import enum
 import itertools
+import os.path
+import re
 import typing as T
 from functools import lru_cache
 
-from .. import coredata
-from .. import mlog
-from .. import mesonlib
-from ..mesonlib import (
-    HoldableObject,
-    EnvironmentException, MesonException,
-    Popen_safe_logged, LibType, TemporaryDirectoryWinProof, OptionKey,
-)
-
+from .. import coredata, mesonlib, mlog
 from ..arglist import CompilerArgs
+from ..mesonlib import (
+    EnvironmentException, HoldableObject, LibType, MesonException, OptionKey, Popen_safe_logged,
+    TemporaryDirectoryWinProof
+)
 
 if T.TYPE_CHECKING:
     from ..build import BuildTarget, DFeatures
-    from ..coredata import MutableKeyedOptionDictType, KeyedOptionDictType
+    from ..coredata import KeyedOptionDictType, MutableKeyedOptionDictType
+    from ..dependencies import Dependency
     from ..envconfig import MachineInfo
     from ..environment import Environment
     from ..linkers import RSPFileSyntax
     from ..linkers.linkers import DynamicLinker
     from ..mesonlib import MachineChoice
-    from ..dependencies import Dependency
 
     CompilerType = T.TypeVar('CompilerType', bound='Compiler')
     _T = T.TypeVar('_T')

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -8,33 +8,27 @@ import functools
 import os.path
 import typing as T
 
-from .. import coredata
-from .. import mlog
-from ..mesonlib import MesonException, version_compare, OptionKey
-
-from .compilers import (
-    gnu_winlibs,
-    msvc_winlibs,
-    Compiler,
-    CompileCheckMode,
-)
-from .c_function_attributes import CXX_FUNC_ATTRIBUTES, C_FUNC_ATTRIBUTES
-from .mixins.clike import CLikeCompiler
+from .. import coredata, mlog
+from ..mesonlib import MesonException, OptionKey, version_compare
+from .c_function_attributes import C_FUNC_ATTRIBUTES, CXX_FUNC_ATTRIBUTES
+from .compilers import CompileCheckMode, Compiler, gnu_winlibs, msvc_winlibs
+from .mixins.arm import ArmclangCompiler, ArmCompiler
 from .mixins.ccrx import CcrxCompiler
-from .mixins.ti import TICompiler
-from .mixins.arm import ArmCompiler, ArmclangCompiler
-from .mixins.visualstudio import MSVCCompiler, ClangClCompiler
+from .mixins.clang import ClangCompiler
+from .mixins.clike import CLikeCompiler
+from .mixins.elbrus import ElbrusCompiler
+from .mixins.emscripten import EmscriptenMixin
 from .mixins.gnu import GnuCompiler, gnu_common_warning_args, gnu_cpp_warning_args
 from .mixins.intel import IntelGnuLikeCompiler, IntelVisualStudioLikeCompiler
-from .mixins.clang import ClangCompiler
-from .mixins.elbrus import ElbrusCompiler
+from .mixins.metrowerks import (
+    MetrowerksCompiler, mwccarm_instruction_set_args, mwcceppc_instruction_set_args
+)
 from .mixins.pgi import PGICompiler
-from .mixins.emscripten import EmscriptenMixin
-from .mixins.metrowerks import MetrowerksCompiler
-from .mixins.metrowerks import mwccarm_instruction_set_args, mwcceppc_instruction_set_args
+from .mixins.ti import TICompiler
+from .mixins.visualstudio import ClangClCompiler, MSVCCompiler
 
 if T.TYPE_CHECKING:
-    from ..coredata import MutableKeyedOptionDictType, KeyedOptionDictType
+    from ..coredata import KeyedOptionDictType, MutableKeyedOptionDictType
     from ..dependencies import Dependency
     from ..envconfig import MachineInfo
     from ..environment import Environment

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -3,13 +3,13 @@
 
 from __future__ import annotations
 
-import os.path, subprocess
+import os.path
+import subprocess
 import textwrap
 import typing as T
 
-from ..mesonlib import EnvironmentException
 from ..linkers import RSPFileSyntax
-
+from ..mesonlib import EnvironmentException
 from .compilers import Compiler
 from .mixins.islinker import BasicLinkerIsCompilerMixin
 

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -8,24 +8,22 @@ import os.path
 import string
 import typing as T
 
-from .. import coredata
-from .. import mlog
+from .. import coredata, mlog
 from ..mesonlib import (
-    EnvironmentException, Popen_safe,
-    is_windows, LibType, OptionKey, version_compare,
+    EnvironmentException, LibType, OptionKey, Popen_safe, is_windows, version_compare
 )
 from .compilers import Compiler
 
 if T.TYPE_CHECKING:
-    from .compilers import CompileCheckMode
     from ..build import BuildTarget
-    from ..coredata import MutableKeyedOptionDictType, KeyedOptionDictType
+    from ..coredata import KeyedOptionDictType, MutableKeyedOptionDictType
     from ..dependencies import Dependency
-    from ..environment import Environment  # noqa: F401
     from ..envconfig import MachineInfo
+    from ..environment import Environment  # noqa: F401
     from ..linkers.linkers import DynamicLinker
     from ..mesonlib import MachineChoice
     from ..programs import ExternalProgram
+    from .compilers import CompileCheckMode
 
 
 cuda_optimization_args: T.Dict[str, T.List[str]] = {

--- a/mesonbuild/compilers/cython.py
+++ b/mesonbuild/compilers/cython.py
@@ -11,7 +11,7 @@ from ..mesonlib import EnvironmentException, OptionKey, version_compare
 from .compilers import Compiler
 
 if T.TYPE_CHECKING:
-    from ..coredata import MutableKeyedOptionDictType, KeyedOptionDictType
+    from ..coredata import KeyedOptionDictType, MutableKeyedOptionDictType
     from ..environment import Environment
 
 

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -8,31 +8,22 @@ import re
 import subprocess
 import typing as T
 
-from .. import mesonlib
-from .. import mlog
+from .. import mesonlib, mlog
 from ..arglist import CompilerArgs
 from ..linkers import RSPFileSyntax
-from ..mesonlib import (
-    EnvironmentException, version_compare, OptionKey, is_windows
-)
-
+from ..mesonlib import EnvironmentException, OptionKey, is_windows, version_compare
 from . import compilers
-from .compilers import (
-    clike_debug_args,
-    Compiler,
-    CompileCheckMode,
-)
-from .mixins.gnu import GnuCompiler
-from .mixins.gnu import gnu_common_warning_args
+from .compilers import CompileCheckMode, Compiler, clike_debug_args
+from .mixins.gnu import GnuCompiler, gnu_common_warning_args
 
 if T.TYPE_CHECKING:
     from ..build import DFeatures
     from ..dependencies import Dependency
-    from ..programs import ExternalProgram
     from ..envconfig import MachineInfo
     from ..environment import Environment
     from ..linkers.linkers import DynamicLinker
     from ..mesonlib import MachineChoice
+    from ..programs import ExternalProgram
 
     CompilerMixinBase = Compiler
 else:

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -3,32 +3,31 @@
 
 from __future__ import annotations
 
-from ..mesonlib import (
-    MesonException, EnvironmentException, MachineChoice, join_args,
-    search_version, is_windows, Popen_safe, Popen_safe_logged, windows_proof_rm,
-)
-from ..envconfig import BinaryTable
-from .. import mlog
-
-from ..linkers import guess_win_linker, guess_nix_linker
-
-import subprocess
+import os
 import platform
 import re
 import shutil
+import subprocess
 import tempfile
-import os
 import typing as T
 
+from .. import mlog
+from ..envconfig import BinaryTable
+from ..linkers import guess_nix_linker, guess_win_linker
+from ..mesonlib import (
+    EnvironmentException, MachineChoice, MesonException, Popen_safe, Popen_safe_logged, is_windows,
+    join_args, search_version, windows_proof_rm
+)
+
 if T.TYPE_CHECKING:
-    from .compilers import Compiler
+    from ..environment import Environment
+    from ..linkers.linkers import DynamicLinker, StaticLinker
+    from ..programs import ExternalProgram
     from .c import CCompiler
+    from .compilers import Compiler
     from .cpp import CPPCompiler
     from .fortran import FortranCompiler
     from .rust import RustCompiler
-    from ..linkers.linkers import StaticLinker, DynamicLinker
-    from ..environment import Environment
-    from ..programs import ExternalProgram
 
 
 # Default compilers and linkers
@@ -155,8 +154,8 @@ def _handle_exceptions(
 # ===============
 
 def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker:
-    from . import d
     from ..linkers import linkers
+    from . import d
     linker = env.lookup_binary_entry(compiler.for_machine, 'ar')
     if linker is not None:
         trials = [linker]
@@ -257,8 +256,8 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
     the compiler (GCC or Clang usually) as their shared linker, to find
     the linker they need.
     """
-    from . import c, cpp
     from ..linkers import linkers
+    from . import c, cpp
     popen_exceptions: T.Dict[str, T.Union[Exception, str]] = {}
     compilers, ccache, exe_wrap = _get_compilers(env, lang, for_machine)
     if override_compiler is not None:
@@ -605,8 +604,8 @@ def detect_cpp_compiler(env: 'Environment', for_machine: MachineChoice) -> Compi
     return _detect_c_or_cpp_compiler(env, 'cpp', for_machine)
 
 def detect_cuda_compiler(env: 'Environment', for_machine: MachineChoice) -> Compiler:
-    from .cuda import CudaCompiler
     from ..linkers.linkers import CudaLinker
+    from .cuda import CudaCompiler
     popen_exceptions = {}
     is_cross = env.is_cross_build(for_machine)
     compilers, ccache, exe_wrap = _get_compilers(env, 'cuda', for_machine)
@@ -642,8 +641,8 @@ def detect_cuda_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
     raise EnvironmentException(f'Could not find suitable CUDA compiler: "{"; ".join([" ".join(c) for c in compilers])}"')
 
 def detect_fortran_compiler(env: 'Environment', for_machine: MachineChoice) -> Compiler:
-    from . import fortran
     from ..linkers import linkers
+    from . import fortran
     popen_exceptions: T.Dict[str, T.Union[Exception, str]] = {}
     compilers, ccache, exe_wrap = _get_compilers(env, 'fortran', for_machine)
     is_cross = env.is_cross_build(for_machine)
@@ -968,8 +967,8 @@ def detect_vala_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
     raise EnvironmentException('Unknown compiler: ' + join_args(exelist))
 
 def detect_rust_compiler(env: 'Environment', for_machine: MachineChoice) -> RustCompiler:
-    from . import rust
     from ..linkers import linkers
+    from . import rust
     popen_exceptions: T.Dict[str, Exception] = {}
     compilers, _, exe_wrap = _get_compilers(env, 'rust', for_machine)
     is_cross = env.is_cross_build(for_machine)
@@ -1222,7 +1221,9 @@ def detect_swift_compiler(env: 'Environment', for_machine: MachineChoice) -> Com
     raise EnvironmentException('Unknown compiler: ' + join_args(exelist))
 
 def detect_nasm_compiler(env: 'Environment', for_machine: MachineChoice) -> Compiler:
-    from .asm import NasmCompiler, YasmCompiler, MetrowerksAsmCompilerARM, MetrowerksAsmCompilerEmbeddedPowerPC
+    from .asm import (
+        MetrowerksAsmCompilerARM, MetrowerksAsmCompilerEmbeddedPowerPC, NasmCompiler, YasmCompiler
+    )
     compilers, _, _ = _get_compilers(env, 'nasm', for_machine)
     is_cross = env.is_cross_build(for_machine)
 
@@ -1278,7 +1279,7 @@ def detect_masm_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
     else:
         info = env.machines[for_machine]
 
-    from .asm import MasmCompiler, MasmARMCompiler
+    from .asm import MasmARMCompiler, MasmCompiler
     comp_class: T.Type[Compiler]
     if info.cpu_family == 'x86':
         comp = ['ml']

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -3,29 +3,22 @@
 
 from __future__ import annotations
 
-import typing as T
 import os
+import typing as T
+
+from mesonbuild.mesonlib import LibType, MesonException, OptionKey, version_compare
 
 from .. import coredata
-from .compilers import (
-    clike_debug_args,
-    Compiler,
-    CompileCheckMode,
-)
-from .mixins.clike import CLikeCompiler
-from .mixins.gnu import GnuCompiler,  gnu_optimization_args
-from .mixins.intel import IntelGnuLikeCompiler, IntelVisualStudioLikeCompiler
+from .compilers import CompileCheckMode, Compiler, clike_debug_args
 from .mixins.clang import ClangCompiler
+from .mixins.clike import CLikeCompiler
 from .mixins.elbrus import ElbrusCompiler
+from .mixins.gnu import GnuCompiler, gnu_optimization_args
+from .mixins.intel import IntelGnuLikeCompiler, IntelVisualStudioLikeCompiler
 from .mixins.pgi import PGICompiler
 
-from mesonbuild.mesonlib import (
-    version_compare, MesonException,
-    LibType, OptionKey,
-)
-
 if T.TYPE_CHECKING:
-    from ..coredata import MutableKeyedOptionDictType, KeyedOptionDictType
+    from ..coredata import KeyedOptionDictType, MutableKeyedOptionDictType
     from ..dependencies import Dependency
     from ..envconfig import MachineInfo
     from ..environment import Environment

--- a/mesonbuild/compilers/mixins/arm.py
+++ b/mesonbuild/compilers/mixins/arm.py
@@ -15,8 +15,8 @@ from ..compilers import clike_debug_args
 from .clang import clang_color_args
 
 if T.TYPE_CHECKING:
-    from ...environment import Environment
     from ...compilers.compilers import Compiler
+    from ...environment import Environment
 else:
     # This is a bit clever, for mypy we pretend that these mixins descend from
     # Compiler, so we get all of the methods and attributes defined for us, but

--- a/mesonbuild/compilers/mixins/ccrx.py
+++ b/mesonbuild/compilers/mixins/ccrx.py
@@ -11,9 +11,9 @@ import typing as T
 from ...mesonlib import EnvironmentException
 
 if T.TYPE_CHECKING:
+    from ...compilers.compilers import Compiler
     from ...envconfig import MachineInfo
     from ...environment import Environment
-    from ...compilers.compilers import Compiler
 else:
     # This is a bit clever, for mypy we pretend that these mixins descend from
     # Compiler, so we get all of the methods and attributes defined for us, but

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -10,15 +10,17 @@ import shutil
 import typing as T
 
 from ... import mesonlib
-from ...linkers.linkers import AppleDynamicLinker, ClangClDynamicLinker, LLVMDynamicLinker, GnuGoldDynamicLinker, \
+from ...linkers.linkers import (
+    AppleDynamicLinker, ClangClDynamicLinker, GnuGoldDynamicLinker, LLVMDynamicLinker,
     MoldDynamicLinker
+)
 from ...mesonlib import OptionKey
 from ..compilers import CompileCheckMode
 from .gnu import GnuLikeCompiler
 
 if T.TYPE_CHECKING:
-    from ...environment import Environment
     from ...dependencies import Dependency  # noqa: F401
+    from ...environment import Environment
 
 clang_color_args: T.Dict[str, T.List[str]] = {
     'auto': ['-fdiagnostics-color=auto'],

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-
 """Mixin classes to be shared between C and C++ compilers.
 
 Without this we'll end up with awful diamond inheritance problems. The goal
@@ -12,30 +11,30 @@ standalone, they only work through inheritance.
 """
 
 import collections
+import copy
 import functools
 import glob
 import itertools
 import os
 import re
 import subprocess
-import copy
 import typing as T
 from pathlib import Path
 
-from ... import arglist
-from ... import mesonlib
-from ... import mlog
-from ...linkers.linkers import GnuLikeDynamicLinkerMixin, SolarisDynamicLinker, CompCertDynamicLinker
+from ... import arglist, mesonlib, mlog
+from ...linkers.linkers import (
+    CompCertDynamicLinker, GnuLikeDynamicLinkerMixin, SolarisDynamicLinker
+)
 from ...mesonlib import LibType, OptionKey
 from .. import compilers
 from ..compilers import CompileCheckMode
 from .visualstudio import VisualStudioLikeCompiler
 
 if T.TYPE_CHECKING:
-    from ...dependencies import Dependency
     from ..._typing import ImmutableListProtocol
-    from ...environment import Environment
     from ...compilers.compilers import Compiler
+    from ...dependencies import Dependency
+    from ...environment import Environment
     from ...programs import ExternalProgram
 else:
     # This is a bit clever, for mypy we pretend that these mixins descend from

--- a/mesonbuild/compilers/mixins/compcert.py
+++ b/mesonbuild/compilers/mixins/compcert.py
@@ -10,9 +10,9 @@ import re
 import typing as T
 
 if T.TYPE_CHECKING:
+    from ...compilers.compilers import Compiler
     from ...envconfig import MachineInfo
     from ...environment import Environment
-    from ...compilers.compilers import Compiler
 else:
     # This is a bit clever, for mypy we pretend that these mixins descend from
     # Compiler, so we get all of the methods and attributes defined for us, but

--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -7,17 +7,16 @@ from __future__ import annotations
 
 import functools
 import os
-import typing as T
-import subprocess
 import re
+import subprocess
+import typing as T
 
-from .gnu import GnuLikeCompiler
-from .gnu import gnu_optimization_args
-from ...mesonlib import Popen_safe, OptionKey
+from ...mesonlib import OptionKey, Popen_safe
+from .gnu import GnuLikeCompiler, gnu_optimization_args
 
 if T.TYPE_CHECKING:
-    from ...environment import Environment
     from ...coredata import KeyedOptionDictType
+    from ...environment import Environment
 
 
 class ElbrusCompiler(GnuLikeCompiler):

--- a/mesonbuild/compilers/mixins/emscripten.py
+++ b/mesonbuild/compilers/mixins/emscripten.py
@@ -8,16 +8,15 @@ from __future__ import annotations
 import os.path
 import typing as T
 
-from ... import coredata
-from ... import mesonlib
-from ...mesonlib import OptionKey
-from ...mesonlib import LibType
 from mesonbuild.compilers.compilers import CompileCheckMode
 
+from ... import coredata, mesonlib
+from ...mesonlib import LibType, OptionKey
+
 if T.TYPE_CHECKING:
-    from ...environment import Environment
     from ...compilers.compilers import Compiler
     from ...dependencies import Dependency
+    from ...environment import Environment
 else:
     # This is a bit clever, for mypy we pretend that these mixins descend from
     # Compiler, so we get all of the methods and attributes defined for us, but

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -7,17 +7,17 @@ from __future__ import annotations
 
 import abc
 import functools
-import os
 import multiprocessing
+import os
 import pathlib
 import re
 import subprocess
 import typing as T
 
-from ... import mesonlib
-from ... import mlog
-from ...mesonlib import OptionKey
 from mesonbuild.compilers.compilers import CompileCheckMode
+
+from ... import mesonlib, mlog
+from ...mesonlib import OptionKey
 
 if T.TYPE_CHECKING:
     from ..._typing import ImmutableListProtocol

--- a/mesonbuild/compilers/mixins/islinker.py
+++ b/mesonbuild/compilers/mixins/islinker.py
@@ -16,9 +16,9 @@ import typing as T
 from ...mesonlib import EnvironmentException, MesonException, is_windows
 
 if T.TYPE_CHECKING:
+    from ...compilers.compilers import Compiler
     from ...coredata import KeyedOptionDictType
     from ...environment import Environment
-    from ...compilers.compilers import Compiler
 else:
     # This is a bit clever, for mypy we pretend that these mixins descend from
     # Compiler, so we get all of the methods and attributes defined for us, but

--- a/mesonbuild/compilers/mixins/metrowerks.py
+++ b/mesonbuild/compilers/mixins/metrowerks.py
@@ -11,8 +11,8 @@ import typing as T
 from ...mesonlib import EnvironmentException, OptionKey
 
 if T.TYPE_CHECKING:
+    from ...compilers.compilers import CompileCheckMode, Compiler
     from ...envconfig import MachineInfo
-    from ...compilers.compilers import Compiler, CompileCheckMode
 else:
     # This is a bit clever, for mypy we pretend that these mixins descend from
     # Compiler, so we get all of the methods and attributes defined for us, but

--- a/mesonbuild/compilers/mixins/pgi.py
+++ b/mesonbuild/compilers/mixins/pgi.py
@@ -5,16 +5,16 @@ from __future__ import annotations
 
 """Abstractions for the PGI family of compilers."""
 
-import typing as T
 import os
+import typing as T
 from pathlib import Path
 
-from ..compilers import clike_debug_args, clike_optimization_args
 from ...mesonlib import OptionKey
+from ..compilers import clike_debug_args, clike_optimization_args
 
 if T.TYPE_CHECKING:
-    from ...environment import Environment
     from ...compilers.compilers import Compiler
+    from ...environment import Environment
 else:
     # This is a bit clever, for mypy we pretend that these mixins descend from
     # Compiler, so we get all of the methods and attributes defined for us, but

--- a/mesonbuild/compilers/mixins/ti.py
+++ b/mesonbuild/compilers/mixins/ti.py
@@ -11,9 +11,9 @@ import typing as T
 from ...mesonlib import EnvironmentException
 
 if T.TYPE_CHECKING:
+    from ...compilers.compilers import Compiler
     from ...envconfig import MachineInfo
     from ...environment import Environment
-    from ...compilers.compilers import Compiler
 else:
     # This is a bit clever, for mypy we pretend that these mixins descend from
     # Compiler, so we get all of the methods and attributes defined for us, but

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -11,14 +11,13 @@ import abc
 import os
 import typing as T
 
-from ... import arglist
-from ... import mesonlib
-from ... import mlog
 from mesonbuild.compilers.compilers import CompileCheckMode
 
+from ... import arglist, mesonlib, mlog
+
 if T.TYPE_CHECKING:
-    from ...environment import Environment
     from ...dependencies import Dependency
+    from ...environment import Environment
     from .clike import CLikeCompiler as Compiler
 else:
     # This is a bit clever, for mypy we pretend that these mixins descend from

--- a/mesonbuild/compilers/mixins/xc16.py
+++ b/mesonbuild/compilers/mixins/xc16.py
@@ -11,9 +11,9 @@ import typing as T
 from ...mesonlib import EnvironmentException
 
 if T.TYPE_CHECKING:
+    from ...compilers.compilers import Compiler
     from ...envconfig import MachineInfo
     from ...environment import Environment
-    from ...compilers.compilers import Compiler
 else:
     # This is a bit clever, for mypy we pretend that these mixins descend from
     # Compiler, so we get all of the methods and attributes defined for us, but

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -7,18 +7,17 @@ import typing as T
 
 from .. import coredata
 from ..mesonlib import OptionKey
-
 from .compilers import Compiler
+from .mixins.clang import ClangCompiler
 from .mixins.clike import CLikeCompiler
 from .mixins.gnu import GnuCompiler, gnu_common_warning_args, gnu_objc_warning_args
-from .mixins.clang import ClangCompiler
 
 if T.TYPE_CHECKING:
-    from ..programs import ExternalProgram
     from ..envconfig import MachineInfo
     from ..environment import Environment
     from ..linkers.linkers import DynamicLinker
     from ..mesonlib import MachineChoice
+    from ..programs import ExternalProgram
 
 
 class ObjCCompiler(CLikeCompiler, Compiler):

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -7,18 +7,17 @@ import typing as T
 
 from .. import coredata
 from ..mesonlib import OptionKey
-
-from .mixins.clike import CLikeCompiler
 from .compilers import Compiler
-from .mixins.gnu import GnuCompiler, gnu_common_warning_args, gnu_objc_warning_args
 from .mixins.clang import ClangCompiler
+from .mixins.clike import CLikeCompiler
+from .mixins.gnu import GnuCompiler, gnu_common_warning_args, gnu_objc_warning_args
 
 if T.TYPE_CHECKING:
-    from ..programs import ExternalProgram
     from ..envconfig import MachineInfo
     from ..environment import Environment
     from ..linkers.linkers import DynamicLinker
     from ..mesonlib import MachineChoice
+    from ..programs import ExternalProgram
 
 class ObjCPPCompiler(CLikeCompiler, Compiler):
 

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -4,23 +4,24 @@
 from __future__ import annotations
 
 import functools
-import subprocess, os.path
-import textwrap
+import os.path
 import re
+import subprocess
+import textwrap
 import typing as T
 
 from .. import coredata
-from ..mesonlib import EnvironmentException, MesonException, Popen_safe_logged, OptionKey
+from ..mesonlib import EnvironmentException, MesonException, OptionKey, Popen_safe_logged
 from .compilers import Compiler, clike_debug_args
 
 if T.TYPE_CHECKING:
-    from ..coredata import MutableKeyedOptionDictType, KeyedOptionDictType
+    from ..coredata import KeyedOptionDictType, MutableKeyedOptionDictType
+    from ..dependencies import Dependency
     from ..envconfig import MachineInfo
     from ..environment import Environment  # noqa: F401
     from ..linkers.linkers import DynamicLinker
     from ..mesonlib import MachineChoice
     from ..programs import ExternalProgram
-    from ..dependencies import Dependency
 
 
 rust_optimization_args: T.Dict[str, T.List[str]] = {

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -3,11 +3,11 @@
 
 from __future__ import annotations
 
-import subprocess, os.path
+import os.path
+import subprocess
 import typing as T
 
 from ..mesonlib import EnvironmentException
-
 from .compilers import Compiler, clike_debug_args
 
 if T.TYPE_CHECKING:

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -7,7 +7,7 @@ import os.path
 import typing as T
 
 from .. import mlog
-from ..mesonlib import EnvironmentException, version_compare, LibType, OptionKey
+from ..mesonlib import EnvironmentException, LibType, OptionKey, version_compare
 from .compilers import CompileCheckMode, Compiler
 
 if T.TYPE_CHECKING:

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -3,40 +3,38 @@
 
 from __future__ import annotations
 
+import argparse
+import ast
+import configparser
 import copy
-
-from . import mlog, mparser
-import pickle, os, uuid
+import enum
+import os
+import pickle
+import shlex
 import sys
-from itertools import chain
-from pathlib import PurePath
+import typing as T
+import uuid
 from collections import OrderedDict, abc
 from dataclasses import dataclass
+from itertools import chain
+from pathlib import PurePath
 
+from . import mlog, mparser
 from .mesonlib import (
-    HoldableObject,
-    MesonException, EnvironmentException, MachineChoice, PerMachine,
-    PerMachineDefaultable, default_libdir, default_libexecdir,
-    default_prefix, default_datadir, default_includedir, default_infodir,
-    default_localedir, default_mandir, default_sbindir, default_sysconfdir,
-    split_args, OptionKey, OptionType, stringlistify,
-    pickle_load
+    EnvironmentException, HoldableObject, MachineChoice, MesonException, OptionKey, OptionType,
+    PerMachine, PerMachineDefaultable, default_datadir, default_includedir, default_infodir,
+    default_libdir, default_libexecdir, default_localedir, default_mandir, default_prefix,
+    default_sbindir, default_sysconfdir, pickle_load, split_args, stringlistify
 )
 from .wrap import WrapMode
-import ast
-import argparse
-import configparser
-import enum
-import shlex
-import typing as T
 
 if T.TYPE_CHECKING:
     from . import dependencies
-    from .compilers.compilers import Compiler, CompileResult, RunResult, CompileCheckMode
+    from .cmake.traceparser import CMakeCacheEntry
+    from .compilers.compilers import CompileCheckMode, Compiler, CompileResult, RunResult
     from .dependencies.detect import TV_DepID
     from .environment import Environment
     from .mesonlib import FileOrString
-    from .cmake.traceparser import CMakeCacheEntry
 
     OptionDictType = T.Union[T.Dict[str, 'UserOption[T.Any]'], 'OptionsView']
     MutableKeyedOptionDictType = T.Dict['OptionKey', 'UserOption[T.Any]']
@@ -1005,6 +1003,7 @@ class CoreData:
                       for_machine: MachineChoice, env: 'Environment') -> None:
         """Add global language arguments that are needed before compiler/linker detection."""
         from .compilers import compilers
+
         # These options are all new at this point, because the compiler is
         # responsible for adding its own options, thus calling
         # `self.options.update()`` is perfectly safe.

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -153,11 +153,16 @@ dependencies and hold the one it found. There are a number of drawbacks to
 this approach, and no new dependencies should do this.
 """
 
-from .base import Dependency, InternalDependency, ExternalDependency, NotFoundDependency, MissingCompiler
+from __future__ import annotations
+
 from .base import (
-        ExternalLibrary, DependencyException, DependencyMethods,
-        BuiltinDependency, SystemDependency, get_leaf_external_dependencies)
-from .detect import find_external_dependency, get_dep_identifier, packages, _packages_accept_language
+    BuiltinDependency, Dependency, DependencyException, DependencyMethods, ExternalDependency,
+    ExternalLibrary, InternalDependency, MissingCompiler, NotFoundDependency, SystemDependency,
+    get_leaf_external_dependencies
+)
+from .detect import (
+    _packages_accept_language, find_external_dependency, get_dep_identifier, packages
+)
 
 __all__ = [
     'Dependency',

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -1,30 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2017 The Meson development team
 
-
-from .base import Dependency, InternalDependency, ExternalDependency, NotFoundDependency, MissingCompiler
-from .base import (
-        ExternalLibrary, DependencyException, DependencyMethods,
-        BuiltinDependency, SystemDependency, get_leaf_external_dependencies)
-from .detect import find_external_dependency, get_dep_identifier, packages, _packages_accept_language
-
-__all__ = [
-    'Dependency',
-    'InternalDependency',
-    'ExternalDependency',
-    'SystemDependency',
-    'BuiltinDependency',
-    'NotFoundDependency',
-    'ExternalLibrary',
-    'DependencyException',
-    'DependencyMethods',
-    'MissingCompiler',
-
-    'find_external_dependency',
-    'get_dep_identifier',
-    'get_leaf_external_dependencies',
-]
-
 """Dependency representations and discovery logic.
 
 Meson attempts to largely abstract away dependency discovery information, and
@@ -176,6 +152,29 @@ _Note_ before we moved to factory functions it was common to use an
 dependencies and hold the one it found. There are a number of drawbacks to
 this approach, and no new dependencies should do this.
 """
+
+from .base import Dependency, InternalDependency, ExternalDependency, NotFoundDependency, MissingCompiler
+from .base import (
+        ExternalLibrary, DependencyException, DependencyMethods,
+        BuiltinDependency, SystemDependency, get_leaf_external_dependencies)
+from .detect import find_external_dependency, get_dep_identifier, packages, _packages_accept_language
+
+__all__ = [
+    'Dependency',
+    'InternalDependency',
+    'ExternalDependency',
+    'SystemDependency',
+    'BuiltinDependency',
+    'NotFoundDependency',
+    'ExternalLibrary',
+    'DependencyException',
+    'DependencyMethods',
+    'MissingCompiler',
+
+    'find_external_dependency',
+    'get_dep_identifier',
+    'get_leaf_external_dependencies',
+]
 
 # This is a dict where the keys should be strings, and the values must be one
 # of:

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -4,28 +4,31 @@
 """Base implementation for for external dependencies."""
 
 from __future__ import annotations
-import copy
-import os
+
 import collections
+import copy
 import itertools
+import os
 import typing as T
 from enum import Enum
 
-from .. import mlog, mesonlib
+from .. import mesonlib, mlog
 from ..compilers import clib_langs
-from ..mesonlib import LibType, MachineChoice, MesonException, HoldableObject, OptionKey
-from ..mesonlib import version_compare_many
+from ..mesonlib import (
+    HoldableObject, LibType, MachineChoice, MesonException, OptionKey, version_compare_many
+)
+
 #from ..interpreterbase import FeatureDeprecated, FeatureNew
 
 if T.TYPE_CHECKING:
+    from ..build import (
+        CustomTarget, CustomTargetIndex, ExtractedObjects, GeneratedTypes, IncludeDirs, LibTypes,
+        StaticLibrary, StructuredSources
+    )
     from ..compilers.compilers import Compiler
     from ..environment import Environment
-    from ..interpreterbase import FeatureCheckBase
-    from ..build import (
-        CustomTarget, IncludeDirs, CustomTargetIndex, LibTypes,
-        StaticLibrary, StructuredSources, ExtractedObjects, GeneratedTypes
-    )
     from ..interpreter.type_checking import PkgConfigDefineType
+    from ..interpreterbase import FeatureCheckBase
 
     _MissingCompilerBase = Compiler
 else:
@@ -328,7 +331,7 @@ class InternalDependency(Dependency):
         raise DependencyException(f'Could not get an internal variable and no default provided for {self!r}')
 
     def generate_link_whole_dependency(self) -> Dependency:
-        from ..build import SharedLibrary, CustomTarget, CustomTargetIndex
+        from ..build import CustomTarget, CustomTargetIndex, SharedLibrary
         new_dep = copy.deepcopy(self)
         for x in new_dep.libraries:
             if isinstance(x, SharedLibrary):

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2013-2018 The Meson development team
 
-# This file contains the detection logic for external dependencies.
-# Custom logic for several other packages are in separate files.
+"""Base implementation for for external dependencies."""
 
 from __future__ import annotations
 import copy

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -3,19 +3,17 @@
 
 from __future__ import annotations
 
-import re
 import dataclasses
 import functools
+import re
 import typing as T
 from pathlib import Path
 
-from .. import mlog
-from .. import mesonlib
-
+from .. import mesonlib, mlog
 from .base import DependencyException, SystemDependency
 from .detect import packages
-from .pkgconfig import PkgConfigDependency
 from .misc import threads_factory
+from .pkgconfig import PkgConfigDependency
 
 if T.TYPE_CHECKING:
     from ..envconfig import Properties

--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -3,23 +3,27 @@
 
 from __future__ import annotations
 
-from .base import ExternalDependency, DependencyException, DependencyTypeName
-from ..mesonlib import is_windows, MesonException, PerMachine, stringlistify, extract_as_list
-from ..cmake import CMakeExecutor, CMakeTraceParser, CMakeException, CMakeToolchain, CMakeExecScope, check_cmake_args, resolve_cmake_trace_targets, cmake_is_debug
-from .. import mlog
-import importlib.resources
-from pathlib import Path
 import functools
-import re
+import importlib.resources
 import os
+import re
 import shutil
 import textwrap
 import typing as T
+from pathlib import Path
+
+from .. import mlog
+from ..cmake import (
+    CMakeException, CMakeExecScope, CMakeExecutor, CMakeToolchain, CMakeTraceParser,
+    check_cmake_args, cmake_is_debug, resolve_cmake_trace_targets
+)
+from ..mesonlib import MesonException, PerMachine, extract_as_list, is_windows, stringlistify
+from .base import DependencyException, DependencyTypeName, ExternalDependency
 
 if T.TYPE_CHECKING:
     from ..cmake import CMakeTarget
-    from ..environment import Environment
     from ..envconfig import MachineInfo
+    from ..environment import Environment
     from ..interpreter.type_checking import PkgConfigDefineType
 
 class CMakeInfo(T.NamedTuple):

--- a/mesonbuild/dependencies/coarrays.py
+++ b/mesonbuild/dependencies/coarrays.py
@@ -6,16 +6,16 @@ from __future__ import annotations
 import functools
 import typing as T
 
-from .base import DependencyMethods, detect_compiler, SystemDependency
+from .base import DependencyMethods, SystemDependency, detect_compiler
 from .cmake import CMakeDependency
 from .detect import packages
-from .pkgconfig import PkgConfigDependency
 from .factory import factory_methods
+from .pkgconfig import PkgConfigDependency
 
 if T.TYPE_CHECKING:
-    from . factory import DependencyGenerator
     from ..environment import Environment
     from ..mesonlib import MachineChoice
+    from .factory import DependencyGenerator
 
 
 @factory_methods({DependencyMethods.PKGCONFIG, DependencyMethods.CMAKE, DependencyMethods.SYSTEM})

--- a/mesonbuild/dependencies/configtool.py
+++ b/mesonbuild/dependencies/configtool.py
@@ -3,14 +3,17 @@
 
 from __future__ import annotations
 
-from .base import ExternalDependency, DependencyException, DependencyTypeName
-from ..mesonlib import listify, Popen_safe, Popen_safe_logged, split_args, version_compare, version_compare_many
-from ..programs import find_external_program
-from .. import mlog
 import re
 import typing as T
 
 from mesonbuild import mesonlib
+
+from .. import mlog
+from ..mesonlib import (
+    Popen_safe, Popen_safe_logged, listify, split_args, version_compare, version_compare_many
+)
+from ..programs import find_external_program
+from .base import DependencyException, DependencyTypeName, ExternalDependency
 
 if T.TYPE_CHECKING:
     from ..environment import Environment

--- a/mesonbuild/dependencies/cuda.py
+++ b/mesonbuild/dependencies/cuda.py
@@ -4,21 +4,19 @@
 from __future__ import annotations
 
 import glob
-import re
 import os
+import re
 import typing as T
 from pathlib import Path
 
-from .. import mesonlib
-from .. import mlog
+from .. import mesonlib, mlog
 from ..environment import detect_cpu_family
 from .base import DependencyException, SystemDependency
 from .detect import packages
 
-
 if T.TYPE_CHECKING:
-    from ..environment import Environment
     from ..compilers import Compiler
+    from ..environment import Environment
 
     TV_ResultTuple = T.Tuple[T.Optional[str], T.Optional[str], bool]
 

--- a/mesonbuild/dependencies/detect.py
+++ b/mesonbuild/dependencies/detect.py
@@ -3,17 +3,18 @@
 
 from __future__ import annotations
 
-import collections, functools, importlib
+import collections
+import functools
+import importlib
 import typing as T
 
-from .base import ExternalDependency, DependencyException, DependencyMethods, NotFoundDependency
-
-from ..mesonlib import listify, MachineChoice, PerMachine
 from .. import mlog
+from ..mesonlib import MachineChoice, PerMachine, listify
+from .base import DependencyException, DependencyMethods, ExternalDependency, NotFoundDependency
 
 if T.TYPE_CHECKING:
     from ..environment import Environment
-    from .factory import DependencyFactory, WrappedFactoryFunc, DependencyGenerator
+    from .factory import DependencyFactory, DependencyGenerator, WrappedFactoryFunc
 
     TV_DepIDEntry = T.Union[str, bool, int, T.Tuple[str, ...]]
     TV_DepID = T.Tuple[T.Tuple[str, TV_DepIDEntry], ...]

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -3,21 +3,26 @@
 
 from __future__ import annotations
 
+import functools
 import glob
 import os
-import re
 import pathlib
+import re
 import shutil
 import subprocess
 import typing as T
-import functools
 
 from mesonbuild.interpreterbase.decorators import FeatureDeprecated
 
 from .. import mesonlib, mlog
 from ..environment import get_llvm_tool_names
-from ..mesonlib import version_compare, version_compare_many, search_version, stringlistify, extract_as_list
-from .base import DependencyException, DependencyMethods, detect_compiler, strip_system_includedirs, strip_system_libdirs, SystemDependency, ExternalDependency, DependencyTypeName
+from ..mesonlib import (
+    extract_as_list, search_version, stringlistify, version_compare, version_compare_many
+)
+from .base import (
+    DependencyException, DependencyMethods, DependencyTypeName, ExternalDependency,
+    SystemDependency, detect_compiler, strip_system_includedirs, strip_system_libdirs
+)
 from .cmake import CMakeDependency
 from .configtool import ConfigToolDependency
 from .detect import packages
@@ -26,10 +31,11 @@ from .misc import threads_factory
 from .pkgconfig import PkgConfigDependency
 
 if T.TYPE_CHECKING:
+    from typing_extensions import TypedDict
+
     from ..envconfig import MachineInfo
     from ..environment import Environment
     from ..mesonlib import MachineChoice
-    from typing_extensions import TypedDict
 
     class JNISystemDependencyKW(TypedDict):
         modules: T.List[str]

--- a/mesonbuild/dependencies/dub.py
+++ b/mesonbuild/dependencies/dub.py
@@ -3,15 +3,16 @@
 
 from __future__ import annotations
 
-from .base import ExternalDependency, DependencyException, DependencyTypeName
-from .pkgconfig import PkgConfigDependency
-from ..mesonlib import (Popen_safe, OptionKey, join_args, version_compare)
-from ..programs import ExternalProgram
-from .. import mlog
-import re
-import os
 import json
+import os
+import re
 import typing as T
+
+from .. import mlog
+from ..mesonlib import OptionKey, Popen_safe, join_args, version_compare
+from ..programs import ExternalProgram
+from .base import DependencyException, DependencyTypeName, ExternalDependency
+from .pkgconfig import PkgConfigDependency
 
 if T.TYPE_CHECKING:
     from ..environment import Environment

--- a/mesonbuild/dependencies/factory.py
+++ b/mesonbuild/dependencies/factory.py
@@ -7,18 +7,18 @@ from __future__ import annotations
 import functools
 import typing as T
 
-from .base import DependencyException, DependencyMethods
-from .base import process_method_kw
-from .base import BuiltinDependency, SystemDependency
+from .base import (
+    BuiltinDependency, DependencyException, DependencyMethods, SystemDependency, process_method_kw
+)
 from .cmake import CMakeDependency
 from .framework import ExtraFrameworkDependency
 from .pkgconfig import PkgConfigDependency
 
 if T.TYPE_CHECKING:
-    from .base import ExternalDependency
-    from .configtool import ConfigToolDependency
     from ..environment import Environment
     from ..mesonlib import MachineChoice
+    from .base import ExternalDependency
+    from .configtool import ConfigToolDependency
 
     DependencyGenerator = T.Callable[[], ExternalDependency]
     FactoryFunc = T.Callable[

--- a/mesonbuild/dependencies/framework.py
+++ b/mesonbuild/dependencies/framework.py
@@ -3,11 +3,12 @@
 
 from __future__ import annotations
 
-from .base import DependencyTypeName, ExternalDependency, DependencyException
-from ..mesonlib import MesonException, Version, stringlistify
-from .. import mlog
-from pathlib import Path
 import typing as T
+from pathlib import Path
+
+from .. import mlog
+from ..mesonlib import MesonException, Version, stringlistify
+from .base import DependencyException, DependencyTypeName, ExternalDependency
 
 if T.TYPE_CHECKING:
     from ..environment import Environment

--- a/mesonbuild/dependencies/hdf5.py
+++ b/mesonbuild/dependencies/hdf5.py
@@ -7,20 +7,20 @@ from __future__ import annotations
 import functools
 import os
 import re
+import typing as T
 from pathlib import Path
 
 from ..mesonlib import OrderedSet, join_args
 from .base import DependencyException, DependencyMethods
 from .configtool import ConfigToolDependency
 from .detect import packages
-from .pkgconfig import PkgConfigDependency, PkgConfigInterface
 from .factory import factory_methods
-import typing as T
+from .pkgconfig import PkgConfigDependency, PkgConfigInterface
 
 if T.TYPE_CHECKING:
-    from .factory import DependencyGenerator
     from ..environment import Environment
     from ..mesonlib import MachineChoice
+    from .factory import DependencyGenerator
 
 
 class HDF5PkgConfigDependency(PkgConfigDependency):

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -8,10 +8,8 @@ import functools
 import re
 import typing as T
 
-from .. import mesonlib
-from .. import mlog
-from .base import DependencyException, DependencyMethods
-from .base import BuiltinDependency, SystemDependency
+from .. import mesonlib, mlog
+from .base import BuiltinDependency, DependencyException, DependencyMethods, SystemDependency
 from .cmake import CMakeDependency, CMakeDependencyFactory
 from .configtool import ConfigToolDependency
 from .detect import packages

--- a/mesonbuild/dependencies/mpi.py
+++ b/mesonbuild/dependencies/mpi.py
@@ -4,21 +4,21 @@
 from __future__ import annotations
 
 import functools
-import typing as T
 import os
 import re
+import typing as T
 
 from ..environment import detect_cpu_family
-from .base import DependencyMethods, detect_compiler, SystemDependency
+from .base import DependencyMethods, SystemDependency, detect_compiler
 from .configtool import ConfigToolDependency
 from .detect import packages
 from .factory import factory_methods
 from .pkgconfig import PkgConfigDependency
 
 if T.TYPE_CHECKING:
-    from .factory import DependencyGenerator
     from ..environment import Environment
     from ..mesonlib import MachineChoice
+    from .factory import DependencyGenerator
 
 
 @factory_methods({DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.SYSTEM})

--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -3,26 +3,28 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
-from .base import ExternalDependency, DependencyException, sort_libpaths, DependencyTypeName
-from ..mesonlib import EnvironmentVariables, OptionKey, OrderedSet, PerMachine, Popen_safe, Popen_safe_logged, MachineChoice, join_args
-from ..programs import find_external_program, ExternalProgram
-from .. import mlog
-from pathlib import PurePath
-from functools import lru_cache
-import re
 import os
+import re
 import shlex
 import typing as T
+from functools import lru_cache
+from pathlib import Path, PurePath
+
+from .. import mlog
+from ..mesonlib import (
+    EnvironmentVariables, MachineChoice, OptionKey, OrderedSet, PerMachine, Popen_safe,
+    Popen_safe_logged, join_args
+)
+from ..programs import ExternalProgram, find_external_program
+from .base import DependencyException, DependencyTypeName, ExternalDependency, sort_libpaths
 
 if T.TYPE_CHECKING:
     from typing_extensions import Literal
-    from .._typing import ImmutableListProtocol
 
+    from .._typing import ImmutableListProtocol
     from ..environment import Environment
-    from ..utils.core import EnvironOrDict
     from ..interpreter.type_checking import PkgConfigDefineType
+    from ..utils.core import EnvironOrDict
 
 class PkgConfigInterface:
     '''Base class wrapping a pkg-config implementation'''

--- a/mesonbuild/dependencies/platform.py
+++ b/mesonbuild/dependencies/platform.py
@@ -5,10 +5,11 @@
 # platform-specific (generally speaking).
 from __future__ import annotations
 
-from .base import DependencyTypeName, ExternalDependency, DependencyException
-from .detect import packages
-from ..mesonlib import MesonException
 import typing as T
+
+from ..mesonlib import MesonException
+from .base import DependencyException, DependencyTypeName, ExternalDependency
+from .detect import packages
 
 if T.TYPE_CHECKING:
     from ..environment import Environment

--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -3,26 +3,32 @@
 
 from __future__ import annotations
 
-import functools, json, os, textwrap
-from pathlib import Path
+import functools
+import json
+import os
+import textwrap
 import typing as T
+from pathlib import Path
 
 from .. import mesonlib, mlog
-from .base import process_method_kw, DependencyException, DependencyMethods, DependencyTypeName, ExternalDependency, SystemDependency
+from ..environment import detect_cpu_family
+from ..programs import ExternalProgram
+from .base import (
+    DependencyException, DependencyMethods, DependencyTypeName, ExternalDependency,
+    SystemDependency, process_method_kw
+)
 from .configtool import ConfigToolDependency
 from .detect import packages
 from .factory import DependencyFactory
 from .framework import ExtraFrameworkDependency
 from .pkgconfig import PkgConfigDependency
-from ..environment import detect_cpu_family
-from ..programs import ExternalProgram
 
 if T.TYPE_CHECKING:
     from typing_extensions import TypedDict
 
-    from .factory import DependencyGenerator
     from ..environment import Environment
     from ..mesonlib import MachineChoice
+    from .factory import DependencyGenerator
 
     class PythonIntrospectionDict(TypedDict):
 

--- a/mesonbuild/dependencies/qt.py
+++ b/mesonbuild/dependencies/qt.py
@@ -7,24 +7,23 @@ from __future__ import annotations
 """Dependency finders for the Qt framework."""
 
 import abc
-import re
 import os
+import re
 import typing as T
 
+from .. import mesonlib, mlog
 from .base import DependencyException, DependencyMethods
 from .configtool import ConfigToolDependency
 from .detect import packages
+from .factory import DependencyFactory
 from .framework import ExtraFrameworkDependency
 from .pkgconfig import PkgConfigDependency
-from .factory import DependencyFactory
-from .. import mlog
-from .. import mesonlib
 
 if T.TYPE_CHECKING:
     from ..compilers import Compiler
+    from ..dependencies import MissingCompiler
     from ..envconfig import MachineInfo
     from ..environment import Environment
-    from ..dependencies import MissingCompiler
 
 
 def _qt_get_private_includes(mod_inc_dir: str, module: str, mod_version: str) -> T.List[str]:

--- a/mesonbuild/dependencies/scalapack.py
+++ b/mesonbuild/dependencies/scalapack.py
@@ -3,17 +3,17 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import functools
 import os
 import typing as T
+from pathlib import Path
 
 from ..mesonlib import OptionKey
 from .base import DependencyMethods
 from .cmake import CMakeDependency
 from .detect import packages
-from .pkgconfig import PkgConfigDependency
 from .factory import factory_methods
+from .pkgconfig import PkgConfigDependency
 
 if T.TYPE_CHECKING:
     from ..environment import Environment

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -10,14 +10,10 @@ import re
 import subprocess
 import typing as T
 
-from .. import mlog
-from .. import mesonlib
+from .. import mesonlib, mlog
 from ..compilers.compilers import CrossNoRunException
-from ..mesonlib import (
-    Popen_safe, extract_as_list, version_compare_many
-)
 from ..environment import detect_cpu_family
-
+from ..mesonlib import Popen_safe, extract_as_list, version_compare_many
 from .base import DependencyException, DependencyMethods, DependencyTypeName, SystemDependency
 from .configtool import ConfigToolDependency
 from .detect import packages

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -3,16 +3,14 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import subprocess
 import typing as T
+from dataclasses import dataclass
 from enum import Enum
-
-from . import mesonlib
-from .mesonlib import EnvironmentException, HoldableObject
-from . import mlog
 from pathlib import Path
 
+from . import mesonlib, mlog
+from .mesonlib import EnvironmentException, HoldableObject
 
 # These classes contains all the data pulled from configuration files (native
 # and cross file currently), and also assists with the reading environment

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -3,36 +3,26 @@
 
 from __future__ import annotations
 
-import itertools
-import os, platform, re, sys, shutil
-import typing as T
 import collections
-
-from . import coredata
-from . import mesonlib
-from .mesonlib import (
-    MesonException, MachineChoice, Popen_safe, PerMachine,
-    PerMachineDefaultable, PerThreeMachineDefaultable, split_args, quote_arg, OptionKey,
-    search_version, MesonBugException
-)
-from . import mlog
-from .programs import ExternalProgram
-
-from .envconfig import (
-    BinaryTable, MachineInfo, Properties, known_cpu_families, CMakeVariables,
-)
-from . import compilers
-from .compilers import (
-    is_assembly,
-    is_header,
-    is_library,
-    is_llvm_ir,
-    is_object,
-    is_source,
-)
-
+import itertools
+import os
+import platform
+import re
+import shutil
+import sys
+import typing as T
 from functools import lru_cache
+
 from mesonbuild import envconfig
+
+from . import compilers, coredata, mesonlib, mlog
+from .compilers import is_assembly, is_header, is_library, is_llvm_ir, is_object, is_source
+from .envconfig import BinaryTable, CMakeVariables, MachineInfo, Properties, known_cpu_families
+from .mesonlib import (
+    MachineChoice, MesonBugException, MesonException, OptionKey, PerMachine, PerMachineDefaultable,
+    PerThreeMachineDefaultable, Popen_safe, quote_arg, search_version, split_args
+)
+from .programs import ExternalProgram
 
 if T.TYPE_CHECKING:
     import argparse

--- a/mesonbuild/interpreter/__init__.py
+++ b/mesonbuild/interpreter/__init__.py
@@ -4,6 +4,22 @@
 
 """Meson interpreter."""
 
+from .interpreter import Interpreter, permitted_dependency_kwargs
+from .compiler import CompilerHolder
+from .interpreterobjects import (ExecutableHolder, BuildTargetHolder, CustomTargetHolder,
+                                 CustomTargetIndexHolder, MachineHolder, Test,
+                                 ConfigurationDataHolder, SubprojectHolder, DependencyHolder,
+                                 GeneratedListHolder, ExternalProgramHolder,
+                                 extract_required_kwarg)
+
+from .primitives import (
+    ArrayHolder,
+    BooleanHolder,
+    DictHolder,
+    IntegerHolder,
+    StringHolder,
+)
+
 __all__ = [
     'Interpreter',
     'permitted_dependency_kwargs',
@@ -29,19 +45,3 @@ __all__ = [
     'IntegerHolder',
     'StringHolder',
 ]
-
-from .interpreter import Interpreter, permitted_dependency_kwargs
-from .compiler import CompilerHolder
-from .interpreterobjects import (ExecutableHolder, BuildTargetHolder, CustomTargetHolder,
-                                 CustomTargetIndexHolder, MachineHolder, Test,
-                                 ConfigurationDataHolder, SubprojectHolder, DependencyHolder,
-                                 GeneratedListHolder, ExternalProgramHolder,
-                                 extract_required_kwarg)
-
-from .primitives import (
-    ArrayHolder,
-    BooleanHolder,
-    DictHolder,
-    IntegerHolder,
-    StringHolder,
-)

--- a/mesonbuild/interpreter/__init__.py
+++ b/mesonbuild/interpreter/__init__.py
@@ -4,21 +4,16 @@
 
 """Meson interpreter."""
 
-from .interpreter import Interpreter, permitted_dependency_kwargs
-from .compiler import CompilerHolder
-from .interpreterobjects import (ExecutableHolder, BuildTargetHolder, CustomTargetHolder,
-                                 CustomTargetIndexHolder, MachineHolder, Test,
-                                 ConfigurationDataHolder, SubprojectHolder, DependencyHolder,
-                                 GeneratedListHolder, ExternalProgramHolder,
-                                 extract_required_kwarg)
+from __future__ import annotations
 
-from .primitives import (
-    ArrayHolder,
-    BooleanHolder,
-    DictHolder,
-    IntegerHolder,
-    StringHolder,
+from .compiler import CompilerHolder
+from .interpreter import Interpreter, permitted_dependency_kwargs
+from .interpreterobjects import (
+    BuildTargetHolder, ConfigurationDataHolder, CustomTargetHolder, CustomTargetIndexHolder,
+    DependencyHolder, ExecutableHolder, ExternalProgramHolder, GeneratedListHolder, MachineHolder,
+    SubprojectHolder, Test, extract_required_kwarg
 )
+from .primitives import ArrayHolder, BooleanHolder, DictHolder, IntegerHolder, StringHolder
 
 __all__ = [
     'Interpreter',

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -6,34 +6,31 @@ from __future__ import annotations
 import collections
 import enum
 import functools
-import os
 import itertools
+import os
 import typing as T
 
-from .. import build
-from .. import coredata
-from .. import dependencies
-from .. import mesonlib
-from .. import mlog
+from .. import build, coredata, dependencies, mesonlib, mlog
 from ..compilers import SUFFIX_TO_LANG
 from ..compilers.compilers import CompileCheckMode
-from ..interpreterbase import (ObjectHolder, noPosargs, noKwargs,
-                               FeatureNew, FeatureNewKwargs, disablerIfNotFound,
-                               InterpreterException)
-from ..interpreterbase.decorators import ContainerTypeInfo, typed_kwargs, KwargInfo, typed_pos_args
+from ..interpreterbase import (
+    FeatureNew, FeatureNewKwargs, InterpreterException, ObjectHolder, disablerIfNotFound, noKwargs,
+    noPosargs
+)
+from ..interpreterbase.decorators import ContainerTypeInfo, KwargInfo, typed_kwargs, typed_pos_args
 from ..mesonlib import OptionKey
-from .interpreterobjects import (extract_required_kwarg, extract_search_dirs)
-from .type_checking import REQUIRED_KW, in_set_validator, NoneType
+from .interpreterobjects import extract_required_kwarg, extract_search_dirs
+from .type_checking import REQUIRED_KW, NoneType, in_set_validator
 
 if T.TYPE_CHECKING:
-    from ..interpreter import Interpreter
-    from ..compilers import Compiler, RunResult
-    from ..interpreterbase import TYPE_var, TYPE_kwargs
-    from .kwargs import ExtractRequired, ExtractSearchDirs
-    from .interpreter import SourceOutputs
-    from ..mlog import TV_LoggableList
+    from typing_extensions import Literal, TypedDict
 
-    from typing_extensions import TypedDict, Literal
+    from ..compilers import Compiler, RunResult
+    from ..interpreter import Interpreter
+    from ..interpreterbase import TYPE_kwargs, TYPE_var
+    from ..mlog import TV_LoggableList
+    from .interpreter import SourceOutputs
+    from .kwargs import ExtractRequired, ExtractSearchDirs
 
     class GetSupportedArgumentKw(TypedDict):
 

--- a/mesonbuild/interpreter/dependencyfallbacks.py
+++ b/mesonbuild/interpreter/dependencyfallbacks.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
-from .interpreterobjects import extract_required_kwarg
-from .. import mlog
-from .. import dependencies
-from .. import build
-from ..wrap import WrapMode
-from ..mesonlib import OptionKey, extract_as_list, stringlistify, version_compare_many, listify
-from ..dependencies import Dependency, DependencyException, NotFoundDependency
-from ..interpreterbase import (MesonInterpreterObject, FeatureNew,
-                               InterpreterException, InvalidArguments)
-
 import typing as T
+
+from .. import build, dependencies, mlog
+from ..dependencies import Dependency, DependencyException, NotFoundDependency
+from ..interpreterbase import (
+    FeatureNew, InterpreterException, InvalidArguments, MesonInterpreterObject
+)
+from ..mesonlib import OptionKey, extract_as_list, listify, stringlistify, version_compare_many
+from ..wrap import WrapMode
+from .interpreterobjects import extract_required_kwarg
+
 if T.TYPE_CHECKING:
-    from .interpreter import Interpreter
     from ..interpreterbase import TYPE_nkwargs, TYPE_nvar
+    from .interpreter import Interpreter
     from .interpreterobjects import SubprojectHolder
 
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -4,114 +4,70 @@
 
 from __future__ import annotations
 
-from .. import mparser
-from .. import environment
-from .. import coredata
-from .. import dependencies
-from .. import mlog
-from .. import build
-from .. import optinterpreter
-from .. import compilers
-from .. import envconfig
-from ..wrap import wrap, WrapMode
-from .. import mesonlib
-from ..mesonlib import (EnvironmentVariables, ExecutableSerialisation, MesonBugException, MesonException, HoldableObject,
-                        FileMode, MachineChoice, OptionKey, listify,
-                        extract_as_list, has_path_sep, path_is_in_root, PerMachine)
-from ..programs import ExternalProgram, NonExistingExternalProgram
+import collections
+import copy
+import importlib
+import os
+import re
+import shutil
+import stat
+import textwrap
+import typing as T
+import uuid
+from enum import Enum
+from pathlib import Path
+
+from .. import (
+    build, compilers, coredata, dependencies, envconfig, environment, mesonlib, mlog, mparser,
+    optinterpreter
+)
 from ..dependencies import Dependency
 from ..depfile import DepFile
-from ..interpreterbase import ContainerTypeInfo, InterpreterBase, KwargInfo, typed_kwargs, typed_pos_args
-from ..interpreterbase import noPosargs, noKwargs, permittedKwargs, noArgsFlattening, noSecondLevelHolderResolving, unholder_return
-from ..interpreterbase import InterpreterException, InvalidArguments, InvalidCode, SubdirDoneRequest
-from ..interpreterbase import Disabler, disablerIfNotFound
-from ..interpreterbase import FeatureNew, FeatureDeprecated, FeatureBroken, FeatureNewKwargs
-from ..interpreterbase import ObjectHolder, ContextManagerObject
-from ..interpreterbase import stringifyUserArguments
-from ..modules import ExtensionModule, ModuleObject, MutableModuleObject, NewExtensionModule, NotFoundExtensionModule
+from ..interpreterbase import (
+    ContainerTypeInfo, ContextManagerObject, Disabler, FeatureBroken, FeatureDeprecated, FeatureNew,
+    FeatureNewKwargs, InterpreterBase, InterpreterException, InvalidArguments, InvalidCode,
+    KwargInfo, ObjectHolder, SubdirDoneRequest, disablerIfNotFound, noArgsFlattening, noKwargs,
+    noPosargs, noSecondLevelHolderResolving, permittedKwargs, stringifyUserArguments, typed_kwargs,
+    typed_pos_args, unholder_return
+)
+from ..mesonlib import (
+    EnvironmentVariables, ExecutableSerialisation, FileMode, HoldableObject, MachineChoice,
+    MesonBugException, MesonException, OptionKey, PerMachine, extract_as_list, has_path_sep,
+    listify, path_is_in_root
+)
+from ..modules import (
+    ExtensionModule, ModuleObject, MutableModuleObject, NewExtensionModule, NotFoundExtensionModule
+)
 from ..optinterpreter import optname_regex
-
-from . import interpreterobjects as OBJ
+from ..programs import ExternalProgram, NonExistingExternalProgram
+from ..wrap import WrapMode, wrap
 from . import compiler as compilerOBJ
-from .mesonmain import MesonMain
+from . import interpreterobjects as OBJ
+from . import primitives as P_OBJ
 from .dependencyfallbacks import DependencyFallbacksHolder
 from .interpreterobjects import (
-    SubprojectHolder,
-    Test,
-    RunProcess,
-    extract_required_kwarg,
-    extract_search_dirs,
-    NullSubprojectInterpreter,
+    NullSubprojectInterpreter, RunProcess, SubprojectHolder, Test, extract_required_kwarg,
+    extract_search_dirs
 )
+from .mesonmain import MesonMain
 from .type_checking import (
-    BUILD_TARGET_KWS,
-    COMMAND_KW,
-    CT_BUILD_ALWAYS,
-    CT_BUILD_ALWAYS_STALE,
-    CT_BUILD_BY_DEFAULT,
-    CT_INPUT_KW,
-    CT_INSTALL_DIR_KW,
-    EXECUTABLE_KWS,
-    JAR_KWS,
-    LIBRARY_KWS,
-    MULTI_OUTPUT_KW,
-    OUTPUT_KW,
-    DEFAULT_OPTIONS,
-    DEPENDENCIES_KW,
-    DEPENDS_KW,
-    DEPEND_FILES_KW,
-    DEPFILE_KW,
-    DISABLER_KW,
-    D_MODULE_VERSIONS_KW,
-    ENV_KW,
-    ENV_METHOD_KW,
-    ENV_SEPARATOR_KW,
-    INCLUDE_DIRECTORIES,
-    INSTALL_KW,
-    INSTALL_DIR_KW,
-    INSTALL_MODE_KW,
-    INSTALL_FOLLOW_SYMLINKS,
-    LINK_WITH_KW,
-    LINK_WHOLE_KW,
-    CT_INSTALL_TAG_KW,
-    INSTALL_TAG_KW,
-    LANGUAGE_KW,
-    NATIVE_KW,
-    PRESERVE_PATH_KW,
-    REQUIRED_KW,
-    SHARED_LIB_KWS,
-    SHARED_MOD_KWS,
-    DEPENDENCY_SOURCES_KW,
-    SOURCES_VARARGS,
-    STATIC_LIB_KWS,
-    VARIABLES_KW,
-    TEST_KWS,
-    NoneType,
-    in_set_validator,
-    env_convertor_with_method
+    BUILD_TARGET_KWS, COMMAND_KW, CT_BUILD_ALWAYS, CT_BUILD_ALWAYS_STALE, CT_BUILD_BY_DEFAULT,
+    CT_INPUT_KW, CT_INSTALL_DIR_KW, CT_INSTALL_TAG_KW, D_MODULE_VERSIONS_KW, DEFAULT_OPTIONS,
+    DEPEND_FILES_KW, DEPENDENCIES_KW, DEPENDENCY_SOURCES_KW, DEPENDS_KW, DEPFILE_KW, DISABLER_KW,
+    ENV_KW, ENV_METHOD_KW, ENV_SEPARATOR_KW, EXECUTABLE_KWS, INCLUDE_DIRECTORIES, INSTALL_DIR_KW,
+    INSTALL_FOLLOW_SYMLINKS, INSTALL_KW, INSTALL_MODE_KW, INSTALL_TAG_KW, JAR_KWS, LANGUAGE_KW,
+    LIBRARY_KWS, LINK_WHOLE_KW, LINK_WITH_KW, MULTI_OUTPUT_KW, NATIVE_KW, OUTPUT_KW,
+    PRESERVE_PATH_KW, REQUIRED_KW, SHARED_LIB_KWS, SHARED_MOD_KWS, SOURCES_VARARGS, STATIC_LIB_KWS,
+    TEST_KWS, VARIABLES_KW, NoneType, env_convertor_with_method, in_set_validator
 )
-from . import primitives as P_OBJ
-
-from pathlib import Path
-from enum import Enum
-import os
-import shutil
-import uuid
-import re
-import stat
-import collections
-import typing as T
-import textwrap
-import importlib
-import copy
 
 if T.TYPE_CHECKING:
     import argparse
 
-    from . import kwargs as kwtypes
     from ..backend.backends import Backend
-    from ..interpreterbase.baseobjects import InterpreterObject, TYPE_var, TYPE_kwargs
+    from ..interpreterbase.baseobjects import InterpreterObject, TYPE_kwargs, TYPE_var
     from ..programs import OverrideProgram
+    from . import kwargs as kwtypes
     from .type_checking import SourcesVarargsType
 
     # Input source types passed to Targets

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -1,41 +1,38 @@
 from __future__ import annotations
+
+import copy
 import os
 import shlex
 import subprocess
-import copy
 import textwrap
-
+import typing as T
 from pathlib import Path, PurePath
 
-from .. import mesonlib
-from .. import coredata
-from .. import build
-from .. import mlog
-
-from ..modules import ModuleReturnValue, ModuleObject, ModuleState, ExtensionModule
+from .. import build, coredata, mesonlib, mlog
 from ..backend.backends import TestProtocol
-from ..interpreterbase import (
-                               ContainerTypeInfo, KwargInfo, MesonOperator,
-                               MesonInterpreterObject, ObjectHolder, MutableInterpreterObject,
-                               FeatureNew, FeatureDeprecated,
-                               typed_pos_args, typed_kwargs, typed_operator,
-                               noArgsFlattening, noPosargs, noKwargs, unholder_return,
-                               flatten, resolve_second_level_holders, InterpreterException, InvalidArguments, InvalidCode)
-from ..interpreter.type_checking import NoneType, ENV_KW, ENV_SEPARATOR_KW, PKGCONFIG_DEFINE_KW
 from ..dependencies import Dependency, ExternalLibrary, InternalDependency
+from ..interpreter.type_checking import ENV_KW, ENV_SEPARATOR_KW, PKGCONFIG_DEFINE_KW, NoneType
+from ..interpreterbase import (
+    ContainerTypeInfo, FeatureDeprecated, FeatureNew, InterpreterException, InvalidArguments,
+    InvalidCode, KwargInfo, MesonInterpreterObject, MesonOperator, MutableInterpreterObject,
+    ObjectHolder, flatten, noArgsFlattening, noKwargs, noPosargs, resolve_second_level_holders,
+    typed_kwargs, typed_operator, typed_pos_args, unholder_return
+)
+from ..mesonlib import HoldableObject, OptionKey, Popen_safe, listify
+from ..modules import ExtensionModule, ModuleObject, ModuleReturnValue, ModuleState
 from ..programs import ExternalProgram
-from ..mesonlib import HoldableObject, OptionKey, listify, Popen_safe
-
-import typing as T
 
 if T.TYPE_CHECKING:
-    from . import kwargs
+    from typing_extensions import TypedDict
+
     from ..cmake.interpreter import CMakeInterpreter
     from ..envconfig import MachineInfo
-    from ..interpreterbase import FeatureCheckBase, InterpreterObject, SubProject, TYPE_var, TYPE_kwargs, TYPE_nvar, TYPE_nkwargs
+    from ..interpreterbase import (
+        FeatureCheckBase, InterpreterObject, SubProject, TYPE_kwargs, TYPE_nkwargs, TYPE_nvar,
+        TYPE_var
+    )
+    from . import kwargs
     from .interpreter import Interpreter
-
-    from typing_extensions import TypedDict
 
     class EnvironmentSeparatorKW(TypedDict):
 

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -7,16 +7,16 @@ from __future__ import annotations
 
 import typing as T
 
-from typing_extensions import TypedDict, Literal, Protocol, NotRequired
+from typing_extensions import Literal, NotRequired, Protocol, TypedDict
 
-from .. import build
-from .. import coredata
+from .. import build, coredata
 from ..compilers import Compiler
 from ..dependencies.base import Dependency
-from ..mesonlib import EnvironmentVariables, MachineChoice, File, FileMode, FileOrString, OptionKey
+from ..mesonlib import EnvironmentVariables, File, FileMode, FileOrString, MachineChoice, OptionKey
 from ..modules.cmake import CMakeSubprojectOptions
 from ..programs import ExternalProgram
 from .type_checking import PkgConfigDefineType, SourcesVarargsType
+
 
 class FuncAddProjectArgs(TypedDict):
 

--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -6,17 +6,16 @@ from __future__ import annotations
 import os
 import typing as T
 
-from .. import mesonlib
-from .. import dependencies
-from .. import build
-from .. import mlog, coredata
-
+from .. import build, coredata, dependencies, mesonlib, mlog
+from ..interpreter.type_checking import (
+    ENV_KW, ENV_METHOD_KW, ENV_SEPARATOR_KW, env_convertor_with_method
+)
+from ..interpreterbase import (
+    FeatureDeprecated, FeatureNew, InterpreterException, KwargInfo, MesonInterpreterObject,
+    noArgsFlattening, noKwargs, noPosargs, typed_kwargs, typed_pos_args
+)
 from ..mesonlib import MachineChoice, OptionKey
-from ..programs import OverrideProgram, ExternalProgram
-from ..interpreter.type_checking import ENV_KW, ENV_METHOD_KW, ENV_SEPARATOR_KW, env_convertor_with_method
-from ..interpreterbase import (MesonInterpreterObject, FeatureNew, FeatureDeprecated,
-                               typed_pos_args,  noArgsFlattening, noPosargs, noKwargs,
-                               typed_kwargs, KwargInfo, InterpreterException)
+from ..programs import ExternalProgram, OverrideProgram
 from .primitives import MesonVersionString
 from .type_checking import NATIVE_KW, NoneType
 

--- a/mesonbuild/interpreter/primitives/__init__.py
+++ b/mesonbuild/interpreter/primitives/__init__.py
@@ -1,6 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2021 The Meson development team
 
+from .array import ArrayHolder
+from .boolean import BooleanHolder
+from .dict import DictHolder
+from .integer import IntegerHolder
+from .range import RangeHolder
+from .string import (
+    StringHolder,
+    MesonVersionString, MesonVersionStringHolder,
+    DependencyVariableString, DependencyVariableStringHolder,
+    OptionString, OptionStringHolder,
+)
+
 __all__ = [
     'ArrayHolder',
     'BooleanHolder',
@@ -15,15 +27,3 @@ __all__ = [
     'OptionString',
     'OptionStringHolder',
 ]
-
-from .array import ArrayHolder
-from .boolean import BooleanHolder
-from .dict import DictHolder
-from .integer import IntegerHolder
-from .range import RangeHolder
-from .string import (
-    StringHolder,
-    MesonVersionString, MesonVersionStringHolder,
-    DependencyVariableString, DependencyVariableStringHolder,
-    OptionString, OptionStringHolder,
-)

--- a/mesonbuild/interpreter/primitives/__init__.py
+++ b/mesonbuild/interpreter/primitives/__init__.py
@@ -1,16 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2021 The Meson development team
 
+from __future__ import annotations
+
 from .array import ArrayHolder
 from .boolean import BooleanHolder
 from .dict import DictHolder
 from .integer import IntegerHolder
 from .range import RangeHolder
 from .string import (
-    StringHolder,
-    MesonVersionString, MesonVersionStringHolder,
-    DependencyVariableString, DependencyVariableStringHolder,
-    OptionString, OptionStringHolder,
+    DependencyVariableString, DependencyVariableStringHolder, MesonVersionString,
+    MesonVersionStringHolder, OptionString, OptionStringHolder, StringHolder
 )
 
 __all__ = [

--- a/mesonbuild/interpreter/primitives/array.py
+++ b/mesonbuild/interpreter/primitives/array.py
@@ -5,19 +5,8 @@ from __future__ import annotations
 import typing as T
 
 from ...interpreterbase import (
-    ObjectHolder,
-    IterableObject,
-    MesonOperator,
-    typed_operator,
-    noKwargs,
-    noPosargs,
-    noArgsFlattening,
-    typed_pos_args,
-    FeatureNew,
-
-    TYPE_var,
-
-    InvalidArguments,
+    FeatureNew, InvalidArguments, IterableObject, MesonOperator, ObjectHolder, TYPE_var,
+    noArgsFlattening, noKwargs, noPosargs, typed_operator, typed_pos_args
 )
 from ...mparser import PlusAssignmentNode
 

--- a/mesonbuild/interpreter/primitives/boolean.py
+++ b/mesonbuild/interpreter/primitives/boolean.py
@@ -2,22 +2,16 @@
 # SPDX-license-identifier: Apache-2.0
 from __future__ import annotations
 
-from ...interpreterbase import (
-    ObjectHolder,
-    MesonOperator,
-    typed_pos_args,
-    noKwargs,
-    noPosargs,
-
-    InvalidArguments
-)
-
 import typing as T
+
+from ...interpreterbase import (
+    InvalidArguments, MesonOperator, ObjectHolder, noKwargs, noPosargs, typed_pos_args
+)
 
 if T.TYPE_CHECKING:
     # Object holders need the actual interpreter
     from ...interpreter import Interpreter
-    from ...interpreterbase import TYPE_var, TYPE_kwargs
+    from ...interpreterbase import TYPE_kwargs, TYPE_var
 
 class BooleanHolder(ObjectHolder[bool]):
     def __init__(self, obj: bool, interpreter: 'Interpreter') -> None:

--- a/mesonbuild/interpreter/primitives/dict.py
+++ b/mesonbuild/interpreter/primitives/dict.py
@@ -5,18 +5,8 @@ from __future__ import annotations
 import typing as T
 
 from ...interpreterbase import (
-    ObjectHolder,
-    IterableObject,
-    MesonOperator,
-    typed_operator,
-    noKwargs,
-    noPosargs,
-    noArgsFlattening,
-    typed_pos_args,
-
-    TYPE_var,
-
-    InvalidArguments,
+    InvalidArguments, IterableObject, MesonOperator, ObjectHolder, TYPE_var, noArgsFlattening,
+    noKwargs, noPosargs, typed_operator, typed_pos_args
 )
 
 if T.TYPE_CHECKING:

--- a/mesonbuild/interpreter/primitives/integer.py
+++ b/mesonbuild/interpreter/primitives/integer.py
@@ -2,17 +2,17 @@
 # Copyright 2021 The Meson development team
 from __future__ import annotations
 
-from ...interpreterbase import (
-    FeatureBroken, InvalidArguments, MesonOperator, ObjectHolder, KwargInfo,
-    noKwargs, noPosargs, typed_operator, typed_kwargs
-)
-
 import typing as T
+
+from ...interpreterbase import (
+    FeatureBroken, InvalidArguments, KwargInfo, MesonOperator, ObjectHolder, noKwargs, noPosargs,
+    typed_kwargs, typed_operator
+)
 
 if T.TYPE_CHECKING:
     # Object holders need the actual interpreter
     from ...interpreter import Interpreter
-    from ...interpreterbase import TYPE_var, TYPE_kwargs
+    from ...interpreterbase import TYPE_kwargs, TYPE_var
 
 class IntegerHolder(ObjectHolder[int]):
     def __init__(self, obj: int, interpreter: 'Interpreter') -> None:

--- a/mesonbuild/interpreter/primitives/range.py
+++ b/mesonbuild/interpreter/primitives/range.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 import typing as T
 
 from ...interpreterbase import (
-    MesonInterpreterObject,
-    IterableObject,
-    MesonOperator,
-    InvalidArguments,
+    InvalidArguments, IterableObject, MesonInterpreterObject, MesonOperator
 )
 
 if T.TYPE_CHECKING:

--- a/mesonbuild/interpreter/primitives/string.py
+++ b/mesonbuild/interpreter/primitives/string.py
@@ -2,31 +2,20 @@
 # Copyright 2021 The Meson development team
 from __future__ import annotations
 
-import re
 import os
-
+import re
 import typing as T
 
-from ...mesonlib import version_compare
 from ...interpreterbase import (
-    ObjectHolder,
-    MesonOperator,
-    FeatureNew,
-    typed_operator,
-    noArgsFlattening,
-    noKwargs,
-    noPosargs,
-    typed_pos_args,
-    InvalidArguments,
-    FeatureBroken,
-    stringifyUserArguments,
+    FeatureBroken, FeatureNew, InvalidArguments, MesonOperator, ObjectHolder, noArgsFlattening,
+    noKwargs, noPosargs, stringifyUserArguments, typed_operator, typed_pos_args
 )
-
+from ...mesonlib import version_compare
 
 if T.TYPE_CHECKING:
     # Object holders need the actual interpreter
     from ...interpreter import Interpreter
-    from ...interpreterbase import TYPE_var, TYPE_kwargs
+    from ...interpreterbase import TYPE_kwargs, TYPE_var
 
 class StringHolder(ObjectHolder[str]):
     def __init__(self, obj: str, interpreter: 'Interpreter') -> None:

--- a/mesonbuild/interpreter/summary.py
+++ b/mesonbuild/interpreter/summary.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2012-2023 The Meson development team
+
+from __future__ import annotations
+
+import collections
+import shutil
+import typing as T
+
+from .. import mlog
+from ..coredata import UserOption
+from ..dependencies import Dependency
+from ..interpreterbase import FeatureNew, InterpreterException
+from ..interpreterbase.disabler import Disabler
+from ..programs import ExternalProgram
+from ..utils.universal import listify
+
+if T.TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
+    from .._typing import SizedStringProtocol
+    from ..interpreterbase.baseobjects import SubProject
+
+    _SummaryValueTypes: TypeAlias = T.Union[str, int, bool, ExternalProgram, Dependency, Disabler, UserOption]
+    _SummaryValues: TypeAlias = T.Dict[str, T.Union[T.List[_SummaryValueTypes], _SummaryValueTypes]]
+    _Loggable: TypeAlias = T.Union[SizedStringProtocol, mlog.AnsiDecorator]
+
+
+class Summary:
+    def __init__(self, project_name: str, project_version: str):
+        self.project_name = project_name
+        self.project_version = project_version
+        self.sections: T.DefaultDict[str, T.Dict[str, T.Tuple[T.List[_Loggable], T.Optional[str]]]] = collections.defaultdict(dict)
+        self.max_key_len = 0
+
+    def add_section(self, section: str, values: _SummaryValues,
+                    bool_yn: bool, list_sep: T.Optional[str],
+                    subproject: SubProject) -> None:
+        for k, v in values.items():
+            if k in self.sections[section]:
+                raise InterpreterException(f'Summary section {section!r} already have key {k!r}')
+            formatted_values: T.List[_Loggable] = []
+            i: _SummaryValueTypes
+            for i in listify(v):
+                if isinstance(i, bool):
+                    if bool_yn:
+                        formatted_values.append(mlog.green('YES') if i else mlog.red('NO'))
+                    else:
+                        formatted_values.append('true' if i else 'false')
+                elif isinstance(i, (str, int)):
+                    formatted_values.append(str(i))
+                elif isinstance(i, (ExternalProgram, Dependency)):
+                    FeatureNew.single_use('dependency or external program in summary', '0.57.0', subproject)
+                    formatted_values.append(i.summary_value())
+                elif isinstance(i, Disabler):
+                    FeatureNew.single_use('disabler in summary', '0.64.0', subproject)
+                    formatted_values.append(mlog.red('NO'))
+                elif isinstance(i, UserOption):
+                    FeatureNew.single_use('feature option in summary', '0.58.0', subproject)
+                    formatted_values.append(i.printable_value())
+                else:
+                    m = 'Summary value in section {!r}, key {!r}, must be string, integer, boolean, dependency, disabler, or external program'
+                    raise InterpreterException(m.format(section, k))
+            self.sections[section][k] = (formatted_values, list_sep)
+            self.max_key_len = max(self.max_key_len, len(k))
+
+    def dump(self) -> None:
+        mlog.log(self.project_name, mlog.normal_cyan(self.project_version))
+        for section, values in self.sections.items():
+            mlog.log('')  # newline
+            if section:
+                mlog.log(' ', mlog.bold(section))
+            for k, rv in values.items():
+                v, list_sep = rv
+                padding = self.max_key_len - len(k)
+                end = ' ' if v else ''
+                mlog.log(' ' * 3, k + ' ' * padding + ':', end=end)
+                indent = self.max_key_len + 6
+                self.dump_value(v, list_sep, indent)
+        mlog.log('')  # newline
+
+    def dump_value(self, arr: T.List[_Loggable], list_sep: T.Optional[str], indent: int) -> None:
+        lines_sep = '\n' + ' ' * indent
+        if list_sep is None:
+            mlog.log(*arr, sep=lines_sep, display_timestamp=False)
+            return
+        max_len = shutil.get_terminal_size().columns
+        line: T.List[_Loggable] = []
+        line_len = indent
+        lines_sep = list_sep.rstrip() + lines_sep
+        for v in arr:
+            v_len = len(v) + len(list_sep)
+            if line and line_len + v_len > max_len:
+                mlog.log(*line, sep=list_sep, end=lines_sep)
+                line_len = indent
+                line = []
+            line.append(v)
+            line_len += v_len
+        mlog.log(*line, sep=list_sep, display_timestamp=False)

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -4,18 +4,23 @@
 """Helpers for strict type checking."""
 
 from __future__ import annotations
-import itertools, os, re
+
+import itertools
+import os
+import re
 import typing as T
 
 from .. import compilers
-from ..build import (CustomTarget, BuildTarget,
-                     CustomTargetIndex, ExtractedObjects, GeneratedList, IncludeDirs,
-                     BothLibraries, SharedLibrary, StaticLibrary, Jar, Executable, StructuredSources)
+from ..build import (
+    BothLibraries, BuildTarget, CustomTarget, CustomTargetIndex, Executable, ExtractedObjects,
+    GeneratedList, IncludeDirs, Jar, SharedLibrary, StaticLibrary, StructuredSources
+)
 from ..coredata import UserFeatureOption
 from ..dependencies import Dependency, InternalDependency
-from ..interpreterbase.decorators import KwargInfo, ContainerTypeInfo
-from ..mesonlib import (File, FileMode, MachineChoice, listify, has_path_sep,
-                        OptionKey, EnvironmentVariables)
+from ..interpreterbase.decorators import ContainerTypeInfo, KwargInfo
+from ..mesonlib import (
+    EnvironmentVariables, File, FileMode, MachineChoice, OptionKey, has_path_sep, listify
+)
 from ..programs import ExternalProgram
 
 # Helper definition for type checks that are `Optional[T]`

--- a/mesonbuild/interpreterbase/__init__.py
+++ b/mesonbuild/interpreterbase/__init__.py
@@ -1,65 +1,26 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2013-2021 The Meson development team
 
+from __future__ import annotations
+
 from .baseobjects import (
-    InterpreterObject,
-    MesonInterpreterObject,
-    ObjectHolder,
-    IterableObject,
-    MutableInterpreterObject,
-    ContextManagerObject,
-
-    TV_func,
-    TYPE_elementary,
-    TYPE_var,
-    TYPE_nvar,
-    TYPE_kwargs,
-    TYPE_nkwargs,
-    TYPE_key_resolver,
-    TYPE_HoldableTypes,
-
-    SubProject,
-
-    HoldableTypes,
+    ContextManagerObject, HoldableTypes, InterpreterObject, IterableObject, MesonInterpreterObject,
+    MutableInterpreterObject, ObjectHolder, SubProject, TV_func, TYPE_elementary,
+    TYPE_HoldableTypes, TYPE_key_resolver, TYPE_kwargs, TYPE_nkwargs, TYPE_nvar, TYPE_var
 )
-
 from .decorators import (
-    noPosargs,
-    noKwargs,
-    stringArgs,
-    noArgsFlattening,
-    noSecondLevelHolderResolving,
-    unholder_return,
-    disablerIfNotFound,
-    permittedKwargs,
-    typed_pos_args,
-    ContainerTypeInfo,
-    KwargInfo,
-    typed_operator,
-    typed_kwargs,
-    FeatureCheckBase,
-    FeatureNew,
-    FeatureDeprecated,
-    FeatureBroken,
-    FeatureNewKwargs,
-    FeatureDeprecatedKwargs,
+    ContainerTypeInfo, FeatureBroken, FeatureCheckBase, FeatureDeprecated, FeatureDeprecatedKwargs,
+    FeatureNew, FeatureNewKwargs, KwargInfo, disablerIfNotFound, noArgsFlattening, noKwargs,
+    noPosargs, noSecondLevelHolderResolving, permittedKwargs, stringArgs, typed_kwargs,
+    typed_operator, typed_pos_args, unholder_return
 )
-
-from .exceptions import (
-    InterpreterException,
-    InvalidCode,
-    InvalidArguments,
-    SubdirDoneRequest,
-    ContinueRequest,
-    BreakRequest,
-)
-
 from .disabler import Disabler, is_disabled
+from .exceptions import (
+    BreakRequest, ContinueRequest, InterpreterException, InvalidArguments, InvalidCode,
+    SubdirDoneRequest
+)
 from .helpers import (
-    default_resolve_key,
-    flatten,
-    resolve_second_level_holders,
-    stringifyUserArguments,
+    default_resolve_key, flatten, resolve_second_level_holders, stringifyUserArguments
 )
 from .interpreterbase import InterpreterBase
 from .operator import MesonOperator

--- a/mesonbuild/interpreterbase/__init__.py
+++ b/mesonbuild/interpreterbase/__init__.py
@@ -1,67 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2013-2021 The Meson development team
 
-__all__ = [
-    'InterpreterObject',
-    'MesonInterpreterObject',
-    'ObjectHolder',
-    'IterableObject',
-    'MutableInterpreterObject',
-    'ContextManagerObject',
-
-    'MesonOperator',
-
-    'Disabler',
-    'is_disabled',
-
-    'InterpreterException',
-    'InvalidCode',
-    'InvalidArguments',
-    'SubdirDoneRequest',
-    'ContinueRequest',
-    'BreakRequest',
-
-    'default_resolve_key',
-    'flatten',
-    'resolve_second_level_holders',
-    'stringifyUserArguments',
-
-    'noPosargs',
-    'noKwargs',
-    'stringArgs',
-    'noArgsFlattening',
-    'noSecondLevelHolderResolving',
-    'unholder_return',
-    'disablerIfNotFound',
-    'permittedKwargs',
-    'typed_operator',
-    'typed_pos_args',
-    'ContainerTypeInfo',
-    'KwargInfo',
-    'typed_kwargs',
-    'FeatureCheckBase',
-    'FeatureNew',
-    'FeatureDeprecated',
-    'FeatureBroken',
-    'FeatureNewKwargs',
-    'FeatureDeprecatedKwargs',
-
-    'InterpreterBase',
-
-    'SubProject',
-
-    'TV_func',
-    'TYPE_elementary',
-    'TYPE_var',
-    'TYPE_nvar',
-    'TYPE_kwargs',
-    'TYPE_nkwargs',
-    'TYPE_key_resolver',
-    'TYPE_HoldableTypes',
-
-    'HoldableTypes',
-]
-
 from .baseobjects import (
     InterpreterObject,
     MesonInterpreterObject,
@@ -124,3 +63,64 @@ from .helpers import (
 )
 from .interpreterbase import InterpreterBase
 from .operator import MesonOperator
+
+__all__ = [
+    'InterpreterObject',
+    'MesonInterpreterObject',
+    'ObjectHolder',
+    'IterableObject',
+    'MutableInterpreterObject',
+    'ContextManagerObject',
+
+    'MesonOperator',
+
+    'Disabler',
+    'is_disabled',
+
+    'InterpreterException',
+    'InvalidCode',
+    'InvalidArguments',
+    'SubdirDoneRequest',
+    'ContinueRequest',
+    'BreakRequest',
+
+    'default_resolve_key',
+    'flatten',
+    'resolve_second_level_holders',
+    'stringifyUserArguments',
+
+    'noPosargs',
+    'noKwargs',
+    'stringArgs',
+    'noArgsFlattening',
+    'noSecondLevelHolderResolving',
+    'unholder_return',
+    'disablerIfNotFound',
+    'permittedKwargs',
+    'typed_operator',
+    'typed_pos_args',
+    'ContainerTypeInfo',
+    'KwargInfo',
+    'typed_kwargs',
+    'FeatureCheckBase',
+    'FeatureNew',
+    'FeatureDeprecated',
+    'FeatureBroken',
+    'FeatureNewKwargs',
+    'FeatureDeprecatedKwargs',
+
+    'InterpreterBase',
+
+    'SubProject',
+
+    'TV_func',
+    'TYPE_elementary',
+    'TYPE_var',
+    'TYPE_nvar',
+    'TYPE_kwargs',
+    'TYPE_nkwargs',
+    'TYPE_key_resolver',
+    'TYPE_HoldableTypes',
+
+    'HoldableTypes',
+]

--- a/mesonbuild/interpreterbase/_unholder.py
+++ b/mesonbuild/interpreterbase/_unholder.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 
 import typing as T
 
-from .baseobjects import InterpreterObject, MesonInterpreterObject, ObjectHolder, HoldableTypes
-from .exceptions import InvalidArguments
 from ..mesonlib import HoldableObject, MesonBugException
+from .baseobjects import HoldableTypes, InterpreterObject, MesonInterpreterObject, ObjectHolder
+from .exceptions import InvalidArguments
 
 if T.TYPE_CHECKING:
     from .baseobjects import TYPE_var

--- a/mesonbuild/interpreterbase/baseobjects.py
+++ b/mesonbuild/interpreterbase/baseobjects.py
@@ -3,16 +3,16 @@
 
 from __future__ import annotations
 
-from .. import mparser
-from .exceptions import InvalidCode, InvalidArguments
-from .helpers import flatten, resolve_second_level_holders
-from .operator import MesonOperator
-from ..mesonlib import HoldableObject, MesonBugException
 import textwrap
-
 import typing as T
 from abc import ABCMeta
 from contextlib import AbstractContextManager
+
+from .. import mparser
+from ..mesonlib import HoldableObject, MesonBugException
+from .exceptions import InvalidArguments, InvalidCode
+from .helpers import flatten, resolve_second_level_holders
+from .operator import MesonOperator
 
 if T.TYPE_CHECKING:
     from typing_extensions import Protocol

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -3,23 +3,23 @@
 
 from __future__ import annotations
 
-from .. import mesonlib, mlog
-from .disabler import Disabler
-from .exceptions import InterpreterException, InvalidArguments
-from ._unholder import _unholder
-
+import abc
+import copy
+import itertools
+import typing as T
 from dataclasses import dataclass
 from functools import wraps
-import abc
-import itertools
-import copy
-import typing as T
+
+from .. import mesonlib, mlog
+from ._unholder import _unholder
+from .disabler import Disabler
+from .exceptions import InterpreterException, InvalidArguments
 
 if T.TYPE_CHECKING:
     from typing_extensions import Protocol
 
     from .. import mparser
-    from .baseobjects import InterpreterObject, SubProject, TV_func, TYPE_var, TYPE_kwargs
+    from .baseobjects import InterpreterObject, SubProject, TV_func, TYPE_kwargs, TYPE_var
     from .operator import MesonOperator
 
     _TV_IntegerObject = T.TypeVar('_TV_IntegerObject', bound=InterpreterObject, contravariant=True)

--- a/mesonbuild/interpreterbase/disabler.py
+++ b/mesonbuild/interpreterbase/disabler.py
@@ -8,7 +8,7 @@ import typing as T
 from .baseobjects import MesonInterpreterObject
 
 if T.TYPE_CHECKING:
-    from .baseobjects import TYPE_var, TYPE_kwargs
+    from .baseobjects import TYPE_kwargs, TYPE_var
 
 class Disabler(MesonInterpreterObject):
     def method_call(self, method_name: str, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> TYPE_var:

--- a/mesonbuild/interpreterbase/exceptions.py
+++ b/mesonbuild/interpreterbase/exceptions.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2013-2021 The Meson development team
 
+from __future__ import annotations
+
 from ..mesonlib import MesonException
+
 
 class InterpreterException(MesonException):
     pass

--- a/mesonbuild/interpreterbase/helpers.py
+++ b/mesonbuild/interpreterbase/helpers.py
@@ -3,16 +3,15 @@
 
 from __future__ import annotations
 
-from .. import mesonlib, mparser
-from .exceptions import InterpreterException, InvalidArguments
-from ..coredata import UserOption
-
-
 import collections.abc
 import typing as T
 
+from .. import mesonlib, mparser
+from ..coredata import UserOption
+from .exceptions import InterpreterException, InvalidArguments
+
 if T.TYPE_CHECKING:
-    from .baseobjects import TYPE_var, TYPE_kwargs, SubProject
+    from .baseobjects import SubProject, TYPE_kwargs, TYPE_var
 
 def flatten(args: T.Union['TYPE_var', T.List['TYPE_var']]) -> T.List['TYPE_var']:
     if isinstance(args, mparser.BaseStringNode):

--- a/mesonbuild/interpreterbase/interpreterbase.py
+++ b/mesonbuild/interpreterbase/interpreterbase.py
@@ -3,41 +3,33 @@
 
 from __future__ import annotations
 
-from .. import environment, mparser, mesonlib
+import copy
+import os
+import pathlib
+import re
+import textwrap
+import typing as T
 
+from .. import environment, mesonlib, mparser
+from ._unholder import _unholder
 from .baseobjects import (
-    InterpreterObject,
-    MesonInterpreterObject,
-    MutableInterpreterObject,
-    ObjectHolder,
-    IterableObject,
-    ContextManagerObject,
-
-    HoldableTypes,
+    ContextManagerObject, HoldableTypes, InterpreterObject, IterableObject, MesonInterpreterObject,
+    MutableInterpreterObject, ObjectHolder
 )
-
-from .exceptions import (
-    BreakRequest,
-    ContinueRequest,
-    InterpreterException,
-    InvalidArguments,
-    InvalidCode,
-    SubdirDoneRequest,
-)
-
 from .decorators import FeatureNew
 from .disabler import Disabler, is_disabled
-from .helpers import default_resolve_key, flatten, resolve_second_level_holders, stringifyUserArguments
+from .exceptions import (
+    BreakRequest, ContinueRequest, InterpreterException, InvalidArguments, InvalidCode,
+    SubdirDoneRequest
+)
+from .helpers import (
+    default_resolve_key, flatten, resolve_second_level_holders, stringifyUserArguments
+)
 from .operator import MesonOperator
-from ._unholder import _unholder
-
-import os, copy, re, pathlib
-import typing as T
-import textwrap
 
 if T.TYPE_CHECKING:
-    from .baseobjects import InterpreterObjectTypeVar, SubProject, TYPE_kwargs, TYPE_var
     from ..interpreter import Interpreter
+    from .baseobjects import InterpreterObjectTypeVar, SubProject, TYPE_kwargs, TYPE_var
 
     HolderMapType = T.Dict[
         T.Union[

--- a/mesonbuild/interpreterbase/interpreterbase.py
+++ b/mesonbuild/interpreterbase/interpreterbase.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016-2017 The Meson development team
 
-# This class contains the basic functionality needed to run any interpreter
-# or an interpreter-based tool.
 from __future__ import annotations
 
 from .. import environment, mparser, mesonlib

--- a/mesonbuild/interpreterbase/operator.py
+++ b/mesonbuild/interpreterbase/operator.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from enum import Enum
+
 
 class MesonOperator(Enum):
     # Arithmetic

--- a/mesonbuild/linkers/__init__.py
+++ b/mesonbuild/linkers/__init__.py
@@ -1,12 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2012-2021 The Meson development team
 
+from __future__ import annotations
+
 from .base import ArLikeLinker, RSPFileSyntax
-from .detect import (
-    defaults,
-    guess_win_linker,
-    guess_nix_linker,
-)
+from .detect import defaults, guess_nix_linker, guess_win_linker
 
 __all__ = [
     # base.py

--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -3,21 +3,20 @@
 
 from __future__ import annotations
 
-from .. import mlog
-from ..mesonlib import (
-    EnvironmentException,
-    Popen_safe, Popen_safe_logged, join_args, search_version
-)
-
 import re
 import shlex
 import typing as T
 
+from .. import mlog
+from ..mesonlib import (
+    EnvironmentException, Popen_safe, Popen_safe_logged, join_args, search_version
+)
+
 if T.TYPE_CHECKING:
-    from .linkers import DynamicLinker, GnuDynamicLinker
-    from ..environment import Environment
     from ..compilers import Compiler
+    from ..environment import Environment
     from ..mesonlib import MachineChoice
+    from .linkers import DynamicLinker, GnuDynamicLinker
 
 defaults: T.Dict[str, T.List[str]] = {}
 defaults['static_linker'] = ['ar', 'gar']

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 
 import abc
 import os
-import typing as T
 import re
+import typing as T
 
-from .base import ArLikeLinker, RSPFileSyntax
 from .. import mesonlib
-from ..mesonlib import EnvironmentException, MesonException
 from ..arglist import CompilerArgs
+from ..mesonlib import EnvironmentException, MesonException
+from .base import ArLikeLinker, RSPFileSyntax
 
 if T.TYPE_CHECKING:
     from ..coredata import KeyedOptionDictType

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -5,21 +5,21 @@ from __future__ import annotations
 
 """Entrypoint script for backend agnostic compile."""
 
-import os
 import json
+import os
 import re
-import sys
 import shutil
+import sys
 import typing as T
 from collections import defaultdict
 from pathlib import Path
 
-from . import mlog
-from . import mesonlib
-from .mesonlib import MesonException, RealPathAction, join_args, setup_vsenv
-from mesonbuild.environment import detect_ninja
-from mesonbuild.coredata import UserArrayOption
 from mesonbuild import build
+from mesonbuild.coredata import UserArrayOption
+from mesonbuild.environment import detect_ninja
+
+from . import mesonlib, mlog
+from .mesonlib import MesonException, RealPathAction, join_args, setup_vsenv
 
 if T.TYPE_CHECKING:
     import argparse

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -3,19 +3,14 @@
 
 from __future__ import annotations
 
+import collections
 import itertools
-import shutil
 import os
+import shutil
 import textwrap
 import typing as T
-import collections
 
-from . import build
-from . import coredata
-from . import environment
-from . import mesonlib
-from . import mintro
-from . import mlog
+from . import build, coredata, environment, mesonlib, mintro, mlog
 from .ast import AstIDGenerator, IntrospectionInterpreter
 from .mesonlib import MachineChoice, OptionKey
 

--- a/mesonbuild/mdevenv.py
+++ b/mesonbuild/mdevenv.py
@@ -1,18 +1,19 @@
 from __future__ import annotations
 
-import os, subprocess
 import argparse
-import tempfile
-import shutil
 import itertools
+import os
+import shutil
+import subprocess
+import tempfile
 import typing as T
-
 from pathlib import Path
-from . import build, minstall
-from .mesonlib import (EnvironmentVariables, MesonException, is_windows, setup_vsenv, OptionKey,
-                       get_wine_shortpath, MachineChoice)
-from . import mlog
 
+from . import build, minstall, mlog
+from .mesonlib import (
+    EnvironmentVariables, MachineChoice, MesonException, OptionKey, get_wine_shortpath, is_windows,
+    setup_vsenv
+)
 
 if T.TYPE_CHECKING:
     from .backend.backends import InstallData

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -3,29 +3,30 @@
 
 from __future__ import annotations
 
-
 import abc
 import argparse
 import gzip
+import hashlib
 import os
-import sys
 import shlex
 import shutil
 import subprocess
+import sys
 import tarfile
 import tempfile
-import hashlib
 import typing as T
-
 from dataclasses import dataclass
 from glob import glob
 from pathlib import Path
+
+from mesonbuild import build, coredata, mlog
 from mesonbuild.environment import detect_ninja
-from mesonbuild.mesonlib import (MesonException, RealPathAction, quiet_git,
-                                 windows_proof_rmtree, setup_vsenv, OptionKey)
+from mesonbuild.mesonlib import (
+    MesonException, OptionKey, RealPathAction, quiet_git, setup_vsenv, windows_proof_rmtree
+)
 from mesonbuild.msetup import add_arguments as msetup_argparse
 from mesonbuild.wrap import wrap
-from mesonbuild import mlog, build, coredata
+
 from .scripts.meson_exe import run_exe
 
 if T.TYPE_CHECKING:

--- a/mesonbuild/mesondata.py
+++ b/mesonbuild/mesondata.py
@@ -3,10 +3,9 @@
 
 from __future__ import annotations
 
-
 import importlib.resources
-from pathlib import PurePosixPath, Path
 import typing as T
+from pathlib import Path, PurePosixPath
 
 if T.TYPE_CHECKING:
     from .environment import Environment

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -1,7 +1,7 @@
 # SPDX-license-identifier: Apache-2.0
 # Copyright 2012-2021 The Meson development team
 # Copyright © 2021-2023 Intel Corporation
-
+#
 # pylint: skip-file
 
 """Helper functions and classes."""

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -6,12 +6,13 @@
 
 """Helper functions and classes."""
 
+from __future__ import annotations
+
 import os
 
 from .utils.core import *
-from .utils.vsenv import *
-
 from .utils.universal import *
+from .utils.vsenv import *
 
 # Here we import either the posix implementations, the windows implementations,
 # or a generic no-op implementation

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -3,22 +3,25 @@
 
 from __future__ import annotations
 
-# Work around some pathlib bugs...
+import sys
 
 from . import _pathlib
-import sys
+
+# Work around some pathlib bugs...
+
 sys.modules['pathlib'] = _pathlib
 
+import argparse
+import importlib
 # This file is an entry point for all commands, including scripts. Include the
 # strict minimum python modules for performance reasons.
 import os.path
 import platform
-import importlib
-import argparse
 import typing as T
 
-from .utils.core import MesonException, MesonBugException
 from . import mlog
+from .utils.core import MesonBugException, MesonException
+
 
 def errorhandler(e: Exception, command: str) -> int:
     import traceback
@@ -61,10 +64,14 @@ def errorhandler(e: Exception, command: str) -> int:
 class CommandLineParser:
     def __init__(self) -> None:
         # only import these once we do full argparse processing
-        from . import mconf, mdist, minit, minstall, mintro, msetup, mtest, rewriter, msubprojects, munstable_coredata, mcompile, mdevenv
+        import shutil
+
+        from . import (
+            mcompile, mconf, mdevenv, mdist, minit, minstall, mintro, msetup, msubprojects, mtest,
+            munstable_coredata, rewriter
+        )
         from .scripts import env2mfile
         from .wrap import wraptool
-        import shutil
 
         self.term_width = shutil.get_terminal_size().columns
         self.formatter = lambda prog: argparse.HelpFormatter(prog, max_help_position=int(self.term_width / 2), width=self.term_width)

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -5,15 +5,15 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-from enum import Enum
-import subprocess
-import shutil
-import sys
 import os
 import re
-from glob import glob
+import shutil
+import subprocess
+import sys
 import typing as T
+from enum import Enum
+from glob import glob
+from pathlib import Path
 
 from mesonbuild import build, mesonlib, mlog
 from mesonbuild.coredata import FORBIDDEN_TARGET_NAMES
@@ -24,7 +24,7 @@ from mesonbuild.templates.samplefactory import sample_generator
 if T.TYPE_CHECKING:
     import argparse
 
-    from typing_extensions import Protocol, Literal
+    from typing_extensions import Literal, Protocol
 
     class Arguments(Protocol):
 

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -3,24 +3,27 @@
 
 from __future__ import annotations
 
-from glob import glob
 import argparse
 import errno
 import os
+import re
 import selectors
 import shlex
 import shutil
 import subprocess
 import sys
 import typing as T
-import re
+from glob import glob
 
 from . import build, environment
 from .backend.backends import InstallData
-from .mesonlib import (MesonException, Popen_safe, RealPathAction, is_windows,
-                       is_aix, setup_vsenv, pickle_load, is_osx, OptionKey)
+from .mesonlib import (
+    MesonException, OptionKey, Popen_safe, RealPathAction, is_aix, is_osx, is_windows, pickle_load,
+    setup_vsenv
+)
 from .scripts import depfixer, destdir_join
 from .scripts.meson_exe import run_exe
+
 try:
     from __main__ import __file__ as main_file
 except ImportError:
@@ -30,10 +33,9 @@ except ImportError:
 
 if T.TYPE_CHECKING:
     from .backend.backends import (
-            InstallDataBase, InstallEmptyDir,
-            InstallSymlinkData, TargetInstallData
+        InstallDataBase, InstallEmptyDir, InstallSymlinkData, TargetInstallData
     )
-    from .mesonlib import FileMode, EnvironOrDict, ExecutableSerialisation
+    from .mesonlib import EnvironOrDict, ExecutableSerialisation, FileMode
 
     try:
         from typing import Protocol

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -10,23 +10,27 @@ tests and so on. All output is in JSON for simple parsing.
 Currently only works for the Ninja backend. Others use generated
 project files and don't need this info."""
 
-from contextlib import redirect_stdout
 import collections
 import dataclasses
 import json
 import os
-from pathlib import Path, PurePath
 import sys
 import typing as T
+from contextlib import redirect_stdout
+from pathlib import Path, PurePath
 
-from . import build, mesonlib, coredata as cdata
-from .ast import IntrospectionInterpreter, BUILD_TARGET_FUNCTIONS, AstConditionLevel, AstIDGenerator, AstIndentationGenerator, AstJSONPrinter
+from . import build
+from . import coredata as cdata
+from . import environment, mesonlib
+from .ast import (
+    BUILD_TARGET_FUNCTIONS, AstConditionLevel, AstIDGenerator, AstIndentationGenerator,
+    AstJSONPrinter, IntrospectionInterpreter
+)
 from .backend import backends
 from .dependencies import Dependency
-from . import environment
 from .interpreterbase import ObjectHolder
 from .mesonlib import OptionKey
-from .mparser import FunctionNode, ArrayNode, ArgumentNode, BaseStringNode
+from .mparser import ArgumentNode, ArrayNode, BaseStringNode, FunctionNode
 
 if T.TYPE_CHECKING:
     import argparse

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -8,22 +8,21 @@ some to logging dir and some goes to both."""
 from __future__ import annotations
 
 import enum
-import os
 import io
-import sys
-import time
+import os
 import platform
 import shlex
-import subprocess
 import shutil
+import subprocess
+import sys
+import time
 import typing as T
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 
 if T.TYPE_CHECKING:
-    from ._typing import StringProtocol, SizedStringProtocol
-
+    from ._typing import SizedStringProtocol, StringProtocol
     from .mparser import BaseNode
 
     TV_Loggable = T.Union[str, 'AnsiDecorator', StringProtocol]
@@ -35,7 +34,7 @@ def is_windows() -> bool:
 
 def _windows_ansi() -> bool:
     # windll only exists on windows, so mypy will get mad
-    from ctypes import windll, byref  # type: ignore
+    from ctypes import byref, windll  # type: ignore
     from ctypes.wintypes import DWORD
 
     kernel = windll.kernel32

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
 
-# This file contains the base representation for import('modname')
+"""Module implementation."""
 
 from __future__ import annotations
 import dataclasses

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -4,22 +4,23 @@
 """Module implementation."""
 
 from __future__ import annotations
+
 import dataclasses
 import typing as T
 
 from .. import build, mesonlib
 from ..build import IncludeDirs
 from ..interpreterbase.decorators import noKwargs, noPosargs
-from ..mesonlib import relpath, HoldableObject, MachineChoice
+from ..mesonlib import HoldableObject, MachineChoice, relpath
 from ..programs import ExternalProgram
 
 if T.TYPE_CHECKING:
+    from ..dependencies import Dependency
     from ..interpreter import Interpreter
     from ..interpreter.interpreter import ProgramVersionFunc
-    from ..interpreterbase import TYPE_var, TYPE_kwargs
+    from ..interpreterbase import TYPE_kwargs, TYPE_var
     from ..programs import OverrideProgram
     from ..wrap import WrapMode
-    from ..dependencies import Dependency
 
 class ModuleState:
     """Object passed to all module methods.

--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -2,43 +2,32 @@
 # Copyright 2018 The Meson development team
 
 from __future__ import annotations
+
+import os
+import os.path
+import pathlib
 import re
-import os, os.path, pathlib
 import shutil
 import typing as T
 
-from . import ExtensionModule, ModuleReturnValue, ModuleObject, ModuleInfo
-
-from .. import build, mesonlib, mlog, dependencies
+from .. import build, dependencies, mesonlib, mlog
 from ..cmake import TargetOptions, cmake_defines_to_args
 from ..interpreter import SubprojectHolder
-from ..interpreter.type_checking import REQUIRED_KW, INSTALL_DIR_KW, NoneType, in_set_validator
+from ..interpreter.type_checking import INSTALL_DIR_KW, REQUIRED_KW, NoneType, in_set_validator
 from ..interpreterbase import (
-    FeatureNew,
-    FeatureNewKwargs,
-
-    stringArgs,
-    permittedKwargs,
-    noPosargs,
-    noKwargs,
-
-    InvalidArguments,
-    InterpreterException,
-
-    typed_pos_args,
-    typed_kwargs,
-    KwargInfo,
-    ContainerTypeInfo,
+    ContainerTypeInfo, FeatureNew, FeatureNewKwargs, InterpreterException, InvalidArguments,
+    KwargInfo, noKwargs, noPosargs, permittedKwargs, stringArgs, typed_kwargs, typed_pos_args
 )
+from . import ExtensionModule, ModuleInfo, ModuleObject, ModuleReturnValue
 
 if T.TYPE_CHECKING:
     from typing_extensions import TypedDict
 
-    from . import ModuleState
     from ..cmake import SingleTargetOptions
     from ..environment import Environment
     from ..interpreter import Interpreter, kwargs
     from ..interpreterbase import TYPE_kwargs, TYPE_var
+    from . import ModuleState
 
     class WriteBasicPackageVersionFile(TypedDict):
 

--- a/mesonbuild/modules/cuda.py
+++ b/mesonbuild/modules/cuda.py
@@ -3,22 +3,17 @@
 
 from __future__ import annotations
 
-import typing as T
 import re
+import typing as T
 
-from ..mesonlib import version_compare
 from ..compilers.cuda import CudaCompiler
-
-from . import NewExtensionModule, ModuleInfo
-
-from ..interpreterbase import (
-    flatten, permittedKwargs, noKwargs,
-    InvalidArguments
-)
+from ..interpreterbase import InvalidArguments, flatten, noKwargs, permittedKwargs
+from ..mesonlib import version_compare
+from . import ModuleInfo, NewExtensionModule
 
 if T.TYPE_CHECKING:
-    from . import ModuleState
     from ..compilers import Compiler
+    from . import ModuleState
 
 class CudaModule(NewExtensionModule):
 

--- a/mesonbuild/modules/dlang.py
+++ b/mesonbuild/modules/dlang.py
@@ -8,12 +8,13 @@ from __future__ import annotations
 import json
 import os
 
-from . import ExtensionModule, ModuleInfo
 from .. import mlog
 from ..dependencies import Dependency
 from ..dependencies.dub import DubDependency
 from ..interpreterbase import typed_pos_args
-from ..mesonlib import Popen_safe, MesonException, listify
+from ..mesonlib import MesonException, Popen_safe, listify
+from . import ExtensionModule, ModuleInfo
+
 
 class DlangModule(ExtensionModule):
     class_dubbin = None

--- a/mesonbuild/modules/external_project.py
+++ b/mesonbuild/modules/external_project.py
@@ -3,34 +3,36 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import os
 import shlex
 import subprocess
 import typing as T
+from pathlib import Path
 
-from . import ExtensionModule, ModuleReturnValue, NewExtensionModule, ModuleInfo
-from .. import mlog, build
+from .. import build, mlog
 from ..compilers.compilers import CFLAGS_MAPPING
-from ..envconfig import ENV_VAR_PROG_MAP
 from ..dependencies import InternalDependency
 from ..dependencies.pkgconfig import PkgConfigInterface
+from ..envconfig import ENV_VAR_PROG_MAP
+from ..interpreter.type_checking import DEPENDS_KW, ENV_KW
 from ..interpreterbase import FeatureNew
-from ..interpreter.type_checking import ENV_KW, DEPENDS_KW
 from ..interpreterbase.decorators import ContainerTypeInfo, KwargInfo, typed_kwargs, typed_pos_args
-from ..mesonlib import (EnvironmentException, MesonException, Popen_safe, MachineChoice,
-                        get_variable_regex, do_replacement, join_args, OptionKey)
+from ..mesonlib import (
+    EnvironmentException, MachineChoice, MesonException, OptionKey, Popen_safe, do_replacement,
+    get_variable_regex, join_args
+)
+from . import ExtensionModule, ModuleInfo, ModuleReturnValue, NewExtensionModule
 
 if T.TYPE_CHECKING:
     from typing_extensions import TypedDict
 
-    from . import ModuleState
     from .._typing import ImmutableListProtocol
     from ..build import BuildTarget, CustomTarget
     from ..interpreter import Interpreter
     from ..interpreterbase import TYPE_var
     from ..mesonlib import EnvironmentVariables
     from ..utils.core import EnvironOrDict
+    from . import ModuleState
 
     class Dependency(TypedDict):
 

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -2,26 +2,27 @@
 # Copyright 2019 The Meson development team
 
 from __future__ import annotations
-from pathlib import Path, PurePath, PureWindowsPath
+
 import hashlib
 import os
 import typing as T
+from pathlib import Path, PurePath, PureWindowsPath
 
-from . import ExtensionModule, ModuleReturnValue, ModuleInfo
 from .. import mlog
 from ..build import BuildTarget, CustomTarget, CustomTargetIndex, InvalidArguments
 from ..interpreter.type_checking import INSTALL_KW, INSTALL_MODE_KW, INSTALL_TAG_KW, NoneType
-from ..interpreterbase import FeatureNew, KwargInfo, typed_kwargs, typed_pos_args, noKwargs
+from ..interpreterbase import FeatureNew, KwargInfo, noKwargs, typed_kwargs, typed_pos_args
 from ..mesonlib import File, MesonException, has_path_sep, path_is_in_root, relpath
+from . import ExtensionModule, ModuleInfo, ModuleReturnValue
 
 if T.TYPE_CHECKING:
-    from . import ModuleState
+    from typing_extensions import TypedDict
+
     from ..build import BuildTargetTypes
     from ..interpreter import Interpreter
     from ..interpreterbase import TYPE_kwargs
-    from ..mesonlib import FileOrString, FileMode
-
-    from typing_extensions import TypedDict
+    from ..mesonlib import FileMode, FileOrString
+    from . import ModuleState
 
     class ReadKwArgs(TypedDict):
         """Keyword Arguments for fs.read."""

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -6,44 +6,43 @@ functionality such as gobject-introspection, gresources and gtk-doc'''
 from __future__ import annotations
 
 import copy
-import itertools
 import functools
+import itertools
 import os
 import subprocess
 import textwrap
 import typing as T
 
-from . import (
-    ExtensionModule, GirTarget, GResourceHeaderTarget, GResourceTarget, ModuleInfo,
-    ModuleReturnValue, TypelibTarget, VapiTarget,
-)
-from .. import build
-from .. import interpreter
-from .. import mesonlib
-from .. import mlog
+from .. import build, interpreter, mesonlib, mlog
 from ..build import CustomTarget, CustomTargetIndex, Executable, GeneratedList, InvalidArguments
 from ..dependencies import Dependency, InternalDependency
 from ..dependencies.pkgconfig import PkgConfigDependency, PkgConfigInterface
-from ..interpreter.type_checking import DEPENDS_KW, DEPEND_FILES_KW, ENV_KW, INSTALL_DIR_KW, INSTALL_KW, NoneType, DEPENDENCY_SOURCES_KW, in_set_validator
-from ..interpreterbase import noPosargs, noKwargs, FeatureNew, FeatureDeprecated
-from ..interpreterbase import typed_kwargs, KwargInfo, ContainerTypeInfo
-from ..interpreterbase.decorators import typed_pos_args
-from ..mesonlib import (
-    MachineChoice, MesonException, OrderedSet, Popen_safe, join_args, quote_arg
+from ..interpreter.type_checking import (
+    DEPEND_FILES_KW, DEPENDENCY_SOURCES_KW, DEPENDS_KW, ENV_KW, INSTALL_DIR_KW, INSTALL_KW,
+    NoneType, in_set_validator
 )
+from ..interpreterbase import (
+    ContainerTypeInfo, FeatureDeprecated, FeatureNew, KwargInfo, noKwargs, noPosargs, typed_kwargs
+)
+from ..interpreterbase.decorators import typed_pos_args
+from ..mesonlib import MachineChoice, MesonException, OrderedSet, Popen_safe, join_args, quote_arg
 from ..programs import OverrideProgram
 from ..scripts.gettext import read_linguas
+from . import (
+    ExtensionModule, GirTarget, GResourceHeaderTarget, GResourceTarget, ModuleInfo,
+    ModuleReturnValue, TypelibTarget, VapiTarget
+)
 
 if T.TYPE_CHECKING:
     from typing_extensions import Literal, TypedDict
 
-    from . import ModuleState
     from ..build import BuildTarget
     from ..compilers import Compiler
     from ..interpreter import Interpreter
-    from ..interpreterbase import TYPE_var, TYPE_kwargs
+    from ..interpreterbase import TYPE_kwargs, TYPE_var
     from ..mesonlib import FileOrString
     from ..programs import ExternalProgram
+    from . import ModuleState
 
     class PostInstall(TypedDict):
         glib_compile_schemas: bool

--- a/mesonbuild/modules/hotdoc.py
+++ b/mesonbuild/modules/hotdoc.py
@@ -5,29 +5,30 @@ from __future__ import annotations
 
 '''This module provides helper functions for generating documentation using hotdoc'''
 
-import os, subprocess
+import os
+import subprocess
 import typing as T
 
-from . import ExtensionModule, ModuleReturnValue, ModuleInfo
 from .. import build, mesonlib, mlog
 from ..build import CustomTarget, CustomTargetIndex
 from ..dependencies import Dependency, InternalDependency
-from ..interpreterbase import (
-    InvalidArguments, noPosargs, noKwargs, typed_kwargs, FeatureDeprecated,
-    ContainerTypeInfo, KwargInfo, typed_pos_args
-)
 from ..interpreter.interpreterobjects import _CustomTargetHolder
 from ..interpreter.type_checking import NoneType
+from ..interpreterbase import (
+    ContainerTypeInfo, FeatureDeprecated, InvalidArguments, KwargInfo, noKwargs, noPosargs,
+    typed_kwargs, typed_pos_args
+)
 from ..mesonlib import File, MesonException
 from ..programs import ExternalProgram
+from . import ExtensionModule, ModuleInfo, ModuleReturnValue
 
 if T.TYPE_CHECKING:
     from typing_extensions import TypedDict
 
-    from . import ModuleState
     from ..environment import Environment
     from ..interpreter import Interpreter
     from ..interpreterbase import TYPE_kwargs, TYPE_var
+    from . import ModuleState
 
     _T = T.TypeVar('_T')
 

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -3,27 +3,30 @@
 
 from __future__ import annotations
 
-from os import path
 import shlex
 import typing as T
+from os import path
 
-from . import ExtensionModule, ModuleReturnValue, ModuleInfo
-from .. import build
-from .. import mesonlib
-from .. import mlog
-from ..interpreter.type_checking import CT_BUILD_BY_DEFAULT, CT_INPUT_KW, INSTALL_TAG_KW, OUTPUT_KW, INSTALL_DIR_KW, INSTALL_KW, NoneType, in_set_validator
+from .. import build, mesonlib, mlog
+from ..interpreter.type_checking import (
+    CT_BUILD_BY_DEFAULT, CT_INPUT_KW, INSTALL_DIR_KW, INSTALL_KW, INSTALL_TAG_KW, OUTPUT_KW,
+    NoneType, in_set_validator
+)
 from ..interpreterbase import FeatureNew
-from ..interpreterbase.decorators import ContainerTypeInfo, KwargInfo, noPosargs, typed_kwargs, typed_pos_args
+from ..interpreterbase.decorators import (
+    ContainerTypeInfo, KwargInfo, noPosargs, typed_kwargs, typed_pos_args
+)
 from ..programs import ExternalProgram
 from ..scripts.gettext import read_linguas
+from . import ExtensionModule, ModuleInfo, ModuleReturnValue
 
 if T.TYPE_CHECKING:
     from typing_extensions import Literal, TypedDict
 
-    from . import ModuleState
     from ..build import Target
     from ..interpreter import Interpreter
     from ..interpreterbase import TYPE_var
+    from . import ModuleState
 
     class MergeFile(TypedDict):
 

--- a/mesonbuild/modules/icestorm.py
+++ b/mesonbuild/modules/icestorm.py
@@ -2,21 +2,21 @@
 # Copyright 2017 The Meson development team
 
 from __future__ import annotations
+
 import itertools
 import typing as T
 
-from . import ExtensionModule, ModuleReturnValue, ModuleInfo
-from .. import build
-from .. import mesonlib
+from .. import build, mesonlib
 from ..interpreter.type_checking import CT_INPUT_KW
 from ..interpreterbase.decorators import KwargInfo, typed_kwargs, typed_pos_args
+from . import ExtensionModule, ModuleInfo, ModuleReturnValue
 
 if T.TYPE_CHECKING:
     from typing_extensions import TypedDict
 
-    from . import ModuleState
     from ..interpreter import Interpreter
     from ..programs import ExternalProgram
+    from . import ModuleState
 
     class ProjectKwargs(TypedDict):
 

--- a/mesonbuild/modules/java.py
+++ b/mesonbuild/modules/java.py
@@ -9,15 +9,18 @@ import typing as T
 from mesonbuild import mesonlib
 from mesonbuild.build import CustomTarget, CustomTargetIndex, GeneratedList, Target
 from mesonbuild.compilers import detect_compiler_for
-from mesonbuild.interpreterbase.decorators import ContainerTypeInfo, FeatureDeprecated, FeatureNew, KwargInfo, typed_pos_args, typed_kwargs
-from mesonbuild.mesonlib import version_compare, MachineChoice
-from . import NewExtensionModule, ModuleReturnValue, ModuleInfo
+from mesonbuild.interpreterbase.decorators import (
+    ContainerTypeInfo, FeatureDeprecated, FeatureNew, KwargInfo, typed_kwargs, typed_pos_args
+)
+from mesonbuild.mesonlib import MachineChoice, version_compare
+
 from ..interpreter.type_checking import NoneType
+from . import ModuleInfo, ModuleReturnValue, NewExtensionModule
 
 if T.TYPE_CHECKING:
-    from . import ModuleState
     from ..compilers import Compiler
     from ..interpreter import Interpreter
+    from . import ModuleState
 
 class JavaModule(NewExtensionModule):
 

--- a/mesonbuild/modules/keyval.py
+++ b/mesonbuild/modules/keyval.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 import os
 import typing as T
 
-from . import ExtensionModule, ModuleInfo
 from .. import mesonlib
 from ..interpreterbase import noKwargs, typed_pos_args
+from . import ExtensionModule, ModuleInfo
 
 if T.TYPE_CHECKING:
     from ..interpreter import Interpreter

--- a/mesonbuild/modules/modtest.py
+++ b/mesonbuild/modules/modtest.py
@@ -2,15 +2,16 @@
 # Copyright 2015 The Meson development team
 
 from __future__ import annotations
+
 import typing as T
 
-from . import NewExtensionModule, ModuleInfo
 from ..interpreterbase import noKwargs, noPosargs
+from . import ModuleInfo, NewExtensionModule
 
 if T.TYPE_CHECKING:
-    from . import ModuleState
     from ..interpreter.interpreter import Interpreter
     from ..interpreterbase.baseobjects import TYPE_kwargs, TYPE_var
+    from . import ModuleState
 
 
 class TestModule(NewExtensionModule):

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -2,30 +2,27 @@
 # Copyright 2015-2022 The Meson development team
 
 from __future__ import annotations
+
+import os
+import typing as T
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import PurePath
-import os
-import typing as T
 
-from . import NewExtensionModule, ModuleInfo
-from . import ModuleReturnValue
-from .. import build
-from .. import dependencies
-from .. import mesonlib
-from .. import mlog
+from .. import build, dependencies, mesonlib, mlog
 from ..coredata import BUILTIN_DIR_OPTIONS
 from ..dependencies.pkgconfig import PkgConfigDependency, PkgConfigInterface
 from ..interpreter.type_checking import D_MODULE_VERSIONS_KW, INSTALL_DIR_KW, VARIABLES_KW, NoneType
-from ..interpreterbase import FeatureNew, FeatureDeprecated
+from ..interpreterbase import FeatureDeprecated, FeatureNew
 from ..interpreterbase.decorators import ContainerTypeInfo, KwargInfo, typed_kwargs, typed_pos_args
+from . import ModuleInfo, ModuleReturnValue, NewExtensionModule
 
 if T.TYPE_CHECKING:
     from typing_extensions import TypedDict
 
-    from . import ModuleState
     from .. import mparser
     from ..interpreter import Interpreter
+    from . import ModuleState
 
     ANY_DEP = T.Union[dependencies.Dependency, build.BuildTargetTypes, str]
     LIBS = T.Union[build.LibTypes, str]

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -3,38 +3,45 @@
 
 from __future__ import annotations
 
-import copy, json, os, shutil, re
+import copy
+import json
+import os
+import re
+import shutil
 import typing as T
 
-from . import ExtensionModule, ModuleInfo
-from .. import mesonlib
-from .. import mlog
+from .. import mesonlib, mlog
+from ..build import (
+    BuildTarget, CustomTarget, CustomTargetIndex, ExtractedObjects, GeneratedList, SharedModule,
+    StructuredSources, known_shmod_kwargs
+)
 from ..coredata import UserFeatureOption
-from ..build import known_shmod_kwargs, CustomTarget, CustomTargetIndex, BuildTarget, GeneratedList, StructuredSources, ExtractedObjects, SharedModule
 from ..dependencies import NotFoundDependency
-from ..dependencies.detect import get_dep_identifier, find_external_dependency
-from ..dependencies.python import BasicPythonExternalProgram, python_factory, _PythonDependencyBase
-from ..interpreter import extract_required_kwarg, permitted_dependency_kwargs, primitives as P_OBJ
+from ..dependencies.detect import find_external_dependency, get_dep_identifier
+from ..dependencies.python import BasicPythonExternalProgram, _PythonDependencyBase, python_factory
+from ..interpreter import extract_required_kwarg, permitted_dependency_kwargs
+from ..interpreter import primitives as P_OBJ
 from ..interpreter.interpreterobjects import _ExternalProgramHolder
-from ..interpreter.type_checking import NoneType, PRESERVE_PATH_KW, SHARED_MOD_KWS
+from ..interpreter.type_checking import PRESERVE_PATH_KW, SHARED_MOD_KWS, NoneType
 from ..interpreterbase import (
-    noPosargs, noKwargs, permittedKwargs, ContainerTypeInfo,
-    InvalidArguments, typed_pos_args, typed_kwargs, KwargInfo,
-    FeatureNew, FeatureNewKwargs, disablerIfNotFound
+    ContainerTypeInfo, FeatureNew, FeatureNewKwargs, InvalidArguments, KwargInfo,
+    disablerIfNotFound, noKwargs, noPosargs, permittedKwargs, typed_kwargs, typed_pos_args
 )
 from ..mesonlib import MachineChoice, OptionKey
 from ..programs import ExternalProgram, NonExistingExternalProgram
+from . import ExtensionModule, ModuleInfo
 
 if T.TYPE_CHECKING:
-    from typing_extensions import TypedDict, NotRequired
+    from typing_extensions import NotRequired, TypedDict
 
-    from . import ModuleState
     from ..build import Build, Data
     from ..dependencies import Dependency
     from ..interpreter import Interpreter
     from ..interpreter.interpreter import BuildTargetSource
-    from ..interpreter.kwargs import ExtractRequired, SharedModule as SharedModuleKw
-    from ..interpreterbase.baseobjects import TYPE_var, TYPE_kwargs
+    from ..interpreter.kwargs import ExtractRequired
+    from ..interpreter.kwargs import SharedModule as SharedModuleKw
+    from ..interpreterbase.baseobjects import TYPE_kwargs, TYPE_var
+    from . import ModuleState
 
     class PyInstallKw(TypedDict):
 

--- a/mesonbuild/modules/python3.py
+++ b/mesonbuild/modules/python3.py
@@ -7,14 +7,14 @@ import sysconfig
 import typing as T
 
 from .. import mesonlib
-from . import ExtensionModule, ModuleInfo, ModuleState
 from ..build import (
-    BuildTarget, CustomTarget, CustomTargetIndex, ExtractedObjects,
-    GeneratedList, SharedModule, StructuredSources, known_shmod_kwargs
+    BuildTarget, CustomTarget, CustomTargetIndex, ExtractedObjects, GeneratedList, SharedModule,
+    StructuredSources, known_shmod_kwargs
 )
 from ..interpreter.type_checking import SHARED_MOD_KWS
-from ..interpreterbase import typed_kwargs, typed_pos_args, noPosargs, noKwargs, permittedKwargs
+from ..interpreterbase import noKwargs, noPosargs, permittedKwargs, typed_kwargs, typed_pos_args
 from ..programs import ExternalProgram
+from . import ExtensionModule, ModuleInfo, ModuleState
 
 if T.TYPE_CHECKING:
     from ..interpreter.interpreter import BuildTargetSource

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -9,24 +9,23 @@ import shutil
 import typing as T
 import xml.etree.ElementTree as ET
 
-from . import ModuleReturnValue, ExtensionModule
-from .. import build
-from .. import coredata
-from .. import mlog
-from ..dependencies import find_external_dependency, Dependency, ExternalLibrary, InternalDependency
-from ..mesonlib import MesonException, File, version_compare, Popen_safe
+from .. import build, coredata, mlog
+from ..dependencies import Dependency, ExternalLibrary, InternalDependency, find_external_dependency
 from ..interpreter import extract_required_kwarg
 from ..interpreter.type_checking import INSTALL_DIR_KW, INSTALL_KW, NoneType
-from ..interpreterbase import ContainerTypeInfo, FeatureDeprecated, KwargInfo, noPosargs, FeatureNew, typed_kwargs
+from ..interpreterbase import (
+    ContainerTypeInfo, FeatureDeprecated, FeatureNew, KwargInfo, noPosargs, typed_kwargs
+)
+from ..mesonlib import File, MesonException, Popen_safe, version_compare
 from ..programs import NonExistingExternalProgram
+from . import ExtensionModule, ModuleReturnValue
 
 if T.TYPE_CHECKING:
-    from . import ModuleState
-    from ..dependencies.qt import QtPkgConfigDependency, QmakeQtDependency
-    from ..interpreter import Interpreter
-    from ..interpreter import kwargs
+    from ..dependencies.qt import QmakeQtDependency, QtPkgConfigDependency
+    from ..interpreter import Interpreter, kwargs
     from ..mesonlib import FileOrString
     from ..programs import ExternalProgram
+    from . import ModuleState
 
     QtDependencyType = T.Union[QtPkgConfigDependency, QmakeQtDependency]
 

--- a/mesonbuild/modules/qt4.py
+++ b/mesonbuild/modules/qt4.py
@@ -2,10 +2,11 @@
 # Copyright 2015 The Meson development team
 
 from __future__ import annotations
+
 import typing as T
 
-from .qt import QtBaseModule
 from . import ModuleInfo
+from .qt import QtBaseModule
 
 if T.TYPE_CHECKING:
     from ..interpreter import Interpreter

--- a/mesonbuild/modules/qt5.py
+++ b/mesonbuild/modules/qt5.py
@@ -2,10 +2,11 @@
 # Copyright 2015 The Meson development team
 
 from __future__ import annotations
+
 import typing as T
 
-from .qt import QtBaseModule
 from . import ModuleInfo
+from .qt import QtBaseModule
 
 if T.TYPE_CHECKING:
     from ..interpreter import Interpreter

--- a/mesonbuild/modules/qt6.py
+++ b/mesonbuild/modules/qt6.py
@@ -2,10 +2,11 @@
 # Copyright 2020 The Meson development team
 
 from __future__ import annotations
+
 import typing as T
 
-from .qt import QtBaseModule
 from . import ModuleInfo
+from .qt import QtBaseModule
 
 if T.TYPE_CHECKING:
     from ..interpreter import Interpreter

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -2,32 +2,41 @@
 # Copyright © 2020-2024 Intel Corporation
 
 from __future__ import annotations
+
 import itertools
 import os
 import typing as T
 
 from mesonbuild.interpreterbase.decorators import FeatureNew
 
-from . import ExtensionModule, ModuleReturnValue, ModuleInfo
 from .. import mlog
-from ..build import (BothLibraries, BuildTarget, CustomTargetIndex, Executable, ExtractedObjects, GeneratedList,
-                     CustomTarget, InvalidArguments, Jar, StructuredSources, SharedLibrary)
+from ..build import (
+    BothLibraries, BuildTarget, CustomTarget, CustomTargetIndex, Executable, ExtractedObjects,
+    GeneratedList, InvalidArguments, Jar, SharedLibrary, StructuredSources
+)
 from ..compilers.compilers import are_asserts_disabled
-from ..interpreter.type_checking import DEPENDENCIES_KW, LINK_WITH_KW, SHARED_LIB_KWS, TEST_KWS, OUTPUT_KW, INCLUDE_DIRECTORIES, SOURCES_VARARGS
-from ..interpreterbase import ContainerTypeInfo, InterpreterException, KwargInfo, typed_kwargs, typed_pos_args, noPosargs, permittedKwargs
+from ..interpreter.type_checking import (
+    DEPENDENCIES_KW, INCLUDE_DIRECTORIES, LINK_WITH_KW, OUTPUT_KW, SHARED_LIB_KWS, SOURCES_VARARGS,
+    TEST_KWS
+)
+from ..interpreterbase import (
+    ContainerTypeInfo, InterpreterException, KwargInfo, noPosargs, permittedKwargs, typed_kwargs,
+    typed_pos_args
+)
 from ..mesonlib import File
+from . import ExtensionModule, ModuleInfo, ModuleReturnValue
 
 if T.TYPE_CHECKING:
-    from . import ModuleState
+    from typing_extensions import TypedDict
+
     from ..build import IncludeDirs, LibTypes
     from ..dependencies import Dependency, ExternalLibrary
     from ..interpreter import Interpreter
     from ..interpreter import kwargs as _kwargs
     from ..interpreter.interpreter import SourceInputs, SourceOutputs
-    from ..programs import ExternalProgram, OverrideProgram
     from ..interpreter.type_checking import SourcesVarargsType
-
-    from typing_extensions import TypedDict
+    from ..programs import ExternalProgram, OverrideProgram
+    from . import ModuleState
 
     class FuncTest(_kwargs.BaseTest):
 

--- a/mesonbuild/modules/simd.py
+++ b/mesonbuild/modules/simd.py
@@ -5,18 +5,17 @@ from __future__ import annotations
 
 import typing as T
 
-from .. import mesonlib, mlog
-from .. import build
+from .. import build, mesonlib, mlog
 from ..compilers import Compiler
 from ..interpreter.type_checking import BT_SOURCES_KW, STATIC_LIB_KWS
-from ..interpreterbase.decorators import KwargInfo, permittedKwargs, typed_pos_args, typed_kwargs
-
+from ..interpreterbase.decorators import KwargInfo, permittedKwargs, typed_kwargs, typed_pos_args
 from . import ExtensionModule, ModuleInfo
 
 if T.TYPE_CHECKING:
-    from . import ModuleState
-    from ..interpreter import Interpreter, kwargs as kwtypes
+    from ..interpreter import Interpreter
+    from ..interpreter import kwargs as kwtypes
     from ..interpreter.type_checking import SourcesVarargsType
+    from . import ModuleState
 
     class CheckKw(kwtypes.StaticLibrary):
 

--- a/mesonbuild/modules/sourceset.py
+++ b/mesonbuild/modules/sourceset.py
@@ -2,25 +2,23 @@
 # Copyright 2019 The Meson development team
 
 from __future__ import annotations
+
 import typing as T
 
-from . import ExtensionModule, ModuleObject, MutableModuleObject, ModuleInfo
-from .. import build
-from .. import dependencies
-from .. import mesonlib
+from .. import build, dependencies, mesonlib
 from ..interpreterbase import (
-    noPosargs, noKwargs,
-    InterpreterException, InvalidArguments, InvalidCode, FeatureNew,
+    FeatureNew, InterpreterException, InvalidArguments, InvalidCode, noKwargs, noPosargs
 )
 from ..interpreterbase.decorators import ContainerTypeInfo, KwargInfo, typed_kwargs, typed_pos_args
 from ..mesonlib import OrderedSet
+from . import ExtensionModule, ModuleInfo, ModuleObject, MutableModuleObject
 
 if T.TYPE_CHECKING:
     from typing_extensions import TypedDict
 
-    from . import ModuleState
     from ..interpreter import Interpreter
-    from ..interpreterbase import TYPE_var, TYPE_kwargs
+    from ..interpreterbase import TYPE_kwargs, TYPE_var
+    from . import ModuleState
 
     class AddKwargs(TypedDict):
 

--- a/mesonbuild/modules/wayland.py
+++ b/mesonbuild/modules/wayland.py
@@ -2,24 +2,25 @@
 # Copyright 2022 Mark Bolhuis <mark@bolhuis.dev>
 
 from __future__ import annotations
+
 import os
 import typing as T
 
-from . import ExtensionModule, ModuleReturnValue, ModuleInfo
 from ..build import CustomTarget
 from ..interpreter.type_checking import NoneType, in_set_validator
-from ..interpreterbase import typed_pos_args, typed_kwargs, KwargInfo
+from ..interpreterbase import KwargInfo, typed_kwargs, typed_pos_args
 from ..mesonlib import File, MesonException
+from . import ExtensionModule, ModuleInfo, ModuleReturnValue
 
 if T.TYPE_CHECKING:
     from typing_extensions import Literal, TypedDict
 
-    from . import ModuleState
     from ..build import Executable
     from ..dependencies import Dependency
     from ..interpreter import Interpreter
-    from ..programs import ExternalProgram
     from ..mesonlib import FileOrString
+    from ..programs import ExternalProgram
+    from . import ModuleState
 
     class ScanXML(TypedDict):
 

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -8,22 +8,21 @@ import os
 import re
 import typing as T
 
-
-from . import ExtensionModule, ModuleInfo
-from . import ModuleReturnValue
-from .. import mesonlib, build
-from .. import mlog
+from .. import build, mesonlib, mlog
 from ..interpreter.type_checking import DEPEND_FILES_KW, DEPENDS_KW, INCLUDE_DIRECTORIES
-from ..interpreterbase.decorators import ContainerTypeInfo, FeatureNew, KwargInfo, typed_kwargs, typed_pos_args
+from ..interpreterbase.decorators import (
+    ContainerTypeInfo, FeatureNew, KwargInfo, typed_kwargs, typed_pos_args
+)
 from ..mesonlib import MachineChoice, MesonException
 from ..programs import ExternalProgram
+from . import ExtensionModule, ModuleInfo, ModuleReturnValue
 
 if T.TYPE_CHECKING:
-    from . import ModuleState
+    from typing_extensions import TypedDict
+
     from ..compilers import Compiler
     from ..interpreter import Interpreter
-
-    from typing_extensions import TypedDict
+    from . import ModuleState
 
     class CompileResources(TypedDict):
 

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -2,14 +2,15 @@
 # Copyright 2014-2017 The Meson development team
 
 from __future__ import annotations
-from dataclasses import dataclass, field
-import re
+
 import codecs
 import os
+import re
 import typing as T
+from dataclasses import dataclass, field
 
-from .mesonlib import MesonException
 from . import mlog
+from .mesonlib import MesonException
 
 if T.TYPE_CHECKING:
     from typing_extensions import Literal

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -3,10 +3,19 @@
 
 from __future__ import annotations
 
-import argparse, datetime, glob, json, os, platform, shutil, sys, tempfile, time
+import argparse
 import cProfile as profile
-from pathlib import Path
+import datetime
+import glob
+import json
+import os
+import platform
+import shutil
+import sys
+import tempfile
+import time
 import typing as T
+from pathlib import Path
 
 from . import build, coredata, environment, interpreter, mesonlib, mintro, mlog
 from .mesonlib import MesonException

--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -1,23 +1,25 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, InitVar
-import os, subprocess
 import argparse
 import asyncio
-import threading
 import copy
+import os
 import shutil
-from concurrent.futures.thread import ThreadPoolExecutor
-from pathlib import Path
-import typing as T
+import subprocess
 import tarfile
+import threading
+import typing as T
 import zipfile
+from concurrent.futures.thread import ThreadPoolExecutor
+from dataclasses import InitVar, dataclass
+from pathlib import Path
 
 from . import mlog
 from .ast import IntrospectionInterpreter
-from .mesonlib import quiet_git, GitException, Popen_safe, MesonException, windows_proof_rmtree
-from .wrap.wrap import (Resolver, WrapException, ALL_TYPES,
-                        parse_patch_url, update_wrap_file, get_releases)
+from .mesonlib import GitException, MesonException, Popen_safe, quiet_git, windows_proof_rmtree
+from .wrap.wrap import (
+    ALL_TYPES, Resolver, WrapException, get_releases, parse_patch_url, update_wrap_file
+)
 
 if T.TYPE_CHECKING:
     from typing_extensions import Protocol

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -4,11 +4,6 @@
 # A tool to run tests in many different ways.
 from __future__ import annotations
 
-from pathlib import Path
-from collections import deque
-from contextlib import suppress
-from copy import deepcopy
-from fnmatch import fnmatch
 import argparse
 import asyncio
 import datetime
@@ -20,26 +15,31 @@ import pickle
 import platform
 import random
 import re
+import shlex
 import signal
 import subprocess
-import shlex
 import sys
 import textwrap
 import time
 import typing as T
 import unicodedata
 import xml.etree.ElementTree as et
+from collections import deque
+from contextlib import suppress
+from copy import deepcopy
+from fnmatch import fnmatch
+from pathlib import Path
 
-from . import build
-from . import environment
-from . import mlog
+from . import build, environment, mlog
+from .backend.backends import TestProtocol, TestSerialisation
 from .coredata import MesonVersionMismatchException, major_versions_differ
 from .coredata import version as coredata_version
-from .mesonlib import (MesonException, OptionKey, OrderedSet, RealPathAction,
-                       get_wine_shortpath, join_args, split_args, setup_vsenv)
+from .mesonlib import (
+    MesonException, OptionKey, OrderedSet, RealPathAction, get_wine_shortpath, join_args,
+    setup_vsenv, split_args
+)
 from .mintro import get_infodir, load_info_file
 from .programs import ExternalProgram
-from .backend.backends import TestProtocol, TestSerialisation
 
 if T.TYPE_CHECKING:
     TYPE_TAPResult = T.Union['TAPParser.Test',

--- a/mesonbuild/munstable_coredata.py
+++ b/mesonbuild/munstable_coredata.py
@@ -3,13 +3,13 @@
 
 from __future__ import annotations
 
+import os.path
+import pprint
+import textwrap
 
 from . import coredata as cdata
 from .mesonlib import MachineChoice, OptionKey
 
-import os.path
-import pprint
-import textwrap
 
 # Note: when adding arguments, please also add them to the completion
 # scripts in $MESONSRC/data/shell-completions/

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -6,17 +6,16 @@ from __future__ import annotations
 import re
 import typing as T
 
-from . import coredata
-from . import mesonlib
-from . import mparser
-from . import mlog
-from .interpreterbase import FeatureNew, FeatureDeprecated, typed_pos_args, typed_kwargs, ContainerTypeInfo, KwargInfo
+from . import coredata, mesonlib, mlog, mparser
 from .interpreter.type_checking import NoneType, in_set_validator
+from .interpreterbase import (
+    ContainerTypeInfo, FeatureDeprecated, FeatureNew, KwargInfo, typed_kwargs, typed_pos_args
+)
 
 if T.TYPE_CHECKING:
-    from .interpreterbase import TYPE_var, TYPE_kwargs
-    from .interpreterbase import SubProject
-    from typing_extensions import TypedDict, Literal
+    from typing_extensions import Literal, TypedDict
+
+    from .interpreterbase import SubProject, TYPE_kwargs, TYPE_var
 
     _DEPRECATED_ARGS = T.Union[bool, str, T.Dict[str, str], T.List[str]]
 

--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -7,15 +7,14 @@ from __future__ import annotations
 
 import functools
 import os
+import re
 import shutil
 import stat
 import sys
-import re
 import typing as T
 from pathlib import Path
 
-from . import mesonlib
-from . import mlog
+from . import mesonlib, mlog
 from .mesonlib import MachineChoice, OrderedSet
 
 if T.TYPE_CHECKING:

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -9,16 +9,28 @@
 # - reindent?
 from __future__ import annotations
 
-from .ast import IntrospectionInterpreter, BUILD_TARGET_FUNCTIONS, AstConditionLevel, AstIDGenerator, AstIndentationGenerator, AstPrinter
-from mesonbuild.mesonlib import MesonException, setup_vsenv
-from . import mlog, environment
-from functools import wraps
-from .mparser import Token, ArrayNode, ArgumentNode, AssignmentNode, BaseStringNode, BooleanNode, ElementaryNode, IdNode, FunctionNode, StringNode, SymbolNode
-import json, os, re, sys
+import json
+import os
+import re
+import sys
 import typing as T
+from functools import wraps
+
+from mesonbuild.mesonlib import MesonException, setup_vsenv
+
+from . import environment, mlog
+from .ast import (
+    BUILD_TARGET_FUNCTIONS, AstConditionLevel, AstIDGenerator, AstIndentationGenerator, AstPrinter,
+    IntrospectionInterpreter
+)
+from .mparser import (
+    ArgumentNode, ArrayNode, AssignmentNode, BaseStringNode, BooleanNode, ElementaryNode,
+    FunctionNode, IdNode, StringNode, SymbolNode, Token
+)
 
 if T.TYPE_CHECKING:
     from argparse import ArgumentParser, HelpFormatter
+
     from .mparser import BaseNode
 
 class RewriterException(MesonException):

--- a/mesonbuild/scripts/__init__.py
+++ b/mesonbuild/scripts/__init__.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016 The Meson development team
 
+from __future__ import annotations
+
 from pathlib import PurePath
+
 
 def destdir_join(d1: str, d2: str) -> str:
     if not d1:

--- a/mesonbuild/scripts/clangformat.py
+++ b/mesonbuild/scripts/clangformat.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 
 import argparse
 import subprocess
+import typing as T
 from pathlib import Path
 
-from .run_tool import run_tool
 from ..environment import detect_clangformat
 from ..mesonlib import version_compare
 from ..programs import ExternalProgram
-import typing as T
+from .run_tool import run_tool
+
 
 def run_clang_format(fname: Path, exelist: T.List[str], check: bool, cformat_ver: T.Optional[str]) -> subprocess.CompletedProcess:
     clangformat_10 = False

--- a/mesonbuild/scripts/clangtidy.py
+++ b/mesonbuild/scripts/clangtidy.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 
 import argparse
 import subprocess
+import typing as T
 from pathlib import Path
 
 from .run_tool import run_tool
-import typing as T
+
 
 def run_clang_tidy(fname: Path, builddir: Path) -> subprocess.CompletedProcess:
     return subprocess.run(['clang-tidy', '-p', str(builddir), str(fname)])

--- a/mesonbuild/scripts/cleantrees.py
+++ b/mesonbuild/scripts/cleantrees.py
@@ -4,10 +4,11 @@
 from __future__ import annotations
 
 import os
-import sys
-import shutil
 import pickle
+import shutil
+import sys
 import typing as T
+
 
 def rmtrees(build_dir: str, trees: T.List[str]) -> None:
     for t in trees:

--- a/mesonbuild/scripts/cmake_run_ctgt.py
+++ b/mesonbuild/scripts/cmake_run_ctgt.py
@@ -2,11 +2,12 @@
 from __future__ import annotations
 
 import argparse
-import subprocess
 import shutil
+import subprocess
 import sys
-from pathlib import Path
 import typing as T
+from pathlib import Path
+
 
 def run(argsv: T.List[str]) -> int:
     commands: T.List[T.List[str]] = [[]]

--- a/mesonbuild/scripts/coverage.py
+++ b/mesonbuild/scripts/coverage.py
@@ -3,10 +3,17 @@
 
 from __future__ import annotations
 
+import argparse
+import os
+import pathlib
+import re
+import stat
+import subprocess
+import sys
+import typing as T
+
 from mesonbuild import environment, mesonlib
 
-import argparse, re, sys, os, subprocess, pathlib, stat
-import typing as T
 
 def coverage(outputs: T.List[str], source_root: str, subproject_root: str, build_root: str, log_dir: str, use_llvm_cov: bool) -> int:
     outfiles = []

--- a/mesonbuild/scripts/delwithsuffix.py
+++ b/mesonbuild/scripts/delwithsuffix.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
-import os, sys
+import os
+import sys
 import typing as T
+
 
 def run(args: T.List[str]) -> int:
     if len(args) != 2:

--- a/mesonbuild/scripts/depfixer.py
+++ b/mesonbuild/scripts/depfixer.py
@@ -3,16 +3,15 @@
 
 from __future__ import annotations
 
-
-import sys
 import os
+import shutil
 import stat
 import struct
-import shutil
 import subprocess
+import sys
 import typing as T
 
-from ..mesonlib import OrderedSet, generate_list, Popen_safe
+from ..mesonlib import OrderedSet, Popen_safe, generate_list
 
 SHT_STRTAB = 3
 DT_NEEDED = 1

--- a/mesonbuild/scripts/dirchanger.py
+++ b/mesonbuild/scripts/dirchanger.py
@@ -6,8 +6,11 @@ from __future__ import annotations
 '''CD into dir given as first argument and execute
 the command given in the rest of the arguments.'''
 
-import os, subprocess, sys
+import os
+import subprocess
+import sys
 import typing as T
+
 
 def run(args: T.List[str]) -> int:
     dirname = args[0]

--- a/mesonbuild/scripts/env2mfile.py
+++ b/mesonbuild/scripts/env2mfile.py
@@ -3,12 +3,14 @@
 
 from __future__ import annotations
 
-import sys, os, subprocess, shutil
+import os
 import shlex
+import shutil
+import subprocess
+import sys
 import typing as T
 
-from .. import envconfig
-from .. import mlog
+from .. import envconfig, mlog
 from ..compilers import compilers
 from ..compilers.detect import defaults as compiler_names
 

--- a/mesonbuild/scripts/externalproject.py
+++ b/mesonbuild/scripts/externalproject.py
@@ -3,14 +3,15 @@
 
 from __future__ import annotations
 
-import os
 import argparse
 import multiprocessing
+import os
 import subprocess
-from pathlib import Path
 import typing as T
+from pathlib import Path
 
 from ..mesonlib import Popen_safe, split_args
+
 
 class ExternalProject:
     def __init__(self, options: argparse.Namespace):

--- a/mesonbuild/scripts/gettext.py
+++ b/mesonbuild/scripts/gettext.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
-import os
 import argparse
+import os
 import subprocess
 import typing as T
 

--- a/mesonbuild/scripts/gtkdochelper.py
+++ b/mesonbuild/scripts/gtkdochelper.py
@@ -3,13 +3,15 @@
 
 from __future__ import annotations
 
-import sys, os
-import subprocess
-import shutil
 import argparse
-from ..mesonlib import MesonException, Popen_safe, is_windows, is_cygwin, split_args
-from . import destdir_join
+import os
+import shutil
+import subprocess
+import sys
 import typing as T
+
+from ..mesonlib import MesonException, Popen_safe, is_cygwin, is_windows, split_args
+from . import destdir_join
 
 parser = argparse.ArgumentParser()
 

--- a/mesonbuild/scripts/hotdochelper.py
+++ b/mesonbuild/scripts/hotdochelper.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
+import argparse
 import os
 import shutil
 import subprocess
+import typing as T
 
 from . import destdir_join
-
-import argparse
-import typing as T
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--install')

--- a/mesonbuild/scripts/itstool.py
+++ b/mesonbuild/scripts/itstool.py
@@ -3,12 +3,12 @@
 
 from __future__ import annotations
 
-import os
 import argparse
-import subprocess
-import tempfile
+import os
 import shlex
 import shutil
+import subprocess
+import tempfile
 import typing as T
 
 parser = argparse.ArgumentParser()

--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -3,15 +3,16 @@
 
 from __future__ import annotations
 
-import os
-import sys
 import argparse
+import locale
+import os
 import pickle
 import subprocess
+import sys
 import typing as T
-import locale
 
 from ..utils.core import ExecutableSerialisation
+
 
 def buildparser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description='Custom executable wrapper for Meson. Do not run on your own, mmm\'kay?')

--- a/mesonbuild/scripts/msgfmthelper.py
+++ b/mesonbuild/scripts/msgfmthelper.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import argparse
-import subprocess
 import os
+import subprocess
 import typing as T
 
 parser = argparse.ArgumentParser()

--- a/mesonbuild/scripts/pycompile.py
+++ b/mesonbuild/scripts/pycompile.py
@@ -6,7 +6,12 @@
 # type: ignore
 # pylint: disable=deprecated-module
 
-import json, os, subprocess, sys
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
 from compileall import compile_file
 
 quiet = int(os.environ.get('MESON_INSTALL_QUIET', 0))

--- a/mesonbuild/scripts/pycompile.py
+++ b/mesonbuild/scripts/pycompile.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016 The Meson development team
-
+#
 # ignore all lints for this file, since it is run by python2 as well
-
+#
 # type: ignore
 # pylint: disable=deprecated-module
 

--- a/mesonbuild/scripts/python_info.py
+++ b/mesonbuild/scripts/python_info.py
@@ -6,6 +6,8 @@
 # type: ignore
 # pylint: disable=deprecated-module
 
+from __future__ import annotations
+
 import sys
 
 # do not inject mesonbuild.scripts
@@ -13,7 +15,10 @@ import sys
 if sys.path[0].endswith('scripts'):
     del sys.path[0]
 
-import json, os, sysconfig
+import json
+import os
+import sysconfig
+
 
 def get_distutils_paths(scheme=None, prefix=None):
     import distutils.dist

--- a/mesonbuild/scripts/python_info.py
+++ b/mesonbuild/scripts/python_info.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
-
+# SPDX-License-Identifier: Apache-2.0
+#
 # ignore all lints for this file, since it is run by python2 as well
-
+#
 # type: ignore
 # pylint: disable=deprecated-module
 

--- a/mesonbuild/scripts/regen_checker.py
+++ b/mesonbuild/scripts/regen_checker.py
@@ -3,11 +3,14 @@
 
 from __future__ import annotations
 
-import sys, os
-import pickle, subprocess
+import os
+import pickle
+import subprocess
+import sys
 import typing as T
-from ..coredata import CoreData
+
 from ..backend.backends import RegenInfo
+from ..coredata import CoreData
 from ..mesonlib import OptionKey
 
 # This could also be used for XCode.

--- a/mesonbuild/scripts/run_tool.py
+++ b/mesonbuild/scripts/run_tool.py
@@ -3,14 +3,14 @@
 
 from __future__ import annotations
 
-import itertools
 import fnmatch
-from pathlib import Path
+import itertools
+import typing as T
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 
 from ..compilers import lang_suffixes
 from ..mesonlib import quiet_git
-import typing as T
 
 if T.TYPE_CHECKING:
     import subprocess

--- a/mesonbuild/scripts/scanbuild.py
+++ b/mesonbuild/scripts/scanbuild.py
@@ -3,16 +3,18 @@
 
 from __future__ import annotations
 
-import subprocess
+import os
 import shutil
+import subprocess
 import tempfile
-from ..environment import detect_ninja, detect_scanbuild
-from ..coredata import get_cmd_line_file, CmdLineFileParser
-from ..mesonlib import windows_proof_rmtree
-from pathlib import Path
 import typing as T
 from ast import literal_eval
-import os
+from pathlib import Path
+
+from ..coredata import CmdLineFileParser, get_cmd_line_file
+from ..environment import detect_ninja, detect_scanbuild
+from ..mesonlib import windows_proof_rmtree
+
 
 def scanbuild(exelist: T.List[str], srcdir: Path, blddir: Path, privdir: Path, logdir: Path, subprojdir: Path, args: T.List[str]) -> int:
     # In case of problems leave the temp directory around

--- a/mesonbuild/scripts/symbolextractor.py
+++ b/mesonbuild/scripts/symbolextractor.py
@@ -1,13 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2013-2016 The Meson development team
 
-# This script extracts the symbols of a given shared library
-# into a file. If the symbols have not changed, the file is not
-# touched. This information is used to skip link steps if the
-# ABI has not changed.
+"""This script extracts the symbols of a given shared library into a file.
 
-# This file is basically a reimplementation of
-# http://cgit.freedesktop.org/libreoffice/core/commit/?id=3213cd54b76bc80a6f0516aac75a48ff3b2ad67c
+If the symbols have not changed, the file is not touched. This information is
+used to skip link steps if the ABI has not changed.
+
+This file is basically a reimplementation of
+http://cgit.freedesktop.org/libreoffice/core/commit/?id=3213cd54b76bc80a6f0516aac75a48ff3b2ad67c
+"""
+
 from __future__ import annotations
 
 import typing as T

--- a/mesonbuild/scripts/symbolextractor.py
+++ b/mesonbuild/scripts/symbolextractor.py
@@ -12,12 +12,13 @@ http://cgit.freedesktop.org/libreoffice/core/commit/?id=3213cd54b76bc80a6f0516aa
 
 from __future__ import annotations
 
-import typing as T
-import os, sys
-from .. import mesonlib
-from .. import mlog
-from ..mesonlib import Popen_safe
 import argparse
+import os
+import sys
+import typing as T
+
+from .. import mesonlib, mlog
+from ..mesonlib import Popen_safe
 
 parser = argparse.ArgumentParser()
 

--- a/mesonbuild/scripts/tags.py
+++ b/mesonbuild/scripts/tags.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 
 import os
 import subprocess
-from pathlib import Path
 import typing as T
+from pathlib import Path
+
 
 def ls_as_bytestream() -> bytes:
     if os.path.exists('.git'):

--- a/mesonbuild/scripts/test_loaded_modules.py
+++ b/mesonbuild/scripts/test_loaded_modules.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-import sys
 import json
+import sys
 import typing as T
 
 from . import meson_exe
+
 
 # This script is used by run_unittests.py to verify we don't load too many
 # modules when executing a wrapped command.

--- a/mesonbuild/scripts/vcstagger.py
+++ b/mesonbuild/scripts/vcstagger.py
@@ -3,8 +3,12 @@
 
 from __future__ import annotations
 
-import sys, os, subprocess, re
+import os
+import re
+import subprocess
+import sys
 import typing as T
+
 
 def config_vcs_tag(infile: str, outfile: str, fallback: str, source_dir: str, replace_string: str, regex_selector: str, cmd: T.List[str]) -> None:
     try:

--- a/mesonbuild/scripts/yasm.py
+++ b/mesonbuild/scripts/yasm.py
@@ -4,6 +4,7 @@ import argparse
 import subprocess
 import typing as T
 
+
 def run(args: T.List[str]) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('--depfile')

--- a/mesonbuild/templates/cpptemplates.py
+++ b/mesonbuild/templates/cpptemplates.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from mesonbuild.templates.sampleimpl import FileHeaderImpl
 
-
 hello_cpp_template = '''#include <iostream>
 
 #define PROJECT_NAME "{project_name}"

--- a/mesonbuild/templates/cstemplates.py
+++ b/mesonbuild/templates/cstemplates.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from mesonbuild.templates.sampleimpl import ClassImpl
 
-
 hello_cs_template = '''using System;
 
 public class {class_name} {{

--- a/mesonbuild/templates/ctemplates.py
+++ b/mesonbuild/templates/ctemplates.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from mesonbuild.templates.sampleimpl import FileHeaderImpl
 
-
 lib_h_template = '''#pragma once
 #if defined _WIN32 || defined __CYGWIN__
   #ifdef BUILDING_{utoken}

--- a/mesonbuild/templates/cudatemplates.py
+++ b/mesonbuild/templates/cudatemplates.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from mesonbuild.templates.sampleimpl import FileHeaderImpl
 
-
 hello_cuda_template = '''#include <iostream>
 
 #define PROJECT_NAME "{project_name}"

--- a/mesonbuild/templates/dlangtemplates.py
+++ b/mesonbuild/templates/dlangtemplates.py
@@ -3,10 +3,9 @@
 
 from __future__ import annotations
 
-from mesonbuild.templates.sampleimpl import FileImpl
-
 import typing as T
 
+from mesonbuild.templates.sampleimpl import FileImpl
 
 hello_d_template = '''module main;
 import std.stdio;

--- a/mesonbuild/templates/javatemplates.py
+++ b/mesonbuild/templates/javatemplates.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from mesonbuild.templates.sampleimpl import ClassImpl
 
-
 hello_java_template = '''
 
 public class {class_name} {{

--- a/mesonbuild/templates/objcpptemplates.py
+++ b/mesonbuild/templates/objcpptemplates.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from mesonbuild.templates.sampleimpl import FileHeaderImpl
 
-
 lib_h_template = '''#pragma once
 #if defined _WIN32 || defined __CYGWIN__
   #ifdef BUILDING_{utoken}

--- a/mesonbuild/templates/objctemplates.py
+++ b/mesonbuild/templates/objctemplates.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from mesonbuild.templates.sampleimpl import FileHeaderImpl
 
-
 lib_h_template = '''#pragma once
 #if defined _WIN32 || defined __CYGWIN__
   #ifdef BUILDING_{utoken}

--- a/mesonbuild/templates/rusttemplates.py
+++ b/mesonbuild/templates/rusttemplates.py
@@ -7,7 +7,6 @@ import typing as T
 
 from mesonbuild.templates.sampleimpl import FileImpl
 
-
 lib_rust_template = '''#![crate_name = "{crate_file}"]
 
 /* This function will not be exported and is not

--- a/mesonbuild/templates/samplefactory.py
+++ b/mesonbuild/templates/samplefactory.py
@@ -5,17 +5,17 @@ from __future__ import annotations
 
 import typing as T
 
-from mesonbuild.templates.valatemplates import ValaProject
-from mesonbuild.templates.fortrantemplates import FortranProject
-from mesonbuild.templates.objcpptemplates import ObjCppProject
-from mesonbuild.templates.dlangtemplates import DlangProject
-from mesonbuild.templates.rusttemplates import RustProject
-from mesonbuild.templates.javatemplates import JavaProject
-from mesonbuild.templates.cudatemplates import CudaProject
-from mesonbuild.templates.objctemplates import ObjCProject
 from mesonbuild.templates.cpptemplates import CppProject
 from mesonbuild.templates.cstemplates import CSharpProject
 from mesonbuild.templates.ctemplates import CProject
+from mesonbuild.templates.cudatemplates import CudaProject
+from mesonbuild.templates.dlangtemplates import DlangProject
+from mesonbuild.templates.fortrantemplates import FortranProject
+from mesonbuild.templates.javatemplates import JavaProject
+from mesonbuild.templates.objcpptemplates import ObjCppProject
+from mesonbuild.templates.objctemplates import ObjCProject
+from mesonbuild.templates.rusttemplates import RustProject
+from mesonbuild.templates.valatemplates import ValaProject
 
 if T.TYPE_CHECKING:
     from ..minit import Arguments

--- a/mesonbuild/templates/valatemplates.py
+++ b/mesonbuild/templates/valatemplates.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from mesonbuild.templates.sampleimpl import FileImpl
 
-
 hello_vala_template = '''void main (string[] args) {{
     stdout.printf ("Hello {project_name}!\\n");
 }}

--- a/mesonbuild/utils/core.py
+++ b/mesonbuild/utils/core.py
@@ -10,16 +10,19 @@ as possible for performance reasons.
 """
 
 from __future__ import annotations
-from dataclasses import dataclass
-import os
+
 import abc
+import os
 import typing as T
+from dataclasses import dataclass
 
 if T.TYPE_CHECKING:
     from hashlib import _Hash
+
     from typing_extensions import Literal
-    from ..mparser import BaseNode
+
     from .. import programs
+    from ..mparser import BaseNode
 
     EnvironOrDict = T.Union[T.Dict[str, str], os._Environ[str]]
 

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -5,35 +5,43 @@
 """A library of random helper functionality."""
 
 from __future__ import annotations
-from pathlib import Path
-import argparse
-import enum
-import sys
-import stat
-import time
+
 import abc
-import platform, subprocess, operator, os, shlex, shutil, re
+import argparse
 import collections
-from functools import lru_cache, wraps, total_ordering
-from itertools import tee
-from tempfile import TemporaryDirectory, NamedTemporaryFile
-import typing as T
-import textwrap
-import pickle
+import enum
 import errno
 import json
+import operator
+import os
+import pickle
+import platform
+import re
+import shlex
+import shutil
+import stat
+import subprocess
+import sys
+import textwrap
+import time
+import typing as T
+from functools import lru_cache, total_ordering, wraps
+from itertools import tee
+from pathlib import Path
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 from mesonbuild import mlog
-from .core import MesonException, HoldableObject
+
+from .core import HoldableObject, MesonException
 
 if T.TYPE_CHECKING:
     from typing_extensions import Literal, Protocol
 
     from .._typing import ImmutableListProtocol
     from ..build import ConfigurationData
+    from ..compilers.compilers import Compiler
     from ..coredata import StrOrBytesPath
     from ..environment import Environment
-    from ..compilers.compilers import Compiler
     from ..interpreterbase.baseobjects import SubProject
 
     class _EnvPickleLoadable(Protocol):
@@ -245,6 +253,7 @@ def is_ascii_string(astring: T.Union[str, bytes]) -> bool:
 
 def check_direntry_issues(direntry_array: T.Union[T.Iterable[T.Union[str, bytes]], str, bytes]) -> None:
     import locale
+
     # Warn if the locale is not UTF-8. This can cause various unfixable issues
     # such as os.stat not being able to decode filenames with unicode in them.
     # There is no way to reset both the preferred encoding and the filesystem
@@ -2402,8 +2411,8 @@ def pickle_load(filename: str, object_name: str, object_type: T.Type[_PL], sugge
     else:
         version = T.cast('_EnvPickleLoadable', obj).environment.coredata.version
 
+    from ..coredata import MesonVersionMismatchException, major_versions_differ
     from ..coredata import version as coredata_version
-    from ..coredata import major_versions_differ, MesonVersionMismatchException
     if major_versions_differ(version, coredata_version):
         raise MesonVersionMismatchException(version, coredata_version, extra_msg)
     return obj

--- a/mesonbuild/utils/vsenv.py
+++ b/mesonbuild/utils/vsenv.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
 
-import os
-import subprocess
 import json
+import locale
+import os
 import pathlib
 import shutil
+import subprocess
 import tempfile
-import locale
 
 from .. import mlog
 from .core import MesonException
 from .universal import is_windows, windows_detect_native_arch
-
 
 __all__ = [
     'setup_vsenv',

--- a/mesonbuild/wrap/__init__.py
+++ b/mesonbuild/wrap/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import Enum
 
 # Used for the --wrap-mode command-line argument

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -3,39 +3,36 @@
 
 from __future__ import annotations
 
-from .. import mlog
+import configparser
 import contextlib
-from dataclasses import dataclass
-import urllib.request
-import urllib.error
-import urllib.parse
-import os
 import hashlib
+import json
+import os
 import shutil
-import tempfile
 import stat
 import subprocess
 import sys
-import configparser
+import tempfile
+import textwrap
 import time
 import typing as T
-import textwrap
-import json
-
+import urllib.error
+import urllib.parse
+import urllib.request
 from base64 import b64encode
+from dataclasses import dataclass
+from functools import lru_cache
 from netrc import netrc
 from pathlib import Path, PurePath
-from functools import lru_cache
 
+from .. import coredata, mesonlib, mlog
+from ..interpreterbase import FeatureNew, SubProject
+from ..mesonlib import GIT, MesonException, Popen_safe, ProgressBar, quiet_git, windows_proof_rmtree
 from . import WrapMode
-from .. import coredata
-from ..mesonlib import quiet_git, GIT, ProgressBar, MesonException, windows_proof_rmtree, Popen_safe
-from ..interpreterbase import FeatureNew
-from ..interpreterbase import SubProject
-from .. import mesonlib
 
 if T.TYPE_CHECKING:
     import http.client
+
     from typing_extensions import Literal
 
     Method = Literal['meson', 'cmake', 'cargo']

--- a/mesonbuild/wrap/wraptool.py
+++ b/mesonbuild/wrap/wraptool.py
@@ -3,17 +3,16 @@
 
 from __future__ import annotations
 
-import sys, os
 import configparser
+import os
 import shutil
+import sys
 import typing as T
-
 from glob import glob
-from .wrap import (open_wrapdburl, WrapException, get_releases, get_releases_data,
-                   parse_patch_url)
 from pathlib import Path
 
 from .. import mesonlib, msubprojects
+from .wrap import WrapException, get_releases, get_releases_data, open_wrapdburl, parse_patch_url
 
 if T.TYPE_CHECKING:
     import argparse

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1,65 +1,61 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016-2021 The Meson development team
 
-import subprocess
-import re
+from __future__ import annotations
+
 import json
+import os
+import pickle
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
 import tempfile
 import textwrap
-import os
-import shutil
-import platform
-import pickle
-import zipfile, tarfile
-import sys
-from unittest import mock, SkipTest, skipIf, skipUnless
+import typing as T
+import zipfile
 from contextlib import contextmanager
 from glob import glob
-from pathlib import (PurePath, Path)
-import typing as T
+from pathlib import Path, PurePath
+from unittest import SkipTest, mock, skipIf, skipUnless
 
-import mesonbuild.mlog
-import mesonbuild.depfile
+import mesonbuild.coredata
 import mesonbuild.dependencies.base
 import mesonbuild.dependencies.factory
+import mesonbuild.depfile
 import mesonbuild.envconfig
 import mesonbuild.environment
-import mesonbuild.coredata
+import mesonbuild.mlog
 import mesonbuild.modules.gnome
-from mesonbuild.mesonlib import (
-    BuildDirLock, MachineChoice, is_windows, is_osx, is_cygwin, is_dragonflybsd,
-    is_sunos, windows_proof_rmtree, python_command, version_compare, split_args, quote_arg,
-    relpath, is_linux, git, search_version, do_conf_file, do_conf_str, default_prefix,
-    MesonException, EnvironmentException, OptionKey,
-    windows_proof_rm
+import mesonbuild.modules.pkgconfig
+from mesonbuild import mtest
+from mesonbuild.build import ConfigurationData, Executable, SharedLibrary, StaticLibrary, Target
+from mesonbuild.compilers import (
+    compiler_from_language, detect_c_compiler, detect_compiler_for, detect_static_linker
 )
-from mesonbuild.programs import ExternalProgram
-
+from mesonbuild.compilers.c import ClangClCCompiler, VisualStudioCCompiler
+from mesonbuild.compilers.cpp import ClangClCPPCompiler, VisualStudioCPPCompiler
 from mesonbuild.compilers.mixins.clang import ClangCompiler
 from mesonbuild.compilers.mixins.gnu import GnuCompiler
 from mesonbuild.compilers.mixins.intel import IntelGnuLikeCompiler
-from mesonbuild.compilers.c import VisualStudioCCompiler, ClangClCCompiler
-from mesonbuild.compilers.cpp import VisualStudioCPPCompiler, ClangClCPPCompiler
-from mesonbuild.compilers import (
-    detect_static_linker, detect_c_compiler, compiler_from_language,
-    detect_compiler_for
-)
-from mesonbuild.linkers import linkers
-
 from mesonbuild.dependencies.pkgconfig import PkgConfigDependency
-from mesonbuild.build import Target, ConfigurationData, Executable, SharedLibrary, StaticLibrary
-from mesonbuild import mtest
-import mesonbuild.modules.pkgconfig
-from mesonbuild.scripts import destdir_join
-
-from mesonbuild.wrap.wrap import PackageDefinition, WrapException
-
-from run_tests import (
-    Backend, exe_suffix, get_fake_env, get_convincing_fake_env_and_cc
+from mesonbuild.linkers import linkers
+from mesonbuild.mesonlib import (
+    BuildDirLock, EnvironmentException, MachineChoice, MesonException, OptionKey, default_prefix,
+    do_conf_file, do_conf_str, git, is_cygwin, is_dragonflybsd, is_linux, is_osx, is_sunos,
+    is_windows, python_command, quote_arg, relpath, search_version, split_args, version_compare,
+    windows_proof_rm, windows_proof_rmtree
 )
+from mesonbuild.programs import ExternalProgram
+from mesonbuild.scripts import destdir_join
+from mesonbuild.wrap.wrap import PackageDefinition, WrapException
+from run_tests import Backend, exe_suffix, get_convincing_fake_env_and_cc, get_fake_env
 
 from .baseplatformtests import BasePlatformTests
 from .helpers import *
+
 
 @contextmanager
 def temp_filename():

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -1,38 +1,36 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016-2021 The Meson development team
 
-from pathlib import PurePath
-from unittest import mock, TestCase, SkipTest
-import json
+from __future__ import annotations
+
 import io
+import json
 import os
 import re
 import subprocess
 import sys
 import tempfile
 import typing as T
+from pathlib import PurePath
+from unittest import SkipTest, TestCase, mock
 
-import mesonbuild.mlog
-import mesonbuild.depfile
+import mesonbuild.compilers
+import mesonbuild.coredata
 import mesonbuild.dependencies.base
 import mesonbuild.dependencies.factory
-import mesonbuild.compilers
+import mesonbuild.depfile
 import mesonbuild.envconfig
 import mesonbuild.environment
-import mesonbuild.coredata
+import mesonbuild.mlog
 import mesonbuild.modules.gnome
-from mesonbuild.mesonlib import (
-    is_cygwin, join_args, split_args, windows_proof_rmtree, python_command
-)
 import mesonbuild.modules.pkgconfig
-
-
-from run_tests import (
-    Backend, ensure_backend_detects_changes, get_backend_commands,
-    get_builddir_target_args, get_meson_script, run_configure_inprocess,
-    run_mtest_inprocess, handle_meson_skip_test,
+from mesonbuild.mesonlib import (
+    is_cygwin, join_args, python_command, split_args, windows_proof_rmtree
 )
-
+from run_tests import (
+    Backend, ensure_backend_detects_changes, get_backend_commands, get_builddir_target_args,
+    get_meson_script, handle_meson_skip_test, run_configure_inprocess, run_mtest_inprocess
+)
 
 # magic attribute used by unittest.result.TestResult._is_relevant_tb_level
 # This causes tracebacks to hide these internal implementation details,

--- a/unittests/cargotests.py
+++ b/unittests/cargotests.py
@@ -2,8 +2,9 @@
 # Copyright © 2022-2023 Intel Corporation
 
 from __future__ import annotations
-import unittest
+
 import typing as T
+import unittest
 
 from mesonbuild.cargo import builder, cfg
 from mesonbuild.cargo.cfg import TokenType

--- a/unittests/darwintests.py
+++ b/unittests/darwintests.py
@@ -1,25 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016-2021 The Meson development team
 
-import subprocess
-import re
+from __future__ import annotations
+
 import os
+import re
+import subprocess
 import unittest
 
-from mesonbuild.mesonlib import (
-    MachineChoice, is_osx
-)
-from mesonbuild.compilers import (
-    detect_c_compiler
-)
-
-
-from run_tests import (
-    get_fake_env
-)
+from mesonbuild.compilers import detect_c_compiler
+from mesonbuild.mesonlib import MachineChoice, is_osx
+from run_tests import get_fake_env
 
 from .baseplatformtests import BasePlatformTests
 from .helpers import *
+
 
 @unittest.skipUnless(is_osx(), "requires Darwin")
 class DarwinTests(BasePlatformTests):

--- a/unittests/datatests.py
+++ b/unittests/datatests.py
@@ -1,36 +1,31 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016-2021 The Meson development team
 
+from __future__ import annotations
+
 import re
 import unittest
 from itertools import chain
 from pathlib import Path
 from unittest import mock
 
-import mesonbuild.mlog
-import mesonbuild.depfile
+import mesonbuild.coredata
 import mesonbuild.dependencies.base
 import mesonbuild.dependencies.factory
+import mesonbuild.depfile
 import mesonbuild.envconfig
 import mesonbuild.environment
-import mesonbuild.coredata
+import mesonbuild.mlog
 import mesonbuild.modules.gnome
-from mesonbuild.interpreter import Interpreter
-from mesonbuild.ast import AstInterpreter
-from mesonbuild.mesonlib import (
-    MachineChoice, OptionKey
-)
-from mesonbuild.compilers import (
-    detect_c_compiler, detect_cpp_compiler
-)
 import mesonbuild.modules.pkgconfig
-
-
-from run_tests import (
-    FakeBuild, get_fake_env
-)
+from mesonbuild.ast import AstInterpreter
+from mesonbuild.compilers import detect_c_compiler, detect_cpp_compiler
+from mesonbuild.interpreter import Interpreter
+from mesonbuild.mesonlib import MachineChoice, OptionKey
+from run_tests import FakeBuild, get_fake_env
 
 from .helpers import *
+
 
 @unittest.skipIf(is_tarball(), 'Skipping because this is a tarball release')
 class DataTests(unittest.TestCase):

--- a/unittests/failuretests.py
+++ b/unittests/failuretests.py
@@ -1,29 +1,26 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016-2021 The Meson development team
 
-import subprocess
-import tempfile
+from __future__ import annotations
+
 import os
 import shutil
+import subprocess
+import tempfile
 import unittest
 from contextlib import contextmanager
 
+from mesonbuild.compilers import detect_objc_compiler, detect_objcpp_compiler
 from mesonbuild.mesonlib import (
-    MachineChoice, is_windows, is_osx, windows_proof_rmtree, windows_proof_rm
+    EnvironmentException, MachineChoice, MesonException, is_osx, is_windows, windows_proof_rm,
+    windows_proof_rmtree
 )
-from mesonbuild.compilers import (
-    detect_objc_compiler, detect_objcpp_compiler
-)
-from mesonbuild.mesonlib import EnvironmentException, MesonException
 from mesonbuild.programs import ExternalProgram
-
-
-from run_tests import (
-    get_fake_env
-)
+from run_tests import get_fake_env
 
 from .baseplatformtests import BasePlatformTests
 from .helpers import *
+
 
 @contextmanager
 def no_pkgconfig():

--- a/unittests/helpers.py
+++ b/unittests/helpers.py
@@ -1,18 +1,19 @@
-import subprocess
-import os
-import shutil
-import unittest
-import functools
-import re
-import typing as T
-import zipfile
-from pathlib import Path
-from contextlib import contextmanager
+from __future__ import annotations
 
-from mesonbuild.compilers import detect_c_compiler, compiler_from_language
+import functools
+import os
+import re
+import shutil
+import subprocess
+import typing as T
+import unittest
+import zipfile
+from contextlib import contextmanager
+from pathlib import Path
+
+from mesonbuild.compilers import compiler_from_language, detect_c_compiler
 from mesonbuild.mesonlib import (
-    MachineChoice, is_osx, is_cygwin, EnvironmentException, OptionKey, MachineChoice,
-    OrderedSet
+    EnvironmentException, MachineChoice, OptionKey, OrderedSet, is_cygwin, is_osx
 )
 from run_tests import get_fake_env
 

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016-2021 The Meson development team
 
-from configparser import ConfigParser
-from pathlib import Path
-from unittest import mock
+from __future__ import annotations
+
 import contextlib
 import io
 import json
@@ -15,37 +14,37 @@ import subprocess
 import tempfile
 import typing as T
 import unittest
+from configparser import ConfigParser
+from pathlib import Path
+from unittest import mock
 
-import mesonbuild.mlog
-import mesonbuild.depfile
 import mesonbuild.dependencies.base
 import mesonbuild.dependencies.factory
+import mesonbuild.depfile
 import mesonbuild.envconfig
 import mesonbuild.environment
+import mesonbuild.mlog
 import mesonbuild.modules.gnome
+import mesonbuild.modules.pkgconfig
 from mesonbuild import coredata
 from mesonbuild.compilers.c import ClangCCompiler, GnuCCompiler
 from mesonbuild.compilers.cpp import VisualStudioCPPCompiler
 from mesonbuild.compilers.d import DmdDCompiler
+from mesonbuild.dependencies.pkgconfig import PkgConfigCLI, PkgConfigDependency, PkgConfigInterface
+from mesonbuild.interpreter.type_checking import NoneType, in_set_validator
+from mesonbuild.interpreterbase import (
+    ContainerTypeInfo, InvalidArguments, KwargInfo, ObjectHolder, typed_kwargs, typed_pos_args
+)
 from mesonbuild.linkers import linkers
-from mesonbuild.interpreterbase import typed_pos_args, InvalidArguments, ObjectHolder
-from mesonbuild.interpreterbase import typed_pos_args, InvalidArguments, typed_kwargs, ContainerTypeInfo, KwargInfo
 from mesonbuild.mesonlib import (
-    LibType, MachineChoice, PerMachine, Version, is_windows, is_osx,
-    is_cygwin, is_openbsd, search_version, MesonException, OptionKey,
-    OptionType
+    LibType, MachineChoice, MesonException, OptionKey, OptionType, PerMachine, Version, is_cygwin,
+    is_openbsd, is_osx, is_windows, search_version
 )
-from mesonbuild.interpreter.type_checking import in_set_validator, NoneType
-from mesonbuild.dependencies.pkgconfig import PkgConfigDependency, PkgConfigInterface, PkgConfigCLI
 from mesonbuild.programs import ExternalProgram
-import mesonbuild.modules.pkgconfig
-
-
-from run_tests import (
-    FakeCompilerOptions, get_fake_env, get_fake_options
-)
+from run_tests import FakeCompilerOptions, get_fake_env, get_fake_options
 
 from .helpers import *
+
 
 class InternalTests(unittest.TestCase):
 
@@ -1002,11 +1001,13 @@ class InternalTests(unittest.TestCase):
     def test_validate_json(self) -> None:
         """Validate the json schema for the test cases."""
         try:
-            from fastjsonschema import compile, JsonSchemaValueException as JsonSchemaFailure
+            from fastjsonschema import JsonSchemaValueException as JsonSchemaFailure
+            from fastjsonschema import compile
             fast = True
         except ImportError:
             try:
-                from jsonschema import validate, ValidationError as JsonSchemaFailure
+                from jsonschema import ValidationError as JsonSchemaFailure
+                from jsonschema import validate
                 fast = False
             except:
                 if is_ci():

--- a/unittests/linuxcrosstests.py
+++ b/unittests/linuxcrosstests.py
@@ -1,20 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016-2021 The Meson development team
 
+from __future__ import annotations
+
 import os
+import platform
 import shutil
 import unittest
-import platform
 
-from mesonbuild.mesonlib import (
-    is_windows, is_cygwin
-)
-from mesonbuild.mesonlib import MesonException
-
-
+from mesonbuild.mesonlib import MesonException, is_cygwin, is_windows
 
 from .baseplatformtests import BasePlatformTests
 from .helpers import *
+
 
 class BaseLinuxCrossTests(BasePlatformTests):
     # Don't pass --libdir when cross-compiling. We have tests that

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -1,51 +1,49 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016-2022 The Meson development team
 
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import shutil
 import stat
 import subprocess
-import re
 import tempfile
 import textwrap
-import os
-import shutil
-import hashlib
-from unittest import mock, skipUnless, SkipTest
+import typing as T
 from glob import glob
 from pathlib import Path
-import typing as T
+from unittest import SkipTest, mock, skipUnless
 
-import mesonbuild.mlog
-import mesonbuild.depfile
+import mesonbuild.coredata
 import mesonbuild.dependencies.base
 import mesonbuild.dependencies.factory
+import mesonbuild.depfile
 import mesonbuild.envconfig
 import mesonbuild.environment
-import mesonbuild.coredata
+import mesonbuild.mlog
 import mesonbuild.modules.gnome
-from mesonbuild.mesonlib import (
-    MachineChoice, is_windows, is_osx, is_cygwin, is_openbsd, is_haiku,
-    is_sunos, windows_proof_rmtree, version_compare, is_linux,
-    OptionKey, EnvironmentException
-)
-from mesonbuild.compilers import (
-    detect_c_compiler, detect_cpp_compiler, compiler_from_language,
-)
+import mesonbuild.modules.pkgconfig
+from mesonbuild.compilers import compiler_from_language, detect_c_compiler, detect_cpp_compiler
 from mesonbuild.compilers.c import AppleClangCCompiler
 from mesonbuild.compilers.cpp import AppleClangCPPCompiler
 from mesonbuild.compilers.objc import AppleClangObjCCompiler
 from mesonbuild.compilers.objcpp import AppleClangObjCPPCompiler
-from mesonbuild.dependencies.pkgconfig import PkgConfigDependency, PkgConfigCLI, PkgConfigInterface
-import mesonbuild.modules.pkgconfig
+from mesonbuild.dependencies.pkgconfig import PkgConfigCLI, PkgConfigDependency, PkgConfigInterface
+from mesonbuild.mesonlib import (
+    EnvironmentException, MachineChoice, OptionKey, is_cygwin, is_haiku, is_linux, is_openbsd,
+    is_osx, is_sunos, is_windows, version_compare, windows_proof_rmtree
+)
 
 PKG_CONFIG = os.environ.get('PKG_CONFIG', 'pkg-config')
 
 
-from run_tests import (
-    get_fake_env
-)
+from run_tests import get_fake_env
 
 from .baseplatformtests import BasePlatformTests
 from .helpers import *
+
 
 def _prepend_pkg_config_path(path: str) -> str:
     """Prepend a string value to pkg_config_path

--- a/unittests/machinefiletests.py
+++ b/unittests/machinefiletests.py
@@ -3,42 +3,34 @@
 
 from __future__ import annotations
 
-import subprocess
-import tempfile
-import textwrap
+import functools
 import os
 import shutil
-import functools
-import threading
+import subprocess
 import sys
-from itertools import chain
-from unittest import mock, skipIf, SkipTest
-from pathlib import Path
+import tempfile
+import textwrap
+import threading
 import typing as T
+from itertools import chain
+from pathlib import Path
+from unittest import SkipTest, mock, skipIf
 
-import mesonbuild.mlog
-import mesonbuild.depfile
+import mesonbuild.coredata
 import mesonbuild.dependencies.factory
+import mesonbuild.depfile
 import mesonbuild.envconfig
 import mesonbuild.environment
-import mesonbuild.coredata
+import mesonbuild.mlog
 import mesonbuild.modules.gnome
-from mesonbuild.mesonlib import (
-    MachineChoice, is_windows, is_osx, is_cygwin, is_haiku, is_sunos
-)
-from mesonbuild.compilers import (
-    detect_swift_compiler, compiler_from_language
-)
 import mesonbuild.modules.pkgconfig
-
-
-from run_tests import (
-    Backend,
-    get_fake_env
-)
+from mesonbuild.compilers import compiler_from_language, detect_swift_compiler
+from mesonbuild.mesonlib import MachineChoice, is_cygwin, is_haiku, is_osx, is_sunos, is_windows
+from run_tests import Backend, get_fake_env
 
 from .baseplatformtests import BasePlatformTests
 from .helpers import *
+
 
 @functools.lru_cache()
 def is_real_gnu_compiler(path):

--- a/unittests/platformagnostictests.py
+++ b/unittests/platformagnostictests.py
@@ -1,21 +1,27 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2021 The Meson development team
 
+from __future__ import annotations
+
 import json
 import os
 import pickle
-import tempfile
-import subprocess
-import textwrap
 import shutil
-from unittest import skipIf, SkipTest
+import subprocess
+import tempfile
+import textwrap
 from pathlib import Path
+from unittest import SkipTest, skipIf
+
+from mesonbuild.mesonlib import (
+    EnvironmentVariables, ExecutableSerialisation, is_linux, python_command
+)
+from mesonbuild.optinterpreter import OptionException, OptionInterpreter
+from run_tests import Backend
 
 from .baseplatformtests import BasePlatformTests
 from .helpers import is_ci
-from mesonbuild.mesonlib import EnvironmentVariables, ExecutableSerialisation, is_linux, python_command
-from mesonbuild.optinterpreter import OptionInterpreter, OptionException
-from run_tests import Backend
+
 
 @skipIf(is_ci() and not is_linux(), "Run only on fast platforms")
 class PlatformAgnosticTests(BasePlatformTests):

--- a/unittests/pythontests.py
+++ b/unittests/pythontests.py
@@ -1,18 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016-2021 The Meson development team
 
-import glob, os, pathlib, shutil, subprocess, unittest
+from __future__ import annotations
 
-from run_tests import (
-    Backend
-)
+import glob
+import os
+import pathlib
+import shutil
+import subprocess
+import unittest
+
+from mesonbuild.mesonlib import MachineChoice, TemporaryDirectoryWinProof
+from mesonbuild.modules.python import PythonModule
+from run_tests import Backend
 
 from .allplatformstests import git_init
 from .baseplatformtests import BasePlatformTests
 from .helpers import *
 
-from mesonbuild.mesonlib import MachineChoice, TemporaryDirectoryWinProof
-from mesonbuild.modules.python import PythonModule
 
 class PythonTests(BasePlatformTests):
     '''

--- a/unittests/rewritetests.py
+++ b/unittests/rewritetests.py
@@ -1,18 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016-2021 The Meson development team
 
-import subprocess
-from itertools import zip_longest
+from __future__ import annotations
+
 import json
 import os
-from pathlib import Path
 import shutil
+import subprocess
 import unittest
+from itertools import zip_longest
+from pathlib import Path
 
-from mesonbuild.ast import IntrospectionInterpreter, AstIDGenerator
+from mesonbuild.ast import AstIDGenerator, IntrospectionInterpreter
 from mesonbuild.ast.printer import RawPrinter
 from mesonbuild.mesonlib import windows_proof_rmtree
+
 from .baseplatformtests import BasePlatformTests
+
 
 class RewriterTests(BasePlatformTests):
     def setUp(self):

--- a/unittests/subprojectscommandtests.py
+++ b/unittests/subprojectscommandtests.py
@@ -1,21 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016-2021 The Meson development team
 
+from __future__ import annotations
+
+import os
 import subprocess
 import tempfile
 import textwrap
-import os
-from pathlib import Path
 import typing as T
+from pathlib import Path
 
-from mesonbuild.mesonlib import (
-    version_compare, git, search_version
-)
-
-
+from mesonbuild.mesonlib import git, search_version, version_compare
 
 from .baseplatformtests import BasePlatformTests
 from .helpers import *
+
 
 class SubprojectsCommandTests(BasePlatformTests):
     def setUp(self):

--- a/unittests/taptests.py
+++ b/unittests/taptests.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016-2021 The Meson development team
 
-import unittest
+from __future__ import annotations
+
 import io
+import unittest
 
 from mesonbuild.mtest import TAPParser, TestResult
 

--- a/unittests/windowstests.py
+++ b/unittests/windowstests.py
@@ -1,38 +1,35 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016-2021 The Meson development team
 
-import subprocess
-import re
-import os
-import shutil
-from unittest import mock, SkipTest, skipUnless, skipIf
-from glob import glob
+from __future__ import annotations
 
-import mesonbuild.mlog
-import mesonbuild.depfile
+import os
+import re
+import shutil
+import subprocess
+from glob import glob
+from unittest import SkipTest, mock, skipIf, skipUnless
+
+import mesonbuild.coredata
+import mesonbuild.dependencies.base
 import mesonbuild.dependencies.factory
+import mesonbuild.depfile
 import mesonbuild.envconfig
 import mesonbuild.environment
-import mesonbuild.coredata
+import mesonbuild.mlog
 import mesonbuild.modules.gnome
+import mesonbuild.modules.pkgconfig
+from mesonbuild.compilers import compiler_from_language, detect_c_compiler, detect_d_compiler
 from mesonbuild.mesonlib import (
-    MachineChoice, is_windows, is_cygwin, python_command, version_compare,
-    EnvironmentException, OptionKey
-)
-from mesonbuild.compilers import (
-    detect_c_compiler, detect_d_compiler, compiler_from_language,
+    EnvironmentException, MachineChoice, OptionKey, is_cygwin, is_windows, python_command,
+    version_compare
 )
 from mesonbuild.programs import ExternalProgram
-import mesonbuild.dependencies.base
-import mesonbuild.modules.pkgconfig
-
-
-from run_tests import (
-    Backend, get_fake_env
-)
+from run_tests import Backend, get_fake_env
 
 from .baseplatformtests import BasePlatformTests
 from .helpers import *
+
 
 @skipUnless(is_windows() or is_cygwin(), "requires Windows (or Windows via Cygwin)")
 class WindowsTests(BasePlatformTests):


### PR DESCRIPTION
I have a previous attempt at this from a year ago https://github.com/mesonbuild/meson/pull/11476, you can read the history there if you like. I started a new PR because this one is a from scratch rewrite, with a number of fixes.

I think for the most part everyone agrees that we should use isort, but there's some debate about how it should be used. I see several competing concerns (in no particular order):
 - readability
 - white space use
 - git diff collisions
 - continuity with the wider python community

The first is very subjective, but in general humans are best able to parse alphabetically sorted lists, and isort does that by default.

The second has merit, especially for editors that do not fold/hide/condense imports by default (like vim does), to that end I've used the grid hanging format for `from X import (a, b, c)` format, which will drop the `)` onto a newline, but align to the left:
```python
from mod import (
    Class1, Class2, func1, func2
)
```
This takes up a little more whitespace than cuddling the closing brace would, but minimizes git diffs by not having to move the `)` around.

The final change, the one that seems the most contentious is that I set this to follow the two most common styles guides (PEP8 and Google) and place individual imports on a single line:
```python
import os
import sys
import zlib
```
This does use more whitespace thatn `import os, sys, zlib` would, but it also creates fewer git collisions. It is also the standard used widely across the python community.

The big patch here is autogenerated, and it does not make sense to attempt to rebase it. Just throw it away and regenerate