### PR TITLE
determine_windows_extra_paths: append external dependencies after internal ones

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1195,25 +1195,31 @@ class Backend:
         links to and return them so they can be used in unit
         tests.
         """
-        result: T.Set[str] = set()
         prospectives: T.Set[build.BuildTargetTypes] = set()
+        internal_deps: T.Set[str] = set()
+        external_deps: T.Set[str] = set()
+
         if isinstance(target, build.BuildTarget):
             prospectives.update(target.get_all_link_deps())
-            # External deps
-            result.update(self.extract_dll_paths(target))
 
         for bdep in extra_bdeps:
             prospectives.add(bdep)
             if isinstance(bdep, build.BuildTarget):
                 prospectives.update(bdep.get_all_link_deps())
+
         # Internal deps
         for ld in prospectives:
             dirseg = os.path.join(self.environment.get_build_dir(), self.get_target_dir(ld))
-            result.add(dirseg)
-        if (isinstance(target, build.BuildTarget) and
-                not self.environment.machines.matches_build_machine(target.for_machine)):
-            result.update(self.get_mingw_extra_paths(target))
-        return list(result)
+            internal_deps.add(dirseg)
+
+        if isinstance(target, build.BuildTarget):
+            # External deps
+            external_deps.update(self.extract_dll_paths(target))
+
+            if not self.environment.machines.matches_build_machine(target.for_machine):
+                external_deps.update(self.get_mingw_extra_paths(target))
+
+        return list(internal_deps) + list(external_deps)
 
     def write_benchmark_file(self, datafile: T.BinaryIO) -> None:
         self.write_test_serialisation(self.build.get_benchmarks(), datafile)


### PR DESCRIPTION
This PR switches to using an `OrderedSet` to keep track of the directories that will be added in `PATH`. Using an OrderedSet seems the right choice because:

1. We don't want duplicate entries in `PATH`
2. Order really matters
3. While we may use an unordered set for internal deps and an unordered set for external deps, then concatenate at the end, it's best to have deterministic results. Due to that, we also use an `OrderedSet` for the `prospectives`

Fixes #12330
Fixes #14400