### PR TITLE
Simplify Python code with some ruff rules SIM

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -963,7 +963,7 @@ class NinjaBackend(backends.Backend):
         # This will be set as dependencies of all the target's sources. At the
         # same time, also deal with generated sources that need to be compiled.
         generated_source_files: T.List[File] = []
-        for rel_src in generated_sources.keys():
+        for rel_src in generated_sources:
             raw_src = File.from_built_relative(rel_src)
             if self.environment.is_source(rel_src):
                 if is_unity and self.get_target_source_can_unity(target, rel_src):
@@ -1103,9 +1103,7 @@ class NinjaBackend(backends.Backend):
             return False
         if not mesonlib.current_vs_supports_modules():
             return False
-        if mesonlib.version_compare(cpp.version, '<19.28.28617'):
-            return False
-        return True
+        return not mesonlib.version_compare(cpp.version, '<19.28.28617')
 
     def generate_dependency_scan_target(self, target: build.BuildTarget,
                                         compiled_sources: T.List[str],
@@ -1430,7 +1428,7 @@ class NinjaBackend(backends.Backend):
         # Add possible java generated files to src list
         generated_sources = self.get_target_generated_sources(target)
         gen_src_list = []
-        for rel_src in generated_sources.keys():
+        for rel_src in generated_sources:
             raw_src = File.from_built_relative(rel_src)
             if rel_src.endswith('.java'):
                 gen_src_list.append(raw_src)
@@ -1517,7 +1515,7 @@ class NinjaBackend(backends.Backend):
             outputs = [outname_rel]
         generated_sources = self.get_target_generated_sources(target)
         generated_rel_srcs = []
-        for rel_src in generated_sources.keys():
+        for rel_src in generated_sources:
             if rel_src.lower().endswith('.cs'):
                 generated_rel_srcs.append(os.path.normpath(rel_src))
             deps.append(os.path.normpath(rel_src))
@@ -1551,7 +1549,7 @@ class NinjaBackend(backends.Backend):
     def generate_java_compile(self, srcs, target, compiler, args):
         deps = [os.path.join(self.get_target_dir(l), l.get_filename()) for l in target.link_targets]
         generated_sources = self.get_target_generated_sources(target)
-        for rel_src in generated_sources.keys():
+        for rel_src in generated_sources:
             if rel_src.endswith('.java'):
                 deps.append(rel_src)
 
@@ -2936,7 +2934,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
 
         use_pch = self.target_uses_pch(target)
 
-        for src_type_str in target.compilers.keys():
+        for src_type_str in target.compilers:
             compiler = target.compilers[src_type_str]
             commands = self._generate_single_compile_base_args(target, compiler)
 

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -296,8 +296,7 @@ class Vs2010Backend(backends.Backend):
 
         # Use vcvarsall.bat if we found it.
         if 'VCINSTALLDIR' in os.environ:
-            vs_version = os.environ['VisualStudioVersion'] \
-                if 'VisualStudioVersion' in os.environ else None
+            vs_version = os.environ.get('VisualStudioVersion', None)
             relative_path = 'Auxiliary\\Build\\' if vs_version is not None and vs_version >= '15.0' else ''
             script_path = os.environ['VCINSTALLDIR'] + relative_path + 'vcvarsall.bat'
             if os.path.exists(script_path):
@@ -426,7 +425,7 @@ class Vs2010Backend(backends.Backend):
                 target = self.build.targets[prj[0]]
                 lang = 'default'
                 if hasattr(target, 'compilers') and target.compilers:
-                    for lang_out in target.compilers.keys():
+                    for lang_out in target.compilers:
                         lang = lang_out
                         break
                 prj_line = prj_templ % (
@@ -870,7 +869,7 @@ class Vs2010Backend(backends.Backend):
         # defs/dirs/opts that are set for the nominal 'primary' src type.
         ext = src.split('.')[-1]
         lang = compilers.compilers.SUFFIX_TO_LANG.get(ext, None)
-        if lang in defs_paths_opts_per_lang_and_buildtype.keys():
+        if lang in defs_paths_opts_per_lang_and_buildtype:
             # This is a non-primary src type for which can't simply reference the project's nmake fields;
             # we must laboriously fill in the fields for all buildtypes.
             for buildtype in coredata.get_genvs_default_buildtype_list():
@@ -1011,7 +1010,7 @@ class Vs2010Backend(backends.Backend):
                 file_args[l] += args
         # Compile args added from the env or cross file: CFLAGS/CXXFLAGS, etc. We want these
         # to override all the defaults, but not the per-target compile args.
-        for lang in file_args.keys():
+        for lang in file_args:
             file_args[lang] += target.get_option(OptionKey(f'{lang}_args', machine=target.for_machine))
         for args in file_args.values():
             # This is where Visual Studio will insert target_args, target_defines,

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2695,9 +2695,7 @@ class CustomTarget(Target, CustomTargetBase, CommandBase):
         if output.endswith(('.a', '.dll', '.lib', '.so', '.dylib')):
             return True
         # libfoo.so.X soname
-        if re.search(r'\.so(\.\d+)*$', output):
-            return True
-        return False
+        return bool(re.search('\\.so(\\.\\d+)*$', output))
 
     def is_linkable_target(self) -> bool:
         if len(self.outputs) != 1:

--- a/mesonbuild/cargo/cfg.py
+++ b/mesonbuild/cargo/cfg.py
@@ -176,9 +176,8 @@ def _parse(ast: _LEX_STREAM_AH) -> IR:
         ntoken, _ = (None, None)
 
     stream: T.List[_LEX_TOKEN]
-    if token is TokenType.IDENTIFIER:
-        if ntoken is TokenType.EQUAL:
-            return Equal(Identifier(value), _parse(ast))
+    if token is TokenType.IDENTIFIER and ntoken is TokenType.EQUAL:
+        return Equal(Identifier(value), _parse(ast))
     if token is TokenType.STRING:
         return String(value)
     if token is TokenType.EQUAL:

--- a/mesonbuild/cmake/fileapi.py
+++ b/mesonbuild/cmake/fileapi.py
@@ -319,6 +319,6 @@ class CMakeFileAPI:
 
         data = json.loads(real_path.read_text(encoding='utf-8'))
         assert isinstance(data, dict)
-        for i in data.keys():
+        for i in data:
             assert isinstance(i, str)
         return data

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -452,9 +452,7 @@ class ConverterTarget:
         def check_flag(flag: str) -> bool:
             if flag.lower() in BLACKLIST_LINK_FLAGS or flag in BLACKLIST_COMPILER_FLAGS or flag in BLACKLIST_CLANG_CL_LINK_FLAGS:
                 return False
-            if flag.startswith('/D'):
-                return False
-            return True
+            return not flag.startswith('/D')
 
         self.link_libraries = [x for x in self.link_libraries if x.lower() not in BLACKLIST_LINK_LIBS]
         self.link_flags = [x for x in self.link_flags if check_flag(x)]

--- a/mesonbuild/compilers/mixins/emscripten.py
+++ b/mesonbuild/compilers/mixins/emscripten.py
@@ -78,9 +78,8 @@ class EmscriptenMixin(Compiler):
                      libtype: LibType = LibType.PREFER_SHARED, lib_prefix_warning: bool = True) -> T.Optional[T.List[str]]:
         if not libname.endswith('.js'):
             return super().find_library(libname, env, extra_dirs, libtype, lib_prefix_warning)
-        if os.path.isabs(libname):
-            if os.path.exists(libname):
-                return [libname]
+        if os.path.isabs(libname) and os.path.exists(libname):
+            return [libname]
         if len(extra_dirs) == 0:
             raise mesonlib.EnvironmentException('Looking up Emscripten JS libraries requires either an absolute path or specifying extra_dirs.')
         for d in extra_dirs:

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -164,7 +164,7 @@ class ValaCompiler(Compiler):
                 if a:
                     p = a[0]
                     n = p[max(p.rfind('/'), p.rfind('\\'))+1:]
-                    if not n == d.get_name():
+                    if n != d.get_name():
                         args += ['--pkg=' + d.get_name()] # This is used by gio-2.0 among others.
                     else:
                         args += ['--pkg=' + n]

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -882,7 +882,7 @@ def parse_cmd_line_options(args: SharedCMDOptions) -> None:
     # Merge builtin options set with --option into the dict.
     for key in chain(
             options.BUILTIN_OPTIONS.keys(),
-            (k.as_build() for k in options.BUILTIN_OPTIONS_PER_MACHINE.keys()),
+            (k.as_build() for k in options.BUILTIN_OPTIONS_PER_MACHINE),
             options.BUILTIN_OPTIONS_PER_MACHINE.keys(),
     ):
         name = str(key)

--- a/mesonbuild/dependencies/factory.py
+++ b/mesonbuild/dependencies/factory.py
@@ -110,10 +110,7 @@ class DependencyFactory:
         By default this only remove EXTRAFRAMEWORK dependencies for non-mac platforms.
         """
         # Extra frameworks are only valid for macOS and other apple products
-        if (method is DependencyMethods.EXTRAFRAMEWORK and
-                not env.machines[for_machine].is_darwin()):
-            return False
-        return True
+        return not (method is DependencyMethods.EXTRAFRAMEWORK and not env.machines[for_machine].is_darwin())
 
     def __call__(self, env: 'Environment', for_machine: MachineChoice,
                  kwargs: T.Dict[str, T.Any]) -> T.List['DependencyGenerator']:

--- a/mesonbuild/dependencies/qt.py
+++ b/mesonbuild/dependencies/qt.py
@@ -76,9 +76,8 @@ def _get_modules_lib_suffix(version: str, info: 'MachineInfo', is_debug: bool) -
             suffix += 'd'
         if version.startswith('4'):
             suffix += '4'
-    if info.is_darwin():
-        if is_debug:
-            suffix += '_debug'
+    if info.is_darwin() and is_debug:
+        suffix += '_debug'
     if mesonlib.version_compare(version, '>= 5.14.0'):
         if info.is_android():
             if info.cpu_family == 'x86':

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -102,7 +102,7 @@ class GnuStepDependency(ConfigToolDependency):
                     or f.startswith('-f') \
                     or f.startswith('-I') \
                     or f == '-pthread' \
-                    or (f.startswith('-W') and not f == '-Wall'):
+                    or (f.startswith('-W') and f != '-Wall'):
                 result.append(f)
         return result
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -581,7 +581,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             machine_choices.append(MachineChoice.BUILD)
         for for_machine in machine_choices:
             props = self.build.environment.properties[for_machine]
-            for l in self.coredata.compilers[for_machine].keys():
+            for l in self.coredata.compilers[for_machine]:
                 try:
                     di = mesonlib.stringlistify(props.get_stdlib(l))
                 except KeyError:
@@ -745,13 +745,11 @@ class Interpreter(InterpreterBase, HoldableObject):
             raise InterpreterException('Assert failed: ' + message)
 
     def validate_arguments(self, args, argcount, arg_types):
-        if argcount is not None:
-            if argcount != len(args):
-                raise InvalidArguments(f'Expected {argcount} arguments, got {len(args)}.')
+        if argcount is not None and argcount != len(args):
+            raise InvalidArguments(f'Expected {argcount} arguments, got {len(args)}.')
         for actual, wanted in zip(args, arg_types):
-            if wanted is not None:
-                if not isinstance(actual, wanted):
-                    raise InvalidArguments('Incorrect argument type.')
+            if wanted is not None and not isinstance(actual, wanted):
+                raise InvalidArguments('Incorrect argument type.')
 
     # Executables aren't actually accepted, but we allow them here to allow for
     # better error messages when overridden
@@ -1127,7 +1125,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             return
         from ..backend import backends
 
-        if OptionKey('genvslite') in self.user_defined_options.cmd_line_options.keys():
+        if OptionKey('genvslite') in self.user_defined_options.cmd_line_options:
             # Use of the '--genvslite vsxxxx' option ultimately overrides any '--backend xxx'
             # option the user may specify.
             backend_name = self.coredata.get_option(OptionKey('genvslite'))
@@ -3472,7 +3470,7 @@ This will become a hard error in the future.''', location=self.current_node)
             kwargs['d_import_dirs'] = cleaned_items
 
     def add_stdlib_info(self, target):
-        for l in target.compilers.keys():
+        for l in target.compilers:
             dep = self.build.stdlibs[target.for_machine].get(l, None)
             if dep:
                 target.add_deps(dep)

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -75,7 +75,7 @@ def _install_mode_validator(mode: T.List[T.Union[str, bool, int]]) -> T.Optional
         return 'first component must be a permissions string or False'
 
     if isinstance(perms, str):
-        if not len(perms) == 9:
+        if len(perms) != 9:
             return ('permissions string must be exactly 9 characters in the form rwxr-xr-x,'
                     f' got {len(perms)}')
         for i in [0, 3, 6]:

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -290,9 +290,7 @@ class ContainerTypeInfo:
             return False
         if self.pairs and len(value) % 2 != 0:
             return False
-        if not value and not self.allow_empty:
-            return False
-        return True
+        return bool(value or self.allow_empty)
 
     def check_any(self, value: T.Any) -> bool:
         """Check a value should emit new/deprecated feature.
@@ -506,7 +504,7 @@ def typed_kwargs(name: str, *types: KwargInfo, allow_unknown: bool = False) -> T
                         if n in value:
                             warning = f'value "{n}" in list'
                     elif isinstance(value, dict):
-                        if n in value.keys():
+                        if n in value:
                             warning = f'value "{n}" in dict keys'
                     elif n == value:
                         warning = f'value "{n}"'

--- a/mesonbuild/modules/dlang.py
+++ b/mesonbuild/modules/dlang.py
@@ -40,9 +40,8 @@ class DlangModule(ExtensionModule):
         else:
             self.dubbin = DlangModule.class_dubbin
 
-        if not self.dubbin:
-            if not self.dubbin:
-                raise MesonException('DUB not found.')
+        if not self.dubbin and not self.dubbin:
+            raise MesonException('DUB not found.')
 
     @typed_pos_args('dlang.generate_dub_file', str, str)
     def generate_dub_file(self, state, args, kwargs):

--- a/mesonbuild/modules/java.py
+++ b/mesonbuild/modules/java.py
@@ -87,7 +87,7 @@ class JavaModule(NewExtensionModule):
             '@INPUT@',
         ])
 
