### PR TITLE
Add zig linker support 

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -62,6 +62,7 @@ These are return values of the `get_linker_id` method in a compiler object.
 | ld.mold    | The fast MOLD linker                        |
 | ld.solaris | Solaris and illumos                         |
 | ld.wasm    | emscripten's wasm-ld linker                 |
+| ld.zigcc   | The Zig linker (C/C++ frontend; GNU-like)   |
 | ld64       | Apple ld64                                  |
 | ld64.lld   | The LLVM linker, with the ld64 interface    |
 | link       | MSVC linker                                 |

--- a/docs/markdown/snippets/zig_ld.md
+++ b/docs/markdown/snippets/zig_ld.md
@@ -1,0 +1,18 @@
+## Zig 0.11 can be used as a C/C++ compiler frontend
+
+Zig offers
+[a C/C++ frontend](https://andrewkelley.me/post/zig-cc-powerful-drop-in-replacement-gcc-clang.html) as a drop-in replacement for Clang. It worked fine with Meson up to Zig 0.10. Since 0.11, Zig's
+dynamic linker reports itself as `zig ld`, which wasn't known to Meson. Meson now correctly handles
+Zig's linker.
+
+You can use Zig's frontend via a [machine file](Machine-files.md):
+
+```ini
+[binaries]
+c = ['zig', 'cc']
+cpp = ['zig', 'c++']
+ar = ['zig', 'ar']
+ranlib = ['zig', 'ranlib']
+lib = ['zig', 'lib']
+dlltool = ['zig', 'dlltool']
+```

--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -227,6 +227,9 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
         linker = linkers.AIXDynamicLinker(
             compiler, for_machine, comp_class.LINKER_PREFIX, override,
             version=search_version(e))
+    elif o.startswith('zig ld'):
+        linker = linkers.ZigCCDynamicLinker(
+            compiler, for_machine, comp_class.LINKER_PREFIX, override, version=v)
     else:
         __failed_to_detect_linker(compiler, check_args, o, e)
     return linker

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -705,7 +705,9 @@ class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
         args.extend(self._apply_prefix('-rpath,' + paths))
 
         # TODO: should this actually be "for solaris/sunos"?
-        if mesonlib.is_sunos():
+        # NOTE: Remove the zigcc check once zig support "-rpath-link"
+        # See https://github.com/ziglang/zig/issues/18713
+        if mesonlib.is_sunos() or self.id == 'ld.zigcc':
             return (args, rpath_dirs_to_remove)
 
         # Rpaths to use while linking must be absolute. These are not

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -936,6 +936,13 @@ class LLVMDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, Dyna
             raise mesonlib.MesonBugException(f'win_subsystem: {value} not handled in lld linker. This should not be possible.')
 
 
+class ZigCCDynamicLinker(LLVMDynamicLinker):
+    id = 'ld.zigcc'
+
+    def get_thinlto_cache_args(self, path: str) -> T.List[str]:
+        return []
+
+
 class WASMDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, DynamicLinker):
 
     """Emscripten's wasm-ld."""


### PR DESCRIPTION
Adds support for Zig's linker (zld)

Merges #13493, #12293, and #12953.

Context from https://github.com/mesonbuild/meson/pull/13493#issuecomment-2269602518

> What we really need here is to have a single PR that contains all the necessary changes:
> 
>     * this patch
> 
>     * the patch from [linkers: basic support for the 'zig cc' linker #12293](https://github.com/mesonbuild/meson/pull/12293)
> 
>     * a patch to enable zig in the CI workflows, see [Add Zig to ubuntu-rolling image, CI test #12953](https://github.com/mesonbuild/meson/pull/12953)
> 
> 
> And a second PR that adds zig to the CI images _without_ adding it to the CI workflows, see #12953 again.
> 
> Currently everything is spread out quite a bit and it's difficult to get a handle on whether it all works.

