### PR TITLE
New `add_test_suite` function

### DIFF
--- a/data/syntax-highlighting/vim/syntax/meson.vim
+++ b/data/syntax-highlighting/vim/syntax/meson.vim
@@ -76,6 +76,7 @@ syn keyword mesonBuiltin
   \ add_project_dependencies
   \ add_project_link_arguments
   \ add_test_setup
+  \ add_test_suite
   \ alias_target
   \ assert
   \ benchmark

--- a/docs/markdown/snippets/add_test_suite.md
+++ b/docs/markdown/snippets/add_test_suite.md
@@ -1,0 +1,5 @@
+## New `add_test_suite` function
+
+This function allows to attach new suite labels to already defined tests
+or benchmarks. In is used in the context you want to label a series of test
+with a specific label.

--- a/docs/yaml/functions/add_test_suite.yaml
+++ b/docs/yaml/functions/add_test_suite.yaml
@@ -1,0 +1,21 @@
+name: add_test_suite
+returns: void
+since: 1.5.0
+description: |
+  Add the specified tests or benchmarks to a test suite.
+  This function allows to gather in one place all the tests belonging to a
+  given suite.
+
+posargs:
+  suite:
+    type: str
+    description: |
+      `'label'` to attach to the tests.
+      The suite name is qualified by a (sub)project
+      name resulting in `(sub)project_name:label`.
+  
+varargs:
+  name: Test
+  type: test
+  min_varargs: 1
+  description: The test or benchmark on which to attach the label.

--- a/docs/yaml/functions/benchmark.yaml
+++ b/docs/yaml/functions/benchmark.yaml
@@ -1,5 +1,5 @@
 name: benchmark
-returns: void
+returns: test
 description: |
   Creates a benchmark item that will be run when the benchmark target is
   run. The behavior of this function is identical to [[test]]

--- a/docs/yaml/functions/test.yaml
+++ b/docs/yaml/functions/test.yaml
@@ -1,5 +1,5 @@
 name: test
-returns: void
+returns: test
 description: |
   Defines a test to run with the test harness. Takes two positional
   arguments, the first is the name of the test and the second is the

--- a/docs/yaml/objects/test.yaml
+++ b/docs/yaml/objects/test.yaml
@@ -1,0 +1,4 @@
+name: test
+long_name: Test Target
+description: Opaque object for test and benchmark targets
+since: 1.5.0

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -146,6 +146,7 @@ class AstInterpreter(InterpreterBase):
                            'option': self.func_do_nothing,
                            'both_libraries': self.func_do_nothing,
                            'add_test_setup': self.func_do_nothing,
+                           'add_test_suite': self.func_do_nothing,
                            'subdir_done': self.func_do_nothing,
                            'alias_target': self.func_do_nothing,
                            'summary': self.func_do_nothing,

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -349,6 +349,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                            'add_project_dependencies': self.func_add_project_dependencies,
                            'add_project_link_arguments': self.func_add_project_link_arguments,
                            'add_test_setup': self.func_add_test_setup,
+                           'add_test_suite': self.func_add_test_suite,
                            'alias_target': self.func_alias_target,
                            'assert': self.func_assert,
                            'benchmark': self.func_benchmark,
@@ -2883,6 +2884,18 @@ class Interpreter(InterpreterBase, HoldableObject):
             self.build.test_setup_default_name = setup_name
         self.build.test_setups[setup_name] = build.TestSetup(exe_wrapper, kwargs['gdb'], timeout_multiplier, kwargs['env'],
                                                              kwargs['exclude_suites'])
+
+    @FeatureNew('add_test_suite', '1.5.0')
+    @typed_pos_args('add_test_suite', str, varargs=Test, min_varargs=1)
+    @noKwargs
+    def func_add_test_suite(self, node: mparser.FunctionNode, args: T.Tuple[str, T.List[Test]], kwargs: TYPE_kwargs) -> None:
+        suite, tests = args
+        if suite:
+            suite = ':' + suite
+        for test in tests:
+            suite_name = test.project_name.replace(' ', '_').replace(':', '_') + suite
+            if suite_name not in test.suite:
+                test.suite.append(suite_name)
 
     @typed_pos_args('add_global_arguments', varargs=str)
     @typed_kwargs('add_global_arguments', NATIVE_KW, LANGUAGE_KW)

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -754,7 +754,7 @@ class EmptyDirHolder(ObjectHolder[build.EmptyDir]):
 class GeneratedObjectsHolder(ObjectHolder[build.ExtractedObjects]):
     pass
 
-class Test(MesonInterpreterObject):
+class Test(MesonInterpreterObject, HoldableObject):
     def __init__(self, name: str, project: str, suite: T.List[str],
                  exe: T.Union[ExternalProgram, build.Executable, build.CustomTarget, build.CustomTargetIndex],
                  depends: T.List[T.Union[build.CustomTarget, build.BuildTarget]],
@@ -784,6 +784,9 @@ class Test(MesonInterpreterObject):
 
     def get_name(self) -> str:
         return self.name
+
+class TestHolder(ObjectHolder[Test]):
+    pass
 
 class NullSubprojectInterpreter(HoldableObject):
     pass

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -2113,11 +2113,11 @@ class TestHarness:
             for l in self.loggers:
                 await l.finish(self)
 
-def list_tests(th: TestHarness) -> bool:
+def list_tests(th: TestHarness) -> int:
     tests = th.get_tests(errorfile=sys.stderr)
     for t in tests:
         print(th.get_pretty_suite(t))
-    return not tests
+    return 0 if tests else 1
 
 def rebuild_deps(ninja: T.List[str], wd: str, tests: T.List[TestSerialisation]) -> bool:
     def convert_path_to_target(path: str) -> str:

--- a/run_tests.py
+++ b/run_tests.py
@@ -282,7 +282,7 @@ def get_backend_commands(backend: Backend, debug: bool = False) -> \
         raise AssertionError(f'Unknown backend: {backend!r}')
     return cmd, clean_cmd, test_cmd, install_cmd, uninstall_cmd
 
-def run_mtest_inprocess(commandlist: T.List[str]) -> T.Tuple[int, str, str]:
+def run_mtest_inprocess(commandlist: T.List[str]) -> T.Tuple[int, str]:
     out = StringIO()
     with mock.patch.object(sys, 'stdout', out), mock.patch.object(sys, 'stderr', out):
         returncode = mtest.run_with_args(commandlist)

--- a/test cases/unit/124 test suite/meson.build
+++ b/test cases/unit/124 test suite/meson.build
@@ -1,0 +1,13 @@
+project('test suite', meson_version: '>= 1.5.0')
+
+py = find_program('python3')
+args = ['-c', 'raise SystemExit(0)']
+
+test_a = test('test A', py, args: args, suite: 'A')
+test_b = test('test B', py, args: args, suite: ['A', 'B'])
+test_c = test('test C', py, args: args)
+bench_d = benchmark('bench D', py, args: args)
+
+add_test_suite('all', test_a, test_b, test_c)
+add_test_suite('everything', [test_a, [test_b], test_c], bench_d)
+add_test_suite('A', test_a, test_c)


### PR DESCRIPTION
This function allows to attach new suite labels to already defined tests
or benchmarks. It is used in the context you want to label a series of
test with a specific label.