### PR TITLE
mformat: fix formatting of empty build file

### DIFF
--- a/mesonbuild/mformat.py
+++ b/mesonbuild/mformat.py
@@ -396,6 +396,8 @@ class TrimWhitespaces(FullAstVisitor):
         if node.lines:
             self.move_whitespaces(node.lines[-1], node)
         else:
+            node.whitespaces.value = node.pre_whitespaces.value + node.whitespaces.value
+            node.pre_whitespaces.value = ''
             node.whitespaces.accept(self)
 
         if node.condition_level == 0 and self.config.insert_final_newline:

--- a/unittests/platformagnostictests.py
+++ b/unittests/platformagnostictests.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from .baseplatformtests import BasePlatformTests
 from .helpers import is_ci
 from mesonbuild.mesonlib import EnvironmentVariables, ExecutableSerialisation, MesonException, is_linux, python_command
-from mesonbuild.mformat import match_path
+from mesonbuild.mformat import Formatter, match_path
 from mesonbuild.optinterpreter import OptionInterpreter, OptionException
 from mesonbuild.options import OptionStore
 from run_tests import Backend
@@ -336,7 +336,13 @@ class PlatformAgnosticTests(BasePlatformTests):
 
         for filename, pattern, expected in cases:
             self.assertTrue(match_path(filename, pattern) is expected, f'{filename} -> {pattern}')
-
+    
+    def test_format_empty_file(self) -> None:
+        formatter = Formatter(None, use_editor_config=False, fetch_subdirs=False)
+        for code in ('', '\n'):
+            formatted = formatter.format(code, Path())
+            self.assertEqual('\n', formatted)
+        
     def test_error_configuring_subdir(self):
         testdir = os.path.join(self.common_test_dir, '152 index customtarget')
         out = self.init(os.path.join(testdir, 'subdir'), allow_fail=True)


### PR DESCRIPTION
Running meson format multiple times on an empty file was adding a new line each time, which is bad for pre-commit checks...