### PR TITLE
depfixer: fix darwin regression when install rpaths are used

### DIFF
--- a/mesonbuild/scripts/depfixer.py
+++ b/mesonbuild/scripts/depfixer.py
@@ -406,7 +406,7 @@ def fix_darwin(fname: str, rpath_dirs_to_remove: T.Set[bytes], new_rpath: str, f
         return
     new_rpaths: OrderedSet[str] = OrderedSet()
     if new_rpath:
-        new_rpaths.update(new_rpath)
+        new_rpaths.update(new_rpath.split(':'))
     # filter out build-only rpath entries, like in
     # fix_rpathtype_entry
     remove_rpaths = [x.decode('utf8') for x in rpath_dirs_to_remove]


### PR DESCRIPTION
Fixes regression in commit 78e9009ff9d36925e04f329f9082841002ddd848.

new_rpath is only set when install_rpath appears in meson.build.

Before this commit, we treated new_rpath as a single string to pass to -add_rpath. This worked as long as new_rpath had a single rpath in it, though for ELF we explicitly supported multiple rpaths separated with ":" (as binutils ld is quite happy with that too).

install_name_tool does not support paths with colons in it:
```
21:12 <awilfox> Load command 19          cmd LC_RPATH      cmdsize 40         path /bar:/baz:/eli:/ldap (offset 12)
21:12 <awilfox> Load command 20          cmd LC_RPATH      cmdsize 24         path /foo (offset 12)
21:14 <awilfox> so the result is: do not use colons
```

After commit 78e9009ff9d36925e04f329f9082841002ddd848, we simply ended up with one load command for LC_RPATH per char in new_rpath, which was wrong in every possible case.

What we actually need to do is pass every distinct rpath as a separate `-add_rpath` argument, so we split it on the colons instead. We do the same splitting to ensure proper diff'ability for ELF anyways...

Fixes #13355