### PR TITLE
_pathlib: fix missing PosixPath/WindowsPath

### DIFF
--- a/mesonbuild/_pathlib.py
+++ b/mesonbuild/_pathlib.py
@@ -24,16 +24,6 @@ import pathlib
 import os
 import platform
 
-__all__ = [
-    'PurePath',
-    'PurePosixPath',
-    'PureWindowsPath',
-    'Path',
-]
-
-PurePath = pathlib.PurePath
-PurePosixPath = pathlib.PurePosixPath
-PureWindowsPath = pathlib.PureWindowsPath
 
 # Only patch on platforms where the bug occurs
 if platform.system().lower() in {'windows'}:
@@ -54,10 +44,11 @@ if platform.system().lower() in {'windows'}:
                 return Path(os.path.normpath(self))
 else:
     Path = pathlib.Path
-    PosixPath = pathlib.PosixPath
-    WindowsPath = pathlib.WindowsPath
 
-    __all__ += [
-        'PosixPath',
-        'WindowsPath',
-    ]
+def __dir__():
+    return dir(pathlib)
+
+def __getattr__(name):
+    if name == 'Path':
+        return Path
+    return getattr(pathlib, name)


### PR DESCRIPTION
In case the pytest hypothesis plugin is installed it somehow calls into trio which tries to import various pathlib types. This fails since the meson shim does not expose everything the real pathlib does:

```python
  File "C:/msys64/ucrt64/lib/python3.11/site-packages/trio/__init__.py", line 76, in <module>
    from ._path import Path as Path, PosixPath as PosixPath, WindowsPath as WindowsPath
  File "C:/msys64/ucrt64/lib/python3.11/site-packages/trio/_path.py", line 248, in <module>
    class PosixPath(Path, pathlib.PurePosixPath):
  File "C:/msys64/ucrt64/lib/python3.11/site-packages/trio/_path.py", line 253, in PosixPath
    _wrapped_cls: ClassVar[type[pathlib.Path]] = pathlib.PosixPath
                                                 ^^^^^^^^^^^^^^^^^
AttributeError: module 'mesonbuild._pathlib' has no attribute 'PosixPath'. Did you mean: 'PurePosixPath'?
```

To avoid needing to keep up with what pathlib exposes just implement \_\_getattr\_\_/\_\_dir\_\_ to forward everything except the replaced class to the original pathlib.