### PR TITLE
Ensure private directory exists for custom targets

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1574,9 +1574,9 @@ class Backend:
                     dfilename = os.path.join(outdir, target.depfile)
                     i = i.replace('@DEPFILE@', dfilename)
                 if '@PRIVATE_DIR@' in i:
-                    if target.absolute_paths:
-                        pdir = self.get_target_private_dir_abs(target)
-                    else:
+                    pdir = self.get_target_private_dir_abs(target)
+                    os.makedirs(pdir, exist_ok=True)
+                    if not target.absolute_paths:
                         pdir = self.get_target_private_dir(target)
                     i = i.replace('@PRIVATE_DIR@', pdir)
             else:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -865,11 +865,8 @@ class NinjaBackend(backends.Backend):
             tgt[lnk_hash] = lnk_block
 
     def generate_target(self, target):
-        try:
-            if isinstance(target, build.BuildTarget):
-                os.makedirs(self.get_target_private_dir_abs(target))
-        except FileExistsError:
-            pass
+        if isinstance(target, build.BuildTarget):
+            os.makedirs(self.get_target_private_dir_abs(target), exist_ok=True)
         if isinstance(target, build.CustomTarget):
             self.generate_custom_target(target)
         if isinstance(target, build.RunTarget):

--- a/test cases/common/277 custom target private dir/meson.build
+++ b/test cases/common/277 custom target private dir/meson.build
@@ -1,0 +1,16 @@
+project('277 custom target private dir')
+
+python = find_program('python3')
+
+custom_target(
+  'check-private-dir',
+  command: [
+    python,
+    '-c',
+    'import os, sys; os.chdir(sys.argv[1]); open(sys.argv[2], "w")',
+    '@PRIVATE_DIR@',
+    '@OUTPUT@',
+  ],
+  output: 'check-private-dir',
+  build_by_default: true,
+)


### PR DESCRIPTION
Some custom target commands will expect the `@PRIVATE_DIR@` to already exist, such as with `make -C @PRIVATE_DIR@ ...`