### PR TITLE
Fix base and compiler options not reconfigurable. 

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -106,7 +106,7 @@ def detect_compiler_for(env: 'Environment', lang: str, for_machine: MachineChoic
     if comp is None:
         return comp
     assert comp.for_machine == for_machine
-    env.coredata.process_new_compiler(lang, comp, env)
+    env.coredata.process_compiler_options(lang, comp, env)
     if not skip_sanity_check:
         comp.sanity_check(env.get_scratch_dir(), env)
     env.coredata.compilers[comp.for_machine][lang] = comp

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1003,11 +1003,9 @@ class CoreData:
             # not differ between them even when they are valid for both.
             if subproject and k.is_builtin() and self.options[k.evolve(subproject='', machine=MachineChoice.HOST)].yielding:
                 continue
-            # Skip compiler and backend options, they are handled when
+            # Skip base, compiler, and backend options, they are handled when
             # adding languages and setting backend.
-            if k.type in {OptionType.COMPILER, OptionType.BACKEND}:
-                continue
-            if k.type == OptionType.BASE and env.first_invocation:
+            if k.type in {OptionType.COMPILER, OptionType.BACKEND, OptionType.BASE}:
                 continue
             options[k] = v
 

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -974,6 +974,8 @@ class CoreData:
         return dirty
 
     def set_default_options(self, default_options: T.MutableMapping[OptionKey, str], subproject: str, env: 'Environment') -> None:
+        from .compilers import base_options
+
         # Main project can set default options on subprojects, but subprojects
         # can only set default options on themselves.
         # Preserve order: if env.options has 'buildtype' it must come after
@@ -1005,7 +1007,10 @@ class CoreData:
                 continue
             # Skip base, compiler, and backend options, they are handled when
             # adding languages and setting backend.
-            if k.type in {OptionType.COMPILER, OptionType.BACKEND, OptionType.BASE}:
+            if k.type in {OptionType.COMPILER, OptionType.BACKEND}:
+                continue
+            if k.type == OptionType.BASE and k in base_options:
+                # set_options will report unknown base options
                 continue
             options[k] = v
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1518,6 +1518,9 @@ class Interpreter(InterpreterBase, HoldableObject):
                         continue
                     else:
                         raise
+            else:
+                # update new values from commandline, if it applies
+                self.coredata.process_compiler_options(lang, comp, self.environment)
 
             # Add per-subproject compiler options. They inherit value from main project.
             if self.subproject:

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -981,7 +981,7 @@ def have_working_compiler(lang: str, use_tmp: bool) -> bool:
             return False
         if not compiler:
             return False
-        env.coredata.process_new_compiler(lang, compiler, env)
+        env.coredata.process_compiler_options(lang, compiler, env)
         try:
             compiler.sanity_check(env.get_scratch_dir(), env)
         except mesonlib.MesonException:

--- a/test cases/unit/122 reconfigure base options/meson.build
+++ b/test cases/unit/122 reconfigure base options/meson.build
@@ -1,0 +1,5 @@
+project('reconfigure', 'c',
+default_options: ['c_std=c89'])
+
+message('b_ndebug: ' + get_option('b_ndebug'))
+message('c_std: ' + get_option('c_std'))

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -2694,7 +2694,7 @@ class AllPlatformTests(BasePlatformTests):
 
         # It is not an error to set wrong option for unknown subprojects or
         # language because we don't have control on which one will be selected.
-        self.init(testdir, extra_args=['-Dc_wrong=1', '-Dwrong:bad=1', '-Db_wrong=1'])
+        self.init(testdir, extra_args=['-Dc_wrong=1', '-Dwrong:bad=1'])
         self.wipe()
 
         # Test we can set subproject option

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -471,7 +471,7 @@ class AllPlatformTests(BasePlatformTests):
         # Ensure command output and JSON / text logs are not mangled.
         raw_output_sample = '\x00\x01\x02\x03\x04\x05\x06\x07\x08\x0b'
         assert raw_output_sample in tests_command_output
-        text_log = Path(self.logdir, 'testlog.txt').read_text()
+        text_log = Path(self.logdir, 'testlog.txt').read_text(encoding='utf-8')
         assert raw_output_sample in text_log
         json_log = json.loads(Path(self.logdir, 'testlog.json').read_bytes())
         assert raw_output_sample in json_log['stdout']

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -85,6 +85,7 @@ class BasePlatformTests(TestCase):
             # XCode backend is untested with unit tests, help welcome!
             self.no_rebuild_stdout = [f'UNKNOWN BACKEND {self.backend.name!r}']
         os.environ['COLUMNS'] = '80'
+        os.environ['PYTHONIOENCODING'] = 'utf8'
 
         self.builddirs = []
         self.new_builddir()

--- a/unittests/platformagnostictests.py
+++ b/unittests/platformagnostictests.py
@@ -285,3 +285,10 @@ class PlatformAgnosticTests(BasePlatformTests):
         out = self.init(testdir, extra_args=['--reconfigure', '-Db_ndebug=if-release', '-Dc_std=c99'])
         self.assertIn('\nMessage: b_ndebug: if-release\n', out)
         self.assertIn('\nMessage: c_std: c99\n', out)
+
+    def test_setup_with_unknown_option(self):
+        testdir = os.path.join(self.common_test_dir, '1 trivial')
+
+        for option in ('not_an_option', 'b_not_an_option'):
+            out = self.init(testdir, extra_args=['--wipe', f'-D{option}=1'], allow_fail=True)
+            self.assertIn(f'ERROR: Unknown options: "{option}"', out)

--- a/unittests/platformagnostictests.py
+++ b/unittests/platformagnostictests.py
@@ -275,3 +275,13 @@ class PlatformAgnosticTests(BasePlatformTests):
         self.assertIn('first statement must be a call to project()', out)
         # provide guidance diagnostics by finding a file whose first AST statement is project()
         self.assertIn(f'Did you mean to run meson from the directory: "{testdir}"?', out)
+
+    def test_reconfigure_base_options(self):
+        testdir = os.path.join(self.unit_test_dir, '122 reconfigure base options')
+        out = self.init(testdir, extra_args=['-Db_ndebug=true'])
+        self.assertIn('\nMessage: b_ndebug: true\n', out)
+        self.assertIn('\nMessage: c_std: c89\n', out)
+
+        out = self.init(testdir, extra_args=['--reconfigure', '-Db_ndebug=if-release', '-Dc_std=c99'])
+        self.assertIn('\nMessage: b_ndebug: if-release\n', out)
+        self.assertIn('\nMessage: c_std: c99\n', out)


### PR DESCRIPTION
Fixes #12920.

Note: #12923 is still an issue, i.e. when no languages are setup.