-        prefix = classes[0] if not package else package
+        prefix = package if package else classes[0]
 
         target = CustomTarget(f'{prefix}-native-headers',
                               state.subdir,

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -441,7 +441,7 @@ class PkgConfigModule(NewExtensionModule):
                                  pkgroot: T.Optional[str] = None) -> None:
         coredata = state.environment.get_coredata()
         referenced_vars = set()
-        optnames = [x.name for x in BUILTIN_DIR_OPTIONS.keys()]
+        optnames = [x.name for x in BUILTIN_DIR_OPTIONS]
 
         if not dataonly:
             # includedir is always implied, although libdir may not be

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -325,7 +325,7 @@ def run_genvslite_setup(options: CMDOptions) -> None:
     # The command line may specify a '--backend' option, which doesn't make sense in conjunction with
     # '--genvslite', where we always want to use a ninja back end -
     k_backend = OptionKey('backend')
-    if k_backend in options.cmd_line_options.keys():
+    if k_backend in options.cmd_line_options:
         if options.cmd_line_options[k_backend] != 'ninja':
             raise MesonException('Explicitly specifying a backend option with \'genvslite\' is not necessary '
                                  '(the ninja backend is always used) but specifying a non-ninja backend '
@@ -358,7 +358,7 @@ def run(options: T.Union[CMDOptions, T.List[str]]) -> int:
     # lie
     options.pager = False
 
-    if OptionKey('genvslite') in options.cmd_line_options.keys():
+    if OptionKey('genvslite') in options.cmd_line_options:
         run_genvslite_setup(options)
     else:
         app = MesonApp(options)

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -151,7 +151,7 @@ class OptionInterpreter:
             raise OptionException('All keyword arguments must be after positional arguments.')
         reduced_pos = [self.reduce_single(arg) for arg in args.arguments]
         reduced_kw = {}
-        for key in args.kwargs.keys():
+        for key in args.kwargs:
             if not isinstance(key, mparser.IdNode):
                 raise OptionException('Keyword argument name is not a string.')
             a = args.kwargs[key]

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -779,9 +779,7 @@ class OptionStore:
         # values. It is not, thank you very much.
         if prefix in ('b', 'backend'): # pylint: disable=R6201
             return True
-        if prefix in self.all_languages:
-            return True
-        return False
+        return prefix in self.all_languages
 
     def is_builtin_option(self, key: OptionKey) -> bool:
         """Convenience method to check if this is a builtin option."""
@@ -802,9 +800,7 @@ class OptionStore:
         if '_' not in key.name:
             return False
         prefix = key.name.split('_')[0]
-        if prefix in self.all_languages:
-            return True
-        return False
+        return prefix in self.all_languages
 
     def is_module_option(self, key: OptionKey) -> bool:
         return key in self.module_options

--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -153,9 +153,8 @@ class ExternalProgram(mesonlib.HoldableObject):
 
     @staticmethod
     def from_entry(name: str, command: T.Union[str, T.List[str]]) -> 'ExternalProgram':
-        if isinstance(command, list):
-            if len(command) == 1:
-                command = command[0]
+        if isinstance(command, list) and len(command) == 1:
+            command = command[0]
         # We cannot do any searching if the command is a list, and we don't
         # need to search if the path is an absolute path.
         if isinstance(command, list) or os.path.isabs(command):

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -456,7 +456,7 @@ class Rewriter:
             'id': "/",
             'operation': 'remove_regex',
             'kwargs': {
-                'default_options': [f'{x}=.*' for x in cmd['options'].keys()]
+                'default_options': [f'{x}=.*' for x in cmd['options']]
             }
         }
         self.process_kwargs(kwargs_cmd)
