### PR TITLE
Update the meson man page.

### DIFF
--- a/man/meson.1
+++ b/man/meson.1
@@ -406,6 +406,53 @@ Remove all wrap-based subproject artifacts
 \fBpackagefiles\fR
 Manage the packagefiles overlay
 
+.SH The rewrite command
+
+.B meson rewrite
+modifies the project definition.
+ 
+.B meson rewrite [
+.I options
+.B ] [
+.I command
+.B ]
+
+.SS "options:"
+
+.TP
+\fB\-h, \-\-help\fR
+show this help message and exit
+
+.TP
+\fB\-s SRCDIR, \-\-sourcedir SRCDIR\fR
+Path to source directory.
+
+.TP
+\fB\-V, \-\-verbose\fR
+Enable verbose output
+
+.TP
+\fB\-S, \-\-skip\-errors\fR
+Skip errors instead of aborting
+
+.SS "commands:"
+
+.TP
+\fBtarget (tgt)\fR
+Modify a target
+
+.TP
+\fBkwargs\fR
+Modify keyword arguments
+
+.TP
+\fBdefault-options (def)\fR
+Modify the project default options
+
+.TP
+\fBcommand (cmd)\fR
+Execute a JSON array of commands
+
 .SH EXIT STATUS
 
 .TP

--- a/man/meson.1
+++ b/man/meson.1
@@ -453,6 +453,62 @@ Modify the project default options
 \fBcommand (cmd)\fR
 Execute a JSON array of commands
 
+.SH The compile command
+
+.B meson compile
+builds the project.
+
+.B meson compile [
+.I options
+.B ] [
+.I TARGET...
+.B ]
+
+.SS "positional arguments:"
+.TP
+\fBTARGET\fR
+Targets to build. Target has the following format:
+[PATH_TO_TARGET/]TARGET_NAME.TARGET_SUFFIX[:TARGET_TYPE].
+
+.SS "options:"
+
+.TP
+\fB\-h, \-\-help\fR
+show this help message and exit
+
+.TP
+\fB\-\-clean\fR
+Clean the build directory.
+
+.TP
+\fB\-C WD\fR
+directory to cd into before running
+
+.TP
+\fB\-j JOBS, \-\-jobs JOBS\fR
+The number of worker jobs to run (if supported). If the value is less
+than 1 the build program will guess.
+
+.TP
+\fB\-l LOAD_AVERAGE, \-\-load-average LOAD_AVERAGE\fR
+The system load average to try to maintain (if supported).
+
+.TP
+\fB\-v, \-\-verbose\fR
+Show more verbose output.
+
+.TP
+\fB\-\-ninja\-args NINJA_ARGS\fR
+Arguments to pass to `ninja` (applied only on `ninja` backend).
+
+.TP
+\fB\-\-vs\-args VS_ARGS\fR
+Arguments to pass to `msbuild` (applied only on `vs` backend).
+
+.TP
+\fB\-\-xcode\-args XCODE_ARGS\fR
+Arguments to pass to `xcodebuild` (applied only on `xcode` backend).
+
 .SH EXIT STATUS
 
 .TP

--- a/man/meson.1
+++ b/man/meson.1
@@ -509,6 +509,46 @@ Arguments to pass to `msbuild` (applied only on `vs` backend).
 \fB\-\-xcode\-args XCODE_ARGS\fR
 Arguments to pass to `xcodebuild` (applied only on `xcode` backend).
 
+.SH The devenv command
+
+.B meson devenv
+runs commands in the developer environment.
+
+.B meson devenv [
+.I options
+.B ] [
+.I command
+.B ]
+
+.SS "positional arguments:"
+
+.TP
+\fBcommand\fR
+Command to run in developer environment (default: interactive shell)
+
+.SS "options:"
+
+.TP
+\fB\-h, \-\-help\fR
+show this help message and exit
+
+.TP
+\fB\-C BUILDDIR\fR
+Path to build directory
+
+.TP
+\fB\-\-workdir WORKDIR, \-w WORKDIR\fR
+Directory to cd into before running (default: builddir, Since 1.0.0)
+
+.TP
+\fB\-\-dump [DUMP]\fR
+Only print required environment (Since 0.62.0) Takes an optional file
+path (Since 1.1.0)
+
+.TP
+\fB\-\-dump-format {sh,export,vscode}\fR
+Format used with --dump (Since 1.1.0)
+
 .SH EXIT STATUS
 
 .TP

