### PR TITLE
mdist: gracefully handle stale Git index

### DIFF
--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -140,6 +140,7 @@ class GitDist(Dist):
 
     def have_dirty_index(self) -> bool:
         '''Check whether there are uncommitted changes in git'''
+        subprocess.check_call(['git', '-C', self.src_root, 'update-index', '-q', '--refresh'])
         ret = subprocess.call(['git', '-C', self.src_root, 'diff-index', '--quiet', 'HEAD'])
         return ret == 1
 

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1494,7 +1494,8 @@ class AllPlatformTests(BasePlatformTests):
                     subproject('tarballsub', required : false)
                     subproject('samerepo', required : false)
                     '''))
-            with open(os.path.join(project_dir, 'distexe.c'), 'w', encoding='utf-8') as ofile:
+            distexe_c = os.path.join(project_dir, 'distexe.c')
+            with open(distexe_c, 'w', encoding='utf-8') as ofile:
                 ofile.write(textwrap.dedent('''\
                     #include<stdio.h>
 
@@ -1528,6 +1529,8 @@ class AllPlatformTests(BasePlatformTests):
             self.assertPathDoesNotExist(gz_checksumfile)
             self.assertPathDoesNotExist(zip_distfile)
             self.assertPathDoesNotExist(zip_checksumfile)
+            # update a source file timestamp; dist should succeed anyway
+            os.utime(distexe_c)
             self._run(self.meson_command + ['dist', '--formats', 'bztar'],
                       workdir=self.builddir)
             self.assertPathExists(bz_distfile)


### PR DESCRIPTION
Running `touch` on a tracked file in Git, to update its timestamp, and then running `meson dist` would cause dist to fail:

    ERROR: Repository has uncommitted changes that will not be included in the dist tarball
    Use --allow-dirty to ignore the warning and proceed anyway

Unlike `git status` and `git diff`, `git diff-index` doesn't refresh the index before comparing, so stat changes are assumed to imply content changes.  Run `git update-index -q --refresh` first to refresh the index.

Fixes: #12985