### PR TITLE
interpreter: Fix dependency(..., modules: x) fallback

### DIFF
--- a/mesonbuild/interpreter/dependencyfallbacks.py
+++ b/mesonbuild/interpreter/dependencyfallbacks.py
@@ -209,6 +209,10 @@ class DependencyFallbacksHolder(MesonInterpreterObject):
         wanted_vers = stringlistify(kwargs.get('version', []))
 
         override = self.build.dependency_overrides[for_machine].get(identifier)
+        if not override and self.subproject_name:
+            identifier_without_modules = tuple((k, v) for k, v in identifier if k not in {'modules', 'optional_modules'})
+            if identifier_without_modules != identifier:
+                override = self.build.dependency_overrides[for_machine].get(identifier_without_modules)
         if override:
             info = [mlog.blue('(overridden)' if override.explicit else '(cached)')]
             cached_dep = override.dep


### PR DESCRIPTION
Where the subproject got registered without modules, but is later looked up with modules specified.

We cannot do the filtering in get_dep_identifier(), as the list of modules matters in case of external dependencies.