@@ -729,7 +729,7 @@ class Rewriter:
                 # Specifying `extra_files` with a list that flattens to empty gives an empty
                 # target['extra_files'] list, account for that.
                 try:
-                    extra_files_key = next(k for k in tgt_function.args.kwargs.keys() if isinstance(k, IdNode) and k.value == 'extra_files')
+                    extra_files_key = next(k for k in tgt_function.args.kwargs if isinstance(k, IdNode) and k.value == 'extra_files')
                     node = tgt_function.args.kwargs[extra_files_key]
                 except StopIteration:
                     # Target has no extra_files kwarg, create one

--- a/mesonbuild/scripts/depfixer.py
+++ b/mesonbuild/scripts/depfixer.py
@@ -328,9 +328,8 @@ class Elf(DataSizes):
             # specified by user with build_rpath.
             for rpath_dir in old_rpath.split(b':'):
                 if not (rpath_dir in rpath_dirs_to_remove or
-                        rpath_dir == (b'X' * len(rpath_dir))):
-                    if rpath_dir:
-                        new_rpaths.add(rpath_dir)
+                        rpath_dir == (b'X' * len(rpath_dir))) and rpath_dir:
+                    new_rpaths.add(rpath_dir)
 
         # Prepend user-specified new entries while preserving the ones that came from pkgconfig etc.
         new_rpath = b':'.join(new_rpaths)

