### PR TITLE
dependencies: find extraframeworks on case-sensitive filesystems

### DIFF
--- a/test cases/osx/11 case sensitive apfs/meson.build
+++ b/test cases/osx/11 case sensitive apfs/meson.build
@@ -1,0 +1,5 @@
+project('case-sensitive APFS with extra frameworks test', 'c')
+
+dep = dependency('FoUnDaTiOn')
+
+exe = executable('prog', 'prog.c', install : true, dependencies: dep)

--- a/test cases/osx/11 case sensitive apfs/prog.c
+++ b/test cases/osx/11 case sensitive apfs/prog.c
@@ -1,0 +1,3 @@
+int main(void) {
+    return 0;
+}

--- a/test cases/osx/11 case sensitive apfs/test.json
+++ b/test cases/osx/11 case sensitive apfs/test.json
@@ -1,0 +1,5 @@
+{
+  "installed": [
+    {"type": "file", "file": "usr/bin/prog"}
+  ]
+}


### PR DESCRIPTION
This PR fixes a test failure on case-sensitive filesystems when a CMake dependency is turned into an Apple framework. I ran into this issue while working on the Darwin stdenv in nixpkgs after Meson was updated to 1.4.0 because my Nix store is installed on a case-sensitive APFS volume.

The extraframeworks search logic was already case insensitive. The fix was to use the match’s actual name instead of the one that was requested. I included a test, though the original test for https://github.com/mesonbuild/meson/pull/12181 also serves as a test for case-sensitive filesystems.

I found https://github.com/mesonbuild/meson/issues/12480 in the issue tracker, but the scope of fixing that seems like a much larger fix and wouldn’t address the issue I encountered building the Darwin stdenv in nixpkgs.