### PR TITLE
Revert PR12972 as a regression.

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2013-2018 The Meson development team
-# Copyright © 2024 Intel Corporation
 
 # This file contains the detection logic for external dependencies.
 # Custom logic for several other packages are in separate files.
@@ -107,9 +106,6 @@ class Dependency(HoldableObject):
         return kwargs['include_type']
 
     def __init__(self, type_name: DependencyTypeName, kwargs: T.Dict[str, T.Any]) -> None:
-        # This allows two Dependencies to be compared even after being copied.
-        # The purpose is to allow the name to be changed, but still have a proper comparison
-        self.__id = id(self)
         self.name = f'dep{id(self)}'
         self.version:  T.Optional[str] = None
         self.language: T.Optional[str] = None # None means C-like
@@ -127,14 +123,6 @@ class Dependency(HoldableObject):
         self.d_features: T.DefaultDict[str, T.List[T.Any]] = collections.defaultdict(list)
         self.featurechecks: T.List['FeatureCheckBase'] = []
         self.feature_since: T.Optional[T.Tuple[str, str]] = None
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, Dependency):
-            return NotImplemented
-        return self.__id == other.__id
-
-    def __hash__(self) -> int:
-        return self.__id
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__} {self.name}: {self.is_found}>'

--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2012-2021 The Meson development team
-# Copyright © 2021-2024 Intel Corporation
+# Copyright © 2021 Intel Corporation
 from __future__ import annotations
 
-import copy
 import os
 import typing as T
 
@@ -347,16 +346,6 @@ class MesonMain(MesonInterpreterObject):
         name, dep = args
         if not name:
             raise InterpreterException('First argument must be a string and cannot be empty')
-
-        # Make a copy since we're going to mutate.
-        #
-        #   dep = declare_dependency()
-        #   meson.override_dependency('foo', dep)
-        #   meson.override_dependency('foo-1.0', dep)
-        #   dep = dependency('foo')
-        #   dep.name() # == 'foo-1.0'
-        dep = copy.copy(dep)
-        dep.name = name
 
         optkey = OptionKey('default_library', subproject=self.interpreter.subproject)
         default_library = self.interpreter.coredata.get_option(optkey)

--- a/test cases/common/98 subproject subdir/meson.build
+++ b/test cases/common/98 subproject subdir/meson.build
@@ -1,7 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-# Copyright 2016-2023 The Meson Developers
-# Copyright © 2024 Intel Corporation
-
 project('proj', 'c')
 subproject('sub')
 libSub = dependency('sub', fallback: ['sub', 'libSub'])
@@ -10,19 +6,7 @@ exe = executable('prog', 'prog.c', dependencies: libSub)
 test('subproject subdir', exe)
 
 # Verify the subproject has placed dependency override.
-d = dependency('sub-1.0')
-
-# verify that the name is the overridden name
-assert(d.name() == 'sub-1.0', 'name was not properly set, should have been "sub-1.0", but was @0@'.format(d.name()))
-
-# Verify that when a dependency object is used for two overrides, the correct
-# name is used
-meson.override_dependency('new-dep', d)
-d2 = dependency('new-dep')
-assert(d2.name() == 'new-dep', 'name was not properly set, should have been "new-dep", but was @0@'.format(d2.name()))
-
-# And that the old dependency wasn't changed
-assert(d.name() == 'sub-1.0', 'original dependency was mutated.')
+dependency('sub-1.0')
 
 # Verify we can now take 'sub' dependency without fallback, but only version 1.0.
 dependency('sub')


### PR DESCRIPTION
Revert "interpreter: when overriding a dependency make its name match"

This reverts commit b1340e9bb1f243e4de8f2d89415a45ade476a3dc.

Revert "dependency: define equality and hash operators for Dependency"

This reverts commit 6d713e40f81512eadb0cc4654408d90cb22ba774.

This caused some projects to fail to build, such as libplacebo and libepoxy. Taking libplacebo as the example, the produced build.ninja does not include libvulkan.so as a linker input for src/libplacebo.so.338.

We are probably getting dependency hashing wrong somewhere. Unsure where exactly and unsure how to create a test case. We are also deep into rc2. Revert it for now and try to re-land these changes for 1.6.

Bug: https://bugs.gentoo.org/935443
Fixes: #13352