### PR TITLE
Fix handling of C standard support for Emscripten

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -201,6 +201,16 @@ class EmscriptenCCompiler(EmscriptenMixin, ClangCCompiler):
 
     id = 'emscripten'
 
+    # Emscripten uses different version numbers than Clang; `emcc -v` will show
+    # the Clang version number used as well (but `emcc --version` does not).
+    # See https://github.com/pyodide/pyodide/discussions/4762 for more on
+    # emcc <--> clang versions. Note that c17/c18/c2x are always available, since
+    # the lowest supported Emscripten version used a new-enough Clang version.
+    _C17_VERSION = '>=1.38.35'
+    _C18_VERSION = '>=1.38.35'
+    _C2X_VERSION = '>=1.38.35'  # 1.38.35 used Clang 9.0.0
+    _C23_VERSION = '>=3.0.0'    # 3.0.0 used Clang 18.0.0
+
     def __init__(self, ccache: T.List[str], exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo',
                  linker: T.Optional['DynamicLinker'] = None,

--- a/test cases/wasm/1 basic/meson.build
+++ b/test cases/wasm/1 basic/meson.build
@@ -1,4 +1,9 @@
-project('emcctest', 'c', 'cpp')
+project('emcctest', 'c', 'cpp',
+  default_options: [
+    'c_std=c17',
+    'cpp_std=c++17',
+  ]
+)
 
 executable('hello-c', 'hello.c')
 executable('hello', 'hello.cpp')


### PR DESCRIPTION
Emscripten version numbers are unrelated to Clang version numbers, so it is necessary to change the version checks for `c_std=c17` & co. Without that, no project that defaults to C17 or newer will build with Emscripten.

See https://github.com/pyodide/pyodide/discussions/4762 for more context. Also note that this bug caused defaulting to C17 in scikit-learn to be reverted (scikit-learn#29015), and it may be a problem for SciPy 1.14.0 too since that release will upgrade from C99 to C17.

Cc @lesteve.