### PR TITLE
Refactor getting option values

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -988,7 +988,6 @@ class Backend:
         # starting from hard-coded defaults followed by build options and so on.
         commands = compiler.compiler_args()
 
-        copt_proxy = target.get_options()
         # First, the trivial ones that are impossible to override.
         #
         # Add -nostdinc/-nostdinc++ if needed; can't be overridden
@@ -1005,7 +1004,7 @@ class Backend:
             commands += compiler.get_werror_args()
         # Add compile args for c_* or cpp_* build options set on the
         # command-line or default_options inside project().
-        commands += compiler.get_option_compile_args(copt_proxy)
+        commands += compiler.get_option_compile_args(target, self.environment)
 
         optimization = self.get_target_option(target, 'optimization')
         assert isinstance(optimization, str), 'for mypy'

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1004,7 +1004,7 @@ class Backend:
             commands += compiler.get_werror_args()
         # Add compile args for c_* or cpp_* build options set on the
         # command-line or default_options inside project().
-        commands += compiler.get_option_compile_args(target, self.environment)
+        commands += compiler.get_option_compile_args(target, self.environment, target.subproject)
 
         optimization = self.get_target_option(target, 'optimization')
         assert isinstance(optimization, str), 'for mypy'
@@ -2090,10 +2090,12 @@ class Backend:
 
     def get_target_option(self, target: build.Target, name: T.Union[str, OptionKey]) -> T.Union[str, int, bool, 'WrapMode']:
         if isinstance(name, str):
-            key = OptionKey(name)
+            key = OptionKey(name, subproject=target.subproject)
         elif isinstance(name, OptionKey):
             key = name
         else:
             import sys
             sys.exit('Internal error: invalid option type.')
+        if key.name == 'std':
+            pass
         return self.environment.coredata.get_option_for_target(target, key)

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -2080,7 +2080,14 @@ class Backend:
                                           target.output_templ, target.depends)
 
     def is_unity(self, target: build.BuildTarget) -> bool:
-        return target.is_unity
+        val = self.get_target_option(target, 'unity')
+        if val == 'on':
+            return True
+        if val == 'off':
+            return False
+        if val == 'subprojects':
+            return target.subproject != ''
+        sys.exit('Internal error: invalid option type for "unity".')
 
     def get_target_option(self, target: build.Target, name: T.Union[str, OptionKey]) -> T.Union[str, int, bool, 'WrapMode']:
         if isinstance(name, str):
@@ -2089,5 +2096,5 @@ class Backend:
             key = name
         else:
             import sys
-            sys.exit('Internal error: invalid option type')
-        return target.get_option(key)
+            sys.exit('Internal error: invalid option type.')
+        return self.environment.coredata.get_option_for_target(target, key)

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -38,6 +38,7 @@ if T.TYPE_CHECKING:
     from ..interpreter import Interpreter, Test
     from ..linkers.linkers import StaticLinker
     from ..mesonlib import FileMode, FileOrString
+    from ..wrap import WrapMode
 
     from typing_extensions import TypedDict
 
@@ -420,7 +421,7 @@ class Backend:
         abs_files: T.List[str] = []
         result: T.List[mesonlib.File] = []
         compsrcs = classify_unity_sources(target.compilers.values(), unity_src)
-        unity_size = target.get_option(OptionKey('unity_size'))
+        unity_size = self.get_target_option(target, 'unity_size')
         assert isinstance(unity_size, int), 'for mypy'
 
         def init_language_file(suffix: str, unity_file_number: int) -> T.TextIO:
@@ -905,10 +906,10 @@ class Backend:
         # With unity builds, sources don't map directly to objects,
         # we only support extracting all the objects in this mode,
         # so just return all object files.
-        if extobj.target.is_unity:
+        if self.is_unity(extobj.target):
             compsrcs = classify_unity_sources(extobj.target.compilers.values(), sources)
             sources = []
-            unity_size = extobj.target.get_option(OptionKey('unity_size'))
+            unity_size = self.get_target_option(extobj.target, 'unity_size')
             assert isinstance(unity_size, int), 'for mypy'
 
             for comp, srcs in compsrcs.items():
@@ -961,7 +962,7 @@ class Backend:
 
     def target_uses_pch(self, target: build.BuildTarget) -> bool:
         try:
-            return T.cast('bool', target.get_option(OptionKey('b_pch')))
+            return T.cast('bool', self.get_target_option(target, 'b_pch'))
         except (KeyError, AttributeError):
             return False
 
@@ -995,22 +996,22 @@ class Backend:
         # Add things like /NOLOGO or -pipe; usually can't be overridden
         commands += compiler.get_always_args()
         # warning_level is a string, but mypy can't determine that
-        commands += compiler.get_warn_args(T.cast('str', target.get_option(OptionKey('warning_level'))))
+        commands += compiler.get_warn_args(T.cast('str', self.get_target_option(target, 'warning_level')))
         # Add -Werror if werror=true is set in the build options set on the
         # command-line or default_options inside project(). This only sets the
         # action to be done for warnings if/when they are emitted, so it's ok
         # to set it after or get_warn_args().
-        if target.get_option(OptionKey('werror')):
+        if self.get_target_option(target, 'werror'):
             commands += compiler.get_werror_args()
         # Add compile args for c_* or cpp_* build options set on the
         # command-line or default_options inside project().
         commands += compiler.get_option_compile_args(copt_proxy)
 
-        optimization = target.get_option(OptionKey('optimization'))
+        optimization = self.get_target_option(target, 'optimization')
         assert isinstance(optimization, str), 'for mypy'
         commands += compiler.get_optimization_args(optimization)
 
-        debug = target.get_option(OptionKey('debug'))
+        debug = self.get_target_option(target, 'debug')
         assert isinstance(debug, bool), 'for mypy'
         commands += compiler.get_debug_args(debug)
 
@@ -1733,7 +1734,7 @@ class Backend:
                 # TODO: Create GNUStrip/AppleStrip/etc. hierarchy for more
                 #       fine-grained stripping of static archives.
                 can_strip = not isinstance(t, build.StaticLibrary)
-                should_strip = can_strip and t.get_option(OptionKey('strip'))
+                should_strip = can_strip and self.get_target_option(t, 'strip')
                 assert isinstance(should_strip, bool), 'for mypy'
                 # Install primary build output (library/executable/jar, etc)
                 # Done separately because of strip/aliases/rpath
@@ -2077,3 +2078,16 @@ class Backend:
         all_sources = T.cast('_ALL_SOURCES_TYPE', target.sources) + T.cast('_ALL_SOURCES_TYPE', target.generated)
         return self.compiler_to_generator(target, target.compiler, all_sources,
                                           target.output_templ, target.depends)
+
+    def is_unity(self, target: build.BuildTarget) -> bool:
+        return target.is_unity
+
+    def get_target_option(self, target: build.Target, name: T.Union[str, OptionKey]) -> T.Union[str, int, bool, 'WrapMode']:
+        if isinstance(name, str):
+            key = OptionKey(name)
+        elif isinstance(name, OptionKey):
+            key = name
+        else:
+            import sys
+            sys.exit('Internal error: invalid option type')
+        return target.get_option(key)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -23,6 +23,7 @@ from .. import modules
 from .. import environment, mesonlib
 from .. import build
 from .. import mlog
+from .. options import OptionParts
 from .. import compilers
 from ..arglist import CompilerArgs
 from ..compilers import Compiler
@@ -623,7 +624,7 @@ class NinjaBackend(backends.Backend):
             outfile.write('# Do not edit by hand.\n\n')
             outfile.write('ninja_required_version = 1.8.2\n\n')
 
-            num_pools = self.environment.coredata.optstore.get_value_for('backend_max_links')
+            num_pools = self.environment.coredata.optstore.get_value_for(OptionParts('backend_max_links'))
             if num_pools > 0:
                 outfile.write(f'''pool link_pool
   depth = {num_pools}
@@ -655,9 +656,9 @@ class NinjaBackend(backends.Backend):
             mlog.log_timestamp("Install generated")
             self.generate_dist()
             mlog.log_timestamp("Dist generated")
-            key = OptionKey('b_coverage')
-            if self.environment.coredata.optstore.has_option('b_coverage', None) and\
-                    self.environment.coredata.optstore.get_value_for('b_coverage'):
+            ckey = OptionParts('b_coverage')
+            if self.environment.coredata.optstore.has_option(ckey) and\
+                    self.environment.coredata.optstore.get_value_for(ckey):
                 gcovr_exe, gcovr_version, lcov_exe, lcov_version, genhtml_exe, llvm_cov_exe = environment.find_coverage_tools(self.environment.coredata)
                 mlog.debug(f'Using {gcovr_exe} ({gcovr_version}), {lcov_exe} and {llvm_cov_exe} for code coverage')
                 if gcovr_exe or (lcov_exe and genhtml_exe):
@@ -2294,7 +2295,7 @@ class NinjaBackend(backends.Backend):
         return options
 
     def generate_static_link_rules(self):
-        num_pools = self.environment.coredata.optstore.get_value_for('backend_max_links')
+        num_pools = self.environment.coredata.optstore.get_value_for(OptionParts('backend_max_links'))
         if 'java' in self.environment.coredata.compilers.host:
             self.generate_java_link()
         for for_machine in MachineChoice:
@@ -2342,7 +2343,7 @@ class NinjaBackend(backends.Backend):
             self.add_rule(NinjaRule(rule, cmdlist, args, description, **options, extra=pool))
 
     def generate_dynamic_link_rules(self):
-        num_pools = self.environment.coredata.optstore.get_value_for('backend_max_links')
+        num_pools = self.environment.coredata.optstore.get_value_for(OptionParts('backend_max_links'))
         for for_machine in MachineChoice:
             complist = self.environment.coredata.compilers[for_machine]
             for langname, compiler in complist.items():
@@ -3733,8 +3734,9 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         if ctlist:
             elem.add_dep(self.generate_custom_target_clean(ctlist))
 
-        if self.environment.coredata.optstore.has_option('b_coverage', None) and \
-           self.environment.coredata.optstore.get_value_for('b_coverage'):
+        ckey = OptionParts('b_coverage')
+        if self.environment.coredata.optstore.has_option(ckey) and \
+           self.environment.coredata.optstore.get_value_for(ckey):
             self.generate_gcov_clean()
             elem.add_dep('clean-gcda')
             elem.add_dep('clean-gcno')

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3254,7 +3254,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 commands += linker.gen_vs_module_defs_args(target.vs_module_defs.rel_to_builddir(self.build_to_src))
         elif isinstance(target, build.SharedLibrary):
             if isinstance(target, build.SharedModule):
-                commands += linker.get_std_shared_module_link_args(target.get_options())
+                commands += linker.get_std_shared_module_link_args(target)
             else:
                 commands += linker.get_std_shared_lib_link_args()
             # All shared libraries are PIC

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1090,7 +1090,10 @@ class NinjaBackend(backends.Backend):
         cpp = target.compilers['cpp']
         if cpp.get_id() != 'msvc':
             return False
-        cppversion = self.get_target_option(target, OptionKey('std', machine=target.for_machine, lang='cpp'))
+        cppversion = self.get_target_option(target, OptionKey('std',
+                                                              machine=target.for_machine,
+                                                              lang='cpp',
+                                                              subproject=target.subproject))
         if cppversion not in ('latest', 'c++latest', 'vc++latest'):
             return False
         if not mesonlib.current_vs_supports_modules():

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -623,7 +623,7 @@ class NinjaBackend(backends.Backend):
             outfile.write('# Do not edit by hand.\n\n')
             outfile.write('ninja_required_version = 1.8.2\n\n')
 
-            num_pools = self.environment.coredata.optstore.get_value('backend_max_links')
+            num_pools = self.environment.coredata.optstore.get_value_for('backend_max_links')
             if num_pools > 0:
                 outfile.write(f'''pool link_pool
   depth = {num_pools}
@@ -656,8 +656,8 @@ class NinjaBackend(backends.Backend):
             self.generate_dist()
             mlog.log_timestamp("Dist generated")
             key = OptionKey('b_coverage')
-            if (key in self.environment.coredata.optstore and
-                    self.environment.coredata.optstore.get_value(key)):
+            if self.environment.coredata.optstore.has_option('b_coverage', None) and\
+                    self.environment.coredata.optstore.get_value_for('b_coverage'):
                 gcovr_exe, gcovr_version, lcov_exe, lcov_version, genhtml_exe, llvm_cov_exe = environment.find_coverage_tools(self.environment.coredata)
                 mlog.debug(f'Using {gcovr_exe} ({gcovr_version}), {lcov_exe} and {llvm_cov_exe} for code coverage')
                 if gcovr_exe or (lcov_exe and genhtml_exe):
@@ -2294,7 +2294,7 @@ class NinjaBackend(backends.Backend):
         return options
 
     def generate_static_link_rules(self):
-        num_pools = self.environment.coredata.optstore.get_value('backend_max_links')
+        num_pools = self.environment.coredata.optstore.get_value_for('backend_max_links')
         if 'java' in self.environment.coredata.compilers.host:
             self.generate_java_link()
         for for_machine in MachineChoice:
@@ -2342,7 +2342,7 @@ class NinjaBackend(backends.Backend):
             self.add_rule(NinjaRule(rule, cmdlist, args, description, **options, extra=pool))
 
     def generate_dynamic_link_rules(self):
-        num_pools = self.environment.coredata.optstore.get_value('backend_max_links')
+        num_pools = self.environment.coredata.optstore.get_value_for('backend_max_links')
         for for_machine in MachineChoice:
             complist = self.environment.coredata.compilers[for_machine]
             for langname, compiler in complist.items():
@@ -3601,6 +3601,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         self.add_build(gcda_elem)
 
     def get_user_option_args(self):
+        if True:
+            return [] # FIXME
         cmds = []
         for k, v in self.environment.coredata.optstore.items():
             if k.is_project():
@@ -3731,8 +3733,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         if ctlist:
             elem.add_dep(self.generate_custom_target_clean(ctlist))
 
-        if OptionKey('b_coverage') in self.environment.coredata.optstore and \
-           self.environment.coredata.optstore.get_value('b_coverage'):
+        if self.environment.coredata.optstore.has_option('b_coverage', None) and \
+           self.environment.coredata.optstore.get_value_for('b_coverage'):
             self.generate_gcov_clean()
             elem.add_dep('clean-gcda')
             elem.add_dep('clean-gcno')

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2850,7 +2850,6 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         return commands
 
     def _generate_single_compile_base_args(self, target: build.BuildTarget, compiler: 'Compiler') -> 'CompilerArgs':
-        base_proxy = target.get_options()
         # Create an empty commands list, and start adding arguments from
         # various sources in the order in which they must override each other
         commands = compiler.compiler_args()
@@ -2859,7 +2858,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         # Add compiler args for compiling this target derived from 'base' build
         # options passed on the command-line, in default_options, etc.
         # These have the lowest priority.
-        commands += compilers.get_base_compile_args(base_proxy,
+        commands += compilers.get_base_compile_args(target,
                                                     compiler, self.environment)
         return commands
 
@@ -3430,12 +3429,11 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         # options passed on the command-line, in default_options, etc.
         # These have the lowest priority.
         if isinstance(target, build.StaticLibrary):
-            commands += linker.get_base_link_args(target.get_options())
+            commands += linker.get_base_link_args(target, linker, self.environment)
         else:
-            commands += compilers.get_base_link_args(target.get_options(),
+            commands += compilers.get_base_link_args(target,
                                                      linker,
-                                                     isinstance(target, build.SharedModule),
-                                                     self.environment.get_build_dir())
+                                                     self.environment)
         # Add -nostdlib if needed; can't be overridden
         commands += self.get_no_stdlib_link_args(target, linker)
         # Add things like /NOLOGO; usually can't be overridden
@@ -3530,7 +3528,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             #
             # We shouldn't check whether we are making a static library, because
             # in the LTO case we do use a real compiler here.
-            commands += linker.get_option_link_args(target.get_options())
+            commands += linker.get_option_link_args(target, self.environment)
 
         dep_targets = []
         dep_targets.extend(self.guess_external_link_dependencies(linker, target, commands, internal))

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1902,10 +1902,9 @@ class NinjaBackend(backends.Backend):
         # Rust compiler takes only the main file as input and
         # figures out what other files are needed via import
         # statements and magic.
-        base_proxy = target.get_options()
         args = rustc.compiler_args()
         # Compiler args for compiling this target
-        args += compilers.get_base_compile_args(base_proxy, rustc, self.environment)
+        args += compilers.get_base_compile_args(target, rustc, self.environment)
         self.generate_generator_list_rules(target)
 
         # dependencies need to cause a relink, they're not just for ordering

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -933,7 +933,7 @@ class NinjaBackend(backends.Backend):
         # Generate rules for building the remaining source files in this target
         outname = self.get_target_filename(target)
         obj_list = []
-        is_unity = target.is_unity
+        is_unity = self.is_unity(target)
         header_deps = []
         unity_src = []
         unity_deps = [] # Generated sources that must be built before compiling a Unity target.
@@ -1090,7 +1090,7 @@ class NinjaBackend(backends.Backend):
         cpp = target.compilers['cpp']
         if cpp.get_id() != 'msvc':
             return False
-        cppversion = target.get_option(OptionKey('std', machine=target.for_machine, lang='cpp'))
+        cppversion = self.get_target_option(target, OptionKey('std', machine=target.for_machine, lang='cpp'))
         if cppversion not in ('latest', 'c++latest', 'vc++latest'):
             return False
         if not mesonlib.current_vs_supports_modules():
@@ -1697,7 +1697,7 @@ class NinjaBackend(backends.Backend):
             valac_outputs.append(vala_c_file)
 
         args = self.generate_basic_compiler_args(target, valac)
-        args += valac.get_colorout_args(target.get_option(OptionKey('b_colorout')))
+        args += valac.get_colorout_args(self.get_target_option(target, 'b_colorout'))
         # Tell Valac to output everything in our private directory. Sadly this
         # means it will also preserve the directory components of Vala sources
         # found inside the build tree (generated sources).
@@ -1709,7 +1709,7 @@ class NinjaBackend(backends.Backend):
             # Outputted header
             hname = os.path.join(self.get_target_dir(target), target.vala_header)
             args += ['--header', hname]
-            if target.is_unity:
+            if self.is_unity(target):
                 # Without this the declarations will get duplicated in the .c
                 # files and cause a build failure when all of them are
                 # #include-d in one .c file.
@@ -1775,14 +1775,14 @@ class NinjaBackend(backends.Backend):
 
         args: T.List[str] = []
         args += cython.get_always_args()
-        args += cython.get_debug_args(target.get_option(OptionKey('debug')))
-        args += cython.get_optimization_args(target.get_option(OptionKey('optimization')))
+        args += cython.get_debug_args(self.get_target_option(target, 'debug'))
+        args += cython.get_optimization_args(self.get_target_option(target, 'optimization'))
         args += cython.get_option_compile_args(target.get_options())
         args += self.build.get_global_args(cython, target.for_machine)
         args += self.build.get_project_args(cython, target.subproject, target.for_machine)
         args += target.get_extra_args('cython')
 
-        ext = target.get_option(OptionKey('language', machine=target.for_machine, lang='cython'))
+        ext = self.get_target_option(target, OptionKey('language', machine=target.for_machine, lang='cython'))
 
         pyx_sources = []  # Keep track of sources we're adding to build
 
@@ -1985,8 +1985,8 @@ class NinjaBackend(backends.Backend):
         # https://github.com/rust-lang/rust/issues/39016
         if not isinstance(target, build.StaticLibrary):
             try:
-                buildtype = target.get_option(OptionKey('buildtype'))
-                crt = target.get_option(OptionKey('b_vscrt'))
+                buildtype = self.get_target_option(target, 'buildtype')
+                crt = self.get_target_option(target, 'b_vscrt')
                 args += rustc.get_crt_link_args(crt, buildtype)
             except (KeyError, AttributeError):
                 pass
@@ -3441,9 +3441,9 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         # Add things like /NOLOGO; usually can't be overridden
         commands += linker.get_linker_always_args()
         # Add buildtype linker args: optimization level, etc.
-        commands += linker.get_optimization_link_args(target.get_option(OptionKey('optimization')))
+        commands += linker.get_optimization_link_args(self.get_target_option(target, 'optimization'))
         # Add /DEBUG and the pdb filename when using MSVC
-        if target.get_option(OptionKey('debug')):
+        if self.get_target_option(target, 'debug'):
             commands += self.get_link_debugfile_args(linker, target)
             debugfile = self.get_link_debugfile_name(linker, target)
             if debugfile is not None:

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -1685,7 +1685,7 @@ class XCodeBackend(backends.Backend):
                 if compiler is None:
                     continue
                 # Start with warning args
-                warn_args = compiler.get_warn_args(target.get_option(OptionKey('warning_level')))
+                warn_args = compiler.get_warn_args(self.get_target_option(target, 'warning_level'))
                 copt_proxy = target.get_options()
                 std_args = compiler.get_option_compile_args(copt_proxy)
                 # Add compile args added using add_project_arguments()
@@ -1738,9 +1738,9 @@ class XCodeBackend(backends.Backend):
             if target.suffix:
                 suffix = '.' + target.suffix
                 settings_dict.add_item('EXECUTABLE_SUFFIX', suffix)
-            settings_dict.add_item('GCC_GENERATE_DEBUGGING_SYMBOLS', BOOL2XCODEBOOL[target.get_option(OptionKey('debug'))])
+            settings_dict.add_item('GCC_GENERATE_DEBUGGING_SYMBOLS', BOOL2XCODEBOOL[self.get_target_option(target, 'debug')])
             settings_dict.add_item('GCC_INLINES_ARE_PRIVATE_EXTERN', 'NO')
-            opt_flag = OPT2XCODEOPT[target.get_option(OptionKey('optimization'))]
+            opt_flag = OPT2XCODEOPT[self.get_target_option(target, 'optimization')]
             if opt_flag is not None:
                 settings_dict.add_item('GCC_OPTIMIZATION_LEVEL', opt_flag)
             if target.has_pch:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -668,6 +668,9 @@ class Target(HoldableObject, metaclass=abc.ABCMeta):
         # in the future we might be able to remove the cast here
         return T.cast('T.Union[str, int, bool]', self.options.get_value(key))
 
+    def get_raw_override(self, key: str) -> T.Optional(str):
+        return None # FIXME
+
     @staticmethod
     def parse_overrides(kwargs: T.Dict[str, T.Any]) -> T.Dict[OptionKey, str]:
         opts = kwargs.get('override_options', [])

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -662,6 +662,8 @@ class Target(HoldableObject, metaclass=abc.ABCMeta):
         return self.options
 
     def get_option(self, key: 'OptionKey') -> T.Union[str, int, bool]:
+        # We don't actually have wrapmode here to do an assert, so just do a
+        # cast, we know what's in coredata anyway.
         # TODO: if it's possible to annotate get_option or validate_option_value
         # in the future we might be able to remove the cast here
         return T.cast('T.Union[str, int, bool]', self.options.get_value(key))
@@ -812,6 +814,7 @@ class BuildTarget(Target):
     def __str__(self):
         return f"{self.name}"
 
+    # FIXME: this entire method needs to be removed.
     @property
     def is_unity(self) -> bool:
         unity_opt = self.get_option(OptionKey('unity'))

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -671,8 +671,14 @@ class Target(HoldableObject, metaclass=abc.ABCMeta):
         self.raw_overrides = self.parse_overrides(kwargs)
 >>>>>>> 772e9033d (Refactor code to use per-target option methods.)
 
-    def get_raw_override(self, key: str) -> T.Optional(str):
-        return None # FIXME
+    def get_override(self, name, fallback):
+        if isinstance(name, str):
+            name = OptionKey(name)
+        # FIXME. A target object should store overrides in the original string form.
+        # We need to refactor to make feasible.
+        if name in self.raw_overrides:
+            return str(self.raw_overrides.get(name, fallback))
+        return fallback
 
     @staticmethod
     def parse_overrides(kwargs: T.Dict[str, T.Any]) -> T.Dict[OptionKey, str]:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -18,6 +18,7 @@ from . import coredata
 from . import dependencies
 from . import mlog
 from . import programs
+from . import options
 from .mesonlib import (
     HoldableObject, SecondLevelHolder,
     File, MesonException, MachineChoice, PerMachine, OrderedSet, listify,
@@ -529,10 +530,6 @@ class Target(HoldableObject, metaclass=abc.ABCMeta):
                    for k, v in overrides.items()}
         else:
             ovr = {}
-<<<<<<< HEAD
-        self.options = coredata.OptionsView(self.environment.coredata.optstore, self.subproject, ovr)
-=======
->>>>>>> 772e9033d (Refactor code to use per-target option methods.)
         # XXX: this should happen in the interpreter
         if has_path_sep(self.name):
             # Fix failing test 53 when this becomes an error.
@@ -647,29 +644,7 @@ class Target(HoldableObject, metaclass=abc.ABCMeta):
             # set, use the value of 'install' if it's enabled.
             self.build_by_default = True
 
-<<<<<<< HEAD
-        self.set_option_overrides(self.parse_overrides(kwargs))
-
-    def set_option_overrides(self, option_overrides: T.Dict[OptionKey, str]) -> None:
-        self.options.overrides = {}
-        for k, v in option_overrides.items():
-            if k.lang:
-                self.options.overrides[k.evolve(machine=self.for_machine)] = v
-            else:
-                self.options.overrides[k] = v
-
-    def get_options(self) -> coredata.OptionsView:
-        return self.options
-
-    def get_option(self, key: 'OptionKey') -> T.Union[str, int, bool]:
-        # We don't actually have wrapmode here to do an assert, so just do a
-        # cast, we know what's in coredata anyway.
-        # TODO: if it's possible to annotate get_option or validate_option_value
-        # in the future we might be able to remove the cast here
-        return T.cast('T.Union[str, int, bool]', self.options.get_value(key))
-=======
         self.raw_overrides = self.parse_overrides(kwargs)
->>>>>>> 772e9033d (Refactor code to use per-target option methods.)
 
     def get_override(self, name, fallback):
         if isinstance(name, str):
@@ -1248,16 +1223,13 @@ class BuildTarget(Target):
             mlog.warning(f"Use the '{arg}' kwarg instead of passing '-f{arg}' manually to {self.name!r}")
             return True
 
-        k = OptionKey(option)
+        k = options.OptionParts(option)
         if kwargs.get(arg) is not None:
             val = T.cast('bool', kwargs[arg])
-<<<<<<< HEAD
-        elif k in self.environment.coredata.optstore:
-            val = self.environment.coredata.optstore.get_value(k)
-=======
         elif self.environment.coredata.optstore.has_option(k.name, k.subproject):
             val = self.environment.coredata.optstore.get_value_for(k.name, k.subproject)
->>>>>>> 9097b283a (Hook up new option store to the old code. Can compile simple projects.)
+        elif self.environment.coredata.optstore.has_option(k):
+            val = self.environment.coredata.optstore.get_value_for(k)
         else:
             val = False
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1251,8 +1251,13 @@ class BuildTarget(Target):
         k = OptionKey(option)
         if kwargs.get(arg) is not None:
             val = T.cast('bool', kwargs[arg])
+<<<<<<< HEAD
         elif k in self.environment.coredata.optstore:
             val = self.environment.coredata.optstore.get_value(k)
+=======
+        elif self.environment.coredata.optstore.has_option(k.name, k.subproject):
+            val = self.environment.coredata.optstore.get_value_for(k.name, k.subproject)
+>>>>>>> 9097b283a (Hook up new option store to the old code. Can compile simple projects.)
         else:
             val = False
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -413,10 +413,6 @@ class ExtractedObjects(HoldableObject):
     recursive: bool = True
     pch: bool = False
 
-    def __post_init__(self) -> None:
-        if self.target.is_unity:
-            self.check_unity_compatible()
-
     def __repr__(self) -> str:
         r = '<{0} {1!r}: {2}>'
         return r.format(self.__class__.__name__, self.target.name, self.srclist)
@@ -533,7 +529,10 @@ class Target(HoldableObject, metaclass=abc.ABCMeta):
                    for k, v in overrides.items()}
         else:
             ovr = {}
+<<<<<<< HEAD
         self.options = coredata.OptionsView(self.environment.coredata.optstore, self.subproject, ovr)
+=======
+>>>>>>> 772e9033d (Refactor code to use per-target option methods.)
         # XXX: this should happen in the interpreter
         if has_path_sep(self.name):
             # Fix failing test 53 when this becomes an error.
@@ -648,6 +647,7 @@ class Target(HoldableObject, metaclass=abc.ABCMeta):
             # set, use the value of 'install' if it's enabled.
             self.build_by_default = True
 
+<<<<<<< HEAD
         self.set_option_overrides(self.parse_overrides(kwargs))
 
     def set_option_overrides(self, option_overrides: T.Dict[OptionKey, str]) -> None:
@@ -667,6 +667,9 @@ class Target(HoldableObject, metaclass=abc.ABCMeta):
         # TODO: if it's possible to annotate get_option or validate_option_value
         # in the future we might be able to remove the cast here
         return T.cast('T.Union[str, int, bool]', self.options.get_value(key))
+=======
+        self.raw_overrides = self.parse_overrides(kwargs)
+>>>>>>> 772e9033d (Refactor code to use per-target option methods.)
 
     def get_raw_override(self, key: str) -> T.Optional(str):
         return None # FIXME
@@ -816,12 +819,6 @@ class BuildTarget(Target):
 
     def __str__(self):
         return f"{self.name}"
-
-    # FIXME: this entire method needs to be removed.
-    @property
-    def is_unity(self) -> bool:
-        unity_opt = self.get_option(OptionKey('unity'))
-        return unity_opt == 'on' or (unity_opt == 'subprojects' and self.subproject != '')
 
     def validate_install(self):
         if self.for_machine is MachineChoice.BUILD and self.install:
@@ -2792,10 +2789,6 @@ class CompileTarget(BuildTarget):
 
     def type_suffix(self) -> str:
         return "@compile"
-
-    @property
-    def is_unity(self) -> bool:
-        return False
 
     def _add_output(self, f: File) -> None:
         plainname = os.path.basename(f.fname)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1915,9 +1915,9 @@ class Executable(BuildTarget):
             environment: environment.Environment,
             compilers: T.Dict[str, 'Compiler'],
             kwargs):
