### PR TITLE
 fix: modules/gnome: gnome.compile_resources() must have `install_dir` if installing

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -479,8 +479,11 @@ class GnomeModule(ExtensionModule):
             else:
                 raise MesonException('Compiling GResources into code is only supported in C and C++ projects')
 
-        if kwargs['install'] and not gresource:
-            raise MesonException('The install kwarg only applies to gresource bundles, see install_header')
+        if kwargs['install']:
+            if not gresource:
+                raise MesonException('The install kwarg only applies to gresource bundles, see install_header')
+            elif not kwargs['install_dir']:
+                raise MesonException('gnome.compile_resources: "install_dir" keyword argument must be set when "install" is true.')
 
         install_header = kwargs['install_header']
         if install_header and gresource:


### PR DESCRIPTION
CustomTargets must have `install_dir` if installing. Since they do not implement a default install dir like BuildTargets do.
gnome.compile_resources() would result in an unhandled python exception when missing install_dir argument together with providing following arguments:

  gresource_bundle: true
  install: true

closes: https://github.com/mesonbuild/meson/issues/13447