### PR TITLE
Optional cuda thin archives

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1531,6 +1531,10 @@ class Interpreter(InterpreterBase, HoldableObject):
                         continue
                     else:
                         raise
+                if lang == 'cuda' and hasattr(self.backend, 'allow_thin_archives'):
+                    # see NinjaBackend.__init__() why we need to disable thin archives for cuda
+                    mlog.debug('added cuda as language, disabling thin archives for {}, since nvcc/nvlink cannot handle thin archives natively'.format(for_machine))
+                    self.backend.allow_thin_archives[for_machine] = False
             else:
                 # update new values from commandline, if it applies
                 self.coredata.process_compiler_options(lang, comp, self.environment, self.subproject)

--- a/test cases/cuda/17 separate compilation linking/meson.build
+++ b/test cases/cuda/17 separate compilation linking/meson.build
@@ -3,7 +3,10 @@
 # code:
 #   https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#examples
 
-project('device linking', ['cpp', 'cuda'], version : '1.0.0')
+project('device linking', ['cpp'], version : '1.0.0')
+
+# test that optional initialization of cuda works to disable thin archives
+add_languages('cuda')
 
 nvcc = meson.get_compiler('cuda')
 cuda = import('unstable-cuda')


### PR DESCRIPTION
This fixes the problem of thin archives when CUDA is optional and only added later through `add_languages('cuda')`