### PR TITLE
mdist: don't fail on readonly source trees

### DIFF
--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -141,7 +141,9 @@ class GitDist(Dist):
 
     def have_dirty_index(self) -> bool:
         '''Check whether there are uncommitted changes in git'''
-        subprocess.check_call(['git', '-C', self.src_root, 'update-index', '-q', '--refresh'])
+        # Optimistically call update-index, and disregard its return value. It could be read-only,
+        # and only the output of diff-index matters.
+        subprocess.call(['git', '-C', self.src_root, 'update-index', '-q', '--refresh'])
         ret = subprocess.call(['git', '-C', self.src_root, 'diff-index', '--quiet', 'HEAD'])
         return ret == 1
 


### PR DESCRIPTION
In commit c9aa4aff66ebbbcd3eed3da8fbc3af0e0a8b90a2 we added a refresh call to git to catch cases where checking for uncommitted changes would misfire. Unfortunately, that refresh performs a write operation, which in turn misfires on readonly media. We don't actually care about the return value of the refresh, since its purpose is solely to make the next command more accurate -- so ignore it.

Fixes: c9aa4aff66ebbbcd3eed3da8fbc3af0e0a8b90a2
Fixes: #13461