### PR TITLE
gnome: Improve mkenums_simple code generation and running tests

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1874,20 +1874,21 @@ class GnomeModule(ExtensionModule):
             GType
             {func_prefix}@enum_name@_get_type (void)
             {{
-            static gsize gtype_id = 0;
-            static const G@Type@Value values[] = {{'''))
+                static gsize gtype_id = 0;
+                static const G@Type@Value values[] = {{'''))
 
-        c_cmd.extend(['--vprod', '    { C_@TYPE@(@VALUENAME@), "@VALUENAME@", "@valuenick@" },'])
+        c_cmd.extend(['--vprod', '        { C_@TYPE@ (@VALUENAME@), "@VALUENAME@", "@valuenick@" },'])
 
         c_cmd.append('--vtail')
         c_cmd.append(textwrap.dedent(
-            '''    { 0, NULL, NULL }
-            };
-            if (g_once_init_enter (&gtype_id)) {
-                GType new_type = g_@type@_register_static (g_intern_static_string ("@EnumName@"), values);
-                g_once_init_leave (&gtype_id, new_type);
-            }
-            return (GType) gtype_id;
+            '''\
+                    { 0, NULL, NULL }
+                };
+                if (g_once_init_enter (&gtype_id)) {
+                    GType new_type = g_@type@_register_static (g_intern_static_string ("@EnumName@"), values);
+                    g_once_init_leave (&gtype_id, new_type);
+                }
+                return (GType) gtype_id;
             }'''))
         c_cmd.append('@INPUT@')
 
@@ -1896,13 +1897,16 @@ class GnomeModule(ExtensionModule):
         # .h file generation
         h_cmd = cmd.copy()
 
+        if header_prefix and not header_prefix.endswith('\n'):
+            header_prefix += '\n'  # Extra trailing newline for style
+
         h_cmd.append('--fhead')
         h_cmd.append(textwrap.dedent(
-            f'''#pragma once
+            f'''\
+            #pragma once
 
             #include <glib-object.h>
             {header_prefix}
-
             G_BEGIN_DECLS
             '''))
 
@@ -1912,9 +1916,13 @@ class GnomeModule(ExtensionModule):
             /* enumerations from "@basename@" */
             '''))
 
+        extra_newline = ''
+        if decl_decorator:
+            extra_newline = '\n'  # Extra leading newline for style
+
         h_cmd.append('--vhead')
-        h_cmd.append(textwrap.dedent(
-            f'''
+        h_cmd.append(extra_newline + textwrap.dedent(
+            f'''\
             {decl_decorator}
             GType {func_prefix}@enum_name@_get_type (void);
             #define @ENUMPREFIX@_TYPE_@ENUMSHORT@ ({func_prefix}@enum_name@_get_type())'''))

--- a/test cases/frameworks/7 gnome/mkenums/meson.build
+++ b/test cases/frameworks/7 gnome/mkenums/meson.build
@@ -121,6 +121,7 @@ test('enum test 3', enumexe3)
 enums4 = gnome.mkenums_simple('enums4', sources : files('meson-sample.h'),
                               function_prefix : '_')
 enumexe4 = executable('enumprog4', 'main4.c', enums4, dependencies : gobj)
+test('enum test 4', enumexe4)
 
 enums5 = gnome.mkenums_simple('enums5', sources : 'meson-sample.h',
                               install_header : true,
@@ -135,6 +136,7 @@ main = configure_file(
   configuration : conf)
 
 enumexe5 = executable('enumprog5', main, enums5, dependencies : gobj)
+test('enum test 5', enumexe5)
 
 # Generate template then use as input to mkenums
 
@@ -161,7 +163,7 @@ main = configure_file(
 
 enumexe6 = executable('enumprog6', main, enums_c2, enums_h6,
 dependencies : gobj)
-test('enum test 4', enumexe6)
+test('enum test 6', enumexe6)
 
 # Test with headers coming from other directories
 # https://github.com/mesonbuild/meson/pull/10855
@@ -169,6 +171,8 @@ subdir('subdir')
 enums7 = gnome.mkenums_simple('enums7', sources: ['meson-sample.h', h2, h3])
 main = configure_file(
   input : 'main.c',
-  output : 'mai7.c',
+  output : 'main7.c',
   configuration : {'ENUM_FILE': 'enums7.h'})
-test('enums7 test', executable('enumprog7', main, enums7, dependencies : gobj))
+
+enumexe7 = executable('enumprog7', main, enums7, dependencies : gobj)
+test('enum test 7', enumexe7)


### PR DESCRIPTION
Commit 83facb39593fbfa4d9cd68e86f5f56f86f1fe1eb switched to using `textwrap.dedent` for the code templates for `gnome.mkenums_simple`. That changed indentation, however, making the generated code harder to understand.

We improve this by properly indenting the multiline strings before dedenting them. For optional parameters `decl_decorator` and `header_prefix`, we add a newline if they are set to keep separation between generated code blocks.

Also, some tests for `gnome.mkenums_simple` were only compiled, but not run. Most bugs will be caught by compilation alone, but it's better to run the generated binary too in case there are runtime issues in the generated code. The naming of all enum tests is now unified as well.

**Before and after**\
To illustrate what I mean with hard to understand, see the difference here in the first function of the generated `enums4.c` from the test.

**Before**
```c
GType
meson_the_xenum_get_type (void)
{
static gsize gtype_id = 0;
static const GEnumValue values[] = {
    { C_ENUM(MESON_THE_XVALUE), "MESON_THE_XVALUE", "the-xvalue" },
    { C_ENUM(MESON_ANOTHER_VALUE), "MESON_ANOTHER_VALUE", "another-value" },
{ 0, NULL, NULL }
        };
        if (g_once_init_enter (&gtype_id)) {
            GType new_type = g_enum_register_static (g_intern_static_string ("MesonTheXEnum"), values);
            g_once_init_leave (&gtype_id, new_type);
        }
        return (GType) gtype_id;
        }
```
**After**
```c
GType
meson_the_xenum_get_type (void)
{
    static gsize gtype_id = 0;
    static const GEnumValue values[] = {
        { C_ENUM (MESON_THE_XVALUE), "MESON_THE_XVALUE", "the-xvalue" },
        { C_ENUM (MESON_ANOTHER_VALUE), "MESON_ANOTHER_VALUE", "another-value" },
        { 0, NULL, NULL }
    };
    if (g_once_init_enter (&gtype_id)) {
        GType new_type = g_enum_register_static (g_intern_static_string ("MesonTheXEnum"), values);
        g_once_init_leave (&gtype_id, new_type);
    }
    return (GType) gtype_id;
}
```