### PR TITLE
Interpret TAP bailout output without test plan or test line as error

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1115,7 +1115,8 @@ class TestRunTAP(TestRun):
                                      'This is probably a bug in the test; if they are not TAP syntax, prefix them with a #')
         if all(t.result is TestResult.SKIP for t in self.results):
             # This includes the case where self.results is empty
-            res = TestResult.SKIP
+            if res != TestResult.ERROR:
+                res = TestResult.SKIP
 
         if res and self.res == TestResult.RUNNING:
             self.res = res


### PR DESCRIPTION
Fixes #13535 