### PR TITLE
dependency/base: Add 'delete' option for `include_type`

### DIFF
--- a/docs/yaml/functions/dependency.yaml
+++ b/docs/yaml/functions/dependency.yaml
@@ -196,11 +196,15 @@ kwargs:
     since: 0.52.0
     description: |
       An enum flag, marking how the dependency
-      flags should be converted. Supported values are `'preserve'`, `'system'` and
-      `'non-system'`. System dependencies may be handled differently on some
+      flags should be converted. Supported values are `'preserve'`, `'system'`,
+      `'non-system'` and *(since 1.5.0)* `'delete'`.
+      System dependencies may be handled differently on some
       platforms, for instance, using `-isystem` instead of `-I`, where possible.
       If `include_type` is set to `'preserve'`, no additional conversion will be
       performed.
+
+      *Since 1.5.0* if `include_type` is set to `'delete'`, these flags are deleted
+      and not passed to compilers.
 
   disabler:
     type: bool

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -102,8 +102,8 @@ class Dependency(HoldableObject):
             return 'preserve'
         if not isinstance(kwargs['include_type'], str):
             raise DependencyException('The include_type kwarg must be a string type')
-        if kwargs['include_type'] not in ['preserve', 'system', 'non-system']:
-            raise DependencyException("include_type may only be one of ['preserve', 'system', 'non-system']")
+        if kwargs['include_type'] not in ['preserve', 'system', 'non-system', 'delete']:
+            raise DependencyException("include_type may only be one of ['preserve', 'system', 'non-system', 'delete']")
         return kwargs['include_type']
 
     def __init__(self, type_name: DependencyTypeName, kwargs: T.Dict[str, T.Any]) -> None:
@@ -164,6 +164,12 @@ class Dependency(HoldableObject):
                 if i.startswith('-isystem'):
                     converted += ['-I' + i[8:]]
                 else:
+                    converted += [i]
+            return converted
+        if self.include_type == 'delete':
+            converted = []
+            for i in self.compile_args:
+                if not (i.startswith('-I') or i.startswith('/I') or i.startswith('-isystem')):
                     converted += [i]
             return converted
         return self.compile_args

--- a/test cases/common/219 include_type dependency/meson.build
+++ b/test cases/common/219 include_type dependency/meson.build
@@ -26,6 +26,9 @@ assert(dep2.include_type() == 'system', 'include_type must be true when set')
 dep2_sys = dep2.as_system('non-system')
 assert(dep2_sys.include_type() == 'non-system', 'as_system must set include_type correctly')
 
+dep3_del = dep2.as_system('delete')
+assert(dep3_del.include_type() == 'delete', 'as_system must set include_type correctly')
+
 sp = subproject('subDep')
 sp_dep = sp.get_variable('subDep_dep')
 assert(sp_dep.include_type() == 'preserve', 'default is preserve')


### PR DESCRIPTION
This can be used to filter out unwanted include flags. For example, on Debian mysqlclient has `${prefix}/include/mysql`, which results in

    $ pkgconf --cflags mysqlclient
    -I/usr/include/mysql

In this specific case of mysqlclient, there is a header called <errmsg.h>, so using this dependency allows

    #include <errmsg.h>

However, it's not apparent that this is a mysqlclient header; it's better to follow a standard path from `/usr/include`, which looks like

    #include <mysql/errmsg.h>

And if we always include headers as such, those include flags from pkgconf are useless and only take up space in generated files. Hence this new option is provided to remove them.