### PR TITLE
Add Swift/C++ interoperability support

### DIFF
--- a/docs/markdown/snippets/swift_cxx_interoperability.md
+++ b/docs/markdown/snippets/swift_cxx_interoperability.md
@@ -1,0 +1,13 @@
+## Swift/C++ interoperability is now supported
+
+It is now possible to create Swift executables that can link to C++ or
+Objective-C++ libraries. Only specifying a bridging header for the Swift
+target is required.
+
+Swift 5.9 is required to use this feature. Xcode 15 is required if the
+Xcode backend is used.
+
+```meson
+lib = static_library('mylib', 'mylib.cpp')
+exe = executable('prog', 'main.swift', 'mylib.h', link_with: lib)
+```

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2266,6 +2266,10 @@ class NinjaBackend(backends.Backend):
         os.makedirs(self.get_target_private_dir_abs(target), exist_ok=True)
         compile_args = self.generate_basic_compiler_args(target, swiftc)
         compile_args += swiftc.get_module_args(module_name)
+        if mesonlib.version_compare(swiftc.version, '>=5.9'):
+            compile_args += swiftc.get_cxx_interoperability_args(target.compilers)
+        compile_args += self.build.get_project_args(swiftc, target.subproject, target.for_machine)
+        compile_args += self.build.get_global_args(swiftc, target.for_machine)
         for i in reversed(target.get_include_dirs()):
             basedir = i.get_curdir()
             for d in i.get_incdirs():

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -1596,6 +1596,7 @@ class XCodeBackend(backends.Backend):
             headerdirs = []
             bridging_header = ""
             is_swift = self.is_swift_target(target)
+            langs = set()
             for d in target.include_dirs:
                 for sd in d.incdirs:
                     cd = os.path.join(d.curdir, sd)
@@ -1715,6 +1716,7 @@ class XCodeBackend(backends.Backend):
                         lang = 'c'
                     elif lang == 'objcpp':
                         lang = 'cpp'
+                    langs.add(lang)
                     langname = LANGNAMEMAP[lang]
                     langargs.setdefault(langname, [])
                     langargs[langname] = cargs + cti_args + args
@@ -1776,6 +1778,8 @@ class XCodeBackend(backends.Backend):
             settings_dict.add_item('SECTORDER_FLAGS', '')
             if is_swift and bridging_header:
                 settings_dict.add_item('SWIFT_OBJC_BRIDGING_HEADER', bridging_header)
+                if self.objversion >= 60 and 'cpp' in langs:
+                    settings_dict.add_item('SWIFT_OBJC_INTEROP_MODE', 'objcxx')
             settings_dict.add_item('BUILD_DIR', symroot)
             settings_dict.add_item('OBJROOT', f'{symroot}/build')
             sysheader_arr = PbxArray()

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1119,6 +1119,9 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
     def get_compile_only_args(self) -> T.List[str]:
         return []
 
+    def get_cxx_interoperability_args(self, lang: T.Dict[str, Compiler]) -> T.List[str]:
+        raise EnvironmentException('This compiler does not support CXX interoperability')
+
     def get_preprocess_only_args(self) -> T.List[str]:
         raise EnvironmentException('This compiler does not have a preprocessor')
 

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -153,6 +153,12 @@ class SwiftCompiler(Compiler):
 
         return ['-working-directory', path]
 
+    def get_cxx_interoperability_args(self, lang: T.Dict[str, Compiler]) -> T.List[str]:
+        if 'cpp' in lang or 'objcpp' in lang:
+            return ['-cxx-interoperability-mode=default']
+        else:
+            return ['-cxx-interoperability-mode=off']
+
     def compute_parameters_with_absolute_paths(self, parameter_list: T.List[str],
                                                build_dir: str) -> T.List[str]:
         for idx, i in enumerate(parameter_list):

--- a/test cases/swift/10 mixed cpp/main.swift
+++ b/test cases/swift/10 mixed cpp/main.swift
@@ -1,0 +1,6 @@
+testCallFromSwift()
+testCallWithParam("Calling C++ function from Swift with param is working")
+
+var test = Test()
+var testtwo = Test(1)
+test.testCallFromClass()

