### PR TITLE
dependencies/dub: First try to describe local project

### DIFF
--- a/ci/ciimage/opensuse/install.sh
+++ b/ci/ciimage/opensuse/install.sh
@@ -42,11 +42,12 @@ echo 'ulimit -n -S 10000' >> /ci/env_vars.sh
 
 source /ci/env_vars.sh
 
-dub_fetch urld
-dub build --deep urld --arch=x86_64 --compiler=dmd --build=debug
-dub_fetch dubtestproject
-dub build dubtestproject:test1 --compiler=dmd
-dub build dubtestproject:test2 --compiler=dmd
+dub_fetch dubtestproject@1.2.0
+dub build dubtestproject:test1 --compiler=dmd --arch=x86_64
+dub build dubtestproject:test2 --compiler=dmd --arch=x86_64
+dub build dubtestproject:test3 --compiler=dmd --arch=x86_64
+dub_fetch urld@3.0.0
+dub build urld --compiler=dmd --arch=x86_64
 
 # Cleanup
 zypper --non-interactive clean --all

--- a/ci/ciimage/ubuntu-rolling/install.sh
+++ b/ci/ciimage/ubuntu-rolling/install.sh
@@ -50,11 +50,12 @@ install_python_packages hotdoc
 echo 'ulimit -n -S 10000' >> /ci/env_vars.sh
 ulimit -n -S 10000
 # dub stuff
-dub_fetch urld
-dub build --deep urld --arch=x86_64 --compiler=gdc --build=debug
-dub_fetch dubtestproject
-dub build dubtestproject:test1 --compiler=ldc2
-dub build dubtestproject:test2 --compiler=ldc2
+dub_fetch dubtestproject@1.2.0
+dub build dubtestproject:test1 --compiler=ldc2 --arch=x86_64
+dub build dubtestproject:test2 --compiler=ldc2 --arch=x86_64
+dub build dubtestproject:test3 --compiler=gdc --arch=x86_64
+dub_fetch urld@3.0.0
+dub build urld --compiler=gdc --arch=x86_64
 
 # Remove debian version of Rust and install latest with rustup.
 # This is needed to get the cross toolchain as well.

--- a/test cases/d/11 dub/meson.build
+++ b/test cases/d/11 dub/meson.build
@@ -17,7 +17,7 @@ test('test urld', test_exe)
 
 # If you want meson to generate/update a dub.json file
 dlang = import('dlang')
-dlang.generate_dub_file(meson.project_name().to_lower(), meson.source_root(),
+dlang.generate_dub_file(meson.project_name().to_lower(), meson.build_root(),
                         authors: 'Meson Team',
                         description: 'Test executable',
                         copyright: 'Copyright © 2018, Meson Team',

--- a/test cases/d/17 dub and meson project/.gitignore
+++ b/test cases/d/17 dub and meson project/.gitignore
@@ -1,0 +1,2 @@
+17-dub-meson-project*
+lib17-dub-meson-project*

--- a/test cases/d/17 dub and meson project/dub.json
+++ b/test cases/d/17 dub and meson project/dub.json
@@ -1,0 +1,11 @@
+{
+  "name": "17-dub-meson-project",
+  "dependencies": {
+    "urld": ">=3.0.0 <3.0.1",
+    "dubtestproject:test3": "1.2.0",
+    ":multi-configuration": "*"
+  },
+  "subPackages": [
+    "multi-configuration"
+  ]
+}

--- a/test cases/d/17 dub and meson project/dub.selections.json
+++ b/test cases/d/17 dub and meson project/dub.selections.json
@@ -1,0 +1,7 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"dubtestproject": "1.2.0",
+		"urld": "3.0.0"
+	}
+}

--- a/test cases/d/17 dub and meson project/meson.build
+++ b/test cases/d/17 dub and meson project/meson.build
@@ -1,0 +1,32 @@
+project('Meson integration with dub.json', 'd')
+
+dub_exe = find_program('dub', required : false)
+if not dub_exe.found()
+    error('MESON_SKIP_TEST: Dub not found')
+endif
+
+dub_ver = dub_exe.version()
+if not dub_ver.version_compare('>=1.35.0')
+  error('MESON_SKIP_TEST: test requires dub >=1.35.0')
+endif
+
+# Multiple versions supported
+urld = dependency('urld', method: 'dub', version: [ '>=3.0.0', '<3.0.1' ])
+
+# The version we got is the one in dub.selections.json
+version = urld.version()
+if version != '3.0.0'
+  error(f'Expected urld version to be the one selected in dub.selections.json but got @version@')
+endif
+
+# dependency calls from subdirectories respect meson.project_source_root()/dub.selections.json
+subdir('x/y/z')
+
+# dependencies respect their configuration selected in dub.json
+run_command(dub_exe, 'build', '--deep', ':multi-configuration',
+            '--compiler', meson.get_compiler('d').cmd_array()[0],
+            '--arch', host_machine.cpu_family(),
+            '--root', meson.project_source_root(),
+            '--config', 'lib',
+            check: true)
+found = dependency('17-dub-meson-project:multi-configuration', method: 'dub')

--- a/test cases/d/17 dub and meson project/multi-configuration/.gitignore
+++ b/test cases/d/17 dub and meson project/multi-configuration/.gitignore
@@ -1,0 +1,2 @@
+libmulti-configuration*
+multi-configuration*

--- a/test cases/d/17 dub and meson project/multi-configuration/dub.json
+++ b/test cases/d/17 dub and meson project/multi-configuration/dub.json
@@ -1,0 +1,14 @@
+{
+  "name": "multi-configuration",
+  "configurations": {
+    "app": {
+      "targetType": "executable"
+    },
+    "lib": {
+      "targetType": "library",
+      "excludedSourceFiles": [
+        "source/app.d"
+      ]
+    }
+  }
+}

