### PR TITLE
Fix Type hints

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -153,7 +153,7 @@ def find_coverage_tools(coredata: coredata.CoreData) -> T.Tuple[T.Optional[str],
 
     return gcovr_exe, gcovr_version, lcov_exe, lcov_version, genhtml_exe, llvm_cov_exe
 
-def detect_ninja(version: str = '1.8.2', log: bool = False) -> T.List[str]:
+def detect_ninja(version: str = '1.8.2', log: bool = False) -> T.Optional[T.List[str]]:
     r = detect_ninja_command_and_version(version, log)
     return r[0] if r else None
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -283,7 +283,7 @@ def get_backend_commands(backend: Backend, debug: bool = False) -> \
         raise AssertionError(f'Unknown backend: {backend!r}')
     return cmd, clean_cmd, test_cmd, install_cmd, uninstall_cmd
 
-def run_mtest_inprocess(commandlist: T.List[str]) -> T.Tuple[int, str, str]:
+def run_mtest_inprocess(commandlist: T.List[str]) -> T.Tuple[int, str]:
     out = StringIO()
     with mock.patch.object(sys, 'stdout', out), mock.patch.object(sys, 'stderr', out):
         returncode = mtest.run_with_args(commandlist)


### PR DESCRIPTION
## Description
Fix Several type check warnings reported by Pyre@Google, which were outdated after code modifications.

## Detail
1. update the return type of function `detect_ninja` from `T.List[str]` to `T.Optional[T.List[str]]`, since it could be None after commit https://github.com/mesonbuild/meson/commit/48e6db89ab702c0f7c0fb8b9cbcac857dce9c6ef
2. update the return type of function `run_mtest_inprocess` from `T.Tuple[int, str, str]` to `T.Tuple[int, str]`, since the return value only include two str after commit https://github.com/mesonbuild/meson/commit/faf79f4539841cbf89fe8d53cf35aa91fd8273c9