### PR TITLE
Use werror for gnome.generate_gir(fatal_warnings:)

### DIFF
--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -122,6 +122,9 @@ There are several keyword arguments. Many of these map directly to the
 * `symbol_prefix`: the symbol prefix for the gir object, e.g. `gtk`,
   (*Since 0.43.0*) an ordered list of multiple prefixes is allowed
 * `fatal_warnings`: *Since 0.55.0* turn scanner warnings into fatal errors.
+  If not set, *(Since 1.13.0)* Meson falls back to the value of the `werror`
+  option to determine whether to turn this on automatically. Explicitly
+  passing `true` or `false` always takes precedence over `werror`.
 
 Returns an array of two elements which are: `[gir_target,
 typelib_target]`

--- a/docs/markdown/snippets/use_werror_for_generate_gir_fatal_warnings.md
+++ b/docs/markdown/snippets/use_werror_for_generate_gir_fatal_warnings.md
@@ -1,0 +1,6 @@
+## Use `werror` for `gnome.generate_gir(fatal_warnings:)`
+
+If `fatal_warnings` is not passed to `gnome.generate_gir()`, the value of
+the `werror` option is now read to determine whether to turn it on.
+Explicitly passing `fatal_warnings: true` or `fatal_warnings: false`
+still takes precedence over `werror`.

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -90,7 +90,7 @@ if T.TYPE_CHECKING:
         env: EnvironmentVariables
         export_packages: T.List[str]
         extra_args: T.List[str]
-        fatal_warnings: bool
+        fatal_warnings: T.Optional[bool]
         header: T.List[str]
         identifier_prefix: T.List[str]
         include_directories: T.List[T.Union[build.IncludeDirs, str]]
@@ -1145,7 +1145,7 @@ class GnomeModule(ExtensionModule):
         KwargInfo('dependencies', ContainerTypeInfo(list, Dependency), default=[], listify=True),
         KwargInfo('doc_format', (str, NoneType), since='1.8.0'),
         KwargInfo('export_packages', ContainerTypeInfo(list, str), default=[], listify=True),
-        KwargInfo('fatal_warnings', bool, default=False, since='0.55.0'),
+        KwargInfo('fatal_warnings', (bool, NoneType), default=None, since='0.55.0'),
         KwargInfo('header', ContainerTypeInfo(list, str), default=[], listify=True),
         KwargInfo('identifier_prefix', ContainerTypeInfo(list, str), default=[], listify=True),
         KwargInfo('include_directories', ContainerTypeInfo(list, (str, build.IncludeDirs)), default=[], listify=True),
@@ -1262,7 +1262,11 @@ class GnomeModule(ExtensionModule):
         if '--warn-error' in scan_command:
             FeatureDeprecated.single_use('gnome.generate_gir argument --warn-error', '0.55.0',
                                          state.subproject, 'Use "fatal_warnings" keyword argument', state.current_node)
-        if kwargs['fatal_warnings']:
+        fatal_warnings = kwargs['fatal_warnings']
+        if fatal_warnings is None:
+            fatal_warnings = state.environment.coredata.optstore.get_value_for(
+                OptionKey('werror', machine=MachineChoice.BUILD, subproject=state.subproject))
+        if fatal_warnings:
             scan_command.append('--warn-error')
 
         generated_files: list[build.GeneratedTypes] = []


### PR DESCRIPTION
In addition to the kwarg, Meson will now read werror to determine whether to turn on this warning.