### PR TITLE
cmake: Only propagate PUBLIC linker flags in dependencies

### DIFF
--- a/docs/markdown/snippets/cmake_only_public_link_flags_in_dep.md
+++ b/docs/markdown/snippets/cmake_only_public_link_flags_in_dep.md
@@ -1,0 +1,8 @@
+## Dependencies from CMake subprojects now use only PUBLIC link flags
+
+Any [[@dep]] obtained from a CMake subproject (or `.wrap` with `method = cmake`)
+now only includes link flags marked in CMake as `PUBLIC` or `INTERFACE`.
+Flags marked as `PRIVATE` are now only applied when building the subproject
+library and not when using it as a dependency. This better matches how CMake
+handles link flags and fixes link errors when using some CMake projects as
+subprojects.

--- a/mesonbuild/cmake/tracetargets.py
+++ b/mesonbuild/cmake/tracetargets.py
@@ -42,6 +42,7 @@ class ResolvedTarget:
     def __init__(self) -> None:
         self.include_directories: T.List[str] = []
         self.link_flags:          T.List[str] = []
+        self.public_link_flags:   T.List[str] = []
         self.public_compile_opts: T.List[str] = []
         self.libraries:           T.List[str] = []
 
@@ -111,7 +112,8 @@ def resolve_cmake_trace_targets(target_name: str,
             res.include_directories += [x for x in tgt.properties['INTERFACE_INCLUDE_DIRECTORIES'] if x]
 
         if 'INTERFACE_LINK_OPTIONS' in tgt.properties:
-            res.link_flags += [x for x in tgt.properties['INTERFACE_LINK_OPTIONS'] if x]
+            res.public_link_flags += [x for x in tgt.properties['INTERFACE_LINK_OPTIONS'] if x]
+            res.link_flags += res.public_link_flags
 
         if 'INTERFACE_COMPILE_DEFINITIONS' in tgt.properties:
             res.public_compile_opts += ['-D' + re.sub('^-D', '', x) for x in tgt.properties['INTERFACE_COMPILE_DEFINITIONS'] if x]

--- a/test cases/cmake/2 advanced/main3.cpp
+++ b/test cases/cmake/2 advanced/main3.cpp
@@ -1,0 +1,6 @@
+extern void slib();
+
+int main() {
+  slib();
+  return 0;
+}

--- a/test cases/cmake/2 advanced/meson.build
+++ b/test cases/cmake/2 advanced/meson.build
@@ -15,6 +15,8 @@ sub_sta = sub_pro.dependency('cmModLibStatic')
 # Build some files
 exe1 = executable('main1', ['main.cpp'], dependencies: [sub_dep])
 exe2 = executable('main2', ['main.cpp'], dependencies: [sub_sta])
+slib = shared_library('slib', ['slib.cpp'], dependencies: [sub_dep])
+exe3 = executable('main3', ['main3.cpp'], link_with: slib)
 test('test1', exe1)
 test('test2', exe2)
 

--- a/test cases/cmake/2 advanced/slib.cpp
+++ b/test cases/cmake/2 advanced/slib.cpp
@@ -1,0 +1,14 @@
+#include <iostream>
+#include <cmMod.hpp>
+#include "config.h"
+
+#if CONFIG_OPT != 42
+#error "Invalid value of CONFIG_OPT"
+#endif
+
+using namespace std;
+
+void slib(void) {
+  cmModClass obj("Hello from lib");
+  cout << obj.getStr() << endl;
+}

--- a/test cases/cmake/2 advanced/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/2 advanced/subprojects/cmMod/CMakeLists.txt
@@ -17,6 +17,13 @@ generate_export_header(cmModLib)
 
 set_target_properties(cmModLib PROPERTIES VERSION 1.0.1)
 
+include(CheckLinkerFlag)
+check_linker_flag(CXX "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/vers.map" HAS_VER_SCRIPT)
+if(HAS_VER_SCRIPT)
+  target_link_options(cmModLib PRIVATE
+    "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/vers.map")
+endif()
+
 add_executable(testEXE main.cpp "${CMAKE_CURRENT_BINARY_DIR}/config.h")
 
 target_link_libraries(cmModLib       ZLIB::ZLIB)

--- a/test cases/cmake/2 advanced/subprojects/cmMod/vers.map
+++ b/test cases/cmake/2 advanced/subprojects/cmMod/vers.map
@@ -1,0 +1,7 @@
+{
+  global:
+    extern "C++" {
+      cmModClass::*;
+    };
+  local: *;
+};


### PR DESCRIPTION
CMake has two target properties for linker flags: [`LINK_OPTIONS`](https://cmake.org/cmake/help/latest/prop_tgt/LINK_OPTIONS.html) for those applied to the target itself (`PRIVATE`) and [`INTERFACE_LINK_OPTIONS`](https://cmake.org/cmake/help/latest/prop_tgt/INTERFACE_LINK_OPTIONS.html) for those propagated when the target is linked into other targets (`PUBLIC`/`INTERFACE`). In a CMake subproject, Meson currently concatenates both properties into one and applies the same flags to the both the `*_library()` and `declare_dependency()` generated calls. This causes downstream build failures whenever one of the `PRIVATE` link flags is extremely specific to the target library, e.g. `-Wl,--version-script`.

This PR adds a separate data field for `INTERFACE_LINK_OPTIONS` pulled from the CMake trace, and for all targets (except `static_library`) uses only these `PUBLIC`/`INTERFACE` flags for generated `declare_dependency()` calls.\
The CMake `advanced` test case is expanded to cover this example.

This fixes build errors when trying to use `method = cmake` wraps for some projects, e.g. [oneTBB](https://github.com/oneapi-src/oneTBB).