### PR TITLE
dependencies/dub: Correctly handle dub >= 1.35 as well as older dub (+ fixed Windows CI)

### DIFF
--- a/mesonbuild/modules/dlang.py
+++ b/mesonbuild/modules/dlang.py
@@ -28,8 +28,8 @@ class DlangModule(ExtensionModule):
         })
 
     def _init_dub(self, state):
-        if DlangModule.class_dubbin is None:
-            self.dubbin = DubDependency.class_dubbin
+        if DlangModule.class_dubbin is None and DubDependency.class_dubbin is not None:
+            self.dubbin = DubDependency.class_dubbin[0]
             DlangModule.class_dubbin = self.dubbin
         else:
             self.dubbin = DlangModule.class_dubbin

--- a/test cases/d/11 dub/meson.build
+++ b/test cases/d/11 dub/meson.build
@@ -1,10 +1,13 @@
 project('dub-example', 'd')
 
-error('MESON_SKIP_TEST: Dub support is broken at the moment (#11773)')
-
 dub_exe = find_program('dub', required : false)
 if not dub_exe.found()
   error('MESON_SKIP_TEST: Dub not found')
+endif
+
+dub_ver = dub_exe.version()
+if dub_ver.version_compare('>1.31.1') and dub_ver.version_compare('<1.35.0')
+  error('MESON_SKIP_TEST: Incompatible Dub version ' + dub_ver)
 endif
 
 urld_dep = dependency('urld', method: 'dub')

--- a/test cases/d/14 dub with deps/meson.build
+++ b/test cases/d/14 dub with deps/meson.build
@@ -1,10 +1,13 @@
 project('dub-with-deps-example', ['d'])
 
-error('MESON_SKIP_TEST: Dub support is broken at the moment (#11773)')
-
 dub_exe = find_program('dub', required : false)
 if not dub_exe.found()
     error('MESON_SKIP_TEST: Dub not found')
+endif
+
+dub_ver = dub_exe.version()
+if dub_ver.version_compare('>1.31.1') and dub_ver.version_compare('<1.35.0')
+  error('MESON_SKIP_TEST: Incompatible Dub version')
 endif
 
 if meson.get_compiler('d').get_id() == 'gcc'


### PR DESCRIPTION
This is https://github.com/mesonbuild/meson/pull/12143 with CI fixed for Windows.

---

- check version of DUB for compatibility with Meson
 - use "cacheArtifactPath" to locate DUB libraries in the cache
 - propose `dub build --deep` command to Meson users for missing DUB
   packages

Depending on DUB version, it will look either in the old cache structure
or use this new `dub describe` entry.

Closes: #12143
Closes: #11773