### PR TITLE
Use dl instead of zlib for checking an external dependency

### DIFF
--- a/test cases/unit/71 summary/meson.build
+++ b/test cases/unit/71 summary/meson.build
@@ -13,7 +13,7 @@ summary({'Some boolean': false,
 summary({'missing prog': find_program('xyzzy', required: false),
          'existing prog': find_program(get_option('python')).full_path(),
          'missing dep': dependency('', required: false),
-         'external dep': dependency('zlib', required: false),
+         'external dep': dependency('dl', required: false),
          'internal dep': declare_dependency(),
          'disabler': disabler(),
         }, section: 'Stuff')


### PR DESCRIPTION
Fedora has switched to zlib-ng, which has a version of `1.3.0.zlib-ng`, causing AllPlatformTests.test_summary to fail. dl is much less likely to change format.