### PR TITLE
run_project_tests: Fix Cython compiler detection

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,14 +15,14 @@ on:
       - "test cases/**"
       - "unittests/**"
       - ".github/workflows/macos.yml"
-      - "run_unittests.py"
+      - "run*tests.py"
   pull_request:
     paths:
       - "mesonbuild/**"
       - "test cases/**"
       - "unittests/**"
       - ".github/workflows/macos.yml"
-      - "run_unittests.py"
+      - "run*tests.py"
 
 permissions:
   contents: read

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -15,14 +15,14 @@ on:
       - "test cases/**"
       - "unittests/**"
       - ".github/workflows/msys2.yml"
-      - "run_unittests.py"
+      - "run*tests.py"
   pull_request:
     paths:
       - "mesonbuild/**"
       - "test cases/**"
       - "unittests/**"
       - ".github/workflows/msys2.yml"
-      - "run_unittests.py"
+      - "run*tests.py"
 
 permissions:
   contents: read

--- a/.github/workflows/os_comp.yml
+++ b/.github/workflows/os_comp.yml
@@ -16,7 +16,7 @@ on:
       - "unittests/**"
       - ".github/workflows/images.yml"
       - ".github/workflows/os_comp.yml"
-      - "run_unittests.py"
+      - "run*tests.py"
   pull_request:
     paths:
       - "mesonbuild/**"
@@ -24,7 +24,7 @@ on:
       - "unittests/**"
       - ".github/workflows/images.yml"
       - ".github/workflows/os_comp.yml"
-      - "run_unittests.py"
+      - "run*tests.py"
 
 permissions:
   contents: read


### PR DESCRIPTION
On Debian systems the cython compiler binary is installed as `cython3`. The current logic for detecting whether to run the Cython unit tests instead checks for `cython` or the value of the `CYTHON` environment variable, which leads to cases where the underlying Meson can correctly compile Cython code but the test harness excludes these tests from execution because it cannot find `cython3`.

This commit makes the test harness use the same detection method as Meson itself. It also takes the opportunity to refactor some existing code which does the same job for Objective C and Objective C++ tests to avoid repetition.