### PR TITLE
Improve the warning that LLVM lookup by CMake needs both a C and C++ compiler

### DIFF
--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -413,16 +413,17 @@ class LLVMDependencyCMake(CMakeDependency):
             mlog.warning(
                 'The LLVM dependency was not found via CMake, as this method requires',
                 'both a C and C++ compiler to be enabled, but',
-                'only' if langs else 'neither',
+                'only' if len(langs) == 1 else 'neither',
                 'a',
-                " nor ".join(l.upper() for l in langs),
+                " nor ".join(l.upper() for l in langs).replace('CPP', 'C++'),
                 'compiler is enabled for the',
                 f"{self.for_machine}.",
-                "Consider adding {0} to your project() call or using add_languages({0}, native : {1})".format(
+                'Consider adding "{0}" to your project() call or using add_languages({0}, native : {1})'.format(
                     ', '.join(f"'{l}'" for l in langs),
                     'true' if self.for_machine is mesonlib.MachineChoice.BUILD else 'false',
                 ),
-                'before the LLVM dependency lookup.'
+                'before the LLVM dependency lookup.',
+                fatal=False,
             )
             return
 


### PR DESCRIPTION
The warning we have is not clear, as we've had several questions about why the CMake finder for LLVM isn't being used. I have found the warning that both a C and C++ compiler must be available and enabled to be unclear, and I've attempted to make the warning more helpful. Also make it not fatal, since it's probably not in the control of the end user that the CMake method is being tried