--- a/mesonbuild/scripts/externalproject.py
+++ b/mesonbuild/scripts/externalproject.py
@@ -41,9 +41,7 @@ class ExternalProject:
 
     def supports_jobs_flag(self) -> bool:
         p, o, e = Popen_safe(self.make + ['--version'])
-        if p.returncode == 0 and ('GNU Make' in o or 'waf' in o):
-            return True
-        return False
+        return p.returncode == 0 and ('GNU Make' in o or 'waf' in o)
 
     def build(self) -> int:
         make_cmd = self.make.copy()

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -1904,7 +1904,7 @@ class OrderedSet(T.MutableSet[_T]):
         # Don't print 'OrderedSet("")' for an empty set.
         if self.__container:
             return 'OrderedSet([{}])'.format(
-                ', '.join(repr(e) for e in self.__container.keys()))
+                ', '.join(repr(e) for e in self.__container))
         return 'OrderedSet()'
 
     def __reversed__(self) -> T.Iterator[_T]:

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -354,7 +354,7 @@ class Resolver:
             self.add_wrap(wrap)
 
     def add_wrap(self, wrap: PackageDefinition) -> None:
-        for k in wrap.provided_deps.keys():
+        for k in wrap.provided_deps:
             if k in self.provided_deps:
                 prev_wrap = self.provided_deps[k]
                 m = f'Multiple wrap files provide {k!r} dependency: {wrap.name} and {prev_wrap.name}'

