### PR TITLE
interpreter: implement the `name()` method for `ExternalLibraryHolder`

### DIFF
--- a/docs/markdown/snippets/find_library_name.md
+++ b/docs/markdown/snippets/find_library_name.md
@@ -1,0 +1,3 @@
+## dependencies created by compiler.find_library implement the `name()` method
+
+Which would previously result in Meson crashing.

--- a/docs/yaml/objects/dep.yaml
+++ b/docs/yaml/objects/dep.yaml
@@ -15,6 +15,9 @@ methods:
       Returns `'internal'` for dependencies created with
       [[declare_dependency]].
 
+      NOTE: This was not implemented for dep objects returned by
+      [[compiler.find_library]] until Meson 1.5.0
+
   - name: get_pkgconfig_variable
     since: 0.36.0
     deprecated: 0.56.0

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -644,6 +644,7 @@ class ExternalLibraryHolder(ObjectHolder[ExternalLibrary]):
         self.methods.update({'found': self.found_method,
                              'type_name': self.type_name_method,
                              'partial_dependency': self.partial_dependency_method,
+                             'name': self.name_method,
                              })
 
     @noPosargs
@@ -662,6 +663,13 @@ class ExternalLibraryHolder(ObjectHolder[ExternalLibrary]):
     def partial_dependency_method(self, args: T.List[TYPE_nvar], kwargs: 'kwargs.DependencyMethodPartialDependency') -> Dependency:
         pdep = self.held_object.get_partial_dependency(**kwargs)
         return pdep
+
+    @FeatureNew('name', '1.5.0')
+    @noPosargs
+    @noKwargs
+    def name_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> str:
+        return self.held_object.name
+
 
 # A machine that's statically known from the cross file
 class MachineHolder(ObjectHolder['MachineInfo']):


### PR DESCRIPTION
This allows `cc.find_library().name()` to work, just like `dependency().name()`.

Fixes: #13053