### PR TITLE
Fix LTO-related testcases on Cygwin

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -69,6 +69,7 @@ jobs:
             libgtk3-devel
             libxml2-devel
             libxslt-devel
+            make
             ninja
             python2-devel
             python3-devel

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -13,12 +13,14 @@ on:
     paths:
       - "mesonbuild/**"
       - "test cases/**"
+      - "unittests/**"
       - ".github/workflows/cygwin.yml"
       - "run*tests.py"
   pull_request:
     paths:
       - "mesonbuild/**"
       - "test cases/**"
+      - "unittests/**"
       - ".github/workflows/cygwin.yml"
       - "run*tests.py"
 

--- a/test cases/common/230 external project/test.json
+++ b/test cases/common/230 external project/test.json
@@ -1,6 +1,7 @@
 {
   "installed": [
-    { "type": "shared_lib",  "file": "usr/lib/foo" },
+    { "type": "shared_lib",  "file": "usr/lib/foo", "platform": "!cygwin" },
+    { "type": "file",  "file": "usr/lib/libfoo.dll", "platform": "cygwin" },
     { "type": "file",  "file": "usr/include/libfoo.h" },
     { "type": "file", "file": "usr/lib/pkgconfig/somelib.pc" }
   ]

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1337,7 +1337,6 @@ class AllPlatformTests(BasePlatformTests):
         self.utime(os.path.join(testdir, 'srcgen.py'))
         self.assertRebuiltTarget('basic')
 
-    @skipIf(is_ci() and is_cygwin(), 'A GCC update on 2024-07-21 has broken LTO and is being investigated')
     def test_static_library_lto(self):
         '''
         Test that static libraries can be built with LTO and linked to
@@ -1354,7 +1353,6 @@ class AllPlatformTests(BasePlatformTests):
         self.build()
         self.run_tests()
 
-    @skipIf(is_ci() and is_cygwin(), 'A GCC update on 2024-07-21 has broken LTO and is being investigated')
     @skip_if_not_base_option('b_lto_threads')
     def test_lto_threads(self):
         testdir = os.path.join(self.common_test_dir, '6 linkshared')


### PR DESCRIPTION
Fixes #13465 

`make` is used internally by gcc (for scheduling multithreaded lto) when the '-flto' flag is used.