### PR TITLE
Python: fix limited API logic under GCC on Windows

### DIFF
--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -218,6 +218,8 @@ class _PythonDependencyBase(_Base):
             if self.static:
                 libpath = Path('libs') / f'libpython{vernum}.a'
             else:
+                if limited_api:
+                    vernum = vernum[0]
                 comp = self.get_compiler()
                 if comp.id == "gcc":
                     if imp_lower == 'pypy' and verdot == '3.8':
@@ -228,8 +230,6 @@ class _PythonDependencyBase(_Base):
                     else:
                         libpath = Path(f'python{vernum}.dll')
                 else:
-                    if limited_api:
-                        vernum = vernum[0]
                     if self.is_freethreaded:
                         libpath = Path('libs') / f'python{vernum}t.lib'
                     else:

--- a/test cases/frameworks/24 libgcrypt/test.json
+++ b/test cases/frameworks/24 libgcrypt/test.json
@@ -1,3 +1,3 @@
 {
-  "expect_skip_on_jobname": ["azure", "msys2"]
+  "expect_skip_on_jobname": ["azure", "cygwin", "msys2"]
 }


### PR DESCRIPTION
When building a limited API module on Windows with GCC the library to link with should be python3.dll, not python3X.dll.