### PR TITLE
Fix meson format crash

### DIFF
--- a/mesonbuild/mformat.py
+++ b/mesonbuild/mformat.py
@@ -626,6 +626,7 @@ class ArgumentFormatter(FullAstVisitor):
             if need_comma and not has_trailing_comma:
                 comma = mparser.SymbolNode(mparser.Token('comma', node.filename, 0, 0, 0, (0, 0), ','))
                 comma.condition_level = node.condition_level
+                comma.whitespaces = mparser.WhitespaceNode(mparser.Token('whitespace', node.filename, 0, 0, 0, (0, 0), ''))
                 node.commas.append(comma)
             elif has_trailing_comma and not need_comma:
                 node.commas.pop(-1)

--- a/mesonbuild/mformat.py
+++ b/mesonbuild/mformat.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 import re
 import typing as T
-from configparser import ConfigParser, MissingSectionHeaderError
+from configparser import ConfigParser, MissingSectionHeaderError, ParsingError
 from copy import deepcopy
 from dataclasses import dataclass, field, fields, asdict
 from pathlib import Path
@@ -829,7 +829,10 @@ class Formatter:
         config = FormatterConfig()
         if configuration_file:
             cp = DefaultConfigParser()
-            cp.read_default(configuration_file)
+            try:
+                cp.read_default(configuration_file)
+            except ParsingError as e:
+                raise MesonException(f'Unable to parse configuration file "{configuration_file}":\n{e}') from e
 
             for f in fields(config):
                 getter = f.metadata['getter']

--- a/test cases/format/1 default/gh13242.meson
+++ b/test cases/format/1 default/gh13242.meson
@@ -1,0 +1,18 @@
+# Minimized meson.build
+test(
+    args: [
+        shared_library(
+            f'tstlib-@name@',
+            build_by_default: false,
+            override_options: opt,
+        ),
+    ],
+)
+
+test(
+    should_fail: (settings.get('x', false) and not settings['y'] and dep.version(
+        
+    ).version_compare(
+        '>=1.2.3',
+    )),
+)

--- a/test cases/format/1 default/meson.build
+++ b/test cases/format/1 default/meson.build
@@ -7,6 +7,7 @@ meson_files = {
     'self': files('meson.build'),
     'comments': files('crazy_comments.meson'),
     'indentation': files('indentation.meson'),
+    'gh13242': files('gh13242.meson'),
 }
 
 foreach name, f : meson_files


### PR DESCRIPTION
There was a case where a trailing comma was missing a whitespaces attribute

Fixes https://github.com/mesonbuild/meson/issues/13242