### PR TITLE
Improve the test for a bug in Python module

### DIFF
--- a/test cases/python/5 modules kwarg/meson.build
+++ b/test cases/python/5 modules kwarg/meson.build
@@ -1,7 +1,6 @@
 project('python kwarg',
     default_options: [
-        'python.bytecompile=-1',
-        'python.purelibdir=/pure',
+        'python.bytecompile=-1',  # because there is currently is no way to know the installed filename in test.json
     ]
 )
 

--- a/test cases/python/5 modules kwarg/test.json
+++ b/test cases/python/5 modules kwarg/test.json
@@ -1,5 +1,5 @@
 {
     "installed": [
-        { "type": "python_file", "file": "pure/a.py"}
+        { "type": "python_file", "file": "usr/@PYTHON_PURELIB@/a.py"}
     ]
 }


### PR DESCRIPTION
Fixup for 18c96bcc460b84b965e0bf8230f7786e01b76928. Overriding the pure path is not needed, since there already is an available substitution variable for that.