### PR TITLE
Clean the output of test runs

### DIFF
--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -1235,6 +1235,7 @@ def _run_tests(all_tests: T.List[T.Tuple[str, T.List[TestDef], bool]],
         current_suite = ET.SubElement(junit_root, 'testsuite', {'name': name, 'tests': str(len(test_cases))})
         if skipped:
             futures += [LogRunFuture(['\n', bold(f'Not running {name} tests.'), '\n'])]
+            continue
         else:
             futures += [LogRunFuture(['\n', bold(f'Running {name} tests.'), '\n'])]
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -397,7 +397,7 @@ def main():
         else:
             print(mlog.bold('Running unittests.'))
             print(flush=True)
-            cmd = mesonlib.python_command + ['run_unittests.py', '-v'] + backend_flags
+            cmd = mesonlib.python_command + ['run_unittests.py'] + backend_flags
             if options.failfast:
                 cmd += ['--failfast']
             returncode += subprocess_call(cmd, env=env)

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -48,7 +48,7 @@ foreach qt : ['qt4', 'qt5', 'qt6']
   qtdep = dependency(qt, modules : qt_modules, main : true, private_headers: true, required : required, method : get_option('method'))
   if qtdep.found()
     qtmodule = import(qt)
-    assert(qtmodule.has_tools())
+    assert(qtmodule.has_tools(), 'You may be missing a devel package. (qttools5-dev-tools on Debian based systems)')
 
     # Test that fetching a variable works and yields a non-empty value
     assert(qtdep.get_variable('prefix', configtool: 'QT_INSTALL_PREFIX') != '')


### PR DESCRIPTION
Spamming tons of stuff for passing tests is distracting. Only print errors to stdout.

Also includes a one liner documentation fix because I was too lazy to post it in a separate PR.