### PR TITLE
Update Tutorial.md

### DIFF
--- a/docs/markdown/Tutorial.md
+++ b/docs/markdown/Tutorial.md
@@ -143,7 +143,11 @@ int main(int argc, char **argv)
   GtkApplication *app;
   int status;
 
+#if GLIB_CHECK_VERSION(2, 74, 0)
   app = gtk_application_new(NULL, G_APPLICATION_DEFAULT_FLAGS);
+#else
+  app = gtk_application_new(NULL, G_APPLICATION_FLAGS_NONE);
+#endif
   g_signal_connect(app, "activate", G_CALLBACK(activate), NULL);
   status = g_application_run(G_APPLICATION(app), argc, argv);
   g_object_unref(app);


### PR DESCRIPTION
Add a GLib version check to make the tutorial compatible with GLib versions older than 2.74.