### PR TITLE
Pass wrapmode value around a a string.

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -46,7 +46,6 @@ if T.TYPE_CHECKING:
     from .mesonlib import ExecutableSerialisation, FileMode, FileOrString
     from .modules import ModuleState
     from .mparser import BaseNode
-    from .wrap import WrapMode
 
     GeneratedTypes = T.Union['CustomTarget', 'CustomTargetIndex', 'GeneratedList']
     LibTypes = T.Union['SharedLibrary', 'StaticLibrary', 'CustomTarget', 'CustomTargetIndex']
@@ -662,12 +661,10 @@ class Target(HoldableObject, metaclass=abc.ABCMeta):
     def get_options(self) -> coredata.OptionsView:
         return self.options
 
-    def get_option(self, key: 'OptionKey') -> T.Union[str, int, bool, 'WrapMode']:
-        # We don't actually have wrapmode here to do an assert, so just do a
-        # cast, we know what's in coredata anyway.
+    def get_option(self, key: 'OptionKey') -> T.Union[str, int, bool]:
         # TODO: if it's possible to annotate get_option or validate_option_value
         # in the future we might be able to remove the cast here
-        return T.cast('T.Union[str, int, bool, WrapMode]', self.options[key].value)
+        return T.cast('T.Union[str, int, bool]', self.options[key].value)
 
     @staticmethod
     def parse_overrides(kwargs: T.Dict[str, T.Any]) -> T.Dict[OptionKey, str]:

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -23,7 +23,6 @@ from .mesonlib import (
     listify_array_value, OptionKey, OptionType, stringlistify,
     pickle_load
 )
-from .wrap import WrapMode
 import ast
 import argparse
 import configparser
@@ -749,11 +748,9 @@ class CoreData:
                 'Default project to execute in Visual Studio',
                 '')
 
-    def get_option(self, key: OptionKey) -> T.Union[T.List[str], str, int, bool, WrapMode]:
+    def get_option(self, key: OptionKey) -> T.Union[T.List[str], str, int, bool]:
         try:
             v = self.options[key].value
-            if key.name == 'wrap_mode':
-                return WrapMode[v]
             return v
         except KeyError:
             pass
@@ -761,8 +758,6 @@ class CoreData:
         try:
             v = self.options[key.as_root()]
             if v.yielding:
-                if key.name == 'wrap_mode':
-                    return WrapMode[v.value]
                 return v.value
         except KeyError:
             pass

--- a/mesonbuild/interpreter/dependencyfallbacks.py
+++ b/mesonbuild/interpreter/dependencyfallbacks.py
@@ -315,8 +315,7 @@ class DependencyFallbacksHolder(MesonInterpreterObject):
             return self._notfound_dependency()
 
         # Check if usage of the subproject fallback is forced
-        wrap_mode = self.coredata.get_option(OptionKey('wrap_mode'))
-        assert isinstance(wrap_mode, WrapMode), 'for mypy'
+        wrap_mode = WrapMode.from_string(self.coredata.get_option(OptionKey('wrap_mode')))
         force_fallback_for = self.coredata.get_option(OptionKey('force_fallback_for'))
         assert isinstance(force_fallback_for, list), 'for mypy'
         self.nofallback = wrap_mode == WrapMode.nofallback

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1284,7 +1284,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         self.build.subproject_dir = self.subproject_dir
 
         # Load wrap files from this (sub)project.
-        wrap_mode = self.coredata.get_option(OptionKey('wrap_mode'))
+        wrap_mode = WrapMode.from_string(self.coredata.get_option(OptionKey('wrap_mode')))
         if not self.is_subproject() or wrap_mode != WrapMode.nopromote:
             subdir = os.path.join(self.subdir, spdirname)
             r = wrap.Resolver(self.environment.get_source_dir(), subdir, self.subproject, wrap_mode)
@@ -1679,7 +1679,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             return ExternalProgram('meson', self.environment.get_build_command(), silent=True)
 
         fallback = None
-        wrap_mode = self.coredata.get_option(OptionKey('wrap_mode'))
+        wrap_mode = WrapMode.from_string(self.coredata.get_option(OptionKey('wrap_mode')))
         if wrap_mode != WrapMode.nofallback and self.environment.wrap_resolver:
             fallback = self.environment.wrap_resolver.find_program_provider(args)
         if fallback and wrap_mode == WrapMode.forcefallback:

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -18,7 +18,6 @@ if T.TYPE_CHECKING:
     from ..interpreter.interpreter import ProgramVersionFunc
     from ..interpreterbase import TYPE_var, TYPE_kwargs
     from ..programs import OverrideProgram
-    from ..wrap import WrapMode
     from ..dependencies import Dependency
 
 class ModuleState:
@@ -134,7 +133,7 @@ class ModuleState:
     def get_option(self, name: str, subproject: str = '',
                    machine: MachineChoice = MachineChoice.HOST,
                    lang: T.Optional[str] = None,
-                   module: T.Optional[str] = None) -> T.Union[T.List[str], str, int, bool, 'WrapMode']:
+                   module: T.Optional[str] = None) -> T.Union[T.List[str], str, int, bool]:
         return self.environment.coredata.get_option(mesonlib.OptionKey(name, subproject, machine, lang, module))
 
     def is_user_defined_option(self, name: str, subproject: str = '',


### PR DESCRIPTION
Because the return value of get_option can be WrapMode, _every_ single place where options are used need to handle WrapMode.

This MR changes it to be a basic string combo, which gets transformed into a WrapMode only at the point where it is actually used.

This simplifies things for the option rewrite branch.