### PR TITLE
rust: suggest correct dependency when found in Cargo.lock

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -427,6 +427,18 @@ class Resolver:
                 return wrap_name
         return None
 
+    def get_cargo_wraps(self, cratename: str) -> T.List[str]:
+        found = []
+        for wrap in self.wraps.values():
+            if wrap.get('method') != 'cargo':
+                continue
+            if not wrap.name.endswith('-rs'):
+                continue
+            wrap_cratename = wrap.name.rsplit('-', 2)[0]
+            if wrap_cratename == cratename:
+                found.append(wrap.name)
+        return found
+
     def resolve(self, packagename: str, force_method: T.Optional[Method] = None) -> T.Tuple[str, Method]:
         wrap = self.wraps.get(packagename)
         if wrap is None:

--- a/test cases/failing/132 rust cargo lock suggest dependency/Cargo.lock
+++ b/test cases/failing/132 rust cargo lock suggest dependency/Cargo.lock
@@ -1,0 +1,25 @@
+version = 3
+
+[[package]]
+name = "bar-crate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2f34e570dcd5f9fe32e6863ee16ee73a356d3b77bce0d8c78501b8bc81a860"
+
+[[package]]
+name = "bar-crate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2f34e570dcd5f9fe32e6863ee16ee73a356d3b77bce0d8c78501b8bc81a860"
+
+[[package]]
+name = "bar-crate"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2f34e570dcd5f9fe32e6863ee16ee73a356d3b77bce0d8c78501b8bc81a860"
+
+[[package]]
+name = "bar-crate"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2f34e570dcd5f9fe32e6863ee16ee73a356d3b77bce0d8c78501b8bc81a860"

--- a/test cases/failing/132 rust cargo lock suggest dependency/meson.build
+++ b/test cases/failing/132 rust cargo lock suggest dependency/meson.build
@@ -1,0 +1,3 @@
+project('cargo lock')
+
+dependency('bar-crate-1.0-rs')

--- a/test cases/failing/132 rust cargo lock suggest dependency/test.json
+++ b/test cases/failing/132 rust cargo lock suggest dependency/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/132 rust cargo lock suggest dependency/meson.build:3:0: ERROR: Rust dependency \"bar-crate-1.0-rs\" not found, but following versions were found using Cargo.lock import: \"bar-crate-1-rs\", \"bar-crate-2-rs\", \"bar-crate-0-rs\", \"bar-crate-0.8-rs\""
+    }
+  ]
+}


### PR DESCRIPTION
As we refer to crates using API version instead of plain version, it can be confusing to user which is left with a simple "Dependency X not found".

Thus, when we detect that a rust dependency is missing, and is not available using a wrap file, if we find something compatible using Cargo.lock import, we just list the correct dependencies names.