### PR TITLE
Defer evaluating ModuleState.project_version

### DIFF
--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -40,7 +40,6 @@ class ModuleState:
         self.current_lineno = interpreter.current_lineno
         self.environment = interpreter.environment
         self.project_name = interpreter.build.project_name
-        self.project_version = interpreter.build.dep_manifest[interpreter.active_projectname].version
         # The backend object is under-used right now, but we will need it:
         # https://github.com/mesonbuild/meson/issues/1419
         self.backend = interpreter.backend
@@ -51,6 +50,10 @@ class ModuleState:
         self.global_args = interpreter.build.global_args.host
         self.project_args = interpreter.build.projects_args.host.get(interpreter.subproject, {})
         self.current_node = interpreter.current_node
+
+    @property
+    def project_version(self) -> str:
+        return self._interpreter.build.dep_manifest[self._interpreter.active_projectname].version
 
     def get_include_args(self, include_dirs: T.Iterable[T.Union[str, build.IncludeDirs]], prefix: str = '-I') -> T.List[str]:
         if not include_dirs:

--- a/mesonbuild/modules/external_project.py
+++ b/mesonbuild/modules/external_project.py
@@ -62,7 +62,6 @@ class ExternalProject(NewExtensionModule):
                              })
 
         self.subdir = Path(state.subdir)
-        self.project_version = state.project_version
         self.subproject = state.subproject
         self.env = state.environment
         self.configure_command = configure_command
@@ -262,7 +261,7 @@ class ExternalProject(NewExtensionModule):
             abs_includedir = Path(abs_includedir, kwargs['subdir'])
         abs_libdir = Path(self.install_dir, self.rel_prefix, self.libdir)
 
-        version = self.project_version
+        version = state.project_version
         compile_args = [f'-I{abs_includedir}']
         link_args = [f'-L{abs_libdir}', f'-l{libname}']
         sources = self.target


### PR DESCRIPTION
This property is only used in `pkgconfig.generate`, and `external_project.dependency`, not elsewhere. By avoiding this evaluation, it fixes an exception if using `import` in the `version` argument of `project`.

Fixes #5134

I'm not sure if this should go in a test or not; do we want to codify the example from #5134 as an intended way to do things?