### PR TITLE
Fix environment() description

### DIFF
--- a/docs/yaml/functions/environment.yaml
+++ b/docs/yaml/functions/environment.yaml
@@ -1,7 +1,7 @@
 name: environment
 returns: env
 since: 0.35.0
-description: Returns an empty [[@env]] object.
+description: Returns an [[@env]] object capturing the current environment.
 
 arg_flattening: false
 


### PR DESCRIPTION
The current [description for `environment()`](https://mesonbuild.com/Reference-manual_functions.html#environment) says

> Returns an empty `env` object.

Which doesn't seem true to me. The returned `env` object in fact contains the current environment, no?

This PR fixes the description to reflect that.