### PR TITLE
macros: Add __meson_extra_configure_opts

### DIFF
--- a/data/macros.meson
+++ b/data/macros.meson
@@ -22,6 +22,7 @@
         --sharedstatedir=%{_sharedstatedir} \
         --wrap-mode=%{__meson_wrap_mode} \
         --auto-features=%{__meson_auto_features} \
+        %{?__meson_extra_configure_options} \
         %{_vpath_srcdir} %{_vpath_builddir} \
         %{nil}}
 


### PR DESCRIPTION
Let's allow users to set extra configure options using the __meson_extra_configure_opts macro. This is useful when building an existing rpm spec that uses the %meson macros and we want to set some extra configure options without having to modify the spec itself.