### PR TITLE
Add a new kwarg `error_if:` to `warning()` similar to `required:`

### DIFF
--- a/docs/markdown/snippets/warning_fatal_kwarg.md
+++ b/docs/markdown/snippets/warning_fatal_kwarg.md
@@ -1,0 +1,32 @@
+## Add a `error_if:` keyword-argument to `warning()` similar to `required:`
+
+You can now use `warning('some-msg', error_if: true)` or `warning('some-msg',
+error_if: option)` to convert a warning into an error. The purpose of this is to
+either warn or error out during system detection/configuration and cater to the
+following common use-case:
+
+```meson
+asm_option = get_option('asm')
+cpu_family = host_machine.cpu_family()
+if cpu_family in ['x86', 'x86_64']
+  ...
+elif cpu_family == 'aarch64'
+  ...
+else
+  msg = f'CPU family @cpu_family@ is currently unsupported'
+  if asm_option.enabled()
+    error(msg)
+  else
+    warning(msg)
+  endif
+endif
+```
+
+This can now be written as:
+
+```meson
+...
+else
+  warning(f'CPU family @cpu_family@ is currently unsupported', error_if: asm_option)
+endif
+```

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1426,12 +1426,18 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     @noArgsFlattening
     @FeatureNew('warning', '0.44.0')
-    @noKwargs
-    def func_warning(self, node, args, kwargs):
+    @typed_kwargs(
+        'warning',
+        KwargInfo('error_if', (bool, options.UserFeatureOption), default=False, since='1.6.0'),
+    )
+    def func_warning(self, node, args, kwargs: kwtypes.FuncWarning):
         if len(args) > 1:
             FeatureNew.single_use('warning with more than one argument', '0.54.0', self.subproject, location=node)
-        args_str = self._stringify_user_arguments(args, 'warning')
-        mlog.warning(*args_str, location=node)
+        if kwargs['error_if']:
+            self.func_error(node, args, {})
+        else:
+            args_str = self._stringify_user_arguments(args, 'warning')
+            mlog.warning(*args_str, location=node)
 
     @noArgsFlattening
     @noKwargs

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -476,3 +476,7 @@ class FuncDeclareDependency(TypedDict):
     sources: T.List[T.Union[FileOrString, build.GeneratedTypes]]
     variables: T.Dict[str, str]
     version: T.Optional[str]
+
+class FuncWarning(TypedDict):
+
+    error_if: T.Union[bool, options.UserFeatureOption]


### PR DESCRIPTION
You can now use `warning('some-msg', error_if: true)` or `warning('some-msg', error_if: option)` to convert a warning into an error. The purpose of this is to either warn or error out during system detection/configuration and cater to the following common use-case:

```meson
asm_option = get_option('asm')
cpu_family = host_machine.cpu_family()
if cpu_family in ['x86', 'x86_64']
  ...
elif cpu_family == 'aarch64'
  ...
else
  msg = f'CPU family @cpu_family@ is currently unsupported'
  if asm_option.enabled()
    error(msg)
  else
    warning(msg)
  endif
endif
```

This can now be written as:

```meson
...
else
  warning(f'CPU family @cpu_family@ is currently unsupported', error_if: asm_option)
endif
```