### PR TITLE
cmake: extend library pattern to work on GNU/Hurd as well

### DIFF
--- a/mesonbuild/dependencies/data/CMakePathInfo.txt
+++ b/mesonbuild/dependencies/data/CMakePathInfo.txt
@@ -13,7 +13,7 @@ list(APPEND TMP_PATHS_LIST ${CMAKE_SYSTEM_APPBUNDLE_PATH})
 
 set(LIB_ARCH_LIST)
 if(CMAKE_LIBRARY_ARCHITECTURE_REGEX)
-  file(GLOB implicit_dirs RELATIVE /lib /lib/*-linux-gnu* )
+  file(GLOB implicit_dirs RELATIVE /lib /lib/*-gnu* )
   foreach(dir ${implicit_dirs})
     if("${dir}" MATCHES "${CMAKE_LIBRARY_ARCHITECTURE_REGEX}")
       list(APPEND LIB_ARCH_LIST "${dir}")


### PR DESCRIPTION
The existing `*-linux-gnu*` works on the Debian multiarch model for Linux architectures; tweak it to be `*-gnu*` so it works also for Hurd architectures.

This makes the cmake-based search of dependencies work on Debian GNU/Hurd.