### PR TITLE
Add support for PGO to rust, fix clang pgo

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1910,7 +1910,7 @@ class NinjaBackend(backends.Backend):
         args = rustc.compiler_args()
         # Compiler args for compiling this target
         args += compilers.get_base_compile_args(
-            base_proxy, rustc, self.environment, self.get_target_private_dir_abs(target))
+            base_proxy, rustc, self.environment, self.get_target_private_dir_abs(target), target)
         self.generate_generator_list_rules(target)
 
         # dependencies need to cause a relink, they're not just for ordering
@@ -2800,7 +2800,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         commands = compiler.compiler_args()
         # Compiler args for compiling this target
         commands += compilers.get_base_compile_args(
-            base_proxy, compiler, self.environment, self.get_target_private_dir_abs(target))
+            base_proxy, compiler, self.environment, self.get_target_private_dir_abs(target), target)
         if isinstance(src, File):
             if src.is_built:
                 src_filename = os.path.join(src.subdir, src.fname)
@@ -2866,7 +2866,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         # options passed on the command-line, in default_options, etc.
         # These have the lowest priority.
         commands += compilers.get_base_compile_args(
-            base_proxy, compiler, self.environment, self.get_target_private_dir_abs(target))
+            base_proxy, compiler, self.environment, self.get_target_private_dir_abs(target), target)
         return commands
 
     @lru_cache(maxsize=None)
@@ -3468,7 +3468,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         else:
             commands += compilers.get_base_link_args(
                 target.get_options(), linker, isinstance(target, build.SharedModule),
-                self.environment.get_build_dir(), self.get_target_private_dir(target))
+                self.environment.get_build_dir(), self.get_target_private_dir(target), target)
         # Add -nostdlib if needed; can't be overridden
         commands += self.get_no_stdlib_link_args(target, linker)
         # Add things like /NOLOGO; usually can't be overridden

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1345,6 +1345,7 @@ class NinjaBackend(backends.Backend):
         self.generate_static_link_rules()
         self.generate_dynamic_link_rules()
         self.add_rule_comment(NinjaComment('Other rules'))
