### PR TITLE
Preserve CMake link lib order

### DIFF
--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -520,6 +520,7 @@ class CMakeDependency(ExternalDependency):
         # recognise arguments we should pass directly to the linker
         incDirs = []
         compileOptions = []
+        linkOptions = []
         libraries = []
 
         for i, required in modules:
@@ -541,19 +542,22 @@ class CMakeDependency(ExternalDependency):
                                                )
             incDirs += rtgt.include_directories
             compileOptions += rtgt.public_compile_opts
-            libraries += rtgt.libraries + rtgt.link_flags
+            linkOptions += rtgt.link_flags
+            libraries += rtgt.libraries
 
         # Make sure all elements in the lists are unique and sorted
         incDirs = sorted(set(incDirs))
         compileOptions = sorted(set(compileOptions))
-        libraries = sorted(set(libraries))
+        linkOptions = sorted(set(linkOptions))
+        # Do not change order of libraries, do not remove duplicates ('-framework')
 
         mlog.debug(f'Include Dirs:         {incDirs}')
         mlog.debug(f'Compiler Options:     {compileOptions}')
+        mlog.debug(f'Linker Options:       {linkOptions}')
         mlog.debug(f'Libraries:            {libraries}')
 
         self.compile_args = compileOptions + [f'-I{x}' for x in incDirs]
-        self.link_args = libraries
+        self.link_args = linkOptions + libraries
 
     def _get_build_dir(self) -> Path:
         build_dir = Path(self.cmake_root_dir) / f'cmake_{self.name}'


### PR DESCRIPTION
Cherry-picked and adapted from https://github.com/microsoft/vcpkg/pull/38658:

Keep order of, and duplicates in, link libraries imported from CMake.
"Traditional" linkers need static libraries given in a particular order (independent libs last).

Sorting in `mesonbuild/cmake/tracetargets.py` was already removed in https://github.com/mesonbuild/meson/commit/05f4e0d6c5e74d5dfc1f1b32ac2ee26af664c950.  
This PR removes another sorting step.

(Order of link libs may still be wrong because `tracetargets.py` doesn't implement visit the target digraph in in topological sort order. This left for another PR.)