### PR TITLE
backend/ninja: use `generate_basic_compiler_args()` for C#, Java, Swift

### DIFF
--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -14,6 +14,7 @@ from .compilers import Compiler
 from .mixins.islinker import BasicLinkerIsCompilerMixin
 
 if T.TYPE_CHECKING:
+    from ..dependencies import Dependency
     from ..envconfig import MachineInfo
     from ..environment import Environment
     from ..mesonlib import MachineChoice
@@ -59,6 +60,12 @@ class CsCompiler(BasicLinkerIsCompilerMixin, Compiler):
 
     def get_pic_args(self) -> T.List[str]:
         return []
+
+    def get_dependency_compile_args(self, dep: Dependency) -> T.List[str]:
+        # Historically we ignored all compile args.  Accept what we can, but
+        # filter out -I arguments, which are in some pkg-config files and
+        # aren't accepted by mcs.
+        return [a for a in dep.get_compile_args() if not a.startswith('-I')]
 
     def compute_parameters_with_absolute_paths(self, parameter_list: T.List[str],
                                                build_dir: str) -> T.List[str]:

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -300,6 +300,9 @@ class IntelFortranCompiler(IntelGnuLikeCompiler, FortranCompiler):
     def get_preprocess_only_args(self) -> T.List[str]:
         return ['-cpp', '-EP']
 
+    def get_werror_args(self) -> T.List[str]:
+        return ['-warn', 'errors']
+
     def language_stdlib_only_link_flags(self, env: 'Environment') -> T.List[str]:
         # TODO: needs default search path added
         return ['-lifcore', '-limf']
@@ -348,6 +351,9 @@ class IntelClFortranCompiler(IntelVisualStudioLikeCompiler, FortranCompiler):
         if std.value != 'none':
             args.append('/stand:' + stds[std.value])
         return args
+
+    def get_werror_args(self) -> T.List[str]:
+        return ['/warn:errors']
 
     def get_module_outdir_args(self, path: str) -> T.List[str]:
         return ['/module:' + path]

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -40,11 +40,17 @@ class SwiftCompiler(Compiler):
                          linker=linker)
         self.version = version
 
+    def get_pic_args(self) -> T.List[str]:
+        return []
+
+    def get_pie_args(self) -> T.List[str]:
+        return []
+
     def needs_static_linker(self) -> bool:
         return True
 
     def get_werror_args(self) -> T.List[str]:
-        return ['--fatal-warnings']
+        return ['-warnings-as-errors']
 
     def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
         return ['-emit-dependencies']


### PR DESCRIPTION
C#, Java, and Swift targets were manually collecting compiler arguments rather than using the helper function for this purpose.  This caused each target type to add arguments in a different order, and to forget to add some arguments respectively:

| Language | Arguments |
| -- | -- |
| C# | `/nologo`, `-warnaserror` |
| Java | warning level (`-nowarn`, `-Xlint:all`, `-Xdoclint:all`), debug arguments (`-g`, `-g:none`), `-Werror` |
| Swift | `-warnings-as-errors` |

Fix this.  Also fix up some no-longer-unused argument processing in the `Compiler` implementations and correct werror options for the Intel Fortran compiler.

Fixes https://github.com/mesonbuild/meson/issues/13059.