### PR TITLE
clang-tidy: use -quiet

### DIFF
--- a/mesonbuild/scripts/clangtidy.py
+++ b/mesonbuild/scripts/clangtidy.py
@@ -11,7 +11,7 @@ from .run_tool import run_tool
 import typing as T
 
 def run_clang_tidy(fname: Path, builddir: Path) -> subprocess.CompletedProcess:
-    return subprocess.run(['clang-tidy', '-p', str(builddir), str(fname)])
+    return subprocess.run(['clang-tidy', '-quiet', '-p', str(builddir), str(fname)])
 
 def run_clang_tidy_fix(fname: Path, builddir: Path) -> subprocess.CompletedProcess:
     return subprocess.run(['run-clang-tidy', '-fix', '-format', '-quiet', '-p', str(builddir), str(fname)])


### PR DESCRIPTION
This adds the `-quiet` option when invoking clang-tidy for the generated `clang-tidy` target. (Note that the `clang-tidy-fix` target already does so.)

This prevents messages like
```
Suppressed 1084 warnings (1084 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```
from being repeated for every file, which drowns out the actual warnings/errors from clang-tidy when more than a few files are processed.

Also the tip about `-header-fileter` and `-system-headers` is not very useful here because Meson doesn't currently provide a way to supply these options to clang-tidy.

Even with `-quiet`, clang-tidy still prints a line like `1084 warnings generated.` for each file.

---

Before:
```
$ ninja -C builddir clang-tidy
ninja: Entering directory `builddir'
[0/1] /opt/homebrew/bin/meson --intern...pc /path/to/builddir
1084 warnings generated.
Suppressed 1084 warnings (1084 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
82579 warnings generated.
Suppressed 82609 warnings (82579 in non-user code, 30 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
82625 warnings generated.
Suppressed 82655 warnings (82625 in non-user code, 30 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
92233 warnings generated.
Suppressed 92267 warnings (92233 in non-user code, 34 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
94116 warnings generated.
Suppressed 94154 warnings (94116 in non-user code, 38 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
(and so on)
```

After:
```
$ ninja -C builddir clang-tidy
ninja: Entering directory `builddir'
[0/1] /opt/homebrew/bin/meson --intern...pc /path/to/builddir
1084 warnings generated.
82579 warnings generated.
82625 warnings generated.
92233 warnings generated.
94116 warnings generated.
(and so on)
```