### PR TITLE
dependencies/boost.py: Allow getting `lib_dir` and `include_dir` via pkg-config

### DIFF
--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -653,9 +653,19 @@ class BoostDependency(SystemDependency):
         try:
             boost_pc = PkgConfigDependency('boost', self.env, {'required': False})
             if boost_pc.found():
-                boost_root = boost_pc.get_variable(pkgconfig='prefix')
-                if boost_root:
-                    roots += [Path(boost_root)]
+                boost_lib_dir = boost_pc.get_variable(pkgconfig='libdir')
+                boost_inc_dir = boost_pc.get_variable(pkgconfig='includedir')
+                if boost_lib_dir and boost_inc_dir:
+                    mlog.debug('Trying to find boost with:')
+                    mlog.debug(f'  - boost_includedir = {Path(boost_inc_dir)}')
+                    mlog.debug(f'  - boost_librarydir = {Path(boost_lib_dir)}')
+
+                    self.detect_split_root(Path(boost_inc_dir), Path(boost_lib_dir))
+                    return
+                else:
+                    boost_root = boost_pc.get_variable(pkgconfig='prefix')
+                    if boost_root:
+                        roots += [Path(boost_root)]
         except DependencyException:
             pass
 


### PR DESCRIPTION
`boost_root` doesn't work if lib and include are in different directories like in the `nix` `boost` package.

The `prefix` checking could probably be removed, in 2019 conan (the
reason why the check was added) had `libdir` and `includedir` in its
generated pkg-config file
https://github.com/mesonbuild/meson/issues/5438#issuecomment-498761454

If there's no return then boost isn't found for some reason, further logic is unnecessary in any case if direct paths are passed.

`roots += [Path(boost_lib_dir), Path(boost_inc_dir)]` did not work