### PR TITLE
docs: fix example for feature.require

### DIFF
--- a/docs/yaml/objects/feature.yaml
+++ b/docs/yaml/objects/feature.yaml
@@ -89,7 +89,7 @@ methods:
 
     ```
     if get_option('directx').require(host_machine.system() == 'windows',
-          error_message: 'DirectX only available on Windows').allowed() then
+          error_message: 'DirectX only available on Windows').allowed()
       src += ['directx.c']
       config.set10('HAVE_DIRECTX', true)
     endif


### PR DESCRIPTION
The example incorrectly uses `then` after the if condition, which is incorrect meson syntax as meson does not support a `then` keyword.