### PR TITLE
compilers: do not strip '-isystem' from C build arguments

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -98,12 +98,12 @@ class CLikeCompilerArgs(arglist.CompilerArgs):
                     continue
 
                 # Remove the -isystem and the path if the path is a default path
-                if (each == '-isystem' and
-                        i < (len(new) - 1) and
-                        self._cached_realpath(new[i + 1]) in real_default_dirs):
-                    bad_idx_list += [i, i + 1]
-                elif each.startswith('-isystem=') and self._cached_realpath(each[9:]) in real_default_dirs:
-                    bad_idx_list += [i]
+                if each == '-isystem':
+                    if i < (len(new) - 1) and self._cached_realpath(new[i + 1]) in real_default_dirs:
+                        bad_idx_list += [i, i + 1]
+                elif each.startswith('-isystem='):
+                    if self._cached_realpath(each[9:]) in real_default_dirs:
+                        bad_idx_list += [i]
                 elif self._cached_realpath(each[8:]) in real_default_dirs:
                     bad_idx_list += [i]
             for i in reversed(bad_idx_list):


### PR DESCRIPTION
Meson accidentally strips '-isystem' from C build args like ['-isystem', '/path/to/headers'] if the compiler includes the current working directory in the header search paths. The root cause is that '-isystem'[8:] evaluates to an empty string and os.path.realpath('') returns the absolute path to the current working directory, causing meson to think that '-isystem' specifies a default include path.

Different compiler versions varies whether the current working directory is in its search paths. For example, on Ubuntu 21.04:

```
  # gcc -xc -v -E -
  gcc version 10.3.0 (Ubuntu 10.3.0-1ubuntu1)
  #include "..." search starts here:
  #include <...> search starts here:
   .
   /usr/lib/gcc/x86_64-linux-gnu/10/include
   /usr/local/include
   /usr/include/x86_64-linux-gnu
   /usr/include
  End of search list.
```

While on Ubuntu 24.04:

```
  # gcc -xc -v -E -
  gcc version 13.2.0 (Ubuntu 13.2.0-23ubuntu4)
  ...
  #include "..." search starts here:
  #include <...> search starts here:
   /usr/lib/gcc/x86_64-linux-gnu/13/include
   /usr/local/include
   /usr/include/x86_64-linux-gnu
   /usr/include
  End of search list.
```

Add a length check to ensure that '-isystem' is really followed by a path.