### PR TITLE
Centralise option type lookups in OptionStore

### DIFF
--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -130,7 +130,7 @@ class IntrospectionInterpreter(AstInterpreter):
                         self.do_subproject(SubProject(i))
 
         self.coredata.init_backend_options(self.backend)
-        options = {k: v for k, v in self.environment.options.items() if k.is_backend()}
+        options = {k: v for k, v in self.environment.options.items() if self.environment.coredata.optstore.is_backend_option(k)}
 
         self.coredata.set_options(options)
         self._add_languages(proj_langs, True, MachineChoice.HOST)

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -15,7 +15,8 @@ from .. import coredata as cdata
 from ..build import Executable, Jar, SharedLibrary, SharedModule, StaticLibrary
 from ..compilers import detect_compiler_for
 from ..interpreterbase import InvalidArguments, SubProject
-from ..mesonlib import MachineChoice, OptionKey
+from ..mesonlib import MachineChoice
+from ..options import OptionKey
 from ..mparser import BaseNode, ArithmeticNode, ArrayNode, ElementaryNode, IdNode, FunctionNode, StringNode
 from .interpreter import AstInterpreter
 

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -105,7 +105,7 @@ class IntrospectionInterpreter(AstInterpreter):
         if not os.path.exists(optfile):
             optfile = os.path.join(self.source_root, self.subdir, 'meson_options.txt')
         if os.path.exists(optfile):
-            oi = optinterpreter.OptionInterpreter(self.subproject)
+            oi = optinterpreter.OptionInterpreter(self.coredata.optstore, self.subproject)
             oi.process(optfile)
             assert isinstance(proj_name, str), 'for mypy'
             self.coredata.update_project_options(oi.options, T.cast('SubProject', proj_name))

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -27,8 +27,10 @@ from .. import mlog
 from ..compilers import LANGUAGES_USING_LDFLAGS, detect
 from ..mesonlib import (
     File, MachineChoice, MesonException, OrderedSet,
-    ExecutableSerialisation, classify_unity_sources, OptionKey
+    ExecutableSerialisation, classify_unity_sources,
 )
+from ..options import OptionKey
+
 
 if T.TYPE_CHECKING:
     from .._typing import ImmutableListProtocol
@@ -1677,7 +1679,7 @@ class Backend:
         bindir = Path(prefix, self.environment.get_bindir())
         libdir = Path(prefix, self.environment.get_libdir())
         incdir = Path(prefix, self.environment.get_includedir())
-        _ldir = self.environment.coredata.get_option(mesonlib.OptionKey('localedir'))
+        _ldir = self.environment.coredata.get_option(OptionKey('localedir'))
         assert isinstance(_ldir, str), 'for mypy'
         localedir = Path(prefix, _ldir)
         dest_path = Path(prefix, outdir, Path(fname).name) if outdir else Path(prefix, fname)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -31,7 +31,8 @@ from ..mesonlib import (
     File, LibType, MachineChoice, MesonBugException, MesonException, OrderedSet, PerMachine,
     ProgressBar, quote_arg
 )
-from ..mesonlib import get_compiler_for_source, has_path_sep, OptionKey
+from ..mesonlib import get_compiler_for_source, has_path_sep
+from ..options import OptionKey
 from .backends import CleanTrees
 from ..build import GeneratedList, InvalidArguments
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3603,7 +3603,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
     def get_user_option_args(self):
         cmds = []
         for k, v in self.environment.coredata.optstore.items():
-            if k.is_project():
+            if self.environment.coredata.optstore.is_project_option(k):
                 cmds.append('-D' + str(k) + '=' + (v.value if isinstance(v.value, str) else str(v.value).lower()))
         # The order of these arguments must be the same between runs of Meson
         # to ensure reproducible output. The order we pass them shouldn't

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -19,8 +19,9 @@ from .. import mlog
 from .. import compilers
 from .. import mesonlib
 from ..mesonlib import (
-    File, MesonBugException, MesonException, replace_if_different, OptionKey, version_compare, MachineChoice
+    File, MesonBugException, MesonException, replace_if_different, version_compare, MachineChoice
 )
+from ..options import OptionKey
 from ..environment import Environment, build_filename
 from .. import coredata
 

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -11,7 +11,8 @@ from .. import build
 from .. import mesonlib
 from .. import mlog
 from ..arglist import CompilerArgs
-from ..mesonlib import MesonBugException, MesonException, OptionKey
+from ..mesonlib import MesonBugException, MesonException
+from ..options import OptionKey
 
 if T.TYPE_CHECKING:
     from ..build import BuildTarget

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -23,9 +23,11 @@ from .mesonlib import (
     File, MesonException, MachineChoice, PerMachine, OrderedSet, listify,
     extract_as_list, typeslistify, stringlistify, classify_unity_sources,
     get_filenames_templates_dict, substitute_values, has_path_sep,
-    OptionKey, PerMachineDefaultable,
+    PerMachineDefaultable,
     MesonBugException, EnvironmentVariables, pickle_load,
 )
