### PR TITLE
BUG: Use an F77 snippet for sanity testing Fortran

### DIFF
--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -59,8 +59,8 @@ class FortranCompiler(CLikeCompiler, Compiler):
         return cargs, largs
 
     def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
-        source_name = 'sanitycheckf.f90'
-        code = 'program main; print *, "Fortran compilation is working."; end program\n'
+        source_name = 'sanitycheckf.f'
+        code = '      PROGRAM MAIN\n      PRINT *, "Fortran compilation is working."\n      END\n'
         return self._sanity_check_impl(work_dir, environment, source_name, code)
 
     def get_optimization_args(self, optimization_level: str) -> T.List[str]:


### PR DESCRIPTION
Closes #13319. I'm not sure if there's a way to test this on CI, couldn't find anything for trying various `FFLAGS` with `sanity_check`, but it does work, e.g.

```meson
project('test', 'fortran')
executable('blah', 'sanitizer.f')
```

```fortran
      PROGRAM MAIN
      PRINT *, "Fortran compilation is working."
      END
```

```sh
FFLAGS='-ffixed-form' meson setup bbdir 
meson compile -C bbdir
./bbdir/blah
```

As reported in #13319, without this change, the `setup` line will fail with `meson.build:1:0: ERROR: Compiler gfortran cannot compile programs.`
