### PR TITLE
Users:  Add asteria and mcfgthread

### DIFF
--- a/docs/markdown/Users.md
+++ b/docs/markdown/Users.md
@@ -19,6 +19,7 @@ topic](https://github.com/topics/meson).
  - [Akira](https://github.com/akiraux/Akira), a native Linux app for UI and UX design built in Vala and Gtk
  - [AQEMU](https://github.com/tobimensch/aqemu), a Qt GUI for QEMU virtual machines, since version 0.9.3
  - [Arduino sample project](https://github.com/jpakkane/mesonarduino)
+ - [Asteria](https://github.com/lhmouse/asteria), another scripting language
  - [Audacious](https://github.com/audacious-media-player), a lightweight and versatile audio player
  - [bolt](https://gitlab.freedesktop.org/bolt/bolt), userspace daemon to enable security levels for Thunderbolt™ 3 on Linux
  - [bsdutils](https://github.com/dcantrell/bsdutils), alternative to GNU coreutils using software from FreeBSD
@@ -109,6 +110,7 @@ format files
  - [Libzim](https://github.com/openzim/libzim), the reference implementation for the ZIM file format
  - [LXC](https://github.com/lxc/lxc), Linux container runtime
  - [Marker](https://github.com/fabiocolacio/Marker), a GTK-3 markdown editor
+ - [mcfgthread](https://github.com/lhmouse/mcfgthread), cornerstone library for C++11 threading on mingw-w64
  - [Mesa](https://mesa3d.org/), an open source graphics driver project
  - [Miniz](https://github.com/richgel999/miniz), a zlib replacement library
  - [MiracleCast](https://github.com/albfan/miraclecast), connect external monitors to your system via WiFi-Display specification aka Miracast


### PR DESCRIPTION
- [asteria](https://github.com/lhmouse/asteria) is a scripting language implemented in modern C++, still under development.
- [mcfgthread](https://github.com/lhmouse/mcfgthread) is the cornerstone library for the `mcf` thread model [since GCC 13](https://github.com/gcc-mirror/gcc/commit/f036d759ecee538555fa8c6b11963e4033732463).
