### PR TITLE
Minor optimizations in Python code

### DIFF
--- a/ci/ciimage/build.py
+++ b/ci/ciimage/build.py
@@ -21,7 +21,7 @@ class ImageDef:
         data = json.loads(path.read_text(encoding='utf-8'))
 
         assert isinstance(data, dict)
-        assert all([x in data for x in ['base_image', 'env']])
+        assert all(x in data for x in ['base_image', 'env'])
         assert isinstance(data['base_image'], str)
         assert isinstance(data['env'],  dict)
 

--- a/docs/jsonvalidator.py
+++ b/docs/jsonvalidator.py
@@ -17,7 +17,7 @@ root: dict
 
 def assert_has_typed_keys(path: str, data: dict, keys: T.Dict[str, T.Any]) -> dict:
     assert set(data.keys()).issuperset(keys.keys()), f'{path}: DIFF: {set(data.keys()).difference(keys.keys())}'
-    res = dict()
+    res = {}
     for key, val in keys.items():
         cur = data.pop(key)
         assert isinstance(cur, val), f'{path}: type({key}: {cur}) != {val}'

--- a/docs/refman/generatormd.py
+++ b/docs/refman/generatormd.py
@@ -76,7 +76,7 @@ class GeneratorMD(GeneratorBase):
     def _gen_filename(self, file_id: str, *, extension: str = 'md') -> str:
         parts = file_id.split('.')
         assert parts[0] == 'root'
-        assert all([x for x in parts])
+        assert all(x for x in parts)
         parts[0] = _ROOT_BASENAME
         parts = [re.sub(r'[0-9]+_', '', x) for x in parts]
         return f'{"_".join(parts)}.{extension}'
@@ -215,7 +215,7 @@ class GeneratorMD(GeneratorBase):
             for kwarg in self.sorted_and_filtered(list(func.kwargs.values())):
                 type_str, type_space, name_str, name_space = prepare(kwarg)
                 required = ' <i>[required]</i> ' if kwarg.required else '            '
-                required = required if any([x.required for x in func.kwargs.values()]) else ''
+                required = required if any(x.required for x in func.kwargs.values()) else ''
                 signature += f'  {name_str}{name_space} : {type_str}{type_space} {required} # {self.brief(kwarg)}\n'
 
             return signature + ')'

--- a/mesonbuild/arglist.py
+++ b/mesonbuild/arglist.py
@@ -257,7 +257,7 @@ class CompilerArgs(T.MutableSequence[str]):
         normal_flags = []
         lflags = []
         for i in iterable:
-            if i not in self.always_dedup_args and (i.startswith('-l') or i.startswith('-L')):
+            if i not in self.always_dedup_args and i.startswith(('-l', '-L')):
                 lflags.append(i)
             else:
                 normal_flags.append(i)

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -235,7 +235,7 @@ class AstInterpreter(InterpreterBase):
         arguments, kwargs = self.reduce_arguments(node.args, key_resolver=resolve_key)
         assert not arguments
         self.argument_depth += 1
-        for key, value in kwargs.items():
+        for key in kwargs:
             if isinstance(key, BaseNode):
                 self.evaluate_statement(key)
         self.argument_depth -= 1

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1274,7 +1274,7 @@ class Backend:
                                 ld_lib_path_libs.add(l)
 
                 env_build_dir = self.environment.get_build_dir()
-                ld_lib_path: T.Set[str] = set(os.path.join(env_build_dir, l.get_subdir()) for l in ld_lib_path_libs)
+                ld_lib_path: T.Set[str] = {os.path.join(env_build_dir, l.get_subdir()) for l in ld_lib_path_libs}
 
                 if ld_lib_path:
                     t_env.prepend('LD_LIBRARY_PATH', list(ld_lib_path), ':')

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1470,7 +1470,7 @@ class NinjaBackend(backends.Backend):
             rel_sourcefile = os.path.join(self.build_to_src, target.subdir, r)
             if r.endswith('.resources'):
                 a = '-resource:' + rel_sourcefile
