### PR TITLE
Reload the option file in meson configure if it has changed on disk

### DIFF
--- a/docs/markdown/snippets/meson_configure_options_changes.md
+++ b/docs/markdown/snippets/meson_configure_options_changes.md
@@ -1,0 +1,12 @@
+## Meson configure handles changes to options in more cases
+
+Meson configure now correctly handles updates to the options file without a full
+reconfigure. This allows making a change to the `meson.options` or
+`meson_options.txt` file without a reconfigure.
+
+For example, this now works:
+```sh
+meson setup builddir
+git pull
+meson configure builddir -Doption-added-by-pull=value
+```

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2018 The Meson development team
+# Copyright © 2024 Intel Corporation
 
 # This class contains the basic functionality needed to run any interpreter
 # or an interpreter-based tool
@@ -106,7 +107,8 @@ class IntrospectionInterpreter(AstInterpreter):
         if os.path.exists(optfile):
             oi = optinterpreter.OptionInterpreter(self.subproject)
             oi.process(optfile)
-            self.coredata.update_project_options(oi.options)
+            assert isinstance(proj_name, str), 'for mypy'
+            self.coredata.update_project_options(oi.options, T.cast('SubProject', proj_name))
 
         def_opts = self.flatten_args(kwargs.get('default_options', []))
         _project_default_options = mesonlib.stringlistify(def_opts)

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2013-2024 The Meson development team
-# Copyright © 2023 Intel Corporation
+# Copyright © 2023-2024 Intel Corporation
 
 from __future__ import annotations
 
