### PR TITLE
Add support for detecting free-threaded Python on Windows

### DIFF
--- a/mesonbuild/scripts/python_info.py
+++ b/mesonbuild/scripts/python_info.py
@@ -106,6 +106,9 @@ if sys.version_info >= (3, 2):
 if is_pypy:
     limited_api_suffix = suffix
 
+# Whether we're targeting a free-threaded CPython interpreter
+is_freethreaded = bool(variables.get('Py_GIL_DISABLED', False))
+
 print(json.dumps({
   'variables': variables,
   'paths': paths,
@@ -118,4 +121,5 @@ print(json.dumps({
   'link_libpython': links_against_libpython(),
   'suffix': suffix,
   'limited_api_suffix': limited_api_suffix,
+  'is_freethreaded': is_freethreaded,
 }))


### PR DESCRIPTION
This does a couple of things:

1. Scrape the `Py_GIL_DISABLED` sysconfig var, which is the best way as of today to determine whether the target interpreter was built with `--disable-gil`.
2. Link against the correct `libpython`.
3. On Windows, work around a known issue in the python.org installer with a missing define in `pyconfig.h`, which the CPython devs have said is unlikely to be fixed since headers are shared between the regular and free-threaded builds in a single NSIS installer (see https://discuss.python.org/t/windows-installer-freethreading-and-building-extension-modules/54391/2).

I have tested this with NumPy; the `libpython` change makes numpy build, and the added define fixes the ABI issue that otherwise makes `import numpy` segfault immediately due to the `pyconfig.h` problem. It passes its full test suite under free-threaded CPython then, modulo a few trivial failures.

This fixes the problem reported in gh-13263. I'd like to leave that issue open for now, since adding CI coverage is still to be done. It's too early right now, I don't think there's a good way to install free-threaded CPython 3.13.0b2 yet; there's only the NSIS installer from python.org right now, and even there it's an optional extra that you need to explicitly enable.