-            elif r.endswith('.txt') or r.endswith('.resx'):
+            elif r.endswith(('.txt', '.resx')):
                 ofilebase = os.path.splitext(os.path.basename(r))[0] + '.resources'
                 ofilename = os.path.join(self.get_target_private_dir(target), ofilebase)
                 elem = NinjaBuildElement(self.all_outputs, ofilename, "CUSTOM_COMMAND", rel_sourcefile)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -947,7 +947,7 @@ class Vs2010Backend(backends.Backend):
                 other.append(arg)
             # It's ok if we miss libraries with non-standard extensions here.
             # They will go into the general link arguments.
-            elif arg.endswith('.lib') or arg.endswith('.a'):
+            elif arg.endswith(('.lib', '.a')):
                 # De-dup
                 if arg not in libs:
                     libs.append(arg)

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -1194,7 +1194,7 @@ class XCodeBackend(backends.Backend):
 
     def generate_project_tree(self) -> FileTreeEntry:
         tree_info = FileTreeEntry()
-        for tname, t in self.build_targets.items():
+        for t in self.build_targets.values():
             self.add_target_to_tree(tree_info, t)
         return tree_info
 
@@ -1658,7 +1658,7 @@ class XCodeBackend(backends.Backend):
                     outputs = self.generator_outputs[target_name, generator_id]
                     generator_id += 1
                     for o_abs in outputs:
-                        if o_abs.endswith('.o') or o_abs.endswith('.obj'):
+                        if o_abs.endswith(('.o', '.obj')):
                             ldargs += [r'\"' + o_abs + r'\"']
                 else:
                     if isinstance(o, build.CustomTarget):
@@ -1750,7 +1750,7 @@ class XCodeBackend(backends.Backend):
                 # file. Since Xcode itself already discourages precompiled headers in favor of modules we don't try much harder here.
                 pchs = target.get_pch('c') + target.get_pch('cpp') + target.get_pch('objc') + target.get_pch('objcpp')
                 # Make sure to use headers (other backends require implementation files like *.c *.cpp, etc; these should not be used here)
-                pchs = [pch for pch in pchs if pch.endswith('.h') or pch.endswith('.hh') or pch.endswith('hpp')]
+                pchs = [pch for pch in pchs if pch.endswith(('.h', '.hh', 'hpp'))]
                 if pchs:
                     if len(pchs) > 1:
                         mlog.warning(f'Unsupported Xcode configuration: More than 1 precompiled header found "{pchs!s}". Target "{target.name}" might not compile correctly.')

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -859,7 +859,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         # TODO: There's isn't really any reason for this to be a context manager
 
         # Calculate the key
-        textra_args: T.Tuple[str, ...] = tuple(extra_args) if extra_args is not None else tuple()
+        textra_args: T.Tuple[str, ...] = tuple(extra_args) if extra_args is not None else ()
         key: coredata.CompilerCheckCacheKey = (tuple(self.exelist), self.version, code, textra_args, mode)
 
         # Check if not cached, and generate, otherwise get from the cache

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -196,7 +196,7 @@ class CudaCompiler(Compiler):
         # a temporary host C++ file that includes gcc-style line directives:
         # https://stackoverflow.com/a/31001220
         self.warn_args = {
-            level: self._to_host_flags(list(f for f in flags if f != '-Wpedantic'))
+            level: self._to_host_flags([f for f in flags if f != '-Wpedantic'])
             for level, flags in host_compiler.warn_args.items()
         }
         self.host_werror_args = ['-Xcompiler=' + x for x in self.host_compiler.get_werror_args()]

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -301,7 +301,7 @@ class DmdLikeCompilerMixin(CompilerMixinBase):
                 if suffix in link_flags_with_arg:
                     link_expect_arg = True
 
-                if suffix.startswith('-') or suffix.startswith('@'):
+                if suffix.startswith(('-', '@')):
                     # this is not search path
                     dcargs.append(arg)
                     continue
@@ -312,7 +312,7 @@ class DmdLikeCompilerMixin(CompilerMixinBase):
                     continue
 
                 # Make sure static library files are passed properly to the linker.