-        key = OptionKey('b_pie')
-        if 'pie' not in kwargs and key in environment.coredata.optstore:
-            kwargs['pie'] = environment.coredata.optstore.get_value(key)
+        key = options.OptionParts('b_pie')
+        if 'pie' not in kwargs and  environment.coredata.optstore.has_option(key):
+            kwargs['pie'] = environment.coredata.optstore.get_value_for(key)
         super().__init__(name, subdir, subproject, for_machine, sources, structured_sources, objects,
                          environment, compilers, kwargs)
         self.win_subsystem = kwargs.get('win_subsystem') or 'console'

--- a/mesonbuild/cmake/common.py
+++ b/mesonbuild/cmake/common.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from ..mesonlib import MesonException, OptionKey
+from ..options import OptionParts
 from .. import mlog
 from pathlib import Path
 import typing as T
@@ -51,14 +52,14 @@ blacklist_cmake_defs = [
 ]
 
 def cmake_is_debug(env: 'Environment') -> bool:
-    if OptionKey('b_vscrt') in env.coredata.optstore:
-        is_debug = env.coredata.get_option(OptionKey('buildtype')) == 'debug'
-        if env.coredata.optstore.get_value('b_vscrt') in {'mdd', 'mtd'}:
+    if env.coredata.optstore.has_option('b_vscrt'):
+        is_debug = env.coredata.optstore.get_value_for('buildtype') == 'debug'
+        if env.coredata.optstore.get_value_for('b_vscrt') in {'mdd', 'mtd'}:
             is_debug = True
         return is_debug
     else:
         # Don't directly assign to is_debug to make mypy happy
-        debug_opt = env.coredata.get_option(OptionKey('debug'))
+        debug_opt = env.coredata.optstore.get_value_for('debug')
         assert isinstance(debug_opt, bool)
         return debug_opt
 

--- a/mesonbuild/cmake/executor.py
+++ b/mesonbuild/cmake/executor.py
@@ -12,6 +12,7 @@ import os
 from .. import mlog
 from ..mesonlib import PerMachine, Popen_safe, version_compare, is_windows, OptionKey
 from ..programs import find_external_program, NonExistingExternalProgram
+from ..options import OptionParts
 
 if T.TYPE_CHECKING:
     from pathlib import Path
@@ -51,7 +52,7 @@ class CMakeExecutor:
             self.cmakebin = None
             return
 
-        self.prefix_paths = self.environment.coredata.optstore.get_value(OptionKey('cmake_prefix_path', machine=self.for_machine))
+        self.prefix_paths = self.environment.coredata.optstore.get_value_for('cmake_prefix_path')
         if self.prefix_paths:
             self.extra_cmake_args += ['-DCMAKE_PREFIX_PATH={}'.format(';'.join(self.prefix_paths))]
 

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -443,10 +443,10 @@ class IntelCCompiler(IntelGnuLikeCompiler, CCompiler):
         std_opt.set_versions(stds, gnu=True)
         return opts
 
-    def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+    def get_option_compile_args(self, target: 'BuildTarget', env: 'Environment', subproject=None) -> T.List[str]:
         args = []
         key = self.form_langopt_key('std')
-        std = options.get_value(key)
+        std = env.determine_option_value(key, target, subproject)
         if std != 'none':
             args.append('-std=' + std)
         return args
@@ -511,7 +511,6 @@ class VisualStudioCCompiler(MSVCCompiler, VisualStudioLikeCCompilerMixin, CCompi
     def get_option_compile_args(self, target: 'BuildTarget', env: 'Environment', subproject=None) -> T.List[str]:
         args = []
         key = self.form_langopt_key('std')
-        std = env.coredata.get_option_for_target(target, key)
         # As of MVSC 16.8, /std:c11 and /std:c17 are the only valid C standard options.
         if std in {'c11'}:
             args.append('/std:c11')
@@ -530,9 +529,10 @@ class ClangClCCompiler(_ClangCStds, ClangClCompiler, VisualStudioLikeCCompilerMi
                            full_version=full_version)
         ClangClCompiler.__init__(self, target)
 
-    def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+    def get_option_compile_args(self, target: 'BuildTarget', env: 'Environment', subproject=None) -> T.List[str]:
+        args = []
         key = self.form_langopt_key('std')
-        std = options.get_value(key)
+        std = env.determine_option_value(key, target, subproject)
         if std != "none":
             return [f'/clang:-std={std}']
         return []
@@ -562,10 +562,10 @@ class IntelClCCompiler(IntelVisualStudioLikeCompiler, VisualStudioLikeCCompilerM
         std_opt.set_versions(['c89', 'c99', 'c11'])
         return opts
 
-    def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+    def get_option_compile_args(self, target: 'BuildTarget', env: 'Environment', subproject=None) -> T.List[str]:
         args = []
         key = self.form_langopt_key('std')
-        std = options.get_value(key)
+        std = env.determine_option_value(key, target, subproject)
         if std == 'c89':
             mlog.log("ICL doesn't explicitly implement c89, setting the standard to 'none', which is close.", once=True)
         elif std != 'none':

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -472,10 +472,9 @@ class VisualStudioLikeCCompilerMixin(CompilerMixinBase):
             ),
         )
 
-    def get_option_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
-        # need a TypeDict to make this work
+    def get_option_link_args(self, target: 'BuildTarget', env: 'Environment', subproject=None) -> T.List[str]:
         key = self.form_langopt_key('winlibs')
-        libs = options.get_value(key).copy()
+        libs = env.coredata.get_option_for_target(target, key).copy()
         assert isinstance(libs, list)
         for l in libs:
             assert isinstance(l, str)
@@ -509,12 +508,12 @@ class VisualStudioCCompiler(MSVCCompiler, VisualStudioLikeCCompilerMixin, CCompi
         std_opt.set_versions(stds, gnu=True, gnu_deprecated=True)
         return opts
 
-    def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+    def get_option_compile_args(self, target: 'BuildTarget', env: 'Environment', subproject=None) -> T.List[str]:
         args = []
         key = self.form_langopt_key('std')
-        std = options.get_value(key)
+        std = env.coredata.get_option_for_target(target, key)
         # As of MVSC 16.8, /std:c11 and /std:c17 are the only valid C standard options.
-        if std == 'c11':
+        if std in {'c11'}:
             args.append('/std:c11')
         elif std in {'c17', 'c18'}:
             args.append('/std:c17')

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -316,19 +316,19 @@ class GnuCCompiler(GnuCompiler, CCompiler):
             )
         return opts
 
-    def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+    def get_option_compile_args(self, target: 'BuildTarget', env: 'Environment') -> T.List[str]:
         args = []
         key = self.form_langopt_key('std')
-        std = options.get_value(key)
+        std = env.coredata.get_option_for_target(target, key)
         if std != 'none':
             args.append('-std=' + std)
         return args
 
-    def get_option_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+    def get_option_link_args(self, target: 'BuildTarget', env: 'Environment') -> T.List[str]:
         if self.info.is_windows() or self.info.is_cygwin():
             # without a typeddict mypy can't figure this out
             key = self.form_langopt_key('winlibs')
-            libs: T.List[str] = options.get_value(key).copy()
+            libs: T.List[str] = env.get_option_for_target(target, key).copy()
             assert isinstance(libs, list)
             for l in libs:
                 assert isinstance(l, str)

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -316,10 +316,13 @@ class GnuCCompiler(GnuCompiler, CCompiler):
             )
         return opts
 
-    def get_option_compile_args(self, target: 'BuildTarget', env: 'Environment') -> T.List[str]:
+    def get_option_compile_args(self, target: 'BuildTarget', env: 'Environment', subproject=None) -> T.List[str]:
         args = []
         key = self.form_langopt_key('std')
-        std = env.coredata.get_option_for_target(target, key)
+        if target:
+            std = env.coredata.get_option_for_target(target, key)
+        else:
+            std = env.coredata.get_option_for_subproject(key, subproject)
         if std != 'none':
             args.append('-std=' + std)
         return args

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -327,11 +327,21 @@ class GnuCCompiler(GnuCompiler, CCompiler):
             args.append('-std=' + std)
         return args
 
-    def get_option_link_args(self, target: 'BuildTarget', env: 'Environment') -> T.List[str]:
+    def get_option_link_args(self, target: 'BuildTarget', env: 'Environment', subproject=None) -> T.List[str]:
         if self.info.is_windows() or self.info.is_cygwin():
             # without a typeddict mypy can't figure this out
             key = self.form_langopt_key('winlibs')
-            libs: T.List[str] = env.get_option_for_target(target, key).copy()
+            if target:
+                libs: T.List[str] = env.get_option_for_target(target,
+                                                              OptionKey('winlibs',
+                                                                        lang=self.language,
+                                                                        machine=self.for_machine)).copy()
+            else:
+                libs: T.List[str] = env.get_option_for_subproject(OptionKey('winlibs',
+                                                                            lang=self.language,
+                                                                            machine=self.for_machine),
+                                                                            subproject).copy()
+
             assert isinstance(libs, list)
             for l in libs:
                 assert isinstance(l, str)

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -622,7 +622,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
     def get_options(self) -> 'MutableKeyedOptionDictType':
         return {}
 
