### PR TITLE
create_test_serialisation: Significantly improve performance with many transitive deps

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1263,12 +1263,16 @@ class Backend:
 
             t_env = copy.deepcopy(t.env)
             if not machine.is_windows() and not machine.is_cygwin() and not machine.is_darwin():
-                ld_lib_path: T.Set[str] = set()
+                ld_lib_path_libs: T.Set[build.SharedLibrary] = set()
                 for d in depends:
                     if isinstance(d, build.BuildTarget):
                         for l in d.get_all_link_deps():
                             if isinstance(l, build.SharedLibrary):
-                                ld_lib_path.add(os.path.join(self.environment.get_build_dir(), l.get_subdir()))
+                                ld_lib_path_libs.add(l)
+
+                env_build_dir = self.environment.get_build_dir()
+                ld_lib_path: T.Set[str] = set(os.path.join(env_build_dir, l.get_subdir()) for l in ld_lib_path_libs)
+
                 if ld_lib_path:
                     t_env.prepend('LD_LIBRARY_PATH', list(ld_lib_path), ':')
 


### PR DESCRIPTION
In large monolithic codebases with many intertwined shared libraries, test serialization in meson master can cause configuration times to balloon massively from a single `test()` invocation. Using py-spy to find where meson is spinning its wheels shows that most of the time is being spent running `os.path.join`. After investigating, I found that this function was being run on many duplicate paths.

This PR mitigates the aforementioned issue by first deduplicating all transient dependent shared libraries in create_test_serialisation, *then* constructing the paths for the test's ld_library_path. In the tested codebase and using meson 1.4.1, this change dropped the total time to run `meson setup` from 215 seconds to 28 seconds - a nearly 8x improvement.