### PR TITLE
Add a system dependency for numpy

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -656,9 +656,20 @@ The `language` keyword may used.
 
 *(added 1.4.0)*
 
-`method` may be `auto`, `pkg-config`, or `config-tool`.
+`method` may be `auto`, `pkg-config`, `config-tool`, or `system`.
 `dependency('numpy')` supports regular use of the NumPy C API.
 Use of `numpy.f2py` for binding Fortran code isn't yet supported.
+
+The use of the `system` method is useful and necessary only for NumPy
+1.x; for NumPy 2.0 and up the pkg-config and config-tool methods are available
+and preferred. Importantly, the system method requires passing in the target
+Python installation:
+
+```meson
+py = import('python').find_installation(pure: false)
+
+numpy_dep = dependency('numpy', interpreter: py)
+```
 
 ## pcap
 

--- a/mesonbuild/dependencies/detect.py
+++ b/mesonbuild/dependencies/detect.py
@@ -41,7 +41,7 @@ _packages_accept_language: T.Set[str] = set()
 def get_dep_identifier(name: str, kwargs: T.Dict[str, T.Any]) -> 'TV_DepID':
     identifier: 'TV_DepID' = (('name', name), )
     from ..interpreter import permitted_dependency_kwargs
-    assert len(permitted_dependency_kwargs) == 19, \
+    assert len(permitted_dependency_kwargs) == 20, \
            'Extra kwargs have been added to dependency(), please review if it makes sense to handle it here'
     for key, value in kwargs.items():
         # 'version' is irrelevant for caching; the caller must check version matches
@@ -53,8 +53,10 @@ def get_dep_identifier(name: str, kwargs: T.Dict[str, T.Any]) -> 'TV_DepID':
         # 'default_options' is only used in fallback case
         # 'not_found_message' has no impact on the dependency lookup
         # 'include_type' is handled after the dependency lookup
+        # 'interpreter' is the result of a `import('python').find_installation()` call
+        #     (i.e., an ExternalProgram)
         if key in {'version', 'native', 'required', 'fallback', 'allow_fallback', 'default_options',
-                   'not_found_message', 'include_type'}:
+                   'not_found_message', 'include_type', 'interpreter'}:
             continue
         # All keyword arguments are strings, ints, or lists (or lists of lists)
         if isinstance(value, list):

--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import functools, json, os, textwrap
 from pathlib import Path
+import subprocess
 import typing as T
 
 from .. import mesonlib, mlog
@@ -70,6 +71,34 @@ class NumPyConfigToolDependency(ConfigToolDependency):
         if not self.is_found:
             return
         self.compile_args = self.get_config_value(['--cflags'], 'compile_args')
+
+
+class NumPySystemDependency(SystemDependency):
+    """
+    This dependency should only be needed for NumPy 1.x; from NumPy 2.0 onwards,
+    numpy-config should always be available.
+    """
+    def __init__(self, name: str, environment: 'Environment', kwargs: T.Dict[str, T.Any]) -> None:
+        super().__init__(name, environment, kwargs, language='c')
+
+        # We need `numpy` for the Python interpreter that the user is building for.
+        # To get at the result of import('python').find_installation(...), we need the
+        # user to pass it in.
+        py_interpreter: str = mesonlib.extract_as_list(kwargs, 'interpreter')[0]
+        if not py_interpreter.found():
+            self.is_found = False
+            return
+
+        cmd = py_interpreter.command + ['-c', 'import numpy; print(numpy.get_include())']
+
+        p = subprocess.run(cmd, capture_output=True, text=True)
+        incdir = p.stdout.strip()
+        if p.returncode != 0 or not os.path.exists(incdir):
+            self.is_found = False
+            return
+
+        self.is_found = True
+        self.compile_args = ['-I' + incdir]
 
 
 class BasicPythonExternalProgram(ExternalProgram):
@@ -426,6 +455,7 @@ packages['pybind11'] = pybind11_factory = DependencyFactory(
 
 packages['numpy'] = numpy_factory = DependencyFactory(
     'numpy',
-    [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL],
+    [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.SYSTEM],
     configtool_class=NumPyConfigToolDependency,
+    system_class=NumPySystemDependency,
 )

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -239,6 +239,7 @@ permitted_dependency_kwargs = {
     'default_options',
     'fallback',
     'include_type',
+    'interpreter',
     'language',
     'main',
     'method',


### PR DESCRIPTION
As a follow-up to gh-12799, and addresses gh-9598.

Opening as draft for now, because the key issue (how to get at the target Python installation) required a new keyword for `dependency`, which I suspect is going to lead to a bit of discussion. To get at the right `numpy` package, the install found by `import('python').find_installation(...)` _must_ be used. There may even be several such installation objects floating around in a user's `meson.build` files. It doesn't seem possible to get at those without the user passing in the target interpreter. I went with this API:
```meson
py = import('python').find_installation(pure: false)

dependency('numpy', interpreter: py)
```

Alternatives to achieve this I considered are:
    
- `dependency('numpy', interpreter: py.path())  # not as nice, but does keep keyword value as a string`
- `dependency('numpy', dependencies: py_dep)`
- reusing an existing keyword like `modules` or `components` (but nothing really seems to fit here)

Of course the last alternative is deciding that any of these solutions are not acceptable, and letting users wait until they no longer need NumPy 1.x (1.5 to 3 years from now for widely used packages). Until that time they'd have to use this very ugly code block to support 1.x: 

https://github.com/PyWavelets/pywt/blob/e69b126c096868b0ea7650d38ed11cd95a9dc182/pywt/_extensions/meson.build#L15-L39

This new keyword is in principle not only applicable to numpy, but to system dependencies for other Python packages with C APIs as well. There aren't too many of those though, so I'm not sure how compelling an argument that is.