### PR TITLE
Don't sanitize a None path when checking for, but could not find, uns…

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -287,8 +287,8 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
             # practice, Meson will block waiting for Watcom's cl.exe to
             # exit, which requires user input and thus will never exit.
             if 'WATCOM' in os.environ:
-                def sanitize(p: str) -> str:
-                    return os.path.normcase(os.path.abspath(p))
+                def sanitize(p: T.Optional[str]) -> T.Optional[str]:
+                    return os.path.normcase(os.path.abspath(p)) if p else None
 
                 watcom_cls = [sanitize(os.path.join(os.environ['WATCOM'], 'BINNT', 'cl')),
                               sanitize(os.path.join(os.environ['WATCOM'], 'BINNT', 'cl.exe')),


### PR DESCRIPTION
…upported cl clones.

When running Meson, if:
1. You have the `WATCOM` environment variable set, but
2. _Neither_ Watcom's `cl` wrapper nor Microsoft/Clang's `cl` on your path

You will get an obscure `TypeError: expected str, bytes or os.PathLike object, not NoneType` when trying to filter unsupported `cl` clones (because `shutil.which` won't find any compilers at all, and then will pass `None` to `os.path.abspath`).

I've tested this locally against a 1.26.4 build of Numpy, and the build succeeded with this patch.

This was an edge case I didn't consider when writing #2237 and #9509. Even though I appear to be one of the only people to ever run into this problem over the years, I figured I should make the detection better :).

Who knows? Maybe one day I'll go back to #2309...