### PR TITLE
rust: Link with rlib external dependencies

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1979,6 +1979,8 @@ class NinjaBackend(backends.Backend):
         for d in target_deps:
             linkdirs.add(d.subdir)
             deps.append(self.get_dependency_filename(d))
+            if isinstance(d, build.StaticLibrary):
+                external_deps.extend(d.external_deps)
             if d.uses_rust_abi():
                 if d not in itertools.chain(target.link_targets, target.link_whole_targets):
                     # Indirect Rust ABI dependency, we only need its path in linkdirs.
@@ -1992,9 +1994,6 @@ class NinjaBackend(backends.Backend):
                 continue
 
             # Link a C ABI library
-
-            if isinstance(d, build.StaticLibrary):
-                external_deps.extend(d.external_deps)
 
             # Pass native libraries directly to the linker with "-C link-arg"
             # because rustc's "-l:+verbatim=" is not portable and we cannot rely

--- a/test cases/rust/24 system deps/main.rs
+++ b/test cases/rust/24 system deps/main.rs
@@ -1,0 +1,5 @@
+extern crate wrapper;
+
+fn main() {
+    wrapper::func();
+}

--- a/test cases/rust/24 system deps/meson.build
+++ b/test cases/rust/24 system deps/meson.build
@@ -1,0 +1,9 @@
+project('system deps', 'rust')
+
+glib = dependency('glib-2.0', required: false)
+if not glib.found()
+  error('MESON_SKIP_TEST: Need glib system dependency')
+endif
+
+rlib = static_library('wrapper', 'wrapper.rs', dependencies: glib)
+exe = executable('main', 'main.rs', link_with: rlib)

--- a/test cases/rust/24 system deps/wrapper.rs
+++ b/test cases/rust/24 system deps/wrapper.rs
@@ -1,0 +1,9 @@
+extern "C" {
+    fn g_hash_table_new() -> *mut std::ffi::c_void;
+}
+
+pub fn func() {
+    unsafe {
+        g_hash_table_new();
+    }
+}


### PR DESCRIPTION
    When linking with a Rust rlib, we should also link with its external
    system dependencies. This was currently done only for C ABI crates, do
    it for both rlib and staticlib now.
