### PR TITLE
devenv: Don't use Path.relative_to() to resolve relative paths

### DIFF
--- a/mesonbuild/mdevenv.py
+++ b/mesonbuild/mdevenv.py
@@ -10,7 +10,7 @@ import typing as T
 from pathlib import Path
 from . import build, minstall
 from .mesonlib import (EnvironmentVariables, MesonException, is_windows, setup_vsenv, OptionKey,
-                       get_wine_shortpath, MachineChoice)
+                       get_wine_shortpath, MachineChoice, relpath)
 from . import mlog
 
 
@@ -140,7 +140,7 @@ def write_gdb_script(privatedir: Path, install_data: 'InstallData', workdir: Pat
         if first_time:
             gdbinit_path = gdbinit_path.resolve()
             workdir_path = workdir.resolve()
-            rel_path = gdbinit_path.relative_to(workdir_path)
+            rel_path = Path(relpath(gdbinit_path, workdir_path))
             mlog.log('Meson detected GDB helpers and added config in', mlog.bold(str(rel_path)))
             mlog.log('To load it automatically you might need to:')
             mlog.log(' - Add', mlog.bold(f'add-auto-load-safe-path {gdbinit_path.parent}'),

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -1930,14 +1930,14 @@ class OrderedSet(T.MutableSet[_T]):
         for item in iterable:
             self.discard(item)
 
-def relpath(path: str, start: str) -> str:
+def relpath(path: T.Union[str, Path], start: T.Union[str, Path]) -> str:
     # On Windows a relative path can't be evaluated for paths on two different
     # drives (i.e. c:\foo and f:\bar).  The only thing left to do is to use the
     # original absolute path.
     try:
         return os.path.relpath(path, start)
     except (TypeError, ValueError):
-        return path
+        return str(path)
 
 def path_is_in_root(path: Path, root: Path, resolve: bool = False) -> bool:
     # Check whether a path is within the root directory root


### PR DESCRIPTION
It's utterly broken, and only works when one path is inside the other:

```
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/mesonbuild/mesonmain.py", line 194, in run
    return options.run_func(options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/mesonbuild/mdevenv.py", line 188, in run
    write_gdb_script(privatedir, install_data, workdir)
  File "/usr/lib/python3.12/site-packages/mesonbuild/mdevenv.py", line 142, in write_gdb_script
    rel_path = gdbinit_path.relative_to(workdir_path)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/pathlib.py", line 682, in relative_to
    raise ValueError(f"{str(self)!r} is not in the subpath of {str(other)!r}")
ValueError: '/path/to/builddir/.gdbinit' is not in the subpath of '/path/to/workdir'

ERROR: Unhandled python exception

    This is a Meson bug and should be reported!
```