### PR TITLE
Detect utf8 bom from meson build files

### DIFF
--- a/mesonbuild/interpreterbase/interpreterbase.py
+++ b/mesonbuild/interpreterbase/interpreterbase.py
@@ -107,10 +107,11 @@ class InterpreterBase:
             self.handle_meson_version_from_ast()
         except mparser.ParseException as me:
             me.file = mesonfile
-            # try to detect parser errors from new syntax added by future
-            # meson versions, and just tell the user to update meson
-            self.ast = me.ast
-            self.handle_meson_version_from_ast()
+            if me.ast:
+                # try to detect parser errors from new syntax added by future
+                # meson versions, and just tell the user to update meson
+                self.ast = me.ast
+                self.handle_meson_version_from_ast()
             raise me
 
     def parse_project(self) -> None:

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -96,6 +96,10 @@ class Token(T.Generic[TV_TokenTypes]):
 
 class Lexer:
     def __init__(self, code: str):
+        if code.startswith(codecs.BOM_UTF8.decode('utf-8')):
+            line, *_ = code.split('\n', maxsplit=1)
+            raise ParseException('Builder file must be encoded in UTF-8 (with no BOM)', line, lineno=0, colno=0)
+
         self.code = code
         self.keywords = {'true', 'false', 'if', 'else', 'elif',
                          'endif', 'and', 'or', 'not', 'foreach', 'endforeach',

--- a/test cases/failing/130 utf8 with bom/meson.build
+++ b/test cases/failing/130 utf8 with bom/meson.build
@@ -1,0 +1,3 @@
+﻿project('utf8 with bom')
+
+subdir('subdir')

--- a/test cases/failing/130 utf8 with bom/test.json
+++ b/test cases/failing/130 utf8 with bom/test.json
@@ -1,0 +1,8 @@
+{
+    "stdout": [
+      {
+        "line": "test cases/failing/130 utf8 with bom/meson.build:0:0: ERROR: Builder file must be encoded in UTF-8 (with no BOM)"
+      }
+    ]
+  }
+  

--- a/test cases/failing/131 utf8 with bom subdir/meson.build
+++ b/test cases/failing/131 utf8 with bom subdir/meson.build
@@ -1,0 +1,3 @@
+project('utf8 with bom subdir')
+
+subdir('subdir')

--- a/test cases/failing/131 utf8 with bom subdir/subdir/meson.build
+++ b/test cases/failing/131 utf8 with bom subdir/subdir/meson.build
@@ -1,0 +1,1 @@
+﻿a = 'Hello, World!'

--- a/test cases/failing/131 utf8 with bom subdir/test.json
+++ b/test cases/failing/131 utf8 with bom subdir/test.json
@@ -1,0 +1,8 @@
+{
+    "stdout": [
+      {
+        "line": "test cases/failing/131 utf8 with bom subdir/subdir/meson.build:0:0: ERROR: Builder file must be encoded in UTF-8 (with no BOM)"
+      }
+    ]
+  }
+  

--- a/test cases/failing/132 utf8 with bom options/meson.build
+++ b/test cases/failing/132 utf8 with bom options/meson.build
@@ -1,0 +1,1 @@
+project('utf8 with bom options')

--- a/test cases/failing/132 utf8 with bom options/meson.options
+++ b/test cases/failing/132 utf8 with bom options/meson.options
@@ -1,0 +1,1 @@
+﻿option('someoption', type : 'string', value : 'optval', description : 'An option')

--- a/test cases/failing/132 utf8 with bom options/test.json
+++ b/test cases/failing/132 utf8 with bom options/test.json
@@ -1,0 +1,8 @@
+{
+    "stdout": [
+      {
+        "line": "test cases/failing/132 utf8 with bom options/meson.options:0:0: ERROR: Builder file must be encoded in UTF-8 (with no BOM)"
+      }
+    ]
+  }
+  


### PR DESCRIPTION
Some text editors on Windows may use utf8bom encoding by default. Prevent crash by stripping the bom before trying to interpret the build files.

Fixing this at the Lexer level allows to do it at one place. Another solution would be to open the build files with `utf-8-sig` encoding, but that would require to do it at each places build files are opened.

Fixes #12766.