+from .options import OptionKey
+
 from .compilers import (
     is_header, is_object, is_source, clink_langs, sort_clink, all_languages,
     is_known_suffix, detect_static_linker

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -23,7 +23,8 @@ import typing as T
 
 from . import builder
 from . import version
-from ..mesonlib import MesonException, Popen_safe, OptionKey
+from ..mesonlib import MesonException, Popen_safe
+from ..options import OptionKey
 from .. import coredata, options, mlog
 from ..wrap.wrap import PackageDefinition
 

--- a/mesonbuild/cmake/common.py
+++ b/mesonbuild/cmake/common.py
@@ -3,7 +3,8 @@
 
 from __future__ import annotations
 
-from ..mesonlib import MesonException, OptionKey
+from ..mesonlib import MesonException
+from ..options import OptionKey
 from .. import mlog
 from pathlib import Path
 import typing as T

--- a/mesonbuild/cmake/executor.py
+++ b/mesonbuild/cmake/executor.py
@@ -10,7 +10,8 @@ import re
 import os
 
 from .. import mlog
-from ..mesonlib import PerMachine, Popen_safe, version_compare, is_windows, OptionKey
+from ..mesonlib import PerMachine, Popen_safe, version_compare, is_windows
+from ..options import OptionKey
 from ..programs import find_external_program, NonExistingExternalProgram
 
 if T.TYPE_CHECKING:

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -18,7 +18,8 @@ from .toolchain import CMakeToolchain, CMakeExecScope
 from .traceparser import CMakeTraceParser
 from .tracetargets import resolve_cmake_trace_targets
 from .. import mlog, mesonlib
-from ..mesonlib import MachineChoice, OrderedSet, path_is_in_root, relative_to_if_possible, OptionKey
+from ..mesonlib import MachineChoice, OrderedSet, path_is_in_root, relative_to_if_possible
+from ..options import OptionKey
 from ..mesondata import DataFile
 from ..compilers.compilers import assembler_suffixes, lang_suffixes, header_suffixes, obj_suffixes, lib_suffixes, is_header
 from ..programs import ExternalProgram

--- a/mesonbuild/compilers/asm.py
+++ b/mesonbuild/compilers/asm.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import os
 import typing as T
 
-from ..mesonlib import EnvironmentException, OptionKey, get_meson_command
+from ..mesonlib import EnvironmentException, get_meson_command
+from ..options import OptionKey
 from .compilers import Compiler
 from .mixins.metrowerks import MetrowerksCompiler, mwasmarm_instruction_set_args, mwasmeppc_instruction_set_args
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -19,8 +19,10 @@ from .. import options
 from ..mesonlib import (
     HoldableObject,
     EnvironmentException, MesonException,
-    Popen_safe_logged, LibType, TemporaryDirectoryWinProof, OptionKey,
+    Popen_safe_logged, LibType, TemporaryDirectoryWinProof,
 )
+
+from ..options import OptionKey
 
 from ..arglist import CompilerArgs
 

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -13,8 +13,9 @@ from .. import options
 from .. import mlog
 from ..mesonlib import (
     EnvironmentException, Popen_safe,
-    is_windows, LibType, version_compare, OptionKey
+    is_windows, LibType, version_compare
 )
+from ..options import OptionKey
 from .compilers import Compiler
 
 if T.TYPE_CHECKING:

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -12,8 +12,9 @@ from .. import mesonlib
 from ..arglist import CompilerArgs
 from ..linkers import RSPFileSyntax
 from ..mesonlib import (
-    EnvironmentException, version_compare, OptionKey, is_windows
+    EnvironmentException, version_compare, is_windows
 )
+from ..options import OptionKey
 
 from . import compilers
 from .compilers import (

--- a/mesonbuild/compilers/mixins/arm.py
+++ b/mesonbuild/compilers/mixins/arm.py
@@ -10,7 +10,7 @@ import typing as T
 
 from ... import mesonlib
 from ...linkers.linkers import ArmClangDynamicLinker
-from ...mesonlib import OptionKey
+from ...options import OptionKey
 from ..compilers import clike_debug_args
 from .clang import clang_color_args
 

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -12,7 +12,7 @@ import typing as T
 from ... import mesonlib
 from ...linkers.linkers import AppleDynamicLinker, ClangClDynamicLinker, LLVMDynamicLinker, GnuGoldDynamicLinker, \
     MoldDynamicLinker, MSVCDynamicLinker
-from ...mesonlib import OptionKey
+from ...options import OptionKey
 from ..compilers import CompileCheckMode
 from .gnu import GnuLikeCompiler
 

--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -13,7 +13,8 @@ import re
 
 from .gnu import GnuLikeCompiler
 from .gnu import gnu_optimization_args
-from ...mesonlib import Popen_safe, OptionKey
+from ...mesonlib import Popen_safe
+from ...options import OptionKey
 
 if T.TYPE_CHECKING:
     from ...environment import Environment

--- a/mesonbuild/compilers/mixins/emscripten.py
+++ b/mesonbuild/compilers/mixins/emscripten.py
@@ -11,7 +11,7 @@ import typing as T
 from ... import coredata
 from ... import options
 from ... import mesonlib
-from ...mesonlib import OptionKey
+from ...options import OptionKey
 from ...mesonlib import LibType
 from mesonbuild.compilers.compilers import CompileCheckMode
 

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -16,7 +16,7 @@ import typing as T
 
 from ... import mesonlib
 from ... import mlog
-from ...mesonlib import OptionKey
+from ...options import OptionKey
 from mesonbuild.compilers.compilers import CompileCheckMode
 
 if T.TYPE_CHECKING:

--- a/mesonbuild/compilers/mixins/intel.py
+++ b/mesonbuild/compilers/mixins/intel.py
@@ -18,6 +18,7 @@ from ... import mesonlib
 from ..compilers import CompileCheckMode
 from .gnu import GnuLikeCompiler
 from .visualstudio import VisualStudioLikeCompiler
+from ...options import OptionKey
 
 if T.TYPE_CHECKING:
     from ...environment import Environment
@@ -66,7 +67,7 @@ class IntelGnuLikeCompiler(GnuLikeCompiler):
         # It does have IPO, which serves much the same purpose as LOT, but
         # there is an unfortunate rule for using IPO (you can't control the
         # name of the output file) which break assumptions meson makes
-        self.base_options = {mesonlib.OptionKey(o) for o in [
+        self.base_options = {OptionKey(o) for o in [
             'b_pch', 'b_lundef', 'b_asneeded', 'b_pgo', 'b_coverage',
             'b_ndebug', 'b_staticpic', 'b_pie']}
         self.lang_header = 'none'

--- a/mesonbuild/compilers/mixins/metrowerks.py
+++ b/mesonbuild/compilers/mixins/metrowerks.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 import os
 import typing as T
 
-from ...mesonlib import EnvironmentException, OptionKey
+from ...mesonlib import EnvironmentException
+from ...options import OptionKey
 
 if T.TYPE_CHECKING:
     from ...envconfig import MachineInfo

--- a/mesonbuild/compilers/mixins/pgi.py
+++ b/mesonbuild/compilers/mixins/pgi.py
@@ -10,7 +10,7 @@ import os
 from pathlib import Path
 
 from ..compilers import clike_debug_args, clike_optimization_args
-from ...mesonlib import OptionKey
+from ...options import OptionKey
 
 if T.TYPE_CHECKING:
     from ...environment import Environment

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -15,6 +15,7 @@ from ... import arglist
 from ... import mesonlib
 from ... import mlog
 from mesonbuild.compilers.compilers import CompileCheckMode
+from ...options import OptionKey
 
 if T.TYPE_CHECKING:
     from ...environment import Environment
@@ -110,7 +111,7 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
     INVOKES_LINKER = False
 
     def __init__(self, target: str):
-        self.base_options = {mesonlib.OptionKey(o) for o in ['b_pch', 'b_ndebug', 'b_vscrt']} # FIXME add lto, pgo and the like
+        self.base_options = {OptionKey(o) for o in ['b_pch', 'b_ndebug', 'b_vscrt']} # FIXME add lto, pgo and the like
         self.target = target
         self.is_64 = ('x64' in target) or ('x86_64' in target)
         # do some canonicalization of target machine
@@ -125,7 +126,7 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
         else:
             self.machine = target
         if mesonlib.version_compare(self.version, '>=19.28.29910'): # VS 16.9.0 includes cl 19.28.29910
-            self.base_options.add(mesonlib.OptionKey('b_sanitize'))
+            self.base_options.add(OptionKey('b_sanitize'))
         assert self.linker is not None
         self.linker.machine = self.machine
 

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -7,7 +7,7 @@ import typing as T
 
 from .. import coredata
 from .. import options
-from ..mesonlib import OptionKey
+from ..options import OptionKey
 
 from .compilers import Compiler
 from .mixins.clike import CLikeCompiler

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -7,7 +7,7 @@ import typing as T
 
 from .. import coredata
 from .. import options
-from ..mesonlib import OptionKey
+from ..options import OptionKey
 
 from .mixins.clike import CLikeCompiler
 from .compilers import Compiler

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -10,7 +10,8 @@ import re
 import typing as T
 
 from .. import options
-from ..mesonlib import EnvironmentException, MesonException, Popen_safe_logged, OptionKey
+from ..mesonlib import EnvironmentException, MesonException, Popen_safe_logged
+from ..options import OptionKey
 from .compilers import Compiler, clike_debug_args
 
 if T.TYPE_CHECKING:

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -8,7 +8,8 @@ import typing as T
 
 from .. import mlog
 from .. import mesonlib
-from ..mesonlib import EnvironmentException, version_compare, LibType, OptionKey
+from ..mesonlib import EnvironmentException, version_compare, LibType
+from ..options import OptionKey
 from .compilers import CompileCheckMode, Compiler
 from ..arglist import CompilerArgs
 

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -18,9 +18,11 @@ from .mesonlib import (
     MesonBugException,
     MesonException, MachineChoice, PerMachine,
     PerMachineDefaultable,
-    OptionKey, OptionType, stringlistify,
+    stringlistify,
     pickle_load
 )
+
+from .options import OptionKey, OptionType
 
 from .machinefile import CmdLineFileParser
 

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -453,7 +453,7 @@ class CoreData:
 
     def set_option(self, key: OptionKey, value, first_invocation: bool = False) -> bool:
         dirty = False
-        if key.is_builtin():
+        if self.optstore.is_builtin_option(key):
             if key.name == 'prefix':
                 value = self.sanitize_prefix(value)
             else:
@@ -694,7 +694,7 @@ class CoreData:
             # Always test this using the HOST machine, as many builtin options
             # are not valid for the BUILD machine, but the yielding value does
             # not differ between them even when they are valid for both.
-            if subproject and k.is_builtin() and self.optstore.get_value_object(k.evolve(subproject='', machine=MachineChoice.HOST)).yielding:
+            if subproject and self.optstore.is_builtin_option(k) and self.optstore.get_value_object(k.evolve(subproject='', machine=MachineChoice.HOST)).yielding:
                 continue
             # Skip base, compiler, and backend options, they are handled when
             # adding languages and setting backend.

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -584,7 +584,7 @@ class CoreData:
 
     def update_project_options(self, project_options: 'MutableKeyedOptionDictType', subproject: SubProject) -> None:
         for key, value in project_options.items():
-            if not key.is_project():
+            if not self.optstore.is_project_option(key):
                 continue
             if key not in self.optstore:
                 self.optstore.add_project_option(key, value)
@@ -608,7 +608,7 @@ class CoreData:
 
         # Find any extranious keys for this project and remove them
         for key in self.optstore.keys() - project_options.keys():
-            if key.is_project() and key.subproject == subproject:
+            if self.optstore.is_project_option(key) and key.subproject == subproject:
                 self.optstore.remove(key)
 
     def is_cross_build(self, when_building_for: MachineChoice = MachineChoice.HOST) -> bool:
@@ -906,7 +906,7 @@ class OptionsView(abc.Mapping):
         # FIXME: This is fundamentally the same algorithm than interpreter.get_option_internal().
         # We should try to share the code somehow.
         key = key.evolve(subproject=self.subproject)
-        if not key.is_project():
+        if not key.is_project_hack_for_optionsview():
             opt = self.original_options.get(key)
             if opt is None or opt.yielding:
                 key2 = key.as_root()

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -14,8 +14,8 @@ from enum import Enum
 
 from .. import mlog, mesonlib
 from ..compilers import clib_langs
-from ..mesonlib import LibType, MachineChoice, MesonException, HoldableObject, OptionKey
-from ..mesonlib import version_compare_many
+from ..mesonlib import LibType, MachineChoice, MesonException, HoldableObject, version_compare_many
+from ..options import OptionKey
 #from ..interpreterbase import FeatureDeprecated, FeatureNew
 
 if T.TYPE_CHECKING:

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from .. import mlog
 from .. import mesonlib
+from ..options import OptionKey
 
 from .base import DependencyException, SystemDependency
 from .detect import packages
@@ -340,7 +341,7 @@ class BoostLibraryFile():
 class BoostDependency(SystemDependency):
     def __init__(self, environment: Environment, kwargs: T.Dict[str, T.Any]) -> None:
         super().__init__('boost', environment, kwargs, language='cpp')
-        buildtype = environment.coredata.get_option(mesonlib.OptionKey('buildtype'))
+        buildtype = environment.coredata.get_option(OptionKey('buildtype'))
         assert isinstance(buildtype, str)
         self.debug = buildtype.startswith('debug')
         self.multithreading = kwargs.get('threading', 'multi') == 'multi'

--- a/mesonbuild/dependencies/dub.py
+++ b/mesonbuild/dependencies/dub.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 from .base import ExternalDependency, DependencyException, DependencyTypeName
 from .pkgconfig import PkgConfigDependency
-from ..mesonlib import (Popen_safe, OptionKey, join_args, version_compare)
+from ..mesonlib import (Popen_safe, join_args, version_compare)
+from ..options import OptionKey
 from ..programs import ExternalProgram
 from .. import mlog
 import re

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -17,6 +17,7 @@ from .configtool import ConfigToolDependency
 from .detect import packages
 from .factory import DependencyFactory, factory_methods
 from .pkgconfig import PkgConfigDependency
+from ..options import OptionKey
 
 if T.TYPE_CHECKING:
     from ..environment import Environment
@@ -541,7 +542,7 @@ def shaderc_factory(env: 'Environment',
         shared_libs = ['shaderc']
         static_libs = ['shaderc_combined', 'shaderc_static']
 
-        if kwargs.get('static', env.coredata.get_option(mesonlib.OptionKey('prefer_static'))):
+        if kwargs.get('static', env.coredata.get_option(OptionKey('prefer_static'))):
             c = [functools.partial(PkgConfigDependency, name, env, kwargs)
                  for name in static_libs + shared_libs]
         else:

--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 from pathlib import Path
 
 from .base import ExternalDependency, DependencyException, sort_libpaths, DependencyTypeName
-from ..mesonlib import EnvironmentVariables, OptionKey, OrderedSet, PerMachine, Popen_safe, Popen_safe_logged, MachineChoice, join_args
+from ..mesonlib import EnvironmentVariables, OrderedSet, PerMachine, Popen_safe, Popen_safe_logged, MachineChoice, join_args
+from ..options import OptionKey
 from ..programs import find_external_program, ExternalProgram
 from .. import mlog
 from pathlib import PurePath

--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -16,6 +16,7 @@ from .framework import ExtraFrameworkDependency
 from .pkgconfig import PkgConfigDependency
 from ..environment import detect_cpu_family
 from ..programs import ExternalProgram
+from ..options import OptionKey
 
 if T.TYPE_CHECKING:
     from typing_extensions import TypedDict
@@ -240,13 +241,13 @@ class _PythonDependencyBase(_Base):
                     # Python itself (except with pybind11, which has an ugly
                     # hack to work around this) - so emit a warning to explain
                     # the cause of the expected link error.
-                    buildtype = self.env.coredata.get_option(mesonlib.OptionKey('buildtype'))
+                    buildtype = self.env.coredata.get_option(OptionKey('buildtype'))
                     assert isinstance(buildtype, str)
-                    debug = self.env.coredata.get_option(mesonlib.OptionKey('debug'))
+                    debug = self.env.coredata.get_option(OptionKey('debug'))
                     # `debugoptimized` buildtype may not set debug=True currently, see gh-11645
                     is_debug_build = debug or buildtype == 'debug'
                     vscrt_debug = False
-                    if mesonlib.OptionKey('b_vscrt') in self.env.coredata.optstore:
+                    if OptionKey('b_vscrt') in self.env.coredata.optstore:
                         vscrt = self.env.coredata.optstore.get_value('b_vscrt')
                         if vscrt in {'mdd', 'mtd', 'from_buildtype', 'static_from_buildtype'}:
                             vscrt_debug = True

--- a/mesonbuild/dependencies/qt.py
+++ b/mesonbuild/dependencies/qt.py
@@ -19,6 +19,7 @@ from .pkgconfig import PkgConfigDependency
 from .factory import DependencyFactory
 from .. import mlog
 from .. import mesonlib
+from ..options import OptionKey
 
 if T.TYPE_CHECKING:
     from ..compilers import Compiler
@@ -296,8 +297,8 @@ class QmakeQtDependency(_QtBase, ConfigToolDependency, metaclass=abc.ABCMeta):
 
         # Use the buildtype by default, but look at the b_vscrt option if the
         # compiler supports it.
-        is_debug = self.env.coredata.get_option(mesonlib.OptionKey('buildtype')) == 'debug'
-        if mesonlib.OptionKey('b_vscrt') in self.env.coredata.optstore:
+        is_debug = self.env.coredata.get_option(OptionKey('buildtype')) == 'debug'
+        if OptionKey('b_vscrt') in self.env.coredata.optstore:
             if self.env.coredata.optstore.get_value('b_vscrt') in {'mdd', 'mtd'}:
                 is_debug = True
         modules_lib_suffix = _get_modules_lib_suffix(self.version, self.env.machines[self.for_machine], is_debug)

--- a/mesonbuild/dependencies/scalapack.py
+++ b/mesonbuild/dependencies/scalapack.py
@@ -8,7 +8,7 @@ import functools
 import os
 import typing as T
 
-from ..mesonlib import OptionKey
+from ..options import OptionKey
 from .base import DependencyMethods
 from .cmake import CMakeDependency
 from .detect import packages

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -17,9 +17,10 @@ CmdLineFileParser = machinefile.CmdLineFileParser
 
 from .mesonlib import (
     MesonException, MachineChoice, Popen_safe, PerMachine,
-    PerMachineDefaultable, PerThreeMachineDefaultable, split_args, quote_arg, OptionKey,
+    PerMachineDefaultable, PerThreeMachineDefaultable, split_args, quote_arg,
     search_version, MesonBugException
 )
+from .options import OptionKey
 from . import mlog
 from .programs import ExternalProgram
 

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -22,7 +22,7 @@ from ..interpreterbase import (ObjectHolder, noPosargs, noKwargs,
                                FeatureNew, FeatureNewKwargs, disablerIfNotFound,
                                InterpreterException)
 from ..interpreterbase.decorators import ContainerTypeInfo, typed_kwargs, KwargInfo, typed_pos_args
-from ..mesonlib import OptionKey
+from ..options import OptionKey
 from .interpreterobjects import (extract_required_kwarg, extract_search_dirs)
 from .type_checking import REQUIRED_KW, in_set_validator, NoneType
 

--- a/mesonbuild/interpreter/dependencyfallbacks.py
+++ b/mesonbuild/interpreter/dependencyfallbacks.py
@@ -5,7 +5,8 @@ from .. import mlog
 from .. import dependencies
 from .. import build
 from ..wrap import WrapMode
-from ..mesonlib import OptionKey, extract_as_list, stringlistify, version_compare_many, listify
+from ..mesonlib import extract_as_list, stringlistify, version_compare_many, listify
+from ..options import OptionKey
 from ..dependencies import Dependency, DependencyException, NotFoundDependency
 from ..interpreterbase import (MesonInterpreterObject, FeatureNew,
                                InterpreterException, InvalidArguments)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1051,7 +1051,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     def get_option_internal(self, optname: str) -> options.UserOption:
         key = OptionKey.from_string(optname).evolve(subproject=self.subproject)
 
-        if not key.is_project():
+        if not self.environment.coredata.optstore.is_project_option(key):
             for opts in [self.coredata.optstore, compilers.base_options]:
                 v = opts.get(key)
                 if v is None or v.yielding:
@@ -1198,7 +1198,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                 # We want fast  not cryptographically secure, this is just to
                 # see if the option file has changed
                 self.coredata.options_files[self.subproject] = (option_file, hashlib.sha1(f.read()).hexdigest())
-            oi = optinterpreter.OptionInterpreter(self.subproject)
+            oi = optinterpreter.OptionInterpreter(self.environment.coredata.optstore, self.subproject)
             oi.process(option_file)
             self.coredata.update_project_options(oi.options, self.subproject)
             self.add_build_def_file(option_file)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1148,7 +1148,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         if self.environment.first_invocation:
             self.coredata.init_backend_options(backend_name)
 
-        options = {k: v for k, v in self.environment.options.items() if k.is_backend()}
+        options = {k: v for k, v in self.environment.options.items() if self.environment.coredata.optstore.is_backend_option(k)}
         self.coredata.set_options(options)
 
     @typed_pos_args('project', str, varargs=str)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -19,8 +19,9 @@ from .. import envconfig
 from ..wrap import wrap, WrapMode
 from .. import mesonlib
 from ..mesonlib import (EnvironmentVariables, ExecutableSerialisation, MesonBugException, MesonException, HoldableObject,
-                        FileMode, MachineChoice, OptionKey, listify,
+                        FileMode, MachineChoice, listify,
                         extract_as_list, has_path_sep, path_is_in_root, PerMachine)
+from ..options import OptionKey
 from ..programs import ExternalProgram, NonExistingExternalProgram
 from ..dependencies import Dependency
 from ..depfile import DepFile

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -13,7 +13,8 @@ from .. import build
 from .. import options
 from ..compilers import Compiler
 from ..dependencies.base import Dependency
-from ..mesonlib import EnvironmentVariables, MachineChoice, File, FileMode, FileOrString, OptionKey
+from ..mesonlib import EnvironmentVariables, MachineChoice, File, FileMode, FileOrString
+from ..options import OptionKey
 from ..modules.cmake import CMakeSubprojectOptions
 from ..programs import ExternalProgram
 from .type_checking import PkgConfigDefineType, SourcesVarargsType

--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -11,7 +11,8 @@ from .. import dependencies
 from .. import build
 from .. import mlog, coredata
 
-from ..mesonlib import MachineChoice, OptionKey
+from ..mesonlib import MachineChoice
+from ..options import OptionKey
 from ..programs import OverrideProgram, ExternalProgram
 from ..interpreter.type_checking import ENV_KW, ENV_METHOD_KW, ENV_SEPARATOR_KW, env_convertor_with_method
 from ..interpreterbase import (MesonInterpreterObject, FeatureNew, FeatureDeprecated,

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -15,7 +15,8 @@ from ..options import UserFeatureOption
 from ..dependencies import Dependency, InternalDependency
 from ..interpreterbase.decorators import KwargInfo, ContainerTypeInfo
 from ..mesonlib import (File, FileMode, MachineChoice, listify, has_path_sep,
-                        OptionKey, EnvironmentVariables)
+                        EnvironmentVariables)
+from ..options import OptionKey
 from ..programs import ExternalProgram
 
 # Helper definition for type checks that are `Optional[T]`

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from . import mlog
 from . import mesonlib
+from .options import OptionKey
 from .mesonlib import MesonException, RealPathAction, join_args, listify_array_value, setup_vsenv
 from mesonbuild.environment import detect_ninja
 from mesonbuild import build
@@ -354,14 +355,14 @@ def run(options: 'argparse.Namespace') -> int:
 
     b = build.load(options.wd)
     cdata = b.environment.coredata
-    need_vsenv = T.cast('bool', cdata.get_option(mesonlib.OptionKey('vsenv')))
+    need_vsenv = T.cast('bool', cdata.get_option(OptionKey('vsenv')))
     if setup_vsenv(need_vsenv):
         mlog.log(mlog.green('INFO:'), 'automatically activated MSVC compiler environment')
 
     cmd: T.List[str] = []
     env: T.Optional[T.Dict[str, str]] = None
 
-    backend = cdata.get_option(mesonlib.OptionKey('backend'))
+    backend = cdata.get_option(OptionKey('backend'))
     assert isinstance(backend, str)
     mlog.log(mlog.green('INFO:'), 'autodetecting backend as', backend)
     if backend == 'ninja':

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -292,7 +292,7 @@ class Conf:
         if show_build_options:
             self.print_options('', build_core_options[''])
         self.print_options('Backend options', {k: v for k, v in self.coredata.optstore.items() if k.is_backend()})
-        self.print_options('Base options', {k: v for k, v in self.coredata.optstore.items() if k.is_base()})
+        self.print_options('Base options', {k: v for k, v in self.coredata.optstore.items() if self.coredata.optstore.is_base_option(k)})
         self.print_options('Compiler options', host_compiler_options.get('', {}))
         if show_build_options:
             self.print_options('', build_compiler_options.get('', {}))

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -282,8 +282,8 @@ class Conf:
 
         host_core_options = self.split_options_per_subproject({k: v for k, v in core_options.items() if k.machine is MachineChoice.HOST})
         build_core_options = self.split_options_per_subproject({k: v for k, v in core_options.items() if k.machine is MachineChoice.BUILD})
-        host_compiler_options = self.split_options_per_subproject({k: v for k, v in self.coredata.optstore.items() if k.is_compiler() and k.machine is MachineChoice.HOST})
-        build_compiler_options = self.split_options_per_subproject({k: v for k, v in self.coredata.optstore.items() if k.is_compiler() and k.machine is MachineChoice.BUILD})
+        host_compiler_options = self.split_options_per_subproject({k: v for k, v in self.coredata.optstore.items() if self.coredata.optstore.is_compiler_option(k) and k.machine is MachineChoice.HOST})
+        build_compiler_options = self.split_options_per_subproject({k: v for k, v in self.coredata.optstore.items() if self.coredata.optstore.is_compiler_option(k) and k.machine is MachineChoice.BUILD})
         project_options = self.split_options_per_subproject({k: v for k, v in self.coredata.optstore.items() if self.coredata.optstore.is_project_option(k)})
         show_build_options = self.default_values_only or self.build.environment.is_cross_build()
 

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -20,7 +20,8 @@ from . import mesonlib
 from . import mintro
 from . import mlog
 from .ast import AstIDGenerator, IntrospectionInterpreter
-from .mesonlib import MachineChoice, OptionKey
+from .mesonlib import MachineChoice
+from .options import OptionKey
 from .optinterpreter import OptionInterpreter
 
 if T.TYPE_CHECKING:

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -92,7 +92,7 @@ class Conf:
                     with open(opfile, 'rb') as f:
                         ophash = hashlib.sha1(f.read()).hexdigest()
                         if ophash != conf_options[1]:
-                            oi = OptionInterpreter(sub)
+                            oi = OptionInterpreter(self.coredata.optstore, sub)
                             oi.process(opfile)
                             self.coredata.update_project_options(oi.options, sub)
                             self.coredata.options_files[sub] = (opfile, ophash)
@@ -101,7 +101,7 @@ class Conf:
                     if not os.path.exists(opfile):
                         opfile = os.path.join(self.source_dir, 'meson_options.txt')
                     if os.path.exists(opfile):
-                        oi = OptionInterpreter(sub)
+                        oi = OptionInterpreter(self.coredata.optstore, sub)
                         oi.process(opfile)
                         self.coredata.update_project_options(oi.options, sub)
                         with open(opfile, 'rb') as f:
@@ -284,7 +284,7 @@ class Conf:
         build_core_options = self.split_options_per_subproject({k: v for k, v in core_options.items() if k.machine is MachineChoice.BUILD})
         host_compiler_options = self.split_options_per_subproject({k: v for k, v in self.coredata.optstore.items() if k.is_compiler() and k.machine is MachineChoice.HOST})
         build_compiler_options = self.split_options_per_subproject({k: v for k, v in self.coredata.optstore.items() if k.is_compiler() and k.machine is MachineChoice.BUILD})
-        project_options = self.split_options_per_subproject({k: v for k, v in self.coredata.optstore.items() if k.is_project()})
+        project_options = self.split_options_per_subproject({k: v for k, v in self.coredata.optstore.items() if self.coredata.optstore.is_project_option(k)})
         show_build_options = self.default_values_only or self.build.environment.is_cross_build()
 
         self.add_section('Main project options')

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -291,7 +291,7 @@ class Conf:
         self.print_options('Core options', host_core_options[''])
         if show_build_options:
             self.print_options('', build_core_options[''])
-        self.print_options('Backend options', {k: v for k, v in self.coredata.optstore.items() if k.is_backend()})
+        self.print_options('Backend options', {k: v for k, v in self.coredata.optstore.items() if self.coredata.optstore.is_backend_option(k)})
         self.print_options('Base options', {k: v for k, v in self.coredata.optstore.items() if self.coredata.optstore.is_base_option(k)})
         self.print_options('Compiler options', host_compiler_options.get('', {}))
         if show_build_options:

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -277,7 +277,7 @@ class Conf:
                 if self.build and k.module not in self.build.modules:
                     continue
                 module_options[k.module][k] = v
-            elif k.is_builtin():
+            elif self.coredata.optstore.is_builtin_option(k):
                 core_options[k] = v
 
         host_core_options = self.split_options_per_subproject({k: v for k, v in core_options.items() if k.machine is MachineChoice.HOST})

--- a/mesonbuild/mdevenv.py
+++ b/mesonbuild/mdevenv.py
@@ -9,8 +9,9 @@ import typing as T
 
 from pathlib import Path
 from . import build, minstall
-from .mesonlib import (EnvironmentVariables, MesonException, is_windows, setup_vsenv, OptionKey,
+from .mesonlib import (EnvironmentVariables, MesonException, is_windows, setup_vsenv,
                        get_wine_shortpath, MachineChoice, relpath)
+from .options import OptionKey
 from . import mlog
 
 

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -23,7 +23,8 @@ from glob import glob
 from pathlib import Path
 from mesonbuild.environment import Environment, detect_ninja
 from mesonbuild.mesonlib import (MesonException, RealPathAction, get_meson_command, quiet_git,
-                                 windows_proof_rmtree, setup_vsenv, OptionKey)
+                                 windows_proof_rmtree, setup_vsenv)
+from .options import OptionKey
 from mesonbuild.msetup import add_arguments as msetup_argparse
 from mesonbuild.wrap import wrap
 from mesonbuild import mlog, build, coredata

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -20,6 +20,7 @@ from mesonbuild.coredata import FORBIDDEN_TARGET_NAMES
 from mesonbuild.environment import detect_ninja
 from mesonbuild.templates.mesontemplates import create_meson_build
 from mesonbuild.templates.samplefactory import sample_generator
+from mesonbuild.options import OptionKey
 
 if T.TYPE_CHECKING:
     import argparse
@@ -192,7 +193,7 @@ def run(options: Arguments) -> int:
             raise SystemExit
 
         b = build.load(options.builddir)
-        need_vsenv = T.cast('bool', b.environment.coredata.get_option(mesonlib.OptionKey('vsenv')))
+        need_vsenv = T.cast('bool', b.environment.coredata.get_option(OptionKey('vsenv')))
         vsenv_active = mesonlib.setup_vsenv(need_vsenv)
         if vsenv_active:
             mlog.log(mlog.green('INFO:'), 'automatically activated MSVC compiler environment')

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -18,7 +18,8 @@ import re
 from . import build, environment
 from .backend.backends import InstallData
 from .mesonlib import (MesonException, Popen_safe, RealPathAction, is_windows,
-                       is_aix, setup_vsenv, pickle_load, is_osx, OptionKey)
+                       is_aix, setup_vsenv, pickle_load, is_osx)
+from .options import OptionKey
 from .scripts import depfixer, destdir_join
 from .scripts.meson_exe import run_exe
 try:

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -329,7 +329,7 @@ def list_buildoptions(coredata: cdata.CoreData, subprojects: T.Optional[T.List[s
 
     add_keys(core_options, 'core')
     add_keys({k: v for k, v in coredata.optstore.items() if k.is_backend()}, 'backend')
-    add_keys({k: v for k, v in coredata.optstore.items() if k.is_base()}, 'base')
+    add_keys({k: v for k, v in coredata.optstore.items() if coredata.optstore.is_base_option(k)}, 'base')
     add_keys(
         {k: v for k, v in sorted(coredata.optstore.items(), key=lambda i: i[0].machine) if k.is_compiler()},
         'compiler',

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -328,7 +328,7 @@ def list_buildoptions(coredata: cdata.CoreData, subprojects: T.Optional[T.List[s
             optlist.append(optdict)
 
     add_keys(core_options, 'core')
-    add_keys({k: v for k, v in coredata.optstore.items() if k.is_backend()}, 'backend')
+    add_keys({k: v for k, v in coredata.optstore.items() if coredata.optstore.is_backend_option(k)}, 'backend')
     add_keys({k: v for k, v in coredata.optstore.items() if coredata.optstore.is_base_option(k)}, 'base')
     add_keys(
         {k: v for k, v in sorted(coredata.optstore.items(), key=lambda i: i[0].machine) if k.is_compiler()},

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -298,7 +298,7 @@ def list_buildoptions(coredata: cdata.CoreData, subprojects: T.Optional[T.List[s
             dir_options[k] = v
         elif k in test_option_names:
             test_options[k] = v
-        elif k.is_builtin():
+        elif coredata.optstore.is_builtin_option(k):
             core_options[k] = v
             if not v.yielding:
                 for s in subprojects:

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -25,7 +25,7 @@ from .backend import backends
 from .dependencies import Dependency
 from . import environment
 from .interpreterbase import ObjectHolder
-from .mesonlib import OptionKey
+from .options import OptionKey
 from .mparser import FunctionNode, ArrayNode, ArgumentNode, StringNode
 
 if T.TYPE_CHECKING:

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -335,7 +335,7 @@ def list_buildoptions(coredata: cdata.CoreData, subprojects: T.Optional[T.List[s
         'compiler',
     )
     add_keys(dir_options, 'directory')
-    add_keys({k: v for k, v in coredata.optstore.items() if k.is_project()}, 'user')
+    add_keys({k: v for k, v in coredata.optstore.items() if coredata.optstore.is_project_option(k)}, 'user')
     add_keys(test_options, 'test')
     return optlist
 

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -331,7 +331,7 @@ def list_buildoptions(coredata: cdata.CoreData, subprojects: T.Optional[T.List[s
     add_keys({k: v for k, v in coredata.optstore.items() if coredata.optstore.is_backend_option(k)}, 'backend')
     add_keys({k: v for k, v in coredata.optstore.items() if coredata.optstore.is_base_option(k)}, 'base')
     add_keys(
-        {k: v for k, v in sorted(coredata.optstore.items(), key=lambda i: i[0].machine) if k.is_compiler()},
+        {k: v for k, v in sorted(coredata.optstore.items(), key=lambda i: i[0].machine) if coredata.optstore.is_compiler_option(k)},
         'compiler',
     )
     add_keys(dir_options, 'directory')

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -8,6 +8,7 @@ import dataclasses
 import typing as T
 
 from .. import build, mesonlib
+from ..options import OptionKey
 from ..build import IncludeDirs
 from ..interpreterbase.decorators import noKwargs, noPosargs
 from ..mesonlib import relpath, HoldableObject, MachineChoice
@@ -134,13 +135,13 @@ class ModuleState:
                    machine: MachineChoice = MachineChoice.HOST,
                    lang: T.Optional[str] = None,
                    module: T.Optional[str] = None) -> T.Union[T.List[str], str, int, bool]:
-        return self.environment.coredata.get_option(mesonlib.OptionKey(name, subproject, machine, lang, module))
+        return self.environment.coredata.get_option(OptionKey(name, subproject, machine, lang, module))
 
     def is_user_defined_option(self, name: str, subproject: str = '',
                                machine: MachineChoice = MachineChoice.HOST,
                                lang: T.Optional[str] = None,
                                module: T.Optional[str] = None) -> bool:
-        key = mesonlib.OptionKey(name, subproject, machine, lang, module)
+        key = OptionKey(name, subproject, machine, lang, module)
         return key in self._interpreter.user_defined_options.cmd_line_options
 
     def process_include_dirs(self, dirs: T.Iterable[T.Union[str, IncludeDirs]]) -> T.Iterable[IncludeDirs]:

--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -10,6 +10,7 @@ import typing as T
 from . import ExtensionModule, ModuleReturnValue, ModuleObject, ModuleInfo
 
 from .. import build, mesonlib, mlog, dependencies
+from ..options import OptionKey
 from ..cmake import TargetOptions, cmake_defines_to_args
 from ..interpreter import SubprojectHolder
 from ..interpreter.type_checking import REQUIRED_KW, INSTALL_DIR_KW, NoneType, in_set_validator
@@ -299,7 +300,7 @@ class CmakeModule(ExtensionModule):
 
         pkgroot = pkgroot_name = kwargs['install_dir']
         if pkgroot is None:
-            pkgroot = os.path.join(state.environment.coredata.get_option(mesonlib.OptionKey('libdir')), 'cmake', name)
+            pkgroot = os.path.join(state.environment.coredata.get_option(OptionKey('libdir')), 'cmake', name)
             pkgroot_name = os.path.join('{libdir}', 'cmake', name)
 
         template_file = os.path.join(self.cmake_root, 'Modules', f'BasicConfigVersion-{compatibility}.cmake.in')
@@ -370,14 +371,14 @@ class CmakeModule(ExtensionModule):
 
         install_dir = kwargs['install_dir']
         if install_dir is None:
-            install_dir = os.path.join(state.environment.coredata.get_option(mesonlib.OptionKey('libdir')), 'cmake', name)
+            install_dir = os.path.join(state.environment.coredata.get_option(OptionKey('libdir')), 'cmake', name)
 
         conf = kwargs['configuration']
         if isinstance(conf, dict):
             FeatureNew.single_use('cmake.configure_package_config_file dict as configuration', '0.62.0', state.subproject, location=state.current_node)
             conf = build.ConfigurationData(conf)
 
-        prefix = state.environment.coredata.get_option(mesonlib.OptionKey('prefix'))
+        prefix = state.environment.coredata.get_option(OptionKey('prefix'))
         abs_install_dir = install_dir
         if not os.path.isabs(abs_install_dir):
             abs_install_dir = os.path.join(prefix, install_dir)

--- a/mesonbuild/modules/external_project.py
+++ b/mesonbuild/modules/external_project.py
@@ -19,7 +19,8 @@ from ..interpreterbase import FeatureNew
 from ..interpreter.type_checking import ENV_KW, DEPENDS_KW
 from ..interpreterbase.decorators import ContainerTypeInfo, KwargInfo, typed_kwargs, typed_pos_args
 from ..mesonlib import (EnvironmentException, MesonException, Popen_safe, MachineChoice,
-                        get_variable_regex, do_replacement, join_args, OptionKey)
+                        get_variable_regex, do_replacement, join_args)
+from ..options import OptionKey
 
 if T.TYPE_CHECKING:
     from typing_extensions import TypedDict

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -31,6 +31,7 @@ from ..interpreterbase.decorators import typed_pos_args
 from ..mesonlib import (
     MachineChoice, MesonException, OrderedSet, Popen_safe, join_args, quote_arg
 )
+from ..options import OptionKey
 from ..programs import OverrideProgram
 from ..scripts.gettext import read_linguas
 
@@ -516,7 +517,7 @@ class GnomeModule(ExtensionModule):
         if gresource: # Only one target for .gresource files
             return ModuleReturnValue(target_c, [target_c])
 
-        install_dir = kwargs['install_dir'] or state.environment.coredata.get_option(mesonlib.OptionKey('includedir'))
+        install_dir = kwargs['install_dir'] or state.environment.coredata.get_option(OptionKey('includedir'))
         assert isinstance(install_dir, str), 'for mypy'
         target_h = GResourceHeaderTarget(
             f'{target_name}_h',
@@ -905,7 +906,7 @@ class GnomeModule(ExtensionModule):
                 cflags += state.global_args[lang]
             if state.project_args.get(lang):
                 cflags += state.project_args[lang]
-            if mesonlib.OptionKey('b_sanitize') in compiler.base_options:
+            if OptionKey('b_sanitize') in compiler.base_options:
                 sanitize = state.environment.coredata.optstore.get_value('b_sanitize')
                 cflags += compiler.sanitizer_compile_args(sanitize)
                 sanitize = sanitize.split(',')
@@ -1642,7 +1643,7 @@ class GnomeModule(ExtensionModule):
 
         targets = []
         install_header = kwargs['install_header']
-        install_dir = kwargs['install_dir'] or state.environment.coredata.get_option(mesonlib.OptionKey('includedir'))
+        install_dir = kwargs['install_dir'] or state.environment.coredata.get_option(OptionKey('includedir'))
         assert isinstance(install_dir, str), 'for mypy'
 
         output = namebase + '.c'
@@ -1954,7 +1955,7 @@ class GnomeModule(ExtensionModule):
             ) -> build.CustomTarget:
         real_cmd: T.List[T.Union[str, 'ToolType']] = [self._find_tool(state, 'glib-mkenums')]
         real_cmd.extend(cmd)
-        _install_dir = install_dir or state.environment.coredata.get_option(mesonlib.OptionKey('includedir'))
+        _install_dir = install_dir or state.environment.coredata.get_option(OptionKey('includedir'))
         assert isinstance(_install_dir, str), 'for mypy'
 
         return CustomTarget(
@@ -2166,7 +2167,7 @@ class GnomeModule(ExtensionModule):
                 cmd.append(gir_file)
 
         vapi_output = library + '.vapi'
-        datadir = state.environment.coredata.get_option(mesonlib.OptionKey('datadir'))
+        datadir = state.environment.coredata.get_option(OptionKey('datadir'))
         assert isinstance(datadir, str), 'for mypy'
         install_dir = kwargs['install_dir'] or os.path.join(datadir, 'vala', 'vapi')
 

--- a/mesonbuild/modules/hotdoc.py
+++ b/mesonbuild/modules/hotdoc.py
@@ -20,6 +20,7 @@ from ..interpreter.interpreterobjects import _CustomTargetHolder
 from ..interpreter.type_checking import NoneType
 from ..mesonlib import File, MesonException
 from ..programs import ExternalProgram
+from ..options import OptionKey
 
 if T.TYPE_CHECKING:
     from typing_extensions import TypedDict
@@ -330,7 +331,7 @@ class HotdocTargetBuilder:
         for path in self.include_paths:
             self.cmd.extend(['--include-path', path])
 
-        if self.state.environment.coredata.get_option(mesonlib.OptionKey('werror', subproject=self.state.subproject)):
+        if self.state.environment.coredata.get_option(OptionKey('werror', subproject=self.state.subproject)):
             self.cmd.append('--fatal-warnings')
         self.generate_hotdoc_config()
 

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -10,6 +10,7 @@ import typing as T
 from . import ExtensionModule, ModuleReturnValue, ModuleInfo
 from .. import build
 from .. import mesonlib
+from ..options import OptionKey
 from .. import mlog
 from ..interpreter.type_checking import CT_BUILD_BY_DEFAULT, CT_INPUT_KW, INSTALL_TAG_KW, OUTPUT_KW, INSTALL_DIR_KW, INSTALL_KW, NoneType, in_set_validator
 from ..interpreterbase import FeatureNew, InvalidArguments
@@ -277,7 +278,7 @@ class I18nModule(ExtensionModule):
         targets.append(pottarget)
 
         install = kwargs['install']
-        install_dir = kwargs['install_dir'] or state.environment.coredata.get_option(mesonlib.OptionKey('localedir'))
+        install_dir = kwargs['install_dir'] or state.environment.coredata.get_option(OptionKey('localedir'))
         assert isinstance(install_dir, str), 'for mypy'
         if not languages:
             languages = read_linguas(path.join(state.environment.source_dir, state.subdir))

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -13,6 +13,7 @@ from . import ModuleReturnValue
 from .. import build
 from .. import dependencies
 from .. import mesonlib
+from ..options import OptionKey
 from .. import mlog
 from ..options import BUILTIN_DIR_OPTIONS
 from ..dependencies.pkgconfig import PkgConfigDependency, PkgConfigInterface
@@ -482,7 +483,7 @@ class PkgConfigModule(NewExtensionModule):
             srcdir = PurePath(state.environment.get_source_dir())
         else:
             outdir = state.environment.scratch_dir
-            prefix = PurePath(_as_str(coredata.get_option(mesonlib.OptionKey('prefix'))))
+            prefix = PurePath(_as_str(coredata.get_option(OptionKey('prefix'))))
             if pkgroot:
                 pkgroot_ = PurePath(pkgroot)
                 if not pkgroot_.is_absolute():
@@ -499,7 +500,7 @@ class PkgConfigModule(NewExtensionModule):
                     if optname == 'prefix':
                         ofile.write('prefix={}\n'.format(self._escape(prefix)))
                     else:
-                        dirpath = PurePath(_as_str(coredata.get_option(mesonlib.OptionKey(optname))))
+                        dirpath = PurePath(_as_str(coredata.get_option(OptionKey(optname))))
                         ofile.write('{}={}\n'.format(optname, self._escape('${prefix}' / dirpath)))
             if uninstalled and not dataonly:
                 ofile.write('srcdir={}\n'.format(self._escape(srcdir)))
@@ -694,13 +695,13 @@ class PkgConfigModule(NewExtensionModule):
         pkgroot = pkgroot_name = kwargs['install_dir'] or default_install_dir
         if pkgroot is None:
             if mesonlib.is_freebsd():
-                pkgroot = os.path.join(_as_str(state.environment.coredata.get_option(mesonlib.OptionKey('prefix'))), 'libdata', 'pkgconfig')
+                pkgroot = os.path.join(_as_str(state.environment.coredata.get_option(OptionKey('prefix'))), 'libdata', 'pkgconfig')
                 pkgroot_name = os.path.join('{prefix}', 'libdata', 'pkgconfig')
             elif mesonlib.is_haiku():
-                pkgroot = os.path.join(_as_str(state.environment.coredata.get_option(mesonlib.OptionKey('prefix'))), 'develop', 'lib', 'pkgconfig')
+                pkgroot = os.path.join(_as_str(state.environment.coredata.get_option(OptionKey('prefix'))), 'develop', 'lib', 'pkgconfig')
                 pkgroot_name = os.path.join('{prefix}', 'develop', 'lib', 'pkgconfig')
             else:
-                pkgroot = os.path.join(_as_str(state.environment.coredata.get_option(mesonlib.OptionKey('libdir'))), 'pkgconfig')
+                pkgroot = os.path.join(_as_str(state.environment.coredata.get_option(OptionKey('libdir'))), 'pkgconfig')
                 pkgroot_name = os.path.join('{libdir}', 'pkgconfig')
         relocatable = state.get_option('relocatable', module='pkgconfig')
         self._generate_pkgconfig_file(state, deps, subdirs, name, description, url,

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -22,7 +22,8 @@ from ..interpreterbase import (
     InvalidArguments, typed_pos_args, typed_kwargs, KwargInfo,
     FeatureNew, FeatureNewKwargs, disablerIfNotFound
 )
-from ..mesonlib import MachineChoice, OptionKey
+from ..mesonlib import MachineChoice
+from ..options import OptionKey
 from ..programs import ExternalProgram, NonExistingExternalProgram
 
 if T.TYPE_CHECKING:
@@ -112,7 +113,7 @@ class PythonInstallation(_ExternalProgramHolder['PythonExternalProgram']):
     def __init__(self, python: 'PythonExternalProgram', interpreter: 'Interpreter'):
         _ExternalProgramHolder.__init__(self, python, interpreter)
         info = python.info
-        prefix = self.interpreter.environment.coredata.get_option(mesonlib.OptionKey('prefix'))
+        prefix = self.interpreter.environment.coredata.get_option(OptionKey('prefix'))
         assert isinstance(prefix, str), 'for mypy'
         self.variables = info['variables']
         self.suffix = info['suffix']
@@ -373,7 +374,7 @@ class PythonModule(ExtensionModule):
     def _get_install_scripts(self) -> T.List[mesonlib.ExecutableSerialisation]:
         backend = self.interpreter.backend
         ret = []
-        optlevel = self.interpreter.environment.coredata.get_option(mesonlib.OptionKey('bytecompile', module='python'))
+        optlevel = self.interpreter.environment.coredata.get_option(OptionKey('bytecompile', module='python'))
         if optlevel == -1:
             return ret
         if not any(PythonExternalProgram.run_bytecompile.values()):

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -11,6 +11,7 @@ import typing as T
 
 from . import build, coredata, environment, interpreter, mesonlib, mintro, mlog
 from .mesonlib import MesonException
+from .options import OptionKey
 
 if T.TYPE_CHECKING:
     from typing_extensions import Protocol
@@ -320,10 +321,10 @@ def run_genvslite_setup(options: CMDOptions) -> None:
     # invoke the appropriate 'meson compile ...' build commands upon the normal visual studio build/rebuild/clean actions, instead of using
     # the native VS/msbuild system.
     builddir_prefix = options.builddir
-    genvsliteval = options.cmd_line_options.pop(mesonlib.OptionKey('genvslite'))
+    genvsliteval = options.cmd_line_options.pop(OptionKey('genvslite'))
     # The command line may specify a '--backend' option, which doesn't make sense in conjunction with
     # '--genvslite', where we always want to use a ninja back end -
-    k_backend = mesonlib.OptionKey('backend')
+    k_backend = OptionKey('backend')
     if k_backend in options.cmd_line_options.keys():
         if options.cmd_line_options[k_backend] != 'ninja':
             raise MesonException('Explicitly specifying a backend option with \'genvslite\' is not necessary '
@@ -336,12 +337,12 @@ def run_genvslite_setup(options: CMDOptions) -> None:
 
     for buildtypestr in buildtypes_list:
         options.builddir = f'{builddir_prefix}_{buildtypestr}' # E.g. builddir_release
-        options.cmd_line_options[mesonlib.OptionKey('buildtype')] = buildtypestr
+        options.cmd_line_options[OptionKey('buildtype')] = buildtypestr
         app = MesonApp(options)
         vslite_ctx[buildtypestr] = app.generate(capture=True)
     #Now for generating the 'lite' solution and project files, which will use these builds we've just set up, above.
     options.builddir = f'{builddir_prefix}_vs'
-    options.cmd_line_options[mesonlib.OptionKey('genvslite')] = genvsliteval
+    options.cmd_line_options[OptionKey('genvslite')] = genvsliteval
     app = MesonApp(options)
     app.generate(capture=False, vslite_ctx=vslite_ctx)
 
@@ -357,7 +358,7 @@ def run(options: T.Union[CMDOptions, T.List[str]]) -> int:
     # lie
     options.pager = False
 
-    if mesonlib.OptionKey('genvslite') in options.cmd_line_options.keys():
+    if OptionKey('genvslite') in options.cmd_line_options.keys():
         run_genvslite_setup(options)
     else:
         app = MesonApp(options)

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -35,8 +35,9 @@ from . import environment
 from . import mlog
 from .coredata import MesonVersionMismatchException, major_versions_differ
 from .coredata import version as coredata_version
-from .mesonlib import (MesonException, OptionKey, OrderedSet, RealPathAction,
+from .mesonlib import (MesonException, OrderedSet, RealPathAction,
                        get_wine_shortpath, join_args, split_args, setup_vsenv)
+from .options import OptionKey
 from .mintro import get_infodir, load_info_file
 from .programs import ExternalProgram
 from .backend.backends import TestProtocol, TestSerialisation

--- a/mesonbuild/munstable_coredata.py
+++ b/mesonbuild/munstable_coredata.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 
 from . import coredata as cdata
-from .mesonlib import MachineChoice, OptionKey
+from .mesonlib import MachineChoice
+from .options import OptionKey
 
 import os.path
 import pprint

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -9,6 +9,7 @@ import typing as T
 from . import coredata
 from . import options
 from . import mesonlib
+from .options import OptionKey
 from . import mparser
 from . import mlog
 from .interpreterbase import FeatureNew, FeatureDeprecated, typed_pos_args, typed_kwargs, ContainerTypeInfo, KwargInfo
@@ -190,7 +191,7 @@ class OptionInterpreter:
         opt_name = args[0]
         if optname_regex.search(opt_name) is not None:
             raise OptionException('Option names can only contain letters, numbers or dashes.')
-        key = mesonlib.OptionKey.from_string(opt_name).evolve(subproject=self.subproject)
+        key = OptionKey.from_string(opt_name).evolve(subproject=self.subproject)
         if self.optionstore.is_reserved_name(key):
             raise OptionException('Option name %s is reserved.' % opt_name)
 

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -8,6 +8,7 @@ import argparse
 from .mesonlib import (
     HoldableObject,
     OptionKey,
+    OptionType,
     default_prefix,
     default_datadir,
     default_includedir,
@@ -536,3 +537,10 @@ class OptionStore:
 
     def get(self, *args, **kwargs) -> UserOption:
         return self.d.get(*args, **kwargs)
+
+    def is_project_option(self, key: OptionKey) -> bool:
+        """Convenience method to check if this is a project option."""
+        return key.type is OptionType.PROJECT
+
+    def is_reserved_name(self, key: OptionKey) -> bool:
+        return not self.is_project_option(key)

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -556,3 +556,7 @@ class OptionStore:
     def is_backend_option(self, key: OptionKey) -> bool:
         """Convenience method to check if this is a backend option."""
         return key.type is OptionType.BACKEND
+
+    def is_compiler_option(self, key: OptionKey) -> bool:
+        """Convenience method to check if this is a compiler option."""
+        return key.type is OptionType.COMPILER

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -548,3 +548,7 @@ class OptionStore:
     def is_base_option(self, key: OptionKey) -> bool:
         """Convenience method to check if this is a base option."""
         return key.type is OptionType.BASE
+
+    def is_backend_option(self, key: OptionKey) -> bool:
+        """Convenience method to check if this is a backend option."""
+        return key.type is OptionType.BACKEND

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -3,12 +3,12 @@
 
 from collections import OrderedDict
 from itertools import chain
+from functools import total_ordering
 import argparse
+import enum
 
 from .mesonlib import (
     HoldableObject,
-    OptionKey,
-    OptionType,
     default_prefix,
     default_datadir,
     default_includedir,
@@ -21,6 +21,7 @@ from .mesonlib import (
     default_sysconfdir,
     MesonException,
     listify_array_value,
+    MachineChoice,
 )
 
 from . import mlog
@@ -36,6 +37,239 @@ _T = T.TypeVar('_T')
 backendlist = ['ninja', 'vs', 'vs2010', 'vs2012', 'vs2013', 'vs2015', 'vs2017', 'vs2019', 'vs2022', 'xcode', 'none']
 genvslitelist = ['vs2022']
 buildtypelist = ['plain', 'debug', 'debugoptimized', 'release', 'minsize', 'custom']
+
+
+class OptionType(enum.IntEnum):
+
+    """Enum used to specify what kind of argument a thing is."""
+
+    BUILTIN = 0
+    BACKEND = 1
+    BASE = 2
+    COMPILER = 3
+    PROJECT = 4
+
+def _classify_argument(key: 'OptionKey') -> OptionType:
+    """Classify arguments into groups so we know which dict to assign them to."""
+
+    if key.name.startswith('b_'):
+        return OptionType.BASE
+    elif key.lang is not None:
+        return OptionType.COMPILER
+    elif key.name in _BUILTIN_NAMES or key.module:
+        return OptionType.BUILTIN
+    elif key.name.startswith('backend_'):
+        assert key.machine is MachineChoice.HOST, str(key)
+        return OptionType.BACKEND
+    else:
+        assert key.machine is MachineChoice.HOST, str(key)
+        return OptionType.PROJECT
+
+# This is copied from coredata. There is no way to share this, because this
+# is used in the OptionKey constructor, and the coredata lists are
+# OptionKeys...
+_BUILTIN_NAMES = {
+    'prefix',
+    'bindir',
+    'datadir',
+    'includedir',
+    'infodir',
+    'libdir',
+    'licensedir',
+    'libexecdir',
+    'localedir',
+    'localstatedir',
+    'mandir',
+    'sbindir',
+    'sharedstatedir',
+    'sysconfdir',
+    'auto_features',
+    'backend',
+    'buildtype',
+    'debug',
+    'default_library',
+    'errorlogs',
+    'genvslite',
+    'install_umask',
+    'layout',
+    'optimization',
+    'prefer_static',
+    'stdsplit',
+    'strip',
+    'unity',
+    'unity_size',
+    'warning_level',
+    'werror',
+    'wrap_mode',
+    'force_fallback_for',
+    'pkg_config_path',
+    'cmake_prefix_path',
+    'vsenv',
+}
+
+@total_ordering
+class OptionKey:
+
+    """Represents an option key in the various option dictionaries.
+
+    This provides a flexible, powerful way to map option names from their
+    external form (things like subproject:build.option) to something that
+    internally easier to reason about and produce.
+    """
+
+    __slots__ = ['name', 'subproject', 'machine', 'lang', '_hash', 'type', 'module']
+
+    name: str
+    subproject: str
+    machine: MachineChoice
+    lang: T.Optional[str]
+    _hash: int
+    type: OptionType
+    module: T.Optional[str]
+
+    def __init__(self, name: str, subproject: str = '',
+                 machine: MachineChoice = MachineChoice.HOST,
+                 lang: T.Optional[str] = None,
+                 module: T.Optional[str] = None,
+                 _type: T.Optional[OptionType] = None):
+        # the _type option to the constructor is kinda private. We want to be
+        # able tos ave the state and avoid the lookup function when
+        # pickling/unpickling, but we need to be able to calculate it when
+        # constructing a new OptionKey
+        object.__setattr__(self, 'name', name)
+        object.__setattr__(self, 'subproject', subproject)
+        object.__setattr__(self, 'machine', machine)
+        object.__setattr__(self, 'lang', lang)
+        object.__setattr__(self, 'module', module)
+        object.__setattr__(self, '_hash', hash((name, subproject, machine, lang, module)))
+        if _type is None:
+            _type = _classify_argument(self)
+        object.__setattr__(self, 'type', _type)
+
+    def __setattr__(self, key: str, value: T.Any) -> None:
+        raise AttributeError('OptionKey instances do not support mutation.')
+
+    def __getstate__(self) -> T.Dict[str, T.Any]:
+        return {
+            'name': self.name,
+            'subproject': self.subproject,
+            'machine': self.machine,
+            'lang': self.lang,
+            '_type': self.type,
+            'module': self.module,
+        }
+
+    def __setstate__(self, state: T.Dict[str, T.Any]) -> None:
+        """De-serialize the state of a pickle.
+
+        This is very clever. __init__ is not a constructor, it's an
+        initializer, therefore it's safe to call more than once. We create a
+        state in the custom __getstate__ method, which is valid to pass
+        splatted to the initializer.
+        """
+        # Mypy doesn't like this, because it's so clever.
+        self.__init__(**state)  # type: ignore
+
+    def __hash__(self) -> int:
+        return self._hash
+
+    def _to_tuple(self) -> T.Tuple[str, OptionType, str, str, MachineChoice, str]:
+        return (self.subproject, self.type, self.lang or '', self.module or '', self.machine, self.name)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, OptionKey):
+            return self._to_tuple() == other._to_tuple()
+        return NotImplemented
+
+    def __lt__(self, other: object) -> bool:
+        if isinstance(other, OptionKey):
+            return self._to_tuple() < other._to_tuple()
+        return NotImplemented
+
+    def __str__(self) -> str:
+        out = self.name
+        if self.lang:
+            out = f'{self.lang}_{out}'
+        if self.machine is MachineChoice.BUILD:
+            out = f'build.{out}'
+        if self.module:
+            out = f'{self.module}.{out}'
+        if self.subproject:
+            out = f'{self.subproject}:{out}'
+        return out
+
+    def __repr__(self) -> str:
+        return f'OptionKey({self.name!r}, {self.subproject!r}, {self.machine!r}, {self.lang!r}, {self.module!r}, {self.type!r})'
+
+    @classmethod
+    def from_string(cls, raw: str) -> 'OptionKey':
+        """Parse the raw command line format into a three part tuple.
+
+        This takes strings like `mysubproject:build.myoption` and Creates an
+        OptionKey out of them.
+        """
+        try:
+            subproject, raw2 = raw.split(':')
+        except ValueError:
+            subproject, raw2 = '', raw
+
+        module = None
+        for_machine = MachineChoice.HOST
+        try:
+            prefix, raw3 = raw2.split('.')
+            if prefix == 'build':
+                for_machine = MachineChoice.BUILD
+            else:
+                module = prefix
+        except ValueError:
+            raw3 = raw2
+
+        from .compilers import all_languages
+        if any(raw3.startswith(f'{l}_') for l in all_languages):
+            lang, opt = raw3.split('_', 1)
+        else:
+            lang, opt = None, raw3
+        assert ':' not in opt
+        assert '.' not in opt
+
+        return cls(opt, subproject, for_machine, lang, module)
+
+    def evolve(self, name: T.Optional[str] = None, subproject: T.Optional[str] = None,
+               machine: T.Optional[MachineChoice] = None, lang: T.Optional[str] = '',
+               module: T.Optional[str] = '') -> 'OptionKey':
+        """Create a new copy of this key, but with altered members.
+
+        For example:
+        >>> a = OptionKey('foo', '', MachineChoice.Host)
+        >>> b = OptionKey('foo', 'bar', MachineChoice.Host)
+        >>> b == a.evolve(subproject='bar')
+        True
+        """
+        # We have to be a little clever with lang here, because lang is valid
+        # as None, for non-compiler options
+        return OptionKey(
+            name if name is not None else self.name,
+            subproject if subproject is not None else self.subproject,
+            machine if machine is not None else self.machine,
+            lang if lang != '' else self.lang,
+            module if module != '' else self.module
+        )
+
+    def as_root(self) -> 'OptionKey':
+        """Convenience method for key.evolve(subproject='')."""
+        return self.evolve(subproject='')
+
+    def as_build(self) -> 'OptionKey':
+        """Convenience method for key.evolve(machine=MachineChoice.BUILD)."""
+        return self.evolve(machine=MachineChoice.BUILD)
+
+    def as_host(self) -> 'OptionKey':
+        """Convenience method for key.evolve(machine=MachineChoice.HOST)."""
+        return self.evolve(machine=MachineChoice.HOST)
+
+    def is_project_hack_for_optionsview(self) -> bool:
+        """This method will be removed once we can delete OptionsView."""
+        return self.type is OptionType.PROJECT
 
 
 class UserOption(T.Generic[_T], HoldableObject):

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -545,6 +545,10 @@ class OptionStore:
     def is_reserved_name(self, key: OptionKey) -> bool:
         return not self.is_project_option(key)
 
+    def is_builtin_option(self, key: OptionKey) -> bool:
+        """Convenience method to check if this is a builtin option."""
+        return key.type is OptionType.BUILTIN
+
     def is_base_option(self, key: OptionKey) -> bool:
         """Convenience method to check if this is a base option."""
         return key.type is OptionType.BASE

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -544,3 +544,7 @@ class OptionStore:
 
     def is_reserved_name(self, key: OptionKey) -> bool:
         return not self.is_project_option(key)
+
+    def is_base_option(self, key: OptionKey) -> bool:
+        """Convenience method to check if this is a base option."""
+        return key.type is OptionType.BASE

--- a/mesonbuild/scripts/regen_checker.py
+++ b/mesonbuild/scripts/regen_checker.py
@@ -8,7 +8,7 @@ import pickle, subprocess
 import typing as T
 from ..coredata import CoreData
 from ..backend.backends import RegenInfo
-from ..mesonlib import OptionKey
+from ..options import OptionKey
 
 # This could also be used for XCode.
 

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -2387,10 +2387,6 @@ class OptionKey:
         """Convenience method for key.evolve(machine=MachineChoice.HOST)."""
         return self.evolve(machine=MachineChoice.HOST)
 
-    def is_backend(self) -> bool:
-        """Convenience method to check if this is a backend option."""
-        return self.type is OptionType.BACKEND
-
     def is_builtin(self) -> bool:
         """Convenience method to check if this is a builtin option."""
         return self.type is OptionType.BUILTIN

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -2403,10 +2403,6 @@ class OptionKey:
         """This method will be removed once we can delete OptionsView."""
         return self.type is OptionType.PROJECT
 
-    def is_base(self) -> bool:
-        """Convenience method to check if this is a base option."""
-        return self.type is OptionType.BASE
-
 
 def pickle_load(filename: str, object_name: str, object_type: T.Type[_PL], suggest_reconfigure: bool = True) -> _PL:
     load_fail_msg = f'{object_name} file {filename!r} is corrupted.'

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -2387,10 +2387,6 @@ class OptionKey:
         """Convenience method for key.evolve(machine=MachineChoice.HOST)."""
         return self.evolve(machine=MachineChoice.HOST)
 
-    def is_builtin(self) -> bool:
-        """Convenience method to check if this is a builtin option."""
-        return self.type is OptionType.BUILTIN
-
     def is_compiler(self) -> bool:
         """Convenience method to check if this is a builtin option."""
         return self.type is OptionType.COMPILER

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -15,7 +15,7 @@ import time
 import abc
 import platform, subprocess, operator, os, shlex, shutil, re
 import collections
-from functools import lru_cache, wraps, total_ordering
+from functools import lru_cache, wraps
 from itertools import tee
 from tempfile import TemporaryDirectory, NamedTemporaryFile
 import typing as T
@@ -67,9 +67,7 @@ __all__ = [
     'EnvironmentException',
     'FileOrString',
     'GitException',
-    'OptionKey',
     'dump_conf_header',
-    'OptionType',
     'OrderedSet',
     'PerMachine',
     'PerMachineDefaultable',
@@ -1981,7 +1979,58 @@ class LibType(enum.IntEnum):
 
 class ProgressBarFallback:  # lgtm [py/iter-returns-non-self]
     '''
-    Fallback progress bar implementation when tqdm is not found
+    Fallback progress bar implementation when tqdm is not foundclass OptionType(enum.IntEnum):
+
+    """Enum used to specify what kind of argument a thing is."""
+
+    BUILTIN = 0
+    BACKEND = 1
+    BASE = 2
+    COMPILER = 3
+    PROJECT = 4
+
+# This is copied from coredata. There is no way to share this, because this
+# is used in the OptionKey constructor, and the coredata lists are
+# OptionKeys...
+_BUILTIN_NAMES = {
+    'prefix',
+    'bindir',
+    'datadir',
+    'includedir',
+    'infodir',
+    'libdir',
+    'licensedir',
+    'libexecdir',
+    'localedir',
+    'localstatedir',
+    'mandir',
+    'sbindir',
+    'sharedstatedir',
+    'sysconfdir',
+    'auto_features',
+    'backend',
+    'buildtype',
+    'debug',
+    'default_library',
+    'errorlogs',
+    'genvslite',
+    'install_umask',
+    'layout',
+    'optimization',
+    'prefer_static',
+    'stdsplit',
+    'strip',
+    'unity',
+    'unity_size',
+    'warning_level',
+    'werror',
+    'wrap_mode',
+    'force_fallback_for',
+    'pkg_config_path',
+    'cmake_prefix_path',
+    'vsenv',
+}
+
 
     Since this class is not an actual iterator, but only provides a minimal
     fallback, it is safe to ignore the 'Iterator does not return self from
@@ -2155,241 +2204,6 @@ def generate_list(func: T.Callable[..., T.Generator[_T, None, None]]) -> T.Calla
         return list(func(*args, **kwargs))
 
     return wrapper
-
-
-class OptionType(enum.IntEnum):
-
-    """Enum used to specify what kind of argument a thing is."""
-
-    BUILTIN = 0
-    BACKEND = 1
-    BASE = 2
-    COMPILER = 3
-    PROJECT = 4
-
-# This is copied from coredata. There is no way to share this, because this
-# is used in the OptionKey constructor, and the coredata lists are
-# OptionKeys...
-_BUILTIN_NAMES = {
-    'prefix',
-    'bindir',
-    'datadir',
-    'includedir',
-    'infodir',
-    'libdir',
-    'licensedir',
-    'libexecdir',
-    'localedir',
-    'localstatedir',
-    'mandir',
-    'sbindir',
-    'sharedstatedir',
-    'sysconfdir',
-    'auto_features',
-    'backend',
-    'buildtype',
-    'debug',
-    'default_library',
-    'errorlogs',
-    'genvslite',
-    'install_umask',
-    'layout',
-    'optimization',
-    'prefer_static',
-    'stdsplit',
-    'strip',
-    'unity',
-    'unity_size',
-    'warning_level',
-    'werror',
-    'wrap_mode',
-    'force_fallback_for',
-    'pkg_config_path',
-    'cmake_prefix_path',
-    'vsenv',
-}
-
-
-def _classify_argument(key: 'OptionKey') -> OptionType:
-    """Classify arguments into groups so we know which dict to assign them to."""
-
-    if key.name.startswith('b_'):
-        return OptionType.BASE
-    elif key.lang is not None:
-        return OptionType.COMPILER
-    elif key.name in _BUILTIN_NAMES or key.module:
-        return OptionType.BUILTIN
-    elif key.name.startswith('backend_'):
-        assert key.machine is MachineChoice.HOST, str(key)
-        return OptionType.BACKEND
-    else:
-        assert key.machine is MachineChoice.HOST, str(key)
-        return OptionType.PROJECT
-
-
-@total_ordering
-class OptionKey:
-
-    """Represents an option key in the various option dictionaries.
-
-    This provides a flexible, powerful way to map option names from their
-    external form (things like subproject:build.option) to something that
-    internally easier to reason about and produce.
-    """
-
-    __slots__ = ['name', 'subproject', 'machine', 'lang', '_hash', 'type', 'module']
-
-    name: str
-    subproject: str
-    machine: MachineChoice
-    lang: T.Optional[str]
-    _hash: int
-    type: OptionType
-    module: T.Optional[str]
-
-    def __init__(self, name: str, subproject: str = '',
-                 machine: MachineChoice = MachineChoice.HOST,
-                 lang: T.Optional[str] = None,
-                 module: T.Optional[str] = None,
-                 _type: T.Optional[OptionType] = None):
-        # the _type option to the constructor is kinda private. We want to be
-        # able tos ave the state and avoid the lookup function when
-        # pickling/unpickling, but we need to be able to calculate it when
-        # constructing a new OptionKey
-        object.__setattr__(self, 'name', name)
-        object.__setattr__(self, 'subproject', subproject)
-        object.__setattr__(self, 'machine', machine)
-        object.__setattr__(self, 'lang', lang)
-        object.__setattr__(self, 'module', module)
-        object.__setattr__(self, '_hash', hash((name, subproject, machine, lang, module)))
-        if _type is None:
-            _type = _classify_argument(self)
-        object.__setattr__(self, 'type', _type)
-
-    def __setattr__(self, key: str, value: T.Any) -> None:
-        raise AttributeError('OptionKey instances do not support mutation.')
-
-    def __getstate__(self) -> T.Dict[str, T.Any]:
-        return {
-            'name': self.name,
-            'subproject': self.subproject,
-            'machine': self.machine,
-            'lang': self.lang,
-            '_type': self.type,
-            'module': self.module,
-        }
-
-    def __setstate__(self, state: T.Dict[str, T.Any]) -> None:
-        """De-serialize the state of a pickle.
-
-        This is very clever. __init__ is not a constructor, it's an
-        initializer, therefore it's safe to call more than once. We create a
-        state in the custom __getstate__ method, which is valid to pass
-        splatted to the initializer.
-        """
-        # Mypy doesn't like this, because it's so clever.
-        self.__init__(**state)  # type: ignore
-
-    def __hash__(self) -> int:
-        return self._hash
-
-    def _to_tuple(self) -> T.Tuple[str, OptionType, str, str, MachineChoice, str]:
-        return (self.subproject, self.type, self.lang or '', self.module or '', self.machine, self.name)
-
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, OptionKey):
-            return self._to_tuple() == other._to_tuple()
-        return NotImplemented
-
-    def __lt__(self, other: object) -> bool:
-        if isinstance(other, OptionKey):
-            return self._to_tuple() < other._to_tuple()
-        return NotImplemented
-
-    def __str__(self) -> str:
-        out = self.name
-        if self.lang:
-            out = f'{self.lang}_{out}'
-        if self.machine is MachineChoice.BUILD:
-            out = f'build.{out}'
-        if self.module:
-            out = f'{self.module}.{out}'
-        if self.subproject:
-            out = f'{self.subproject}:{out}'
-        return out
-
-    def __repr__(self) -> str:
-        return f'OptionKey({self.name!r}, {self.subproject!r}, {self.machine!r}, {self.lang!r}, {self.module!r}, {self.type!r})'
-
-    @classmethod
-    def from_string(cls, raw: str) -> 'OptionKey':
-        """Parse the raw command line format into a three part tuple.
-
-        This takes strings like `mysubproject:build.myoption` and Creates an
-        OptionKey out of them.
-        """
-        try:
-            subproject, raw2 = raw.split(':')
-        except ValueError:
-            subproject, raw2 = '', raw
-
-        module = None
-        for_machine = MachineChoice.HOST
-        try:
-            prefix, raw3 = raw2.split('.')
-            if prefix == 'build':
-                for_machine = MachineChoice.BUILD
-            else:
-                module = prefix
-        except ValueError:
-            raw3 = raw2
-
-        from ..compilers import all_languages
-        if any(raw3.startswith(f'{l}_') for l in all_languages):
-            lang, opt = raw3.split('_', 1)
-        else:
-            lang, opt = None, raw3
-        assert ':' not in opt
-        assert '.' not in opt
-
-        return cls(opt, subproject, for_machine, lang, module)
-
-    def evolve(self, name: T.Optional[str] = None, subproject: T.Optional[str] = None,
-               machine: T.Optional[MachineChoice] = None, lang: T.Optional[str] = '',
-               module: T.Optional[str] = '') -> 'OptionKey':
-        """Create a new copy of this key, but with altered members.
-
-        For example:
-        >>> a = OptionKey('foo', '', MachineChoice.Host)
-        >>> b = OptionKey('foo', 'bar', MachineChoice.Host)
-        >>> b == a.evolve(subproject='bar')
-        True
-        """
-        # We have to be a little clever with lang here, because lang is valid
-        # as None, for non-compiler options
-        return OptionKey(
-            name if name is not None else self.name,
-            subproject if subproject is not None else self.subproject,
-            machine if machine is not None else self.machine,
-            lang if lang != '' else self.lang,
-            module if module != '' else self.module
-        )
-
-    def as_root(self) -> 'OptionKey':
-        """Convenience method for key.evolve(subproject='')."""
-        return self.evolve(subproject='')
-
-    def as_build(self) -> 'OptionKey':
-        """Convenience method for key.evolve(machine=MachineChoice.BUILD)."""
-        return self.evolve(machine=MachineChoice.BUILD)
-
-    def as_host(self) -> 'OptionKey':
-        """Convenience method for key.evolve(machine=MachineChoice.HOST)."""
-        return self.evolve(machine=MachineChoice.HOST)
-
-    def is_project_hack_for_optionsview(self) -> bool:
-        """This method will be removed once we can delete OptionsView."""
-        return self.type is OptionType.PROJECT
 
 
 def pickle_load(filename: str, object_name: str, object_type: T.Type[_PL], suggest_reconfigure: bool = True) -> _PL:

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -2387,10 +2387,6 @@ class OptionKey:
         """Convenience method for key.evolve(machine=MachineChoice.HOST)."""
         return self.evolve(machine=MachineChoice.HOST)
 
-    def is_compiler(self) -> bool:
-        """Convenience method to check if this is a builtin option."""
-        return self.type is OptionType.COMPILER
-
     def is_project_hack_for_optionsview(self) -> bool:
         """This method will be removed once we can delete OptionsView."""
         return self.type is OptionType.PROJECT

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -2399,8 +2399,8 @@ class OptionKey:
         """Convenience method to check if this is a builtin option."""
         return self.type is OptionType.COMPILER
 
-    def is_project(self) -> bool:
-        """Convenience method to check if this is a project option."""
+    def is_project_hack_for_optionsview(self) -> bool:
+        """This method will be removed once we can delete OptionsView."""
         return self.type is OptionType.PROJECT
 
     def is_base(self) -> bool:

--- a/run_tests.py
+++ b/run_tests.py
@@ -35,7 +35,8 @@ from mesonbuild import mlog
 from mesonbuild.environment import Environment, detect_ninja, detect_machine_info
 from mesonbuild.coredata import version as meson_version
 from mesonbuild.options import backendlist
-from mesonbuild.mesonlib import OptionKey, setup_vsenv
+from mesonbuild.mesonlib import setup_vsenv
+from mesonbuild.options import OptionKey
 
 if T.TYPE_CHECKING:
     from mesonbuild.coredata import SharedCMDOptions

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -31,9 +31,10 @@ from mesonbuild.mesonlib import (
     BuildDirLock, MachineChoice, is_windows, is_osx, is_cygwin, is_dragonflybsd,
     is_sunos, windows_proof_rmtree, python_command, version_compare, split_args, quote_arg,
     relpath, is_linux, git, search_version, do_conf_file, do_conf_str, default_prefix,
-    MesonException, EnvironmentException, OptionKey,
+    MesonException, EnvironmentException,
     windows_proof_rm
 )
+from mesonbuild.options import OptionKey
 from mesonbuild.programs import ExternalProgram
 
 from mesonbuild.compilers.mixins.clang import ClangCompiler

--- a/unittests/datatests.py
+++ b/unittests/datatests.py
@@ -18,9 +18,8 @@ import mesonbuild.options
 import mesonbuild.modules.gnome
 from mesonbuild.interpreter import Interpreter
 from mesonbuild.ast import AstInterpreter
-from mesonbuild.mesonlib import (
-    MachineChoice, OptionKey
-)
+from mesonbuild.mesonlib import MachineChoice
+from mesonbuild.options import OptionKey
 from mesonbuild.compilers import (
     detect_c_compiler, detect_cpp_compiler
 )

--- a/unittests/helpers.py
+++ b/unittests/helpers.py
@@ -11,9 +11,10 @@ from contextlib import contextmanager
 
 from mesonbuild.compilers import detect_c_compiler, compiler_from_language
 from mesonbuild.mesonlib import (
-    MachineChoice, is_osx, is_cygwin, EnvironmentException, OptionKey, MachineChoice,
+    MachineChoice, is_osx, is_cygwin, EnvironmentException, MachineChoice,
     OrderedSet
 )
+from mesonbuild.options import OptionKey
 from run_tests import get_fake_env
 
 

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -32,9 +32,9 @@ from mesonbuild.interpreterbase import typed_pos_args, InvalidArguments, ObjectH
 from mesonbuild.interpreterbase import typed_pos_args, InvalidArguments, typed_kwargs, ContainerTypeInfo, KwargInfo
 from mesonbuild.mesonlib import (
     LibType, MachineChoice, PerMachine, Version, is_windows, is_osx,
-    is_cygwin, is_openbsd, search_version, MesonException, OptionKey,
-    OptionType
+    is_cygwin, is_openbsd, search_version, MesonException,
 )
+from mesonbuild.options import OptionKey, OptionType
 from mesonbuild.interpreter.type_checking import in_set_validator, NoneType
 from mesonbuild.dependencies.pkgconfig import PkgConfigDependency, PkgConfigInterface, PkgConfigCLI
 from mesonbuild.programs import ExternalProgram

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -25,8 +25,9 @@ import mesonbuild.modules.gnome
 from mesonbuild.mesonlib import (
     MachineChoice, is_windows, is_osx, is_cygwin, is_openbsd, is_haiku,
     is_sunos, windows_proof_rmtree, version_compare, is_linux,
-    OptionKey, EnvironmentException
+    EnvironmentException
 )
+from mesonbuild.options import OptionKey
 from mesonbuild.compilers import (
     detect_c_compiler, detect_cpp_compiler, compiler_from_language,
 )

--- a/unittests/platformagnostictests.py
+++ b/unittests/platformagnostictests.py
@@ -18,6 +18,7 @@ from .helpers import is_ci
 from mesonbuild.mesonlib import EnvironmentVariables, ExecutableSerialisation, MesonException, is_linux, python_command
 from mesonbuild.mformat import match_path
 from mesonbuild.optinterpreter import OptionInterpreter, OptionException
+from mesonbuild.options import OptionStore
 from run_tests import Backend
 
 @skipIf(is_ci() and not is_linux(), "Run only on fast platforms")
@@ -35,7 +36,8 @@ class PlatformAgnosticTests(BasePlatformTests):
         self.init(testdir, workdir=testdir)
 
     def test_invalid_option_names(self):
-        interp = OptionInterpreter('')
+        store = OptionStore()
+        interp = OptionInterpreter(store, '')
 
         def write_file(code: str):
             with tempfile.NamedTemporaryFile('w', dir=self.builddir, encoding='utf-8', delete=False) as f:
@@ -68,7 +70,8 @@ class PlatformAgnosticTests(BasePlatformTests):
 
     def test_option_validation(self):
         """Test cases that are not catch by the optinterpreter itself."""
-        interp = OptionInterpreter('')
+        store = OptionStore()
+        interp = OptionInterpreter(store, '')
 
         def write_file(code: str):
             with tempfile.NamedTemporaryFile('w', dir=self.builddir, encoding='utf-8', delete=False) as f:

--- a/unittests/windowstests.py
+++ b/unittests/windowstests.py
@@ -17,8 +17,9 @@ import mesonbuild.coredata
 import mesonbuild.modules.gnome
 from mesonbuild.mesonlib import (
     MachineChoice, is_windows, is_cygwin, python_command, version_compare,
-    EnvironmentException, OptionKey
+    EnvironmentException
 )
+from mesonbuild.options import OptionKey
 from mesonbuild.compilers import (
     detect_c_compiler, detect_d_compiler, compiler_from_language,
 )


### PR DESCRIPTION
Centralise all "is option of type X" into OptionStore.

Basically the plan going forward is:

- Move all functionality away from OptionKey
- The only things that remain in it are name, subproject and whether is is for build just like `OptionParts` in #13086
- Delete OptionsView and all that stuff (might not go in this MR)
- Delete OptionParts from the refactor branch
- Merge parts of OptionRefactor that can be done standalone
- Merge the remaining things OptionRefactor once everything else is finished
- Profit