@@ -15,7 +15,7 @@ from collections import OrderedDict, abc
 from dataclasses import dataclass
 
 from .mesonlib import (
-    HoldableObject,
+    HoldableObject, MesonBugException,
     MesonException, EnvironmentException, MachineChoice, PerMachine,
     PerMachineDefaultable, default_libdir, default_libexecdir,
     default_prefix, default_datadir, default_includedir, default_infodir,
@@ -40,6 +40,7 @@ if T.TYPE_CHECKING:
     from .environment import Environment
     from .mesonlib import FileOrString
     from .cmake.traceparser import CMakeCacheEntry
+    from .interpreterbase import SubProject
 
     class SharedCMDOptions(Protocol):
 
@@ -892,13 +893,15 @@ class CoreData:
         # mypy cannot analyze type of OptionKey
         return T.cast('T.List[str]', self.options[OptionKey('link_args', machine=for_machine, lang=lang)].value)
 
-    def update_project_options(self, options: 'MutableKeyedOptionDictType') -> None:
+    def update_project_options(self, options: 'MutableKeyedOptionDictType', subproject: SubProject) -> None:
         for key, value in options.items():
             if not key.is_project():
                 continue
             if key not in self.options:
                 self.options[key] = value
                 continue
+            if key.subproject != subproject:
+                raise MesonBugException(f'Tried to set an option for subproject {key.subproject} from {subproject}!')
 
             oldval = self.options[key]
             if type(oldval) is not type(value):
@@ -913,6 +916,11 @@ class CoreData:
                 except MesonException:
                     mlog.warning(f'Old value(s) of {key} are no longer valid, resetting to default ({value.value}).',
                                  fatal=False)
+
+        # Find any extranious keys for this project and remove them
+        for key in list(self.options.keys() - options.keys()):
+            if key.is_project() and key.subproject == subproject:
+                del self.options[key]
 
     def is_cross_build(self, when_building_for: MachineChoice = MachineChoice.HOST) -> bool:
         if when_building_for == MachineChoice.BUILD:

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -575,6 +575,11 @@ class CoreData:
         self.cross_files = self.__load_config_files(options, scratch_dir, 'cross')
         self.compilers: PerMachine[T.Dict[str, Compiler]] = PerMachine(OrderedDict(), OrderedDict())
 
+        # Stores the (name, hash) of the options file, The name will be either
+        # "meson_options.txt" or "meson.options".
+        # This is used by mconf to reload the option file if it's changed.
+        self.options_files: T.Dict[SubProject, T.Optional[T.Tuple[str, str]]] = {}
+
         # Set of subprojects that have already been initialized once, this is
         # required to be stored and reloaded with the coredata, as we don't
         # want to overwrite options for such subprojects.

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1190,8 +1190,8 @@ class Interpreter(InterpreterBase, HoldableObject):
             option_file = old_option_file
         if os.path.exists(option_file):
             with open(option_file, 'rb') as f:
-                # We want fast, not cryptographically secure, this is just to see of
-                # the option file has changed
+                # We want fast  not cryptographically secure, this is just to
+                # see if the option file has changed
                 self.coredata.options_files[self.subproject] = (option_file, hashlib.sha1(f.read()).hexdigest())
             oi = optinterpreter.OptionInterpreter(self.subproject)
             oi.process(option_file)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1035,7 +1035,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         FeatureNew.single_use('Cargo subproject', '1.3.0', self.subproject, location=self.current_node)
         with mlog.nested(subp_name):
             ast, options = cargo.interpret(subp_name, subdir, self.environment)
-            self.coredata.update_project_options(options)
+            self.coredata.update_project_options(options, subp_name)
             return self._do_subproject_meson(
                 subp_name, subdir, default_options, kwargs, ast,
                 # FIXME: Are there other files used by cargo interpreter?
@@ -1189,7 +1189,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         if os.path.exists(option_file):
             oi = optinterpreter.OptionInterpreter(self.subproject)
             oi.process(option_file)
-            self.coredata.update_project_options(oi.options)
+            self.coredata.update_project_options(oi.options, self.subproject)
             self.add_build_def_file(option_file)
 
         if self.subproject:

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -289,9 +289,11 @@ class BasePlatformTests(TestCase):
         '''
         return self.build(target=target, override_envvars=override_envvars)
 
-    def setconf(self, arg, will_build=True):
-        if not isinstance(arg, list):
+    def setconf(self, arg: T.Sequence[str], will_build: bool = True) -> None:
+        if isinstance(arg, str):
             arg = [arg]
+        else:
+            arg = list(arg)
         if will_build:
             ensure_backend_detects_changes(self.backend)
         self._run(self.mconf_command + arg + [self.builddir])

--- a/unittests/platformagnostictests.py
+++ b/unittests/platformagnostictests.py
@@ -10,7 +10,7 @@ import tempfile
 import subprocess
 import textwrap
 import shutil
-from unittest import expectedFailure, skipIf, SkipTest
+from unittest import skipIf, SkipTest
 from pathlib import Path
 
 from .baseplatformtests import BasePlatformTests
@@ -318,7 +318,6 @@ class PlatformAgnosticTests(BasePlatformTests):
             out = self.init(testdir, extra_args=['--wipe', f'-D{option}=1'], allow_fail=True)
             self.assertIn(f'ERROR: Unknown options: "{option}"', out)
 
-    @expectedFailure
     def test_configure_new_option(self) -> None:
         """Adding a new option without reconfiguring should work."""
         testdir = self.copy_srcdir(os.path.join(self.common_test_dir, '40 options'))
@@ -328,7 +327,6 @@ class PlatformAgnosticTests(BasePlatformTests):
         self.setconf('-Dnew_option=true')
         self.assertEqual(self.getconf('new_option'), True)
 
-    @expectedFailure
     def test_configure_removed_option(self) -> None:
         """Removing an options without reconfiguring should still give an error."""
         testdir = self.copy_srcdir(os.path.join(self.common_test_dir, '40 options'))
@@ -344,7 +342,6 @@ class PlatformAgnosticTests(BasePlatformTests):
             self.setconf('-Dneg_int_opt=0')
         self.assertIn('Unknown options: "neg_int_opt"', e.exception.stdout)
 
-    @expectedFailure
     def test_configure_option_changed_constraints(self) -> None:
         """Changing the constraints of an option without reconfiguring should work."""
         testdir = self.copy_srcdir(os.path.join(self.common_test_dir, '40 options'))
@@ -360,7 +357,6 @@ class PlatformAgnosticTests(BasePlatformTests):
         self.setconf('-Dneg_int_opt=-10')
         self.assertEqual(self.getconf('neg_int_opt'), -10)
 
-    @expectedFailure
     def test_configure_meson_options_txt_to_meson_options(self) -> None:
         """Changing from a meson_options.txt to meson.options should still be detected."""
         testdir = self.copy_srcdir(os.path.join(self.common_test_dir, '40 options'))
@@ -377,7 +373,6 @@ class PlatformAgnosticTests(BasePlatformTests):
         self.setconf('-Dneg_int_opt=-10')
         self.assertEqual(self.getconf('neg_int_opt'), -10)
 
-    @expectedFailure
     def test_configure_options_file_deleted(self) -> None:
         """Deleting all option files should make seting a project option an error."""
         testdir = self.copy_srcdir(os.path.join(self.common_test_dir, '40 options'))
@@ -387,7 +382,6 @@ class PlatformAgnosticTests(BasePlatformTests):
             self.setconf('-Dneg_int_opt=0')
         self.assertIn('Unknown options: "neg_int_opt"', e.exception.stdout)
 
-    @expectedFailure
     def test_configure_options_file_added(self) -> None:
         """A new project option file should be detected."""
         testdir = self.copy_srcdir(os.path.join(self.common_test_dir, '1 trivial'))
@@ -397,7 +391,6 @@ class PlatformAgnosticTests(BasePlatformTests):
         self.setconf('-Dnew_option=bar')
         self.assertEqual(self.getconf('new_option'), 'bar')
 
-    @expectedFailure
     def test_configure_options_file_added_old(self) -> None:
         """A new project option file should be detected."""
         testdir = self.copy_srcdir(os.path.join(self.common_test_dir, '1 trivial'))
@@ -407,7 +400,6 @@ class PlatformAgnosticTests(BasePlatformTests):
         self.setconf('-Dnew_option=bar')
         self.assertEqual(self.getconf('new_option'), 'bar')
 
-    @expectedFailure
     def test_configure_new_option_subproject(self) -> None:
         """Adding a new option to a subproject without reconfiguring should work."""
         testdir = self.copy_srcdir(os.path.join(self.common_test_dir, '43 subproject options'))


### PR DESCRIPTION
It was pointed out to me recently that doing the following will not work:

```
meson setup builddir
echo "option('foo', type : 'string', value : 'foo')" > meson.options
meson configure builddir -Dfoo=bar
```
Since meson doesn't know that for exists. This does not make for a good user experience.

This PR attempts to make that situation better in most cases. This works by tracking which option file (meson.options or meson_options.txt) was used, and a hash of that file. When `meson configure` is called, if the option file has been added, removed, or the hash has changed, then meson setup will reload the options, which allows it to correctly set new or changed options, as well as correctly rejecting options that have been removed.

There is one case I know that doesn't work, which is the case of unconfigured subprojects. I have no idea how we would go about that without having meson configure fetch a subproject.