### PR TITLE
build: Optimize transitive link dep resolution

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1199,14 +1199,14 @@ class Backend:
         result: T.Set[str] = set()
         prospectives: T.Set[build.BuildTargetTypes] = set()
         if isinstance(target, build.BuildTarget):
-            prospectives.update(target.get_transitive_link_deps())
+            prospectives.update(target.get_all_link_deps())
             # External deps
             result.update(self.extract_dll_paths(target))
 
         for bdep in extra_bdeps:
             prospectives.add(bdep)
             if isinstance(bdep, build.BuildTarget):
-                prospectives.update(bdep.get_transitive_link_deps())
+                prospectives.update(bdep.get_all_link_deps())
         # Internal deps
         for ld in prospectives:
             dirseg = os.path.join(self.environment.get_build_dir(), self.get_target_dir(ld))

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2,7 +2,7 @@
 # Copyright 2012-2017 The Meson development team
 
 from __future__ import annotations
-from collections import defaultdict, OrderedDict
+from collections import defaultdict, deque, OrderedDict
 from dataclasses import dataclass, field, InitVar
 from functools import lru_cache
 import abc
@@ -1049,15 +1049,29 @@ class BuildTarget(Target):
         return ExtractedObjects(self, self.sources, self.generated, self.objects,
                                 recursive, pch=True)
 
-    def get_all_link_deps(self) -> ImmutableListProtocol[BuildTargetTypes]:
-        return self.get_transitive_link_deps()
-
     @lru_cache(maxsize=None)
-    def get_transitive_link_deps(self) -> ImmutableListProtocol[BuildTargetTypes]:
-        result: T.List[Target] = []
-        for i in self.link_targets:
-            result += i.get_all_link_deps()
-        return result
+    def get_all_link_deps(self) -> ImmutableListProtocol[BuildTargetTypes]:
+        """ Get all shared libraries dependencies
+        This returns all shared libraries in the entire dependency tree. Those
+        are libraries needed at runtime which is different from the set needed
+        at link time, see get_dependencies() for that.
+        """
+        result: OrderedSet[BuildTargetTypes] = OrderedSet()
+        stack: T.Deque[BuildTargetTypes] = deque()
+        stack.appendleft(self)
+        while stack:
+            t = stack.pop()
+            if t in result:
+                continue
+            if isinstance(t, CustomTargetIndex):
+                stack.appendleft(t.target)
+                continue
+            if isinstance(t, SharedLibrary):
+                result.add(t)
+            if isinstance(t, BuildTarget):
+                stack.extendleft(t.link_targets)
+                stack.extendleft(t.link_whole_targets)
+        return list(result)
 
     def get_link_deps_mapping(self, prefix: str) -> T.Mapping[str, str]:
         return self.get_transitive_link_deps_mapping(prefix)
@@ -2414,9 +2428,6 @@ class SharedLibrary(BuildTarget):
         Returns None if the build won't create any debuginfo file
         """
         return self.debug_filename
-
-    def get_all_link_deps(self):
-        return [self] + self.get_transitive_link_deps()
 
     def get_aliases(self) -> T.List[T.Tuple[str, str, str]]:
         """


### PR DESCRIPTION
In large repositories, transitive link dependency resolution using the current recursive algorithm can result in enough duplicate calls to cause the full system memory space to be used up.

This commit simplifies link dep resolution by converting the currently used recursive algorithm to an iterative one that avoids performing work more than once. If a target's direct dependencies have already been processed, that target will not be processed again.

These changes result in multiple orders of magnitude of improvements to dep resolution time and memory usage in the worst case. In a repro provided by @andrei-pavel, the following stats on `meson setup` were achieved on [this project](https://gitlab.isc.org/isc-projects/kea/-/tree/1f158da82886b9b9a41adda4c0abfb1d72672d8f):


| | 1.7.0 | #13532 |
|-|---|---|
| Memory | 19GB | 58MB |
| Time | 78s | 5s |

Thanks to @xclaesse for substantial review on #13359, which helped inform this complete revision of the original.

Closes: #11322