### PR TITLE
mformat: correctly handle editorconfig files without the root setting

### DIFF
--- a/mesonbuild/mformat.py
+++ b/mesonbuild/mformat.py
@@ -823,7 +823,8 @@ class Formatter:
                     if value is not None:
                         setattr(config, f.name, value)
 
-            if cp.getboolean(cp.default_section, 'root'):
+            # Root is not required except in the top level .editorconfig.
+            if cp.getboolean(cp.default_section, 'root', fallback=False):
                 break
 
         return config

--- a/test cases/format/3 editorconfig/meson.build
+++ b/test cases/format/3 editorconfig/meson.build
@@ -7,6 +7,7 @@ meson_files = {
 	'self': files('meson.build'),
 	'comments': files('crazy_comments.meson'),
 	'indentation': files('indentation.meson'),
+	'subdir editorconfig': files('subdir/sub.meson'),
 }
 
 foreach name, f : meson_files

--- a/test cases/format/3 editorconfig/subdir/.editorconfig
+++ b/test cases/format/3 editorconfig/subdir/.editorconfig
@@ -1,0 +1,2 @@
+[*]
+max_line_length = 120

--- a/test cases/format/3 editorconfig/subdir/sub.meson
+++ b/test cases/format/3 editorconfig/subdir/sub.meson
@@ -1,0 +1,3 @@
+project('line')
+
+msg = 'this is a very long line, and it should be be wrapped because we have line length limit of 120, not 60'


### PR DESCRIPTION
Which happens when a .editorconfig is in a subdirectory, not the root. In this case we need Set the fallback value to `False`, which is what editorconfig expects.

Closes: #13568