### PR TITLE
Fix an error when using /MANIFEST:NO with VS backend

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -129,6 +129,14 @@ def get_non_primary_lang_intellisense_fields(vslite_ctx: dict,
             defs_paths_opts_per_lang_and_buildtype[src_lang][buildtype] = Vs2010Backend._extract_nmake_fields(args_list)
     return defs_paths_opts_per_lang_and_buildtype
 
+# Returns if a target generates a manifest or not.
+def get_gen_manifest(target):
+    if isinstance(target, build.BuildTarget):
+        upper_args = [arg.upper() for arg in target.link_args]
+        manifest_args = [arg for arg in upper_args if arg == '/MANIFEST' or arg.startswith('/MANIFEST:')]
+        return len(manifest_args) == 0 or manifest_args[-1] != '/MANIFEST:NO'
+    return True
+
 class Vs2010Backend(backends.Backend):
 
     name = 'vs2010'
@@ -616,7 +624,8 @@ class Vs2010Backend(backends.Backend):
                              guid,
                              conftype='Utility',
                              target_ext=None,
-                             target_platform=None) -> T.Tuple[ET.Element, ET.Element]:
+                             target_platform=None,
+                             gen_manifest=True) -> T.Tuple[ET.Element, ET.Element]:
         root = ET.Element('Project', {'DefaultTargets': "Build",
                                       'ToolsVersion': '4.0',
                                       'xmlns': 'http://schemas.microsoft.com/developer/msbuild/2003'})
@@ -688,13 +697,16 @@ class Vs2010Backend(backends.Backend):
                 ET.SubElement(direlem, 'TargetExt').text = target_ext
 
             ET.SubElement(direlem, 'EmbedManifest').text = 'false'
+            if not gen_manifest:
+                ET.SubElement(direlem, 'GenerateManifest').text = 'false'
 
         return (root, type_config)
 
     def gen_run_target_vcxproj(self, target: build.RunTarget, ofname: str, guid: str) -> None:
         (root, type_config) = self.create_basic_project(target.name,
                                                         temp_dir=target.get_id(),
-                                                        guid=guid)
+                                                        guid=guid,
+                                                        gen_manifest=get_gen_manifest(target))
         depend_files = self.get_target_depend_files(target)
 
         if not target.command:
@@ -729,7 +741,8 @@ class Vs2010Backend(backends.Backend):
         (root, type_config) = self.create_basic_project(target.name,
                                                         temp_dir=target.get_id(),
                                                         guid=guid,
-                                                        target_platform=platform)
+                                                        target_platform=platform,
+                                                        gen_manifest=get_gen_manifest(target))
         # We need to always use absolute paths because our invocation is always
         # from the target dir, not the build root.
         target.absolute_paths = True
@@ -769,7 +782,8 @@ class Vs2010Backend(backends.Backend):
         (root, type_config) = self.create_basic_project(target.name,
                                                         temp_dir=target.get_id(),
                                                         guid=guid,
-                                                        target_platform=platform)
+                                                        target_platform=platform,
+                                                        gen_manifest=get_gen_manifest(target))
         ET.SubElement(root, 'Import', Project=r'$(VCTargetsPath)\Microsoft.Cpp.targets')
         target.generated = [self.compile_target_to_generator(target)]
         target.sources = []
@@ -1601,7 +1615,8 @@ class Vs2010Backend(backends.Backend):
                                                         guid=guid,
                                                         conftype=conftype,
                                                         target_ext=tfilename[1],
