### PR TITLE
Update windows.py

### DIFF
--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -87,7 +87,7 @@ class WindowsModule(ExtensionModule):
 
         for (arg, match, rc_type) in [
                 ('/?', '^.*Microsoft.*Resource Compiler.*$', ResourceCompilerType.rc),
-                ('/?', 'LLVM Resource Converter.*$', ResourceCompilerType.rc),
+                ('/?', '^.*LLVM Resource Converter.*$', ResourceCompilerType.rc),
                 ('--version', '^.*GNU windres.*$', ResourceCompilerType.windres),
                 ('--version', '^.*Wine Resource Compiler.*$', ResourceCompilerType.wrc),
         ]:


### PR DESCRIPTION
Fix llvm-rc Matching Error

Clang Version：16.0.5

The command line output of `llvm-rc /?` is:
```
>llvm-rc /?
OVERVIEW: Resource Converter

USAGE: rc [options] file...

OPTIONS:
  /?             Display this help and exit.
  /C <value>     Set the codepage used for input strings.
  /dry-run       Don't compile the input; only try to parse it.
  /D <value>     Define a symbol for the C preprocessor.
  /FO <value>    Change the output file location.
  /H             Display this help and exit.
  /I <value>     Add an include path.
  /LN <value>    Set the default language name.
  /L <value>     Set the default language identifier.
  /no-preprocess Don't try to preprocess the input file.
  /N             Null-terminate all strings in the string table.
  /U <value>     Undefine a symbol for the C preprocessor.
  /V             Be verbose.
  /X             Ignore 'include' variable.
  /Y             Suppress warnings on duplicate resource IDs.
```
Additionally, this issue also leads to: [4105](https://github.com/mesonbuild/meson/issues/4105)

