### PR TITLE
coverage: Change --html-details to --html-nested (gcovr)

### DIFF
--- a/mesonbuild/scripts/coverage.py
+++ b/mesonbuild/scripts/coverage.py
@@ -161,7 +161,7 @@ def coverage(outputs: T.List[str], source_root: str, subproject_root: str, build
                 os.mkdir(htmloutdir)
             subprocess.check_call(gcovr_base_cmd + gcovr_config +
                                   ['--html',
-                                   '--html-details',
+                                   '--html-nested',
                                    '--print-summary',
                                    '-o', os.path.join(htmloutdir, 'index.html'),
                                    ] + gcov_exe_args)


### PR DESCRIPTION
--html-details option is used to create a separate web page for each file. Each of these web pages includes the contents of file with annotations that summarize code coverage.
--html-nested option is used to create a separate web page for each file **and directory**. Each of these web pages includes the contents of file with annotations that summarize code coverage.
(https://github.com/gcovr/gcovr/blob/main/doc/source/output/html.rst)