### PR TITLE
compilers: detect: fix pre-processor scraping by defining language

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -340,7 +340,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
             guess_gcc_or_lcc = None
 
         if guess_gcc_or_lcc:
-            defines = _get_gnu_compiler_defines(compiler)
+            defines = _get_gnu_compiler_defines(compiler, lang)
             if not defines:
                 popen_exceptions[join_args(compiler)] = 'no pre-processor defines'
                 continue
@@ -449,7 +449,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
         if 'clang' in out or 'Clang' in out:
             linker = None
 
-            defines = _get_clang_compiler_defines(compiler)
+            defines = _get_clang_compiler_defines(compiler, lang)
 
             # Even if the for_machine is darwin, we could be using vanilla
             # clang.
@@ -676,7 +676,7 @@ def detect_fortran_compiler(env: 'Environment', for_machine: MachineChoice) -> C
                 guess_gcc_or_lcc = 'lcc'
 
             if guess_gcc_or_lcc:
-                defines = _get_gnu_compiler_defines(compiler)
+                defines = _get_gnu_compiler_defines(compiler, 'fortran')
                 if not defines:
                     popen_exceptions[join_args(compiler)] = 'no pre-processor defines'
                     continue
@@ -843,7 +843,7 @@ def _detect_objc_or_objcpp_compiler(env: 'Environment', lang: str, for_machine: 
             continue
         version = search_version(out)
         if 'Free Software Foundation' in out:
-            defines = _get_gnu_compiler_defines(compiler)
+            defines = _get_gnu_compiler_defines(compiler, lang)
             if not defines:
                 popen_exceptions[join_args(compiler)] = 'no pre-processor defines'
                 continue
@@ -855,7 +855,7 @@ def _detect_objc_or_objcpp_compiler(env: 'Environment', lang: str, for_machine: 
                 defines, linker=linker)
         if 'clang' in out:
             linker = None
-            defines = _get_clang_compiler_defines(compiler)
+            defines = _get_clang_compiler_defines(compiler, lang)
             if not defines:
                 popen_exceptions[join_args(compiler)] = 'no pre-processor defines'
                 continue
@@ -1329,19 +1329,43 @@ def detect_masm_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
 # GNU/Clang defines and version
 # =============================
 
-def _get_gnu_compiler_defines(compiler: T.List[str]) -> T.Dict[str, str]:
+def _get_gnu_compiler_defines(compiler: T.List[str], lang: str) -> T.Dict[str, str]:
     """
     Get the list of GCC pre-processor defines
     """
+    from .mixins.gnu import _LANG_MAP as gnu_LANG_MAP
+
+    def _try_obtain_compiler_defines(args: T.List[str]) -> str:
+        mlog.debug(f'Running command: {join_args(args)}')
+        p, output, error = Popen_safe(compiler + args, write='', stdin=subprocess.PIPE)
+        if p.returncode != 0:
+            raise EnvironmentException('Unable to get gcc pre-processor defines:\n'
+                                       f'Compiler stdout:\n{output}\n-----\n'
+                                       f'Compiler stderr:\n{error}\n-----\n')
+        return output
+
     # Arguments to output compiler pre-processor defines to stdout
     # gcc, g++, and gfortran all support these arguments
-    args = compiler + ['-E', '-dM', '-']
-    mlog.debug(f'Running command: {join_args(args)}')
-    p, output, error = Popen_safe(args, write='', stdin=subprocess.PIPE)
-    if p.returncode != 0:
-        raise EnvironmentException('Unable to detect gcc pre-processor defines:\n'
-                                   f'Compiler stdout:\n{output}\n-----\n'
-                                   f'Compiler stderr:\n{error}\n-----\n')
+    baseline_test_args = ['-E', '-dM', '-']
+    try:
+        # We assume that when _get_gnu_compiler_defines is called, it's
+        # close enough to a GCCish compiler so we reuse the _LANG_MAP
+        # from the GCC mixin. This isn't a dangerous assumption because
+        # we fallback if the detection fails anyway.
+
+        # We might not have a match for Fortran, so fallback to detection
+        # based on the driver.
+        lang = gnu_LANG_MAP[lang]
+
+        # The compiler may not infer the target language based on the driver name
+        # so first, try with '-cpp -x lang', then fallback without given it's less
+        # portable. We try with '-cpp' as GCC needs it for Fortran at least, and
+        # it seems to do no harm.
+        output = _try_obtain_compiler_defines(['-cpp', '-x', lang] + baseline_test_args)
+    except (EnvironmentException, KeyError):
+        mlog.debug(f'pre-processor extraction using -cpp -x {lang} failed, falling back w/o lang')
+        output = _try_obtain_compiler_defines(baseline_test_args)
+
     # Parse several lines of the type:
     # `#define ___SOME_DEF some_value`
     # and extract `___SOME_DEF`
@@ -1358,17 +1382,42 @@ def _get_gnu_compiler_defines(compiler: T.List[str]) -> T.Dict[str, str]:
             defines[rest[0]] = rest[1]
     return defines
 
-def _get_clang_compiler_defines(compiler: T.List[str]) -> T.Dict[str, str]:
+def _get_clang_compiler_defines(compiler: T.List[str], lang: str) -> T.Dict[str, str]:
     """
     Get the list of Clang pre-processor defines
     """
-    args = compiler + ['-E', '-dM', '-']
-    mlog.debug(f'Running command: {join_args(args)}')
-    p, output, error = Popen_safe(args, write='', stdin=subprocess.PIPE)
-    if p.returncode != 0:
-        raise EnvironmentException('Unable to get clang pre-processor defines:\n'
-                                   f'Compiler stdout:\n{output}\n-----\n'
-                                   f'Compiler stderr:\n{error}\n-----\n')
+    from .mixins.clang import _LANG_MAP as clang_LANG_MAP
+
+    def _try_obtain_compiler_defines(args: T.List[str]) -> str:
+        mlog.debug(f'Running command: {join_args(args)}')
+        p, output, error = Popen_safe(compiler + args, write='', stdin=subprocess.PIPE)
+        if p.returncode != 0:
+            raise EnvironmentException('Unable to get clang pre-processor defines:\n'
+                                       f'Compiler stdout:\n{output}\n-----\n'
+                                       f'Compiler stderr:\n{error}\n-----\n')
+        return output
+
+    # Arguments to output compiler pre-processor defines to stdout
+    baseline_test_args = ['-E', '-dM', '-']
+    try:
+        # We assume that when _get_clang_compiler_defines is called, it's
+        # close enough to a Clangish compiler so we reuse the _LANG_MAP
+        # from the Clang mixin. This isn't a dangerous assumption because
+        # we fallback if the detection fails anyway.
+
+        # We might not have a match for Fortran, so fallback to detection
+        # based on the driver.
+        lang = clang_LANG_MAP[lang]
+
+        # The compiler may not infer the target language based on the driver name
+        # so first, try with '-cpp -x lang', then fallback without given it's less
+        # portable. We try with '-cpp' as GCC needs it for Fortran at least, and
+        # it seems to do no harm.
+        output = _try_obtain_compiler_defines(['-cpp', '-x', lang] + baseline_test_args)
+    except (EnvironmentException, KeyError):
+        mlog.debug(f'pre-processor extraction using -cpp -x {lang} failed, falling back w/o lang')
+        output = _try_obtain_compiler_defines(baseline_test_args)
+
     defines: T.Dict[str, str] = {}
     for line in output.split('\n'):
         if not line:

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -179,7 +179,7 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
             else:
                 trials = default_linkers
         elif compiler.id == 'intel-cl' and compiler.language == 'c': # why not cpp? Is this a bug?
-            # Intel has it's own linker that acts like microsoft's lib
+            # Intel has its own linker that acts like microsoft's lib
             trials = [['xilib']]
         elif is_windows() and compiler.id == 'pgi': # this handles cpp / nvidia HPC, in addition to just c/fortran
             trials = [['ar']]  # For PGI on Windows, "ar" is just a wrapper calling link/lib.

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -1331,7 +1331,7 @@ def detect_masm_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
 
 def _get_gnu_compiler_defines(compiler: T.List[str]) -> T.Dict[str, str]:
     """
-    Detect GNU compiler platform type (Apple, MinGW, Unix)
+    Get the list of GCC pre-processor defines
     """
     # Arguments to output compiler pre-processor defines to stdout
     # gcc, g++, and gfortran all support these arguments
@@ -1339,7 +1339,7 @@ def _get_gnu_compiler_defines(compiler: T.List[str]) -> T.Dict[str, str]:
     mlog.debug(f'Running command: {join_args(args)}')
     p, output, error = Popen_safe(args, write='', stdin=subprocess.PIPE)
     if p.returncode != 0:
-        raise EnvironmentException('Unable to detect GNU compiler type:\n'
+        raise EnvironmentException('Unable to detect gcc pre-processor defines:\n'
                                    f'Compiler stdout:\n{output}\n-----\n'
                                    f'Compiler stderr:\n{error}\n-----\n')
     # Parse several lines of the type:

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -1333,7 +1333,7 @@ def _get_gnu_compiler_defines(compiler: T.List[str], lang: str) -> T.Dict[str, s
     """
     Get the list of GCC pre-processor defines
     """
-    from .mixins.gnu import _LANG_MAP as gnu_LANG_MAP
+    from .mixins.gnu import gnu_lang_map
 
     def _try_obtain_compiler_defines(args: T.List[str]) -> str:
         mlog.debug(f'Running command: {join_args(args)}')
@@ -1355,7 +1355,7 @@ def _get_gnu_compiler_defines(compiler: T.List[str], lang: str) -> T.Dict[str, s
 
         # We might not have a match for Fortran, so fallback to detection
         # based on the driver.
-        lang = gnu_LANG_MAP[lang]
+        lang = gnu_lang_map[lang]
 
         # The compiler may not infer the target language based on the driver name
         # so first, try with '-cpp -x lang', then fallback without given it's less
@@ -1386,7 +1386,7 @@ def _get_clang_compiler_defines(compiler: T.List[str], lang: str) -> T.Dict[str,
     """
     Get the list of Clang pre-processor defines
     """
-    from .mixins.clang import _LANG_MAP as clang_LANG_MAP
+    from .mixins.clang import clang_lang_map
 
     def _try_obtain_compiler_defines(args: T.List[str]) -> str:
         mlog.debug(f'Running command: {join_args(args)}')
@@ -1407,7 +1407,7 @@ def _get_clang_compiler_defines(compiler: T.List[str], lang: str) -> T.Dict[str,
 
         # We might not have a match for Fortran, so fallback to detection
         # based on the driver.
-        lang = clang_LANG_MAP[lang]
+        lang = clang_lang_map[lang]
 
         # The compiler may not infer the target language based on the driver name
         # so first, try with '-cpp -x lang', then fallback without given it's less

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -36,6 +36,13 @@ clang_optimization_args: T.Dict[str, T.List[str]] = {
     's': ['-Oz'],
 }
 
+_LANG_MAP = {
+    'c': 'c',
+    'cpp': 'c++',
+    'objc': 'objective-c',
+    'objcpp': 'objective-c++',
+}
+
 class ClangCompiler(GnuLikeCompiler):
 
     id = 'clang'

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -36,7 +36,7 @@ clang_optimization_args: T.Dict[str, T.List[str]] = {
     's': ['-Oz'],
 }
 
-_LANG_MAP = {
+clang_lang_map = {
     'c': 'c',
     'cpp': 'c++',
     'objc': 'objective-c',

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -309,7 +309,7 @@ gnu_objc_warning_args: T.Dict[str, T.List[str]] = {
     ],
 }
 
-_LANG_MAP = {
+gnu_lang_map = {
     'c': 'c',
     'cpp': 'c++',
     'objc': 'objective-c',
@@ -318,9 +318,9 @@ _LANG_MAP = {
 
 @functools.lru_cache(maxsize=None)
 def gnulike_default_include_dirs(compiler: T.Tuple[str, ...], lang: str) -> 'ImmutableListProtocol[str]':
-    if lang not in _LANG_MAP:
+    if lang not in gnu_lang_map:
         return []
-    lang = _LANG_MAP[lang]
+    lang = gnu_lang_map[lang]
     env = os.environ.copy()
     env["LC_ALL"] = 'C'
     cmd = list(compiler) + [f'-x{lang}', '-E', '-v', '-']
@@ -534,7 +534,7 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
         # We want to allow preprocessing files with any extension, such as
         # foo.c.in. In that case we need to tell GCC/CLANG to treat them as
         # assembly file.
-        lang = _LANG_MAP.get(self.language, 'assembler-with-cpp')
+        lang = gnu_lang_map.get(self.language, 'assembler-with-cpp')
         return self.get_preprocess_only_args() + [f'-x{lang}']
 
 


### PR DESCRIPTION
_get_gnu_compiler_defines and _get_clang_compiler_defines were broken by not defining the language they used.

Neither GCC nor Clang infer the language based on the driver name which means `self.defines` isn't populated correctly in compilers/cpp.py.

e.g.
```
 $ echo "" | g++ -E -dM - | grep -i cplus

 $ echo "" | g++ -x c++ -E -dM - | grep -i cplus
 #define __cplusplus 201703L
```

Fix that by passing '-x LANGUAGE' as a first pass. If it fails, try again without '-x LANGUAGE' as before, as its portability isn't certain.

While here, make the debug & error message strings consistent between the GCC and Clang probes.

Without this change, a63739d394dd77314270f5a46f79171a8c544e77 is only partially effective. It works if the system has injected Clang options via /etc/clang configuration files, but not by e.g. patching the driver (or for GCC there too).