### PR TITLE
depfixer: fix rpath iterating on chars

### DIFF
--- a/mesonbuild/scripts/depfixer.py
+++ b/mesonbuild/scripts/depfixer.py
@@ -406,10 +406,10 @@ def fix_darwin(fname: str, rpath_dirs_to_remove: T.Set[bytes], new_rpath: str, f
         return
     new_rpaths: OrderedSet[str] = OrderedSet()
     if new_rpath:
-        new_rpaths.update(new_rpath)
+        new_rpaths.add(new_rpath)
     # filter out build-only rpath entries, like in
     # fix_rpathtype_entry
-    remove_rpaths = [x.decode('utf8') for x in rpath_dirs_to_remove]
+    remove_rpaths = {x.decode('utf8') for x in rpath_dirs_to_remove}
     for rpath_dir in old_rpaths:
         if rpath_dir and rpath_dir not in remove_rpaths:
             new_rpaths.add(rpath_dir)


### PR DESCRIPTION
Fixes #13355. Regression was caused by #13012.