### PR TITLE
run_target/DEPENDS_KW: accept CustomTargetIndex

### DIFF
--- a/docs/markdown/Windows-module.md
+++ b/docs/markdown/Windows-module.md
@@ -12,7 +12,7 @@ Windows.
   windows.compile_resources(...(string | File | CustomTarget | CustomTargetIndex),
                             args: []string,
                             depend_files: [](string | File),
-                            depends: [](BuildTarget | CustomTarget)
+                            depends: [](BuildTarget | CustomTarget | CustomTargetIndex)
                             include_directories: [](IncludeDirectories | string)): []CustomTarget
 ```
 

--- a/docs/yaml/functions/custom_target.yaml
+++ b/docs/yaml/functions/custom_target.yaml
@@ -138,14 +138,15 @@ kwargs:
       argument. Useful for adding regen dependencies.
 
   depends:
-    type: list[build_tgt | custom_tgt]
+    type: list[build_tgt | custom_tgt | custom_idx]
     description: |
       Specifies that this target depends on the specified
       target(s), even though it does not take any of them as a command
       line argument. This is meant for cases where you have a tool that
       e.g. does globbing internally. Usually you should just put the
       generated sources as inputs and Meson will set up all dependencies
-      automatically.
+      automatically (custom_idx was unavailable as a type between 0.60
+      and 1.4.0).
 
   depfile:
     type: str

--- a/docs/yaml/functions/generator.yaml
+++ b/docs/yaml/functions/generator.yaml
@@ -50,12 +50,13 @@ kwargs:
 
   depends:
     # Not sure why this is not just `target`
-    type: list[build_tgt | custom_tgt]
+    type: list[build_tgt | custom_tgt | custom_idx]
     since: 0.51.0
     description: |
       An array of build targets that must be built before
       this generator can be run. This is used if you have a generator that calls
-      a second executable that is built in this project.
+      a second executable that is built in this project (custom_idx was not
+      available between 0.60 and 1.4.0).
 
   depfile:
     type: str

--- a/docs/yaml/functions/run_target.yaml
+++ b/docs/yaml/functions/run_target.yaml
@@ -40,11 +40,12 @@ kwargs:
       the first item will find that command in `PATH` and run it.
 
   depends:
-    type: list[build_tgt | custom_tgt]
+    type: list[build_tgt | custom_tgt | custom_idx]
     description: |
       A list of targets that this target depends on but which
       are not listed in the command array (because, for example, the
-      script does file globbing internally)
+      script does file globbing internally, custom_idx was not possible
+      as a type between 0.60 and 1.4.0).
 
   env:
     since: 0.57.0

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -324,9 +324,12 @@ class Vs2010Backend(backends.Backend):
                 result[o.target.get_id()] = o.target
         return result.items()
 
-    def get_target_deps(self, t: T.Dict[T.Any, build.Target], recursive=False):
+    def get_target_deps(self, t: T.Dict[T.Any, T.Union[build.Target, build.CustomTargetIndex]], recursive=False):
         all_deps: T.Dict[str, build.Target] = {}
         for target in t.values():
+            if isinstance(target, build.CustomTargetIndex):
+                # just transfer it to the CustomTarget code
+                target = target.target
             if isinstance(target, build.CustomTarget):
                 for d in target.get_target_dependencies():
                     # FIXME: this isn't strictly correct, as the target doesn't

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2815,11 +2815,11 @@ class RunTarget(Target, CommandBase):
 
     def __init__(self, name: str,
                  command: T.Sequence[T.Union[str, File, BuildTargetTypes, programs.ExternalProgram]],
-                 dependencies: T.Sequence[Target],
+                 dependencies: T.Sequence[T.Union[Target, CustomTargetIndex]],
                  subdir: str,
                  subproject: str,
                  environment: environment.Environment,
-                 env: T.Optional['EnvironmentVariables'] = None,
+                 env: T.Optional[EnvironmentVariables] = None,
                  default_env: bool = True):
         # These don't produce output artifacts
         super().__init__(name, subdir, subproject, False, MachineChoice.BUILD, environment)
@@ -2834,10 +2834,10 @@ class RunTarget(Target, CommandBase):
         repr_str = "<{0} {1}: {2}>"
         return repr_str.format(self.__class__.__name__, self.get_id(), self.command[0])
 
-    def get_dependencies(self) -> T.List[T.Union[BuildTarget, 'CustomTarget']]:
+    def get_dependencies(self) -> T.List[T.Union[BuildTarget, CustomTarget, CustomTargetIndex]]:
         return self.dependencies
 
-    def get_generated_sources(self) -> T.List['GeneratedTypes']:
+    def get_generated_sources(self) -> T.List[GeneratedTypes]:
         return []
 
     def get_sources(self) -> T.List[File]:

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -268,12 +268,12 @@ DEPFILE_KW: KwargInfo[T.Optional[str]] = KwargInfo(
     validator=lambda x: 'Depfile must be a plain filename with a subdirectory' if has_path_sep(x) else None
 )
 
-# TODO: CustomTargetIndex should be supported here as well
-DEPENDS_KW: KwargInfo[T.List[T.Union[BuildTarget, CustomTarget]]] = KwargInfo(
+DEPENDS_KW: KwargInfo[T.List[T.Union[BuildTarget, CustomTarget, CustomTargetIndex]]] = KwargInfo(
     'depends',
-    ContainerTypeInfo(list, (BuildTarget, CustomTarget)),
+    ContainerTypeInfo(list, (BuildTarget, CustomTarget, CustomTargetIndex)),
     listify=True,
     default=[],
+    since_values={CustomTargetIndex: '1.5.0'},
 )
 
 DEPEND_FILES_KW: KwargInfo[T.List[T.Union[str, File]]] = KwargInfo(

--- a/test cases/common/51 run target/meson.build
+++ b/test cases/common/51 run target/meson.build
@@ -33,6 +33,11 @@ run_target('upload2',
   depends : hex,
 )
 
+run_target('upload3',
+  command : [fakeburner, 'x:@0@:y'.format(hex.full_path())],
+  depends : hex[0],
+)
+
 python3 = find_program('python3', required : false)
 if not python3.found()
   python3 = find_program('python')

--- a/test cases/common/71 ctarget dependency/meson.build
+++ b/test cases/common/71 ctarget dependency/meson.build
@@ -18,3 +18,8 @@ custom_target('output',
 output : 'output.dat',
 command : [g2, '@OUTDIR@', '@OUTPUT@'],
 depends : c1)
+
+custom_target('output2',
+output : 'output2.dat',
+command : [g2, '@OUTDIR@', '@OUTPUT@'],
+depends : c1[0])


### PR DESCRIPTION
Code like
```meson
a = custom_target(..., output: 'foo', 'bar')
foo = a[0]

run_target(..., depends: foo)
```
does not setup otherwise.