### PR TITLE
Add -export_dynamic flag for AppleDynamicLinker

### DIFF
--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -834,6 +834,9 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
     def get_thinlto_cache_args(self, path: str) -> T.List[str]:
         return ["-Wl,-cache_path_lto," + path]
 
+    def export_dynamic_args(self, env: 'Environment') -> T.List[str]:
+        return self._apply_prefix('-export_dynamic')
+
 
 class LLVMLD64DynamicLinker(AppleDynamicLinker):
 

--- a/unittests/darwintests.py
+++ b/unittests/darwintests.py
@@ -81,6 +81,18 @@ class DarwinTests(BasePlatformTests):
         self.build()
         self.run_tests()
 
+    def test_apple_lto_export_dynamic(self):
+        '''
+        Tests that -Wl,-export_dynamic is correctly added, when export_dynamic: true is set.
+        On macOS, this is relevant for LTO builds only.
+        '''
+        testdir = os.path.join(self.common_test_dir, '148 shared module resolving symbol in executable')
+        # Ensure that it builds even with LTO enabled
+        env = {'CFLAGS': '-flto'}
+        self.init(testdir, override_envvars=env)
+        self.build()
+        self.run_tests()
+
     def _get_darwin_versions(self, fname):
         fname = os.path.join(self.builddir, fname)
         out = subprocess.check_output(['otool', '-L', fname], universal_newlines=True)


### PR DESCRIPTION
The apple linker uses -export_dynamic instead of --export-dynamic [1]. This should be set when setting export_dynamic: true.

Resolves #13290

[1]: https://opensource.apple.com/source/ld64/ld64-609/doc/man/man1/ld.1.auto.html