### PR TITLE
mtest: set MSAN_OPTIONS to abort by default

### DIFF
--- a/docs/markdown/Unit-tests.md
+++ b/docs/markdown/Unit-tests.md
@@ -38,11 +38,11 @@ set to a random value between 1..255. This can help find memory leaks on
 configurations using glibc, including with non-GCC compilers. This feature
 can be disabled as discussed in [[test]].
 
-### ASAN_OPTIONS and UBSAN_OPTIONS
+### ASAN_OPTIONS, UBSAN_OPTIONS, and MSAN_OPTIONS
 
-By default, the environment variables `ASAN_OPTIONS` and `UBSAN_OPTIONS` are
-set to enable aborting on detected violations and to give a backtrace. This
-feature can be disabled as discussed in [[test]].
+By default, the environment variables `ASAN_OPTIONS`, `UBSAN_OPTIONS`, and
+`MSAN_OPTIONS` are set to enable aborting on detected violations and to give a
+backtrace. This feature can be disabled as discussed in [[test]].
 
 ## Coverage
 

--- a/docs/markdown/snippets/sanitizers_test.md
+++ b/docs/markdown/snippets/sanitizers_test.md
@@ -1,0 +1,6 @@
+## Tests now abort on errors by default under more sanitizers
+
+Sanitizers like MemorySanitizer do not abort
+by default on detected violations. Meson now exports `MSAN_OPTIONS` (in addition to
+`ASAN_OPTIONS` and `UBSAN_OPTIONS` from a previous release) when unset in the
+environment to provide sensible abort-by-default behavior.

--- a/docs/yaml/functions/test.yaml
+++ b/docs/yaml/functions/test.yaml
@@ -33,9 +33,10 @@ description: |
   test(..., env: nomalloc, ...)
   ```
 
-  By default, the environment variables `ASAN_OPTIONS` and `UBSAN_OPTIONS` are
-  set to enable aborting on detected violations and to give a backtrace. To suppress
-  this, `ASAN_OPTIONS` and `UBSAN_OPTIONS` can be set in the environment.
+  By default, the environment variables `ASAN_OPTIONS`, `UBSAN_OPTIONS`,
+  and `MSAN_OPTIONS` are set to enable aborting on detected violations and to
+  give a backtrace. To suppress this, `ASAN_OPTIONS`, `UBSAN_OPTIONS`, or
+  `MSAN_OPTIONS` can be set in the environment.
 
   In addition to running individual executables as test cases, `test()`
   can also be used to invoke an external test harness.  In this case,

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1414,6 +1414,8 @@ class SingleTestRunner:
             env['ASAN_OPTIONS'] = 'halt_on_error=1:abort_on_error=1:print_summary=1'
         if ('UBSAN_OPTIONS' not in env or not env['UBSAN_OPTIONS']):
             env['UBSAN_OPTIONS'] = 'halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1'
+        if ('MSAN_OPTIONS' not in env or not env['MSAN_OPTIONS']):
+            env['UBSAN_OPTIONS'] = 'halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1'
 
         if self.options.gdb or self.test.timeout is None or self.test.timeout <= 0:
             timeout = None


### PR DESCRIPTION
Followup to 7b7d2e060b447de9c2642848847370a58711ac1c which handles ASAN and UBSAN.

It turns out that MSAN needs the same treatment. I've checked other sanitizers like HWASAN and TSAN - it looks like they may both need it too, but Meson doesn't currently suppose those anyway (see https://github.com/mesonbuild/meson/pull/12648).