### PR TITLE
Move all logic from OptionKey to OptionStore

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1091,7 +1091,7 @@ class NinjaBackend(backends.Backend):
         cpp = target.compilers['cpp']
         if cpp.get_id() != 'msvc':
             return False
-        cppversion = target.get_option(OptionKey('std', machine=target.for_machine, lang='cpp'))
+        cppversion = target.get_option(OptionKey('cpp_std', machine=target.for_machine))
         if cppversion not in ('latest', 'c++latest', 'vc++latest'):
             return False
         if not mesonlib.current_vs_supports_modules():
@@ -1783,7 +1783,7 @@ class NinjaBackend(backends.Backend):
         args += self.build.get_project_args(cython, target.subproject, target.for_machine)
         args += target.get_extra_args('cython')
 
-        ext = target.get_option(OptionKey('language', machine=target.for_machine, lang='cython'))
+        ext = target.get_option(OptionKey('cython_language', machine=target.for_machine))
 
         pyx_sources = []  # Keep track of sources we're adding to build
 

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1011,8 +1011,8 @@ class Vs2010Backend(backends.Backend):
                 file_args[l] += args
         # Compile args added from the env or cross file: CFLAGS/CXXFLAGS, etc. We want these
         # to override all the defaults, but not the per-target compile args.
-        for l in file_args.keys():
-            file_args[l] += target.get_option(OptionKey('args', machine=target.for_machine, lang=l))
+        for lang in file_args.keys():
+            file_args[lang] += target.get_option(OptionKey(f'{lang}_args', machine=target.for_machine))
         for args in file_args.values():
             # This is where Visual Studio will insert target_args, target_defines,
             # etc, which are added later from external deps (see below).
@@ -1340,7 +1340,7 @@ class Vs2010Backend(backends.Backend):
         # Exception handling has to be set in the xml in addition to the "AdditionalOptions" because otherwise
         # cl will give warning D9025: overriding '/Ehs' with cpp_eh value
         if 'cpp' in target.compilers:
-            eh = target.get_option(OptionKey('eh', machine=target.for_machine, lang='cpp'))
+            eh = target.get_option(OptionKey('cpp_eh', machine=target.for_machine))
             if eh == 'a':
                 ET.SubElement(clconf, 'ExceptionHandling').text = 'Async'
             elif eh == 's':

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -535,7 +535,7 @@ class ConverterTarget:
     @lru_cache(maxsize=None)
     def _all_lang_stds(self, lang: str) -> 'ImmutableListProtocol[str]':
         try:
-            res = self.env.coredata.optstore.get_value_object(OptionKey('std', machine=MachineChoice.BUILD, lang=lang)).choices
+            res = self.env.coredata.optstore.get_value_object(OptionKey(f'{lang}_std', machine=MachineChoice.BUILD)).choices
         except KeyError:
             return []
 

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -310,7 +310,7 @@ class GnuCCompiler(GnuCompiler, CCompiler):
             self.update_options(
                 opts,
                 self.create_option(options.UserArrayOption,
-                                   key.evolve('winlibs'),
+                                   key.evolve('c_winlibs'),
                                    'Standard Win libraries to link against',
                                    gnu_winlibs),
             )

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1355,7 +1355,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         raise EnvironmentException(f'{self.get_id()} does not support preprocessor')
 
     def form_compileropt_key(self, basename: str) -> OptionKey:
-        return OptionKey(basename, machine=self.for_machine, lang=self.language)
+        return OptionKey(f'{self.language}_{basename}', machine=self.for_machine)
 
 def get_global_options(lang: str,
                        comp: T.Type[Compiler],
@@ -1363,9 +1363,9 @@ def get_global_options(lang: str,
                        env: 'Environment') -> 'dict[OptionKey, options.UserOption[Any]]':
     """Retrieve options that apply to all compilers for a given language."""
     description = f'Extra arguments passed to the {lang}'
-    argkey = OptionKey('args', lang=lang, machine=for_machine)
-    largkey = argkey.evolve('link_args')
-    envkey = argkey.evolve('env_args')
+    argkey = OptionKey(f'{lang}_args', machine=for_machine)
+    largkey = argkey.evolve(f'{lang}_link_args')
+    envkey = argkey.evolve(f'{lang}_env_args')
 
     comp_key = argkey if argkey in env.options else envkey
 

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -475,7 +475,7 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCompiler, CPPCompiler):
             self.update_options(
                 opts,
                 self.create_option(options.UserArrayOption,
-                                   key.evolve('winlibs'),
+                                   key.evolve('cpp_winlibs'),
                                    'Standard Win libraries to link against',
                                    gnu_winlibs),
             )
