### PR TITLE
Provide a better error message when mixing host and build machines

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1482,7 +1482,7 @@ class BuildTarget(Target):
         if not self.uses_rust() and links_with_rust_abi:
             raise InvalidArguments(f'Try to link Rust ABI library {t.name!r} with a non-Rust target {self.name!r}')
         if self.for_machine is not t.for_machine and (not links_with_rust_abi or t.rust_crate_type != 'proc-macro'):
-            msg = f'Tried to mix libraries for machines {self.for_machine} and {t.for_machine} in target {self.name!r}'
+            msg = f'Tried to tied to mix a {t.for_machine} library ("{t.name}") with a {self.for_machine} target "{self.name}"'
             if self.environment.is_cross_build():
                 raise InvalidArguments(msg + ' This is not possible in a cross build.')
             else:


### PR DESCRIPTION
Since we don't get a location for these errors, we can at least tell you which targets you happen to be mixing together that produce this problem.

Ran into while trying to debug a target mixing bug.