### PR TITLE
compilers: cpp: fix header name and return value use in header check

### DIFF
--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -185,7 +185,7 @@ class _StdCPPLibMixin(CompilerMixinBase):
 
     def language_stdlib_provider(self, env: Environment) -> str:
         # https://stackoverflow.com/a/31658120
-        header = 'version' if self.has_header('<version>', '', env) else 'ciso646'
+        header = 'version' if self.has_header('version', '', env)[0] else 'ciso646'
         is_libcxx = self.has_header_symbol(header, '_LIBCPP_VERSION', '', env)[0]
         lib = 'c++' if is_libcxx else 'stdc++'
         return lib


### PR DESCRIPTION
There are two issues:

1. has_header() wants just the header name without surrounding <> or similar; it fails otherwise.

2. has_header() returns a tuple of two bools, where the first element determines whether or not the header has been found. So use that element specifically, otherwise the tuple will always evaluate to true because it is not empty.