+        self.generate_pgo_rules()
         # Ninja errors out if you have deps = gcc but no depfile, so we must
         # have two rules for custom commands.
         self.add_rule(NinjaRule('CUSTOM_COMMAND', ['$COMMAND'], [], '$DESC',
@@ -2555,6 +2556,16 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         description = 'Module scanner.'
         rule = NinjaRule(rulename, command, args, description)
         self.add_rule(rule)
+
+    def generate_pgo_rules(self) -> None:
+        rulename = 'PGO_MERGE_LLVM'
+        if rulename in self.ruledict:
+            # This command is the same for host and build machine
+            return
+        self.add_rule(
+            NinjaRule(rulename, ['llvm-profdata', 'merge'],
+                      [NinjaCommandArg('-output=$out', Quoting.none), '$in'],
+                      'LLVM PGO data accumulator'))
 
     def generate_compile_rules(self):
         for for_machine in MachineChoice:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -987,7 +987,7 @@ class NinjaBackend(backends.Backend):
             if self.environment.is_llvm_ir(src):
                 o, s = self.generate_llvm_ir_compile(target, src)
             else:
-                o, s = self.generate_single_compile(target, src, True, order_deps=header_deps)
+                o, s = self.generate_single_compile(target, src, True, full_deps=header_deps)
             compiled_sources.append(s)
             source2object[s] = o
             obj_list.append(o)
@@ -1031,7 +1031,7 @@ class NinjaBackend(backends.Backend):
             else:
                 transpiled_source_files.append(raw_src)
         for src in transpiled_source_files:
-            o, s = self.generate_single_compile(target, src, True, [], header_deps)
+            o, s = self.generate_single_compile(target, src, True, full_deps=header_deps)
             obj_list.append(o)
 
         # Generate compile targets for all the preexisting sources for this target
@@ -1045,17 +1045,21 @@ class NinjaBackend(backends.Backend):
                                            src.rel_to_builddir(self.build_to_src))
                     unity_src.append(abs_src)
                 else:
-                    o, s = self.generate_single_compile(target, src, False, [],
-                                                        header_deps + d_generated_deps + fortran_order_deps,
-                                                        fortran_inc_args)
+                    o, s = self.generate_single_compile(
+                        target, src, False,
+                        full_deps=header_deps + d_generated_deps + fortran_order_deps,
+                        extra_args=fortran_inc_args)
                     obj_list.append(o)
                     compiled_sources.append(s)
                     source2object[s] = o
 
         if is_unity:
             for src in self.generate_unity_files(target, unity_src):
-                o, s = self.generate_single_compile(target, src, True, unity_deps + header_deps + d_generated_deps,
-                                                    fortran_order_deps, fortran_inc_args, unity_src)
+                o, s = self.generate_single_compile(
+                    target, src, True,
+                    full_deps=unity_deps + header_deps + d_generated_deps + fortran_order_deps,
+                    extra_args=fortran_inc_args,
+                    unity_sources=unity_src)
                 obj_list.append(o)
                 compiled_sources.append(s)
                 source2object[s] = o
@@ -2950,8 +2954,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
     def generate_single_compile(self, target: build.BuildTarget,
                                 src: mesonlib.FileOrString,
                                 is_generated: bool = False,
-                                header_deps: T.Optional[T.Sequence[mesonlib.FileOrString]] = None,
-                                order_deps: T.Optional[T.List['mesonlib.FileOrString']] = None,
+                                order_deps: T.Optional[T.Sequence[mesonlib.FileOrString]] = None,
+                                full_deps: T.Optional[T.List['mesonlib.FileOrString']] = None,
                                 extra_args: T.Optional[T.List[str]] = None,
                                 unity_sources: T.Optional[T.List[mesonlib.FileOrString]] = None,
                                 ) -> T.Tuple[str, str]:
@@ -2960,14 +2964,14 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         :param target: The target which the source belongs to
         :param src: The source to be compiled
         :param is_generated: Whether this source is generated or static, defaults to False
-        :param header_deps: order only dependencies, defaults to None
-        :param order_deps: dependencies which cause a full rebuild, defaults to None
+        :param order_deps: order only dependencies, defaults to None
+        :param full_deps: dependencies which cause a full rebuild, defaults to None
         :param extra_args: extra arguments just for this compilation unit, defaults to None
         :param unity_sources: the sources that were combined into this unity, defaults to None
         :return: A tuple with the object file that will be created and the source that was compiled
         """
-        header_deps = header_deps if header_deps is not None else []
         order_deps = order_deps if order_deps is not None else []
+        full_deps = full_deps if full_deps is not None else []
 
         if isinstance(src, str) and src.endswith('.h'):
             raise AssertionError(f'BUG: sources should not contain headers {src!r}')
@@ -3059,7 +3063,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             commands.extend(extra_args)
 
         element = NinjaBuildElement(self.all_outputs, rel_obj, compiler_name, rel_src)
-        self.add_full_deps(target, element, header_deps)
+        self.add_full_deps(target, element, full_deps)
         for d in extra_deps:
             element.add_dep(d)
         self.add_order_deps(target, element, order_deps)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3062,12 +3062,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         self.add_full_deps(target, element, header_deps)
         for d in extra_deps:
             element.add_dep(d)
-        for d in order_deps:
-            if isinstance(d, File):
-                d = d.rel_to_builddir(self.build_to_src)
-            elif not self.has_dir_part(d):
-                d = os.path.join(self.get_target_private_dir(target), d)
-            element.add_orderdep(d)
+        self.add_order_deps(target, element, order_deps)
         element.add_dep(pch_dep)
         for i in self.get_fortran_orderdeps(target, compiler):
             element.add_orderdep(i)
@@ -3120,6 +3115,17 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
     def get_dep_scan_file_for(self, target: build.BuildTarget) -> str:
         return os.path.join(self.get_target_private_dir(target), 'depscan.dd')
 
+    def _add_deps(self, target: build.BuildTarget, deps: T.Sequence[mesonlib.FileOrString],
+                  to: T.Callable[[str], None]) -> None:
+        if isinstance(deps, str):
+            deps = [deps]
+        for d in deps:
+            if isinstance(d, File):
+                d = d.rel_to_builddir(self.build_to_src)
+            elif not self.has_dir_part(d):
+                d = os.path.join(self.get_target_private_dir(target), d)
+            to(d)
+
     def add_full_deps(self, target: build.BuildTarget, ninja_element: NinjaBuildElement,
                       deps: T.Sequence[mesonlib.FileOrString]) -> None:
         """Add multiple full dependencies.
@@ -3128,14 +3134,17 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         :param ninja_element: The Ninja build Element being modified
         :param deps: The dependencies being added
         """
-        if isinstance(deps, str):
-            deps = [deps]
-        for d in deps:
-            if isinstance(d, File):
-                d = d.rel_to_builddir(self.build_to_src)
-            elif not self.has_dir_part(d):
-                d = os.path.join(self.get_target_private_dir(target), d)
-            ninja_element.add_dep(d)
+        self._add_deps(target, deps, ninja_element.add_dep)
+
+    def add_order_deps(self, target: build.BuildTarget, ninja_element: NinjaBuildElement,
+                       deps: T.Sequence[mesonlib.FileOrString]) -> None:
+        """Add multiple order-only dependencies.
+
+        :param target: The Target which the sources come from
+        :param ninja_element: The Ninja build Element being modified
+        :param deps: The dependencies being added
+        """
+        self._add_deps(target, deps, ninja_element.add_orderdep)
 
     def has_dir_part(self, fname: mesonlib.FileOrString) -> bool:
         # FIXME FIXME: The usage of this is a terrible and unreliable hack
@@ -3202,7 +3211,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         dep = os.path.splitext(dst)[0] + '.' + compiler.get_depfile_suffix()
         return commands, dep, dst, []  # mwcc compilers do not create an object file during pch generation.
 
-    def generate_pch(self, target, header_deps=None):
+    def generate_pch(self, target: build.BuildTarget, header_deps: T.Optional[T.Sequence[mesonlib.FileOrString]] = None) -> T.List[str]:
         header_deps = header_deps if header_deps is not None else []
         pch_objects = []
         for lang in ['c', 'cpp']:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2947,14 +2947,24 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             src_type_to_args[src_type_str] = commands.to_native()
         return src_type_to_args
 
-    def generate_single_compile(self, target: build.BuildTarget, src,
-                                is_generated: bool = False, header_deps=None,
+    def generate_single_compile(self, target: build.BuildTarget,
+                                src: mesonlib.FileOrString,
+                                is_generated: bool = False,
+                                header_deps: T.Optional[T.Sequence[mesonlib.FileOrString]] = None,
                                 order_deps: T.Optional[T.List['mesonlib.FileOrString']] = None,
                                 extra_args: T.Optional[T.List[str]] = None,
                                 unity_sources: T.Optional[T.List[mesonlib.FileOrString]] = None,
                                 ) -> T.Tuple[str, str]:
-        """
-        Compiles C/C++, ObjC/ObjC++, Fortran, and D sources
+        """Compiles C/C++, ObjC/ObjC++, Fortran, and D sources.
+
+        :param target: The target which the source belongs to
+        :param src: The source to be compiled
+        :param is_generated: Whether this source is generated or static, defaults to False
+        :param header_deps: order only dependencies, defaults to None
+        :param order_deps: dependencies which cause a full rebuild, defaults to None
+        :param extra_args: extra arguments just for this compilation unit, defaults to None
+        :param unity_sources: the sources that were combined into this unity, defaults to None
+        :return: A tuple with the object file that will be created and the source that was compiled
         """
         header_deps = header_deps if header_deps is not None else []
         order_deps = order_deps if order_deps is not None else []

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1909,7 +1909,8 @@ class NinjaBackend(backends.Backend):
         base_proxy = target.get_options()
         args = rustc.compiler_args()
         # Compiler args for compiling this target
-        args += compilers.get_base_compile_args(base_proxy, rustc, self.environment)
+        args += compilers.get_base_compile_args(
+            base_proxy, rustc, self.environment, self.get_target_private_dir_abs(target))
         self.generate_generator_list_rules(target)
 
         # dependencies need to cause a relink, they're not just for ordering
@@ -2798,7 +2799,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         compiler = get_compiler_for_source(target.compilers.values(), src)
         commands = compiler.compiler_args()
         # Compiler args for compiling this target
-        commands += compilers.get_base_compile_args(base_proxy, compiler, self.environment)
+        commands += compilers.get_base_compile_args(
+            base_proxy, compiler, self.environment, self.get_target_private_dir_abs(target))
         if isinstance(src, File):
             if src.is_built:
                 src_filename = os.path.join(src.subdir, src.fname)
@@ -2863,8 +2865,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         # Add compiler args for compiling this target derived from 'base' build
         # options passed on the command-line, in default_options, etc.
         # These have the lowest priority.
-        commands += compilers.get_base_compile_args(base_proxy,
-                                                    compiler, self.environment)
+        commands += compilers.get_base_compile_args(
+            base_proxy, compiler, self.environment, self.get_target_private_dir_abs(target))
         return commands
 
     @lru_cache(maxsize=None)
@@ -3464,10 +3466,9 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         if isinstance(target, build.StaticLibrary):
             commands += linker.get_base_link_args(target.get_options())
         else:
-            commands += compilers.get_base_link_args(target.get_options(),
-                                                     linker,
-                                                     isinstance(target, build.SharedModule),
-                                                     self.environment.get_build_dir())
+            commands += compilers.get_base_link_args(
+                target.get_options(), linker, isinstance(target, build.SharedModule),
+                self.environment.get_build_dir(), self.get_target_private_dir(target))
         # Add -nostdlib if needed; can't be overridden
         commands += self.get_no_stdlib_link_args(target, linker)
         # Add things like /NOLOGO; usually can't be overridden

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3059,7 +3059,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             commands.extend(extra_args)
 
         element = NinjaBuildElement(self.all_outputs, rel_obj, compiler_name, rel_src)
-        self.add_header_deps(target, element, header_deps)
+        self.add_full_deps(target, element, header_deps)
         for d in extra_deps:
             element.add_dep(d)
         for d in order_deps:
@@ -3120,8 +3120,17 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
     def get_dep_scan_file_for(self, target: build.BuildTarget) -> str:
         return os.path.join(self.get_target_private_dir(target), 'depscan.dd')
 
-    def add_header_deps(self, target, ninja_element, header_deps):
-        for d in header_deps:
+    def add_full_deps(self, target: build.BuildTarget, ninja_element: NinjaBuildElement,
+                      deps: T.Sequence[mesonlib.FileOrString]) -> None:
+        """Add multiple full dependencies.
+
+        :param target: The Target which the sources come from
+        :param ninja_element: The Ninja build Element being modified
+        :param deps: The dependencies being added
+        """
+        if isinstance(deps, str):
+            deps = [deps]
+        for d in deps:
             if isinstance(d, File):
                 d = d.rel_to_builddir(self.build_to_src)
             elif not self.has_dir_part(d):
@@ -3224,7 +3233,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             elem = NinjaBuildElement(self.all_outputs, objs + [dst], rulename, src)
             if extradep is not None:
                 elem.add_dep(extradep)
-            self.add_header_deps(target, elem, header_deps)
+            self.add_full_deps(target, elem, header_deps)
             elem.add_item('ARGS', commands)
             elem.add_item('DEPFILE', dep)
             self.add_build(elem)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -995,7 +995,7 @@ class Vs2010Backend(backends.Backend):
         for l, comp in target.compilers.items():
             if l in file_args:
                 file_args[l] += compilers.get_base_compile_args(
-                    target.get_options(), comp, self.environment)
+                    target.get_options(), comp, self.environment, self.get_target_private_dir_abs(target))
                 file_args[l] += comp.get_option_compile_args(
                     target.get_options())
 

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -995,7 +995,7 @@ class Vs2010Backend(backends.Backend):
         for l, comp in target.compilers.items():
             if l in file_args:
                 file_args[l] += compilers.get_base_compile_args(
-                    target.get_options(), comp, self.environment, self.get_target_private_dir_abs(target))
+                    target.get_options(), comp, self.environment, self.get_target_private_dir_abs(target), target)
                 file_args[l] += comp.get_option_compile_args(
                     target.get_options())
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -313,10 +313,11 @@ def get_base_compile_args(options: 'KeyedOptionDictType', compiler: 'Compiler', 
         pass
     try:
         pgo_val = options.get_value(OptionKey('b_pgo'))
+        pgo_dir = os.path.join(privatedir, 'pgo')
         if pgo_val == 'generate':
-            args.extend(compiler.get_profile_generate_args())
+            args.extend(compiler.get_profile_generate_args(pgo_dir))
         elif pgo_val == 'use':
-            args.extend(compiler.get_profile_use_args())
+            args.extend(compiler.get_profile_use_args(pgo_dir))
     except (KeyError, AttributeError):
         pass
     try:
@@ -367,10 +368,11 @@ def get_base_link_args(options: 'KeyedOptionDictType', linker: 'Compiler',
         pass
     try:
         pgo_val = options.get_value('b_pgo')
+        pgo_dir = os.path.join(privatedir, 'pgo')
         if pgo_val == 'generate':
-            args.extend(linker.get_profile_generate_args())
+            args.extend(linker.get_profile_generate_args(pgo_dir))
         elif pgo_val == 'use':
-            args.extend(linker.get_profile_use_args())
+            args.extend(linker.get_profile_use_args(pgo_dir))
     except (KeyError, AttributeError):
         pass
     try:
@@ -989,11 +991,23 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         """
         return 'other'
 
-    def get_profile_generate_args(self) -> T.List[str]:
+    def get_profile_generate_args(self, pgo_dir: str) -> T.List[str]:
+        """Create arguments for generating PGO data
+
+        :param pgo_dir: A directory which may be used to output implementation files
+        :raises EnvironmentException: If the compiler does not implement PGO
+        :return: A string list of arguments to generate PGO
+        """
         raise EnvironmentException(
             '%s does not support get_profile_generate_args ' % self.get_id())
 
-    def get_profile_use_args(self) -> T.List[str]:
+    def get_profile_use_args(self, pgo_dir: str) -> T.List[str]:
+        """Create arguments for using PGO data.
+
+        :param pgo_dir: A directory which may be used to read and write implementation files
+        :raises EnvironmentException: If the compiler does not implement PGO
+        :return: A list of string argumetns for using PGO
+        """
         raise EnvironmentException(
             '%s does not support get_profile_use_args ' % self.get_id())
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1011,6 +1011,9 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         raise EnvironmentException(
             '%s does not support get_profile_use_args ' % self.get_id())
 
+    def get_profile_merged_file(self, private_dir: str) -> str:
+        return os.path.join(private_dir, 'merged.profdata')
+
     def remove_linkerlike_args(self, args: T.List[str]) -> T.List[str]:
         rm_exact = ('-headerpad_max_install_names',)
         rm_prefixes = ('-Wl,', '-L',)

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -285,7 +285,16 @@ def are_asserts_disabled(options: KeyedOptionDictType) -> bool:
              options.get_value('buildtype') in {'release', 'plain'}))
 
 
-def get_base_compile_args(options: 'KeyedOptionDictType', compiler: 'Compiler', env: 'Environment') -> T.List[str]:
+def get_base_compile_args(options: 'KeyedOptionDictType', compiler: 'Compiler', env: 'Environment', privatedir: str) -> T.List[str]:
+    """Get common compiler arguments for all units of a single language in a
+    Target.
+
+    :param options: A Mapping with all options
+    :param compiler: The Compiler to create arguments for
+    :param env: The Environment object
+    :param privatedir: The Target's private directory
+    :return: A list of string arguments
+    """
     args: T.List[str] = []
     try:
         if options.get_value(OptionKey('b_lto')):
@@ -334,7 +343,7 @@ def get_base_compile_args(options: 'KeyedOptionDictType', compiler: 'Compiler', 
     return args
 
 def get_base_link_args(options: 'KeyedOptionDictType', linker: 'Compiler',
-                       is_shared_module: bool, build_dir: str) -> T.List[str]:
+                       is_shared_module: bool, build_dir: str, privatedir: str) -> T.List[str]:
     args: T.List[str] = []
     try:
         if options.get_value('b_lto'):

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -801,11 +801,11 @@ class CudaCompiler(Compiler):
         else:
             return []
 
-    def get_profile_generate_args(self) -> T.List[str]:
-        return ['-Xcompiler=' + x for x in self.host_compiler.get_profile_generate_args()]
+    def get_profile_generate_args(self, pgo_dir: str) -> T.List[str]:
+        return ['-Xcompiler=' + x for x in self.host_compiler.get_profile_generate_args(pgo_dir)]
 
-    def get_profile_use_args(self) -> T.List[str]:
-        return ['-Xcompiler=' + x for x in self.host_compiler.get_profile_use_args()]
+    def get_profile_use_args(self, pgo_dir: str) -> T.List[str]:
+        return ['-Xcompiler=' + x for x in self.host_compiler.get_profile_use_args(pgo_dir)]
 
     def get_assert_args(self, disable: bool, env: 'Environment') -> T.List[str]:
         return self.host_compiler.get_assert_args(disable, env)

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -807,5 +807,8 @@ class CudaCompiler(Compiler):
     def get_profile_use_args(self, pgo_dir: str) -> T.List[str]:
         return ['-Xcompiler=' + x for x in self.host_compiler.get_profile_use_args(pgo_dir)]
 
+    def should_pgo_target(self, target: BuildTarget) -> bool:
+        return self.host_compiler.should_pgo_target(target)
+
     def get_assert_args(self, disable: bool, env: 'Environment') -> T.List[str]:
         return self.host_compiler.get_assert_args(disable, env)

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -202,3 +202,10 @@ class ClangCompiler(GnuLikeCompiler):
                 raise mesonlib.MesonException('clang support for LTO threads requires clang >=4.0')
             args.append(f'-flto-jobs={threads}')
         return args
+
+    def get_profile_generate_args(self, pgo_dir: str) -> T.List[str]:
+        return [f'-fprofile-generate={pgo_dir}']
+
+    def get_profile_use_args(self, pgo_dir: str) -> T.List[str]:
+        mf = self.get_profile_merged_file(pgo_dir)
+        return [f'-fprofile-use={mf}']

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -15,6 +15,7 @@ from ...linkers.linkers import AppleDynamicLinker, ClangClDynamicLinker, LLVMDyn
 from ...mesonlib import OptionKey
 from ..compilers import CompileCheckMode
 from .gnu import GnuLikeCompiler
+from .llvm import LLVMCompilerMixin
 
 if T.TYPE_CHECKING:
     from ...environment import Environment
@@ -43,7 +44,7 @@ clang_lang_map = {
     'objcpp': 'objective-c++',
 }
 
-class ClangCompiler(GnuLikeCompiler):
+class ClangCompiler(LLVMCompilerMixin, GnuLikeCompiler):
 
     id = 'clang'
 

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -625,5 +625,5 @@ class GnuCompiler(GnuLikeCompiler):
             return ['-fuse-ld=mold']
         return super().use_linker_args(linker, version)
 
-    def get_profile_use_args(self) -> T.List[str]:
-        return super().get_profile_use_args() + ['-fprofile-correction']
+    def get_profile_use_args(self, priv_dir: str) -> T.List[str]:
+        return super().get_profile_use_args(priv_dir) + ['-fprofile-correction']

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -21,6 +21,7 @@ from mesonbuild.compilers.compilers import CompileCheckMode
 
 if T.TYPE_CHECKING:
     from ..._typing import ImmutableListProtocol
+    from ...build import BuildTarget
     from ...environment import Environment
     from ..compilers import Compiler
 else:
@@ -428,6 +429,9 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
 
     def get_profile_use_args(self, pgo_dir: str) -> T.List[str]:
         return ['-fprofile-use']
+
+    def should_pgo_target(self, target: BuildTarget) -> bool:
+        return True
 
     def compute_parameters_with_absolute_paths(self, parameter_list: T.List[str], build_dir: str) -> T.List[str]:
         for idx, i in enumerate(parameter_list):

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -423,10 +423,10 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
     def get_argument_syntax(self) -> str:
         return 'gcc'
 
-    def get_profile_generate_args(self) -> T.List[str]:
+    def get_profile_generate_args(self, pgo_dir: str) -> T.List[str]:
         return ['-fprofile-generate']
 
-    def get_profile_use_args(self) -> T.List[str]:
+    def get_profile_use_args(self, pgo_dir: str) -> T.List[str]:
         return ['-fprofile-use']
 
     def compute_parameters_with_absolute_paths(self, parameter_list: T.List[str], build_dir: str) -> T.List[str]:
@@ -625,5 +625,5 @@ class GnuCompiler(GnuLikeCompiler):
             return ['-fuse-ld=mold']
         return super().use_linker_args(linker, version)
 
-    def get_profile_use_args(self, priv_dir: str) -> T.List[str]:
-        return super().get_profile_use_args(priv_dir) + ['-fprofile-correction']
+    def get_profile_use_args(self, pgo_dir: str) -> T.List[str]:
+        return super().get_profile_use_args(pgo_dir) + ['-fprofile-correction']

--- a/mesonbuild/compilers/mixins/intel.py
+++ b/mesonbuild/compilers/mixins/intel.py
@@ -98,10 +98,10 @@ class IntelGnuLikeCompiler(GnuLikeCompiler):
         ]
         return super().get_compiler_check_args(mode) + extra_args
 
-    def get_profile_generate_args(self) -> T.List[str]:
+    def get_profile_generate_args(self, pgo_dir: str) -> T.List[str]:
         return ['-prof-gen=threadsafe']
 
-    def get_profile_use_args(self) -> T.List[str]:
+    def get_profile_use_args(self, pgo_dir: str) -> T.List[str]:
         return ['-prof-use']
 
     def get_debug_args(self, is_debug: bool) -> T.List[str]:

--- a/mesonbuild/compilers/mixins/llvm.py
+++ b/mesonbuild/compilers/mixins/llvm.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2024 Intel Corporation
+
+"""Common features of LLVM based compilers."""
+
+from __future__ import annotations
+import typing as T
+
+if T.TYPE_CHECKING:
+    from ...build import BuildTarget
+    from ...compilers.compilers import Compiler
+else:
+    # This is a bit clever, for mypy we pretend that these mixins descend from
+    # Compiler, so we get all of the methods and attributes defined for us, but
+    # for runtime we make them descend from object (which all classes normally
+    # do). This gives up DRYer type checking, with no runtime impact
+    Compiler = object
+
+
+class LLVMCompilerMixin(Compiler):
+
+    def should_pgo_target(self, target: BuildTarget) -> bool:
+        return target.typename != 'static library'

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -12,6 +12,7 @@ import typing as T
 from .. import options
 from ..mesonlib import EnvironmentException, MesonException, Popen_safe_logged, OptionKey
 from .compilers import Compiler, clike_debug_args
+from .mixins.llvm import LLVMCompilerMixin
 
 if T.TYPE_CHECKING:
     from ..coredata import MutableKeyedOptionDictType, KeyedOptionDictType
@@ -32,7 +33,7 @@ rust_optimization_args: T.Dict[str, T.List[str]] = {
     's': ['-C', 'opt-level=s'],
 }
 
-class RustCompiler(Compiler):
+class RustCompiler(LLVMCompilerMixin, Compiler):
 
     # rustc doesn't invoke the compiler itself, it doesn't need a LINKER_PREFIX
     language = 'rust'
@@ -64,7 +65,7 @@ class RustCompiler(Compiler):
         super().__init__([], exelist, version, for_machine, info,
                          is_cross=is_cross, full_version=full_version,
                          linker=linker)
-        self.base_options.update({OptionKey(o) for o in ['b_colorout', 'b_ndebug']})
+        self.base_options.update({OptionKey(o) for o in ['b_colorout', 'b_ndebug', 'b_pgo']})
         if 'link' in self.linker.id:
             self.base_options.add(OptionKey('b_vscrt'))
         self.native_static_libs: T.List[str] = []
@@ -219,6 +220,13 @@ class RustCompiler(Compiler):
     def get_assert_args(self, disable: bool, env: 'Environment') -> T.List[str]:
         action = "no" if disable else "yes"
         return ['-C', f'debug-assertions={action}', '-C', 'overflow-checks=no']
+
+    def get_profile_generate_args(self, pgo_dir: str) -> T.List[str]:
+        return ['-C', f'profile-generate={pgo_dir}']
+
+    def get_profile_use_args(self, pgo_dir: str) -> T.List[str]:
+        mf = self.get_profile_merged_file(pgo_dir)
+        return ['-C', f'profile-use={mf}']
 
 
 class ClippyRustCompiler(RustCompiler):

--- a/test cases/unit/116 empty project/expected_mods.json
+++ b/test cases/unit/116 empty project/expected_mods.json
@@ -184,6 +184,8 @@
       "mesonbuild.compilers",
       "mesonbuild.compilers.compilers",
       "mesonbuild.compilers.detect",
+      "mesonbuild.compilers.mixins",
+      "mesonbuild.compilers.mixins.llvm",
       "mesonbuild.coredata",
       "mesonbuild.dependencies",
       "mesonbuild.dependencies.base",
@@ -239,6 +241,6 @@
       "mesonbuild.wrap",
       "mesonbuild.wrap.wrap"
     ],
-    "count": 69
+    "count": 72
   }
 }

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016-2021 The Meson development team
+# Copyright © 2024 Intel Corporation
 
 import subprocess
 import re
@@ -5009,3 +5010,46 @@ class AllPlatformTests(BasePlatformTests):
             # The first supported std should be selected
             self.setconf('-Dcpp_std=c++11,gnu++11,vc++11')
             self.assertEqual(self.getconf('cpp_std'), 'c++11')
+
+    def test_pgo(self) -> None:
+        env = get_fake_env()
+
+        tests: T.List[T.Tuple[str, str, str]] = [
+            ('C', 'static', os.path.join(self.common_test_dir, '5 linkstatic')),
+            ('C', 'shared', os.path.join(self.common_test_dir, '6 linkshared')),
+            ('Rust', 'static', os.path.join(self.rust_test_dir, '3 staticlib')),
+            ('Rust', 'shared', os.path.join(self.rust_test_dir, '2 sharedlib')),
+        ]
+
+        for lang, name, srcdir in tests:
+            with self.subTest(f'{lang} ({name})'):
+                comp = detect_compiler_for(env, 'c', MachineChoice.HOST, True, '')
+                if not comp:
+                    self.skipTest(f"No compiler found for language: {lang}")
+                if OptionKey('b_pgo') not in comp.base_options:
+                    self.skipTest(f"Compiler for {lang} language does not support pgo")
+
+                self.init(srcdir, extra_args=['-Db_pgo=generate'])
+                self.build()
+                subprocess.run(os.path.join(self.builddir, 'prog'))
+                self.setconf('-Db_pgo=use')
+                self.build()
+
+    def test_pgo_rust_and_c(self) -> None:
+        env = get_fake_env()
+
+        for lang in ['c', 'rust']:
+            comp = detect_compiler_for(env, lang, MachineChoice.HOST, True, '')
+            if not comp:
+                self.skipTest(f"No compiler found for language: {lang}")
+            if OptionKey('b_pgo') not in comp.base_options:
+                self.skipTest(f"Compiler for {lang} language does not support pgo")
+            if (lang == 'c' and comp.id != 'clang') or (lang == 'rust' and not comp.id.startswith('rustc')):
+                self.skipTest('Mixing of Rust and C/C++ is only supported with Clang anr Rustc')
+
+        self.init(os.path.join(self.rust_test_dir, '5 polyglot static'), extra_args=['-Db_pgo=generate'])
+        self.build()
+        subprocess.run(os.path.join(self.builddir, 'prog'))
+        subprocess.run(os.path.join(self.builddir, 'prog2'))
+        self.setconf('-Db_pgo=use')
+        self.build()

--- a/unittests/platformagnostictests.py
+++ b/unittests/platformagnostictests.py
@@ -74,7 +74,7 @@ class PlatformAgnosticTests(BasePlatformTests):
             with tempfile.NamedTemporaryFile('w', dir=self.builddir, encoding='utf-8', delete=False) as f:
                 f.write(code)
                 return f.name
-        
+
         fname = write_file("option('intminmax', type: 'integer', value: 10, min: 0, max: 5)")
         self.assertRaisesRegex(MesonException, 'Value 10 for option "intminmax" is more than maximum value 5.',
                                interp.process, fname)
@@ -82,7 +82,7 @@ class PlatformAgnosticTests(BasePlatformTests):
         fname = write_file("option('array', type: 'array', choices : ['one', 'two', 'three'], value : ['one', 'four'])")
         self.assertRaisesRegex(MesonException, 'Value "four" for option "array" is not in allowed choices: "one, two, three"',
                                interp.process, fname)
-        
+
         fname = write_file("option('array', type: 'array', choices : ['one', 'two', 'three'], value : ['four', 'five', 'six'])")
         self.assertRaisesRegex(MesonException, 'Values "four, five, six" for option "array" are not in allowed choices: "one, two, three"',
                                interp.process, fname)
@@ -271,10 +271,12 @@ class PlatformAgnosticTests(BasePlatformTests):
                 data = json.load(f)['meson']
 
         with open(os.path.join(testdir, 'expected_mods.json'), encoding='utf-8') as f:
-            expected = json.load(f)['meson']['modules']
+            edata = json.load(f)['meson']
+            expected = edata['modules']
+            count = edata['count']
 
         self.assertEqual(data['modules'], expected)
-        self.assertEqual(data['count'], 70)
+        self.assertEqual(data['count'], count)
 
     def test_meson_package_cache_dir(self):
         # Copy testdir into temporary directory to not pollute meson source tree.
@@ -322,7 +324,7 @@ class PlatformAgnosticTests(BasePlatformTests):
             ('a.txt', '{a,b,c}.txt', True),
             ('a.txt', '*.{txt,tex,cpp}', True),
             ('a.hpp', '*.{txt,tex,cpp}', False),
-            
+
             ('a1.txt', 'a{0..9}.txt', True),
             ('a001.txt', 'a{0..9}.txt', True),
             ('a-1.txt', 'a{-10..10}.txt', True),


### PR DESCRIPTION
Clang (and other LLVM compilers) handle PGO slightly differently than GCC based compilers do. The following is a short list of differences:
  1) LLVM compilers generate files that must be merged with llvm-profdata, GCC based compilers do not
  2) LLVM compilers do not generate profile data for static libraries, but GCC based compilers do
  3) LLVM compilers want an explicit path to put their profile data in, while GCC compilers put the data next to the .o files

Fixes #5251 
Fixes #13371

Based on #13377