### PR TITLE
tests: fix OpenAL test case on case sensitive fs on macOS

### DIFF
--- a/test cases/osx/9 framework recasting/meson.build
+++ b/test cases/osx/9 framework recasting/meson.build
@@ -1,5 +1,5 @@
 project('framework recasting', 'c', 'cpp')
 
-x = dependency('openal')
+x = dependency('OpenAL')
 
 y = executable('tt', files('main.cpp'), dependencies: x)


### PR DESCRIPTION
Preface: why are we doing this?

For reasons of cross-platform interop, the Lix team is strongly considering switching to build on a case sensitive filesystem in the macOS installation, since otherwise storing case overlapping filenames is busted and requires very very bad hacks:
https://git.lix.systems/lix-project/lix/issues/332

What's wrong:

```
Command line: `clang++ '/nix/temp/meson/b d01bff197e/meson-private/tmpjqid64j1/testfile.cpp' -o '/nix/temp/meson/b d01bff197e/meson-private/tmpjqid64j1/output.exe' -O0 -fpermissive -Werror=implicit-function-declaration -F/nix/store/qa92ravmclyraw7b46cz3q3m834mmbw9-apple-framework-OpenAL/Library/Frameworks -framework openal` -> 1 stderr:
ld: framework not found openal
clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
```

Why is that happening:

```
$ ls /nix/store/qa92ravmclyraw7b46cz3q3m834mmbw9-apple-framework-OpenAL/Library/Frameworks
OpenAL.framework
```

So the test was relying on case insensitive fs, which is not a reliable assumption on all macOS installations (since weird people like us can set their fs to case sensitive!).