### PR TITLE
modules/gnome: Make 'gnome.yelp()' install actual media with symlinks

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1335,15 +1335,18 @@ class GnomeModule(ExtensionModule):
             for i, m in enumerate(media):
                 m_dir = os.path.dirname(m)
                 m_install_dir = os.path.join(l_install_dir, m_dir)
+                try:
+                    m_file: T.Optional[mesonlib.File] = mesonlib.File.from_source_file(state.environment.source_dir, l_subdir, m)
+                except MesonException:
+                    m_file = None
+
                 l_data: T.Union[build.Data, build.SymlinkData]
-                if symlinks:
+                if symlinks and not m_file:
                     link_target = os.path.join(os.path.relpath(c_install_dir, start=m_install_dir), m)
                     l_data = build.SymlinkData(link_target, os.path.basename(m),
                                                m_install_dir, state.subproject, install_tag='doc')
                 else:
-                    try:
-                        m_file = mesonlib.File.from_source_file(state.environment.source_dir, l_subdir, m)
-                    except MesonException:
+                    if not m_file:
                         m_file = media_files[i]
                     l_data = build.Data([m_file], m_install_dir, m_install_dir,
                                         mesonlib.FileMode(), state.subproject, install_tag='doc')


### PR DESCRIPTION
In cases, when localized media files are provided by some languages, we need to use `gnome.yelp ()` with `symlink_media: false` which copies all files from `C` locale in addition to the localized media. This wastes storage space. The alternative is to use `symlink_media: true` which symlinks entirely to `C` media files ignoring localized media files.

As a middle ground, if the localized media file exists in the source tree for a language, we use that file rather than symlinking to `C` media with the same filename even when `symlink_media: true`. This saves storage space.

If there are no localized media files in non-C language, the existing behaviour is maintained.