### PR TITLE
Rename langopt method

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -95,7 +95,7 @@ class CCompiler(CLikeCompiler, Compiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         opts.update({
             key: options.UserStdOption('C', _ALL_STDS),
         })
@@ -128,7 +128,7 @@ class _ClangCStds(CompilerMixinBase):
             stds += ['c2x']
         if version_compare(self.version, self._C23_VERSION):
             stds += ['c23']
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std_opt = opts[key]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
         std_opt.set_versions(stds, gnu=True)
@@ -157,7 +157,7 @@ class ClangCCompiler(_ClangCStds, ClangCompiler, CCompiler):
             self.update_options(
                 opts,
                 self.create_option(options.UserArrayOption,
-                                   self.form_langopt_key('winlibs'),
+                                   self.form_compileropt_key('winlibs'),
                                    'Standard Win libraries to link against',
                                    gnu_winlibs),
             )
@@ -165,7 +165,7 @@ class ClangCCompiler(_ClangCStds, ClangCompiler, CCompiler):
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std != 'none':
             args.append('-std=' + std)
@@ -174,7 +174,7 @@ class ClangCCompiler(_ClangCStds, ClangCompiler, CCompiler):
     def get_option_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         if self.info.is_windows() or self.info.is_cygwin():
             # without a typedict mypy can't understand this.
-            key = self.form_langopt_key('winlibs')
+            key = self.form_compileropt_key('winlibs')
             libs = options.get_value(key).copy()
             assert isinstance(libs, list)
             for l in libs:
@@ -250,7 +250,7 @@ class ArmclangCCompiler(ArmclangCompiler, CCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = CCompiler.get_options(self)
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std_opt = opts[key]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
         std_opt.set_versions(['c90', 'c99', 'c11'], gnu=True)
@@ -258,7 +258,7 @@ class ArmclangCCompiler(ArmclangCompiler, CCompiler):
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std != 'none':
             args.append('-std=' + std)
@@ -302,7 +302,7 @@ class GnuCCompiler(GnuCompiler, CCompiler):
             stds += ['c2x']
         if version_compare(self.version, self._C23_VERSION):
             stds += ['c23']
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std_opt = opts[key]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
         std_opt.set_versions(stds, gnu=True)
@@ -318,7 +318,7 @@ class GnuCCompiler(GnuCompiler, CCompiler):
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std != 'none':
             args.append('-std=' + std)
@@ -327,7 +327,7 @@ class GnuCCompiler(GnuCompiler, CCompiler):
     def get_option_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         if self.info.is_windows() or self.info.is_cygwin():
             # without a typeddict mypy can't figure this out
-            key = self.form_langopt_key('winlibs')
+            key = self.form_compileropt_key('winlibs')
             libs: T.List[str] = options.get_value(key).copy()
             assert isinstance(libs, list)
             for l in libs:
@@ -384,7 +384,7 @@ class ElbrusCCompiler(ElbrusCompiler, CCompiler):
             stds += ['c90', 'c1x', 'gnu90', 'gnu1x', 'iso9899:2011']
         if version_compare(self.version, '>=1.26.00'):
             stds += ['c17', 'c18', 'iso9899:2017', 'iso9899:2018', 'gnu17', 'gnu18']
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std_opt = opts[key]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
         std_opt.set_versions(stds)
@@ -424,7 +424,7 @@ class IntelCCompiler(IntelGnuLikeCompiler, CCompiler):
         stds = ['c89', 'c99']
         if version_compare(self.version, '>=16.0.0'):
             stds += ['c11']
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std_opt = opts[key]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
         std_opt.set_versions(stds, gnu=True)
@@ -432,7 +432,7 @@ class IntelCCompiler(IntelGnuLikeCompiler, CCompiler):
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std != 'none':
             args.append('-std=' + std)
@@ -453,7 +453,7 @@ class VisualStudioLikeCCompilerMixin(CompilerMixinBase):
             super().get_options(),
             self.create_option(
                 options.UserArrayOption,
-                self.form_langopt_key('winlibs'),
+                self.form_compileropt_key('winlibs'),
                 'Windows libs to link against.',
                 msvc_winlibs,
             ),
@@ -461,7 +461,7 @@ class VisualStudioLikeCCompilerMixin(CompilerMixinBase):
 
     def get_option_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         # need a TypeDict to make this work
-        key = self.form_langopt_key('winlibs')
+        key = self.form_compileropt_key('winlibs')
         libs = options.get_value(key).copy()
         assert isinstance(libs, list)
         for l in libs:
@@ -490,7 +490,7 @@ class VisualStudioCCompiler(MSVCCompiler, VisualStudioLikeCCompilerMixin, CCompi
             stds += ['c11']
         if version_compare(self.version, self._C17_VERSION):
             stds += ['c17', 'c18']
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std_opt = opts[key]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
         std_opt.set_versions(stds, gnu=True, gnu_deprecated=True)
@@ -498,7 +498,7 @@ class VisualStudioCCompiler(MSVCCompiler, VisualStudioLikeCCompilerMixin, CCompi
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         # As of MVSC 16.8, /std:c11 and /std:c17 are the only valid C standard options.
         if std == 'c11':
@@ -519,7 +519,7 @@ class ClangClCCompiler(_ClangCStds, ClangClCompiler, VisualStudioLikeCCompilerMi
         ClangClCompiler.__init__(self, target)
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std != "none":
             return [f'/clang:-std={std}']
@@ -541,7 +541,7 @@ class IntelClCCompiler(IntelVisualStudioLikeCompiler, VisualStudioLikeCCompilerM
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         # To shut up mypy.
         if isinstance(opts, dict):
             raise RuntimeError('This is a transitory issue that should not happen. Please report with full backtrace.')
@@ -552,7 +552,7 @@ class IntelClCCompiler(IntelVisualStudioLikeCompiler, VisualStudioLikeCCompilerM
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std == 'c89':
             mlog.log("ICL doesn't explicitly implement c89, setting the standard to 'none', which is close.", once=True)
@@ -578,7 +578,7 @@ class ArmCCompiler(ArmCompiler, CCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = CCompiler.get_options(self)
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std_opt = opts[key]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
         std_opt.set_versions(['c89', 'c99', 'c11'])
@@ -586,7 +586,7 @@ class ArmCCompiler(ArmCompiler, CCompiler):
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std != 'none':
             args.append('--' + std)
@@ -608,7 +608,7 @@ class CcrxCCompiler(CcrxCompiler, CCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = CCompiler.get_options(self)
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std_opt = opts[key]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
         std_opt.set_versions(['c89', 'c99'])
@@ -619,7 +619,7 @@ class CcrxCCompiler(CcrxCompiler, CCompiler):
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std == 'c89':
             args.append('-lang=c')
@@ -656,7 +656,7 @@ class Xc16CCompiler(Xc16Compiler, CCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = CCompiler.get_options(self)
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std_opt = opts[key]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
         std_opt.set_versions(['c89', 'c99'], gnu=True)
@@ -667,7 +667,7 @@ class Xc16CCompiler(Xc16Compiler, CCompiler):
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std != 'none':
             args.append('-ansi')
@@ -702,7 +702,7 @@ class CompCertCCompiler(CompCertCompiler, CCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = CCompiler.get_options(self)
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std_opt = opts[key]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
         std_opt.set_versions(['c89', 'c99'])
@@ -740,7 +740,7 @@ class TICCompiler(TICompiler, CCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = CCompiler.get_options(self)
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std_opt = opts[key]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
         std_opt.set_versions(['c89', 'c99', 'c11'])
@@ -751,7 +751,7 @@ class TICCompiler(TICompiler, CCompiler):
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std != 'none':
             args.append('--' + std)
@@ -781,13 +781,13 @@ class MetrowerksCCompilerARM(MetrowerksCompiler, CCompiler):
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = CCompiler.get_options(self)
         c_stds = ['c99']
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         opts[key].choices = ['none'] + c_stds
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std != 'none':
             args.append('-lang')
@@ -811,13 +811,13 @@ class MetrowerksCCompilerEmbeddedPowerPC(MetrowerksCompiler, CCompiler):
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = CCompiler.get_options(self)
         c_stds = ['c99']
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         opts[key].choices = ['none'] + c_stds
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std != 'none':
             args.append('-lang ' + std)

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1354,7 +1354,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         """
         raise EnvironmentException(f'{self.get_id()} does not support preprocessor')
 
-    def form_langopt_key(self, basename: str) -> OptionKey:
+    def form_compileropt_key(self, basename: str) -> OptionKey:
         return OptionKey(basename, machine=self.for_machine, lang=self.language)
 
 def get_global_options(lang: str,

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -173,7 +173,7 @@ class CPPCompiler(CLikeCompiler, Compiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         opts.update({
             key: options.UserStdOption('C++', _ALL_STDS),
         })
@@ -243,16 +243,16 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCompiler, CPPCompiler):
         self.update_options(
             opts,
             self.create_option(options.UserComboOption,
-                               self.form_langopt_key('eh'),
+                               self.form_compileropt_key('eh'),
                                'C++ exception handling type.',
                                ['none', 'default', 'a', 's', 'sc'],
                                'default'),
             self.create_option(options.UserBooleanOption,
-                               self.form_langopt_key('rtti'),
+                               self.form_compileropt_key('rtti'),
                                'Enable RTTI',
                                True),
             self.create_option(options.UserBooleanOption,
-                               self.form_langopt_key('debugstl'),
+                               self.form_compileropt_key('debugstl'),
                                'STL debug mode',
                                False),
         )
@@ -263,14 +263,14 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCompiler, CPPCompiler):
             cppstd_choices.append('c++23')
         if version_compare(self.version, self._CPP26_VERSION):
             cppstd_choices.append('c++26')
-        std_opt = opts[self.form_langopt_key('std')]
+        std_opt = opts[self.form_compileropt_key('std')]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
         std_opt.set_versions(cppstd_choices, gnu=True)
         if self.info.is_windows() or self.info.is_cygwin():
             self.update_options(
                 opts,
                 self.create_option(options.UserArrayOption,
-                                   self.form_langopt_key('winlibs'),
+                                   self.form_compileropt_key('winlibs'),
                                    'Standard Win libraries to link against',
                                    gnu_winlibs),
             )
@@ -278,15 +278,15 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCompiler, CPPCompiler):
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args: T.List[str] = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std != 'none':
             args.append(self._find_best_cpp_std(std))
 
-        key = self.form_langopt_key('eh')
+        key = self.form_compileropt_key('eh')
         non_msvc_eh_options(options.get_value(key), args)
 
-        key = self.form_langopt_key('debugstl')
+        key = self.form_compileropt_key('debugstl')
         if options.get_value(key):
             args.append('-D_GLIBCXX_DEBUG=1')
 
@@ -296,7 +296,7 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCompiler, CPPCompiler):
             if version_compare(self.version, '>=18'):
                 args.append('-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG')
 
-        key = self.form_langopt_key('rtti')
+        key = self.form_compileropt_key('rtti')
         if not options.get_value(key):
             args.append('-fno-rtti')
 
@@ -305,7 +305,7 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCompiler, CPPCompiler):
     def get_option_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         if self.info.is_windows() or self.info.is_cygwin():
             # without a typedict mypy can't understand this.
-            key = self.form_langopt_key('winlibs')
+            key = self.form_compileropt_key('winlibs')
             libs = options.get_value(key).copy()
             assert isinstance(libs, list)
             for l in libs:
@@ -365,7 +365,7 @@ class EmscriptenCPPCompiler(EmscriptenMixin, ClangCPPCompiler):
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args: T.List[str] = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std != 'none':
             args.append(self._find_best_cpp_std(std))
@@ -393,7 +393,7 @@ class ArmclangCPPCompiler(ArmclangCompiler, CPPCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = CPPCompiler.get_options(self)
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         self.update_options(
             opts,
             self.create_option(options.UserComboOption,
@@ -409,12 +409,12 @@ class ArmclangCPPCompiler(ArmclangCompiler, CPPCompiler):
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args: T.List[str] = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std != 'none':
             args.append('-std=' + std)
 
-        key = self.form_langopt_key('eh')
+        key = self.form_compileropt_key('eh')
         non_msvc_eh_options(options.get_value(key), args)
 
         return args
@@ -442,21 +442,21 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCompiler, CPPCompiler):
                                          self.supported_warn_args(gnu_cpp_warning_args))}
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         opts = CPPCompiler.get_options(self)
         self.update_options(
             opts,
             self.create_option(options.UserComboOption,
-                               self.form_langopt_key('eh'),
+                               self.form_compileropt_key('eh'),
                                'C++ exception handling type.',
                                ['none', 'default', 'a', 's', 'sc'],
                                'default'),
             self.create_option(options.UserBooleanOption,
-                               self.form_langopt_key('rtti'),
+                               self.form_compileropt_key('rtti'),
                                'Enable RTTI',
                                True),
             self.create_option(options.UserBooleanOption,
-                               self.form_langopt_key('debugstl'),
+                               self.form_compileropt_key('debugstl'),
                                'STL debug mode',
                                False),
         )
@@ -483,7 +483,7 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCompiler, CPPCompiler):
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args: T.List[str] = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std != 'none':
             args.append(self._find_best_cpp_std(std))
@@ -500,7 +500,7 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCompiler, CPPCompiler):
     def get_option_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         if self.info.is_windows() or self.info.is_cygwin():
             # without a typedict mypy can't understand this.
-            key = self.form_langopt_key('winlibs')
+            key = self.form_compileropt_key('winlibs')
             libs = options.get_value(key).copy()
             assert isinstance(libs, list)
             for l in libs:
@@ -583,16 +583,16 @@ class ElbrusCPPCompiler(ElbrusCompiler, CPPCompiler):
         if version_compare(self.version, '>=1.26.00'):
             cpp_stds += ['c++20']
 
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         self.update_options(
             opts,
             self.create_option(options.UserComboOption,
-                               self.form_langopt_key('eh'),
+                               self.form_compileropt_key('eh'),
                                'C++ exception handling type.',
                                ['none', 'default', 'a', 's', 'sc'],
                                'default'),
             self.create_option(options.UserBooleanOption,
-                               self.form_langopt_key('debugstl'),
+                               self.form_compileropt_key('debugstl'),
                                'STL debug mode',
                                False),
         )
@@ -616,15 +616,15 @@ class ElbrusCPPCompiler(ElbrusCompiler, CPPCompiler):
     # Elbrus C++ compiler does not support RTTI, so don't check for it.
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args: T.List[str] = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std.value != 'none':
             args.append(self._find_best_cpp_std(std.value))
 
-        key = self.form_langopt_key('eh')
+        key = self.form_compileropt_key('eh')
         non_msvc_eh_options(options.get_value(key), args)
 
-        key = self.form_langopt_key('debugstl')
+        key = self.form_compileropt_key('debugstl')
         if options.get_value(key):
             args.append('-D_GLIBCXX_DEBUG=1')
         return args
@@ -664,20 +664,20 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
             c_stds += ['c++2a']
             g_stds += ['gnu++2a']
 
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         self.update_options(
             opts,
             self.create_option(options.UserComboOption,
-                               self.form_langopt_key('eh'),
+                               self.form_compileropt_key('eh'),
                                'C++ exception handling type.',
                                ['none', 'default', 'a', 's', 'sc'],
                                'default'),
             self.create_option(options.UserBooleanOption,
-                               self.form_langopt_key('rtti'),
+                               self.form_compileropt_key('rtti'),
                                'Enable RTTI',
                                True),
             self.create_option(options.UserBooleanOption,
-                               self.form_langopt_key('debugstl'),
+                               self.form_compileropt_key('debugstl'),
                                'STL debug mode',
                                False),
         )
@@ -688,7 +688,7 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args: T.List[str] = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std != 'none':
             remap_cpp03 = {
@@ -733,24 +733,24 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
 
     def get_option_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         # need a typeddict for this
-        key = self.form_langopt_key('winlibs')
+        key = self.form_compileropt_key('winlibs')
         return T.cast('T.List[str]', options.get_value(key)[:])
 
     def _get_options_impl(self, opts: 'MutableKeyedOptionDictType', cpp_stds: T.List[str]) -> 'MutableKeyedOptionDictType':
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         self.update_options(
             opts,
             self.create_option(options.UserComboOption,
-                               self.form_langopt_key('eh'),
+                               self.form_compileropt_key('eh'),
                                'C++ exception handling type.',
                                ['none', 'default', 'a', 's', 'sc'],
                                'default'),
             self.create_option(options.UserBooleanOption,
-                               self.form_langopt_key('rtti'),
+                               self.form_compileropt_key('rtti'),
                                'Enable RTTI',
                                True),
             self.create_option(options.UserArrayOption,
-                               self.form_langopt_key('winlibs'),
+                               self.form_compileropt_key('winlibs'),
                                'Windows libs to link against.',
                                msvc_winlibs),
         )
@@ -761,9 +761,9 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args: T.List[str] = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
 
-        eh = options.get_value(self.form_langopt_key('eh'))
+        eh = options.get_value(self.form_compileropt_key('eh'))
         if eh == 'default':
             args.append('/EHsc')
         elif eh == 'none':
@@ -771,7 +771,7 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
         else:
             args.append('/EH' + eh)
 
-        if not options.get_value(self.form_langopt_key('rtti')):
+        if not options.get_value(self.form_compileropt_key('rtti')):
             args.append('/GR-')
 
         permissive, ver = self.VC_VERSION_MAP[options.get_value(key)]
@@ -801,7 +801,7 @@ class CPP11AsCPP14Mixin(CompilerMixinBase):
         # which means setting the C++ standard version to C++14, in compilers that support it
         # (i.e., after VS2015U3)
         # if one is using anything before that point, one cannot set the standard.
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         if options.get_value(key) in {'vc++11', 'c++11'}:
             mlog.warning(self.id, 'does not support C++11;',
                          'attempting best effort; setting the standard to C++14',
@@ -848,7 +848,7 @@ class VisualStudioCPPCompiler(CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixi
         return self._get_options_impl(super().get_options(), cpp_stds)
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         if options.get_value(key) != 'none' and version_compare(self.version, '<19.00.24210'):
             mlog.warning('This version of MSVC does not support cpp_std arguments', fatal=False)
             options = copy.copy(options)
@@ -917,14 +917,14 @@ class ArmCPPCompiler(ArmCompiler, CPPCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = CPPCompiler.get_options(self)
-        std_opt = self.form_langopt_key('std')
+        std_opt = self.form_compileropt_key('std')
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
         std_opt.set_versions(['c++03', 'c++11'])
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args: T.List[str] = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std == 'c++11':
             args.append('--cpp11')
@@ -978,7 +978,7 @@ class TICPPCompiler(TICompiler, CPPCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = CPPCompiler.get_options(self)
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std_opt = opts[key]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
         std_opt.set_versions(['c++03'])
@@ -986,7 +986,7 @@ class TICPPCompiler(TICompiler, CPPCompiler):
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args: T.List[str] = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std != 'none':
             args.append('--' + std)
@@ -1021,13 +1021,13 @@ class MetrowerksCPPCompilerARM(MetrowerksCompiler, CPPCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = CPPCompiler.get_options(self)
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         opts[key].choices = ['none']
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args: T.List[str] = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std != 'none':
             args.append('-lang')
@@ -1050,13 +1050,13 @@ class MetrowerksCPPCompilerEmbeddedPowerPC(MetrowerksCompiler, CPPCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = CPPCompiler.get_options(self)
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         opts[key].choices = ['none']
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args: T.List[str] = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std != 'none':
             args.append('-lang ' + std)

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -646,12 +646,12 @@ class CudaCompiler(Compiler):
         return self.update_options(
             super().get_options(),
             self.create_option(options.UserComboOption,
-                               self.form_langopt_key('std'),
+                               self.form_compileropt_key('std'),
                                'C++ language standard to use with CUDA',
                                cpp_stds,
                                'none'),
             self.create_option(options.UserStringOption,
-                               self.form_langopt_key('ccbindir'),
+                               self.form_compileropt_key('ccbindir'),
                                'CUDA non-default toolchain directory to use (-ccbin)',
                                ''),
         )
@@ -675,7 +675,7 @@ class CudaCompiler(Compiler):
         # the combination of CUDA version and MSVC version; the --std= is thus ignored
         # and attempting to use it will result in a warning: https://stackoverflow.com/a/51272091/741027
         if not is_windows():
-            key = self.form_langopt_key('std')
+            key = self.form_compileropt_key('std')
             std = options.get_value(key)
             if std != 'none':
                 args.append('--std=' + std)
@@ -795,7 +795,7 @@ class CudaCompiler(Compiler):
         return self._to_host_flags(super().get_dependency_link_args(dep), _Phase.LINKER)
 
     def get_ccbin_args(self, ccoptions: 'KeyedOptionDictType') -> T.List[str]:
-        key = self.form_langopt_key('ccbindir')
+        key = self.form_compileropt_key('ccbindir')
         ccbindir = ccoptions.get_value(key)
         if isinstance(ccbindir, str) and ccbindir != '':
             return [self._shield_nvcc_list_arg('-ccbin='+ccbindir, False)]

--- a/mesonbuild/compilers/cython.py
+++ b/mesonbuild/compilers/cython.py
@@ -70,12 +70,12 @@ class CythonCompiler(Compiler):
         return self.update_options(
             super().get_options(),
             self.create_option(options.UserComboOption,
-                               self.form_langopt_key('version'),
+                               self.form_compileropt_key('version'),
                                'Python version to target',
                                ['2', '3'],
                                '3'),
             self.create_option(options.UserComboOption,
-                               self.form_langopt_key('language'),
+                               self.form_compileropt_key('language'),
                                'Output C or C++ files',
                                ['c', 'cpp'],
                                'c'),
@@ -83,10 +83,10 @@ class CythonCompiler(Compiler):
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args: T.List[str] = []
-        key = self.form_langopt_key('version')
+        key = self.form_compileropt_key('version')
         version = options.get_value(key)
         args.append(f'-{version}')
-        key = self.form_langopt_key('language')
+        key = self.form_compileropt_key('language')
         lang = options.get_value(key)
         if lang == 'cpp':
             args.append('--cplus')

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -115,7 +115,7 @@ class FortranCompiler(CLikeCompiler, Compiler):
         return self.update_options(
             super().get_options(),
             self.create_option(options.UserComboOption,
-                               self.form_langopt_key('std'),
+                               self.form_compileropt_key('std'),
                                'Fortran language standard to use',
                                ['none'],
                                'none'),
@@ -147,13 +147,13 @@ class GnuFortranCompiler(GnuCompiler, FortranCompiler):
             fortran_stds += ['f2008']
         if version_compare(self.version, '>=8.0.0'):
             fortran_stds += ['f2018']
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         opts[key].choices = ['none'] + fortran_stds
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args: T.List[str] = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std != 'none':
             args.append('-std=' + std)
@@ -205,7 +205,7 @@ class ElbrusFortranCompiler(ElbrusCompiler, FortranCompiler):
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = FortranCompiler.get_options(self)
         fortran_stds = ['f95', 'f2003', 'f2008', 'gnu', 'legacy', 'f2008ts']
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         opts[key].choices = ['none'] + fortran_stds
         return opts
 
@@ -284,13 +284,13 @@ class IntelFortranCompiler(IntelGnuLikeCompiler, FortranCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = FortranCompiler.get_options(self)
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         opts[key].choices = ['none', 'legacy', 'f95', 'f2003', 'f2008', 'f2018']
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args: T.List[str] = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         stds = {'legacy': 'none', 'f95': 'f95', 'f2003': 'f03', 'f2008': 'f08', 'f2018': 'f18'}
         if std != 'none':
@@ -339,13 +339,13 @@ class IntelClFortranCompiler(IntelVisualStudioLikeCompiler, FortranCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = FortranCompiler.get_options(self)
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         opts[key].choices = ['none', 'legacy', 'f95', 'f2003', 'f2008', 'f2018']
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args: T.List[str] = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         stds = {'legacy': 'none', 'f95': 'f95', 'f2003': 'f03', 'f2008': 'f08', 'f2018': 'f18'}
         if std != 'none':

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -160,7 +160,7 @@ class RustCompiler(Compiler):
 
     def get_options(self) -> MutableKeyedOptionDictType:
         return dict((self.create_option(options.UserComboOption,
-                                        self.form_langopt_key('std'),
+                                        self.form_compileropt_key('std'),
                                         'Rust edition to use',
                                         ['none', '2015', '2018', '2021'],
                                         'none'),))
@@ -173,7 +173,7 @@ class RustCompiler(Compiler):
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args = []
-        key = self.form_langopt_key('std')
+        key = self.form_compileropt_key('std')
         std = options.get_value(key)
         if std != 'none':
             args.append('--edition=' + std)


### PR DESCRIPTION
The public facing name of language options is compiler option, so let's standardise on that.