--- a/man/meson.1
+++ b/man/meson.1
@@ -118,6 +118,58 @@ Include source code of subprojects that have been used for the build.
 \fB\-\-no\-tests\fR
 Do not build and test generated packages.
 
+.SH The install command
+
+.B meson install
+installs the project.
+
+.B meson install [
+.I options
+.B ]
+
+.SS "options:"
+
+.TP
+\fB\-h, \-\-help\fR
+show this help message and exit
+
+.TP
+\fB\-C WD\fR
+directory to cd into before running
+
+.TP
+\fB\-\-no-rebuild\fR
+Do not rebuild before installing.
+
+.TP
+\fB\-\-only\-changed\fR
+Only overwrite files that are older than the copied file.
+
+.TP
+\fB\-\-quiet\fR
+Do not print every file that was installed.
+
+.TP
+\fB\-\-destdir DESTDIR\fR
+Sets or overrides DESTDIR environment.  (Since 0.57.0)
+
+.TP
+\fB\-\-dry\-run, \-n\fR
+Doesn't actually install, but print logs. (Since 0.57.0)
+
+.TP
+\fB\-\-skip\-subprojects [SKIP_SUBPROJECTS]\fR
+Do not install files from given subprojects. (Since 0.58.0)
+
+.TP
+\fB\-\-tags TAGS\fR
+Install only targets having one of the given tags. (Since 0.60.0)
+
+.TP
+\fB\-\-strip\fR
+Strip targets even if strip option was not set during
+configure. (Since 0.62.0)
+
 .SH The introspect command
 
 Meson introspect is a command designed to make it simple to  integrate with

--- a/man/meson.1
+++ b/man/meson.1
@@ -363,6 +363,49 @@ show available versions of the specified project
 \fBstatus\fR
 show installed and available versions of currently used subprojects
 
+.SH The subprojects command
+
+.B meson subprojects
+is used to manage subprojects.
+
+.B meson subprojects [
+.I options
+.B ] [
+.I command
+.B ]
+
+.SS "options:"
+.TP
+\fB\-h, \-\-help\fR
+show this help message and exit
+
+.SS "commands:"
+.TP
+\fBupdate\fR
+Update all subprojects from wrap files
+
+.TP
+\fBcheckout\fR
+Checkout a branch (git only)
+
+.TP
+\fBdownload\fR
+Ensure subprojects are fetched, even if not in use. Already downloaded
+subprojects are not modified. This can be used to pre-fetch all
+subprojects and avoid downloads during configure.
+
+.TP
+\fBforeach\fR
+Execute a command in each subproject directory.
+
+.TP
+\fBpurge\fR
+Remove all wrap-based subproject artifacts
+
+.TP
+\fBpackagefiles\fR
+Manage the packagefiles overlay
+
 .SH EXIT STATUS
 
 .TP

--- a/man/meson.1
+++ b/man/meson.1
@@ -200,6 +200,68 @@ print all unit tests
 \fB\-\-help\fR
 print command line help
 
+.SH The init command
+
+.B meson init
+creates a new project
+
+.B meson init [
+.I options
+.B ] [
+.I sourcefile...
+.B ]
+
+.SS "positional arguments:"
+.TP
+sourcefile...
+source files. default: all recognized files in current directory
+
+.SS "options:"
+.TP
+\fB\-h, \-\-help\fR
+show this help message and exit
+
+.TP
+\fB\-C WD\fR
+directory to cd into before running
+
+.TP
+\fB\-n NAME, \-\-name NAME\fR
+project name. default: name of current directory
+
+.TP
+\fB\-e EXECUTABLE, \-\-executable EXECUTABLE\fR
+executable name. default: project name
+
+.TP
+\fB\-d DEPS, \-\-deps DEPS\fR
+dependencies, comma-separated
+
+.TP
+\fB\-l {c,cpp,cs,cuda,d,fortran,java,objc,objcpp,rust,vala}, \
+\-\-language {c,cpp,cs,cuda,d,fortran,java,objc,objcpp,rust,vala}\fR
+project language. default: autodetected based on source files
+
+.TP
+\fB\-b, \-\-build
+build after generation
+
+.TP
+\fB\-\-builddir BUILDDIR\fR
+directory for build
+
+.TP
+\fB\-f, \-\-force\fR
+force overwrite of existing files and directories.
+
+.TP
+\fB\-\-type {executable,library}\fR
+project type. default: executable based project
+
+.TP
+\fB\-\-version VERSION\fR
+project version. default: 0.1
+
 .SH The test command
 
 .B meson test

