### PR TITLE
tests/d/10: Fix condition with clang++ and gdc

### DIFF
--- a/test cases/d/10 d cpp/meson.build
+++ b/test cases/d/10 d cpp/meson.build
@@ -1,8 +1,9 @@
 project('d and c++', 'd', 'cpp')
 
 cpp = meson.get_compiler('cpp')
+dc = meson.get_compiler('d')
 
-if cpp.get_id() == 'clang'
+if cpp.get_id() == 'clang' and dc.get_id() == 'gcc'
   error('MESON_SKIP_TEST combining Clang C++ with GDC produces broken executables.')
 endif
 


### PR DESCRIPTION
Which just checked for clang++ and aborted, instead of for the combination it claimed.