--- a/test cases/swift/10 mixed cpp/meson.build
+++ b/test cases/swift/10 mixed cpp/meson.build
@@ -1,0 +1,12 @@
+project('mixed cpp', 'cpp', 'swift')
+
+swiftc = meson.get_compiler('swift')
+
+# Testing C++ and Swift interoperability requires Swift 5.9
+if not swiftc.version().version_compare('>= 5.9')
+  error('MESON_SKIP_TEST Test requires Swift 5.9')
+endif
+
+lib = static_library('mylib', 'mylib.cpp')
+exe = executable('prog', 'main.swift', 'mylib.h', link_with: lib)
+test('cpp interface', exe)

--- a/test cases/swift/10 mixed cpp/mylib.cpp
+++ b/test cases/swift/10 mixed cpp/mylib.cpp
@@ -1,0 +1,22 @@
+#include "mylib.h"
+#include <iostream>
+
+Test::Test() {
+    std::cout << "Test initialized" << std::endl;
+}
+    
+Test::Test(int param) {
+    std::cout << "Test initialized with param " << param << std::endl;
+}
+
+void Test::testCallFromClass() {
+    std::cout << "Calling C++ class function from Swift is working" << std::endl;
+}
+
+void testCallFromSwift() {
+    std::cout << "Calling this C++ function from Swift is working" << std::endl;
+}
+
+void testCallWithParam(const std::string &param) {
+    std::cout << param << std::endl;
+}

--- a/test cases/swift/10 mixed cpp/mylib.h
+++ b/test cases/swift/10 mixed cpp/mylib.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <string>
+
+class Test {
+public:
+    Test();
+    Test(int param);
+
+    void testCallFromClass();
+};
+
+void testCallFromSwift();
+void testCallWithParam(const std::string &param);

--- a/test cases/swift/11 mixed objcpp/main.swift
+++ b/test cases/swift/11 mixed objcpp/main.swift
@@ -1,0 +1,2 @@
+var test: ObjCPPTest = ObjCPPTest()
+test.testCallToObjCPP()

--- a/test cases/swift/11 mixed objcpp/meson.build
+++ b/test cases/swift/11 mixed objcpp/meson.build
@@ -1,0 +1,12 @@
+project('mixed objcpp', 'objcpp', 'swift')
+
+swiftc = meson.get_compiler('swift')
+
+# Testing Objective-C++ and Swift interoperability requires Swift 5.9
+if not swiftc.version().version_compare('>= 5.9')
+  error('MESON_SKIP_TEST Test requires Swift 5.9')
+endif
+
+lib = static_library('mylib', 'mylib.mm')
+exe = executable('prog', 'main.swift', 'mylib.h', link_with: lib)
+test('objcpp interface', exe)

--- a/test cases/swift/11 mixed objcpp/mylib.h
+++ b/test cases/swift/11 mixed objcpp/mylib.h
@@ -1,0 +1,17 @@
+#pragma once
+#import <Foundation/Foundation.h>
+
+class Test {
+public:
+    Test();
+
+    void testCallFromClass();
+};
+
+@interface ObjCPPTest: NSObject {
+    @private Test *test;
+}
+- (id)init;
+- (void)dealloc;
+- (void)testCallToObjCPP;
+@end

--- a/test cases/swift/11 mixed objcpp/mylib.mm
+++ b/test cases/swift/11 mixed objcpp/mylib.mm
@@ -1,0 +1,29 @@
+#include "mylib.h"
+#include <iostream>
+
+Test::Test() {
+    std::cout << "Test initialized" << std::endl;
+}
+
+void Test::testCallFromClass() {
+    std::cout << "Calling Objective-C++ class function from Swift is working" << std::endl;
+}
+
+@implementation ObjCPPTest
+- (id)init {
+    self = [super init];
+    if (self) {
+        test = new Test();
+    }
+    return self;
+}
+
+- (void)dealloc {
+    delete test;
+    [super dealloc];
+}
+
+- (void)testCallToObjCPP {
+    test->testCallFromClass();
+}
+@end


### PR DESCRIPTION
Integrating Swift into C++/Objective-C++ codebases is now supported as of Swift 5.9. This PR creates two new test cases and updates the Ninja and Xcode backends to take advantage of this.

Right now, the new test cases only handle calling C++/Objective-C++ functions from Swift. Calling Swift methods from C++/Objective-C++ is still being worked on.