### PR TITLE
add an error message for targets that are not dependencies

### DIFF
--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -136,6 +136,8 @@ class CMakeSubproject(ModuleObject):
         info = self._args_to_info(args)
         if info['func'] == 'executable':
             raise InvalidArguments(f'{args[0]} is an executable and does not support the dependency() method. Use target() instead.')
+        if info['dep'] is None:
+            raise InvalidArguments(f'{args[0]} does not support the dependency() method. Use target() instead.')
         orig = self.get_variable(state, [info['dep']], {})
         assert isinstance(orig, dependencies.Dependency)
         actual = orig.include_type


### PR DESCRIPTION
Add an actual error message for `CMake` targets that are not dependencies

Ref: #12976