### PR TITLE
cmake: build type propagation release notes

### DIFF
--- a/docs/markdown/snippets/cmake_build_type.md
+++ b/docs/markdown/snippets/cmake_build_type.md
@@ -1,0 +1,15 @@
+## Meson now propagates its build type to CMake
+
+When the CMake build type variable, `CMAKE_BUILD_TYPE`, is not set via the
+`add_cmake_defines` method of the [`cmake options` object](CMake-module.md#cmake-options-object),
+it is inferred from the [Meson build type](Builtin-options.md#details-for-buildtype).
+Build types of the two build systems do not match perfectly. The mapping from
+Meson build type to CMake build type is as follows:
+
+- `debug` -> `Debug`
+- `debugoptimized` -> `RelWithDebInfo`
+- `release` -> `Release`
+- `minsize` -> `MinSizeRel`
+
+No CMake build type is set for the `plain` Meson build type. The inferred CMake
+build type overrides any `CMAKE_BUILD_TYPE` environment variable.


### PR DESCRIPTION
This is a follow up to #12947. It contains the release note snippet as well as the formatting/typing changes requested by @dcbaker. I considered adding annotations and all-caps for the constants in `cmake/common.py` as well, but since the `language_map` variable from that module is 'exported' and used elsewhere I decided not to. It may make sense to at least add typing information to that variable, because I wasn't sure whether it was final (i.e. read-only), or whether it would be okay for some other code to extend it.

~Many of the constants typed as sequences could have been typed as collections because that more closely reflects how they are used. However, there are no distinct types for immutable and mutable collections and I figured the immutable nature was more important than the smaller 'interface' of a collection.~ _edit: of course a `Collection` is immutable: it doesn't have `__setitem__`!_ :facepalm: