### PR TITLE
compilers: handle -Wno-attributes= for GCC

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -1268,8 +1268,10 @@ class CLikeCompiler(Compiler):
         for arg in args:
             # some compilers, e.g. GCC, don't warn for unsupported warning-disable
             # flags, so when we are testing a flag like "-Wno-forgotten-towel", also
-            # check the equivalent enable flag too "-Wforgotten-towel"
-            if arg.startswith('-Wno-'):
+            # check the equivalent enable flag too "-Wforgotten-towel".
+            # Make an exception for -Wno-attributes=x as -Wattributes=x is invalid
+            # for GCC at least.
+            if arg.startswith('-Wno-') and not arg.startswith('-Wno-attributes='):
                 new_args.append('-W' + arg[5:])
             if arg.startswith('-Wl,'):
                 mlog.warning(f'{arg} looks like a linker argument, '

--- a/test cases/common/104 has arg/meson.build
+++ b/test cases/common/104 has arg/meson.build
@@ -52,6 +52,12 @@ if cc.get_id() == 'gcc'
   assert(not cc.has_multi_arguments(['-Wno-pragmas', '-Wno-lol-meson-test-flags']), 'should error out even if some -Wno args are valid')
 endif
 
+if cpp.get_id() == 'gcc' and cpp.version().version_compare('>=12.1.0')
+  # Handle special -Wno-attributes=foo where -Wattributes=foo is invalid
+  # i.e. our usual -Wno-foo -Wfoo hack doesn't work for -Wattributes=foo.
+  assert(cpp.has_argument('-Wno-attributes=meson::i_do_not_exist'))
+endif
+
 if cc.get_id() == 'clang' and cc.version().version_compare('<=4.0.0')
   # 4.0.0 does not support -fpeel-loops. Newer versions may.
   # Please adjust above version number as new versions of clang are released.


### PR DESCRIPTION
For other reasons, Meson transforms "-Wno-x" into "-Wx -Wno-x" for GCC, but this breaks with "-Wno-attributes=x" with:
```
cc1plus: error: arguments ignored for '-Wattributes='; use '-Wno-attributes=' instead
```

Suppress that workaround for -Wno-attributes=.

Closes: https://github.com/mesonbuild/meson/issues/13022