### PR TITLE
Docs: Cleaner admonishment styling

### DIFF
--- a/docs/refman/templates/notes.mustache
+++ b/docs/refman/templates/notes.mustache
@@ -1,14 +1,25 @@
 {{#notes}}
-<div class="alert alert-info">
-  <strong>Note:</strong>
+<aside class="note note-info">
+<div class="note-topbar note-topbar-info">
+  <span class="glyphicon glyphicon-info-sign"></span>
+  <span class="note-title">Note:</span>
+</div>
+<div class="note-content">
 
 {{&.}}
 </div>
+</aside>
 {{/notes}}
+
 {{#warnings}}
-<div class="alert alert-warning">
-  <strong>Warning:</strong>
+<aside class="note note-warning">
+<div class="note-topbar note-topbar-warning">
+  <span class="glyphicon glyphicon-warning-sign"></span>
+  <span class="note-title">Warning:</span>
+</div>
+<div class="note-content">
 
 {{&.}}
 </div>
+</aside>
 {{/warnings}}

--- a/docs/theme/extra/css/notes.css
+++ b/docs/theme/extra/css/notes.css
@@ -1,0 +1,41 @@
+.note {
+    border: 0.2rem solid;
+    border-left-width: 0.5rem;
+    border-radius: 0.2rem;
+    margin: 2rem 1rem;
+}
+.note-topbar {
+    padding: 0.4rem 1rem;
+    border-radius: 1rem;
+    position: relative;
+    top: -1rem;
+    left: -1rem;
+    margin-right: auto;
+    min-width: min-content;
+    font-weight: bold;
+    font-size: 120%;
+    color: #fff;
+}
+.note-topbar .glyphicon {
+    top: 2px;
+}
+
+.note-content {
+    padding: 0 1rem;
+    margin-top: -0.5rem;
+}
+
+/* Colors taken from hotdoc_bootstrap_theme */
+.note-info {
+    border-color: #3dced8;
+}
+.note-topbar-info {
+    background-color: #3dced8;
+}
+
+.note-warning {
+    border-color: #e96506;
+}
+.note-topbar-warning {
+    background-color: #e96506;
+}


### PR DESCRIPTION
This PR adds a new documentation theme CSS file (`docs/theme/extra/css/notes.css`) and makes changes to the template which generates admonishment boxes in the Meson documentation (`docs/refman/templates/notes.mustache`), in order to update the styles applied to admonishments and make them more readable.

I don't claim to be a web designer and I'm sure these could be made to look much better, but what I care most about is that the actual contents of the boxes are readable. Now they are, as they share the same styles as the rest of the document.

### Before (light/dark)

![image](https://github.com/user-attachments/assets/ea48163f-f8ea-4fd6-babf-9a2578bbc692)
![image](https://github.com/user-attachments/assets/e07061c9-1fad-48f8-bf16-743446a886fb)


![image](https://github.com/user-attachments/assets/57be8b14-d6a8-46ca-a32d-435626267c6a)
![image](https://github.com/user-attachments/assets/4be2cfc9-7c16-46c7-91e6-57a66f6e5085)



### After (light/dark)

![image](https://github.com/user-attachments/assets/752441ef-2c8e-4810-98f2-10c53e9321dc)
![image](https://github.com/user-attachments/assets/7a041f12-6fbc-4232-9796-c0a736b47c37)

![image](https://github.com/user-attachments/assets/0db1e37c-6228-4692-bfaf-00282e0631d4)
![image](https://github.com/user-attachments/assets/6cab6a3f-2866-43e6-9d7b-d75315b90d81)


Fixes: #12328 