### PR TITLE
`configure_file`: update \@ escape logic

### DIFF
--- a/test cases/common/14 configure file/config6.h.in
+++ b/test cases/common/14 configure file/config6.h.in
@@ -1,19 +1,40 @@
 /* No escape */
 #define MESSAGE1 "@var1@"
 
-/* Single escape means no replace */
-#define MESSAGE2 "\@var1@"
+/* Escaped whole variable */
+#define MESSAGE2 "\\@var1\\@"
 
 /* Replace pairs of escapes before '@' or '\@' with escape characters
  * (note we have to double number of pairs due to C string escaping)
  */
 #define MESSAGE3 "\\\\@var1@"
 
-/* Pairs of escapes and then single escape to avoid replace */
-#define MESSAGE4 "\\\\\@var1@"
+/* Pairs of escapes and then an escaped variable */
+#define MESSAGE4 "\\\\\@var1\@"
 
-/* Check escaped variable does not overlap following variable */
-#define MESSAGE5 "\@var1@var2@"
+/* We don't gobble \@ prefixing some text */
+#define MESSAGE5 "\\\\@var1"
 
-/* Check escape character outside variables */
-#define MESSAGE6 "\\ @ \@ \\\\@ \\\\\@"
+/* Check escape character outside variables
+                  \  @    \@ */
+#define MESSAGE6 "\\ @ \\\\@"
+
+/* Catch any edge cases */
+
+/* no substitution - not a variable */
+#define MESSAGE7 "@var1"
+
+/* Escaped variable followed by another variable */
+#define MESSAGE8 "\\\\@var1@var2@"
+
+/* Variable followed by another variable */
+#define MESSAGE9 "@var1@var2@"
+
+/* Variable followed by another variable and escaped */
+#define MESSAGE10 "@var1@var2\\\\@"
+
+/* Lots of substitutions in a row*/
+#define MESSAGE11 "@var1@@var2@@var3@@var4@"
+
+/* This should never happen in the real world, right? */
+#define MESSAGE12 "@var1@var2\\\\@var3@var4\\\\@"

--- a/test cases/common/14 configure file/meson.build
+++ b/test cases/common/14 configure file/meson.build
@@ -143,6 +143,8 @@ test('test5', executable('prog5', 'prog5.c'))
 conf6 = configuration_data()
 conf6.set('var1', 'foo')
 conf6.set('var2', 'bar')
+conf6.set('var3', 'baz')
+conf6.set('var4', 'qux')
 configure_file(
   input : 'config6.h.in',
   output : '@BASENAME@',

--- a/test cases/common/14 configure file/prog6.c
+++ b/test cases/common/14 configure file/prog6.c
@@ -4,8 +4,14 @@
 int main(void) {
     return strcmp(MESSAGE1, "foo")
         || strcmp(MESSAGE2, "@var1@")
-        || strcmp(MESSAGE3, "\\foo")
+        || strcmp(MESSAGE3, "\\@var1@")
         || strcmp(MESSAGE4, "\\@var1@")
-        || strcmp(MESSAGE5, "@var1bar")
-        || strcmp(MESSAGE6, "\\ @ @ \\@ \\@");
+        || strcmp(MESSAGE5, "\\@var1")
+        || strcmp(MESSAGE6, "\\ @ \\@")
+        || strcmp(MESSAGE7, "@var1")
+        || strcmp(MESSAGE8, "\\@var1bar")
+        || strcmp(MESSAGE9, "foovar2@")
+        || strcmp(MESSAGE10, "foovar2\\@")
+        || strcmp(MESSAGE11, "foobarbazqux")
+        || strcmp(MESSAGE12, "foovar2\\@var3@var4\\@");
 }


### PR DESCRIPTION
Update meson logic to only consider matched pairs of `\@` when escaping variables in 'meson' and 'cmake@'
style `configure_file` invocations.

The previous approach, escaping a single `\@`,
had undesirable side effects, including mangling valid perl that is being configured.

Closes: https://github.com/mesonbuild/meson/issues/7165