### PR TITLE
Improve `nm` usage in symbolextractor script on macOS

### DIFF
--- a/mesonbuild/scripts/symbolextractor.py
+++ b/mesonbuild/scripts/symbolextractor.py
@@ -134,9 +134,10 @@ def osx_syms(libfilename: str, outfilename: str) -> None:
             match = i
             break
     result = [arr[match + 2], arr[match + 5]] # Libreoffice stores all 5 lines but the others seem irrelevant.
-    # Get a list of all symbols exported
-    output = call_tool('nm', ['--extern-only', '--defined-only',
-                              '--format=posix', libfilename])
+    # Get a list of all symbols exported.  `nm -g -U -P` is equivalent to, and more portable than,
+    # `nm --extern-only --defined-only --format=posix`; cctools-port only understands the one-character form,
+    # as does `nm` on very old macOS versions, (see meson#11131). `llvm-nm` understands both forms.
+    output = call_tool('nm', ['-g', '-U', '-P', libfilename])
     if not output:
         dummy_syms(outfilename)
         return


### PR DESCRIPTION
This fixes the unit test `TestAllPlatformTests.test_noop_changes_cause_no_rebuilds`, when run with an `nm` binary from `cctools-port` (as shipped by conda-forge, see https://github.com/conda-forge/cctools-and-ld64-feedstock).

It also addresses the issue discussed in https://github.com/mesonbuild/meson/discussions/11131, and this build warning:
```
[48/1383] Generating symbol file scipy/special/libsf_error_state.dylib.p/libsf_error_state.dylib.symbols
WARNING: ['arm64-apple-darwin20.0.0-nm'] does not work. Relinking will always happen on source changes.
error: arm64-apple-darwin20.0.0-nm: invalid argument --
```
as reported in [scipy#20740](https://github.com/scipy/scipy/issues/20740).

The unit test traceback was:
```
>       self.assertBuildRelinkedOnlyTarget('mylib')
E       AssertionError: Lists differ: ['mylib', 'prog'] != ['mylib']
E
E       First list contains 1 additional elements.
E       First extra element 1:
E       'prog'
E
E       - ['mylib', 'prog']
E       + ['mylib']

unittests/allplatformstests.py:1292: AssertionError
```

The `nm` shipped by Apple yields the exact same results either way; the man page for `nm` only lists the single-character form so this seems preferred either way.