### PR TITLE
Add meson test --max-lines

### DIFF
--- a/data/shell-completions/bash/meson
+++ b/data/shell-completions/bash/meson
@@ -580,6 +580,7 @@ _meson-test() {
     quiet
     timeout-multiplier
     setup
+    max-lines
     test-args
   )
 

--- a/data/shell-completions/zsh/_meson
+++ b/data/shell-completions/zsh/_meson
@@ -196,6 +196,7 @@ local -a meson_commands=(
   '(--quiet -q)'{'--quiet','-q'}'[produce less output to the terminal]'
   '(--timeout-multiplier -t)'{'--timeout-multiplier','-t'}'[a multiplier for test timeouts]:Python floating-point number: '
   '--setup[which test setup to use]:test setup: '
+  '--max-lines[Maximum number of lines to show from a long test log]:Python integer number: '
   '--test-args[arguments to pass to the tests]: : '
   '*:Meson tests:__meson_test_names'
   )

--- a/docs/markdown/Unit-tests.md
+++ b/docs/markdown/Unit-tests.md
@@ -274,6 +274,14 @@ other useful information as the environmental variables. This is
 useful, for example, when you run the tests on Travis-CI, Jenkins and
 the like.
 
+By default, the output from tests will be limited to the last 100 lines. The
+maximum number of lines to show can be configured with the `--max-lines` option
+*(added 1.5.0)*:
+
+```console
+$ meson test --max-lines=1000 testname
+```
+
 **Timeout**
 
 In the test case options, the `timeout` option is specified in a number of seconds.

--- a/docs/markdown/snippets/test_max_lines.md
+++ b/docs/markdown/snippets/test_max_lines.md
@@ -1,0 +1,6 @@
+## The Meson test program supports a new "--max-lines" argument
+
+By default `meson test` only shows the last 100 lines of test output from tests
+that produce large amounts of output. This default can now be changed with the
+new `--max-lines` option. For example, `--max-lines=1000` will increase the
+maximum number of log output lines from 100 to 1000.


### PR DESCRIPTION
Let's allow users to configure how many lines are shown at most when a test fails.