### PR TITLE
fix support for python 3.13

### DIFF
--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -148,23 +148,29 @@ def set_chown(path: str, user: T.Union[str, int, None] = None,
     # be actually passed properly.
     # Not nice, but better than actually rewriting shutil.chown until
     # this python bug is fixed: https://bugs.python.org/issue18108
-    real_os_chown = os.chown
 
-    def chown(path: T.Union[int, str, 'os.PathLike[str]', bytes, 'os.PathLike[bytes]'],
-              uid: int, gid: int, *, dir_fd: T.Optional[int] = dir_fd,
-              follow_symlinks: bool = follow_symlinks) -> None:
-        """Override the default behavior of os.chown
+    if sys.version_info >= (3, 13):
+        # pylint: disable=unexpected-keyword-arg
+        # cannot handle sys.version_info, https://github.com/pylint-dev/pylint/issues/9138
+        shutil.chown(path, user, group, dir_fd=dir_fd, follow_symlinks=follow_symlinks)
+    else:
+        real_os_chown = os.chown
 
-        Use a real function rather than a lambda to help mypy out. Also real
-        functions are faster.
-        """
-        real_os_chown(path, uid, gid, dir_fd=dir_fd, follow_symlinks=follow_symlinks)
+        def chown(path: T.Union[int, str, 'os.PathLike[str]', bytes, 'os.PathLike[bytes]'],
+                  uid: int, gid: int, *, dir_fd: T.Optional[int] = dir_fd,
+                  follow_symlinks: bool = follow_symlinks) -> None:
+            """Override the default behavior of os.chown
 
-    try:
-        os.chown = chown
-        shutil.chown(path, user, group)
-    finally:
-        os.chown = real_os_chown
+            Use a real function rather than a lambda to help mypy out. Also real
+            functions are faster.
+            """
+            real_os_chown(path, uid, gid, dir_fd=dir_fd, follow_symlinks=follow_symlinks)
+
+        try:
+            os.chown = chown
+            shutil.chown(path, user, group)
+        finally:
+            os.chown = real_os_chown
 
 
 def set_chmod(path: str, mode: int, dir_fd: T.Optional[int] = None,

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -242,10 +242,11 @@ class MesonApp:
 
             self.finalize_postconf_hooks(b, intr)
             if self.options.profile:
+                localvars = locals()
                 fname = f'profile-{intr.backend.name}-backend.log'
                 fname = os.path.join(self.build_dir, 'meson-logs', fname)
-                profile.runctx('gen_result = intr.backend.generate(capture, vslite_ctx)', globals(), locals(), filename=fname)
-                captured_compile_args = locals()['gen_result']
+                profile.runctx('gen_result = intr.backend.generate(capture, vslite_ctx)', globals(), localvars, filename=fname)
+                captured_compile_args = localvars['gen_result']
                 assert captured_compile_args is None or isinstance(captured_compile_args, dict)
             else:
                 captured_compile_args = intr.backend.generate(capture, vslite_ctx)


### PR DESCRIPTION
minstall: fix symlink handling on python 3.13

We passed a wrapper hack for shutil.chown because some functionality wasn't available in the stdlib. It was added in python 3.13 beta1, so the tests fail when we actually test symlink handling.

Fixes failure to run test_install_subdir_symlinks_with_default_umask_and_mode on python 3.13.

...

There's still another failing test that I haven't debugged yet but I am running out of time this Friday.