### PR TITLE
GitHub Action lint: Add codespell to find typos

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,6 +38,12 @@ jobs:
           python-version: '3.x'
       - run: python -m pip install flake8
       - run: flake8 --color always mesonbuild/
+  
+  codespell:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: codespell-project/actions-codespell@v2
 
   mypy:
     runs-on: ubuntu-latest

--- a/data/shell-completions/bash/meson
+++ b/data/shell-completions/bash/meson
@@ -30,7 +30,7 @@ _subprojects() {
     local COMPREPLY=()
     _filedir
     # _filedir for whatever reason can't reason about symlinks, so -d will them.
-    # Filter out wrap files with this expresion.
+    # Filter out wrap files with this expression.
     IFS=$'\n' echo "${COMPREPLY[*]}" | grep -vE '\.wrap$' | xargs
   popd &>/dev/null
 }

--- a/docs/markdown/Release-notes-for-1.2.0.md
+++ b/docs/markdown/Release-notes-for-1.2.0.md
@@ -49,7 +49,7 @@ directory, instead of using Visual Studio's native engine.
 ## More data in introspection files
 
 - Used compilers are listed in `intro-compilers.json`
-- Informations about `host`, `build` and `target` machines 
+- Information about `host`, `build` and `target` machines 
   are lister in `intro-machines.json`
 - `intro-dependencies.json` now includes internal dependencies,
   and relations between dependencies.

--- a/docs/markdown/Release-notes-for-1.3.0.md
+++ b/docs/markdown/Release-notes-for-1.3.0.md
@@ -39,7 +39,7 @@ about its value.
 
 ## [[configure_file]] now has a `macro_name` parameter.
 
-This new paramater, `macro_name` allows C macro-style include guards to be added
+This new parameter, `macro_name` allows C macro-style include guards to be added
 to [[configure_file]]'s output when a template file is not given. This change
 simplifies the creation of configure files that define macros with dynamic names
 and want the C-style include guards.
@@ -89,8 +89,8 @@ you to set the environment in which the generator will process inputs.
 In previous versions of meson, a `meson.build` file like this:
 
 ```
-exectuable('foo', 'main.c')
-exectuable('foo', 'main.c', name_suffix: 'bar')
+executable('foo', 'main.c')
+executable('foo', 'main.c', name_suffix: 'bar')
 ```
 
 would result in a configure error because meson internally used
@@ -288,7 +288,7 @@ We now allow passing arguments like `c_static_args` and `c_shared_args`. This
 allows a [[both_libraries]] to have arguments specific to either the shared or
 static library, as well as common arguments to both.
 
-There is a drawback to this, since Meson now cannot re-use object files between
+There is a drawback to this, since Meson now cannot reuse object files between
 the static and shared targets. This could lead to much higher compilation time
 when using a [[both_libraries]] if there are many sources.
 

--- a/docs/markdown/Release-notes-for-1.5.0.md
+++ b/docs/markdown/Release-notes-for-1.5.0.md
@@ -19,7 +19,7 @@ Cargo dependencies names are now in the format `<package_name>-<version>-rs`:
   * `x.y.z` -> 'x'
   * `0.x.y` -> '0.x'
   * `0.0.x` -> '0'
-  It allows to make different dependencies for uncompatible versions of the same
+  It allows to make different dependencies for incompatible versions of the same
   crate.
 - `-rs` suffix is added to distinguish from regular system dependencies, for
   example `gstreamer-1.0` is a system pkg-config dependency and `gstreamer-0.22-rs`

--- a/docs/markdown/Wrap-dependency-system-manual.md
+++ b/docs/markdown/Wrap-dependency-system-manual.md
@@ -323,7 +323,7 @@ name:
   * `x.y.z` -> 'x'
   * `0.x.y` -> '0.x'
   * `0.0.x` -> '0'
