### PR TITLE
Add required kwarg to compiler.{compiles,links,run}

### DIFF
--- a/docs/markdown/snippets/requires_kwarg_on_more_compiler_methods.md
+++ b/docs/markdown/snippets/requires_kwarg_on_more_compiler_methods.md
@@ -1,0 +1,21 @@
+## Required kwarg on more `compiler` methods
+
+The following `compiler` methods now support the `required` keyword argument:
+
+- `compiler.compiles()`
+- `compiler.links()`
+- `compiler.runs()`
+
+```meson
+cc.compiles(valid, name: 'valid', required : true)
+cc.links(valid, name: 'valid', required : true)
+cc.run(valid, name: 'valid', required : true)
+
+assert(not cc.compiles(valid, name: 'valid', required : opt))
+assert(not cc.links(valid, name: 'valid', required : opt))
+res = cc.run(valid, name: 'valid', required : opt)
+assert(res.compiled())
+assert(res.returncode() == 0)
+assert(res.stdout() == '')
+assert(res.stderr() == '')
+```

--- a/docs/yaml/objects/compiler.yaml
+++ b/docs/yaml/objects/compiler.yaml
@@ -121,6 +121,16 @@ methods:
 - name: _compiles
   returns: void
   description: You have found a bug if you can see this!
+  kwargs:
+    required:
+      type: bool | feature
+      default: false
+      since: 1.5.0
+      description:
+        When set to `true`, Meson will halt if the check fails.
+
+        When set to a [`feature`](Build-options.md#features) option, the feature
+        will control if it is searched and whether to fail if not found.
   kwargs_inherit:
     - compiler._args
     - compiler._include_directories

--- a/test cases/common/275 required keyword in compiles functions/invalid.c
+++ b/test cases/common/275 required keyword in compiles functions/invalid.c
@@ -1,0 +1,7 @@
+// The error in this file is an homage to the xz incident :)
+//
+int
+main(void)
+{
+.   return 0;
+}

--- a/test cases/common/275 required keyword in compiles functions/meson.build
+++ b/test cases/common/275 required keyword in compiles functions/meson.build
@@ -1,0 +1,41 @@
+project('required keyword in compiles functions', 'c')
+
+cc = meson.get_compiler('c')
+opt = get_option('opt')
+
+valid = files('valid.c')
+invalid = files('invalid.c')
+
+cc.compiles(valid, name: 'valid', required : true)
+cc.links(valid, name: 'valid', required : true)
+if meson.can_run_host_binaries()
+  cc.run(valid, name: 'valid', required : true)
+endif
+
+assert(not cc.compiles(valid, name: 'valid', required : opt))
+assert(not cc.links(valid, name: 'valid', required : opt))
+if meson.can_run_host_binaries()
+  res = cc.run(valid, name: 'valid', required : opt)
+  assert(res.compiled())
+  assert(res.returncode() == 0)
+  assert(res.stdout() == '')
+  assert(res.stderr() == '')
+endif
+
+testcase expect_error('''compiler.compiles keyword argument 'required' was of type str but should have been one of: bool, UserFeatureOption''')
+  cc.compiles(valid, name: 'valid', required : 'not a bool')
+endtestcase
+
+testcase expect_error('''Could not compile invalid''')
+  cc.compiles(invalid, name: 'invalid', required : true)
+endtestcase
+
+testcase expect_error('''Could not link invalid''')
+  cc.links(invalid, name: 'invalid', required : true)
+endtestcase
+
+if meson.can_run_host_binaries()
+  testcase expect_error('''Could not run invalid''')
+    cc.run(invalid, name: 'invalid', required : true)
+  endtestcase
+endif

--- a/test cases/common/275 required keyword in compiles functions/meson_options.txt
+++ b/test cases/common/275 required keyword in compiles functions/meson_options.txt
@@ -1,0 +1,1 @@
+option('opt', type: 'feature', value: 'disabled')

--- a/test cases/common/275 required keyword in compiles functions/valid.c
+++ b/test cases/common/275 required keyword in compiles functions/valid.c
@@ -1,0 +1,5 @@
+int
+main(void)
+{
+    return 0;
+}


### PR DESCRIPTION
This is a similar commit to the one that added required to all the compiler.has* functions.