--- a/mesonbuild/wrap/wraptool.py
+++ b/mesonbuild/wrap/wraptool.py
@@ -66,7 +66,7 @@ def add_arguments(parser: 'argparse.ArgumentParser') -> None:
 
 def list_projects(options: 'argparse.Namespace') -> None:
     releases = get_releases(options.allow_insecure)
-    for p in releases.keys():
+    for p in releases:
         print(p)
 
 def search(options: 'argparse.Namespace') -> None:

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -967,9 +967,7 @@ def have_d_compiler() -> bool:
         # Don't know why. Don't know how to fix. Skip in this case.
         cp = subprocess.run(['dmd', '--version'],
                             capture_output=True)
-        if cp.stdout == b'':
-            return False
-        return True
+        return cp.stdout != b''
     return False
 
 def have_objc_compiler(use_tmp: bool) -> bool:
@@ -998,9 +996,7 @@ def have_working_compiler(lang: str, use_tmp: bool) -> bool:
     return True
 
 def have_java() -> bool:
-    if shutil.which('javac') and shutil.which('java'):
-        return True
-    return False
+    return bool(shutil.which('javac') and shutil.which('java'))
 
 def skip_dont_care(t: TestDef) -> bool:
     # Everything is optional when not running on CI
@@ -1011,10 +1007,7 @@ def skip_dont_care(t: TestDef) -> bool:
     if not t.category.endswith('frameworks'):
         return True
 
