### PR TITLE
Remove the exe_exists function

### DIFF
--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -680,9 +680,6 @@ def is_qnx() -> bool:
 def is_aix() -> bool:
     return platform.system().lower() == 'aix'
 
-def exe_exists(exe: str) -> bool:
-    return shutil.which(exe) is not None
-
 @lru_cache(maxsize=None)
 def darwin_get_object_archs(objpath: str) -> 'ImmutableListProtocol[str]':
     '''

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -814,10 +814,6 @@ class InternalTests(unittest.TestCase):
         self.assertTrue(vctools_ver.startswith(toolset_ver),
                         msg=f'{vctools_ver!r} does not start with {toolset_ver!r}')
 
-    def test_exe_exists(self):
-        self.assertTrue(utils.universal.exe_exists('python3'))
-        self.assertFalse(utils.universal.exe_exists('command_that_does_not_exist'))
-
     def test_split_args(self):
         split_args = mesonbuild.mesonlib.split_args
         join_args = mesonbuild.mesonlib.join_args


### PR DESCRIPTION
This function is no longer used since shutil.which() is used instead.