### PR TITLE
environment: fix LLVM 18 support in get_llvm_tool_names()

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -209,7 +209,7 @@ def get_llvm_tool_names(tool: str) -> T.List[str]:
         '-3.7', '37',
         '-3.6', '36',
         '-3.5', '35',
-        '-15',    # Debian development snapshot
+        '-19',    # Debian development snapshot
         '-devel', # FreeBSD development snapshot
     ]
     names: T.List[str] = []

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -188,6 +188,7 @@ def get_llvm_tool_names(tool: str) -> T.List[str]:
     # unless it becomes a stable release.
     suffixes = [
         '', # base (no suffix)
+        '-18.1', '18.1',
         '-18',  '18',
         '-17',  '17',
         '-16',  '16',


### PR DESCRIPTION
environment: fix LLVM 18 support in get_llvm_tool_names()

In 67afddbf431140c1ee064bf79a2fa5a95575488e, we added LLVM 18, but LLVM >= 18
uses a new version scheme of X.Y, not X.0.Y (where using "X" was enough).

See https://discourse.llvm.org/t/rfc-name-the-first-release-from-a-branch-n-1-0-instead-of-n-0-0/75384.

Without this, I get a test failure:
```
 mesonbuild.interpreterbase.exceptions.InterpreterException: Assert failed: config-tool and cmake returns different major versions
   -> frameworks: 15 llvm    (method=combination link-static=False)
```

Fixes: https://github.com/mesonbuild/meson/issues/12961
Signed-off-by: Sam James <sam@gentoo.org>