### PR TITLE
find_program: add a kwarg to specify custom version argument

### DIFF
--- a/docs/markdown/snippets/find_program_version_argument.md
+++ b/docs/markdown/snippets/find_program_version_argument.md
@@ -1,0 +1,12 @@
+## New version_argument kwarg for find_program
+
+When finding an external program with `find_program`, the `version_argument`
+can be used to override the default `--version` argument when trying to parse
+the version of the program.
+
+For example, if the following is used:
+```meson
+foo = find_program('foo', version_argument: '-version')
+```
+
+meson will internally run `foo -version` when trying to find the version of `foo`.

--- a/docs/yaml/functions/find_program.yaml
+++ b/docs/yaml/functions/find_program.yaml
@@ -102,12 +102,19 @@ kwargs:
     since: 0.52.0
     description: |
       Specifies the required version, see
-      [[dependency]] for argument format. The version of the program
+      [[dependency]] for argument format. By default, the version of the program
       is determined by running `program_name --version` command. If stdout is empty
       it fallbacks to stderr. If the output contains more text than simply a version
       number, only the first occurrence of numbers separated by dots is kept.
       If the output is more complicated than that, the version checking will have to
       be done manually using [[run_command]].
+
+  version_argument:
+    type: str
+    since: 1.5.0
+    description: |
+      Specifies the argument to pass when trying to find the version of the program.
+      If this is unspecified, `program_name --version` will be used.
 
   dirs:
     type: list[str]

--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -82,6 +82,7 @@ class BasicPythonExternalProgram(ExternalProgram):
             self.command = ext_prog.command
             self.path = ext_prog.path
             self.cached_version = None
+            self.version_arg = '--version'
 
         # We want strong key values, so we always populate this with bogus data.
         # Otherwise to make the type checkers happy we'd have to do .get() for

--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -36,6 +36,7 @@ class ExternalProgram(mesonlib.HoldableObject):
         self.name = name
         self.path: T.Optional[str] = None
         self.cached_version: T.Optional[str] = None
+        self.version_arg = '--version'
         if command is not None:
             self.command = mesonlib.listify(command)
             if mesonlib.is_windows():
@@ -93,9 +94,9 @@ class ExternalProgram(mesonlib.HoldableObject):
 
     def get_version(self, interpreter: T.Optional['Interpreter'] = None) -> str:
         if not self.cached_version:
-            raw_cmd = self.get_command() + ['--version']
+            raw_cmd = self.get_command() + [self.version_arg]
             if interpreter:
-                res = interpreter.run_command_impl((self, ['--version']),
+                res = interpreter.run_command_impl((self, [self.version_arg]),
                                                    {'capture': True,
                                                     'check': True,
                                                     'env': mesonlib.EnvironmentVariables()},

--- a/test cases/common/26 find program/meson.build
+++ b/test cases/common/26 find program/meson.build
@@ -32,6 +32,9 @@ assert(prog.version() == '1.0', 'Program version should be detectable')
 prog = find_program('print-version-with-prefix.py', version : '>=1.0')
 assert(prog.found(), 'Program version should match')
 
+prog = find_program('print-version-custom-argument.py', version : '>=1.0', version_argument : '-version')
+assert(prog.found(), 'Program version should match')
+
 prog = find_program('test_subdir.py', required : false)
 assert(not prog.found(), 'Program should not be found')
 

--- a/test cases/common/26 find program/print-version-custom-argument.py
+++ b/test cases/common/26 find program/print-version-custom-argument.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+
+import sys
+
+if len(sys.argv) != 2 or sys.argv[1] != '-version':
+    exit(1)
+
+print('1.0')


### PR DESCRIPTION
When trying to get the version of a program, meson was previously hardcoded to run the binary with `--version`. This does work with the vast majority of programs, but there are a few outliers (e.g. ffmpeg) which have an unusual argument for printing out the version. Support these programs by introducing a version_argument kwarg in find_program which allows users to override `--version` with whatever the custom argument for printing the version may be for the program.