### PR TITLE
Use correct subdir when generating processed file path

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1818,13 +1818,9 @@ class Generator(HoldableObject):
             env=env if env is not None else EnvironmentVariables())
 
         for e in files:
-            if isinstance(e, CustomTarget):
-                output.depends.add(e)
-            if isinstance(e, CustomTargetIndex):
-                output.depends.add(e.target)
             if isinstance(e, (CustomTarget, CustomTargetIndex)):
                 output.depends.add(e)
-                fs = [File.from_built_file(state.subdir, f) for f in e.get_outputs()]
+                fs = [File.from_built_file(e.get_subdir(), f) for f in e.get_outputs()]
             elif isinstance(e, GeneratedList):
                 if preserve_path_from:
                     raise InvalidArguments("generator.process: 'preserve_path_from' is not allowed if one input is a 'generated_list'.")

--- a/test cases/common/276 generator custom_tgt subdir/include/meson.build
+++ b/test cases/common/276 generator custom_tgt subdir/include/meson.build
@@ -1,0 +1,4 @@
+test_header = custom_target(
+  output: 'test_header.h',
+  command: [python, args, '@OUTPUT@'],
+)

--- a/test cases/common/276 generator custom_tgt subdir/meson.build
+++ b/test cases/common/276 generator custom_tgt subdir/meson.build
@@ -1,0 +1,24 @@
+project('276 generator custom_tgt subdir')
+
+python = find_program('python3', required: true)
+args = [
+  '-c',
+  'import sys; open(sys.argv[1], "w")',
+  '@OUTPUT0@',
+]
+
+subdir('include')
+
+gen = generator(
+  python,
+  arguments: args + ['@OUTPUT@'],
+  output: '@PLAINNAME@.t',
+)
+
+custom_target(
+  'check-headers.stamp',
+  command: [python, args, '@INPUT@'],
+  input: gen.process(test_header),
+  output: 'check-headers.stamp',
+  build_by_default: true,
+)


### PR DESCRIPTION
We need the subdir of where the output file will actually be created, not the current subdir of the interpreter.

Fixes: #13168