### PR TITLE
tests: Fix unit tests with high parallelism

### DIFF
--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016-2021 The Meson development team
+# Copyright © 2024 Intel Corporation
 
+from __future__ import annotations
 from pathlib import PurePath
 from unittest import mock, TestCase, SkipTest
 import json
@@ -9,6 +11,7 @@ import os
 import re
 import subprocess
 import sys
+import shutil
 import tempfile
 import typing as T
 
@@ -492,3 +495,23 @@ class BasePlatformTests(TestCase):
 
     def assertLength(self, val, length):
         assert len(val) == length, f'{val} is not length {length}'
+
+    def copy_srcdir(self, srcdir: str) -> str:
+        """Copies a source tree and returns that copy.
+
+        ensures that the copied tree is deleted after running.
+
+        :param srcdir: The locaiton of the source tree to copy
+        :return: The location of the copy
+        """
+        dest = tempfile.mkdtemp()
+        self.addCleanup(windows_proof_rmtree, dest)
+
+        # shutil.copytree expects the destinatin directory to not exist, Once
+        # python 3.8 is required the `dirs_exist_ok` parameter negates the need
+        # for this
+        dest = os.path.join(dest, 'subdir')
+
+        shutil.copytree(srcdir, dest)
+
+        return dest

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -1411,7 +1411,7 @@ class LinuxlikeTests(BasePlatformTests):
         Test that installation of broken symlinks works fine.
         https://github.com/mesonbuild/meson/issues/3914
         '''
-        testdir = os.path.join(self.common_test_dir, testdir)
+        testdir = self.copy_srcdir(os.path.join(self.common_test_dir, testdir))
         subdir = os.path.join(testdir, subdir_path)
         with chdir(subdir):
             # Can't distribute broken symlinks in the source tree because it breaks
@@ -1419,17 +1419,14 @@ class LinuxlikeTests(BasePlatformTests):
             # hand.
             src = '../../nonexistent.txt'
             os.symlink(src, 'invalid-symlink.txt')
-            try:
-                self.init(testdir)
-                self.build()
-                self.install()
-                install_path = subdir_path.split(os.path.sep)[-1]
-                link = os.path.join(self.installdir, 'usr', 'share', install_path, 'invalid-symlink.txt')
-                self.assertTrue(os.path.islink(link), msg=link)
-                self.assertEqual(src, os.readlink(link))
-                self.assertFalse(os.path.isfile(link), msg=link)
-            finally:
-                os.remove(os.path.join(subdir, 'invalid-symlink.txt'))
+            self.init(testdir)
+            self.build()
+            self.install()
+            install_path = subdir_path.split(os.path.sep)[-1]
+            link = os.path.join(self.installdir, 'usr', 'share', install_path, 'invalid-symlink.txt')
+            self.assertTrue(os.path.islink(link), msg=link)
+            self.assertEqual(src, os.readlink(link))
+            self.assertFalse(os.path.isfile(link), msg=link)
 
     def test_install_subdir_symlinks(self):
         self.install_subdir_invalid_symlinks('59 install subdir', os.path.join('sub', 'sub1'))


### PR DESCRIPTION
On Arch's shiny new 48-core/96-thread build server, the `test_install_log_content` test fails because of an unexpected `invalid-symlink.txt` file. Apparently the test runs in parallel with `test_install_subdir_symlinks`, which modifies the `59 install subdir` source directory.

To fix this, make `install_subdir_invalid_symlinks` copy the entire test into a tmpdir before modifying it.