### PR TITLE
Add support for GCC's null_terminated_string_arg function attribute

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -272,54 +272,55 @@ These values are supported using the GCC style `__attribute__` annotations,
 which are supported by GCC, Clang, and other compilers.
 
 
-| Name                     |
-|--------------------------|
-| alias                    |
-| aligned                  |
-| alloc_size               |
-| always_inline            |
-| artificial               |
-| cold                     |
-| const                    |
-| constructor              |
-| constructor_priority     |
-| deprecated               |
-| destructor               |
-| error                    |
-| externally_visible       |
-| fallthrough              |
-| flatten                  |
-| format                   |
-| format_arg               |
-| force_align_arg_pointer³ |
-| gnu_inline               |
-| hot                      |
-| ifunc                    |
-| malloc                   |
-| noclone                  |
-| noinline                 |
-| nonnull                  |
-| noreturn                 |
-| nothrow                  |
-| optimize                 |
-| packed                   |
-| pure                     |
-| retain⁴                  |
-| returns_nonnull          |
-| section⁵                 |
-| sentinel⁵                |
-| unused                   |
-| used                     |
-| vector_size⁶             |
-| visibility*              |
-| visibility:default†      |
-| visibility:hidden†       |
-| visibility:internal†     |
-| visibility:protected†    |
-| warning                  |
-| warn_unused_result       |
-| weak                     |
-| weakref                  |
+| Name                        |
+|-----------------------------|
+| alias                       |
+| aligned                     |
+| alloc_size                  |
+| always_inline               |
+| artificial                  |
+| cold                        |
+| const                       |
+| constructor                 |
+| constructor_priority        |
+| deprecated                  |
+| destructor                  |
+| error                       |
+| externally_visible          |
+| fallthrough                 |
+| flatten                     |
+| format                      |
+| format_arg                  |
+| force_align_arg_pointer³    |
+| gnu_inline                  |
+| hot                         |
+| ifunc                       |
+| malloc                      |
+| noclone                     |
+| noinline                    |
+| nonnull                     |
+| noreturn                    |
+| nothrow                     |
+| null_terminated_string_arg⁷ |
+| optimize                    |
+| packed                      |
+| pure                        |
+| retain⁴                     |
+| returns_nonnull             |
+| section⁵                    |
+| sentinel⁵                   |
+| unused                      |
+| used                        |
+| vector_size⁶                |
+| visibility*                 |
+| visibility:default†         |
+| visibility:hidden†          |
+| visibility:internal†        |
+| visibility:protected†       |
+| warning                     |
+| warn_unused_result          |
+| weak                        |
+| weakref                     |
 
 \* *Changed in 0.52.0* the "visibility" target no longer includes
 "protected", which is not present in Apple's clang.
@@ -334,6 +335,8 @@ which are supported by GCC, Clang, and other compilers.
 ⁵ *New in 0.63.0*
 
 ⁶ *New in 1.1.0*
+
+⁷ *New in 1.5.0*
 
 ### MSVC __declspec
 

--- a/docs/markdown/snippets/null_terminated_string_arg.md
+++ b/docs/markdown/snippets/null_terminated_string_arg.md
@@ -1,0 +1,13 @@
+## Added support for GCC's `null_terminated_string_arg` function attribute
+
+You can now check if a compiler support the `null_terminated_string_arg`
+function attribute via the `has_function_attribute()` method on the
+[[@compiler]] object.
+
+```meson
+cc = meson.get_compiler('c')
+
+if cc.has_function_attribute('null_terminated_string_arg')
+  # We have it...
+endif
+```

--- a/mesonbuild/compilers/c_function_attributes.py
+++ b/mesonbuild/compilers/c_function_attributes.py
@@ -80,6 +80,8 @@ C_FUNC_ATTRIBUTES = {
         'int foo(void) __attribute__((noreturn));',
     'nothrow':
         'int foo(void) __attribute__((nothrow));',
+    'null_terminated_string_arg':
+        'int foo(const char * p) __attribute__((null_terminated_string_arg(1)));',
     'optimize':
         '__attribute__((optimize(3))) int foo(void) { return 0; }',
     'packed':

--- a/test cases/common/197 function attributes/meson.build
+++ b/test cases/common/197 function attributes/meson.build
@@ -117,6 +117,12 @@ if ['gcc', 'intel'].contains(c.get_id())
   endif
 endif
 
+if c.get_id() == 'gcc'
+  if c.version().version_compare('>= 14.1')
+    attributes += 'null_terminated_string_arg'
+  endif
+endif
+
 if get_option('mode') == 'single'
   foreach a : attributes
     x = c.has_function_attribute(a)


### PR DESCRIPTION
This is new as of 14.1.