### PR TITLE
Fix warning in scan-build

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3574,7 +3574,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             return
         cmd = self.environment.get_build_command() + \
             ['--internal', 'scanbuild', self.environment.source_dir, self.environment.build_dir, self.build.get_subproject_dir()] + \
-            self.environment.get_build_command() + self.get_user_option_args()
+            self.environment.get_build_command() + ['setup'] + self.get_user_option_args()
         elem = self.create_phony_target('scan-build', 'CUSTOM_COMMAND', 'PHONY')
         elem.add_item('COMMAND', cmd)
         elem.add_item('pool', 'console')


### PR DESCRIPTION
Using scan-build gives the following warning: "Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated."

This commit fixes this issue by adding the setup keyword to the scan-build invocation.