### PR TITLE
remove deprecation warning for `configure_file` kwarg 'copy'

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2585,7 +2585,6 @@ class Interpreter(InterpreterBase, HoldableObject):
         ),
         KwargInfo(
             'copy', bool, default=False, since='0.47.0',
-            deprecated='0.64.0', deprecated_message='Use fs.copyfile instead',
         ),
         KwargInfo('encoding', str, default='utf-8', since='0.47.0'),
         KwargInfo('format', str, default='meson', since='0.46.0',


### PR DESCRIPTION
`configure_file` kwarg `copy` runs at configure time, whereas `fs.copyfile` runs at build time. Both have use cases, so this undeprecates the `configure_file` version.

Fixes: #12792