-                if arg.endswith('.a') or arg.endswith('.lib'):
+                if arg.endswith(('.a', '.lib')):
                     if len(suffix) > 0 and not suffix.startswith('-'):
                         dcargs.append('-L=' + suffix)
                         continue

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -253,9 +253,7 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
                 continue
             # cl.exe does not allow specifying both, so remove /utf-8 that we
             # added automatically in the case the user overrides it manually.
-            elif (i.startswith('/source-charset:')
-                    or i.startswith('/execution-charset:')
-                    or i == '/validate-charset-'):
+            elif i.startswith(('/source-charset:', '/execution-charset:')) or i == '/validate-charset-':
                 try:
                     result.remove('/utf-8')
                 except ValueError:

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -359,7 +359,7 @@ class CoreData:
         prefix = os.path.expanduser(prefix)
         if not os.path.isabs(prefix):
             raise MesonException(f'prefix value {prefix!r} must be an absolute path')
-        if prefix.endswith('/') or prefix.endswith('\\'):
+        if prefix.endswith(('/', '\\')):
             # On Windows we need to preserve the trailing slash if the
             # string is of type 'C:\' because 'C:' is not an absolute path.
             if len(prefix) == 3 and prefix[1] == ':':

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -141,7 +141,7 @@ class Dependency(HoldableObject):
         if self.include_type == 'system':
             converted = []
             for i in self.compile_args:
-                if i.startswith('-I') or i.startswith('/I'):
+                if i.startswith(('-I', '/I')):
                     converted += ['-isystem' + i[2:]]
                 else:
                     converted += [i]

--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -235,7 +235,7 @@ class CMakeDependency(ExternalDependency):
         try:
             return tuple((x, str(x).lower()) for x in os.listdir(path))
         except OSError:
-            return tuple()
+            return ()
 
     @staticmethod
     @functools.lru_cache(maxsize=None)
@@ -300,9 +300,9 @@ class CMakeDependency(ExternalDependency):
         # Check PATH
         system_env: T.List[str] = []
         for i in os.environ.get('PATH', '').split(os.pathsep):
-            if i.endswith('/bin') or i.endswith('\\bin'):
+            if i.endswith(('/bin', '\\bin')):
                 i = i[:-4]
-            if i.endswith('/sbin') or i.endswith('\\sbin'):
+            if i.endswith(('/sbin', '\\sbin')):
                 i = i[:-5]
             system_env += [i]
 

--- a/mesonbuild/dependencies/dub.py
+++ b/mesonbuild/dependencies/dub.py
@@ -256,7 +256,7 @@ class DubDependency(ExternalDependency):
 
         for file in bs['sourceFiles']:
             # sourceFiles may contain static libraries
-            if file.endswith('.lib') or file.endswith('.a'):
+            if file.endswith(('.lib', '.a')):
                 self.link_args.append(file)
 
         for flag in bs['lflags']:

--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -325,7 +325,7 @@ class PkgConfigDependency(ExternalDependency):
             return args.copy()
         converted = []
         for arg in args:
-            pargs: T.Tuple[str, ...] = tuple()
+            pargs: T.Tuple[str, ...] = ()
             # Library search path
             if arg.startswith('-L/'):
                 pargs = PurePath(arg[2:]).parts

--- a/mesonbuild/dependencies/qt.py
+++ b/mesonbuild/dependencies/qt.py
@@ -208,7 +208,7 @@ class QtPkgConfigDependency(_QtBase, PkgConfigDependency, metaclass=abc.ABCMeta)
             debug_lib_name = self.qtpkgname + 'Core' + _get_modules_lib_suffix(self.version, self.env.machines[self.for_machine], True)
             is_debug = False
             for arg in self.get_link_args():
