### PR TITLE
Allow skipping the detection of specific tools in `qt.has_tools()`

### DIFF
--- a/docs/markdown/snippets/qt_has_tools_ignore.md
+++ b/docs/markdown/snippets/qt_has_tools_ignore.md
@@ -1,0 +1,10 @@
+## Tools can be skipped when calling `has_tools()` on the Qt modules
+
+When checking for the presence of Qt tools, you can now ask Meson to not check
+for the presence of a list of tools. This is particularly useful when you do
+not need `lrelease` because you are not shipping any translations. For example:
+
+```meson
+qt6_mod = import('qt6')
+qt6_mod.has_tools(required: true, skip: ['lrelease'])
+```

--- a/mesonbuild/modules/_qt.py
+++ b/mesonbuild/modules/_qt.py
@@ -269,6 +269,7 @@ class QtBaseModule(ExtensionModule):
         # will insist this is wrong
         disabled, required, feature = extract_required_kwarg(kwargs, state.subproject, default=False)
         if disabled:
+            assert feature is not None, "for mypy"
             mlog.log('qt.has_tools skipped: feature', mlog.bold(feature), 'disabled')
             return False
         self._detect_tools(state, method, required=False)

--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -242,7 +242,7 @@ class ExternalProgram(mesonlib.HoldableObject):
                         return [trial_ext]
         return None
 
-    def _search_windows_special_cases(self, name: str, command: str) -> T.List[T.Optional[str]]:
+    def _search_windows_special_cases(self, name: str, command: T.Optional[str]) -> T.List[T.Optional[str]]:
         '''
         Lots of weird Windows quirks:
         1. PATH search for @name returns files with extensions from PATHEXT,

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -48,7 +48,12 @@ foreach qt : ['qt4', 'qt5', 'qt6']
   qtdep = dependency(qt, modules : qt_modules, main : true, private_headers: true, required : required, method : get_option('method'))
   if qtdep.found()
     qtmodule = import(qt)
-    assert(qtmodule.has_tools(), 'You may be missing a devel package. (qttools5-dev-tools on Debian based systems)')
+    if get_option('expect_lrelease')
+      assert(qtmodule.has_tools(), 'You may be missing a devel package. (qttools5-dev-tools on Debian based systems)')
+    else
+      assert(not qtmodule.has_tools(), 'Unexpectedly found lrelease')
+      assert(qtmodule.has_tools(skip: ['lrelease']))
+    endif
 
     # Test that fetching a variable works and yields a non-empty value
     assert(qtdep.get_variable('prefix', configtool: 'QT_INSTALL_PREFIX') != '')
@@ -91,23 +96,25 @@ foreach qt : ['qt4', 'qt5', 'qt6']
     # qt4-rcc and qt5-rcc take different arguments, for example qt4: ['-compress', '3']; qt5: '--compress=3'
     qtmodule.preprocess(qt + 'testrccarg', qresources : files(['stuff.qrc', 'stuff2.qrc']), rcc_extra_arguments : '--compress=3', method : get_option('method'))
 
-    translations_cpp = qtmodule.compile_translations(qresource: qt+'_lang.qrc')
-    # unity builds suck and definitely cannot handle two qrc embeds in one compilation unit
-    unityproof_translations = static_library(qt+'unityproof_translations', translations_cpp, dependencies: qtdep)
+    if get_option('expect_lrelease')
+      translations_cpp = qtmodule.compile_translations(qresource: qt+'_lang.qrc')
+      # unity builds suck and definitely cannot handle two qrc embeds in one compilation unit
+      unityproof_translations = static_library(qt+'unityproof_translations', translations_cpp, dependencies: qtdep)
 
-    extra_cpp_args += '-DQT="@0@"'.format(qt)
-    qexe = executable(qt + 'app',
-      sources : ['main.cpp', 'mainWindow.cpp', # Sources that don't need preprocessing.
-      prep, prep_rcc],
-      dependencies : qtdep,
-      link_with: unityproof_translations,
-      cpp_args: extra_cpp_args,
-      gui_app : true)
+      extra_cpp_args += '-DQT="@0@"'.format(qt)
+      qexe = executable(qt + 'app',
+        sources : ['main.cpp', 'mainWindow.cpp', # Sources that don't need preprocessing.
+        prep, prep_rcc],
+        dependencies : qtdep,
+        link_with: unityproof_translations,
+        cpp_args: extra_cpp_args,
+        gui_app : true)
 
-    # We need a console test application because some test environments
-    # do not have an X server.
+      # We need a console test application because some test environments
+      # do not have an X server.
 
-    translations = qtmodule.compile_translations(ts_files : qt+'core_fr.ts', build_by_default : true)
+      translations = qtmodule.compile_translations(ts_files : qt+'core_fr.ts', build_by_default : true)
+    endif
 
     qtcore = dependency(qt, modules : 'Core', method : get_option('method'))
 

--- a/test cases/frameworks/4 qt/meson_options.txt
+++ b/test cases/frameworks/4 qt/meson_options.txt
@@ -1,2 +1,3 @@
 option('method', type : 'string', value : 'auto', description : 'The method to use to find Qt')
 option('required', type : 'string', value : 'qt5', description : 'The version of Qt which is required to be present')
+option('expect_lrelease', type: 'boolean', value: true)

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -318,6 +318,19 @@ class LinuxlikeTests(BasePlatformTests):
         self.init(testdir, extra_args=['-Db_sanitize=address', '-Db_lundef=false'])
         self.build()
 
+    def test_qt5dependency_no_lrelease(self):
+        '''
+        Test that qt5 detection with qmake works. This can't be an ordinary
+        test case because it involves setting the environment.
+        '''
+        testdir = os.path.join(self.framework_test_dir, '4 qt')
+        def _no_lrelease(self, prog, *args, **kwargs):
+            if 'lrelease' in prog:
+                prog = 'lrelease-not-found'
+            return self._interpreter.find_program_impl(prog, *args, **kwargs)
+        with mock.patch.object(mesonbuild.modules.ModuleState, 'find_program', _no_lrelease):
+            self.init(testdir, inprocess=True, extra_args=['-Dmethod=qmake', '-Dexpect_lrelease=false'])
+
     def test_qt5dependency_qmake_detection(self):
         '''
         Test that qt5 detection with qmake works. This can't be an ordinary


### PR DESCRIPTION
This has been an annoying problem because we are unconditionally checking for `lrelease` in `qt.has_tools()`, and that program is shipped in Debian/Ubuntu with (f.ex.) [qttools5-dev-tools](https://packages.debian.org/sid/qttools5-dev-tools), which pulls in the kitchen sink (100+ packages, including GStreamer).

This is really annoying when trying to do CI builds of libraries or frameworks like GStreamer that use Qt but will never ship translations.