--- a/man/meson.1
+++ b/man/meson.1
@@ -608,6 +608,53 @@ Define cpu family for cross compilation.
 \fB\-\-endian {big,little}\fR
 Define endianness for cross compilation.
 
+.SH The format command
+
+.B meson format
+formats a meson source file.
+
+.B meson format [
+.I options
+.B ] [
+.I sources...
+.B ]
+
+.SS "positional arguments:"
+
+.TP
+\fBsources...\fR
+meson source files
+
+.SS "options:"
+
+.TP
+\fB-h, --help\fR
+show this help message and exit
+
+.TP
+\fB-q, --check-only\fR
+exit with 1 if files would be modified by meson format
+
+.TP
+\fB-i, --inplace\fR
+format files in-place
+
+.TP
+\fB-r, --recursive\fR
+recurse subdirs (requires --check-only or --inplace option)
+
+.TP
+\fB-c meson.format, --configuration meson.format\fR
+read configuration from meson.format
+
+.TP
+\fB-e, --editor-config\fR
+try to read configuration from .editorconfig
+
+.TP
+\fB-o OUTPUT, --output OUTPUT\fR
+output file (implies having exactly one input)
+
 .SH EXIT STATUS
 
 .TP

--- a/man/meson.1
+++ b/man/meson.1
@@ -549,6 +549,65 @@ path (Since 1.1.0)
 \fB\-\-dump-format {sh,export,vscode}\fR
 Format used with --dump (Since 1.1.0)
 
+.SH The env2mfile command
+
+.B meson env2mfile
+converts the current environment to a cross or native file.
+
+.B meson env2mfile [
+.I options
+.B ]
+
+.SS "options:"
+
+.TP
+\fB\-h, \-\-help\fR
+show this help message and exit
+
+.TP
+\fB\-\-debarch DEBARCH\fR
+The dpkg architecture to generate.
+
+.TP
+\fB\-\-gccsuffix GCCSUFFIX\fR
+A particular gcc version suffix if necessary.
+
+.TP
+\fB\-o OUTFILE\fR
+The output file.
+
+.TP
+\fB\-\-cross\fR
+Generate a cross compilation file.
+
+.TP
+\fB\-\-native\fR
+Generate a native compilation file.
+
+.TP
+\fB\-\-system SYSTEM\fR
+Define system for cross compilation.
+
+.TP
+\fB\-\-subsystem SUBSYSTEM\fR
+Define subsystem for cross compilation.
+
+.TP
+\fB\-\-kernel KERNEL\fR
+Define kernel for cross compilation.
+
+.TP
+\fB\-\-cpu CPU\fR
+Define cpu for cross compilation.
+
+.TP
+\fB\-\-cpu-family CPU_FAMILY\fR
+Define cpu family for cross compilation.
+
+.TP
+\fB\-\-endian {big,little}\fR
+Define endianness for cross compilation.
+
 .SH EXIT STATUS
 
 .TP

--- a/man/meson.1
+++ b/man/meson.1
@@ -83,6 +83,41 @@ To set values, use the \-D command line argument like this.
 
 .B meson configure \-Dopt1=value1 \-Dopt2=value2
 
+.SH The dist command
+
+.B meson dist
+generates a release archive.
+
+.B meson dist [
+.I options
+.B ]
+
+.SS "options:"
+.TP
+\fB\-h, \-\-help\fR
+show this help message and exit
+
+.TP
+\fB\-C WD\fR
+directory to cd into before running
+
+.TP
+\fB\-\-allow-dirty\fR
+Allow even when repository contains uncommitted changes.
+
+.TP
+\fB\-\-formats FORMATS\fR
+Comma separated list of archive types to create.  Supports xztar
+(default), gztar, and zip.
+
+.TP
+\fB\-\-include\-subprojects\fR
+Include source code of subprojects that have been used for the build.
+
+.TP
+\fB\-\-no\-tests\fR
+Do not build and test generated packages.
+
 .SH The introspect command
 
 Meson introspect is a command designed to make it simple to  integrate with


### PR DESCRIPTION
The man page has fallen behind the other documentation and so lacks documentation for some of the most useful meson commands. This set of commits adds help for the rest of the commands. The added documentation was manually created from the output of the meson help command in much the same way as the markdown documentation is programmatically created.