### PR TITLE
clike compiler args: ignore -Xclang it and whatever comes after it

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -76,7 +76,15 @@ class CLikeCompilerArgs(arglist.CompilerArgs):
         if isinstance(self.compiler.linker, (GnuLikeDynamicLinkerMixin, SolarisDynamicLinker, CompCertDynamicLinker)):
             group_start = -1
             group_end = -1
+            ignore = False
             for i, each in enumerate(new):
+                if ignore:
+                    ignore = False
+                    continue
+                if each == "-Xclang":
+                    ignore = True
+                    continue
+
                 if not GROUP_FLAGS.search(each):
                     continue
                 group_end = i


### PR DESCRIPTION
I wanted to build QEMU under clang with a custom plugin (for the compiler itself). Via `--extra-cflags`, I shuttled the following into the CFLAGS:

```
-Xclang -load -Xclang /usr/local/lib/carbon-collect.so -Xclang -add-plugin -Xclang carbon-collect -Xclang -plugin-arg-carbon-collect -Xclang "$(pwd)" -Xclang -plugin-arg-carbon-collect -Xclang "$(pwd)"
```

This did not build, meson threw an error, because it bungled the arguments given to the compiler, see #11184 for more details.

I believe that when meson goes about figuring out `'-Wl,--start-group'` and `'-Wl,--end-group'`, it assumes that `/usr/local/lib/carbon-collect.so` is a DSO in the build, when it is in fact a plugin to the compiler itself (which happens to be a shared library).

It seems to me that anything could come after an '-Xclang'.  Do other compilers out there have an analogous command-line option? Does this need to be configurable?