### PR TITLE
Cuda linking

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1080,6 +1080,15 @@ class Backend:
                 continue
             if compiler.get_language() == 'd':
                 arg = '-Wl,' + arg
+            elif compiler.get_linker_id() == 'nvlink' and arg.endswith('.a'):
+                # We need to pass static archives without -Xlinker= to nvcc,
+                # since they may contain relocatable device code. When passing
+                # the static archive to nvcc with -Xlinker=, we bypass the
+                # frontend which means we lose the opportunity to perform device
+                # linking. We only need to do this for static archives, since
+                # nvcc doesn't support device linking with dynamic libraries:
+                # https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#libraries
+                pass
             else:
                 arg = compiler.get_linker_lib_prefix() + arg
             args.append(arg)

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -382,8 +382,11 @@ class CudaCompiler(Compiler):
                 # This is ambiguously either an MVSC-style /switch or an absolute path
                 # to a file. For some magical reason the following works acceptably in
                 # both cases.
+                # We only want to prefix arguments that are NOT static archives, since
+                # the latter could contain relocatable device code (-dc/-rdc=true).
+                prefix = '' if flag.endswith('.a') else f'-X{phase.value}='
                 wrap = '"' if ',' in flag else ''
-                xflags.append(f'-X{phase.value}={wrap}{flag}{wrap}')
+                xflags.append(f'{prefix}{wrap}{flag}{wrap}')
                 continue
             elif len(flag) >= 2 and flag[0] == '-' and flag[1] in 'IDULlmOxmte':
                 # This is a single-letter short option. These options (with the

--- a/mesonbuild/dependencies/cuda.py
+++ b/mesonbuild/dependencies/cuda.py
@@ -24,7 +24,7 @@ if T.TYPE_CHECKING:
 
 class CudaDependency(SystemDependency):
 
-    supported_languages = ['cuda', 'cpp', 'c'] # see also _default_language
+    supported_languages = ['cpp', 'c', 'cuda'] # see also _default_language
 
     def __init__(self, environment: 'Environment', kwargs: T.Dict[str, T.Any]) -> None:
         compilers = environment.coredata.compilers[self.get_for_machine_from_kwargs(kwargs)]

--- a/test cases/cuda/12 cuda dependency (mixed)/meson.build
+++ b/test cases/cuda/12 cuda dependency (mixed)/meson.build
@@ -1,4 +1,4 @@
 project('cuda dependency', 'cpp', 'cuda')
 
-exe = executable('prog', 'prog.cpp', 'kernel.cu', dependencies: dependency('cuda', modules: ['cublas']))
+exe = executable('prog', 'prog.cpp', 'kernel.cu', dependencies: dependency('cuda', modules: ['cublas']), link_language: 'cpp')
 test('cudatest', exe)

--- a/test cases/cuda/17 separate compilation linking/b.cu
+++ b/test cases/cuda/17 separate compilation linking/b.cu
@@ -1,0 +1,5 @@
+#include "b.h"
+
+__device__ int g[N];
+
+__device__ void bar(void) { g[threadIdx.x]++; }

--- a/test cases/cuda/17 separate compilation linking/b.h
+++ b/test cases/cuda/17 separate compilation linking/b.h
@@ -1,0 +1,5 @@
+#define N 8
+
+extern __device__ int g[N];
+
+extern __device__ void bar(void);

--- a/test cases/cuda/17 separate compilation linking/main.cu
+++ b/test cases/cuda/17 separate compilation linking/main.cu
@@ -1,0 +1,44 @@
+#include <stdio.h>
+
+#include "b.h"
+
+__global__ void foo(void)
+{
+    __shared__ int a[N];
+    a[threadIdx.x] = threadIdx.x;
+
+    __syncthreads();
+
+    g[threadIdx.x] = a[blockDim.x - threadIdx.x - 1];
+
+    bar();
+}
+
+int main(void)
+{
+    unsigned int i;
+    int *dg, hg[N];
+    int sum = 0;
+
+    foo<<<1, N>>>();
+
+    if (cudaGetSymbolAddress((void**)&dg, g)) {
+        printf("couldn't get the symbol addr\n");
+        return 1;
+    }
+    if (cudaMemcpy(hg, dg, N * sizeof(int), cudaMemcpyDeviceToHost)) {
+        printf("couldn't memcpy\n");
+        return 1;
+    }
+
+    for (i = 0; i < N; i++) {
+        sum += hg[i];
+    }
+    if (sum == 36) {
+        printf("PASSED\n");
+    } else {
+        printf("FAILED (%d)\n", sum);
+    }
+
+    return 0;
+}

--- a/test cases/cuda/17 separate compilation linking/meson.build
+++ b/test cases/cuda/17 separate compilation linking/meson.build
@@ -1,0 +1,19 @@
+# example here is inspired by Nvidia's blog post:
+#   https://developer.nvidia.com/blog/separate-compilation-linking-cuda-device-code/
+# code:
+#   https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#examples
+
+project('device linking', ['cpp', 'cuda'], version : '1.0.0')
+
+nvcc = meson.get_compiler('cuda')
+cuda = import('unstable-cuda')
+
+arch_flags = cuda.nvcc_arch_flags(nvcc.version(), 'Auto', detected : ['8.0'])
+
+message('NVCC version:   ' + nvcc.version())
+message('NVCC flags:     ' + ' '.join(arch_flags))
+
+# test device linking with -dc (which is equivalent to `--relocatable-device-code true`)
+lib = static_library('devicefuncs', ['b.cu'], cuda_args : ['-dc'] + arch_flags)
+exe = executable('app', 'main.cu', cuda_args : ['-dc'] + arch_flags, link_with : lib, link_args : arch_flags)
+test('cudatest', exe)


### PR DESCRIPTION
This PR fixes two issues:
1. When using `cuda_dep = dependency('cuda')` with another language (such as C or C++), the dependency lacked the correct `-L<CUDA_ROOT>/lib` flag, which lead to broken links:

        /usr/lib/gcc/x86_64-pc-linux-gnu/12/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lcudart_static: No such file or directory
        /usr/lib/gcc/x86_64-pc-linux-gnu/12/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lcublas: No such file or directory

2. Currently, Meson cannot produce valid CUDA binaries when multiple `.cu` files rely on separate compilation/device linking. Device linking implies that the final SASS/machine code is generated at link time, since no one `.cu` file contains all code necessary to build the final kernel code. The fix is somewhat painful, because we cannot pass static libraries to `nvcc` using `-Xlinker`, which requires more conditional code. Passing libraries using `-Xlinker=libfoo.a` would pass `libfoo.a` straight to the linker without `nvcc` being able to perform device linking. Unfortunately, removing `-Xlinker=` triggers the bug mentioned in https://github.com/mesonbuild/meson/issues/9479#issuecomment-953485040, which requires more conditional disabling of thin archives.