### PR TITLE
backend/ninja: stop adding random attributes to BuildTargets

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -721,9 +721,6 @@ class BuildTarget(Target):
         ('cpp', 'cuda'),
     ])
 
-    # This is used by the backend to cache complex computation.
-    cached_generated_headers: T.Optional[T.List[FileOrString]]
-
     def __init__(
             self,
             name: str,


### PR DESCRIPTION
Instead of storing the generated header cache in the Target, store it in the NinjaBackend, as it really is just data for the NinjaBackend to use.