### PR TITLE
Add macros for declarative buildsystems of rpm >= 4.20

### DIFF
--- a/data/macros.meson
+++ b/data/macros.meson
@@ -45,3 +45,11 @@
         --num-processes %{_smp_build_ncpus} \
         --print-errorlogs \
         %{nil}}
+
+# Declarative buildsystem, requires RPM 4.20+ to work
+# https://rpm-software-management.github.io/rpm/manual/buildsystem.html
+%buildsystem_meson_conf() %meson %*
+%buildsystem_meson_generate_buildrequires() %{nil}
+%buildsystem_meson_build() %meson_build %*
+%buildsystem_meson_install() %meson_install %*
+%buildsystem_meson_check() %meson_test %*


### PR DESCRIPTION
In rpm >= 4.20[1], a new feature Declarative Buildsystem[2] will be introduced to simplify spec files. I think we should add support on it.

[1]: https://github.com/rpm-software-management/rpm/issues/1087
[2]: https://rpm-software-management.github.io/rpm/manual/buildsystem.html
