### PR TITLE
backend: xcode fix map access in generate_pbx_sources_build_phase for…

### DIFF
--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -1454,7 +1454,9 @@ class XCodeBackend(backends.Backend):
                         file_arr.add_item(self.custom_target_output_buildfile[o],
                                           os.path.join(self.environment.get_build_dir(), o))
                 elif isinstance(gt, build.CustomTargetIndex):
+                    output_dir = self.get_custom_target_output_dir(gt)
                     for o in gt.get_outputs():
+                        o = os.path.join(output_dir, o)
                         file_arr.add_item(self.custom_target_output_buildfile[o],
                                           os.path.join(self.environment.get_build_dir(), o))
                 elif isinstance(gt, build.GeneratedList):


### PR DESCRIPTION
… CustomTargetIndex

Fix incorrect map access to custom_target_output_buildfile in CustomTargetIndex case. Map keys are file names with the path appended, but the used keys were just the file name. This led to crashes.