### PR TITLE
CI: pin mypy to version 1.8

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,8 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - run: python -m pip install mypy coverage strictyaml types-PyYAML types-tqdm types-chevron
+    # Pin mypy to version 1.8, so we retain the ability to lint for Python 3.7
+    - run: python -m pip install "mypy==1.8" coverage strictyaml types-PyYAML types-tqdm types-chevron
     - run: python run_mypy.py --allver
       env:
         PYTHONUNBUFFERED: 1


### PR DESCRIPTION
Version 1.9 removes support for python 3.7, so we either need to pin the version to 1.8 as long as we're support Python 3.7, or we need to drop linting for 3.7