### PR TITLE
format: fix edge case with empty functions

### DIFF
--- a/mesonbuild/mformat.py
+++ b/mesonbuild/mformat.py
@@ -744,7 +744,7 @@ class ComputeLineLengths(FullAstVisitor):
         self.exit_node(node)
 
     def split_if_needed(self, node: mparser.ArgumentNode) -> None:
-        if not node.is_multiline and self.length > self.config.max_line_length:
+        if len(node) and not node.is_multiline and self.length > self.config.max_line_length:
             arg = self.argument_stack[self.level] if len(self.argument_stack) > self.level else node
             if not arg.is_multiline:
                 arg.is_multiline = True

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -377,7 +377,7 @@ class ArgumentNode(BaseNode):
         return self.order_error
 
     def __len__(self) -> int:
-        return self.num_args() # Fixme
+        return self.num_args() + self.num_kwargs()
 
 @dataclass(unsafe_hash=True)
 class ArrayNode(BaseNode):

--- a/test cases/format/1 default/gh13242.meson
+++ b/test cases/format/1 default/gh13242.meson
@@ -10,9 +10,7 @@ test(
 )
 
 test(
-    should_fail: (settings.get('x', false) and not settings['y'] and dep.version(
-        
-    ).version_compare(
+    should_fail: (settings.get('x', false) and not settings['y'] and dep.version().version_compare(
         '>=1.2.3',
     )),
 )

--- a/test cases/format/1 default/meson.build
+++ b/test cases/format/1 default/meson.build
@@ -10,6 +10,9 @@ meson_files = {
     'gh13242': files('gh13242.meson'),
 }
 
+# Ensure empty function are formatted correctly on long lines
+a = '@0@@1@@2@@3@@4@'.format('one', 'two', 'three', 'four', 'five').strip().strip()
+
 foreach name, f : meson_files
     test(name, meson_cmd, args: ['format', '--check-only', f])
 endforeach


### PR DESCRIPTION
format was adding a new empty line each time when trying to split a long line containing a function with no arguments