### PR TITLE
Remove mention of running ninja directly

### DIFF
--- a/docs/markdown/SimpleStart.md
+++ b/docs/markdown/SimpleStart.md
@@ -149,6 +149,4 @@ is put in the `build` subdirectory and can be run directly from there.
 
 The project is now ready for development. You can edit the code with
 any editor and it is rebuilt by going in the `build` subdirectory and
-executing the `meson compile` command. If your version of Meson is too
-old, you can compile the project by running the command `ninja`
-instead.
+executing the `meson compile` command.


### PR DESCRIPTION
It may be true that if one uses a Meson version that is more than 4 years old, one might need to run `ninja` directly, but details like that should be safe to keep out of the simple getting started guide.