### PR TITLE
coredata: Fix is_per_machine_option() for builtins

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -886,7 +886,7 @@ class CoreData:
 
     @staticmethod
     def is_per_machine_option(optname: OptionKey) -> bool:
-        if optname.name in BUILTIN_OPTIONS_PER_MACHINE:
+        if optname.as_host() in BUILTIN_OPTIONS_PER_MACHINE:
             return True
         return optname.lang is not None
 


### PR DESCRIPTION
The keys in `BUILTIN_OPTIONS_PER_MACHINE` are `OptionKey` values, not strings.

This fixes a regression introduced in 71db6b0.