### PR TITLE
linkers: skip -export_dynamic flag before MacOS 10.7

### DIFF
--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -840,7 +840,9 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
         return ["-Wl,-cache_path_lto," + path]
 
     def export_dynamic_args(self, env: 'Environment') -> T.List[str]:
-        return self._apply_prefix('-export_dynamic')
+        if mesonlib.version_compare(self.version, '>=224.1'):
+            return self._apply_prefix('-export_dynamic')
+        return []
 
 
 class LLVMLD64DynamicLinker(AppleDynamicLinker):

--- a/unittests/darwintests.py
+++ b/unittests/darwintests.py
@@ -4,10 +4,11 @@
 import subprocess
 import re
 import os
+import platform
 import unittest
 
 from mesonbuild.mesonlib import (
-    MachineChoice, is_osx
+    MachineChoice, is_osx, version_compare
 )
 from mesonbuild.compilers import (
     detect_c_compiler
@@ -81,6 +82,7 @@ class DarwinTests(BasePlatformTests):
         self.build()
         self.run_tests()
 
+    @unittest.skipIf(version_compare(platform.mac_ver()[0], '<10.7'), '-export_dynamic was added in 10.7')
     def test_apple_lto_export_dynamic(self):
         '''
         Tests that -Wl,-export_dynamic is correctly added, when export_dynamic: true is set.


### PR DESCRIPTION
Resolves #13543.

@barracuda156 @ryandesign can anyone test this on MacOS 10.6.x and MacOS 10.7 to confirm? I only have a much more recent version available.

CC @tristan957 