### PR TITLE
format: fix indentation of comments

### DIFF
--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -266,6 +266,7 @@ class WhitespaceNode(BaseNode):
         super().__init__(token.lineno, token.colno, token.filename)
         self.value = ''
         self.append(token)
+        self.block_indent = False
 
     def append(self, token: Token[str]) -> None:
         self.value += token.value

--- a/test cases/format/1 default/indentation.meson
+++ b/test cases/format/1 default/indentation.meson
@@ -11,7 +11,10 @@ project(
 )
 
 a = [
+    # comment
+    # comment
     1,
+    # comment
     2,
     3,
     [
@@ -36,8 +39,13 @@ a = [
 d = {}
 
 if meson.project_version().version_compare('>1.2')
+    # comment
+    # comment
     if meson.version().version_compare('>1.0')
+        # comment
+        # comment
         foreach i : a
+            # comment
             e = {
                 'a': 'a',
                 'b': 'b',
@@ -69,9 +77,18 @@ if meson.project_version().version_compare('>1.2')
                 ],
             }
         endforeach
+
+        foreach j : a
+            # comment
+            # comment
+            # comment
+        endforeach
     elif 42 in d
         d += {'foo': 43}
     else  # ensure else is correctly indented (issue #13316)
+        # comment
         k = 'k'
+        # comment
+        # comment
     endif
 endif

--- a/unittests/platformagnostictests.py
+++ b/unittests/platformagnostictests.py
@@ -342,6 +342,21 @@ class PlatformAgnosticTests(BasePlatformTests):
         for code in ('', '\n'):
             formatted = formatter.format(code, Path())
             self.assertEqual('\n', formatted)
+    
+    def test_format_indent_comment_in_brackets(self) -> None:
+        """Ensure comments in arrays and dicts are correctly indented"""
+        formatter = Formatter(None, use_editor_config=False, fetch_subdirs=False)
+        code = 'a = [\n    # comment\n]\n'
+        formatted = formatter.format(code, Path())
+        self.assertEqual(code, formatted)
+        
+        code = 'a = [\n    # comment\n    1,\n]\n'
+        formatted = formatter.format(code, Path())
+        self.assertEqual(code, formatted)
+
+        code = 'a = {\n    # comment\n}\n'
+        formatted = formatter.format(code, Path())
+        self.assertEqual(code, formatted)
         
     def test_error_configuring_subdir(self):
         testdir = os.path.join(self.common_test_dir, '152 index customtarget')


### PR DESCRIPTION
Fixes #13508

- Fix indentation of comments in arrays
- Fix indentation of comments in dicts
- Fix indentation of comments in if clauses
- Fix indentation of comments in foreach clauses