--- a/test cases/d/17 dub and meson project/multi-configuration/dub.selections.json
+++ b/test cases/d/17 dub and meson project/multi-configuration/dub.selections.json
@@ -1,0 +1,5 @@
+{
+	"fileVersion": 1,
+	"versions": {
+	}
+}

--- a/test cases/d/17 dub and meson project/multi-configuration/source/app.d
+++ b/test cases/d/17 dub and meson project/multi-configuration/source/app.d
@@ -1,0 +1,1 @@
+void main () {}

--- a/test cases/d/17 dub and meson project/source/app.d
+++ b/test cases/d/17 dub and meson project/source/app.d
@@ -1,0 +1,1 @@
+void main () {}

--- a/test cases/d/17 dub and meson project/x/y/z/dub.json
+++ b/test cases/d/17 dub and meson project/x/y/z/dub.json
@@ -1,0 +1,6 @@
+{
+	"dependencies": {
+		"dubtestproject:test3": "*"
+	},
+	"name": "dub-respects-project-root-subdir"
+}

--- a/test cases/d/17 dub and meson project/x/y/z/dub.selections.json
+++ b/test cases/d/17 dub and meson project/x/y/z/dub.selections.json
@@ -1,0 +1,6 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"dubtestproject": "1.3.0"
+	}
+}

--- a/test cases/d/17 dub and meson project/x/y/z/meson.build
+++ b/test cases/d/17 dub and meson project/x/y/z/meson.build
@@ -1,0 +1,6 @@
+root = meson.project_source_root()
+dep = dependency('dubtestproject:test3', method: 'dub')
+version = dep.version()
+if version != '1.2.0'
+  error(f'Expected urld version to be the one selected in "@root@/dub.selections.json" but got @version@')
+endif

--- a/test cases/failing/133 dub missing dependency/dub.json
+++ b/test cases/failing/133 dub missing dependency/dub.json
@@ -1,0 +1,3 @@
+{
+  "name": "132-missing-dep"
+}

--- a/test cases/failing/133 dub missing dependency/dub.selections.json
+++ b/test cases/failing/133 dub missing dependency/dub.selections.json
@@ -1,0 +1,5 @@
+{
+	"fileVersion": 1,
+	"versions": {
+	}
+}

--- a/test cases/failing/133 dub missing dependency/meson.build
+++ b/test cases/failing/133 dub missing dependency/meson.build
@@ -1,0 +1,17 @@
+project('Dub dependency not in dub.json')
+
+if not add_languages('d', required: false)
+  error('MESON_SKIP_TEST test requires D compiler')
+endif
+
+dub_exe = find_program('dub', required : false)
+if not dub_exe.found()
+    error('MESON_SKIP_TEST: Dub not found')
+endif
+
+dub_ver = dub_exe.version()
+if not dub_ver.version_compare('>=1.35.0')
+  error('MESON_SKIP_TEST: test requires dub >=1.35.0')
+endif
+
+dep = dependency('urld', method: 'dub') # not in dub.json

--- a/test cases/failing/133 dub missing dependency/source/app.d
+++ b/test cases/failing/133 dub missing dependency/source/app.d
@@ -1,0 +1,1 @@
+void main () {}

--- a/test cases/failing/133 dub missing dependency/test.json
+++ b/test cases/failing/133 dub missing dependency/test.json
@@ -1,0 +1,8 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/132 dub missing dependency/meson.build:17:6: ERROR: Dependency \"urld\" not found",
+      "line": "dub add urld"
+    }
+  ]
+}


### PR DESCRIPTION
The current approach of determining dub dependencies is by specifying a name and, optionally, a version. Dub will then be called to generate a json summary of the package and code in meson will parse that and extract relevant information. This can be insufficient because dub packages can provide multiple configurations for multiple use-cases, examples include providing a configuration for an executable and a configuration for a library. As a practical example, the dub package itself provides an application configuration and multiple library configurations, the json description of dub will, by default, be for the application configuration which will make dub as a library unusable in meson.

This can be solved without modifying the meson build interface by having dub describe the entire local project and collecting dependencies information from that. This way dub will generate information based on the project's 'dub.json' file, which is free to require dependencies in any way accepted by dub, by specifying configurations, by modifying compilation flags etc. This is all transparent to meson as dub's main purpose is to provide a path to the library file generated by the dependency in addition to other command-line arguments for the compiler.

This change will, however, require that projects that want to build with meson also provided a 'dub.json' file in which dependency information is recorded. Failure to do so will not break existing projects that didn't use a 'dub.json', but they will be limited to what the previous implementation offered. Projects that already have a 'dub.json' should be fine, so long as the file is valid and the information in it matches the one in 'meson.build'. For example for a 'dependency()' call in 'meson.build' that dependency must exist in 'dub.json', otherwise the call will now fail when it worked previously.

Using a 'dub.json' also has as a consequence that the version of the dependencies that are found are the ones specified in 'dub.selections.json', which can be helpful for projects that already provide a 'dub.json' in addition to 'meson.build' to de-duplicate code.

In terms of other code changes:
- multiple version requirements for a dub dependency now work, though they can only be used when a 'dub.json' is present in which case the version of dependencies is already pinned by 'dub.selections.json'
- the 'd/11 dub' test case has been changed to auto-generate the 'dub.json' config outside of the source directory, as the auto-generated file triggers warning when parsed by dub, which upsets the new code as the warnings interfere with the legitimate output.