-                if arg == f'-l{debug_lib_name}' or arg.endswith(f'{debug_lib_name}.lib') or arg.endswith(f'{debug_lib_name}.a'):
+                if arg == f'-l{debug_lib_name}' or arg.endswith((f'{debug_lib_name}.lib', f'{debug_lib_name}.a')):
                     is_debug = True
                     break
             libdir = self.get_variable(pkgconfig='libdir')

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -98,11 +98,7 @@ class GnuStepDependency(ConfigToolDependency):
         """
         result = []
         for f in args:
-            if f.startswith('-D') \
-                    or f.startswith('-f') \
-                    or f.startswith('-I') \
-                    or f == '-pthread' \
-                    or (f.startswith('-W') and not f == '-Wall'):
+            if f.startswith(('-D', '-f', '-I')) or f == '-pthread' or f.startswith('-W') and not f == '-Wall':
                 result.append(f)
         return result
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -345,7 +345,7 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
     elif trial.startswith('aarch64'):
         # This can be `aarch64_be`
         trial = 'aarch64'
-    elif trial.startswith('arm') or trial.startswith('earm'):
+    elif trial.startswith(('arm', 'earm')):
         trial = 'arm'
     elif trial.startswith(('powerpc64', 'ppc64')):
         trial = 'ppc64'
@@ -409,7 +409,7 @@ def detect_cpu(compilers: CompilersDict) -> str:
         # Same check as above for cpu_family
         if any_compiler_has_define(compilers, '__i386__'):
             trial = 'i686' # All 64 bit cpus have at least this level of x86 support.
-    elif trial.startswith('aarch64') or trial.startswith('arm64'):
+    elif trial.startswith(('aarch64', 'arm64')):
         # Same check as above for cpu_family
         if any_compiler_has_define(compilers, '__arm__'):
             trial = 'arm'

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2963,7 +2963,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             elif arg in {'-fsanitize', '/fsanitize'} or arg.startswith(('-fsanitize=', '/fsanitize=')):
                 mlog.warning(f'Consider using the built-in option for sanitizers instead of using "{arg}".',
                              location=self.current_node)
-            elif arg.startswith('-std=') or arg.startswith('/std:'):
+            elif arg.startswith(('-std=', '/std:')):
                 mlog.warning(f'Consider using the built-in option for language standard version instead of using "{arg}".',
                              location=self.current_node)
 

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -267,7 +267,7 @@ def check_for_stampfile(fname: str) -> str:
     whose names are not known at configure time.
     Check if this is the case and return the real
     file instead.'''
-    if fname.endswith('.so') or fname.endswith('.dll'):
+    if fname.endswith(('.so', '.dll')):
         if os.stat(fname).st_size == 0:
             (base, suffix) = os.path.splitext(fname)
             files = glob(base + '-*' + suffix)
@@ -276,7 +276,7 @@ def check_for_stampfile(fname: str) -> str:
                 sys.exit(1)
             if len(files) == 1:
                 return files[0]
-    elif fname.endswith('.a') or fname.endswith('.lib'):
+    elif fname.endswith(('.a', '.lib')):
         if os.stat(fname).st_size == 0:
             (base, suffix) = os.path.splitext(fname)
             files = glob(base + '-*' + '.rlib')

--- a/mesonbuild/modules/simd.py
+++ b/mesonbuild/modules/simd.py
@@ -71,7 +71,7 @@ class SimdModule(ExtensionModule):
         if 'sources' in kwargs:
             raise mesonlib.MesonException('SIMD module does not support the "sources" keyword')
 
-        local_kwargs = set((*ISETS, 'compiler'))
+        local_kwargs = {*ISETS, 'compiler'}
         static_lib_kwargs = T.cast('kwtypes.StaticLibrary', {k: v for k, v in kwargs.items() if k not in local_kwargs})
 
         prefix = args[0]

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -371,7 +371,7 @@ dot_C_dot_H_warning = """You are using .C or .H files in your project. This is d
          See https://github.com/mesonbuild/meson/pull/8747 for the discussions."""
 class File(HoldableObject):
     def __init__(self, is_built: bool, subdir: str, fname: str):
-        if fname.endswith(".C") or fname.endswith(".H"):
+        if fname.endswith(('.C', '.H')):
             mlog.warning(dot_C_dot_H_warning, once=True)
         self.is_built = is_built
         self.subdir = subdir