-  It allows to make different dependencies for uncompatible versions of the same
+  It allows to make different dependencies for incompatible versions of the same
   crate.
 - `-rs` suffix is added to distinguish from regular system dependencies, for
   example `gstreamer-1.0` is a system pkg-config dependency and `gstreamer-0.22-rs`
@@ -359,7 +359,7 @@ the main project depends on `foo-1-rs` and `bar-1-rs`, and they both depend on
 configure `common-rs` with a set of features. Later, when `bar-1-rs` does a lookup
 for `common-1-rs` it has already been configured and the set of features cannot be
 changed. If `bar-1-rs` wants extra features from `common-1-rs`, Meson will error out.
-It is currently the responsability of the main project to resolve those
+It is currently the responsibility of the main project to resolve those
 issues by enabling extra features on each subproject:
 ```meson
 project(...,
@@ -379,7 +379,7 @@ Some naming conventions need to be respected:
 
 Since *1.5.0* Cargo wraps can also be provided with `Cargo.lock` file at the root
 of (sub)project source tree. Meson will automatically load that file and convert
-it into a serie of wraps definitions.
+it into a series of wraps definitions.
 
 ## Using wrapped projects
 

--- a/docs/yaml/functions/build_target.yaml
+++ b/docs/yaml/functions/build_target.yaml
@@ -32,7 +32,7 @@ description: |
 
   The returned object also has methods that are documented in [[@build_tgt]].
 
-  *"jar" is deprecated because it is fundementally a different thing than the
+  *"jar" is deprecated because it is fundamentally a different thing than the
   other build_target types.
 
 posargs_inherit: _build_target_base

--- a/docs/yaml/functions/install_data.yaml
+++ b/docs/yaml/functions/install_data.yaml
@@ -13,7 +13,7 @@ varargs:
 warnings:
   - the `install_mode` kwarg ignored integer values between 0.59.0 -- 1.1.0.
   - an omitted `install_dir` kwarg did not work correctly inside of a subproject until 1.3.0.
-  - an omitted `install_dir` kwarg did not work correctly when combined with the `preserve_path` kwarg untill 1.3.0.
+  - an omitted `install_dir` kwarg did not work correctly when combined with the `preserve_path` kwarg until 1.3.0.
 
 kwargs:
   install_dir:

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1135,7 +1135,7 @@ class Backend:
 
         if p.is_file():
             p = p.parent
-        # Heuristic: replace *last* occurence of '/lib'
+        # Heuristic: replace *last* occurrence of '/lib'
         binpath = Path('/bin'.join(p.as_posix().rsplit('/lib', maxsplit=1)))
         for _ in binpath.glob('*.dll'):
             return str(binpath)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -99,7 +99,7 @@ def get_rsp_threshold() -> int:
         # and that has a limit of 8k.
         limit = 8192
     else:
-        # Unix-like OSes usualy have very large command line limits, (On Linux,
+        # Unix-like OSes usually have very large command line limits, (On Linux,
         # for example, this is limited by the kernel's MAX_ARG_STRLEN). However,
         # some programs place much lower limits, notably Wine which enforces a
         # 32k limit like Windows. Therefore, we limit the command line to 32k.

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -116,7 +116,7 @@ def get_primary_source_lang(target_sources: T.List[File], custom_sources: T.List
 # Returns a dictionary (by [src type][build type]) that contains a tuple of -
 # (pre-processor defines, include paths, additional compiler options)
 # fields to use to fill in the respective intellisense fields of sources that can't simply
-# reference and re-use the shared 'primary' language intellisense fields of the vcxproj.
+# reference and reuse the shared 'primary' language intellisense fields of the vcxproj.
 def get_non_primary_lang_intellisense_fields(vslite_ctx: dict,
                                              target_id: str,
                                              primary_src_lang: str) -> T.Dict[str, T.Dict[str, T.Tuple[str, str, str]]]:
@@ -879,7 +879,7 @@ class Vs2010Backend(backends.Backend):
                 ET.SubElement(parent_node, 'PreprocessorDefinitions', Condition=condition).text = defs
                 ET.SubElement(parent_node, 'AdditionalIncludeDirectories', Condition=condition).text = paths
                 ET.SubElement(parent_node, 'AdditionalOptions', Condition=condition).text = opts
-        else: # Can't find bespoke nmake defs/dirs/opts fields for this extention, so just reference the project's fields
+        else: # Can't find bespoke nmake defs/dirs/opts fields for this extension, so just reference the project's fields
             ET.SubElement(parent_node, 'PreprocessorDefinitions').text = '$(NMakePreprocessorDefinitions)'
             ET.SubElement(parent_node, 'AdditionalIncludeDirectories').text = '$(NMakeIncludeSearchPath)'
             ET.SubElement(parent_node, 'AdditionalOptions').text = '$(AdditionalOptions)'
@@ -1542,7 +1542,7 @@ class Vs2010Backend(backends.Backend):
     # the solution's configurations.  Similarly, 'ItemGroup' also doesn't support 'Condition'.  So, without knowing
     # a better (simple) alternative, for now, we'll repoint these generated sources (which will be incorrectly
     # pointing to non-existent files under our '[builddir]_vs' directory) to the appropriate location under one of
-    # our buildtype build directores (e.g. '[builddir]_debug').
+    # our buildtype build directories (e.g. '[builddir]_debug').
     # This will at least allow the user to open the files of generated sources listed in the solution explorer,
     # once a build/compile has generated these sources.
     #

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -728,7 +728,7 @@ def interpret(subp_name: str, subdir: str, env: Environment) -> T.Tuple[mparser.
     ast += _create_meson_subdir(cargo, build)
 
     # Libs are always auto-discovered and there's no other way to handle them,
-    # which is unfortunate for reproducability
+    # which is unfortunate for reproducibility
     if os.path.exists(os.path.join(env.source_dir, cargo.subdir, cargo.path, cargo.lib.path)):
         for crate_type in cargo.lib.crate_type:
             ast.extend(_create_lib(cargo, build, crate_type))

--- a/mesonbuild/cargo/manifest.py
+++ b/mesonbuild/cargo/manifest.py
@@ -179,7 +179,7 @@ class Workspace(TypedDict):
 
     """The representation of a workspace.
 
-    In a vritual manifest the :attribute:`members` is always present, but in a
+    In a virtual manifest the :attribute:`members` is always present, but in a
     project manifest, an empty workspace may be provided, in which case the
     workspace is implicitly filled in by values from the path based dependencies.
 

--- a/mesonbuild/cargo/version.py
+++ b/mesonbuild/cargo/version.py
@@ -40,7 +40,7 @@ def convert(cargo_ver: str) -> T.List[str]:
                 out.append(f'< {int(v[0]) + 1}')
 
         elif '*' in ver:
-            # Rust has astrisk requirements,, which are like 1.* == ~1
+            # Rust has asterisk requirements,, which are like 1.* == ~1
             # https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#wildcard-requirements
             v = ver.split('.')[:-1]
             if v:

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -489,7 +489,7 @@ class ConverterTarget:
             source_files = [x.name for x in i.sources + i.generated]
             for j in stem:
                 # On some platforms (specifically looking at you Windows with vs20xy backend) CMake does
-                # not produce object files with the format `foo.cpp.obj`, instead it skipps the language
+                # not produce object files with the format `foo.cpp.obj`, instead it skips the language
                 # suffix and just produces object files like `foo.obj`. Thus we have to do our best to
                 # undo this step and guess the correct language suffix of the object file. This is done
                 # by trying all language suffixes meson knows and checking if one of them fits.

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -89,7 +89,7 @@ class ClangCompiler(GnuLikeCompiler):
         # chosen, they provide fixit suggestions for the header you should try
         # including.
         #
-        # - With GCC, this is a note appended to the prexisting diagnostic
+        # - With GCC, this is a note appended to the preexisting diagnostic
         #   "error: undeclared identifier"
         #
         # - With clang, the error is converted to a c89'ish implicit function

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -464,7 +464,7 @@ def detect_kernel(system: str) -> T.Optional[str]:
             raise MesonException('Failed to run "/usr/bin/uname -o"')
         out = out.lower().strip()
         if out not in {'illumos', 'solaris'}:
-            mlog.warning(f'Got an unexpected value for kernel on a SunOS derived platform, expcted either "illumos" or "solaris", but got "{out}".'
+            mlog.warning(f'Got an unexpected value for kernel on a SunOS derived platform, expected either "illumos" or "solaris", but got "{out}".'
                          "Please open a Meson issue with the OS you're running and the value detected for your kernel.")
             return None
         return out

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3427,8 +3427,8 @@ class Interpreter(InterpreterBase, HoldableObject):
 
             if kwargs['implib']:
                 if kwargs['export_dynamic'] is False:
-                    FeatureDeprecated.single_use('implib overrides explict export_dynamic off', '1.3.0', self.subproject,
-                                                 'Do not set ths if want export_dynamic disabled if implib is enabled',
+                    FeatureDeprecated.single_use('implib overrides explicit export_dynamic off', '1.3.0', self.subproject,
+                                                 'Do not set this if want export_dynamic disabled if implib is enabled',
                                                  location=node)
                 kwargs['export_dynamic'] = True
             elif kwargs['export_dynamic']:

--- a/mesonbuild/mformat.py
+++ b/mesonbuild/mformat.py
@@ -967,7 +967,7 @@ def run(options: argparse.Namespace) -> int:
 # TODO: magic comment to prevent formatting
 # TODO: handle meson.options ?
 # TODO: split long lines on binary operators
-# TODO: align series of assignements
+# TODO: align series of assignments
 # TODO: align comments
 # TODO: move comments on long lines
 

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -1097,7 +1097,7 @@ class Parser:
             e.ast = block
             raise
 
-        # Remaining whitespaces will not be catched since there are no more nodes
+        # Remaining whitespaces will not be caught since there are no more nodes
         for ws_token in self.current_ws:
             block.append_whitespaces(ws_token)
         self.current_ws = []

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -354,7 +354,7 @@ def run(options: T.Union[CMDOptions, T.List[str]]) -> int:
     coredata.parse_cmd_line_options(options)
 
     # Msetup doesn't actually use this option, but we pass msetup options to
-    # mconf, and it does. We won't actally hit the path that uses it, but don't
+    # mconf, and it does. We won't actually hit the path that uses it, but don't
     # lie
     options.pager = False
 

--- a/mesonbuild/scripts/python_info.py
+++ b/mesonbuild/scripts/python_info.py
@@ -100,7 +100,7 @@ if sys.version_info >= (3, 2):
     except Exception:
         pass
 
-# pypy supports modules targetting the limited api but
+# pypy supports modules targeting the limited api but
 # does not use a special suffix to distinguish them:
 # https://doc.pypy.org/en/latest/cpython_differences.html#permitted-abi-tags-in-extensions
 if is_pypy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
 [build-system]
 requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.codespell]
+ignore-words-list="alltogether,ans,assertin,ccompiler,convertor,couldn,covert,crate,datas,equired,fo,gir,inout,larg,mapp,pard,shouldbe,thirdparty,usere,wasn,wit,wont"
+quiet-level=3
+skip="*.build,*.po,*ptbr.md"

--- a/test cases/format/5 transform/default.expected.meson
+++ b/test cases/format/5 transform/default.expected.meson
@@ -8,7 +8,7 @@ f = files(options_ini, 'expected.meson', 'source.meson')
 # This array should fit on one line
 a1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
 
-# This array is too long and should be splitted
+# This array is too long and should be split
 a2 = [
     2,
     3,

--- a/test cases/format/5 transform/genexpected.cmd
+++ b/test cases/format/5 transform/genexpected.cmd
@@ -1,6 +1,6 @@
 @echo off
 REM This script generates the expected files
-REM Please double-check the contents of those files before commiting them!!!
+REM Please double-check the contents of those files before committing them!!!
 
 python ../../../meson.py format -o default.expected.meson source.meson
 python ../../../meson.py format -c muon.ini -o muon.expected.meson source.meson

--- a/test cases/format/5 transform/muon.expected.meson
+++ b/test cases/format/5 transform/muon.expected.meson
@@ -8,7 +8,7 @@ f = files('expected.meson', 'source.meson', options_ini)
 # This array should fit on one line
 a1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
 
-# This array is too long and should be splitted
+# This array is too long and should be split
 a2 = [
     2,
     3,

--- a/test cases/format/5 transform/options.expected.meson
+++ b/test cases/format/5 transform/options.expected.meson
@@ -8,7 +8,7 @@ f = files(options_ini, 'expected.meson', 'source.meson')
 # This array should fit on one line
 a1 = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21 ]
 
-# This array is too long and should be splitted
+# This array is too long and should be split
 a2 = [ 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22 ]
 
 # space array

--- a/test cases/format/5 transform/source.meson
+++ b/test cases/format/5 transform/source.meson
@@ -12,7 +12,7 @@ f = files(
 # This array should fit on one line
 a1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
 
-# This array is too long and should be splitted
+# This array is too long and should be split
 a2 = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
 
 # space array

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -501,13 +501,13 @@ class BasePlatformTests(TestCase):
 
         ensures that the copied tree is deleted after running.
 
-        :param srcdir: The locaiton of the source tree to copy
+        :param srcdir: The location of the source tree to copy
         :return: The location of the copy
         """
         dest = tempfile.mkdtemp()
         self.addCleanup(windows_proof_rmtree, dest)
 
-        # shutil.copytree expects the destinatin directory to not exist, Once
+        # shutil.copytree expects the destination directory to not exist, Once
         # python 3.8 is required the `dirs_exist_ok` parameter negates the need
         # for this
         dest = os.path.join(dest, 'subdir')

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -176,7 +176,7 @@ class InternalTests(unittest.TestCase):
         # Test that adding to a list with just one old arg works and yields the same array
         a = ['-Ifoo'] + a
         self.assertEqual(a, ['-Ibar', '-Ifoo', '-Ibaz', '-I..', '-I.', '-O3', '-O2', '-Wall'])
-        # Test that adding to a list with just one new arg that is not pre-pended works
+        # Test that adding to a list with just one new arg that is not prepended works
         a = ['-Werror'] + a
         self.assertEqual(a, ['-Ibar', '-Ifoo', '-Ibaz', '-I..', '-I.', '-Werror', '-O3', '-O2', '-Wall'])
         # Test that adding to a list with two new args preserves the order

--- a/unittests/platformagnostictests.py
+++ b/unittests/platformagnostictests.py
@@ -420,7 +420,7 @@ class PlatformAgnosticTests(BasePlatformTests):
         self.assertEqual(self.getconf('neg_int_opt'), -10)
 
     def test_configure_options_file_deleted(self) -> None:
-        """Deleting all option files should make seting a project option an error."""
+        """Deleting all option files should make setting a project option an error."""
         testdir = self.copy_srcdir(os.path.join(self.common_test_dir, '40 options'))
         self.init(testdir)
         os.unlink(os.path.join(testdir, 'meson_options.txt'))


### PR DESCRIPTION
As discussed in:
* #6140
* #9332 
* #11107 

Several pull requests have been merged to fix typos using [`codespell`](https://github.com/codespell-project/codespell#) but each is a point-in-time fix and afterward, new typos are introduced into the codebase.  Let's add an automated test to catch typos in code review.