### PR TITLE
mtest: remove superfluous '\r' from read_decode()

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1194,7 +1194,7 @@ async def read_decode(reader: asyncio.StreamReader,
             except asyncio.LimitOverrunError as e:
                 line_bytes = await reader.readexactly(e.consumed)
             if line_bytes:
-                line = decode(line_bytes)
+                line = decode(line_bytes).replace('\r\n', '\n')
                 stdo_lines.append(line)
                 if console_mode is ConsoleUser.STDOUT:
                     print(line, end='', flush=True)


### PR DESCRIPTION
On **Windows**, the output read from the stream has '\r\n', which in .txt, .json and console logger (when captured to a file) translates to '\n\n'. This results in every log line being separated by an empty line.

Playground project to see the issue: https://github.com/the-risk-taker/meson-playground

Before, the testlog looked like:

```text
==================================== 1/1 =====================================
test:         example_cpp
start time:   18:41:18
duration:     0.01s
result:       exit status 0
command:      ...
----------------------------------- stdout -----------------------------------
Log line: #0

Log line: #1

Log line: #2

Log line: #3

Log line: #4

Log line: #5

Log line: #6

Log line: #7

Log line: #8

Log line: #9
```

With this patch it looks like:

```text
==================================== 1/1 =====================================
test:         example_cpp
start time:   18:42:52
duration:     0.00s
result:       exit status 0
command:      ...
----------------------------------- stdout -----------------------------------
Log line: #0
Log line: #1
Log line: #2
Log line: #3
Log line: #4
Log line: #5
Log line: #6
Log line: #7
Log line: #8
Log line: #9
```