--- a/run_format_tests.py
+++ b/run_format_tests.py
@@ -55,7 +55,7 @@ def check_format() -> None:
         '3 editorconfig',
     }
     for (root, _, filenames) in os.walk('.'):
-        if any([x in root for x in skip_dirs]):
+        if any(x in root for x in skip_dirs):
             continue
         for fname in filenames:
             file = Path(fname)

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -911,8 +911,7 @@ def load_test_json(t: TestDef, stdout_mandatory: bool, skip_category: bool = Fal
             exclude = False
             opt_tuple = [(x[0], x[1]) for x in i]
             for j in matrix['exclude']:
-                ex_list = [(k, v) for k, v in j.items()]
-                if all([x in opt_tuple for x in ex_list]):
+                if all(x in opt_tuple for x in j.items()):
                     exclude = True
                     break
 
@@ -924,8 +923,8 @@ def load_test_json(t: TestDef, stdout_mandatory: bool, skip_category: bool = Fal
     for i in opt_list:
         name = ' '.join([f'{x[0]}={x[1]}' for x in i if x[1] is not None])
         opts = [f'-D{x[0]}={x[1]}' for x in i if x[1] is not None]
-        skip = any([x[2] for x in i])
-        skip_expected = any([x[3] for x in i])
+        skip = any(x[2] for x in i)
+        skip_expected = any(x[3] for x in i)
         test = TestDef(t.path, name, opts, skip or t.skip, skip_category)
         test.env.update(env)
         test.installed_files = installed

--- a/test cases/common/186 test depends/test.py
+++ b/test cases/common/186 test depends/test.py
@@ -7,7 +7,7 @@ import sys
 
 def main():
     print('Looking in:', os.getcwd())
-    not_found = list()
+    not_found = []
     for f in sys.argv[1:]:
         if not os.path.exists(f):
             not_found.append(f)

--- a/test cases/common/208 link custom/custom_stlib.py
+++ b/test cases/common/208 link custom/custom_stlib.py
@@ -72,7 +72,7 @@ def generate_lib(outfile, private_dir, compiler_array):
     c_file = private_dir / 'flob.c'
     c_file.write_text(contents)
     for i in compiler_array:
-        if (i.endswith('cl') or i.endswith('cl.exe')) and 'clang-cl' not in i:
+        if i.endswith(('cl', 'cl.exe')) and 'clang-cl' not in i:
             return generate_lib_msvc(outfile, c_file, private_dir, compiler_array)
     return generate_lib_gnulike(outfile, c_file, private_dir, compiler_array)
 

--- a/test cases/common/209 link custom_i single from multiple/generate_conflicting_stlibs.py
+++ b/test cases/common/209 link custom_i single from multiple/generate_conflicting_stlibs.py
@@ -72,7 +72,7 @@ def generate_lib(outfiles, private_dir, compiler_array):
 
         cl_found = False
         for cl_arg in compiler_array:
-            if (cl_arg.endswith('cl') or cl_arg.endswith('cl.exe')) and 'clang-cl' not in cl_arg:
+            if cl_arg.endswith(('cl', 'cl.exe')) and 'clang-cl' not in cl_arg:
                 ret = generate_lib_msvc(outfile, c_file, private_dir, compiler_array)
                 if ret > 0:
                     return ret

--- a/test cases/common/210 link custom_i multiple from multiple/generate_stlibs.py
+++ b/test cases/common/210 link custom_i multiple from multiple/generate_stlibs.py
@@ -74,7 +74,7 @@ def generate_lib(outfiles, private_dir, compiler_array):
 
         cl_found = False
         for cl_arg in compiler_array:
-            if (cl_arg.endswith('cl') or cl_arg.endswith('cl.exe')) and 'clang-cl' not in cl_arg:
+            if cl_arg.endswith(('cl', 'cl.exe')) and 'clang-cl' not in cl_arg:
                 ret = generate_lib_msvc(outfile, c_file, private_dir, compiler_array)
                 if ret > 0:
                     return ret

--- a/test cases/common/95 manygen/subdir/manygen.py
+++ b/test cases/common/95 manygen/subdir/manygen.py
@@ -21,7 +21,7 @@ if not os.path.isdir(outdir):
 if compiler_type == 'msvc':
     libsuffix = '.lib'
     is_vs = True
-    if any(['clang-cl' in c for c in compiler]):
+    if any('clang-cl' in c for c in compiler):
         linker = 'llvm-lib'
     else:
         linker = 'lib'

--- a/tools/regenerate_docs.py
+++ b/tools/regenerate_docs.py
@@ -103,7 +103,7 @@ def get_commands_data(root_dir: Path) -> T.Dict[str, T.Any]:
     commands = get_commands(output)
     commands.remove('help')
 
-    cmd_data = dict()
+    cmd_data = {}
 
     for cmd in commands:
         cmd_output = _get_meson_output(root_dir, [cmd, '--help'])

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -568,9 +568,7 @@ class AllPlatformTests(BasePlatformTests):
     def read_install_logs(self):
         # Find logged files and directories
         with Path(self.builddir, 'meson-logs', 'install-log.txt').open(encoding='utf-8') as f:
-            return list(map(lambda l: Path(l.strip()),
-                              filter(lambda l: not l.startswith('#'),
-                                     f.readlines())))
+            return [Path(l.strip()) for l in f.readlines() if not l.startswith('#')]
 
     def test_install_log_content(self):
         '''
@@ -3403,7 +3401,7 @@ class AllPlatformTests(BasePlatformTests):
         # Check buildsystem_files
         bs_files = ['meson.build', 'meson_options.txt', 'sharedlib/meson.build', 'staticlib/meson.build']
         bs_files = [os.path.join(testdir, x) for x in bs_files]
-        self.assertPathListEqual(list(sorted(res['buildsystem_files'])), list(sorted(bs_files)))
+        self.assertPathListEqual(sorted(res['buildsystem_files']), sorted(bs_files))
 
         # Check dependencies
         dependencies_to_find = ['threads']
@@ -3943,8 +3941,8 @@ class AllPlatformTests(BasePlatformTests):
         ## Get command sections
 
         section_pattern = re.compile(r'^### (.+)$', re.MULTILINE)
-        md_command_section_matches = [i for i in section_pattern.finditer(md)]
-        md_command_sections = dict()
+        md_command_section_matches = list(section_pattern.finditer(md))
+        md_command_sections = {}
         for i, s in enumerate(md_command_section_matches):
             section_end = len(md) if i == len(md_command_section_matches) - 1 else md_command_section_matches[i + 1].start()
             md_command_sections[s.group(1)] = (s.start(), section_end)
@@ -4324,7 +4322,7 @@ class AllPlatformTests(BasePlatformTests):
         def check_installed_files(extra_args, expected):
             args = ['install', '--destdir', self.installdir] + extra_args
             self._run(self.meson_command + args, workdir=self.builddir)
-            all_files = [p for p in Path(self.installdir).rglob('*')]
+            all_files = list(Path(self.installdir).rglob('*'))
             self.assertEqual(sorted(expected), sorted(all_files))
             windows_proof_rmtree(self.installdir)
 

--- a/unittests/datatests.py
+++ b/unittests/datatests.py
@@ -186,7 +186,7 @@ class DataTests(unittest.TestCase):
         with open("docs/sitemap.txt", encoding='utf-8') as f:
             md = f.read()
         self.assertIsNotNone(md)
-        toc = list(m.group(1) for m in re.finditer(r"^\s*(\w.*)$", md, re.MULTILINE))
+        toc = [m.group(1) for m in re.finditer(r"^\s*(\w.*)$", md, re.MULTILINE)]
         markdownfiles = [f.name for f in Path("docs/markdown").iterdir() if f.is_file() and f.suffix == '.md']
         exceptions = ['_Sidebar.md']
         for f in markdownfiles:

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1387,10 +1387,10 @@ class InternalTests(unittest.TestCase):
             pass
 
         # Should be valid
-        _(None, mock.Mock(), tuple(), dict(input='foo'))
+        _(None, mock.Mock(), (), {'input': 'foo'})
 
         with self.assertRaises(MesonException) as cm:
-            _(None, mock.Mock(), tuple(), dict(input='bar'))
+            _(None, mock.Mock(), (), {'input': 'bar'})
         self.assertEqual(str(cm.exception), "testfunc keyword argument \"input\" invalid!")
 
     def test_typed_kwarg_convertor(self) -> None:
@@ -1401,7 +1401,7 @@ class InternalTests(unittest.TestCase):
         def _(obj, node, args: T.Tuple, kwargs: T.Dict[str, MachineChoice]) -> None:
             assert isinstance(kwargs['native'], MachineChoice)
 
-        _(None, mock.Mock(), tuple(), dict(native=True))
+        _(None, mock.Mock(), (), {'native': True})
 
     @mock.patch('mesonbuild.mesonlib.project_meson_versions', {'': '1.0'})
     def test_typed_kwarg_since_values(self) -> None:


### PR DESCRIPTION
% `ruff check --select=C4,PERF,PIE810 --statistics | grep "\[\*\]"`

Edit as **requested below**:
> [Ruff](https://docs.astral.sh/ruff) has two main command verbs: `check` to lint Python code and `format` to format code in a way that is highly compatible with `psf/black`.  The `--select` option allows us to choose which of the [800+ linting rules](https://docs.astral.sh/ruff/rules/) we wish to apply to the code.  Here we focus on minor optimizations.  The `--statistics` option provides only summary information.
>
> The `grep "\[\*\]"` command says that we are only interested in rules that have automated fixers.
>
> The detailed description of each rule including `Why is this bad?` can be obtained with a command of the form `ruff rule RUF017` as demonstrated below.
```
24	PIE810 	[*] multiple-starts-ends-with
13	C408   	[*] unnecessary-collection-call
 8	C419   	[*] unnecessary-comprehension-in-call
 5	C416   	[*] unnecessary-comprehension
 2	C400   	[*] unnecessary-generator-list
 2	C413   	[*] unnecessary-call-around-sorted
 2	PERF102	[*] incorrect-dict-iterator
 1	C401   	[*] unnecessary-generator-set
 1	C405   	[*] unnecessary-literal-set
 1	C417   	[*] unnecessary-map
```
% `ruff check --select=C4,PERF,PIE810 --fix --unsafe-fixes`
```
Found 140 errors (58 fixed, 82 remaining).
```
% `ruff rule RUF017`
# quadratic-list-summation (RUF017)

Derived from the **Ruff-specific rules** linter.

Fix is always available.

## What it does
Checks for the use of `sum()` to flatten lists of lists, which has
quadratic complexity.

## Why is this bad?
The use of `sum()` to flatten lists of lists is quadratic in the number of
lists, as `sum()` creates a new list for each element in the summation.

Instead, consider using another method of flattening lists to avoid
quadratic complexity. The following methods are all linear in the number of
lists:

- `functools.reduce(operator.iadd, lists, [])`
- `list(itertools.chain.from_iterable(lists))`
- `[item for sublist in lists for item in sublist]`

When fixing relevant violations, Ruff defaults to the `functools.reduce`
form, which outperforms the other methods in [microbenchmarks].

## Example
```python
lists = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
joined = sum(lists, [])
```

Use instead:
```python
import functools
import operator


lists = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
functools.reduce(operator.iadd, lists, [])
```

## References
- [_How Not to Flatten a List of Lists in Python_](https://mathieularose.com/how-not-to-flatten-a-list-of-lists-in-python)
- [_How do I make a flat list out of a list of lists?_](https://stackoverflow.com/questions/952914/how-do-i-make-a-flat-list-out-of-a-list-of-lists/953097#953097)

[microbenchmarks]: https://github.com/astral-sh/ruff/issues/5073#issuecomment-1591836349
