### PR TITLE
mformat: provide nice error message instead of traceback for invalid value

### DIFF
--- a/mesonbuild/mformat.py
+++ b/mesonbuild/mformat.py
@@ -861,7 +861,11 @@ class Formatter:
 
             for f in fields(config):
                 getter = f.metadata['getter']
-                value = getter(cp, cp.default_section, f.name, fallback=None)
+                try:
+                    value = getter(cp, cp.default_section, f.name, fallback=None)
+                except ValueError as e:
+                    raise MesonException(
+                        f'Error parsing "{str(configuration_file)}", option "{f.name}", error: "{e!s}"')
                 if value is not None:
                     setattr(config, f.name, value)
 


### PR DESCRIPTION
I ran into this with `option = true;` (not the trailing `;`). Now we provide a nicer message instead of an uncaught Python traceback.

Closes: #13565