### PR TITLE
compilers: fix partial refactor of coredata options

### DIFF
--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -622,8 +622,8 @@ class ElbrusCPPCompiler(ElbrusCompiler, CPPCompiler):
         args: T.List[str] = []
         key = self.form_compileropt_key('std')
         std = options.get_value(key)
-        if std.value != 'none':
-            args.append(self._find_best_cpp_std(std.value))
+        if std != 'none':
+            args.append(self._find_best_cpp_std(std))
 
         key = self.form_compileropt_key('eh')
         non_msvc_eh_options(options.get_value(key), args)
@@ -699,7 +699,7 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
                 'c++03': 'c++98',
                 'gnu++03': 'gnu++98'
             }
-            args.append('-std=' + remap_cpp03.get(std.value, std))
+            args.append('-std=' + remap_cpp03.get(std, std))
         if options.get_value(key.evolve('eh')) == 'none':
             args.append('-fno-exceptions')
         if not options.get_value(key.evolve('rtti')):


### PR DESCRIPTION
Fallout from the OptionStore refactor, and specifically commit 9a6fcd4d9a0c7bb248c5d0587632b741a3301e03. The `std` object was migrated from having an option itself, to having the value fetched and saved directly. In most cases, this also meant avoiding `.value`, but in a couple cases this refactor went overlooked, and crashed at runtime.

Only affects Elbrus and Intel C++ compilers, seemingly.

Fixes #13401