### PR TITLE
build: iterative algo for transitive dep resolve

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1182,14 +1182,14 @@ class Backend:
         result: T.Set[str] = set()
         prospectives: T.Set[build.BuildTargetTypes] = set()
         if isinstance(target, build.BuildTarget):
-            prospectives.update(target.get_transitive_link_deps())
+            prospectives.update(target.get_all_link_deps())
             # External deps
             result.update(self.extract_dll_paths(target))
 
         for bdep in extra_bdeps:
             prospectives.add(bdep)
             if isinstance(bdep, build.BuildTarget):
-                prospectives.update(bdep.get_transitive_link_deps())
+                prospectives.update(bdep.get_all_link_deps())
         # Internal deps
         for ld in prospectives:
             dirseg = os.path.join(self.environment.get_build_dir(), self.get_target_dir(ld))


### PR DESCRIPTION
In large repositories, transitive dependency resolution using the current recursive algorithm can result in enough duplicate calls to cause the full system memory space to be used up.

This commit converts get_all_link_deps to an iterative algorithm that only performs work on each target once, resulting in multiple orders of magnitude of improvements to dep resolution time and memory usage in large projects.

This algorithm also has the side effect of returning a deduplicated list of deps to avoid doing redundant work in functions that call `get_all_link_deps`. It has been verified to produce the same output as the original version of the function when the latter's output is deduplicated and both are sorted.