### PR TITLE
docs: mention cython_args in cython reference docs

### DIFF
--- a/docs/markdown/Cython.md
+++ b/docs/markdown/Cython.md
@@ -32,6 +32,18 @@ py.extension_module(
 )
 ```
 
+You can pass arguments accepted by the `cython` CLI script with the
+`cython_args` argument:
+
+```meson
+py.extension_module(
+    'foo-bounds'
+    'foo.pyx',
+    dependencies : dep_py,
+    cython_args : ['-Xboundscheck=False'],
+)
+```
+
 ## C++ intermediate support
 
 *(New in 0.60.0)*

--- a/docs/markdown/Python-module.md
+++ b/docs/markdown/Python-module.md
@@ -121,6 +121,8 @@ Additionally, the following diverge from [[shared_module]]'s default behavior:
 - `gnu_symbol_visibility`: if unset, it will default to `'hidden'` on versions
   of Python that support this (the python headers define `PyMODINIT_FUNC` has
   default visibility).
+  
+Note that Cython support uses `extension_module`, see [the reference for Cython](Cython.md).
 
 *since 0.63.0* `extension_module` automatically adds a dependency to the library
 if one is not explicitly provided. To support older versions, the user may need to


### PR DESCRIPTION
Currently `cython_args` only appears [in this table](https://mesonbuild.com/Reference-tables.html#language-arguments-parameter-names). This makes it a little more discoverable along with the other docs. It also adds a cross-reference from the `py.extension_module` docs to the cython reference.