### PR TITLE
Revert various cross compile changes

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -570,7 +570,8 @@ class Backend:
         else:
             extra_paths = []
 
-        if self.environment.need_exe_wrapper(exe_for_machine):
+        is_cross_built = not self.environment.machines.matches_build_machine(exe_for_machine)
+        if is_cross_built and self.environment.need_exe_wrapper():
             if not self.environment.has_exe_wrapper():
                 msg = 'An exe_wrapper is needed but was not found. Please define one ' \
                       'in cross file and check the command and/or add it to PATH.'

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -553,7 +553,7 @@ class CudaCompiler(Compiler):
         flags += self.get_ccbin_args(env.coredata.optstore)
 
         # If cross-compiling, we can't run the sanity check, only compile it.
-        if env.need_exe_wrapper(self.for_machine) and not env.has_exe_wrapper():
+        if self.is_cross and not env.has_exe_wrapper():
             # Linking cross built apps is painful. You can't really
             # tell if you should use -nostdlib or not and for example
             # on OSX the compiler binary is the same but you need
@@ -575,7 +575,7 @@ class CudaCompiler(Compiler):
             raise EnvironmentException(f'Compiler {self.name_string()} cannot compile programs.')
 
         # Run sanity check (if possible)
-        if env.need_exe_wrapper(self.for_machine):
+        if self.is_cross:
             if not env.has_exe_wrapper():
                 return
             else:

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -456,7 +456,7 @@ class DCompiler(Compiler):
         if pc.returncode != 0:
             raise EnvironmentException('D compiler %s cannot compile programs.' % self.name_string())
 
-        if environment.need_exe_wrapper(self.for_machine):
+        if self.is_cross:
             if not environment.has_exe_wrapper():
                 # Can't check if the binaries run so we have to assume they do
                 return

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -278,7 +278,7 @@ class CLikeCompiler(Compiler):
         mode = CompileCheckMode.LINK
         if self.is_cross:
             binname += '_cross'
-            if environment.need_exe_wrapper(self.for_machine) and not environment.has_exe_wrapper():
+            if not environment.has_exe_wrapper():
                 # Linking cross built C/C++ apps is painful. You can't really
                 # tell if you should use -nostdlib or not and for example
                 # on OSX the compiler binary is the same but you need
@@ -308,7 +308,7 @@ class CLikeCompiler(Compiler):
         if pc.returncode != 0:
             raise mesonlib.EnvironmentException(f'Compiler {self.name_string()} cannot compile programs.')
         # Run sanity check
-        if environment.need_exe_wrapper(self.for_machine):
+        if self.is_cross:
             if not environment.has_exe_wrapper():
                 # Can't check if the binaries run so we have to assume they do
                 return

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -87,7 +87,7 @@ class RustCompiler(Compiler):
         if pc.returncode != 0:
             raise EnvironmentException(f'Rust compiler {self.name_string()} cannot compile programs.')
         self._native_static_libs(work_dir, source_name)
-        if environment.need_exe_wrapper(self.for_machine):
+        if self.is_cross:
             if not environment.has_exe_wrapper():
                 # Can't check if the binaries run so we have to assume they do
                 return


### PR DESCRIPTION
c1076241af11f10acac28d771688bb54c6b0b340 changed the logic in multiple places, in particular it looks like it was assumed that is_cross is always the same as need_exe_wrapper(), but that's not true.

Also the commit only talks about mypy, so this was definitely not intended.

This reverts all the cases where need_exe_wrapper() was introduced back to is_cross.

The change in backends.py could be a correct simplification, but I don't know the code base enough, so reverting that too.

See #13403 and #13410