### PR TITLE
Add pre-commit hook(s) for `meson format`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,11 @@
+- id: meson-format
+  name: Formatting Meson files
+  language: python
+  entry: meson format --inplace
+  types: ['file', 'meson']
+
+- id: meson-check-format
+  name: Checking format of Meson files
+  language: python
+  entry: meson format --check-only
+  types: ['file', 'meson']

--- a/docs/markdown/snippets/meson_format_pre_commit.md
+++ b/docs/markdown/snippets/meson_format_pre_commit.md
@@ -1,0 +1,14 @@
+## New pre-commit hook for meson format
+
+Projects using [pre-commit] now can automatically format Meson files by adding
+the following configuration to `.pre-commit-config.yaml`:
+
+```yaml
+hooks:
+- repo: https://github.com/mesonbuild/meson.git
+  rev: '1.5.0'  # Or later version, or specific commit
+  - id: meson-format
+    args: [--configuration, meson.format]  # If you have a meson.format at the repository root
+```
+
+[pre-commit]: https://pre-commit.com/


### PR DESCRIPTION
Now that `meson format` exists, add configuration to run it as part of [pre-commit](https://pre-commit.com/). Once merged (and released), the hooks will be available using the following pre-commit configuration:

```yaml
# .pre-commit-config.yaml
hooks:
- repo: https://github.com/mesonbuild/meson.git
  rev: '1.5.0'  # Or later version, or specific commit
  - id: meson-format
    args: [--configuration, meson.format]  # If you have a meson.format at the repository root
```
