### PR TITLE
Skip broken tests in CI

### DIFF
--- a/test cases/failing/80 dub library/test.json
+++ b/test cases/failing/80 dub library/test.json
@@ -1,4 +1,5 @@
 {
+  "expect_skip_on_jobname": ["opensuse", "ubuntu-rolling"],
   "stdout": [
     {
       "line": "test cases/failing/80 dub library/meson.build:11:0: ERROR: Dependency \"dubtestproject\" not found"

--- a/test cases/failing/81 dub executable/test.json
+++ b/test cases/failing/81 dub executable/test.json
@@ -1,4 +1,5 @@
 {
+  "expect_skip_on_jobname": ["opensuse", "ubuntu-rolling"],
   "stdout": [
     {
       "line": "test cases/failing/81 dub executable/meson.build:11:0: ERROR: Dependency \"dubtestproject:test1\" not found"

--- a/test cases/frameworks/17 mpi/test.json
+++ b/test cases/frameworks/17 mpi/test.json
@@ -13,5 +13,5 @@
       ]
     }
   },
-  "expect_skip_on_jobname": ["azure", "cygwin", "msys2", "opensuse"]
+  "expect_skip_on_jobname": ["azure", "cygwin", "msys2", "opensuse", "ubuntu-rolling"]
 }

--- a/test cases/frameworks/24 libgcrypt/test.json
+++ b/test cases/frameworks/24 libgcrypt/test.json
@@ -1,3 +1,3 @@
 {
-  "expect_skip_on_jobname": ["azure", "cygwin", "msys2"]
+  "expect_skip_on_jobname": ["arch", "azure", "cygwin", "msys2"]
 }


### PR DESCRIPTION
Skips 4 tests in total, these are preventing the CI Image Builder workflow to run.

- failing: 80 dub library: version of dub is incompatible on OpenSUSE and Ubuntu
- failing: 81 dub executable: version of dub is incompatible on OpenSUSE and Ubuntu
- frameworks: 17 mpi: gfortran tries to use invalid symbols on Ubuntu
- frameworks: 24 libgcrypt: libgcrypt-config does not exist on Arch Linux due to the move to pkg-config