### PR TITLE
nasm: Add -mms-bitfields to the list of ignored flags

### DIFF
--- a/mesonbuild/compilers/asm.py
+++ b/mesonbuild/compilers/asm.py
@@ -75,7 +75,7 @@ class NasmCompiler(Compiler):
     def unix_args_to_native(self, args: T.List[str]) -> T.List[str]:
         outargs: T.List[str] = []
         for arg in args:
-            if arg == '-pthread':
+            if arg in {'-mms-bitfields', '-pthread'}:
                 continue
             outargs.append(arg)
         return outargs


### PR DESCRIPTION
Hi all,

This PR fixes building Nasm objects with Meson's native language support, when depending against a library that exports that flag, like Glib.

```
Called: `E:/cerbero-sources/build-tools/bin\pkg-config.EXE --cflags harfbuzz` -> 0
stdout:
-mms-bitfields -IE:/cerbero-sources/dist/mingw_x86_64/include/harfbuzz -IE:/cerbero-sources/dist/mingw_x86_64/include/freetype2 -IE:/cerbero-sources/dist/mingw_x86_64/include/libpng16 -IE:/cerbero-sources/dist/mingw_x86_64/include/glib-2.0 -IE:/cerbero-sources/dist/mingw_x86_64/lib/glib-2.0/include
```

```
FAILED: libass/libass-9.dll.p/x86_blend_bitmaps.asm.obj 
"nasm" "-Ilibass\libass-9.dll.p" "-f" "win64" "-DWIN64" "-D__x86_64__" "-Ox" "-Dprivate_prefix=ass" "-DPIC=1" "-DARCH_X86_64=1" "-IE:/cerbero-sources/dist/mingw_x86_64/include/freetype2" "-IE:/cerbero-sources/dist/mingw_x86_64/include/libpng16" "-mms-bitfields" "-IE:/cerbero-sources/dist/mingw_x86_64/include/harfbuzz" "-IE:/cerbero-sources/dist/mingw_x86_64/include/freetype2" "-IE:/cerbero-sources/dist/mingw_x86_64/include/libpng16" "-IE:/cerbero-sources/dist/mingw_x86_64/include/glib-2.0" "-IE:/cerbero-sources/dist/mingw_x86_64/lib/glib-2.0/include" "-IE:/cerbero-sources/dist/mingw_x86_64/include/fribidi" "-IE:/cerbero-sources/dist/mingw_x86_64/include/freetype2" "-IE:/cerbero-sources/dist/mingw_x86_64/include/libpng16" "-I." "-I..\libass" "-Ilibass" "-I.." "-I." "-I..\libass" "-Ilibass" "-Ilibass\libass-9.dll.p" -MD "libass\libass-9.dll.p\x86_blend_bitmaps.asm.obj.d" -MQ libass/libass-9.dll.p/x86_blend_bitmaps.asm.obj -o libass/libass-9.dll.p/x86_blend_bitmaps.asm.obj ../libass/x86/blend_bitmaps.asm
nasm: error: unrecognised option `-m'
type `nasm -h' for help
```

Let me know what you think.

cc @seungha-yang 