### PR TITLE
rust: recursively pull proc-macro dependencies as well

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1295,8 +1295,6 @@ class BuildTarget(Target):
         for t in self.link_targets:
             if t in result:
                 continue
-            if t.rust_crate_type == 'proc-macro':
-                continue
             if include_internals or not t.is_internal():
                 result.add(t)
             if isinstance(t, StaticLibrary):

--- a/test cases/rust/18 proc-macro/lib.rs
+++ b/test cases/rust/18 proc-macro/lib.rs
@@ -1,0 +1,8 @@
+extern crate proc_macro_examples;
+use proc_macro_examples::make_answer;
+
+make_answer!();
+
+pub fn func() -> u32 {
+    answer()
+}

--- a/test cases/rust/18 proc-macro/meson.build
+++ b/test cases/rust/18 proc-macro/meson.build
@@ -31,3 +31,14 @@ main = executable(
 )
 
 test('main_test2', main)
+
+subdir('subdir')
+
+staticlib = static_library('staticlib', 'lib.rs',
+  link_with: pm_in_subdir,
+  rust_dependency_map : {'proc_macro_examples3' : 'proc_macro_examples'}
+)
+
+executable('transitive-proc-macro', 'transitive-proc-macro.rs',
+  link_with: staticlib,
+)

--- a/test cases/rust/18 proc-macro/subdir/meson.build
+++ b/test cases/rust/18 proc-macro/subdir/meson.build
@@ -1,0 +1,1 @@
+pm_in_subdir = rust.proc_macro('proc_macro_examples3', '../proc.rs')

--- a/test cases/rust/18 proc-macro/transitive-proc-macro.rs
+++ b/test cases/rust/18 proc-macro/transitive-proc-macro.rs
@@ -1,0 +1,7 @@
+extern crate staticlib;
+use staticlib::func;
+
+
+fn main() {
+    assert_eq!(42, func());
+}


### PR DESCRIPTION
When the proc-macro rlib is in a different subdir, it would miss the needed -L argument and rustc would not find it. Meson was assuming that proc-macros are only needed when building libraries that uses it, but it turns out that was wrong, as show by the unit test.