### PR TITLE
Recast CMake's IMPORTED_LOCATION into framework flags

### DIFF
--- a/mesonbuild/cmake/tracetargets.py
+++ b/mesonbuild/cmake/tracetargets.py
@@ -137,9 +137,9 @@ def resolve_cmake_trace_targets(target_name: str,
         elif 'IMPORTED_IMPLIB' in tgt.properties:
             res.libraries += [x for x in tgt.properties['IMPORTED_IMPLIB'] if x]
         elif f'IMPORTED_LOCATION_{cfg}' in tgt.properties:
-            res.libraries += [x for x in tgt.properties[f'IMPORTED_LOCATION_{cfg}'] if x]
+            targets += [x for x in tgt.properties[f'IMPORTED_LOCATION_{cfg}'] if x]
         elif 'IMPORTED_LOCATION' in tgt.properties:
-            res.libraries += [x for x in tgt.properties['IMPORTED_LOCATION'] if x]
+            targets += [x for x in tgt.properties['IMPORTED_LOCATION'] if x]
 
         if 'LINK_LIBRARIES' in tgt.properties:
             targets += [x for x in tgt.properties['LINK_LIBRARIES'] if x]

--- a/test cases/osx/9 framework recasting/meson.build
+++ b/test cases/osx/9 framework recasting/meson.build
@@ -1,5 +1,5 @@
 project('framework recasting', 'c', 'cpp')
 
-x = dependency('OpenAL')
+x = dependency('OpenAL', method: 'cmake')
 
 y = executable('tt', files('main.cpp'), dependencies: x)


### PR DESCRIPTION
Amends #12181:
 - Make the test actually use the cmake dependency method.
 - Make the recasting handle frameworks which appear in IMPORTED_LOCATION properties.

This PR does not:
 - Fix processing of the result. `resolve_cmake_trace_targets` is called from three locations. One of them sorts and removes duplicates, potentially breaking non-trivial cases (https://github.com/mesonbuild/meson/pull/13287#issuecomment-2149476953).
 - Deduplicate framework processing. Another processing loop is in interpreter.py.
 - Deal with `-framework Xyz` in `INTERFACE_LINK_LIBRARIES`.
 - Create proper `ExtraFrameworkDependency` objects.