### PR TITLE
tests: try to fix ubuntu bionic tests

### DIFF
--- a/.github/workflows/os_comp.yml
+++ b/.github/workflows/os_comp.yml
@@ -26,6 +26,12 @@ on:
       - ".github/workflows/os_comp.yml"
       - "run*tests.py"
 
+# make GHA actions use node16 which still works with bionic
+# See https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
+# Unclear how long this will work though
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
by forcing an older nodejs

the node v20 build no longer works in bionic. While actions/checkout@v3 uses node v16 GHA forced it to use v20 some time ago after a deprecation cycle. This env var makes it use v16 again, despite that being EOL.