### PR TITLE
tests: don't expect msys2 llvm cmake tests to skip with llvm 18

### DIFF
--- a/test cases/frameworks/15 llvm/test.json
+++ b/test cases/frameworks/15 llvm/test.json
@@ -3,8 +3,8 @@
     "options": {
       "method": [
         { "val": "config-tool", "expect_skip_on_jobname": ["msys2-gcc"] },
-        { "val": "cmake", "expect_skip_on_jobname": ["msys2"] },
-        { "val": "combination", "expect_skip_on_jobname": ["msys2"] }
+        { "val": "cmake", "expect_skip_on_jobname": ["msys2-gcc"] },
+        { "val": "combination", "expect_skip_on_jobname": ["msys2-gcc"] }
       ],
       "link-static": [
         { "val": true, "expect_skip_on_jobname": ["arch", "opensuse", "linux-gentoo-gcc"] },


### PR DESCRIPTION
They were skipped with llvm 17 based on the version, and they are now no longer skipped with v18 and also pass now.

This depends on #12964 for llvm 18 support in meson.