### PR TITLE
backend/ninja: fix bad @OUTPUTn@ replacements

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2602,17 +2602,18 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         subdir = genlist.subdir
         exe = generator.get_exe()
         infilelist = genlist.get_inputs()
-        outfilelist = genlist.get_outputs()
         extra_dependencies = self.get_target_depend_files(genlist)
-        for i, curfile in enumerate(infilelist):
-            if len(generator.outputs) == 1:
-                sole_output = os.path.join(self.get_target_private_dir(target), outfilelist[i])
-            else:
-                sole_output = f'{curfile}'
+        for curfile in infilelist:
             infilename = curfile.rel_to_builddir(self.build_to_src, self.get_target_private_dir(target))
             base_args = generator.get_arglist(infilename)
             outfiles = genlist.get_outputs_for(curfile)
-            outfiles = [os.path.join(self.get_target_private_dir(target), of) for of in outfiles]
+            outfilespriv = [os.path.join(self.get_target_private_dir(target), of) for of in outfiles]
+
+            if len(generator.outputs) == 1:
+                sole_output = outfilespriv[0]
+            else:
+                sole_output = f'{curfile}'
+
             if generator.depfile is None:
                 rulename = 'CUSTOM_COMMAND'
                 args = base_args
@@ -2623,19 +2624,16 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 args = [x.replace('@DEPFILE@', depfile) for x in base_args]
             args = [x.replace("@INPUT@", infilename).replace('@OUTPUT@', sole_output)
                     for x in args]
-            args = self.replace_outputs(args, self.get_target_private_dir(target), outfilelist)
-            # We have consumed output files, so drop them from the list of remaining outputs.
-            if len(generator.outputs) > 1:
-                outfilelist = outfilelist[len(generator.outputs):]
+            args = self.replace_outputs(args, self.get_target_private_dir(target), outfiles)
             args = self.replace_paths(target, args, override_subdir=subdir)
             cmdlist, reason = self.as_meson_exe_cmdline(exe,
                                                         self.replace_extra_args(args, genlist),
-                                                        capture=outfiles[0] if generator.capture else None,
+                                                        capture=outfilespriv[0] if generator.capture else None,
                                                         env=genlist.env)
             abs_pdir = os.path.join(self.environment.get_build_dir(), self.get_target_dir(target))
             os.makedirs(abs_pdir, exist_ok=True)
 
-            elem = NinjaBuildElement(self.all_outputs, outfiles, rulename, infilename)
+            elem = NinjaBuildElement(self.all_outputs, outfilespriv, rulename, infilename)
             elem.add_dep([self.get_target_filename(x) for x in generator.depends])
             if generator.depfile is not None:
                 elem.add_item('DEPFILE', depfile)

--- a/test cases/common/52 object generator/dir/meson.build
+++ b/test cases/common/52 object generator/dir/meson.build
@@ -1,0 +1,6 @@
+#check with a single @OUTPUT0@ in a subdirectory and multiple inputs
+gen4 = generator(python,
+ output : ['@BASENAME@.o'],
+ arguments : [comp, cc, '@INPUT@', '@OUTPUT0@'])
+
+generated4 = gen4.process(files('source5.c', 'source6.c'))

--- a/test cases/common/52 object generator/dir/source5.c
+++ b/test cases/common/52 object generator/dir/source5.c
@@ -1,0 +1,3 @@
+int func5_in_obj(void) {
+    return 0;
+}

--- a/test cases/common/52 object generator/dir/source6.c
+++ b/test cases/common/52 object generator/dir/source6.c
@@ -1,0 +1,3 @@
+int func6_in_obj(void) {
+    return 0;
+}

--- a/test cases/common/52 object generator/meson.build
+++ b/test cases/common/52 object generator/meson.build
@@ -37,6 +37,8 @@ gen3 = generator(python,
 
 generated3 = gen3.process(['source4.c'])
 
-e = executable('prog', 'prog.c', generated, generated2, generated3)
+subdir('dir')
+
+e = executable('prog', 'prog.c', generated, generated2, generated3, generated4)
 
 test('objgen', e)

--- a/test cases/common/52 object generator/prog.c
+++ b/test cases/common/52 object generator/prog.c
@@ -2,7 +2,10 @@ int func1_in_obj(void);
 int func2_in_obj(void);
 int func3_in_obj(void);
 int func4_in_obj(void);
+int func5_in_obj(void);
+int func6_in_obj(void);
+
 
 int main(void) {
-    return func1_in_obj() + func2_in_obj() + func3_in_obj() + func4_in_obj();
+    return func1_in_obj() + func2_in_obj() + func3_in_obj() + func4_in_obj() + func5_in_obj() + func6_in_obj();
 }


### PR DESCRIPTION
`outfilelist` is the output list of the target, while `outfiles` is the output list of the individual commands

Bug: mesonbuild/meson/pull/13304#issuecomment-2226398671