### PR TITLE
linkers: Loosen the check for GNU interface style in LLD for Windows

### DIFF
--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -64,7 +64,7 @@ def guess_win_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
 
     p, o, _ = Popen_safe(compiler + check_args)
     if 'LLD' in o.split('\n', maxsplit=1)[0]:
-        if '(compatible with GNU linkers)' in o:
+        if 'compatible with GNU linkers' in o:
             return linkers.LLVMDynamicLinker(
                 compiler, for_machine, comp_class.LINKER_PREFIX,
                 override, version=search_version(o))


### PR DESCRIPTION
Don't require the string to be enclosed in parentheses. https://github.com/llvm/llvm-project/pull/97323 changed the LLD version printout to no longer be enclosed in parentheses, which made Meson fail to detect the linker style used here.

The LLD change is being reverted in
https://github.com/llvm/llvm-project/pull/97698 in order to fix building with existing Meson versions, but for the future, loosen the check slightly, to not require the parentheses.