@@ -483,17 +483,21 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCompiler, CPPCompiler):
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args: T.List[str] = []
-        key = self.form_compileropt_key('std')
-        std = options.get_value(key)
+        stdkey = self.form_compileropt_key('std')
+        ehkey = self.form_compileropt_key('eh')
+        rttikey = self.form_compileropt_key('rtti')
+        debugstlkey = self.form_compileropt_key('debugstl')
+
+        std = options.get_value(stdkey)
         if std != 'none':
             args.append(self._find_best_cpp_std(std))
 
-        non_msvc_eh_options(options.get_value(key.evolve('eh')), args)
+        non_msvc_eh_options(options.get_value(ehkey), args)
 
-        if not options.get_value(key.evolve('rtti')):
+        if not options.get_value(rttikey):
             args.append('-fno-rtti')
 
-        if options.get_value(key.evolve('debugstl')):
+        if options.get_value(debugstlkey):
             args.append('-D_GLIBCXX_DEBUG=1')
         return args
 

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -664,7 +664,7 @@ class CudaCompiler(Compiler):
         # We must strip the -std option from the host compiler option set, as NVCC has
         # its own -std flag that may not agree with the host compiler's.
         host_options = {key: master_options.get(key, opt) for key, opt in self.host_compiler.get_options().items()}
-        std_key = OptionKey('std', machine=self.for_machine, lang=self.host_compiler.language)
+        std_key = OptionKey(f'{self.host_compiler.language}_std', machine=self.for_machine)
         overrides = {std_key: 'none'}
         # To shut up mypy.
         return coredata.OptionsView(host_options, overrides=overrides)

--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -85,7 +85,7 @@ class ElbrusCompiler(GnuLikeCompiler):
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args: T.List[str] = []
-        std = options.get_value(OptionKey('std', lang=self.language, machine=self.for_machine))
+        std = options.get_value(OptionKey(f'{self.language}_std', machine=self.for_machine))
         if std != 'none':
             args.append('-std=' + std)
         return args

--- a/mesonbuild/compilers/mixins/emscripten.py
+++ b/mesonbuild/compilers/mixins/emscripten.py
@@ -51,7 +51,7 @@ class EmscriptenMixin(Compiler):
 
     def thread_link_flags(self, env: 'Environment') -> T.List[str]:
         args = ['-pthread']
-        count: int = env.coredata.optstore.get_value(OptionKey('thread_count', lang=self.language, machine=self.for_machine))
+        count: int = env.coredata.optstore.get_value(OptionKey(f'{self.language}_thread_count', machine=self.for_machine))
         if count:
             args.append(f'-sPTHREAD_POOL_SIZE={count}')
         return args
