### PR TITLE
Fix `CMake` variable name

### DIFF
--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -672,11 +672,11 @@ class CMakeTraceParser:
             if i in ignore:
                 continue
 
-            if i in {'INTERFACE', 'LINK_INTERFACE_LIBRARIES', 'PUBLIC', 'PRIVATE', 'LINK_PUBLIC', 'LINK_PRIVATE'}:
+            if i in {'INTERFACE', 'INTERFACE_LINK_LIBRARIES', 'PUBLIC', 'PRIVATE', 'LINK_PUBLIC', 'LINK_PRIVATE'}:
                 mode = i
                 continue
 
-            if mode in {'INTERFACE', 'LINK_INTERFACE_LIBRARIES', 'PUBLIC', 'LINK_PUBLIC'}:
+            if mode in {'INTERFACE', 'INTERFACE_LINK_LIBRARIES', 'PUBLIC', 'LINK_PUBLIC'}:
                 interface += i.split(';')
 
             if mode in {'PUBLIC', 'PRIVATE', 'LINK_PRIVATE'}:

--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -672,25 +672,13 @@ class CMakeTraceParser:
             if i in ignore:
                 continue
 
-            if i in {
-                'INTERFACE',
-                'LINK_INTERFACE_LIBRARIES',
-                'INTERFACE_LINK_LIBRARIES',
-                'PUBLIC',
-                'PRIVATE',
-                'LINK_PUBLIC',
-                'LINK_PRIVATE'
-            }:
+            if i in {'INTERFACE', 'LINK_INTERFACE_LIBRARIES', 'INTERFACE_LINK_LIBRARIES',
+                'PUBLIC', 'PRIVATE', 'LINK_PUBLIC', 'LINK_PRIVATE'}:
                 mode = i
                 continue
 
-            if mode in {
-                'INTERFACE',
-                'LINK_INTERFACE_LIBRARIES',
-                'INTERFACE_LINK_LIBRARIES',
-                'PUBLIC',
-                'LINK_PUBLIC'
-            }:
+            if mode in {'INTERFACE', 'LINK_INTERFACE_LIBRARIES', 'INTERFACE_LINK_LIBRARIES',
+                'PUBLIC', 'LINK_PUBLIC'}:
                 interface += i.split(';')
 
             if mode in {'PUBLIC', 'PRIVATE', 'LINK_PRIVATE'}:

--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -673,12 +673,12 @@ class CMakeTraceParser:
                 continue
 
             if i in {'INTERFACE', 'LINK_INTERFACE_LIBRARIES', 'INTERFACE_LINK_LIBRARIES',
-                'PUBLIC', 'PRIVATE', 'LINK_PUBLIC', 'LINK_PRIVATE'}:
+                     'PUBLIC', 'PRIVATE', 'LINK_PUBLIC', 'LINK_PRIVATE'}:
                 mode = i
                 continue
 
             if mode in {'INTERFACE', 'LINK_INTERFACE_LIBRARIES', 'INTERFACE_LINK_LIBRARIES',
-                'PUBLIC', 'LINK_PUBLIC'}:
+                        'PUBLIC', 'LINK_PUBLIC'}:
                 interface += i.split(';')
 
             if mode in {'PUBLIC', 'PRIVATE', 'LINK_PRIVATE'}:

--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -672,11 +672,25 @@ class CMakeTraceParser:
             if i in ignore:
                 continue
 
-            if i in {'INTERFACE', 'INTERFACE_LINK_LIBRARIES', 'PUBLIC', 'PRIVATE', 'LINK_PUBLIC', 'LINK_PRIVATE'}:
+            if i in {
+                'INTERFACE',
+                'LINK_INTERFACE_LIBRARIES',
+                'INTERFACE_LINK_LIBRARIES',
+                'PUBLIC',
+                'PRIVATE',
+                'LINK_PUBLIC',
+                'LINK_PRIVATE'
+            }:
                 mode = i
                 continue
 
-            if mode in {'INTERFACE', 'INTERFACE_LINK_LIBRARIES', 'PUBLIC', 'LINK_PUBLIC'}:
+            if mode in {
+                'INTERFACE',
+                'LINK_INTERFACE_LIBRARIES',
+                'INTERFACE_LINK_LIBRARIES',
+                'PUBLIC',
+                'LINK_PUBLIC'
+            }:
                 interface += i.split(';')
 
             if mode in {'PUBLIC', 'PRIVATE', 'LINK_PRIVATE'}:


### PR DESCRIPTION
I haven't found the effects of this, but it definitely does not feel right