### PR TITLE
reduce unnecessary use of --start-group in compiler command lines

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -84,7 +84,8 @@ class CLikeCompilerArgs(arglist.CompilerArgs):
                 if group_start < 0:
                     # First occurrence of a library
                     group_start = i
-            if group_start >= 0:
+            # Only add groups if there are multiple libraries.
+            if group_end > group_start >= 0:
                 # Last occurrence of a library
                 new.insert(group_end + 1, '-Wl,--end-group')
                 new.insert(group_start, '-Wl,--start-group')

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -44,7 +44,7 @@ else:
     # do). This gives up DRYer type checking, with no runtime impact
     Compiler = object
 
-GROUP_FLAGS = re.compile(r'''\.so (?:\.[0-9]+)? (?:\.[0-9]+)? (?:\.[0-9]+)?$ |
+GROUP_FLAGS = re.compile(r'''^(?!-Wl,) .*\.so (?:\.[0-9]+)? (?:\.[0-9]+)? (?:\.[0-9]+)?$ |
                              ^(?:-Wl,)?-l |
                              \.a$''', re.X)
 

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -978,7 +978,7 @@ class Xc16DynamicLinker(DynamicLinker):
                          version=version)
 
     def get_link_whole_for(self, args: T.List[str]) -> T.List[str]:
-        if not args:
+        if len(args) < 2:
             return args
         return self._apply_prefix('--start-group') + args + self._apply_prefix('--end-group')
 
@@ -1064,7 +1064,7 @@ class TIDynamicLinker(DynamicLinker):
                          version=version)
 
     def get_link_whole_for(self, args: T.List[str]) -> T.List[str]:
-        if not args:
+        if len(args) < 2:
             return args
         return self._apply_prefix('--start-group') + args + self._apply_prefix('--end-group')
 

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -241,7 +241,7 @@ class InternalTests(unittest.TestCase):
         gcc.get_default_include_dirs = lambda: ['/usr/include', '/usr/share/include', '/usr/local/include']
         ## Test that 'direct' append and extend works
         l = gcc.compiler_args(['-Lfoodir', '-lfoo'])
-        self.assertEqual(l.to_native(copy=True), ['-Lfoodir', '-Wl,--start-group', '-lfoo', '-Wl,--end-group'])
+        self.assertEqual(l.to_native(copy=True), ['-Lfoodir', '-lfoo'])
         # Direct-adding a library and a libpath appends both correctly
         l.extend_direct(['-Lbardir', '-lbar'])
         self.assertEqual(l.to_native(copy=True), ['-Lfoodir', '-Wl,--start-group', '-lfoo', '-Lbardir', '-lbar', '-Wl,--end-group'])
@@ -269,10 +269,10 @@ class InternalTests(unittest.TestCase):
         gcc.get_default_include_dirs = lambda: ['/usr/include', '/usr/share/include', '/usr/local/include']
         ## Test that 'direct' append and extend works
         l = gcc.compiler_args(['-Lfoodir', '-lfoo'])
-        self.assertEqual(l.to_native(copy=True), ['-Lfoodir', '-Wl,--start-group', '-lfoo', '-Wl,--end-group'])
+        self.assertEqual(l.to_native(copy=True), ['-Lfoodir', '-lfoo'])
         ## Test that to_native removes all system includes
         l += ['-isystem/usr/include', '-isystem=/usr/share/include', '-DSOMETHING_IMPORTANT=1', '-isystem', '/usr/local/include']
-        self.assertEqual(l.to_native(copy=True), ['-Lfoodir', '-Wl,--start-group', '-lfoo', '-Wl,--end-group', '-DSOMETHING_IMPORTANT=1'])
+        self.assertEqual(l.to_native(copy=True), ['-Lfoodir', '-lfoo', '-DSOMETHING_IMPORTANT=1'])
 
     def test_string_templates_substitution(self):
         dictfunc = mesonbuild.mesonlib.get_filenames_templates_dict


### PR DESCRIPTION
- We erroneously include `-Wl,-soname,libfoo.so.1` inside of groups
- We pointlessly make a single library into a group.

Ref: https://github.com/google/liblc3/pull/45#issuecomment-1965603859