@@ -61,7 +61,7 @@ class EmscriptenMixin(Compiler):
             super().get_options(),
             self.create_option(
                 options.UserIntegerOption,
-                OptionKey('thread_count', machine=self.for_machine, lang=self.language),
+                OptionKey(f'{self.language}_thread_count', machine=self.for_machine),
                 'Number of threads to use in web assembly, set to 0 to disable',
                 (0, None, 4),  # Default was picked at random
             ),

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -82,7 +82,7 @@ class ClangObjCCompiler(ClangCompiler, ObjCCompiler):
         return self.update_options(
             super().get_options(),
             self.create_option(options.UserComboOption,
-                               OptionKey('std', machine=self.for_machine, lang='c'),
+                               OptionKey('c_std', machine=self.for_machine),
                                'C language standard to use',
                                ['none', 'c89', 'c99', 'c11', 'c17', 'gnu89', 'gnu99', 'gnu11', 'gnu17'],
                                'none'),
@@ -90,7 +90,7 @@ class ClangObjCCompiler(ClangCompiler, ObjCCompiler):
 
     def get_option_compile_args(self, options: 'coredata.KeyedOptionDictType') -> T.List[str]:
         args = []
-        std = options.get_value(OptionKey('std', machine=self.for_machine, lang='c'))
+        std = options.get_value(OptionKey('c_std', machine=self.for_machine))
         if std != 'none':
             args.append('-std=' + std)
         return args

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -82,7 +82,7 @@ class ClangObjCPPCompiler(ClangCompiler, ObjCPPCompiler):
         return self.update_options(
             super().get_options(),
             self.create_option(options.UserComboOption,
-                               OptionKey('std', machine=self.for_machine, lang='cpp'),
+                               OptionKey('cpp_std', machine=self.for_machine),
                                'C++ language standard to use',
                                ['none', 'c++98', 'c++11', 'c++14', 'c++17', 'c++20', 'c++2b',
                                 'gnu++98', 'gnu++11', 'gnu++14', 'gnu++17', 'gnu++20',
@@ -92,7 +92,7 @@ class ClangObjCPPCompiler(ClangCompiler, ObjCPPCompiler):
 
     def get_option_compile_args(self, options: 'coredata.KeyedOptionDictType') -> T.List[str]:
         args = []
-        std = options.get_value(OptionKey('std', machine=self.for_machine, lang='cpp'))
+        std = options.get_value(OptionKey('cpp_std', machine=self.for_machine))
         if std != 'none':
             args.append('-std=' + std)
         return args

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -422,7 +422,11 @@ class CoreData:
             value = opts_map.get_value(key.as_root())
         else:
             value = None
-        opts_map.add_system_option(key, opt.init_option(key, value, options.default_prefix()))
+        if key.has_module_prefix():
+            modulename = key.get_module_prefix()
+            opts_map.add_module_option(modulename, key, opt.init_option(key, value, options.default_prefix()))
+        else:
+            opts_map.add_system_option(key, opt.init_option(key, value, options.default_prefix()))
 
     def init_backend_options(self, backend_name: str) -> None:
         if backend_name == 'ninja':

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -743,14 +743,12 @@ class Environment:
                 # if it changes on future invocations.
                 if self.first_invocation:
                     if keyname == 'ldflags':
-                        key = OptionKey('link_args', machine=for_machine, lang='c')  # needs a language to initialize properly
                         for lang in compilers.compilers.LANGUAGES_USING_LDFLAGS:
-                            key = key.evolve(lang=lang)
+                            key = OptionKey(name=f'{lang}_link_args', machine=for_machine)
                             env_opts[key].extend(p_list)
                     elif keyname == 'cppflags':
-                        key = OptionKey('env_args', machine=for_machine, lang='c')
                         for lang in compilers.compilers.LANGUAGES_USING_CPPFLAGS:
-                            key = key.evolve(lang=lang)
+                            key = OptionKey(f'{lang}_env_args', machine=for_machine)
                             env_opts[key].extend(p_list)
                     else:
                         key = OptionKey.from_string(keyname).evolve(machine=for_machine)
@@ -770,7 +768,8 @@ class Environment:
                             # We still use the original key as the base here, as
                             # we want to inherit the machine and the compiler
                             # language
-                            key = key.evolve('env_args')
+                            lang = key.name.split('_', 1)[0]
+                            key = key.evolve(f'{lang}_env_args')
                         env_opts[key].extend(p_list)
 
         # Only store options that are not already in self.options,

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -272,12 +272,13 @@ class Conf:
                 dir_options[k] = v
             elif k in test_option_names:
                 test_options[k] = v
-            elif k.module:
+            elif k.has_module_prefix():
                 # Ignore module options if we did not use that module during
                 # configuration.
-                if self.build and k.module not in self.build.modules:
+                modname = k.get_module_prefix()
+                if self.build and modname not in self.build.modules:
                     continue
-                module_options[k.module][k] = v
+                module_options[modname][k] = v
             elif self.coredata.optstore.is_builtin_option(k):
                 core_options[k] = v
 

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -133,15 +133,14 @@ class ModuleState:
 
     def get_option(self, name: str, subproject: str = '',
                    machine: MachineChoice = MachineChoice.HOST,
-                   lang: T.Optional[str] = None,
                    module: T.Optional[str] = None) -> T.Union[T.List[str], str, int, bool]:
-        return self.environment.coredata.get_option(OptionKey(name, subproject, machine, lang, module))
+        return self.environment.coredata.get_option(OptionKey(name, subproject, machine, module))
 
     def is_user_defined_option(self, name: str, subproject: str = '',
                                machine: MachineChoice = MachineChoice.HOST,
                                lang: T.Optional[str] = None,
                                module: T.Optional[str] = None) -> bool:
-        key = OptionKey(name, subproject, machine, lang, module)
+        key = OptionKey(name, subproject, machine, module)
         return key in self._interpreter.user_defined_options.cmd_line_options
 
     def process_include_dirs(self, dirs: T.Iterable[T.Union[str, IncludeDirs]]) -> T.Iterable[IncludeDirs]:

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -132,15 +132,13 @@ class ModuleState:
         self._interpreter.func_test(self.current_node, real_args, kwargs)
 
     def get_option(self, name: str, subproject: str = '',
-                   machine: MachineChoice = MachineChoice.HOST,
-                   module: T.Optional[str] = None) -> T.Union[T.List[str], str, int, bool]:
-        return self.environment.coredata.get_option(OptionKey(name, subproject, machine, module))
+                   machine: MachineChoice = MachineChoice.HOST) -> T.Union[T.List[str], str, int, bool]:
+        return self.environment.coredata.get_option(OptionKey(name, subproject, machine))
 
     def is_user_defined_option(self, name: str, subproject: str = '',
                                machine: MachineChoice = MachineChoice.HOST,
-                               lang: T.Optional[str] = None,
-                               module: T.Optional[str] = None) -> bool:
-        key = OptionKey(name, subproject, machine, module)
+                               lang: T.Optional[str] = None) -> bool:
+        key = OptionKey(name, subproject, machine)
         return key in self._interpreter.user_defined_options.cmd_line_options
 
     def process_include_dirs(self, dirs: T.Iterable[T.Union[str, IncludeDirs]]) -> T.Iterable[IncludeDirs]:

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -703,7 +703,7 @@ class PkgConfigModule(NewExtensionModule):
             else:
                 pkgroot = os.path.join(_as_str(state.environment.coredata.get_option(OptionKey('libdir'))), 'pkgconfig')
                 pkgroot_name = os.path.join('{libdir}', 'pkgconfig')
-        relocatable = state.get_option('relocatable', module='pkgconfig')
+        relocatable = state.get_option('pkgconfig.relocatable')
         self._generate_pkgconfig_file(state, deps, subdirs, name, description, url,
                                       version, pcfile, conflicts, variables,
                                       unescaped_variables, False, dataonly,

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -83,13 +83,13 @@ class PythonExternalProgram(BasicPythonExternalProgram):
         if not state:
             # This happens only from run_project_tests.py
             return rel_path
-        value = T.cast('str', state.get_option(f'{key}dir', module='python'))
+        value = T.cast('str', state.get_option(f'python.{key}dir'))
         if value:
-            if state.is_user_defined_option('install_env', module='python'):
+            if state.is_user_defined_option('python.install_env'):
                 raise mesonlib.MesonException(f'python.{key}dir and python.install_env are mutually exclusive')
             return value
 
-        install_env = state.get_option('install_env', module='python')
+        install_env = state.get_option('python.install_env')
         if install_env == 'auto':
             install_env = 'venv' if self.info['is_venv'] else 'system'
 
@@ -169,7 +169,7 @@ class PythonInstallation(_ExternalProgramHolder['PythonExternalProgram']):
                                   self.current_node)
 
         limited_api_version = kwargs.pop('limited_api')
-        allow_limited_api = self.interpreter.environment.coredata.get_option(OptionKey('allow_limited_api', module='python'))
+        allow_limited_api = self.interpreter.environment.coredata.get_option(OptionKey('python.allow_limited_api'))
         if limited_api_version != '' and allow_limited_api:
 
             target_suffix = self.limited_api_suffix
@@ -374,7 +374,7 @@ class PythonModule(ExtensionModule):
     def _get_install_scripts(self) -> T.List[mesonlib.ExecutableSerialisation]:
         backend = self.interpreter.backend
         ret = []
-        optlevel = self.interpreter.environment.coredata.get_option(OptionKey('bytecompile', module='python'))
+        optlevel = self.interpreter.environment.coredata.get_option(OptionKey('python.bytecompile'))
         if optlevel == -1:
             return ret
         if not any(PythonExternalProgram.run_bytecompile.values()):

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -269,7 +269,7 @@ class RustModule(ExtensionModule):
                 raise InterpreterException(f'Unknown file type extension for: {name}')
 
         # We only want include directories and defines, other things may not be valid
-        cargs = state.get_option('args', state.subproject, lang=language)
+        cargs = state.get_option(f'{language}_args', state.subproject)
         assert isinstance(cargs, list), 'for mypy'
         for a in itertools.chain(state.global_args.get(language, []), state.project_args.get(language, []), cargs):
             if a.startswith(('-I', '/I', '-D', '/D', '-U', '/U')):
@@ -280,7 +280,7 @@ class RustModule(ExtensionModule):
 
         # Add the C++ standard to the clang arguments. Attempt to translate VS
         # extension versions into the nearest standard version
-        std = state.get_option('std', lang=language)
+        std = state.get_option(f'{language}_std')
         assert isinstance(std, str), 'for mypy'
         if std.startswith('vc++'):
             if std.endswith('latest'):

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 from itertools import chain
 from functools import total_ordering
 import argparse
-import enum
 
 from .mesonlib import (
     HoldableObject,
@@ -38,32 +37,6 @@ backendlist = ['ninja', 'vs', 'vs2010', 'vs2012', 'vs2013', 'vs2015', 'vs2017', 
 genvslitelist = ['vs2022']
 buildtypelist = ['plain', 'debug', 'debugoptimized', 'release', 'minsize', 'custom']
 
-
-class OptionType(enum.IntEnum):
-
-    """Enum used to specify what kind of argument a thing is."""
-
-    BUILTIN = 0
-    BACKEND = 1
-    BASE = 2
-    COMPILER = 3
-    PROJECT = 4
-
-def _classify_argument(key: 'OptionKey') -> OptionType:
-    """Classify arguments into groups so we know which dict to assign them to."""
-
-    if key.name.startswith('b_'):
-        return OptionType.BASE
-    elif key.lang is not None:
-        return OptionType.COMPILER
-    elif key.name in _BUILTIN_NAMES or key.module:
-        return OptionType.BUILTIN
-    elif key.name.startswith('backend_'):
-        assert key.machine is MachineChoice.HOST, str(key)
-        return OptionType.BACKEND
-    else:
-        assert key.machine is MachineChoice.HOST, str(key)
-        return OptionType.PROJECT
 
 # This is copied from coredata. There is no way to share this, because this
 # is used in the OptionKey constructor, and the coredata lists are
@@ -117,21 +90,19 @@ class OptionKey:
     internally easier to reason about and produce.
     """
 
-    __slots__ = ['name', 'subproject', 'machine', 'lang', '_hash', 'type', 'module']
+    __slots__ = ['name', 'subproject', 'machine', 'lang', '_hash', 'module']
 
     name: str
     subproject: str
     machine: MachineChoice
     lang: T.Optional[str]
     _hash: int
-    type: OptionType
     module: T.Optional[str]
 
     def __init__(self, name: str, subproject: str = '',
                  machine: MachineChoice = MachineChoice.HOST,
                  lang: T.Optional[str] = None,
-                 module: T.Optional[str] = None,
-                 _type: T.Optional[OptionType] = None):
+                 module: T.Optional[str] = None):
         # the _type option to the constructor is kinda private. We want to be
         # able tos ave the state and avoid the lookup function when
         # pickling/unpickling, but we need to be able to calculate it when
@@ -142,9 +113,6 @@ class OptionKey:
         object.__setattr__(self, 'lang', lang)
         object.__setattr__(self, 'module', module)
         object.__setattr__(self, '_hash', hash((name, subproject, machine, lang, module)))
-        if _type is None:
-            _type = _classify_argument(self)
-        object.__setattr__(self, 'type', _type)
 
     def __setattr__(self, key: str, value: T.Any) -> None:
         raise AttributeError('OptionKey instances do not support mutation.')
@@ -155,7 +123,6 @@ class OptionKey:
             'subproject': self.subproject,
             'machine': self.machine,
             'lang': self.lang,
-            '_type': self.type,
             'module': self.module,
         }
 
@@ -173,8 +140,8 @@ class OptionKey:
     def __hash__(self) -> int:
         return self._hash
 
-    def _to_tuple(self) -> T.Tuple[str, OptionType, str, str, MachineChoice, str]:
-        return (self.subproject, self.type, self.lang or '', self.module or '', self.machine, self.name)
+    def _to_tuple(self) -> T.Tuple[str, str, str, MachineChoice, str]:
+        return (self.subproject, self.lang or '', self.module or '', self.machine, self.name)
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, OptionKey):
@@ -199,7 +166,7 @@ class OptionKey:
         return out
 
     def __repr__(self) -> str:
-        return f'OptionKey({self.name!r}, {self.subproject!r}, {self.machine!r}, {self.lang!r}, {self.module!r}, {self.type!r})'
+        return f'OptionKey({self.name!r}, {self.subproject!r}, {self.machine!r}, {self.lang!r}, {self.module!r})'
 
     @classmethod
     def from_string(cls, raw: str) -> 'OptionKey':
@@ -269,7 +236,8 @@ class OptionKey:
 
     def is_project_hack_for_optionsview(self) -> bool:
         """This method will be removed once we can delete OptionsView."""
-        return self.type is OptionType.PROJECT
+        import sys
+        sys.exit('FATAL internal error. This should not make it into an actual release. File a bug.')
 
 
 class UserOption(T.Generic[_T], HoldableObject):
@@ -712,6 +680,7 @@ BUILTIN_DIR_NOPREFIX_OPTIONS: T.Dict[OptionKey, T.Dict[str, str]] = {
 class OptionStore:
     def __init__(self):
         self.d: T.Dict['OptionKey', 'UserOption[T.Any]'] = {}
+        self.project_options = set()
 
     def __len__(self):
         return len(self.d)
@@ -734,6 +703,7 @@ class OptionStore:
     def add_project_option(self, key: T.Union[OptionKey, str], valobj: 'UserOption[T.Any]'):
         key = self.ensure_key(key)
         self.d[key] = valobj
+        self.project_options.add(key)
 
     def set_value(self, key: T.Union[OptionKey, str], new_value: 'T.Any') -> bool:
         key = self.ensure_key(key)
@@ -774,23 +744,39 @@ class OptionStore:
 
     def is_project_option(self, key: OptionKey) -> bool:
         """Convenience method to check if this is a project option."""
-        return key.type is OptionType.PROJECT
+        return key in self.project_options
 
     def is_reserved_name(self, key: OptionKey) -> bool:
-        return not self.is_project_option(key)
+        if key.name in _BUILTIN_NAMES:
+            return True
+        # FIXME, this hack is needed until the lang field is removed from OptionKey.
+        if key.lang is not None:
+            return True
+        if '_' not in key.name:
+            return False
+        prefix = key.name.split('_')[0]
+        # Pylint seems to think that it is faster to build a set object
+        # and all related work just to test whether a string has one of two
+        # values. It is not, thank you very much.
+        if prefix in ('b', 'backend'): # pylint: disable=R6201
+            return True
+        from .compilers import all_languages
+        if prefix in all_languages:
+            return True
+        return False
 
     def is_builtin_option(self, key: OptionKey) -> bool:
         """Convenience method to check if this is a builtin option."""
-        return key.type is OptionType.BUILTIN
+        return key.name in _BUILTIN_NAMES or key.module
 
     def is_base_option(self, key: OptionKey) -> bool:
         """Convenience method to check if this is a base option."""
-        return key.type is OptionType.BASE
+        return key.name.startswith('b_')
 
     def is_backend_option(self, key: OptionKey) -> bool:
         """Convenience method to check if this is a backend option."""
-        return key.type is OptionType.BACKEND
+        return key.name.startswith('backend_')
 
     def is_compiler_option(self, key: OptionKey) -> bool:
         """Convenience method to check if this is a compiler option."""
-        return key.type is OptionType.COMPILER
+        return key.lang is not None

--- a/run_tests.py
+++ b/run_tests.py
@@ -153,7 +153,7 @@ def get_fake_env(sdir: str = '', bdir: T.Optional[str] = None, prefix: str = '',
     if opts is None:
         opts = get_fake_options(prefix)
     env = Environment(sdir, bdir, opts)
-    env.coredata.optstore.set_value_object(OptionKey('args', lang='c'),  FakeCompilerOptions())
+    env.coredata.optstore.set_value_object(OptionKey('c_args'),  FakeCompilerOptions())
     env.machines.host.cpu_family = 'x86_64' # Used on macOS inside find_library
     # Invalidate cache when using a different Environment object.
     clear_meson_configure_class_caches()

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -3758,9 +3758,9 @@ class AllPlatformTests(BasePlatformTests):
 
               User defined options
                 backend        : ''' + self.backend_name + '''
+                enabled_opt    : enabled
                 libdir         : lib
                 prefix         : /usr
-                enabled_opt    : enabled
                 python         : ''' + sys.executable + '''
             ''')
         expected_lines = expected.split('\n')[1:]

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -2725,11 +2725,11 @@ class AllPlatformTests(BasePlatformTests):
         # c_args value should be parsed with split_args
         self.init(testdir, extra_args=['-Dc_args=-Dfoo -Dbar "-Dthird=one two"', '--fatal-meson-warnings'])
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value(OptionKey('args', lang='c')), ['-Dfoo', '-Dbar', '-Dthird=one two'])
+        self.assertEqual(obj.optstore.get_value(OptionKey('c_args')), ['-Dfoo', '-Dbar', '-Dthird=one two'])
 
         self.setconf('-Dc_args="foo bar" one two')
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value(OptionKey('args', lang='c')), ['foo bar', 'one', 'two'])
+        self.assertEqual(obj.optstore.get_value(OptionKey('c_args')), ['foo bar', 'one', 'two'])
         self.wipe()
 
         self.init(testdir, extra_args=['-Dset_percent_opt=myoption%', '--fatal-meson-warnings'])
@@ -2748,7 +2748,7 @@ class AllPlatformTests(BasePlatformTests):
             self.assertEqual(obj.optstore.get_value('bindir'), 'bar')
             self.assertEqual(obj.optstore.get_value('buildtype'), 'release')
             self.assertEqual(obj.optstore.get_value('b_sanitize'), 'thread')
-            self.assertEqual(obj.optstore.get_value(OptionKey('args', lang='c')), ['-Dbar'])
+            self.assertEqual(obj.optstore.get_value(OptionKey('c_args')), ['-Dbar'])
             self.setconf(['--bindir=bar', '--bindir=foo',
                           '-Dbuildtype=release', '-Dbuildtype=plain',
                           '-Db_sanitize=thread', '-Db_sanitize=address',
@@ -2757,7 +2757,7 @@ class AllPlatformTests(BasePlatformTests):
             self.assertEqual(obj.optstore.get_value('bindir'), 'foo')
             self.assertEqual(obj.optstore.get_value('buildtype'), 'plain')
             self.assertEqual(obj.optstore.get_value('b_sanitize'), 'address')
-            self.assertEqual(obj.optstore.get_value(OptionKey('args', lang='c')), ['-Dfoo'])
+            self.assertEqual(obj.optstore.get_value(OptionKey('c_args')), ['-Dfoo'])
             self.wipe()
         except KeyError:
             # Ignore KeyError, it happens on CI for compilers that does not

--- a/unittests/datatests.py
+++ b/unittests/datatests.py
@@ -139,8 +139,8 @@ class DataTests(unittest.TestCase):
             found_entries |= options
 
         self.assertEqual(found_entries, {
-            *(str(k.evolve(module=None)) for k in mesonbuild.options.BUILTIN_OPTIONS),
-            *(str(k.evolve(module=None)) for k in mesonbuild.options.BUILTIN_OPTIONS_PER_MACHINE),
+            *(str(k.without_module_prefix()) for k in mesonbuild.options.BUILTIN_OPTIONS),
+            *(str(k.without_module_prefix()) for k in mesonbuild.options.BUILTIN_OPTIONS_PER_MACHINE),
         })
 
         # Check that `buildtype` table inside `Core options` matches how

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -626,7 +626,7 @@ class InternalTests(unittest.TestCase):
             env = get_fake_env()
             compiler = detect_c_compiler(env, MachineChoice.HOST)
             env.coredata.compilers.host = {'c': compiler}
-            env.coredata.optstore.set_value_object(OptionKey('link_args', lang='c'), FakeCompilerOptions())
+            env.coredata.optstore.set_value_object(OptionKey('c_link_args'), FakeCompilerOptions())
             p1 = Path(tmpdir) / '1'
             p2 = Path(tmpdir) / '2'
             p1.mkdir()
@@ -1704,8 +1704,8 @@ class InternalTests(unittest.TestCase):
 
     def test_option_key_from_string(self) -> None:
         cases = [
-            ('c_args', OptionKey('args', lang='c')),
-            ('build.cpp_args', OptionKey('args', machine=MachineChoice.BUILD, lang='cpp')),
+            ('c_args', OptionKey('c_args')),
+            ('build.cpp_args', OptionKey('cpp_args', machine=MachineChoice.BUILD)),
             ('prefix', OptionKey('prefix')),
             ('made_up', OptionKey('made_up')),
 

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -34,7 +34,7 @@ from mesonbuild.mesonlib import (
     LibType, MachineChoice, PerMachine, Version, is_windows, is_osx,
     is_cygwin, is_openbsd, search_version, MesonException,
 )
-from mesonbuild.options import OptionKey, OptionType
+from mesonbuild.options import OptionKey
 from mesonbuild.interpreter.type_checking import in_set_validator, NoneType
 from mesonbuild.dependencies.pkgconfig import PkgConfigDependency, PkgConfigInterface, PkgConfigCLI
 from mesonbuild.programs import ExternalProgram
@@ -1704,16 +1704,16 @@ class InternalTests(unittest.TestCase):
 
     def test_option_key_from_string(self) -> None:
         cases = [
-            ('c_args', OptionKey('args', lang='c', _type=OptionType.COMPILER)),
-            ('build.cpp_args', OptionKey('args', machine=MachineChoice.BUILD, lang='cpp', _type=OptionType.COMPILER)),
-            ('prefix', OptionKey('prefix', _type=OptionType.BUILTIN)),
-            ('made_up', OptionKey('made_up', _type=OptionType.PROJECT)),
+            ('c_args', OptionKey('args', lang='c')),
+            ('build.cpp_args', OptionKey('args', machine=MachineChoice.BUILD, lang='cpp')),
+            ('prefix', OptionKey('prefix')),
+            ('made_up', OptionKey('made_up')),
 
             # TODO: the from_String method should be splitting the prefix off of
             # these, as we have the type already, but it doesn't. For now have a
             # test so that we don't change the behavior un-intentionally
-            ('b_lto', OptionKey('b_lto', _type=OptionType.BASE)),
-            ('backend_startup_project', OptionKey('backend_startup_project', _type=OptionType.BACKEND)),
+            ('b_lto', OptionKey('b_lto')),
+            ('backend_startup_project', OptionKey('backend_startup_project')),
         ]
 
         for raw, expected in cases:

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -486,7 +486,7 @@ class LinuxlikeTests(BasePlatformTests):
         # Check that all the listed -std=xxx options for this compiler work just fine when used
         # https://en.wikipedia.org/wiki/Xcode#Latest_versions
         # https://www.gnu.org/software/gcc/projects/cxx-status.html
-        key = OptionKey('std', lang=compiler.language)
+        key = OptionKey(f'{compiler.language}_std')
         for v in compiler.get_options()[key].choices:
             # we do it like this to handle gnu++17,c++17 and gnu17,c17 cleanly
             # thus, C++ first


### PR DESCRIPTION
The goal is that `OptionKey` becomes a simple object that only holds option name, subproject and whether it is for build or not. All the "business logic" goes inside `OptionStore` as opposed to being splattered about.

This needs to be done piece by piece. This MR (currently) removes the "option type" only. It will be followed by more standalone commits that remove features one by one. They might go to this one as subsequent commits or they might be standalone, have not decided yet.