-    def get_option_compile_args(self, target: 'BuildTarget', env: 'Environment') -> T.List[str]:
+    def get_option_compile_args(self, target: 'BuildTarget', env: 'Environment', subproject=None) -> T.List[str]:
         return []
 
     def get_option_link_args(self, target: 'BuildTarget', env: 'Environment') -> T.List[str]:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -250,12 +250,16 @@ BASE_OPTIONS: T.Mapping[OptionKey, BaseOption] = {
 
 base_options = {key: base_opt.init_option(key) for key, base_opt in BASE_OPTIONS.items()}
 
-def option_enabled(boptions: T.Set[OptionKey], options: 'KeyedOptionDictType',
-                   option: OptionKey) -> bool:
+def option_enabled(boptions: T.Set[OptionKey],
+                   target: 'BuildTarget',
+                   env: 'Environment',
+                   option: T.Union[str, OptionKey]) -> bool:
+    if isinstance(option, str):
+        option = OptionKey(option)
     try:
         if option not in boptions:
             return False
-        ret = options.get_value(option)
+        ret = env.coredata.get_option_for_target(target, option)
         assert isinstance(ret, bool), 'must return bool'  # could also be str
         return ret
     except KeyError:
@@ -273,37 +277,50 @@ def get_option_value(options: 'KeyedOptionDictType', opt: OptionKey, fallback: '
     # Mypy doesn't understand that the above assert ensures that v is type _T
     return v
 
+def get_target_option_value(target: 'BuildTarget', 
+                            env: 'Environment', 
+                            opt: T.Union[OptionKey, str], 
+                            fallback: '_T') -> '_T':
+    """Get the value of an option, or the fallback value."""
+    try:
+        v: '_T' = env.coredata.get_option_for_target(target, opt)
+    except KeyError:
+        return fallback
 
-def are_asserts_disabled(options: KeyedOptionDictType) -> bool:
+    assert isinstance(v, type(fallback)), f'Should have {type(fallback)!r} but was {type(v)!r}'
+    # Mypy doesn't understand that the above assert ensures that v is type _T
+    return v
+
+
+def are_asserts_disabled(target: 'BuildTarget', env: 'Environment') -> bool:
     """Should debug assertions be disabled
 
     :param options: OptionDictionary
     :return: whether to disable assertions or not
     """
-    return (options.get_value('b_ndebug') == 'true' or
-            (options.get_value('b_ndebug') == 'if-release' and
-             options.get_value('buildtype') in {'release', 'plain'}))
+    return env.coredata.get_option_for_target(target,'b_ndebug') == 'true' or \
+           env.coredata.get_option_for_target(target,'b_ndebug') == 'if-release' and \
+           env.coredata.get_option_for_target(target,'buildtype') in {'release', 'plain'}
 
-
-def get_base_compile_args(options: 'KeyedOptionDictType', compiler: 'Compiler', env: 'Environment') -> T.List[str]:
+def get_base_compile_args(target: 'BuildTarget', compiler: 'Compiler', env: 'Environment') -> T.List[str]:
     args: T.List[str] = []
     try:
-        if options.get_value(OptionKey('b_lto')):
+        if env.coredata.get_option_for_target(target, 'b_lto'):
             args.extend(compiler.get_lto_compile_args(
                 threads=get_option_value(options, OptionKey('b_lto_threads'), 0),
                 mode=get_option_value(options, OptionKey('b_lto_mode'), 'default')))
     except (KeyError, AttributeError):
         pass
     try:
-        args += compiler.get_colorout_args(options.get_value(OptionKey('b_colorout')))
-    except (KeyError, AttributeError):
+        args += compiler.get_colorout_args(env.coredata.get_option_for_target(target,'b_colorout'))
+    except KeyError:
         pass
     try:
-        args += compiler.sanitizer_compile_args(options.get_value(OptionKey('b_sanitize')))
-    except (KeyError, AttributeError):
+        args += compiler.sanitizer_compile_args(env.coredata.get_option_for_target(target, 'b_sanitize'))
+    except KeyError:
         pass
     try:
-        pgo_val = options.get_value(OptionKey('b_pgo'))
+        pgo_val = env.coredata.get_option_for_target(target,'b_pgo')
         if pgo_val == 'generate':
             args.extend(compiler.get_profile_generate_args())
         elif pgo_val == 'use':
@@ -311,21 +328,21 @@ def get_base_compile_args(options: 'KeyedOptionDictType', compiler: 'Compiler', 
     except (KeyError, AttributeError):
         pass
     try:
-        if options.get_value(OptionKey('b_coverage')):
+        if env.coredata.get_option_for_target(target,'b_coverage'):
             args += compiler.get_coverage_args()
     except (KeyError, AttributeError):
         pass
     try:
-        args += compiler.get_assert_args(are_asserts_disabled(options), env)
-    except (KeyError, AttributeError):
+        args += compiler.get_assert_args(are_asserts_disabled(target, env), env)
+    except KeyError:
         pass
     # This does not need a try...except
-    if option_enabled(compiler.base_options, options, OptionKey('b_bitcode')):
+    if option_enabled(compiler.base_options, target, env, 'b_bitcode'):
         args.append('-fembed-bitcode')
     try:
+        crt_val = env.coredata.get_option_for_target(target,'b_vscrt')
+        buildtype = env.coredata.get_option_for_target(target, 'buildtype')
         try:
-            crt_val = options.get_value(OptionKey('b_vscrt'))
-            buildtype = options.get_value(OptionKey('buildtype'))
             args += compiler.get_crt_compile_args(crt_val, buildtype)
         except AttributeError:
             pass
@@ -333,12 +350,14 @@ def get_base_compile_args(options: 'KeyedOptionDictType', compiler: 'Compiler', 
         pass
     return args
 
-def get_base_link_args(options: 'KeyedOptionDictType', linker: 'Compiler',
-                       is_shared_module: bool, build_dir: str) -> T.List[str]:
+def get_base_link_args(target: 'BuildTarget',
+                       linker: 'Compiler',
+                       env: 'Environment') -> T.List[str]:
     args: T.List[str] = []
+    build_dir = env.get_build_dir()
     try:
-        if options.get_value('b_lto'):
-            if options.get_value('werror'):
+        if env.coredata.get_option_for_target(target, 'b_lto'):
+            if env.coredata.get_option_for_target(target, 'werror'):
                 args.extend(linker.get_werror_args())
 
             thinlto_cache_dir = None
@@ -353,11 +372,11 @@ def get_base_link_args(options: 'KeyedOptionDictType', linker: 'Compiler',
     except (KeyError, AttributeError):
         pass
     try:
-        args += linker.sanitizer_link_args(options.get_value('b_sanitize'))
-    except (KeyError, AttributeError):
+        args += linker.sanitizer_link_args(env.coredata.get_option_for_target(target, 'b_sanitize'))
+    except KeyError:
         pass
     try:
-        pgo_val = options.get_value('b_pgo')
+        pgo_val = env.coredata.get_option_for_target(target,'b_pgo')
         if pgo_val == 'generate':
             args.extend(linker.get_profile_generate_args())
         elif pgo_val == 'use':
@@ -365,13 +384,13 @@ def get_base_link_args(options: 'KeyedOptionDictType', linker: 'Compiler',
     except (KeyError, AttributeError):
         pass
     try:
-        if options.get_value('b_coverage'):
+        if env.coredata.get_option_for_target(target, 'b_coverage'):
             args += linker.get_coverage_link_args()
     except (KeyError, AttributeError):
         pass
 
-    as_needed = option_enabled(linker.base_options, options, OptionKey('b_asneeded'))
-    bitcode = option_enabled(linker.base_options, options, OptionKey('b_bitcode'))
+    as_needed = option_enabled(linker.base_options, target, env, 'b_asneeded')
+    bitcode = option_enabled(linker.base_options, target, env, 'b_bitcode')
     # Shared modules cannot be built with bitcode_bundle because
     # -bitcode_bundle is incompatible with -undefined and -bundle
     if bitcode and not is_shared_module:
@@ -383,17 +402,18 @@ def get_base_link_args(options: 'KeyedOptionDictType', linker: 'Compiler',
     # Apple's ld (the only one that supports bitcode) does not like -undefined
     # arguments or -headerpad_max_install_names when bitcode is enabled
     if not bitcode:
+        from ..build import SharedModule
         args.extend(linker.headerpad_args())
-        if (not is_shared_module and
-                option_enabled(linker.base_options, options, OptionKey('b_lundef'))):
+        if (not isinstance(target, SharedModule) and
+                option_enabled(linker.base_options, target, env, 'b_lundef')):
             args.extend(linker.no_undefined_link_args())
         else:
             args.extend(linker.get_allow_undefined_link_args())
 
     try:
+        crt_val = env.coredata.get_option_for_target(target, 'b_vscrt')
+        buildtype =env.coredata.get_option_for_target('buildtype')
         try:
-            crt_val = options.get_value(OptionKey('b_vscrt'))
-            buildtype = options.get_value(OptionKey('buildtype'))
             args += linker.get_crt_link_args(crt_val, buildtype)
         except AttributeError:
             pass
@@ -602,11 +622,11 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
     def get_options(self) -> 'MutableKeyedOptionDictType':
         return {}
 
-    def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+    def get_option_compile_args(self, target: 'BuildTarget', env: 'Environment') -> T.List[str]:
         return []
 
-    def get_option_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
-        return self.linker.get_option_args(options)
+    def get_option_link_args(self, target: 'BuildTarget', env: 'Environment') -> T.List[str]:
+        return self.linker.get_option_args(*args, **kwargs)
 
     def check_header(self, hname: str, prefix: str, env: 'Environment', *,
                      extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -626,7 +626,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         return []
 
     def get_option_link_args(self, target: 'BuildTarget', env: 'Environment', subproject=None) -> T.List[str]:
-        return self.linker.get_option_args(*args, **kwargs)
+        return self.linker.get_option_link_args(target, env, subproject)
 
     def check_header(self, hname: str, prefix: str, env: 'Environment', *,
                      extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,
@@ -916,8 +916,8 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
     def get_std_shared_lib_link_args(self) -> T.List[str]:
         return self.linker.get_std_shared_lib_args()
 
-    def get_std_shared_module_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
-        return self.linker.get_std_shared_module_args(options)
+    def get_std_shared_module_link_args(self, target: 'BuildTarget') -> T.List[str]:
+        return self.linker.get_std_shared_module_args(target)
 
     def get_link_whole_for(self, args: T.List[str]) -> T.List[str]:
         return self.linker.get_link_whole_for(args)

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -625,7 +625,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
     def get_option_compile_args(self, target: 'BuildTarget', env: 'Environment', subproject=None) -> T.List[str]:
         return []
 
-    def get_option_link_args(self, target: 'BuildTarget', env: 'Environment') -> T.List[str]:
+    def get_option_link_args(self, target: 'BuildTarget', env: 'Environment', subproject=None) -> T.List[str]:
         return self.linker.get_option_args(*args, **kwargs)
 
     def check_header(self, hname: str, prefix: str, env: 'Environment', *,

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -412,7 +412,7 @@ def get_base_link_args(target: 'BuildTarget',
 
     try:
         crt_val = env.coredata.get_option_for_target(target, 'b_vscrt')
-        buildtype =env.coredata.get_option_for_target('buildtype')
+        buildtype = env.coredata.get_option_for_target(target, 'buildtype')
         try:
             args += linker.get_crt_link_args(crt_val, buildtype)
         except AttributeError:

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -276,16 +276,16 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCompiler, CPPCompiler):
             )
         return opts
 
-    def get_option_compile_args(self, target: 'BuildTarget', env: 'Environment') -> T.List[str]:
-        args: T.List[str] = []
+    def get_option_compile_args(self, target: 'BuildTarget', env: 'Environment', subproject=None) -> T.List[str]:
+        args = []
         key = self.form_langopt_key('std')
-        std = env.get_option_for_target(target, key)
+        std = env.determine_option_value(key, target, subproject)
         if std != 'none':
             args.append(self._find_best_cpp_std(std))
 
-        non_msvc_eh_options(env.get_option_for_target(key.evolve('eh')), args)
+        non_msvc_eh_options(env.determine_option_value(key.evolve('eh'), target, subproject), args)
 
-        if env.get_option_for_target(target, key.evolve('debugstl')):
+        if env.determine_option_value(key.evolve('debugstl'), target, subproject):
             args.append('-D_GLIBCXX_DEBUG=1')
 
             # We can't do _LIBCPP_DEBUG because it's unreliable unless libc++ was built with it too:
@@ -295,7 +295,7 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCompiler, CPPCompiler):
                 args.append('-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG')
 
         key = self.form_langopt_key('rtti')
-        if not options.get_value(key):
+        if not env.determine_option_value(key, target, subproject):
             args.append('-fno-rtti')
 
         return args

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -276,18 +276,16 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCompiler, CPPCompiler):
             )
         return opts
 
-    def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+    def get_option_compile_args(self, target: 'BuildTarget', env: 'Environment') -> T.List[str]:
         args: T.List[str] = []
         key = self.form_langopt_key('std')
-        std = options.get_value(key)
+        std = env.get_option_for_target(target, key)
         if std != 'none':
             args.append(self._find_best_cpp_std(std))
 
-        key = self.form_langopt_key('eh')
-        non_msvc_eh_options(options.get_value(key), args)
+        non_msvc_eh_options(env.get_option_for_target(key.evolve('eh')), args)
 
-        key = self.form_langopt_key('debugstl')
-        if options.get_value(key):
+        if env.get_option_for_target(target, key.evolve('debugstl')):
             args.append('-D_GLIBCXX_DEBUG=1')
 
             # We can't do _LIBCPP_DEBUG because it's unreliable unless libc++ was built with it too:
@@ -302,11 +300,11 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCompiler, CPPCompiler):
 
         return args
 
-    def get_option_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+    def get_option_link_args(self, target: 'BuildTarget', env: 'Environment') -> T.List[str]:
         if self.info.is_windows() or self.info.is_cygwin():
             # without a typedict mypy can't understand this.
             key = self.form_langopt_key('winlibs')
-            libs = options.get_value(key).copy()
+            libs = env.get_option_for_target(target, key).copy()
             assert isinstance(libs, list)
             for l in libs:
                 assert isinstance(l, str)
@@ -481,27 +479,27 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCompiler, CPPCompiler):
             )
         return opts
 
-    def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+    def get_option_compile_args(self, target: 'BuildTarget', env: 'Environment') -> T.List[str]:
         args: T.List[str] = []
         key = self.form_langopt_key('std')
-        std = options.get_value(key)
+        std = env.coredata.get_option_for_target(target, key)
         if std != 'none':
             args.append(self._find_best_cpp_std(std))
 
-        non_msvc_eh_options(options.get_value(key.evolve('eh')), args)
+        non_msvc_eh_options(env.coredata.get_option_for_target(target, key.evolve('eh')), args)
 
-        if not options.get_value(key.evolve('rtti')):
+        if not env.coredata.get_option_for_target(target, key.evolve('rtti')):
             args.append('-fno-rtti')
 
-        if options.get_value(key.evolve('debugstl')):
+        if env.coredata.get_option_for_target(target, key.evolve('debugstl')):
             args.append('-D_GLIBCXX_DEBUG=1')
         return args
 
-    def get_option_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+    def get_option_link_args(self, target: 'BuildTarget', env: 'Environment') -> T.List[str]:
         if self.info.is_windows() or self.info.is_cygwin():
             # without a typedict mypy can't understand this.
             key = self.form_langopt_key('winlibs')
-            libs = options.get_value(key).copy()
+            libs = env.coredata.get_option_for_target(target, key).copy()
             assert isinstance(libs, list)
             for l in libs:
                 assert isinstance(l, str)

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -742,10 +742,14 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
         'c++latest': (False, "latest"),
     }
 
-    def get_option_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+    def get_option_link_args(self, target: 'BuildTarget', env: 'Environment', subproject=None) -> T.List[str]:
         # need a typeddict for this
         key = self.form_langopt_key('winlibs')
-        return T.cast('T.List[str]', options.get_value(key)[:])
+        if target:
+            value = env.coredata.get_option_for_target(target, key)
+        else:
+            value = env.coredata.get_option_for_subproject(key, subproject)
+        return T.cast('T.List[str]', value[:])
 
     def _get_options_impl(self, opts: 'MutableKeyedOptionDictType', cpp_stds: T.List[str]) -> 'MutableKeyedOptionDictType':
         key = self.form_langopt_key('std')
@@ -770,11 +774,19 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
         std_opt.set_versions(cpp_stds)
         return opts
 
-    def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+    def get_option_compile_args(self, target: 'BuildTarget', env: 'Environment', subproject=None) -> T.List[str]:
         args: T.List[str] = []
         key = self.form_langopt_key('std')
 
-        eh = options.get_value(self.form_langopt_key('eh'))
+        if target is not None:
+            std = env.coredata.get_option_for_target(target, key)
+            eh = env.coredata.get_option_for_target(target, key.evolve('eh'))
+            rtti = env.coredata.get_option_for_target(target, key.evolve('rtti'))
+        else:
+            std = env.coredata.get_option_for_subproject(key, subprojct)
+            eh = env.coredata.get_option_for_target(key.evolve('eh'), subproject)
+            rtti = env.coredata.get_option_for_target(key.evolve('rtti'), subproject)
+
         if eh == 'default':
             args.append('/EHsc')
         elif eh == 'none':
@@ -782,10 +794,10 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
         else:
             args.append('/EH' + eh)
 
-        if not options.get_value(self.form_langopt_key('rtti')):
+        if not rtti:
             args.append('/GR-')
 
-        permissive, ver = self.VC_VERSION_MAP[options.get_value(key)]
+        permissive, ver = self.VC_VERSION_MAP[std]
 
         if ver is not None:
             args.append(f'/std:c++{ver}')
@@ -807,25 +819,18 @@ class CPP11AsCPP14Mixin(CompilerMixinBase):
     This is a limitation of Clang and MSVC that ICL doesn't share.
     """
 
-    def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+    def get_option_compile_args(self, target: 'BuildTarget', env: 'Environment', subproject=None) -> T.List[str]:
         # Note: there is no explicit flag for supporting C++11; we attempt to do the best we can
         # which means setting the C++ standard version to C++14, in compilers that support it
         # (i.e., after VS2015U3)
         # if one is using anything before that point, one cannot set the standard.
         key = self.form_langopt_key('std')
-        if options.get_value(key) in {'vc++11', 'c++11'}:
+        std = env.coredata.get_option_for_target(target, key)
+        if std in {'vc++11', 'c++11'}:
             mlog.warning(self.id, 'does not support C++11;',
                          'attempting best effort; setting the standard to C++14',
                          once=True, fatal=False)
-            # Don't mutate anything we're going to change, we need to use
-            # deepcopy since we're messing with members, and we can't simply
-            # copy the members because the option proxy doesn't support it.
-            options = copy.deepcopy(options)
-            if options.get_value(key) == 'vc++11':
-                options.set_value(key, 'vc++14')
-            else:
-                options.set_value(key,  'c++14')
-        return super().get_option_compile_args(options)
+        return super().get_option_compile_args(target, env, subproject)
 
 
 class VisualStudioCPPCompiler(CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixin, MSVCCompiler, CPPCompiler):
@@ -858,14 +863,13 @@ class VisualStudioCPPCompiler(CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixi
             cpp_stds.extend(['c++20', 'vc++20'])
         return self._get_options_impl(super().get_options(), cpp_stds)
 
-    def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+    def get_option_compile_args(self, target: 'BuildTarget', env: 'Environment', subproject=None) -> T.List[str]:
         key = self.form_langopt_key('std')
-        if options.get_value(key) != 'none' and version_compare(self.version, '<19.00.24210'):
+        std = env.coredata.get_option_for_target(target, key)
+        if std != 'none' and version_compare(self.version, '<19.00.24210'):
             mlog.warning('This version of MSVC does not support cpp_std arguments', fatal=False)
-            options = copy.copy(options)
-            options.set_value(key, 'none')
 
-        args = super().get_option_compile_args(options)
+        args = super().get_option_compile_args(target, env, subproject)
 
         if version_compare(self.version, '<19.11'):
             try:

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -151,10 +151,13 @@ class GnuFortranCompiler(GnuCompiler, FortranCompiler):
         opts[key].choices = ['none'] + fortran_stds
         return opts
 
-    def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+    def get_option_compile_args(self, target: 'BuildTarget', env: 'Environment', subproject=None) -> T.List[str]:
         args: T.List[str] = []
         key = self.form_langopt_key('std')
-        std = options.get_value(key)
+        if target:
+            std = env.coredata.get_option_for_target(target, key)
+        else:
+            std = env.coredata.get_option_for_subproject(key, subproject)
         if std != 'none':
             args.append('-std=' + std)
         return args

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -170,10 +170,13 @@ class RustCompiler(Compiler):
         # provided by the linker flags.
         return []
 
-    def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+    def get_option_compile_args(self, target: 'BuildTarget', env: 'Environment', subproject=None) -> T.List[str]:
         args = []
         key = self.form_langopt_key('std')
-        std = options.get_value(key)
+        if target:
+            std = env.coredata.get_option_for_target(target, key)
+        else:
+            std = env.coredata.get_option_for_subproject(key, subproject)
         if std != 'none':
             args.append('--edition=' + std)
         return args

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -173,6 +173,8 @@ class RustCompiler(Compiler):
     def get_option_compile_args(self, target: 'BuildTarget', env: 'Environment', subproject=None) -> T.List[str]:
         args = []
         key = self.form_langopt_key('std')
+        if target is not None:
+            key = key.copy_with(subproject=target.subproject)
         if target:
             std = env.coredata.get_option_for_target(target, key)
         else:

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -451,6 +451,24 @@ class CoreData:
 
         raise MesonException(f'Tried to get unknown builtin option {str(key)}')
 
+    def get_option_for_target(self, target: BuildTarget, key: OptionKey) -> T.Union[T.List[str], str, int, bool, WrapMode]:
+        override = target.get_raw_override(key.name)
+        if override is not None:
+            # FIXME validate that the value is good.
+            return override
+        # FIXME: This is fundamentally the same algorithm than interpreter.get_option_internal().
+        # We should try to share the code somehow.
+        key = key.evolve(subproject=key.subproject)
+        if not key.is_project():
+            opt = self.options.get(key)
+            if opt is None or opt.yielding:
+                opt = self.options[key.as_root()]
+        else:
+            opt = self.options[key]
+            if opt.yielding:
+                opt = self.options.get(key.as_root(), opt)
+        return opt.value
+
     def set_option(self, key: OptionKey, value, first_invocation: bool = False) -> bool:
         dirty = False
         if key.is_builtin():

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -451,16 +451,22 @@ class CoreData:
 
         raise MesonException(f'Tried to get unknown builtin option {str(key)}')
 
+    def get_option_object_for_target(self, target: BuildTarget, key: T.Union[str, OptionKey]) -> 'UserOption[T.Any]':
+        return self.get_option_for_subproject(key, target.subproject)
+
     def get_option_for_target(self, target: BuildTarget, key: T.Union[str, OptionKey]) -> T.Union[T.List[str], str, int, bool, WrapMode]:
         if isinstance(key, str):
             key = OptionKey(key)
-        override = target.get_raw_override(key.name)
+        option_object = self.get_option_object_for_subproject(key, target.subproject)
+        override = target.get_override(key.name, None)
         if override is not None:
-            # FIXME validate that the value is good.
-            return override
-        return self.get_option_for_subproject(key, target.subproject)
+            return option_object.validate_value(override)
+        return option_object.value
 
-    def get_option_for_subproject(self, key: T.Union[str, OptionKey], subproject) -> T.Union[T.List[str], str, int, bool, WrapMode]:
+    def get_option_for_subproject(self, key: T.Union[str, OptionKey], subproject) -> UserOption[T.Any]:
+        return self.get_option_object_for_subproject(key, subproject).value
+
+    def get_option_object_for_subproject(self, key: T.Union[str, OptionKey], subproject) -> T.Union[T.List[str], str, int, bool, WrapMode]:
         # FIXME: This is fundamentally the same algorithm than interpreter.get_option_internal().
         # We should try to share the code somehow.
         if isinstance(key, str):
@@ -473,7 +479,7 @@ class CoreData:
             opt = self.options[key]
             if opt.yielding:
                 opt = self.options.get(key.as_root(), opt)
-        return opt.value
+        return opt
 
     def set_option(self, key: OptionKey, value, first_invocation: bool = False) -> bool:
         dirty = False

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -458,9 +458,13 @@ class CoreData:
         if override is not None:
             # FIXME validate that the value is good.
             return override
+        return self.get_option_for_subproject(key, target.subproject)
+
+    def get_option_for_subproject(self, key: T.Union[str, OptionKey], subproject) -> T.Union[T.List[str], str, int, bool, WrapMode]:
         # FIXME: This is fundamentally the same algorithm than interpreter.get_option_internal().
         # We should try to share the code somehow.
-        key = key.evolve(subproject=key.subproject)
+        if isinstance(key, str):
+            key = OptionKey(key, subproject=subproject)
         if not key.is_project():
             opt = self.options.get(key)
             if opt is None or opt.yielding:

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -421,7 +421,7 @@ class CoreData:
             value = opts_map.get_value(key.as_root())
         else:
             value = None
-        opts_map.add_system_option(key, opt.init_option(key, value, options.default_prefix()))
+        opts_map.add_system_option(key.name, opt.init_option(key, value, options.default_prefix()))
 
     def init_backend_options(self, backend_name: str) -> None:
         if backend_name == 'ninja':
@@ -437,17 +437,7 @@ class CoreData:
                 ''))
 
     def get_option(self, key: OptionKey) -> T.Union[T.List[str], str, int, bool]:
-        try:
-            return self.options[key].value
-        except KeyError:
-            pass
-
-        try:
-            return self.options[key.as_root()].value
-        except KeyError:
-            pass
-
-        raise MesonException(f'Tried to get unknown builtin option {str(key)}')
+        return self.optstore.get_value_for(key.name, key.subproject)
 
     def get_option_object_for_target(self, target: BuildTarget, key: T.Union[str, OptionKey]) -> 'UserOption[T.Any]':
         return self.get_option_for_subproject(key, target.subproject)
@@ -475,14 +465,18 @@ class CoreData:
         return self.compute_value_for_subproject_option(option_object, key.name, subproject)
 
     def get_option_object_for_subproject(self, key: T.Union[str, OptionKey], subproject) -> T.Union[T.List[str], str, int, bool, WrapMode]:
-        if not key.is_project():
-            opt = self.options.get(key)
-            if opt is None or opt.yielding:
-                opt = self.options[key.as_root()]
+        if key.lang is not None:
+            keyname = f'{key.lang}_{key.name}'
         else:
-            opt = self.options[key]
-            if opt.yielding:
-                opt = self.options.get(key.as_root(), opt)
+            keyname = key.name
+        if not key.is_project():
+            opt = self.optstore.get_value_object_for(keyname, key.subproject)
+            if opt is None or opt.yielding:
+                opt = self.optstore.get_value_object_for(keyname, '')
+        else:
+            opt = self.optstore.get_value_object_for(keyname, key.subproject)
+            if opt.yielding and self.optstore.has_option(keyname, ''):
+                opt = self.optstore.get_value_object_for(keyname, '')
         return opt
 
     def set_option(self, key: OptionKey, value, first_invocation: bool = False) -> bool:
@@ -491,11 +485,11 @@ class CoreData:
             if key.name == 'prefix':
                 value = self.sanitize_prefix(value)
             else:
-                prefix = self.optstore.get_value('prefix')
+                prefix = self.optstore.get_value_for('prefix')
                 value = self.sanitize_dir_option_value(prefix, key, value)
 
         try:
-            opt = self.optstore.get_value_object(key)
+            opt = self.optstore.get_value_object_for(key.name)
         except KeyError:
             raise MesonException(f'Tried to set unknown builtin option {str(key)}')
 
@@ -608,13 +602,11 @@ class CoreData:
 
     def get_external_args(self, for_machine: MachineChoice, lang: str) -> T.List[str]:
         # mypy cannot analyze type of OptionKey
-        key = OptionKey('args', machine=for_machine, lang=lang)
-        return T.cast('T.List[str]', self.optstore.get_value(key))
+        return T.cast('T.List[str]', self.optstore.get_value_for(f'{lang}_args')) # FIXME machine=for_machine
 
     def get_external_link_args(self, for_machine: MachineChoice, lang: str) -> T.List[str]:
         # mypy cannot analyze type of OptionKey
-        key = OptionKey('link_args', machine=for_machine, lang=lang)
-        return T.cast('T.List[str]', self.optstore.get_value(key))
+        return T.cast('T.List[str]', self.optstore.get_value_for(f'{lang}_link_args')) # FIXME machine=for_machine
 
     def update_project_options(self, project_options: 'MutableKeyedOptionDictType', subproject: SubProject) -> None:
         for key, value in project_options.items():
@@ -651,11 +643,14 @@ class CoreData:
         return len(self.cross_files) > 0
 
     def copy_build_options_from_regular_ones(self) -> bool:
+        # FIXME, needs cross compilation support.
+        if True:
+            return False
         dirty = False
         assert not self.is_cross_build()
         for k in options.BUILTIN_OPTIONS_PER_MACHINE:
-            o = self.optstore.get_value_object(k)
-            dirty |= self.optstore.set_value(k.as_build(), o.value)
+            o = self.optstore.get_value_object_for(k.name)
+            dirty |= self.optstore.set_value(k.name, k.subproject, True, o.value)
         for bk, bv in self.optstore.items():
             if bk.machine is MachineChoice.BUILD:
                 hk = bk.as_host()
@@ -684,10 +679,7 @@ class CoreData:
         for k, v in opts_to_set.items():
             if k == pfk:
                 continue
-            elif override_name in self.sp_option_overrides:
-                self.sp_option_overrides[override_name] = v
-                dirty = True
-            elif k in self.optstore:
+            elif self.optstore.has_option(k.name, None):
                 dirty |= self.set_option(k, v, first_invocation)
             elif k.machine != MachineChoice.BUILD and k.type != OptionType.COMPILER:
                 empty = k.name
@@ -731,7 +723,7 @@ class CoreData:
                 raise MesonException(f'Override {keystr} already exists.')
             key = OptionKey.from_string(keystr)
             original_key = key.evolve(subproject='')
-            if original_key not in self.options:
+            if original_key not in self.optstore:
                 raise MesonException('Tried to override a nonexisting key.')
             self.sp_option_overrides[keystr] = valstr
             dirty = True
@@ -818,6 +810,8 @@ class CoreData:
         # responsible for adding its own options, thus calling
         # `self.optstore.update()`` is perfectly safe.
         self.optstore.update(compilers.get_global_options(lang, comp, for_machine, env))
+        for key, valobj in compilers.get_global_options(lang, comp, for_machine, env).items():
+            self.optstore.add_system_option(f'{key.lang}_{key.name}', valobj)
 
     def process_compiler_options(self, lang: str, comp: Compiler, env: Environment, subproject: str) -> None:
         from . import compilers
@@ -830,20 +824,20 @@ class CoreData:
                 skey = key.evolve(subproject=subproject)
             else:
                 skey = key
-            if skey not in self.optstore:
-                self.optstore.add_system_option(skey, copy.deepcopy(compilers.base_options[key]))
+            if not self.optstore.has_option(skey.name, None):
+                self.optstore.add_system_option(skey.name, copy.deepcopy(compilers.base_options[key]))
                 if skey in env.options:
-                    self.optstore.set_value(skey, env.options[skey])
+                    self.optstore[skey].set_value(env.options[skey])
                     enabled_opts.append(skey)
                 elif subproject and key in env.options:
-                    self.optstore.set_value(skey, env.options[key])
+                    self.optstore[skey].set_value(env.options[key])
                     enabled_opts.append(skey)
                 if subproject and key not in self.optstore:
-                    self.optstore.add_system_option(key, copy.deepcopy(self.optstore.get_value_object(skey)))
+                    self.optstore[key] = copy.deepcopy(self.optstore[skey])
             elif skey in env.options:
-                self.optstore.set_value(skey, env.options[skey])
+                self.optstore[skey].set_value(env.options[skey])
             elif subproject and key in env.options:
-                self.optstore.set_value(skey, env.options[key])
+                self.optstore[skey].set_value(env.options[key])
         self.emit_base_options_warnings(enabled_opts)
 
     def emit_base_options_warnings(self, enabled_opts: T.List[OptionKey]) -> None:

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -688,11 +688,16 @@ class CoreData:
 
         unknown_options: T.List[OptionKey] = []
         for k, v in opts_to_set.items():
+            override_name = f'{k.subproject}:{k.name}'
             if k == pfk:
                 continue
+            elif override_name in self.sp_option_overrides:
+                self.sp_option_overrides[override_name] = v
+                dirty = True
             elif k in self.optstore:
                 dirty |= self.set_option(k, v, first_invocation)
             elif k.machine != MachineChoice.BUILD and k.type != OptionType.COMPILER:
+                empty = k.name
                 unknown_options.append(k)
         if unknown_options:
             unknown_options_str = ', '.join(sorted(str(s) for s in unknown_options))

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -969,7 +969,7 @@ def parse_cmd_line_options(args: SharedCMDOptions) -> None:
                 cmdline_name = options.BuiltinOption.argparse_name_to_arg(name)
                 raise MesonException(
                     f'Got argument {name} as both -D{name} and {cmdline_name}. Pick one.')
-            args.cmd_line_options[key] = value
+            args.cmd_line_options[key.name] = value
             delattr(args, name)
 
 @dataclass

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -535,7 +535,7 @@ class CoreData:
 
     def get_nondefault_buildtype_args(self) -> T.List[T.Union[T.Tuple[str, str, str], T.Tuple[str, bool, bool]]]:
         result: T.List[T.Union[T.Tuple[str, str, str], T.Tuple[str, bool, bool]]] = []
-        value = self.optstore.get_value('buildtype')
+        value = self.optstore.get_value_for('buildtype')
         if value == 'plain':
             opt = 'plain'
             debug = False
@@ -554,8 +554,8 @@ class CoreData:
         else:
             assert value == 'custom'
             return []
-        actual_opt = self.optstore.get_value('optimization')
-        actual_debug = self.optstore.get_value('debug')
+        actual_opt = self.optstore.get_value_for('optimization')
+        actual_debug = self.optstore.get_value_for('debug')
         if actual_opt != opt:
             result.append(('optimization', actual_opt, opt))
         if actual_debug != debug:
@@ -719,9 +719,9 @@ class CoreData:
                 raise MesonException(f'Option {keystr} can not be set per subproject.')
             if keystr in self.sp_option_overrides:
                 raise MesonException(f'Override {keystr} already exists.')
-            key = OptionKey.from_string(keystr)
-            original_key = key.evolve(subproject='')
-            if original_key not in self.optstore:
+            key = self.optstore.split_keystring(keystr)
+            original_key = key.copy_with(subproject=None)
+            if not self.optstore.has_option(original_key):
                 raise MesonException('Tried to override a nonexisting key.')
             self.sp_option_overrides[keystr] = valstr
             dirty = True

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -789,8 +789,10 @@ class CoreData:
             if value is not None:
                 o.set_value(value)
                 if not subproject:
-                    self.optstore.set_value_object(k, o)  # override compiler option on reconfigure
-            self.optstore.setdefault(k, o)
+                    # FIXME, add augment
+                    #self.optstore[k] = o  # override compiler option on reconfigure
+                    pass
+            self.optstore.add_system_option(f'{k.lang}_{k.name}', o)
 
 #            if subproject:
 #                sk = k.evolve(subproject=subproject)

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -258,7 +258,7 @@ class CoreData:
         self.target_guids = {}
         self.version = version
         self.optstore = options.OptionStore()
-        self.sp_option_overrides: 'MutableKeyedOptionDictType' = {}
+        self.sp_option_overrides: T.Dict[str, str] = {}
         self.cross_files = self.__load_config_files(cmd_options, scratch_dir, 'cross')
         self.compilers: PerMachine[T.Dict[str, Compiler]] = PerMachine(OrderedDict(), OrderedDict())
 
@@ -444,7 +444,7 @@ class CoreData:
 
     def get_option(self, key: OptionKey) -> T.Union[T.List[str], str, int, bool]:
         try:
-            return self.get_and_clean(key, self.sp_option_overrides)
+            return self.get_and_clean(key, self.options)
         except KeyError:
             pass
 
@@ -465,16 +465,22 @@ class CoreData:
         override = target.get_override(key.name, None)
         if override is not None:
             return option_object.validate_value(override)
+        return self.compute_value_for_subproject_option(option_object, key.name, target.subproject)
+
+    def compute_value_for_subproject_option(self, option_object, name, subproject):
+        sp_override_key = f'{subproject}:{name}'
+        sp_override_value = self.sp_option_overrides.get(sp_override_key, None)
+        if sp_override_value is not None:
+            return option_object.validate_value(sp_override_value)
         return option_object.value
 
     def get_option_for_subproject(self, key: T.Union[str, OptionKey], subproject) -> UserOption[T.Any]:
-        return self.get_option_object_for_subproject(key, subproject).value
-
-    def get_option_object_for_subproject(self, key: T.Union[str, OptionKey], subproject) -> T.Union[T.List[str], str, int, bool, WrapMode]:
-        # FIXME: This is fundamentally the same algorithm than interpreter.get_option_internal().
-        # We should try to share the code somehow.
         if isinstance(key, str):
             key = OptionKey(key, subproject=subproject)
+        option_object = self.get_option_object_for_subproject(key, subproject)
+        return self.compute_value_for_subproject_option(option_object, key.name, subproject)
+
+    def get_option_object_for_subproject(self, key: T.Union[str, OptionKey], subproject) -> T.Union[T.List[str], str, int, bool, WrapMode]:
         if not key.is_project():
             opt = self.options.get(key)
             if opt is None or opt.yielding:
@@ -712,15 +718,13 @@ class CoreData:
                 raise MesonException(f'Option to add override has no subproject: {entry}')
             if not self.can_set_per_sb(keystr):
                 raise MesonException(f'Option {keystr} can not be set per subproject.')
-            key = OptionKey.from_string(keystr)
-            if key in self.sp_option_overrides:
+            if keystr in self.sp_option_overrides:
                 raise MesonException(f'Override {keystr} already exists.')
+            key = OptionKey.from_string(keystr)
             original_key = key.evolve(subproject='')
             if original_key not in self.options:
                 raise MesonException('Tried to override a nonexisting key.')
-            new_opt = copy.deepcopy(self.options[original_key])
-            new_opt.set_value(valstr)
-            self.sp_option_overrides[key] = new_opt
+            self.sp_option_overrides[keystr] = valstr
             dirty = True
         return dirty
 
@@ -729,9 +733,8 @@ class CoreData:
         if U is None:
             return False
         for entry in U:
-            key = OptionKey.from_string(entry)
-            if key in self.options:
-                del self.options[key]
+            if entry in self.sp_option_overrides:
+                del self.sp_option_overrides[entry]
                 dirty = True
             else:
                 pass # Deleting a non-existing key ok, I guess?

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -682,7 +682,6 @@ class CoreData:
 
         unknown_options: T.List[OptionKey] = []
         for k, v in opts_to_set.items():
-            override_name = f'{k.subproject}:{k.name}'
             if k == pfk:
                 continue
             elif override_name in self.sp_option_overrides:
@@ -714,8 +713,7 @@ class CoreData:
                 self.sp_option_overrides[key] = val
                 dirty = True
             else:
-                # FIXME call the default setter, possibly after creating an OptionKey first.
-                pass
+                dirty |= self.set_options({OptionKey(key): val})
         return dirty
 
     def create_sp_options(self, A) -> bool:

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -712,6 +712,18 @@ class CoreData:
     def can_set_per_sb(self, keystr):
         return True
 
+    def set_options_from_configure_strings(self, D) -> bool:
+        dirty = False
+        for entry in D:
+            key, val = entry.split('=', 1)
+            if key in self.sp_option_overrides:
+                self.sp_option_overrides[key] = val
+                dirty = True
+            else:
+                # FIXME call the default setter, possibly after creating an OptionKey first.
+                pass
+        return dirty
+
     def create_sp_options(self, A) -> bool:
         if A is None:
             return False

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -444,19 +444,17 @@ class CoreData:
 
     def get_option_for_target(self, target: BuildTarget, key: T.Union[str, OptionKey]) -> T.Union[T.List[str], str, int, bool, WrapMode]:
         if isinstance(key, str):
-            key = OptionKey(key, target.subproject)
-        option_object = self.get_option_object_for_subproject(key, target.subproject)
-        override = target.get_override(key.name, None)
+            assert ':' not in key
+            oldkey = OptionKey(key, target.subproject)
+        else:
+            oldkey = key
+        newkey = options.convert_oldkey(oldkey)
+        assert newkey.subproject is not None
+        (option_object, value) = self.optstore.get_value_object_and_value_for(newkey)
+        override = target.get_override(newkey.name, None)
         if override is not None:
             return option_object.validate_value(override)
-        return self.compute_value_for_subproject_option(option_object, key.name, target.subproject)
-
-    def compute_value_for_subproject_option(self, option_object, name, subproject):
-        sp_override_key = f'{subproject}:{name}'
-        sp_override_value = self.sp_option_overrides.get(sp_override_key, None)
-        if sp_override_value is not None:
-            return option_object.validate_value(sp_override_value)
-        return option_object.value
+        return value
 
     def get_option_for_subproject(self, key: T.Union[str, OptionKey], subproject) -> UserOption[T.Any]:
         if isinstance(key, str):

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -940,17 +940,14 @@ def register_builtin_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('-D', action='append', dest='projectoptions', default=[], metavar="option",
                         help='Set the value of an option, can be used several times to set multiple options.')
 
-def create_options_dict(options: T.List[str], subproject: str = '') -> T.Dict[OptionKey, str]:
+def create_options_dict(options: T.List[str], subproject: str = '') -> T.Dict[str, str]:
     result: T.OrderedDict[OptionKey, str] = OrderedDict()
     for o in options:
         try:
             (key, value) = o.split('=', 1)
         except ValueError:
             raise MesonException(f'Option {o!r} must have a value separated by equals sign.')
-        k = OptionKey.from_string(key)
-        if subproject:
-            k = k.evolve(subproject=subproject)
-        result[k] = value
+        result[key] = value
     return result
 
 def parse_cmd_line_options(args: SharedCMDOptions) -> None:

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -436,20 +436,14 @@ class CoreData:
                 'Default project to execute in Visual Studio',
                 ''))
 
-    def get_and_clean(self, key, store):
-        v = store[key].value
-        if key.name == 'wrap_mode':
-            return WrapMode[v]
-        return v
-
     def get_option(self, key: OptionKey) -> T.Union[T.List[str], str, int, bool]:
         try:
-            return self.get_and_clean(key, self.options)
+            return self.options[key].value
         except KeyError:
             pass
 
         try:
-            return self.get_and_clean(key.as_root(), self.options)
+            return self.options[key.as_root()].value
         except KeyError:
             pass
 

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -258,6 +258,7 @@ class CoreData:
         self.target_guids = {}
         self.version = version
         self.optstore = options.OptionStore()
+        self.sp_option_overrides: 'MutableKeyedOptionDictType' = {}
         self.cross_files = self.__load_config_files(cmd_options, scratch_dir, 'cross')
         self.compilers: PerMachine[T.Dict[str, Compiler]] = PerMachine(OrderedDict(), OrderedDict())
 
@@ -435,17 +436,20 @@ class CoreData:
                 'Default project to execute in Visual Studio',
                 ''))
 
+    def get_and_clean(self, key, store):
+        v = store[key].value
+        if key.name == 'wrap_mode':
+            return WrapMode[v]
+        return v
+
     def get_option(self, key: OptionKey) -> T.Union[T.List[str], str, int, bool]:
         try:
-            v = self.optstore.get_value(key)
-            return v
+            return self.get_and_clean(key, self.sp_option_overrides)
         except KeyError:
             pass
 
         try:
-            v = self.optstore.get_value_object(key.as_root())
-            if v.yielding:
-                return v.value
+            return self.get_and_clean(key.as_root(), self.options)
         except KeyError:
             pass
 
@@ -692,6 +696,45 @@ class CoreData:
         if not self.is_cross_build():
             dirty |= self.copy_build_options_from_regular_ones()
 
+        return dirty
+
+    def can_set_per_sb(self, keystr):
+        return True
+
+    def create_sp_options(self, A) -> bool:
+        if A is None:
+            return False
+        import copy
+        dirty = False
+        for entry in A:
+            keystr, valstr = entry.split('=', 1)
+            if ':' not in keystr:
+                raise MesonException(f'Option to add override has no subproject: {entry}')
+            if not self.can_set_per_sb(keystr):
+                raise MesonException(f'Option {keystr} can not be set per subproject.')
+            key = OptionKey.from_string(keystr)
+            if key in self.sp_option_overrides:
+                raise MesonException(f'Override {keystr} already exists.')
+            original_key = key.evolve(subproject='')
+            if original_key not in self.options:
+                raise MesonException('Tried to override a nonexisting key.')
+            new_opt = copy.deepcopy(self.options[original_key])
+            new_opt.set_value(valstr)
+            self.sp_option_overrides[key] = new_opt
+            dirty = True
+        return dirty
+
+    def remove_sp_options(self, U) -> bool:
+        dirty = False
+        if U is None:
+            return False
+        for entry in U:
+            key = OptionKey.from_string(entry)
+            if key in self.options:
+                del self.options[key]
+                dirty = True
+            else:
+                pass # Deleting a non-existing key ok, I guess?
         return dirty
 
     def set_default_options(self, default_options: T.MutableMapping[OptionKey, str], subproject: str, env: 'Environment') -> None:

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -663,10 +663,11 @@ class CoreData:
         pfk = OptionKey('prefix')
         if pfk in opts_to_set:
             prefix = self.sanitize_prefix(opts_to_set[pfk])
-            dirty |= self.optstore.set_value('prefix', prefix)
             for key in options.BUILTIN_DIR_NOPREFIX_OPTIONS:
                 if key not in opts_to_set:
-                    dirty |= self.optstore.set_value(key, options.BUILTIN_OPTIONS[key].prefixed_default(key, prefix))
+                    val = options.BUILTIN_OPTIONS[key].prefixed_default(key, prefix)
+                    tmpkey = options.convert_oldkey(key)
+                    dirty |= self.optstore.set_option(tmpkey, val)
 
         unknown_options: T.List[OptionKey] = []
         for k, v in opts_to_set.items():

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -451,7 +451,9 @@ class CoreData:
 
         raise MesonException(f'Tried to get unknown builtin option {str(key)}')
 
-    def get_option_for_target(self, target: BuildTarget, key: OptionKey) -> T.Union[T.List[str], str, int, bool, WrapMode]:
+    def get_option_for_target(self, target: BuildTarget, key: T.Union[str, OptionKey]) -> T.Union[T.List[str], str, int, bool, WrapMode]:
+        if isinstance(key, str):
+            key = OptionKey(key)
         override = target.get_raw_override(key.name)
         if override is not None:
             # FIXME validate that the value is good.

--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from .base import ExternalDependency, DependencyException, sort_libpaths, DependencyTypeName
 from ..mesonlib import EnvironmentVariables, OptionKey, OrderedSet, PerMachine, Popen_safe, Popen_safe_logged, MachineChoice, join_args
 from ..programs import find_external_program, ExternalProgram
+from ..options import OptionParts
 from .. import mlog
 from pathlib import PurePath
 from functools import lru_cache
@@ -237,8 +238,8 @@ class PkgConfigCLI(PkgConfigInterface):
 
     def _get_env(self, uninstalled: bool = False) -> EnvironmentVariables:
         env = EnvironmentVariables()
-        key = OptionKey('pkg_config_path', machine=self.for_machine)
-        extra_paths: T.List[str] = self.env.coredata.optstore.get_value(key)[:]
+        key = OptionParts('pkg_config_path')
+        extra_paths: T.List[str] = self.env.coredata.optstore.get_value_for(key)[:]
         if uninstalled:
             uninstalled_path = Path(self.env.get_build_dir(), 'meson-uninstalled').as_posix()
             if uninstalled_path not in extra_paths:

--- a/mesonbuild/dependencies/qt.py
+++ b/mesonbuild/dependencies/qt.py
@@ -19,6 +19,7 @@ from .pkgconfig import PkgConfigDependency
 from .factory import DependencyFactory
 from .. import mlog
 from .. import mesonlib
+from .. import options
 
 if T.TYPE_CHECKING:
     from ..compilers import Compiler
@@ -296,9 +297,9 @@ class QmakeQtDependency(_QtBase, ConfigToolDependency, metaclass=abc.ABCMeta):
 
         # Use the buildtype by default, but look at the b_vscrt option if the
         # compiler supports it.
-        is_debug = self.env.coredata.get_option(mesonlib.OptionKey('buildtype')) == 'debug'
-        if mesonlib.OptionKey('b_vscrt') in self.env.coredata.optstore:
-            if self.env.coredata.optstore.get_value('b_vscrt') in {'mdd', 'mtd'}:
+        is_debug = self.env.coredata.optstore.get_value_for('buildtype') == 'debug'
+        if self.env.coredata.optstore.has_option('b_vscrt'))
+            if self.env.coredata.optstore.get_value_for('b_vscrt') in {'mdd', 'mtd'}:
                 is_debug = True
         modules_lib_suffix = _get_modules_lib_suffix(self.version, self.env.machines[self.for_machine], is_debug)
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -590,6 +590,8 @@ class Environment:
         # 'optimization' and 'debug' keys, it override them.
         self.options: T.MutableMapping[OptionKey, T.Union[str, T.List[str]]] = collections.OrderedDict()
 
+        self.machinestore = machinefile.MachineFileStore(self.coredata.config_files, self.coredata.cross_files, self.source_dir)
+
         ## Read in native file(s) to override build machine configuration
 
         if self.coredata.config_files is not None:

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -665,7 +665,7 @@ class Environment:
         if paths:
             mlog.deprecation('The [paths] section is deprecated, use the [built-in options] section instead.')
             for k, v in paths.items():
-                self.options[OptionKey.from_string(k).evolve(machine=machine)] = v
+                self.options[k] = v
 
         # Next look for compiler options in the "properties" section, this is
         # also deprecated, and these will also be overwritten by the "built-in
@@ -677,7 +677,7 @@ class Environment:
         for k, v in properties.properties.copy().items():
             if k in deprecated_properties:
                 mlog.deprecation(f'{k} in the [properties] section of the machine file is deprecated, use the [built-in options] section.')
-                self.options[OptionKey.from_string(k).evolve(machine=machine)] = v
+                self.options[k] = v
                 del properties.properties[k]
 
         for section, values in config.items():
@@ -693,7 +693,7 @@ class Environment:
                         mlog.deprecation('Setting build machine options in cross files, please use a native file instead, this will be removed in meson 0.60', once=True)
                     if key.subproject:
                         raise MesonException('Do not set subproject options in [built-in options] section, use [subproject:built-in options] instead.')
-                    self.options[key.evolve(subproject=subproject, machine=machine)] = v
+                    self.options[k] = v
             elif section == 'project options' and machine is MachineChoice.HOST:
                 # Project options are only for the host machine, we don't want
                 # to read these from the native file
@@ -702,7 +702,7 @@ class Environment:
                     key = OptionKey.from_string(k)
                     if key.subproject:
                         raise MesonException('Do not set subproject options in [built-in options] section, use [subproject:built-in options] instead.')
-                    self.options[key.evolve(subproject=subproject)] = v
+                    self.options[k] = v
 
     def _set_default_options_from_env(self) -> None:
         opts: T.List[T.Tuple[str, str]] = (

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -975,4 +975,3 @@ class Environment:
             return self.coredata.get_option_for_target(target, key)
         else:
             return self.coredata.get_option_for_subproject(key, subproject)
-

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -965,3 +965,14 @@ class Environment:
 
     def has_exe_wrapper(self) -> bool:
         return self.exe_wrapper and self.exe_wrapper.found()
+
+    def determine_option_value(self, key: T.Union[str, 'OptionKey'], target: T.Optional['BuildTarget'], subproject: T.Optional[str]) -> T.List[str]:
+        if target is None and subproject is None:
+            raise RuntimeError('Internal error, option value determination is missing arguments.')
+        if isinstance(key, str):
+            key = OptionKey(key)
+        if target:
+            return self.coredata.get_option_for_target(target, key)
+        else:
+            return self.coredata.get_option_for_subproject(key, subproject)
+

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -272,7 +272,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
         if not kwargs['no_builtin_args']:
             args += self.compiler.get_option_compile_args(None, self.interpreter.environment, self.subproject)
             if mode is CompileCheckMode.LINK:
-                args.extend(self.compiler.get_option_link_args(opts))
+                args.extend(self.compiler.get_option_link_args(None, self.interpreter.environment, self.subproject))
         if kwargs.get('werror', False):
             args.extend(self.compiler.get_werror_args())
         args.extend(kwargs['args'])

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -270,8 +270,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
             for idir in i.to_string_list(self.environment.get_source_dir(), self.environment.get_build_dir()):
                 args.extend(self.compiler.get_include_args(idir, False))
         if not kwargs['no_builtin_args']:
-            opts = coredata.OptionsView(self.environment.coredata.optstore, self.subproject)
-            args += self.compiler.get_option_compile_args(opts)
+            args += self.compiler.get_option_compile_args(None, self.interpreter.environment, self.subproject)
             if mode is CompileCheckMode.LINK:
                 args.extend(self.compiler.get_option_link_args(opts))
         if kwargs.get('werror', False):

--- a/mesonbuild/interpreter/dependencyfallbacks.py
+++ b/mesonbuild/interpreter/dependencyfallbacks.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import copy
+
 from .interpreterobjects import extract_required_kwarg
 from .. import mlog
 from .. import dependencies
@@ -18,8 +20,11 @@ if T.TYPE_CHECKING:
 
 
 class DependencyFallbacksHolder(MesonInterpreterObject):
-    def __init__(self, interpreter: 'Interpreter', names: T.List[str], allow_fallback: T.Optional[bool] = None,
-                 default_options: T.Optional[T.Dict[OptionKey, str]] = None) -> None:
+    def __init__(self,
+                 interpreter: 'Interpreter',
+                 names: T.List[str],
+                 allow_fallback: T.Optional[bool] = None,
+                 default_options: T.Optional[T.Dict[str, str]] = None) -> None:
         super().__init__(subproject=interpreter.subproject)
         self.interpreter = interpreter
         self.subproject = interpreter.subproject
@@ -118,7 +123,8 @@ class DependencyFallbacksHolder(MesonInterpreterObject):
         if static is not None and 'default_library' not in default_options:
             default_library = 'static' if static else 'shared'
             mlog.log(f'Building fallback subproject with default_library={default_library}')
-            default_options[OptionKey('default_library')] = default_library
+            default_options = copy.copy(default_options)
+            default_options['default_library'] = default_library
             func_kwargs['default_options'] = default_options
 
         # Configure the subproject

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1106,7 +1106,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         if self.environment.first_invocation:
             self.coredata.init_backend_options(backend_name)
 
-        options = {k: v for k, v in self.environment.options.items() if k.is_backend()}
+        options = {k: v for k, v in self.environment.options.items() if k.startswith('backend_')}
         self.coredata.set_options(options)
 
     @typed_pos_args('project', str, varargs=str)
@@ -1166,7 +1166,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         self.project_default_options = kwargs['default_options']
         if self.environment.first_invocation or (self.subproject != '' and self.subproject not in self.coredata.initialized_subprojects):
             if self.subproject == '':
-                self.coredata.optstore.set_from_top_level_project_call(self.project_default_options)
+                self.coredata.optstore.set_from_top_level_project_call(self.project_default_options, self.user_defined_options.cmd_line_options)
             else:
                 sp_override_options = []
                 self.coredata.optstore.set_from_subproject_call(self.subproject, sp_override_options, self.project_default_options)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -303,7 +303,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             self.default_project_options = default_project_options.copy()
         else:
             self.default_project_options = {}
-        self.project_default_options: T.Dict[OptionKey, str] = {}
+        self.project_default_options: T.List[str] = []
         self.build_func_dict()
         self.build_holder_map()
         self.user_defined_options = user_defined_options
@@ -879,7 +879,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             mlog.log('Subproject', mlog.bold(subp_name), ':', 'skipped: feature', mlog.bold(feature), 'disabled')
             return self.disabled_subproject(subp_name, disabled_feature=feature)
 
-        default_options = {k.evolve(subproject=subp_name): v for k, v in kwargs['default_options'].items()}
+        default_options = kwargs['default_options']
 
         if subp_name == '':
             raise InterpreterException('Subproject name must not be empty.')
@@ -948,7 +948,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             raise e
 
     def _do_subproject_meson(self, subp_name: str, subdir: str,
-                             default_options: T.Dict[OptionKey, str],
+                             default_options: T.List[str],
                              kwargs: kwtypes.DoSubproject,
                              ast: T.Optional[mparser.CodeBlockNode] = None,
                              build_def_files: T.Optional[T.List[str]] = None,
@@ -1009,7 +1009,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         return self.subprojects[subp_name]
 
     def _do_subproject_cmake(self, subp_name: str, subdir: str,
-                             default_options: T.Dict[OptionKey, str],
+                             default_options: T.List[str],
                              kwargs: kwtypes.DoSubproject) -> SubprojectHolder:
         from ..cmake import CMakeInterpreter
         with mlog.nested(subp_name):
@@ -1036,7 +1036,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         return result
 
     def _do_subproject_cargo(self, subp_name: str, subdir: str,
-                             default_options: T.Dict[OptionKey, str],
+                             default_options: T.List[str],
                              kwargs: kwtypes.DoSubproject) -> SubprojectHolder:
         from .. import cargo
         FeatureNew.single_use('Cargo subproject', '1.3.0', self.subproject, location=self.current_node)
@@ -1163,28 +1163,12 @@ class Interpreter(InterpreterBase, HoldableObject):
         else:
             self.coredata.options_files[self.subproject] = None
 
-        if self.subproject:
-            self.project_default_options = {k.evolve(subproject=self.subproject): v
-                                            for k, v in kwargs['default_options'].items()}
-        else:
-            self.project_default_options = kwargs['default_options']
-
-        # Do not set default_options on reconfigure otherwise it would override
-        # values previously set from command line. That means that changing
-        # default_options in a project will trigger a reconfigure but won't
-        # have any effect.
-        #
-        # If this is the first invocation we always need to initialize
-        # builtins, if this is a subproject that is new in a re-invocation we
-        # need to initialize builtins for that
+        self.project_default_options = kwargs['default_options']
         if self.environment.first_invocation or (self.subproject != '' and self.subproject not in self.coredata.initialized_subprojects):
-            default_options = self.project_default_options.copy()
-            default_options.update(self.default_project_options)
-            self.coredata.init_builtins(self.subproject)
-            self.coredata.initialized_subprojects.add(self.subproject)
-        else:
-            default_options = {}
-        self.coredata.set_default_options(default_options, self.subproject, self.environment)
+            if self.subproject == '':
+                self.coredata.optstore.set_from_top_level_project_call(self.project_default_options)
+            else:
+                self.coredata.optstore.set_from_subproject_call(self.subproject, self.project_default_options)
 
         if not self.is_subproject():
             self.build.project_name = proj_name

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1061,8 +1061,19 @@ class Interpreter(InterpreterBase, HoldableObject):
         if optname_regex.search(optname.split('.', maxsplit=1)[-1]) is not None:
             raise InterpreterException(f'Invalid option name {optname!r}')
 
-        opt = self.coredata.get_option_for_subproject(optname, self.subproject)
-        return opt
+        (value_object, value) = self.coredata.optstore.get_value_object_and_value_for(options.OptionParts(optname, self.subproject))
+        if isinstance(value_object, options.UserFeatureOption):
+            ocopy = copy.copy(value_object)
+            ocopy.name = optname
+            ocopy.value = value
+            return ocopy
+        elif isinstance(value_object, options.UserOption):
+            if isinstance(value_object.value, str):
+                return P_OBJ.OptionString(value, f'{{{optname}}}')
+            return value
+        ocopy = copy.copy(value_object)
+        ocopy.value = value
+        return ocopy
 
     @typed_pos_args('configuration_data', optargs=[dict])
     @noKwargs
@@ -1168,8 +1179,8 @@ class Interpreter(InterpreterBase, HoldableObject):
             if self.subproject == '':
                 self.coredata.optstore.set_from_top_level_project_call(self.project_default_options, self.user_defined_options.cmd_line_options)
             else:
-                sp_override_options = []
-                self.coredata.optstore.set_from_subproject_call(self.subproject, sp_override_options, self.project_default_options)
+                invoker_method_default_options = self.default_project_options
+                self.coredata.optstore.set_from_subproject_call(self.subproject, invoker_method_default_options, self.project_default_options)
 
         if not self.is_subproject():
             self.build.project_name = proj_name

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1017,17 +1017,17 @@ class Interpreter(InterpreterBase, HoldableObject):
                              kwargs: kwtypes.DoSubproject) -> SubprojectHolder:
         from ..cmake import CMakeInterpreter
         with mlog.nested(subp_name):
-            prefix = self.coredata.optstore.get_value('prefix')
+            prefix = self.coredata.optstore.get_value_for('prefix')
 
             from ..modules.cmake import CMakeSubprojectOptions
-            options = kwargs.get('options') or CMakeSubprojectOptions()
-            cmake_options = kwargs.get('cmake_options', []) + options.cmake_options
+            kw_opts = kwargs.get('options') or CMakeSubprojectOptions()
+            cmake_options = kwargs.get('cmake_options', []) + kw_opts.cmake_options
             cm_int = CMakeInterpreter(Path(subdir), Path(prefix), self.build.environment, self.backend)
             cm_int.initialise(cmake_options)
             cm_int.analyse()
 
             # Generate a meson ast and execute it with the normal do_subproject_meson
-            ast = cm_int.pretend_to_be_meson(options.target_options)
+            ast = cm_int.pretend_to_be_meson(kw_opts.target_options)
             result = self._do_subproject_meson(
                     subp_name, subdir, default_options,
                     kwargs, ast,

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1168,7 +1168,8 @@ class Interpreter(InterpreterBase, HoldableObject):
             if self.subproject == '':
                 self.coredata.optstore.set_from_top_level_project_call(self.project_default_options)
             else:
-                self.coredata.optstore.set_from_subproject_call(self.subproject, self.project_default_options)
+                sp_override_options = []
+                self.coredata.optstore.set_from_subproject_call(self.subproject, sp_override_options, self.project_default_options)
 
         if not self.is_subproject():
             self.build.project_name = proj_name
@@ -1482,13 +1483,13 @@ class Interpreter(InterpreterBase, HoldableObject):
                 self.coredata.process_compiler_options(lang, comp, self.environment, self.subproject)
 
             # Add per-subproject compiler options. They inherit value from main project.
-            if self.subproject:
-                options = {}
-                for k in comp.get_options():
-                    v = copy.copy(self.coredata.optstore.get_value_object(k))
-                    k = k.evolve(subproject=self.subproject)
-                    options[k] = v
-                self.coredata.add_compiler_options(options, lang, for_machine, self.environment, self.subproject)
+            # if self.subproject:
+            #     options = {}
+            #     for k in comp.get_options():
+            #         v = copy.copy(self.coredata.optstore.get_value_object(k))
+            #         k = k.evolve(subproject=self.subproject)
+            #         options[k] = v
+            #     self.coredata.add_compiler_options(options, lang, for_machine, self.environment, self.subproject)
 
             if for_machine == MachineChoice.HOST or self.environment.is_cross_build():
                 logger_fun = mlog.log

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1048,41 +1048,6 @@ class Interpreter(InterpreterBase, HoldableObject):
                 # FIXME: Are there other files used by cargo interpreter?
                 [os.path.join(subdir, 'Cargo.toml')])
 
-    def get_option_internal(self, optname: str) -> options.UserOption:
-        key = OptionKey.from_string(optname).evolve(subproject=self.subproject)
-
-        if not key.is_project():
-            for opts in [self.coredata.optstore, compilers.base_options]:
-                v = opts.get(key)
-                if v is None or v.yielding:
-                    v = opts.get(key.as_root())
-                if v is not None:
-                    assert isinstance(v, options.UserOption), 'for mypy'
-                    return v
-
-        try:
-            opt = self.coredata.optstore.get_value_object(key)
-            if opt.yielding and key.subproject and key.as_root() in self.coredata.optstore:
-                popt = self.coredata.optstore.get_value_object(key.as_root())
-                if type(opt) is type(popt):
-                    opt = popt
-                else:
-                    # Get class name, then option type as a string
-                    opt_type = opt.__class__.__name__[4:][:-6].lower()
-                    popt_type = popt.__class__.__name__[4:][:-6].lower()
-                    # This is not a hard error to avoid dependency hell, the workaround
-                    # when this happens is to simply set the subproject's option directly.
-                    mlog.warning('Option {0!r} of type {1!r} in subproject {2!r} cannot yield '
-                                 'to parent option of type {3!r}, ignoring parent value. '
-                                 'Use -D{2}:{0}=value to set the value for this option manually'
-                                 '.'.format(optname, opt_type, self.subproject, popt_type),
-                                 location=self.current_node)
-            return opt
-        except KeyError:
-            pass
-
-        raise InterpreterException(f'Tried to access unknown option {optname!r}.')
-
     @typed_pos_args('get_option', str)
     @noKwargs
     def func_get_option(self, nodes: mparser.BaseNode, args: T.Tuple[str],
@@ -1096,14 +1061,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         if optname_regex.search(optname.split('.', maxsplit=1)[-1]) is not None:
             raise InterpreterException(f'Invalid option name {optname!r}')
 
-        opt = self.get_option_internal(optname)
-        if isinstance(opt, options.UserFeatureOption):
-            opt.name = optname
-            return opt
-        elif isinstance(opt, options.UserOption):
-            if isinstance(opt.value, str):
-                return P_OBJ.OptionString(opt.value, f'{{{optname}}}')
-            return opt.value
+        opt = self.coredata.get_option_for_subproject(optname, self.subproject)
         return opt
 
     @typed_pos_args('configuration_data', optargs=[dict])

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1181,10 +1181,13 @@ class Interpreter(InterpreterBase, HoldableObject):
         self.project_default_options = kwargs['default_options']
         if self.environment.first_invocation or (self.subproject != '' and self.subproject not in self.coredata.initialized_subprojects):
             if self.subproject == '':
-                self.coredata.optstore.set_from_top_level_project_call(self.project_default_options, self.user_defined_options.cmd_line_options)
+                self.coredata.optstore.set_from_top_level_project_call(self.project_default_options,
+                                                                       self.user_defined_options.cmd_line_options,
+                                                                       self.environment.options)
             else:
                 invoker_method_default_options = self.default_project_options
                 self.coredata.optstore.set_from_subproject_call(self.subproject, invoker_method_default_options, self.project_default_options)
+
 
         if not self.is_subproject():
             self.build.project_name = proj_name

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -301,6 +301,8 @@ class Interpreter(InterpreterBase, HoldableObject):
         # Passed from the outside, only used in subprojects.
         if default_project_options:
             self.default_project_options = default_project_options.copy()
+            if isinstance(default_project_options, dict):
+                pass
         else:
             self.default_project_options = {}
         self.project_default_options: T.List[str] = []
@@ -874,6 +876,8 @@ class Interpreter(InterpreterBase, HoldableObject):
         return sub
 
     def do_subproject(self, subp_name: str, kwargs: kwtypes.DoSubproject, force_method: T.Optional[wrap.Method] = None) -> SubprojectHolder:
+        if subp_name == 'sub_static':
+            pass
         disabled, required, feature = extract_required_kwarg(kwargs, self.subproject)
         if disabled:
             mlog.log('Subproject', mlog.bold(subp_name), ':', 'skipped: feature', mlog.bold(feature), 'disabled')
@@ -1760,6 +1764,8 @@ class Interpreter(InterpreterBase, HoldableObject):
         if not isinstance(not_found_message, str):
             raise InvalidArguments('The not_found_message must be a string.')
         try:
+            if 'sub_static' in names:
+                pass
             d = df.lookup(kwargs)
         except Exception:
             if not_found_message:

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -11,6 +11,7 @@ from .. import mesonlib
 from .. import options
 from .. import build
 from .. import mlog
+from ..options import OptionParts
 
 from ..modules import ModuleReturnValue, ModuleObject, ModuleState, ExtensionModule
 from ..backend.backends import TestProtocol
@@ -90,7 +91,7 @@ class FeatureOptionHolder(ObjectHolder[options.UserFeatureOption]):
         super().__init__(option, interpreter)
         if option and option.is_auto():
             # TODO: we need to cast here because options is not a TypedDict
-            auto = T.cast('options.UserFeatureOption', self.env.coredata.optstore.get_value_object('auto_features'))
+            auto = T.cast('options.UserFeatureOption', self.env.coredata.optstore.get_value_object_for('auto_features'))
             self.held_object = copy.copy(auto)
             self.held_object.name = option.name
         self.methods.update({'enabled': self.enabled_method,

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -208,7 +208,7 @@ class Project(TypedDict):
 
     version: T.Optional[FileOrString]
     meson_version: T.Optional[str]
-    default_options: T.Dict[OptionKey, T.Union[str, int, bool, T.List[str]]]
+    default_options: T.List[str]]
     license: T.List[str]
     subproject_dir: str
 

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -311,7 +311,7 @@ class Subproject(ExtractRequired):
 
 class DoSubproject(ExtractRequired):
 
-    default_options: T.Dict[OptionKey, T.Union[str, int, bool, T.List[str]]]
+    default_options: T.list[str]
     version: T.List[str]
     cmake_options: T.List[str]
     options: T.Optional[CMakeSubprojectOptions]

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -292,6 +292,7 @@ COMMAND_KW: KwargInfo[T.List[T.Union[str, BuildTarget, CustomTarget, CustomTarge
 )
 
 def _override_options_convertor(raw: T.Union[str, T.List[str], T.Dict[str, T.Union[str, int, bool, T.List[str]]]]) -> T.Dict[OptionKey, T.Union[str, int, bool, T.List[str]]]:
+    # FIXME OPTIONS: this needs to return options as plain strings.
     if isinstance(raw, str):
         raw = [raw]
     if isinstance(raw, list):

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -309,7 +309,6 @@ OVERRIDE_OPTIONS_KW: KwargInfo[T.Union[str, T.Dict[str, T.Union[str, int, bool, 
     (str, ContainerTypeInfo(list, str), ContainerTypeInfo(dict, (str, int, bool, list))),
     default={},
     validator=_options_validator,
-    convertor=_override_options_convertor,
     since_values={dict: '1.2.0'},
 )
 

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -68,7 +68,7 @@ class StaticLinker:
     def openmp_flags(self, env: Environment) -> T.List[str]:
         return []
 
-    def get_option_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+    def get_option_link_args(self, target: 'BuildTarget', env: 'Environment', subproject=None) -> T.List[str]:
         return []
 
     @classmethod
@@ -174,7 +174,10 @@ class DynamicLinker(metaclass=abc.ABCMeta):
 
     # XXX: is use_ldflags a compiler or a linker attribute?
 
-    def get_option_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+    def get_option_args(self, target: 'BuildTarget', env: 'Environment', subproject=None) -> T.List[str]:
+        return []
+
+    def get_option_link_args(self, target: 'BuildTarget', env: 'Environment', subproject=None) -> T.List[str]:
         return []
 
     def has_multi_arguments(self, args: T.List[str], env: 'Environment') -> T.Tuple[bool, bool]:
@@ -201,7 +204,7 @@ class DynamicLinker(metaclass=abc.ABCMeta):
     def get_std_shared_lib_args(self) -> T.List[str]:
         return []
 
-    def get_std_shared_module_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+    def get_std_shared_module_args(self, Target: 'BuildTarget') -> T.List[str]:
         return self.get_std_shared_lib_args()
 
     def get_pie_args(self) -> T.List[str]:

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -35,7 +35,10 @@ class StaticLinker:
         """
         return mesonlib.is_windows()
 
-    def get_base_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+    def get_base_link_args(self,
+                           target: 'BuildTarget',
+                           linker: 'Compiler',
+                           env: 'Environment') -> T.List[str]:
         """Like compilers.get_base_link_args, but for the static linker."""
         return []
 

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -47,6 +47,10 @@ def add_arguments(parser: 'argparse.ArgumentParser') -> None:
                         help='Clear cached state (e.g. found dependencies)')
     parser.add_argument('--no-pager', action='store_false', dest='pager',
                         help='Do not redirect output to a pager')
+    parser.add_argument('-A', action='append', dest='A',
+                        help='Add a subproject option.')
+    parser.add_argument('-U', action='append', dest='U',
+                        help='Remove a subproject option.')
 
 def stringify(val: T.Any) -> str:
     if isinstance(val, bool):
@@ -333,8 +337,24 @@ class Conf:
         for m in mismatching:
             mlog.log(f'{m[0]:21}{m[1]:10}{m[2]:10}')
 
+def has_option_flags(options):
+    if options.cmd_line_options:
+        return True
+    if options.A:
+        return True
+    if options.D:
+        return True
+    return False
+
+def is_print_only(options):
+    if has_option_flags(options):
+        return False
+    if options.clearcache:
+        return False
+    return True
+
 def run_impl(options: CMDOptions, builddir: str) -> int:
-    print_only = not options.cmd_line_options and not options.clearcache
+    print_only = is_print_only(options)
     c = None
     try:
         c = Conf(builddir)
@@ -345,8 +365,10 @@ def run_impl(options: CMDOptions, builddir: str) -> int:
             return 0
 
         save = False
-        if options.cmd_line_options:
-            save = c.set_options(options.cmd_line_options)
+        if has_option_flags(options):
+            save |= c.set_options(options.cmd_line_options)
+            save |= c.coredata.create_sp_options(options.A)
+            save |= c.coredata.remove_sp_options(options.U)
             coredata.update_cmd_line_file(builddir, options)
         if options.clearcache:
             c.clear_cache()

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -375,7 +375,7 @@ def run_impl(options: CMDOptions, builddir: str) -> int:
 
         save = False
         if has_option_flags(options):
-            save |= c.set_options(options.cmd_line_options)
+            save |= c.coredata.set_options_from_configure_strings(options.projectoptions)
             save |= c.coredata.create_sp_options(options.A)
             save |= c.coredata.remove_sp_options(options.U)
             coredata.update_cmd_line_file(builddir, options)

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -235,15 +235,15 @@ class Conf:
             return
         if title:
             self.add_title(title)
-        auto = T.cast('options.UserFeatureOption', self.coredata.optstore.get_value_object('auto_features'))
+        auto = T.cast('options.UserFeatureOption', self.coredata.optstore.get_value_for('auto_features'))
         for k, o in sorted(opts.items()):
             printable_value = o.printable_value()
-            root = k.as_root()
-            if o.yielding and k.subproject and root in self.coredata.optstore:
-                printable_value = '<inherited from main project>'
-            if isinstance(o, options.UserFeatureOption) and o.is_auto():
-                printable_value = auto.printable_value()
-            self.add_option(str(root), o.description, printable_value, o.choices)
+            #root = k.as_root()
+            #if o.yielding and k.subproject and root in self.coredata.options:
+            #    printable_value = '<inherited from main project>'
+            #if isinstance(o, options.UserFeatureOption) and o.is_auto():
+            #    printable_value = auto.printable_value()
+            self.add_option(k.name, o.description, printable_value, o.choices)
 
     def print_conf(self, pager: bool) -> None:
         if pager:
@@ -270,33 +270,33 @@ class Conf:
         test_options: 'coredata.MutableKeyedOptionDictType' = {}
         core_options: 'coredata.MutableKeyedOptionDictType' = {}
         module_options: T.Dict[str, 'coredata.MutableKeyedOptionDictType'] = collections.defaultdict(dict)
-        for k, v in self.coredata.optstore.items():
+        for k, v in self.coredata.optstore.options.items():
             if k in dir_option_names:
                 dir_options[k] = v
             elif k in test_option_names:
                 test_options[k] = v
-            elif k.module:
+            elif False:#k.module:
                 # Ignore module options if we did not use that module during
                 # configuration.
                 if self.build and k.module not in self.build.modules:
                     continue
                 module_options[k.module][k] = v
-            elif k.is_builtin():
+            elif not self.coredata.optstore.is_project_option(k):
                 core_options[k] = v
 
-        host_core_options = self.split_options_per_subproject({k: v for k, v in core_options.items() if k.machine is MachineChoice.HOST})
-        build_core_options = self.split_options_per_subproject({k: v for k, v in core_options.items() if k.machine is MachineChoice.BUILD})
-        host_compiler_options = self.split_options_per_subproject({k: v for k, v in self.coredata.optstore.items() if k.is_compiler() and k.machine is MachineChoice.HOST})
-        build_compiler_options = self.split_options_per_subproject({k: v for k, v in self.coredata.optstore.items() if k.is_compiler() and k.machine is MachineChoice.BUILD})
-        project_options = self.split_options_per_subproject({k: v for k, v in self.coredata.optstore.items() if k.is_project()})
+        host_core_options = self.split_options_per_subproject({k: v for k, v in core_options.items() if True})#k.machine is MachineChoice.HOST})
+        build_core_options = {}#self.split_options_per_subproject({k: v for k, v in core_options.items() if k.machine is MachineChoice.BUILD})
+        host_compiler_options = self.split_options_per_subproject({k: v for k, v in self.coredata.optstore.options.items() if k.name.startswith('c_')})#k.is_compiler() and k.machine is MachineChoice.HOST})
+        build_compiler_options = {}#self.split_options_per_subproject({k: v for k, v in self.coredata.options.items() if k.is_compiler() and k.machine is MachineChoice.BUILD})
+        project_options = self.split_options_per_subproject({k: v for k, v in self.coredata.optstore.options.items() if self.coredata.optstore.is_project_option(k)})
         show_build_options = self.default_values_only or self.build.environment.is_cross_build()
 
         self.add_section('Main project options')
         self.print_options('Core options', host_core_options[''])
         if show_build_options:
             self.print_options('', build_core_options[''])
-        self.print_options('Backend options', {k: v for k, v in self.coredata.optstore.items() if k.is_backend()})
-        self.print_options('Base options', {k: v for k, v in self.coredata.optstore.items() if k.is_base()})
+        self.print_options('Backend options', {k: v for k, v in self.coredata.optstore.options.items() if k.name.startswith('backend_')})
+        self.print_options('Base options', {k: v for k, v in self.coredata.optstore.options.items() if k.name.startswith('b_')})
         self.print_options('Compiler options', host_compiler_options.get('', {}))
         if show_build_options:
             self.print_options('', build_compiler_options.get('', {}))
@@ -327,7 +327,8 @@ class Conf:
             print_default_values_warning()
 
         self.print_nondefault_buildtype_options()
-        self.print_sp_overrides()
+        #self.print_sp_overrides()
+        self.print_augments()
 
     def print_nondefault_buildtype_options(self) -> None:
         mismatching = self.coredata.get_nondefault_buildtype_args()
@@ -343,6 +344,14 @@ class Conf:
             mlog.log('\nThe folowing options have per-subproject overrides:')
             for k, v in self.coredata.sp_option_overrides.items():
                 mlog.log(f'{k:21}{v:10}')
+
+    def print_augments(self) -> None:
+        if self.coredata.optstore.augments:
+            mlog.log('\nCurrently set option augments:')
+            for k, v in self.coredata.optstore.augments.items():
+                mlog.log(f'{k.form_canonical_keystring():21}{v:10}')
+        else:
+            mlog.log('\nThere are no option augments.')
 
 def has_option_flags(options):
     if options.cmd_line_options:
@@ -375,9 +384,7 @@ def run_impl(options: CMDOptions, builddir: str) -> int:
 
         save = False
         if has_option_flags(options):
-            save |= c.coredata.set_options_from_configure_strings(options.projectoptions)
-            save |= c.coredata.create_sp_options(options.A)
-            save |= c.coredata.remove_sp_options(options.U)
+            save |= c.coredata.optstore.set_from_configure_command(options.projectoptions, options.A, options.U)
             coredata.update_cmd_line_file(builddir, options)
         if options.clearcache:
             c.clear_cache()

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -327,6 +327,7 @@ class Conf:
             print_default_values_warning()
 
         self.print_nondefault_buildtype_options()
+        self.print_sp_overrides()
 
     def print_nondefault_buildtype_options(self) -> None:
         mismatching = self.coredata.get_nondefault_buildtype_args()
@@ -337,12 +338,20 @@ class Conf:
         for m in mismatching:
             mlog.log(f'{m[0]:21}{m[1]:10}{m[2]:10}')
 
+    def print_sp_overrides(self) -> None:
+        if self.coredata.sp_option_overrides:
+            mlog.log('\nThe folowing options have per-subproject overrides:')
+            for k, v in self.coredata.sp_option_overrides.items():
+                mlog.log(f'{k:21}{v:10}')
+
 def has_option_flags(options):
     if options.cmd_line_options:
         return True
     if options.A:
         return True
-    if options.D:
+    if hasattr(options, 'D') and options.D:
+        return True
+    if options.U:
         return True
     return False
 

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -284,6 +284,8 @@ def list_buildoptions_from_source(intr: IntrospectionInterpreter) -> T.List[T.Di
 
 def list_buildoptions(coredata: cdata.CoreData, subprojects: T.Optional[T.List[str]] = None) -> T.List[T.Dict[str, T.Union[str, bool, int, T.List[str]]]]:
     optlist: T.List[T.Dict[str, T.Union[str, bool, int, T.List[str]]]] = []
+    if True:
+        return # FIXME
     subprojects = subprojects or []
 
     dir_option_names = set(options.BUILTIN_DIR_OPTIONS)

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -274,9 +274,9 @@ class MesonApp:
 
             # collect warnings about unsupported build configurations; must be done after full arg processing
             # by Interpreter() init, but this is most visible at the end
-            if env.coredata.optstore.get_value('backend') == 'xcode':
+            if env.coredata.optstore.get_value_for('backend') == 'xcode':
                 mlog.warning('xcode backend is currently unmaintained, patches welcome')
-            if env.coredata.optstore.get_value('layout') == 'flat':
+            if env.coredata.optstore.get_value_for('layout') == 'flat':
                 mlog.warning('-Dlayout=flat is unsupported and probably broken. It was a failed experiment at '
                              'making Windows build artifacts runnable while uninstalled, due to PATH considerations, '
                              'but was untested by CI and anyways breaks reasonable use of conflicting targets in different subdirs. '

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -9,7 +9,7 @@ import cProfile as profile
 from pathlib import Path
 import typing as T
 
-from . import build, coredata, environment, interpreter, mesonlib, mintro, mlog
+from . import build, coredata, environment, interpreter, mesonlib, mintro, mlog, options
 from .mesonlib import MesonException
 
 if T.TYPE_CHECKING:
@@ -274,9 +274,9 @@ class MesonApp:
 
             # collect warnings about unsupported build configurations; must be done after full arg processing
             # by Interpreter() init, but this is most visible at the end
-            if env.coredata.optstore.get_value_for('backend') == 'xcode':
+            if env.coredata.optstore.get_value_for(options.OptionParts('backend')) == 'xcode':
                 mlog.warning('xcode backend is currently unmaintained, patches welcome')
-            if env.coredata.optstore.get_value_for('layout') == 'flat':
+            if env.coredata.optstore.get_value_for(options.OptionParts('layout')) == 'flat':
                 mlog.warning('-Dlayout=flat is unsupported and probably broken. It was a failed experiment at '
                              'making Windows build artifacts runnable while uninstalled, due to PATH considerations, '
                              'but was untested by CI and anyways breaks reasonable use of conflicting targets in different subdirs. '

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -504,6 +504,11 @@ class OptionParts:
                            subproject if subproject != BAD_VALUE else self.subproject, # None is a valid value so it can'the default value in method declaration.
                            for_build if for_build != BAD_VALUE else self.for_build)
 
+def convert_oldkey(optkey): # Delete after transition to new keys is done.
+    return OptionParts(optkey.name,
+                       optkey.subproject,
+                       optkey.is_cross())
+
 class OptionStore:
     def __init__(self):
         self.options = {}
@@ -564,7 +569,7 @@ class OptionStore:
         self.options[k] = value_object
         self.project_options.add(k)
 
-    def get_value_object_for(self, optioninfo, subproject=None):
+    def get_value_object_for(self, optioninfo):
         assert isinstance(optioninfo, OptionParts)
         potential = self.options.get(optioninfo, None)
         if potential is None:

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -616,15 +616,21 @@ class OptionStore:
             if delete in self.augments:
                 del self.augments[delete]
 
-    def set_from_top_level_project_call(self, project_default_options):
-        if isinstance(project_default_options, str):
-            project_default_options = [project_default_options]
-        if isinstance(project_default_options, list):
+    def optlist2optdict(self, optlist):
             optdict = {}
-            for p in project_default_options:
+            for p in optlist:
                  k, v = p.split('=', 1)
                  optdict[k] = v
             project_default_options = optdict
+        
+
+    def set_from_top_level_project_call(self, project_default_options, cmd_line_options):
+        if isinstance(project_default_options, str):
+            project_default_options = [project_default_options]
+        if isinstance(project_default_options, list):
+            project_default_options = self.optlist2optdict(project_default_options)
+        if project_default_options is None:
+            project_default_options  = {}
         for keystr, valstr in project_default_options.items():
             key = self.split_keystring(keystr)
             if key.subproject is not None:
@@ -633,6 +639,11 @@ class OptionStore:
                 continue
             if key in self.options:
                 self.set_option(key, valstr)
+        for keystr, valstr in cmd_line_options.items():
+            key = self.split_keystring(keystr)
+            if key.subproject is None:
+                if self.has_option(key):
+                    self.set_option(key, valstr)
 
     def set_from_subproject_call(self, subproject, spcall_default_options, project_default_options):
         for o in itertools.chain(spcall_default_options, project_default_options):

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -31,11 +31,11 @@ DEFAULT_YIELDING = False
 
 # Can't bind this near the class method it seems, sadly.
 _T = T.TypeVar('_T')
+_U = T.TypeVar('_U', bound=UserOption[_T])
 
 backendlist = ['ninja', 'vs', 'vs2010', 'vs2012', 'vs2013', 'vs2015', 'vs2017', 'vs2019', 'vs2022', 'xcode', 'none']
 genvslitelist = ['vs2022']
 buildtypelist = ['plain', 'debug', 'debugoptimized', 'release', 'minsize', 'custom']
-
 
 class UserOption(T.Generic[_T], HoldableObject):
     def __init__(self, name: str, description: str, choices: T.Optional[T.Union[str, T.List[_T]]],
@@ -69,9 +69,6 @@ class UserOption(T.Generic[_T], HoldableObject):
         self.value = self.validate_value(newvalue)
         return self.value != oldvalue
 
-_U = T.TypeVar('_U', bound=UserOption[_T])
-
-
 class UserStringOption(UserOption[str]):
     def __init__(self, name: str, description: str, value: T.Any, yielding: bool = DEFAULT_YIELDING,
                  deprecated: T.Union[bool, str, T.Dict[str, str], T.List[str]] = False):
@@ -82,6 +79,7 @@ class UserStringOption(UserOption[str]):
         if not isinstance(value, str):
             raise MesonException(f'The value of option "{self.name}" is "{value}", which is not a string.')
         return value
+
 
 class UserBooleanOption(UserOption[bool]):
     def __init__(self, name: str, description: str, value: bool, yielding: bool = DEFAULT_YIELDING,
@@ -102,6 +100,7 @@ class UserBooleanOption(UserOption[bool]):
         if value.lower() == 'false':
             return False
         raise MesonException(f'Option "{self.name}" value {value} is not boolean (true or false).')
+
 
 class UserIntegerOption(UserOption[int]):
     def __init__(self, name: str, description: str, value: T.Any, yielding: bool = DEFAULT_YIELDING,
@@ -190,6 +189,7 @@ class UserComboOption(UserOption[str]):
                                      value, _type, self.name, optionsstring))
         return value
 
+
 class UserArrayOption(UserOption[T.List[str]]):
     def __init__(self, name: str, description: str, value: T.Union[str, T.List[str]],
                  split_args: bool = False,
@@ -252,6 +252,7 @@ class UserFeatureOption(UserComboOption):
     def is_auto(self) -> bool:
         return self.value == 'auto'
 
+    
 class UserStdOption(UserComboOption):
     '''
     UserOption specific to c_std and cpp_std options. User can set a list of

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -638,15 +638,23 @@ class OptionStore:
              k, v = p.split('=', 1)
              optdict[k] = v
         return optdict
-        
 
-    def set_from_top_level_project_call(self, project_default_options, cmd_line_options):
+    def set_from_top_level_project_call(self, project_default_options, cmd_line_options, native_file_options):
         if isinstance(project_default_options, str):
             project_default_options = [project_default_options]
         if isinstance(project_default_options, list):
             project_default_options = self.optlist2optdict(project_default_options)
         if project_default_options is None:
             project_default_options  = {}
+        for keystr, valstr in native_file_options.items():
+            key = self.split_keystring(keystr)
+            if key.subproject is not None:
+                #self.pending_project_options[key] = valstr
+                raise MesonException(f'Can not set subproject option {keystr} in machine files.')
+            elif key in self.options:
+                self.set_option(key, valstr)
+            #else:
+            #    self.pending_project_options[key] = valstr
         for keystr, valstr in project_default_options.items():
             key = self.split_keystring(keystr)
             if key.subproject is not None:
@@ -658,10 +666,15 @@ class OptionStore:
         for keystr, valstr in cmd_line_options.items():
             key = self.split_keystring(keystr)
             if key.subproject is None:
+                projectkey = key.copy_with(subproject='')
                 if self.has_option(key):
                     self.set_option(key, valstr)
+                elif self.has_option(projectkey):
+                    self.set_option(projectkey, valstr)
                 else:
                     self.pending_project_options[key] = valstr
+            else:
+                raise MesonException(f'Not implemented option thingy: {keystr}')
 
     def hacky_mchackface_back_to_list(self, optdict):
         if isinstance(optdict, dict):

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -591,11 +591,16 @@ class OptionStore:
         return potential
 
     def get_value_for(self, optioninfo):
+        return self.get_value_object_and_value_for(optioninfo)[1]
+
+    def get_value_object_and_value_for(self, optioninfo):
         assert isinstance(optioninfo, OptionParts)
         vobject = self.get_value_object_for(optioninfo)
         if optioninfo in self.augments:
-            return vobject.validate_value(self.augments[optioninfo])
-        return vobject.value
+            computed_value = vobject.validate_value(self.augments[optioninfo])
+        else:
+            computed_value = vobject.value
+        return (vobject, computed_value)
 
     def set_from_configure_command(self, D, A, U):
         for setval in D:
@@ -617,11 +622,11 @@ class OptionStore:
                 del self.augments[delete]
 
     def optlist2optdict(self, optlist):
-            optdict = {}
-            for p in optlist:
-                 k, v = p.split('=', 1)
-                 optdict[k] = v
-            project_default_options = optdict
+        optdict = {}
+        for p in optlist:
+             k, v = p.split('=', 1)
+             optdict[k] = v
+        return optdict
         
 
     def set_from_top_level_project_call(self, project_default_options, cmd_line_options):

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -593,8 +593,12 @@ class OptionStore:
             top_option = optioninfo.copy_with(subproject=None)
             return self.options[top_option]
         if potential.yielding:
-            top_option = optioninfo.copy_with(subproject='')
-            return self.options.get(top_option, potential)
+            top_option_key = optioninfo.copy_with(subproject='')
+            top_option = self.options.get(top_option_key, None)
+            # If parent object has different type, do not yield.
+            # This should probably be an error.
+            if type(top_option) is type(potential):
+                return top_option
         return potential
 
     def get_value_for(self, optioninfo):
@@ -656,6 +660,8 @@ class OptionStore:
             if key.subproject is None:
                 if self.has_option(key):
                     self.set_option(key, valstr)
+                else:
+                    self.pending_project_options[key] = valstr
 
     def hacky_mchackface_back_to_list(self, optdict):
         if isinstance(optdict, dict):

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -31,7 +31,6 @@ DEFAULT_YIELDING = False
 
 # Can't bind this near the class method it seems, sadly.
 _T = T.TypeVar('_T')
-_U = T.TypeVar('_U', bound=UserOption[_T])
 
 backendlist = ['ninja', 'vs', 'vs2010', 'vs2012', 'vs2013', 'vs2015', 'vs2017', 'vs2019', 'vs2022', 'xcode', 'none']
 genvslitelist = ['vs2022']
@@ -68,6 +67,8 @@ class UserOption(T.Generic[_T], HoldableObject):
         oldvalue = getattr(self, 'value', None)
         self.value = self.validate_value(newvalue)
         return self.value != oldvalue
+
+_U = T.TypeVar('_U', bound=UserOption[_T])
 
 class UserStringOption(UserOption[str]):
     def __init__(self, name: str, description: str, value: T.Any, yielding: bool = DEFAULT_YIELDING,

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -509,13 +509,17 @@ class OptionStore:
         build = len(self.build_options) if self.build_options else 0
         return basic + build
 
+    def has_option(self, name, subproject, for_build=False):
+        cname = self.form_canonical_keystring(name, subproject, for_build)
+        return cname in self.options
+
     def set_option(self, name, subproject, new_value):
         cname = self.form_canonical_keystring(name)
-        self.set_option_from_string(cname, new_value)
+        return self.set_option_from_string(cname, new_value)
 
     def set_option_from_string(self, keystr, new_value):
         m = re.fullmatch(OPTNAME_REGEX, keystr) # Merely for validation
-        self.options[keystr].set_value(new_value)
+        return self.options[keystr].set_value(new_value)
 
     def parts_to_canonical_keystring(self, parts):
         return self.form_canonical_keystring(parts.name, parts.subproject, parts.for_build)
@@ -543,6 +547,7 @@ class OptionStore:
         return self.form_canonical_keystring(parts.name, parts.subproject, parts.for_build)
 
     def add_system_option(self, name, value_object):
+        assert isinstance(name, str)
         cname = self.form_canonical_keystring(name)
         # FIXME; transfer the old value for combos etc.
         if cname not in self.options:

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -521,6 +521,8 @@ class OptionParts:
                            for_build if for_build != BAD_VALUE else self.for_build)
 
 def convert_oldkey(optkey): # Delete after transition to new keys is done.
+    if isinstance(optkey, OptionParts):
+        return optkey
     if optkey.lang:
         name = f'{optkey.lang}_{optkey.name}'
     else:

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -516,7 +516,11 @@ class OptionParts:
                            for_build if for_build != BAD_VALUE else self.for_build)
 
 def convert_oldkey(optkey): # Delete after transition to new keys is done.
-    return OptionParts(optkey.name,
+    if optkey.lang:
+        name = f'{optkey.lang}_{optkey.name}'
+    else:
+        name = optkey.name
+    return OptionParts(name,
                        optkey.subproject,
                        optkey.is_cross())
 

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -617,10 +617,20 @@ class OptionStore:
                 del self.augments[delete]
 
     def set_from_top_level_project_call(self, project_default_options):
-        for p in project_default_options:
-            keystr, valstr = p.split('=', 1)
+        if isinstance(project_default_options, str):
+            project_default_options = [project_default_options]
+        if isinstance(project_default_options, list):
+            optdict = {}
+            for p in project_default_options:
+                 k, v = p.split('=', 1)
+                 optdict[k] = v
+            project_default_options = optdict
+        for keystr, valstr in project_default_options.items():
             key = self.split_keystring(keystr)
-            assert key.subproject is None
+            if key.subproject is not None:
+                # FIXME, add an augment.
+                # test case 87
+                continue
             if key in self.options:
                 self.set_option(key, valstr)
 

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -2407,6 +2407,8 @@ class OptionKey:
         """Convenience method to check if this is a base option."""
         return self.type is OptionType.BASE
 
+    def is_cross(self) -> bool:
+        return self.machine == MachineChoice.BUILD
 
 def pickle_load(filename: str, object_name: str, object_type: T.Type[_PL], suggest_reconfigure: bool = True) -> _PL:
     load_fail_msg = f'{object_name} file {filename!r} is corrupted.'

--- a/test cases/unit/123 persp options/meson.build
+++ b/test cases/unit/123 persp options/meson.build
@@ -7,11 +7,13 @@ if round == 1
 elif round == 2
    assert(opt == '1')
 elif round == 3
-   assert(opt == '3')
+   assert(opt == '1')
 elif round == 4
    assert(opt == '3')
 elif round == 5
    assert(opt == '3')
+elif round == 6
+   assert(opt == '3', opt)
 else
   assert(false, 'Invalid round number')
 endif

--- a/test cases/unit/123 persp options/meson.build
+++ b/test cases/unit/123 persp options/meson.build
@@ -1,0 +1,22 @@
+project('toplevel', 'c')
+
+round = get_option('round')
+opt = get_option('optimization')
+if round == 1
+   assert(opt == '1')
+elif round == 2
+   assert(opt == '1')
+elif round == 3
+   assert(opt == '3')
+elif round == 4
+   assert(opt == '3')
+elif round == 5
+   assert(opt == '3')
+else
+  assert(false, 'Invalid round number')
+endif
+
+executable('toplevel', 'toplevel.c')
+
+subproject('sub1')
+subproject('sub2')

--- a/test cases/unit/123 persp options/meson.options
+++ b/test cases/unit/123 persp options/meson.options
@@ -1,0 +1,1 @@
+option('round', type: 'integer', value: 1, description: 'The test round.')

--- a/test cases/unit/123 persp options/subprojects/sub1/meson.build
+++ b/test cases/unit/123 persp options/subprojects/sub1/meson.build
@@ -11,6 +11,8 @@ elif round == 3
 elif round == 4
    assert(opt == '1')
 elif round == 5
+   assert(opt == '1')
+elif round == 6
    assert(opt == '2')
 else
   assert(false, 'Invalid round number')

--- a/test cases/unit/123 persp options/subprojects/sub1/meson.build
+++ b/test cases/unit/123 persp options/subprojects/sub1/meson.build
@@ -1,0 +1,20 @@
+project('sub1', 'c')
+
+round = get_option('round')
+opt = get_option('optimization')
+if round == 1
+   assert(opt == '1')
+elif round == 2
+   assert(opt == '1')
+elif round == 3
+   assert(opt == '1')
+elif round == 4
+   assert(opt == '1')
+elif round == 5
+   assert(opt == '2')
+else
+  assert(false, 'Invalid round number')
+endif
+
+
+executable('sub1', 'sub1.c')

--- a/test cases/unit/123 persp options/subprojects/sub1/meson.options
+++ b/test cases/unit/123 persp options/subprojects/sub1/meson.options
@@ -1,0 +1,1 @@
+option('round', type: 'integer', value: 1, description: 'The test round.', yield: true)

--- a/test cases/unit/123 persp options/subprojects/sub1/sub1.c
+++ b/test cases/unit/123 persp options/subprojects/sub1/sub1.c
@@ -1,0 +1,6 @@
+#include<stdio.h>
+
+int main(void) {
+    printf("This is subproject 1.\n");
+    return 0;
+}

--- a/test cases/unit/123 persp options/subprojects/sub2/meson.build
+++ b/test cases/unit/123 persp options/subprojects/sub2/meson.build
@@ -5,12 +5,14 @@ opt = get_option('optimization')
 if round == 1
    assert(opt == '1')
 elif round == 2
-   assert(opt == '2')
+   assert(opt == '3')
 elif round == 3
    assert(opt == '2')
 elif round == 4
-   assert(opt == '1')
+   assert(opt == '2')
 elif round == 5
+   assert(opt == '1')
+elif round == 6
    assert(opt == '2')
 else
   assert(false, 'Invalid round number')

--- a/test cases/unit/123 persp options/subprojects/sub2/meson.build
+++ b/test cases/unit/123 persp options/subprojects/sub2/meson.build
@@ -1,0 +1,19 @@
+project('sub2', 'c')
+
+round = get_option('round')
+opt = get_option('optimization')
+if round == 1
+   assert(opt == '1')
+elif round == 2
+   assert(opt == '2')
+elif round == 3
+   assert(opt == '2')
+elif round == 4
+   assert(opt == '1')
+elif round == 5
+   assert(opt == '2')
+else
+  assert(false, 'Invalid round number')
+endif
+
+executable('sub2', 'sub2.c')

--- a/test cases/unit/123 persp options/subprojects/sub2/meson.options
+++ b/test cases/unit/123 persp options/subprojects/sub2/meson.options
@@ -1,0 +1,1 @@
+option('round', type: 'integer', value: 1, description: 'The test round.', yield: true)

--- a/test cases/unit/123 persp options/subprojects/sub2/sub2.c
+++ b/test cases/unit/123 persp options/subprojects/sub2/sub2.c
@@ -1,0 +1,6 @@
+#include<stdio.h>
+
+int main(void) {
+    printf("This is subproject 1.\n");
+    return 0;
+}

--- a/test cases/unit/123 persp options/toplevel.c
+++ b/test cases/unit/123 persp options/toplevel.c
@@ -1,0 +1,6 @@
+#include<stdio.h>
+
+int main(void) {
+    printf("This is the top level project.\n");
+    return 0;
+}

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -296,6 +296,8 @@ class BasePlatformTests(TestCase):
         else:
             arg = list(arg)
         self._run(self.mconf_command + arg + [self.builddir])
+        if will_build:
+            self.build()
 
     def getconf(self, optname: str):
         opts = self.introspect('--buildoptions')

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -1836,24 +1836,28 @@ class LinuxlikeTests(BasePlatformTests):
         self.check_has_flag(compdb, sub2src, '-O1')
 
         # Set subproject option to O2
+        self.setconf(['-Dround=2', '-A', 'sub2:optimization=2'])
         compdb = self.get_compdb()
         self.check_has_flag(compdb, mainsrc, '-O1')
         self.check_has_flag(compdb, sub1src, '-O1')
         self.check_has_flag(compdb, sub2src, '-O2')
 
         # Set top level option to O3
+        self.setconf(['-Dround=3', '-A:optimization=3'])
         compdb = self.get_compdb()
         self.check_has_flag(compdb, mainsrc, '-O3')
         self.check_has_flag(compdb, sub1src, '-O1')
         self.check_has_flag(compdb, sub2src, '-O2')
 
-        # UnsetSet subproject
+        # Unset subproject
+        self.setconf(['-Dround=4', '-U', 'sub2:optimization'])
         compdb = self.get_compdb()
         self.check_has_flag(compdb, mainsrc, '-O3')
         self.check_has_flag(compdb, sub1src, '-O1')
         self.check_has_flag(compdb, sub2src, '-O1')
 
         # Set global value
+        self.setconf(['-Dround=5', '-D', 'optimization=2'])
         compdb = self.get_compdb()
         self.check_has_flag(compdb, mainsrc, '-O3')
         self.check_has_flag(compdb, sub1src, '-O2')

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -1836,28 +1836,35 @@ class LinuxlikeTests(BasePlatformTests):
         self.check_has_flag(compdb, sub2src, '-O1')
 
         # Set subproject option to O2
-        self.setconf(['-Dround=2', '-A', 'sub2:optimization=2'])
+        self.setconf(['-Dround=2', '-A', 'sub2:optimization=3'])
+        compdb = self.get_compdb()
+        self.check_has_flag(compdb, mainsrc, '-O1')
+        self.check_has_flag(compdb, sub1src, '-O1')
+        self.check_has_flag(compdb, sub2src, '-O3')
+
+        # Change an already set override.
+        self.setconf(['-Dround=3', '-D', 'sub2:optimization=2'])
         compdb = self.get_compdb()
         self.check_has_flag(compdb, mainsrc, '-O1')
         self.check_has_flag(compdb, sub1src, '-O1')
         self.check_has_flag(compdb, sub2src, '-O2')
 
         # Set top level option to O3
-        self.setconf(['-Dround=3', '-A:optimization=3'])
+        self.setconf(['-Dround=4', '-A:optimization=3'])
         compdb = self.get_compdb()
         self.check_has_flag(compdb, mainsrc, '-O3')
         self.check_has_flag(compdb, sub1src, '-O1')
         self.check_has_flag(compdb, sub2src, '-O2')
 
         # Unset subproject
-        self.setconf(['-Dround=4', '-U', 'sub2:optimization'])
+        self.setconf(['-Dround=5', '-U', 'sub2:optimization'])
         compdb = self.get_compdb()
         self.check_has_flag(compdb, mainsrc, '-O3')
         self.check_has_flag(compdb, sub1src, '-O1')
         self.check_has_flag(compdb, sub2src, '-O1')
 
         # Set global value
-        self.setconf(['-Dround=5', '-D', 'optimization=2'])
+        self.setconf(['-Dround=6', '-D', 'optimization=2'])
         compdb = self.get_compdb()
         self.check_has_flag(compdb, mainsrc, '-O3')
         self.check_has_flag(compdb, sub1src, '-O2')

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -1816,3 +1816,45 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertIn('build t9-e1: c_LINKER t9-e1.p/main.c.o | libt9-s1.a libt9-s2.a libt9-s3.a\n', content)
         self.assertIn('build t12-e1: c_LINKER t12-e1.p/main.c.o | libt12-s1.a libt12-s2.a libt12-s3.a\n', content)
         self.assertIn('build t13-e1: c_LINKER t13-e1.p/main.c.o | libt12-s1.a libt13-s3.a\n', content)
+
+    def check_has_flag(self, compdb, src, argument):
+        for i in compdb:
+            if src in i['file']:
+                self.assertIn(argument, i['command'])
+                return
+        self.assertTrue(False, f'Source {src} not found in compdb')
+
+    def test_persp_options(self):
+        testdir = os.path.join(self.unit_test_dir, '123 persp options')
+        self.init(testdir, extra_args='-Doptimization=1')
+        compdb = self.get_compdb()
+        mainsrc = 'toplevel.c'
+        sub1src = 'sub1.c'
+        sub2src = 'sub2.c'
+        self.check_has_flag(compdb, mainsrc, '-O1')
+        self.check_has_flag(compdb, sub1src, '-O1')
+        self.check_has_flag(compdb, sub2src, '-O1')
+
+        # Set subproject option to O2
+        compdb = self.get_compdb()
+        self.check_has_flag(compdb, mainsrc, '-O1')
+        self.check_has_flag(compdb, sub1src, '-O1')
+        self.check_has_flag(compdb, sub2src, '-O2')
+
+        # Set top level option to O3
+        compdb = self.get_compdb()
+        self.check_has_flag(compdb, mainsrc, '-O3')
+        self.check_has_flag(compdb, sub1src, '-O1')
+        self.check_has_flag(compdb, sub2src, '-O2')
+
+        # UnsetSet subproject
+        compdb = self.get_compdb()
+        self.check_has_flag(compdb, mainsrc, '-O3')
+        self.check_has_flag(compdb, sub1src, '-O1')
+        self.check_has_flag(compdb, sub2src, '-O1')
+
+        # Set global value
+        compdb = self.get_compdb()
+        self.check_has_flag(compdb, mainsrc, '-O3')
+        self.check_has_flag(compdb, sub1src, '-O2')
+        self.check_has_flag(compdb, sub2src, '-O2')

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -7,7 +7,7 @@ import unittest
 
 
 class OptionTests(unittest.TestCase):
-    
+
     def test_basic(self):
         os = OptionStore()
         name = 'someoption'
@@ -15,3 +15,47 @@ class OptionTests(unittest.TestCase):
         vo = UserStringOption(name, 'An option of some sort', default_value)
         os.add_system_option(name, vo)
         self.assertEqual(os.get_value_for(name), default_value)
+
+    def test_reset(self):
+        os = OptionStore()
+        name = 'someoption'
+        original_value = 'original'
+        reset_value = 'reset'
+        vo = UserStringOption(name, 'An option set twice', original_value)
+        os.add_system_option(name, vo)
+        self.assertEqual(os.get_value_for(name), original_value)
+        self.assertEqual(os.num_options(), 1)
+        vo2 = UserStringOption(name, 'An option set twice', reset_value)
+        os.add_system_option(name, vo2)
+        self.assertEqual(os.get_value_for(name), original_value)
+        self.assertEqual(os.num_options(), 1)
+
+    def test_project_nonyielding(self):
+        os = OptionStore()
+        name = 'someoption'
+        top_value = 'top'
+        sub_value = 'sub'
+        vo = UserStringOption(name, 'A top level option', top_value)
+        os.add_project_option(name, '', False, vo)
+        self.assertEqual(os.get_value_for(name, ''), top_value)
+        self.assertEqual(os.num_options(), 1)
+        vo2 = UserStringOption(name, 'A subproject option', sub_value)
+        os.add_project_option(name, 'sub', False, vo2)
+        self.assertEqual(os.get_value_for(name), top_value)
+        self.assertEqual(os.get_value_for(name, 'sub'), sub_value)
+        self.assertEqual(os.num_options(), 2)
+
+    def test_project_yielding(self):
+        os = OptionStore()
+        name = 'someoption'
+        top_value = 'top'
+        sub_value = 'sub'
+        vo = UserStringOption(name, 'A top level option', top_value)
+        os.add_project_option(name, '', False, vo)
+        self.assertEqual(os.get_value_for(name, ''), top_value)
+        self.assertEqual(os.num_options(), 1)
+        vo2 = UserStringOption(name, 'A subproject option', sub_value)
+        os.add_project_option(name, 'sub', True, vo2)
+        self.assertEqual(os.get_value_for(name), top_value)
+        self.assertEqual(os.get_value_for(name, 'sub'), top_value)
+        self.assertEqual(os.num_options(), 2)

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -9,53 +9,101 @@ import unittest
 class OptionTests(unittest.TestCase):
 
     def test_basic(self):
-        os = OptionStore()
+        optstore = OptionStore()
+        name = 'someoption'
+        default_value = 'somevalue'
+        new_value = 'new_value'
+        vo = UserStringOption(name, 'An option of some sort', default_value)
+        optstore.add_system_option(name, vo)
+        self.assertEqual(optstore.get_value_for(name), default_value)
+        optstore.set_option(name, '', new_value)
+        self.assertEqual(optstore.get_value_for(name), new_value)
+
+    def test_subproject_for_system(self):
+        optstore = OptionStore()
         name = 'someoption'
         default_value = 'somevalue'
         vo = UserStringOption(name, 'An option of some sort', default_value)
-        os.add_system_option(name, vo)
-        self.assertEqual(os.get_value_for(name), default_value)
+        optstore.add_system_option(name, vo)
+        self.assertEqual(optstore.get_value_for(name, 'somesubproject'), default_value)
 
     def test_reset(self):
-        os = OptionStore()
+        optstore = OptionStore()
         name = 'someoption'
         original_value = 'original'
         reset_value = 'reset'
         vo = UserStringOption(name, 'An option set twice', original_value)
-        os.add_system_option(name, vo)
-        self.assertEqual(os.get_value_for(name), original_value)
-        self.assertEqual(os.num_options(), 1)
+        optstore.add_system_option(name, vo)
+        self.assertEqual(optstore.get_value_for(name), original_value)
+        self.assertEqual(optstore.num_options(), 1)
         vo2 = UserStringOption(name, 'An option set twice', reset_value)
-        os.add_system_option(name, vo2)
-        self.assertEqual(os.get_value_for(name), original_value)
-        self.assertEqual(os.num_options(), 1)
+        optstore.add_system_option(name, vo2)
+        self.assertEqual(optstore.get_value_for(name), original_value)
+        self.assertEqual(optstore.num_options(), 1)
 
     def test_project_nonyielding(self):
-        os = OptionStore()
+        optstore = OptionStore()
         name = 'someoption'
         top_value = 'top'
         sub_value = 'sub'
-        vo = UserStringOption(name, 'A top level option', top_value)
-        os.add_project_option(name, '', False, vo)
-        self.assertEqual(os.get_value_for(name, ''), top_value)
-        self.assertEqual(os.num_options(), 1)
+        vo = UserStringOption(name, 'A top level option', top_value, False)
+        optstore.add_project_option(name, '', vo)
+        self.assertEqual(optstore.get_value_for(name, ''), top_value, False)
+        self.assertEqual(optstore.num_options(), 1)
         vo2 = UserStringOption(name, 'A subproject option', sub_value)
-        os.add_project_option(name, 'sub', False, vo2)
-        self.assertEqual(os.get_value_for(name), top_value)
-        self.assertEqual(os.get_value_for(name, 'sub'), sub_value)
-        self.assertEqual(os.num_options(), 2)
+        optstore.add_project_option(name, 'sub', vo2)
+        self.assertEqual(optstore.get_value_for(name), top_value)
+        self.assertEqual(optstore.get_value_for(name, 'sub'), sub_value)
+        self.assertEqual(optstore.num_options(), 2)
 
     def test_project_yielding(self):
-        os = OptionStore()
+        optstore = OptionStore()
         name = 'someoption'
         top_value = 'top'
         sub_value = 'sub'
         vo = UserStringOption(name, 'A top level option', top_value)
-        os.add_project_option(name, '', False, vo)
-        self.assertEqual(os.get_value_for(name, ''), top_value)
-        self.assertEqual(os.num_options(), 1)
-        vo2 = UserStringOption(name, 'A subproject option', sub_value)
-        os.add_project_option(name, 'sub', True, vo2)
-        self.assertEqual(os.get_value_for(name), top_value)
-        self.assertEqual(os.get_value_for(name, 'sub'), top_value)
-        self.assertEqual(os.num_options(), 2)
+        optstore.add_project_option(name, '', vo)
+        self.assertEqual(optstore.get_value_for(name, ''), top_value)
+        self.assertEqual(optstore.num_options(), 1)
+        vo2 = UserStringOption(name, 'A subproject option', sub_value, True)
+        optstore.add_project_option(name, 'sub', vo2)
+        self.assertEqual(optstore.get_value_for(name), top_value)
+        self.assertEqual(optstore.get_value_for(name, 'sub'), top_value)
+        self.assertEqual(optstore.num_options(), 2)
+
+    def test_augments(self):
+        optstore = OptionStore()
+        name = 'cpp_std'
+        sub_name = 'sub'
+        sub2_name = 'sub2'
+        top_value = 'c++11'
+        aug_value = 'c++23'
+
+        co = UserComboOption(name,
+                             'C++ language standard to use',
+                             ['c++98', 'c++11', 'c++14', 'c++17', 'c++20', 'c++23'],
+                             top_value)
+        optstore.add_system_option(name, co)
+        self.assertEqual(optstore.get_value_for(name), top_value)
+        self.assertEqual(optstore.get_value_for(name, sub_name), top_value)
+        self.assertEqual(optstore.get_value_for(name, sub2_name), top_value)
+
+        # First augment a subproject
+        optstore.set_from_configure_command([], [f'{sub_name}:{name}={aug_value}'], [])
+        self.assertEqual(optstore.get_value_for(name), top_value)
+        self.assertEqual(optstore.get_value_for(name, sub_name), aug_value)
+        self.assertEqual(optstore.get_value_for(name, sub2_name), top_value)
+        optstore.set_from_configure_command([], [], [f'{sub_name}:{name}'])
+        self.assertEqual(optstore.get_value_for(name), top_value)
+        self.assertEqual(optstore.get_value_for(name, sub_name), top_value)
+        self.assertEqual(optstore.get_value_for(name, sub2_name), top_value)
+
+        # And now augment the top level option
+        optstore.set_from_configure_command([], [f':{name}={aug_value}'], [])
+        self.assertEqual(optstore.get_value_for(name), aug_value)
+        self.assertEqual(optstore.get_value_for(name, sub_name), top_value)
+        self.assertEqual(optstore.get_value_for(name, sub2_name), top_value)
+        optstore.set_from_configure_command([], [], [f':{name}'])
+        self.assertEqual(optstore.get_value_for(name), top_value)
+        self.assertEqual(optstore.get_value_for(name, sub_name), top_value)
+        self.assertEqual(optstore.get_value_for(name, sub2_name), top_value)

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -19,6 +19,24 @@ class OptionTests(unittest.TestCase):
         optstore.set_option(name, '', new_value)
         self.assertEqual(optstore.get_value_for(name), new_value)
 
+    def test_parsing(self):
+        optstore = OptionStore()
+        s1 = optstore.split_keystring('sub:optname')
+        s1_expected = OptionParts('optname', 'sub', False)
+        self.assertEqual(s1, s1_expected)
+        self.assertEqual(optstore.parts_to_canonical_keystring(s1), 'sub:optname')
+
+        s2 = optstore.split_keystring('optname')
+        s2_expected = OptionParts('optname', None, False)
+        self.assertEqual(s2, s2_expected)
+
+        self.assertEqual(optstore.parts_to_canonical_keystring(s2), 'optname')
+
+        s3 = optstore.split_keystring(':optname')
+        s3_expected = OptionParts('optname', '', False)
+        self.assertEqual(s3, s3_expected)
+        self.assertEqual(optstore.parts_to_canonical_keystring(s3), ':optname')
+
     def test_subproject_for_system(self):
         optstore = OptionStore()
         name = 'someoption'
@@ -52,7 +70,7 @@ class OptionTests(unittest.TestCase):
         self.assertEqual(optstore.num_options(), 1)
         vo2 = UserStringOption(name, 'A subproject option', sub_value)
         optstore.add_project_option(name, 'sub', vo2)
-        self.assertEqual(optstore.get_value_for(name), top_value)
+        self.assertEqual(optstore.get_value_for(name, ''), top_value)
         self.assertEqual(optstore.get_value_for(name, 'sub'), sub_value)
         self.assertEqual(optstore.num_options(), 2)
 
@@ -67,7 +85,7 @@ class OptionTests(unittest.TestCase):
         self.assertEqual(optstore.num_options(), 1)
         vo2 = UserStringOption(name, 'A subproject option', sub_value, True)
         optstore.add_project_option(name, 'sub', vo2)
-        self.assertEqual(optstore.get_value_for(name), top_value)
+        self.assertEqual(optstore.get_value_for(name, ''), top_value)
         self.assertEqual(optstore.get_value_for(name, 'sub'), top_value)
         self.assertEqual(optstore.num_options(), 2)
 
@@ -100,10 +118,52 @@ class OptionTests(unittest.TestCase):
 
         # And now augment the top level option
         optstore.set_from_configure_command([], [f':{name}={aug_value}'], [])
-        self.assertEqual(optstore.get_value_for(name), aug_value)
+        self.assertEqual(optstore.get_value_for(name, None), top_value)
+        self.assertEqual(optstore.get_value_for(name, ''), aug_value)
         self.assertEqual(optstore.get_value_for(name, sub_name), top_value)
         self.assertEqual(optstore.get_value_for(name, sub2_name), top_value)
         optstore.set_from_configure_command([], [], [f':{name}'])
         self.assertEqual(optstore.get_value_for(name), top_value)
         self.assertEqual(optstore.get_value_for(name, sub_name), top_value)
         self.assertEqual(optstore.get_value_for(name, sub2_name), top_value)
+
+    def test_augment_set_sub(self):
+        optstore = OptionStore()
+        name = 'cpp_std'
+        sub_name = 'sub'
+        sub2_name = 'sub2'
+        top_value = 'c++11'
+        aug_value = 'c++23'
+        set_value = 'c++20'
+
+        co = UserComboOption(name,
+                             'C++ language standard to use',
+                             ['c++98', 'c++11', 'c++14', 'c++17', 'c++20', 'c++23'],
+                             top_value)
+        optstore.add_system_option(name, co)
+        optstore.set_from_configure_command([], [f'{sub_name}:{name}={aug_value}'], [])
+        optstore.set_from_configure_command([f'{sub_name}:{name}={set_value}'], [], [])
+        self.assertEqual(optstore.get_value_for(name), top_value)
+        self.assertEqual(optstore.get_value_for(name, sub_name), set_value)
+
+    def test_subproject_call_options(self):
+        optstore = OptionStore()
+        name = 'cpp_std'
+        default_value = 'c++11'
+        override_value = 'c++14'
+        unused_value = 'c++20'
+        subproject = 'sub'
+
+        co = UserComboOption(name,
+                             'C++ language standard to use',
+                             ['c++98', 'c++11', 'c++14', 'c++17', 'c++20', 'c++23'],
+                             default_value)
+        optstore.add_system_option(name, co)
+        optstore.set_subproject_options(subproject, [f'cpp_std={override_value}'], [f'cpp_std={unused_value}'])
+        self.assertEqual(optstore.get_value_for(name), default_value)
+        self.assertEqual(optstore.get_value_for(name, subproject), override_value)
+
+        # Trying again should change nothing
+        optstore.set_subproject_options(subproject, [f'cpp_std={unused_value}'], [f'cpp_std={unused_value}'])
+        self.assertEqual(optstore.get_value_for(name), default_value)
+        self.assertEqual(optstore.get_value_for(name, subproject), override_value)

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 Meson project contributors
+
+from mesonbuild.options import *
+
+import unittest
+
+
+class OptionTests(unittest.TestCase):
+    
+    def test_basic(self):
+        os = OptionStore()
+        name = 'someoption'
+        default_value = 'somevalue'
+        vo = UserStringOption(name, 'An option of some sort', default_value)
+        os.add_system_option(name, vo)
+        self.assertEqual(os.get_value_for(name), default_value)

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -20,6 +20,18 @@ class OptionTests(unittest.TestCase):
         optstore.set_option(k, new_value)
         self.assertEqual(optstore.get_value_for(k), new_value)
 
+    def test_toplevel_project(self):
+        optstore = OptionStore()
+        name = 'someoption'
+        default_value = 'somevalue'
+        new_value = 'new_value'
+        k = OptionParts(name)
+        vo = UserStringOption(k, 'An option of some sort', default_value)
+        optstore.add_system_option(k.name, vo)
+        self.assertEqual(optstore.get_value_for(k), default_value)
+        optstore.set_from_top_level_project_call([f'someoption={new_value}'])
+        self.assertEqual(optstore.get_value_for(k), new_value)
+
     def test_parsing(self):
         optstore = OptionStore()
         s1 = optstore.split_keystring('sub:optname')
@@ -172,13 +184,13 @@ class OptionTests(unittest.TestCase):
                              ['c++98', 'c++11', 'c++14', 'c++17', 'c++20', 'c++23'],
                              default_value)
         optstore.add_system_option(name, co)
-        optstore.set_subproject_options(subproject, [f'cpp_std={override_value}'], [f'cpp_std={unused_value}'])
+        optstore.set_from_subproject_call(subproject, [f'cpp_std={override_value}'], [f'cpp_std={unused_value}'])
         k = OptionParts(name)
         sub_k = k.copy_with(subproject=subproject)
         self.assertEqual(optstore.get_value_for(k), default_value)
         self.assertEqual(optstore.get_value_for(sub_k), override_value)
 
         # Trying again should change nothing
-        optstore.set_subproject_options(subproject, [f'cpp_std={unused_value}'], [f'cpp_std={unused_value}'])
+        optstore.set_from_subproject_call(subproject, [f'cpp_std={unused_value}'], [f'cpp_std={unused_value}'])
         self.assertEqual(optstore.get_value_for(k), default_value)
         self.assertEqual(optstore.get_value_for(sub_k), override_value)

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -13,50 +13,54 @@ class OptionTests(unittest.TestCase):
         name = 'someoption'
         default_value = 'somevalue'
         new_value = 'new_value'
-        vo = UserStringOption(name, 'An option of some sort', default_value)
-        optstore.add_system_option(name, vo)
-        self.assertEqual(optstore.get_value_for(name), default_value)
-        optstore.set_option(name, '', new_value)
-        self.assertEqual(optstore.get_value_for(name), new_value)
+        k = OptionParts(name)
+        vo = UserStringOption(k, 'An option of some sort', default_value)
+        optstore.add_system_option(k.name, vo)
+        self.assertEqual(optstore.get_value_for(k), default_value)
+        optstore.set_option(k, new_value)
+        self.assertEqual(optstore.get_value_for(k), new_value)
 
     def test_parsing(self):
         optstore = OptionStore()
         s1 = optstore.split_keystring('sub:optname')
         s1_expected = OptionParts('optname', 'sub', False)
         self.assertEqual(s1, s1_expected)
-        self.assertEqual(optstore.parts_to_canonical_keystring(s1), 'sub:optname')
+        self.assertEqual(optstore.form_canonical_keystring(s1), 'sub:optname')
 
         s2 = optstore.split_keystring('optname')
         s2_expected = OptionParts('optname', None, False)
         self.assertEqual(s2, s2_expected)
 
-        self.assertEqual(optstore.parts_to_canonical_keystring(s2), 'optname')
+        self.assertEqual(optstore.form_canonical_keystring(s2), 'optname')
 
         s3 = optstore.split_keystring(':optname')
         s3_expected = OptionParts('optname', '', False)
         self.assertEqual(s3, s3_expected)
-        self.assertEqual(optstore.parts_to_canonical_keystring(s3), ':optname')
+        self.assertEqual(optstore.form_canonical_keystring(s3), ':optname')
 
     def test_subproject_for_system(self):
         optstore = OptionStore()
         name = 'someoption'
+        key = OptionParts(name)
+        subkey = key.copy_with(subproject='somesubproject')
         default_value = 'somevalue'
         vo = UserStringOption(name, 'An option of some sort', default_value)
         optstore.add_system_option(name, vo)
-        self.assertEqual(optstore.get_value_for(name, 'somesubproject'), default_value)
+        self.assertEqual(optstore.get_value_for(subkey), default_value)
 
     def test_reset(self):
         optstore = OptionStore()
         name = 'someoption'
         original_value = 'original'
         reset_value = 'reset'
+        k = OptionParts(name)
         vo = UserStringOption(name, 'An option set twice', original_value)
         optstore.add_system_option(name, vo)
-        self.assertEqual(optstore.get_value_for(name), original_value)
+        self.assertEqual(optstore.get_value_for(k), original_value)
         self.assertEqual(optstore.num_options(), 1)
         vo2 = UserStringOption(name, 'An option set twice', reset_value)
         optstore.add_system_option(name, vo2)
-        self.assertEqual(optstore.get_value_for(name), original_value)
+        self.assertEqual(optstore.get_value_for(k), original_value)
         self.assertEqual(optstore.num_options(), 1)
 
     def test_project_nonyielding(self):
@@ -64,14 +68,16 @@ class OptionTests(unittest.TestCase):
         name = 'someoption'
         top_value = 'top'
         sub_value = 'sub'
+        top_key = OptionParts(name, '')
+        sub_key = top_key.copy_with(subproject='sub')
         vo = UserStringOption(name, 'A top level option', top_value, False)
         optstore.add_project_option(name, '', vo)
-        self.assertEqual(optstore.get_value_for(name, ''), top_value, False)
+        self.assertEqual(optstore.get_value_for(top_key), top_value, False)
         self.assertEqual(optstore.num_options(), 1)
         vo2 = UserStringOption(name, 'A subproject option', sub_value)
         optstore.add_project_option(name, 'sub', vo2)
-        self.assertEqual(optstore.get_value_for(name, ''), top_value)
-        self.assertEqual(optstore.get_value_for(name, 'sub'), sub_value)
+        self.assertEqual(optstore.get_value_for(top_key), top_value)
+        self.assertEqual(optstore.get_value_for(sub_key), sub_value)
         self.assertEqual(optstore.num_options(), 2)
 
     def test_project_yielding(self):
@@ -80,13 +86,15 @@ class OptionTests(unittest.TestCase):
         top_value = 'top'
         sub_value = 'sub'
         vo = UserStringOption(name, 'A top level option', top_value)
+        top_key = OptionParts(name, '')
+        sub_key = top_key.copy_with(subproject='sub')
         optstore.add_project_option(name, '', vo)
-        self.assertEqual(optstore.get_value_for(name, ''), top_value)
+        self.assertEqual(optstore.get_value_for(top_key), top_value)
         self.assertEqual(optstore.num_options(), 1)
         vo2 = UserStringOption(name, 'A subproject option', sub_value, True)
         optstore.add_project_option(name, 'sub', vo2)
-        self.assertEqual(optstore.get_value_for(name, ''), top_value)
-        self.assertEqual(optstore.get_value_for(name, 'sub'), top_value)
+        self.assertEqual(optstore.get_value_for(top_key), top_value)
+        self.assertEqual(optstore.get_value_for(sub_key), top_value)
         self.assertEqual(optstore.num_options(), 2)
 
     def test_augments(self):
@@ -96,45 +104,50 @@ class OptionTests(unittest.TestCase):
         sub2_name = 'sub2'
         top_value = 'c++11'
         aug_value = 'c++23'
+        top_key = OptionParts(name)
+        topsub_key = top_key.copy_with(subproject='')
+        sub_key = top_key.copy_with(subproject=sub_name)
+        sub2_key = top_key.copy_with(subproject=sub2_name)
 
         co = UserComboOption(name,
                              'C++ language standard to use',
                              ['c++98', 'c++11', 'c++14', 'c++17', 'c++20', 'c++23'],
                              top_value)
         optstore.add_system_option(name, co)
-        self.assertEqual(optstore.get_value_for(name), top_value)
-        self.assertEqual(optstore.get_value_for(name, sub_name), top_value)
-        self.assertEqual(optstore.get_value_for(name, sub2_name), top_value)
+        self.assertEqual(optstore.get_value_for(top_key), top_value)
+        self.assertEqual(optstore.get_value_for(sub_key), top_value)
+        self.assertEqual(optstore.get_value_for(sub2_key), top_value)
 
         # First augment a subproject
         optstore.set_from_configure_command([], [f'{sub_name}:{name}={aug_value}'], [])
-        self.assertEqual(optstore.get_value_for(name), top_value)
-        self.assertEqual(optstore.get_value_for(name, sub_name), aug_value)
-        self.assertEqual(optstore.get_value_for(name, sub2_name), top_value)
+        self.assertEqual(optstore.get_value_for(top_key), top_value)
+        self.assertEqual(optstore.get_value_for(sub_key), aug_value)
+        self.assertEqual(optstore.get_value_for(sub2_key), top_value)
         optstore.set_from_configure_command([], [], [f'{sub_name}:{name}'])
-        self.assertEqual(optstore.get_value_for(name), top_value)
-        self.assertEqual(optstore.get_value_for(name, sub_name), top_value)
-        self.assertEqual(optstore.get_value_for(name, sub2_name), top_value)
+        self.assertEqual(optstore.get_value_for(top_key), top_value)
+        self.assertEqual(optstore.get_value_for(sub_key), top_value)
+        self.assertEqual(optstore.get_value_for(sub2_key), top_value)
 
         # And now augment the top level option
         optstore.set_from_configure_command([], [f':{name}={aug_value}'], [])
-        self.assertEqual(optstore.get_value_for(name, None), top_value)
-        self.assertEqual(optstore.get_value_for(name, ''), aug_value)
-        self.assertEqual(optstore.get_value_for(name, sub_name), top_value)
-        self.assertEqual(optstore.get_value_for(name, sub2_name), top_value)
+        self.assertEqual(optstore.get_value_for(top_key), top_value)
+        self.assertEqual(optstore.get_value_for(topsub_key), aug_value)
+        self.assertEqual(optstore.get_value_for(sub_key), top_value)
+        self.assertEqual(optstore.get_value_for(sub2_key), top_value)
         optstore.set_from_configure_command([], [], [f':{name}'])
-        self.assertEqual(optstore.get_value_for(name), top_value)
-        self.assertEqual(optstore.get_value_for(name, sub_name), top_value)
-        self.assertEqual(optstore.get_value_for(name, sub2_name), top_value)
+        self.assertEqual(optstore.get_value_for(top_key), top_value)
+        self.assertEqual(optstore.get_value_for(sub_key), top_value)
+        self.assertEqual(optstore.get_value_for(sub2_key), top_value)
 
     def test_augment_set_sub(self):
         optstore = OptionStore()
         name = 'cpp_std'
         sub_name = 'sub'
-        sub2_name = 'sub2'
         top_value = 'c++11'
         aug_value = 'c++23'
         set_value = 'c++20'
+        top_key = OptionParts(name=name)
+        sub_key = top_key.copy_with(subproject=sub_name)
 
         co = UserComboOption(name,
                              'C++ language standard to use',
@@ -143,8 +156,8 @@ class OptionTests(unittest.TestCase):
         optstore.add_system_option(name, co)
         optstore.set_from_configure_command([], [f'{sub_name}:{name}={aug_value}'], [])
         optstore.set_from_configure_command([f'{sub_name}:{name}={set_value}'], [], [])
-        self.assertEqual(optstore.get_value_for(name), top_value)
-        self.assertEqual(optstore.get_value_for(name, sub_name), set_value)
+        self.assertEqual(optstore.get_value_for(top_key), top_value)
+        self.assertEqual(optstore.get_value_for(sub_key), set_value)
 
     def test_subproject_call_options(self):
         optstore = OptionStore()
@@ -160,10 +173,12 @@ class OptionTests(unittest.TestCase):
                              default_value)
         optstore.add_system_option(name, co)
         optstore.set_subproject_options(subproject, [f'cpp_std={override_value}'], [f'cpp_std={unused_value}'])
-        self.assertEqual(optstore.get_value_for(name), default_value)
-        self.assertEqual(optstore.get_value_for(name, subproject), override_value)
+        k = OptionParts(name)
+        sub_k = k.copy_with(subproject=subproject)
+        self.assertEqual(optstore.get_value_for(k), default_value)
+        self.assertEqual(optstore.get_value_for(sub_k), override_value)
 
         # Trying again should change nothing
         optstore.set_subproject_options(subproject, [f'cpp_std={unused_value}'], [f'cpp_std={unused_value}'])
-        self.assertEqual(optstore.get_value_for(name), default_value)
-        self.assertEqual(optstore.get_value_for(name, subproject), override_value)
+        self.assertEqual(optstore.get_value_for(k), default_value)
+        self.assertEqual(optstore.get_value_for(sub_k), override_value)

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -29,7 +29,7 @@ class OptionTests(unittest.TestCase):
         vo = UserStringOption(k, 'An option of some sort', default_value)
         optstore.add_system_option(k.name, vo)
         self.assertEqual(optstore.get_value_for(k), default_value)
-        optstore.set_from_top_level_project_call([f'someoption={new_value}'])
+        optstore.set_from_top_level_project_call([f'someoption={new_value}'], {}, {})
         self.assertEqual(optstore.get_value_for(k), new_value)
 
     def test_parsing(self):


### PR DESCRIPTION
Currently option values for a target are store in the target object as a "view". This works for the current setup but is very inconvenient for #9398. This MR refactors things both to make things simpler and to make overriding values from the command line possible.

- Eventually `build` objects shall only contain "raw data" and computing "option values" for them
- Backends shall use the methods added to the base backend class
- `get_option` shall use a similar sort of centralised method (not yet added)
- Both of these shall (probably) use the same implementation somewhere

This is WIP and will probably fail tests on other platforms. Do not merge yet, I need to add and squash things as outlined in the first commit message before this is ready.

This needs to be merged with a merge commit, because the intermediate commits are many and definitely _not_ working so rebasing would break bisect.