-                                                        target_platform=platform)
+                                                        target_platform=platform,
+                                                        gen_manifest=get_gen_manifest(target))
 
         generated_files, custom_target_output_files, generated_files_include_dirs = self.generate_custom_generator_commands(
             target, root)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -129,14 +129,6 @@ def get_non_primary_lang_intellisense_fields(vslite_ctx: dict,
             defs_paths_opts_per_lang_and_buildtype[src_lang][buildtype] = Vs2010Backend._extract_nmake_fields(args_list)
     return defs_paths_opts_per_lang_and_buildtype
 
-# Returns if a target generates a manifest or not.
-def get_gen_manifest(target):
-    if isinstance(target, build.BuildTarget):
-        upper_args = [arg.upper() for arg in target.link_args]
-        manifest_args = [arg for arg in upper_args if arg == '/MANIFEST' or arg.startswith('/MANIFEST:')]
-        return len(manifest_args) == 0 or manifest_args[-1] != '/MANIFEST:NO'
-    return True
-
 class Vs2010Backend(backends.Backend):
 
     name = 'vs2010'
@@ -706,7 +698,7 @@ class Vs2010Backend(backends.Backend):
         (root, type_config) = self.create_basic_project(target.name,
                                                         temp_dir=target.get_id(),
                                                         guid=guid,
-                                                        gen_manifest=get_gen_manifest(target))
+                                                        gen_manifest=self.get_gen_manifest(target))
         depend_files = self.get_target_depend_files(target)
 
         if not target.command:
@@ -742,7 +734,7 @@ class Vs2010Backend(backends.Backend):
                                                         temp_dir=target.get_id(),
                                                         guid=guid,
                                                         target_platform=platform,
-                                                        gen_manifest=get_gen_manifest(target))
+                                                        gen_manifest=self.get_gen_manifest(target))
         # We need to always use absolute paths because our invocation is always
         # from the target dir, not the build root.
         target.absolute_paths = True
@@ -783,7 +775,7 @@ class Vs2010Backend(backends.Backend):
                                                         temp_dir=target.get_id(),
                                                         guid=guid,
                                                         target_platform=platform,
-                                                        gen_manifest=get_gen_manifest(target))
+                                                        gen_manifest=self.get_gen_manifest(target))
         ET.SubElement(root, 'Import', Project=r'$(VCTargetsPath)\Microsoft.Cpp.targets')
         target.generated = [self.compile_target_to_generator(target)]
         target.sources = []
@@ -1616,7 +1608,7 @@ class Vs2010Backend(backends.Backend):
                                                         conftype=conftype,
                                                         target_ext=tfilename[1],
                                                         target_platform=platform,
-                                                        gen_manifest=get_gen_manifest(target))
+                                                        gen_manifest=self.get_gen_manifest(target))
 
         generated_files, custom_target_output_files, generated_files_include_dirs = self.generate_custom_generator_commands(
             target, root)
@@ -2095,3 +2087,25 @@ class Vs2010Backend(backends.Backend):
 
     def generate_lang_standard_info(self, file_args: T.Dict[str, CompilerArgs], clconf: ET.Element) -> None:
         pass
+
+    # Returns if a target generates a manifest or not.
+    def get_gen_manifest(self, target):
+        if not isinstance(target, build.BuildTarget):
+            return True
+
+        compiler = self._get_cl_compiler(target)
+        link_args = compiler.compiler_args()
+        if not isinstance(target, build.StaticLibrary):
+            link_args += self.build.get_project_link_args(compiler, target.subproject, target.for_machine)
+            link_args += self.build.get_global_link_args(compiler, target.for_machine)
+            link_args += self.environment.coredata.get_external_link_args(
+                target.for_machine, compiler.get_language())
+            link_args += target.link_args
+
+        for arg in reversed(link_args):
+            arg = arg.upper()
+            if arg == '/MANIFEST:NO':
+                return False
+            if arg == '/MANIFEST' or arg.startswith('/MANIFEST:'):
+                break
+        return True


### PR DESCRIPTION
Closes #13041

#12472 disabled the `EmbedManifest` node in `.vcxproj`.
But it conflicts with the `/MANIFEST:NO` option, or the `GenerateManifest` node should be disabled.

This PR make meson set false to `GenerateManifest` when `target.link_args` disables the manifest creation with `/MANIFEST:NO`.