### PR TITLE
mtest: fix setting `MSAN_OPTIONS` when not set, rather than `UBSAN_OPTIONS`

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1415,7 +1415,7 @@ class SingleTestRunner:
         if ('UBSAN_OPTIONS' not in env or not env['UBSAN_OPTIONS']):
             env['UBSAN_OPTIONS'] = 'halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1'
         if ('MSAN_OPTIONS' not in env or not env['MSAN_OPTIONS']):
-            env['UBSAN_OPTIONS'] = 'halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1'
+            env['MSAN_OPTIONS'] = 'halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1'
 
         if self.options.gdb or self.test.timeout is None or self.test.timeout <= 0:
             timeout = None


### PR DESCRIPTION
If `MSAN_OPTIONS` is not set, `UBSAN_OPTIONS` is overwritten, even if `UBSAN_OPTIONS` is already set. This fix sets `MSAN_OPTIONS` instead.