### PR TITLE
test/rust: Replace gcc -m argument with a -f argument

### DIFF
--- a/test cases/rust/12 bindgen/meson.build
+++ b/test cases/rust/12 bindgen/meson.build
@@ -15,7 +15,7 @@ endif
 cc_id = meson.get_compiler('c').get_id()
 compiler_specific_args = []
 if cc_id == 'gcc'
-  compiler_specific_args = ['-mtls-dialect=gnu2']
+  compiler_specific_args = ['-fipa-pta']
 elif cc_id == 'msvc'
   compiler_specific_args = ['/fp:fast']
 endif


### PR DESCRIPTION
-m arguments aren't portable across architectures. -fipa-pta will hopefully be portable for gcc, but also not implemented by clang.

Fixes: #13417