### PR TITLE
doc/Threads: avoid `dependency('threads')` with MinGW + Win32 threading

### DIFF
--- a/docs/markdown/Threads.md
+++ b/docs/markdown/Threads.md
@@ -18,3 +18,17 @@ And then you just use it in a target like this:
 executable('threadedprogram', ...
   dependencies : thread_dep)
 ```
+
+On Windows, `dependency('threads')` does nothing on MSVC and links with
+winpthreads on MinGW.  If your code uses native Win32 thread primitives
+instead of pthreads, `dependency('threads')` will therefore add a spurious
+winpthreads dependency when building with MinGW.  To prevent this, avoid
+`dependency('threads')` on Windows:
+
+```meson
+if host_machine.system() == 'windows'
+  thread_dep = dependency('', required: false)
+else
+  thread_dep = dependency('threads')
+endif
+```


### PR DESCRIPTION
On MinGW, `dependency('threads')` assumes the caller wants POSIX thread primitives instead of Win32 primitives.  This makes sense because the latter doesn't require any additional action, while the former needs a winpthreads dependency.  However, some libraries use Win32 threading on Windows but add `dependency('threads')` anyway, which is undesirable in a build that wants to avoid shipping winpthreads.  Recommend skipping `dependency('threads')` on Windows if POSIX threading is not needed.