### PR TITLE
test cases/common/103 has header symbol: fix for musl 1.2.5

### DIFF
--- a/test cases/common/103 has header symbol/meson.build
+++ b/test cases/common/103 has header symbol/meson.build
@@ -18,10 +18,8 @@ foreach comp : [cc, cpp]
   assert (not comp.has_header_symbol('stdlol.h', 'int'), 'shouldn\'t be able to find "int" with invalid header')
 endforeach
 
-# This is available on Glibc, Solaris & the BSD's, so just test for _GNU_SOURCE
-# on Linux
-if cc.has_function('ppoll') and host_machine.system() == 'linux'
-  assert (not cc.has_header_symbol('poll.h', 'ppoll'), 'ppoll should not be accessible without _GNU_SOURCE')
+# Glibc requires _GNU_SOURCE for ppoll. Other libcs do not.
+if cc.has_function('ppoll') and not cc.has_header_symbol('poll.h', 'ppoll')
   assert (cc.has_header_symbol('poll.h', 'ppoll', prefix : '#define _GNU_SOURCE'), 'ppoll should be accessible with _GNU_SOURCE')
 endif
 


### PR DESCRIPTION
musl 1.2.5 exposes this symbol in the default profile, and in future will expose it unconditionally, as it is on track to becoming part of POSIX.

So rather than maintaining a list of systems to run this on, let's just skip testing the feature test macro if we find ppoll in the default proifle.