-    if mesonlib.is_osx() and '6 gettext' in str(t.path):
-        return True
-
-    return False
+    return mesonlib.is_osx() and '6 gettext' in str(t.path)
 
 def skip_csharp(backend: Backend) -> bool:
     if backend is not Backend.ninja:
@@ -1060,17 +1053,12 @@ def should_skip_rust(backend: Backend) -> bool:
         return True
     if backend is not Backend.ninja:
         return True
-    if mesonlib.is_windows():
-        if has_broken_rustc():
-            return True
-    return False
+    return bool(mesonlib.is_windows() and has_broken_rustc())
 
 def should_skip_wayland() -> bool:
     if mesonlib.is_windows() or mesonlib.is_osx():
         return True
-    if not shutil.which('wayland-scanner'):
-        return True
-    return False
+    return not shutil.which('wayland-scanner')
 
 def detect_tests_to_run(only: T.Dict[str, T.List[str]], use_tmp: bool) -> T.List[T.Tuple[str, T.List[TestDef], bool]]:
     """
@@ -1142,9 +1130,9 @@ def detect_tests_to_run(only: T.Dict[str, T.List[str]], use_tmp: bool) -> T.List
     assert categories == ALL_TESTS, 'argparse("--only", choices=ALL_TESTS) need to be updated to match all_tests categories'
 
     if only:
-        for key in only.keys():
+        for key in only:
             assert key in categories, f'key `{key}` is not a recognized category'
-        all_tests = [t for t in all_tests if t.category in only.keys()]
+        all_tests = [t for t in all_tests if t.category in only]
 
     gathered_tests = [(t.category, gather_tests(Path('test cases', t.subdir), t.stdout_mandatory, only[t.category], t.skip), t.skip) for t in all_tests]
     return gathered_tests

--- a/test cases/common/14 configure file/check_file.py
+++ b/test cases/common/14 configure file/check_file.py
@@ -9,9 +9,7 @@ def permit_osx_workaround(m1,  m2):
         return False
     if m2 % 10000 != 0:
         return False
-    if m1//10000 != m2//10000:
-        return False
-    return True
+    return m1 // 10000 == m2 // 10000
 
 if len(sys.argv) == 2:
     assert os.path.exists(sys.argv[1])

--- a/test cases/common/179 escape and unicode/find.py
+++ b/test cases/common/179 escape and unicode/find.py
@@ -4,6 +4,5 @@ import os
 import sys
 
 for fh in os.listdir('.'):
-    if os.path.isfile(fh):
-        if fh.endswith('.c'):
-            sys.stdout.write(fh + '\0')
+    if os.path.isfile(fh) and fh.endswith('.c'):
+        sys.stdout.write(fh + '\0')

--- a/test cases/common/50 custom target chain/usetarget/subcomp.py
+++ b/test cases/common/50 custom target chain/usetarget/subcomp.py
@@ -2,6 +2,5 @@
 
 import sys
 
-with open(sys.argv[1], 'rb') as ifile:
-    with open(sys.argv[2], 'w') as ofile:
-        ofile.write('Everything ok.\n')
+with open(sys.argv[1], 'rb') as ifile, open(sys.argv[2], 'w') as ofile:
+    ofile.write('Everything ok.\n')

--- a/test cases/failing/89 custom target install data/preproc.py
+++ b/test cases/failing/89 custom target install data/preproc.py
@@ -8,6 +8,5 @@ if len(sys.argv) != 3:
 inf = sys.argv[1]
 outf = sys.argv[2]
 
-with open(outf, 'wb') as o:
-    with open(inf, 'rb') as i:
-        o.write(i.read())
+with open(outf, 'wb') as o, open(inf, 'rb') as i:
+    o.write(i.read())

--- a/tools/regenerate_docs.py
+++ b/tools/regenerate_docs.py
@@ -117,7 +117,7 @@ def generate_hotdoc_includes(root_dir: Path, output_dir: Path) -> None:
     cmd_data = get_commands_data(root_dir)
 
     for cmd, parsed in cmd_data.items():
-        for typ in parsed.keys():
+        for typ in parsed:
             with open(output_dir / (cmd+'_'+typ+'.inc'), 'w', encoding='utf-8') as f:
                 f.write(parsed[typ])
 

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1362,9 +1362,8 @@ class AllPlatformTests(BasePlatformTests):
         env = get_fake_env(testdir, self.builddir, self.prefix)
         cc = detect_c_compiler(env, MachineChoice.HOST)
         extra_args: T.List[str] = []
-        if cc.get_id() == 'clang':
-            if is_windows():
-                raise SkipTest('LTO not (yet) supported by windows clang')
+        if cc.get_id() == 'clang' and is_windows():
+            raise SkipTest('LTO not (yet) supported by windows clang')
 
         self.init(testdir, extra_args=['-Db_lto=true', '-Db_lto_threads=8'] + extra_args)
         self.build()
@@ -1426,11 +1425,7 @@ class AllPlatformTests(BasePlatformTests):
             # This check should not be necessary, but
             # CI under macOS passes the above test even
             # though Mercurial is not installed.
-            if subprocess.call(['hg', '--version'],
-                               stdout=subprocess.DEVNULL,
-                               stderr=subprocess.DEVNULL) != 0:
-                return False
-            return True
+            return subprocess.call(['hg', '--version'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) == 0
         except FileNotFoundError:
             return False
 
@@ -3241,7 +3236,7 @@ class AllPlatformTests(BasePlatformTests):
                 self.assertIn(i[0], obj)
                 self.assertIsInstance(obj[i[0]], i[1])
             if strict:
-                for k in obj.keys():
+                for k in obj:
                     found = False
                     for i in key_type_list:
                         if k == i[0]:

--- a/unittests/helpers.py
+++ b/unittests/helpers.py
@@ -198,9 +198,8 @@ def get_rpath(fname: str) -> T.Optional[str]:
 
 
 def get_classpath(fname: str) -> T.Optional[str]:
-    with zipfile.ZipFile(fname) as zip:
-        with zip.open('META-INF/MANIFEST.MF') as member:
-            contents = member.read().decode().strip()
+    with zipfile.ZipFile(fname) as zip, zip.open('META-INF/MANIFEST.MF') as member:
+        contents = member.read().decode().strip()
     lines: T.List[str] = []
     for line in contents.splitlines():
         if line.startswith(' '):

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -990,24 +990,23 @@ class InternalTests(unittest.TestCase):
     def test_dependency_factory_order(self):
         b = mesonbuild.dependencies.base
         F = mesonbuild.dependencies.factory
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with chdir(tmpdir):
-                env = get_fake_env()
-                env.scratch_dir = tmpdir
+        with tempfile.TemporaryDirectory() as tmpdir, chdir(tmpdir):
+            env = get_fake_env()
+            env.scratch_dir = tmpdir
 
-                f = F.DependencyFactory(
-                    'test_dep',
-                    methods=[b.DependencyMethods.PKGCONFIG, b.DependencyMethods.CMAKE]
-                )
-                actual = [m() for m in f(env, MachineChoice.HOST, {'required': False})]
-                self.assertListEqual([m.type_name for m in actual], ['pkgconfig', 'cmake'])
+            f = F.DependencyFactory(
+                'test_dep',
+                methods=[b.DependencyMethods.PKGCONFIG, b.DependencyMethods.CMAKE]
+            )
+            actual = [m() for m in f(env, MachineChoice.HOST, {'required': False})]
+            self.assertListEqual([m.type_name for m in actual], ['pkgconfig', 'cmake'])
 
-                f = F.DependencyFactory(
-                    'test_dep',
-                    methods=[b.DependencyMethods.CMAKE, b.DependencyMethods.PKGCONFIG]
-                )
-                actual = [m() for m in f(env, MachineChoice.HOST, {'required': False})]
-                self.assertListEqual([m.type_name for m in actual], ['cmake', 'pkgconfig'])
+            f = F.DependencyFactory(
+                'test_dep',
+                methods=[b.DependencyMethods.CMAKE, b.DependencyMethods.PKGCONFIG]
+            )
+            actual = [m() for m in f(env, MachineChoice.HOST, {'required': False})]
+            self.assertListEqual([m.type_name for m in actual], ['cmake', 'pkgconfig'])
 
     def test_validate_json(self) -> None:
         """Validate the json schema for the test cases."""

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -1352,7 +1352,7 @@ class LinuxlikeTests(BasePlatformTests):
         #   before v0.28, Libs flags like -Wl will not kept in context order with -l flags.
         #   see https://gitlab.freedesktop.org/pkg-config/pkg-config/-/blob/master/NEWS
         pkgconfigver = subprocess.check_output([PKG_CONFIG, '--version'])
-        if b'0.28' > pkgconfigver:
+        if pkgconfigver < b'0.28':
             raise SkipTest('pkg-config is too old to be correctly done this.')
         self.run_tests()
 

--- a/unittests/pythontests.py
+++ b/unittests/pythontests.py
@@ -72,7 +72,7 @@ python = pymod.find_installation('python3', required: true)
                         self.assertLength(cached, 2)
                     count += 1
         # there are 5 files x 2 installations
-        if py2 and not cc.get_id() == 'msvc':
+        if py2 and cc.get_id() != 'msvc':
             self.assertEqual(count, 10)
         else:
             self.assertEqual(count, 5)


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/#flake8-simplify-sim

Related to
* #13478

% `ruff check --select=SIM --ignore=SIM105,SIM108,SIM110,SIM112,SIM114,SIM910 --fix --unsafe-fixes`
```
Found 224 errors (139 fixed, 85 remaining).
```
% `ruff rule SIM118`
# in-dict-keys (SIM118)

Derived from the **flake8-simplify** linter.

Fix is always available.

## What it does
Checks for key-existence checks against `dict.keys()` calls.

## Why is this bad?
When checking for the existence of a key in a given dictionary, using
`key in dict` is more readable and efficient than `key in dict.keys()`,
while having the same semantics.

## Example
```python
key in foo.keys()
```

Use instead:
```python
key in foo
```

## Fix safety
Given `key in obj.keys()`, `obj` _could_ be a dictionary, or it could be
another type that defines a `.keys()` method. In the latter case, removing
the `.keys()` attribute could lead to a runtime error. The fix is marked
as safe when the type of `obj` is known to be a dictionary; otherwise, it
is marked as unsafe.

## References
- [Python documentation: Mapping Types](https://docs.python.org/3/library/stdtypes.html#mapping-types-dict)

[preview]: https://docs.astral.sh/ruff/preview/
