### PR TITLE
compiler,rust: fix sanity check and internal deps for baremetal rust …

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2114,6 +2114,11 @@ class StaticLibrary(BuildTarget):
             if self.rust_crate_type == 'staticlib':
                 # FIXME: In the case of no-std we should not add those libraries,
                 # but we have no way to know currently.
+
+                # XXX:
+                #  In the case of no-std, we are likely in a bare metal case
+                #  and thus, machine_info kernel should be set to 'none'.
+                #  In that case, native_static_libs list is empty.
                 rustc = self.compilers['rust']
                 d = dependencies.InternalDependency('undefined', [], [],
                                                     rustc.native_static_libs,


### PR DESCRIPTION
…project/target

Sanity check for bare metal rust wasn't working for a while and there is a pending PR (#12175). To workaround this problem, we used to let sanity check for build machine and manually defined rustc target.

Commit 18f8aeda8b59a132f24fa1af800ff65cac2f61f4 breaks this workaround as, even without an exe_wrapper, native_static_libs are appends as internal deps.

This behaviour makes sense for cross compiled rust in a rich environment but not any for no-std rust. As said in comments, one can't tell if the code is no-std or not because this is an annotation from sources. From our point of view, it is pretty clear that building a no-std rust target means that one has to define system='bare metal' and kernel='none' in his cross-file.

According to that, sanity_check for rust compiler is modified to handle kernel == 'none' case by building a specific no-std rust snippet, with an extra args if rust_ld is `ld.bfd` (in order to prevent the linker to link with a potentially non existing startfile for the given target). 'native_static_libs' is also leave empty in that very case.

This commit fix the spurious native static libs for no-std case and allow us to remove our dirty workaround which by-passed non working sanity check for bare metal rust.

One who wants to use meson for baremetal Rust project only have to define the rust target in their cross file.
 e.g.
>   rust = ['rustc', '--target', '\<rustc valid target\>']
 
 @xclaesse, this PR replace #12175 which could be closed.