### PR TITLE
swift: Fix compilation error when dependency adds the macOS SDK in the include dirs

### DIFF
--- a/test cases/swift/9 sdk path from dep/foo.swift
+++ b/test cases/swift/9 sdk path from dep/foo.swift
@@ -1,0 +1,4 @@
+// This import is needed for swiftc to implictly import the FFI module
+// which will in turn conflict with the dependency's include path and error out
+// if we don't manually replace all SDK paths with the newest one.
+import Foundation

--- a/test cases/swift/9 sdk path from dep/meson.build
+++ b/test cases/swift/9 sdk path from dep/meson.build
@@ -1,0 +1,12 @@
+project('swift sdk include dir test', 'swift')
+
+bar_dep = declare_dependency(
+  # Simulates including 'libffi' from brew as a dep via pkg-config
+  # Without a workaround that replaces all SDK paths with the most recent one,
+  # a compile error will occur due to conflicting definitions of the FFI module.
+  compile_args: '-I/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include/ffi',
+)
+
+foo = static_library('foo', 'foo.swift',
+  dependencies: [bar_dep],
+)


### PR DESCRIPTION
SwiftPM issue with more context: https://github.com/swiftlang/swift-package-manager/issues/6439

Some dependencies can bring include paths pointing to older macOS SDK's. In this case, it was libffi pointing to SDK from 12.0. When the Foundation framework is imported in Swift, swiftc attempts to import the FFI module from the most recent version of the SDK, which causes a compilation error because of conflicting definitions between the two SDK versions.

It would error out like so:
```
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/module.modulemap:1171:1: note: in file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/module.modulemap:1171:
extern module FFI "ffi/module.modulemap"
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/ffi/module.modulemap:1:8: error: redefinition of module 'FFI'
module FFI [system] {
       ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include/ffi/module.modulemap:1:8: note: previously defined here
module FFI [system] [extern_c] {
       ^
ninja: build stopped: subcommand failed.
```

I decided to do exactly what SwiftPM did: https://github.com/swiftlang/swift-package-manager/pull/6772. Let's just naively look for .sdk paths in the compile args of our dependencies and replace them with the most recent one. I saw SwiftPM also patching linking arguments, but in my experience the include dirs are enough to get rid of the issue, and I couldn't replicate a scenario where linking would also be broken, so I'd rather not touch it without testing.

It's done in a very rudimentary way but works. Let me know if something fancier is needed, with proper regex or something. :)

I included a test which is confirmed to fail without the workaround added in this patch. This was not tested on anything else than macOS, but I don't expect it to make the situation worse on iOS and other `darwin` subplatforms.