### PR TITLE
mformat: A triple string with a ' in it cannot be simplified

### DIFF
--- a/mesonbuild/mformat.py
+++ b/mesonbuild/mformat.py
@@ -338,7 +338,7 @@ class TrimWhitespaces(FullAstVisitor):
         self.enter_node(node)
 
         if self.config.simplify_string_literals:
-            if node.is_multiline and '\n' not in node.value:
+            if node.is_multiline and not any(x in node.value for x in ['\n', "'"]):
                 node.is_multiline = False
                 node.value = node.escape()
 

--- a/test cases/format/5 transform/default.expected.meson
+++ b/test cases/format/5 transform/default.expected.meson
@@ -47,6 +47,7 @@ d = {'a': 1, 'b': 2, 'c': 3}
 # string conversion
 'This is not a multiline'
 'This is not a fstring'
+'''This isn't convertible'''
 
 # group arg value
 arguments = [

--- a/test cases/format/5 transform/file_compare.py
+++ b/test cases/format/5 transform/file_compare.py
@@ -1,7 +1,31 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2024 Intel Corporation
 
+import argparse
 import sys
+import difflib
 
-with open(sys.argv[1], 'r', encoding='utf-8') as f, open(sys.argv[2], 'r', encoding='utf-8') as g:
-    if f.read() != g.read():
-        sys.exit('contents are not equal')
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('actual', help='The transformed contents')
+    parser.add_argument('expected', help='the contents we expected')
+    args = parser.parse_args()
+
+    with open(args.actual, 'r') as f:
+        actual = f.readlines()
+    with open(args.expected, 'r') as f:
+        expected = f.readlines()
+
+    if actual == expected:
+        return 0
+
+    diff = difflib.ndiff(expected, actual)
+    for line in diff:
+        print(line, file=sys.stderr, end='')
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test cases/format/5 transform/muon.expected.meson
+++ b/test cases/format/5 transform/muon.expected.meson
@@ -47,6 +47,7 @@ d = {'a': 1, 'b': 2, 'c': 3}
 # string conversion
 '''This is not a multiline'''
 f'This is not a fstring'
+'''This isn't convertible'''
 
 # group arg value
 arguments = [

--- a/test cases/format/5 transform/options.expected.meson
+++ b/test cases/format/5 transform/options.expected.meson
@@ -29,6 +29,7 @@ d = {
 # string conversion
 'This is not a multiline'
 'This is not a fstring'
+'''This isn't convertible'''
 
 # group arg value
 arguments = [

--- a/test cases/format/5 transform/source.meson
+++ b/test cases/format/5 transform/source.meson
@@ -29,6 +29,7 @@ d = {'a': 1, 'b': 2, 'c': 3}
 # string conversion
 '''This is not a multiline'''
 f'This is not a fstring'
+'''This isn't convertible'''
 
 # group arg value
 arguments = ['a', '--opt_a', 'opt_a_value', 'b', 'c', '--opt_d', '--opt_e', 'opt_e_value',


### PR DESCRIPTION
The following is valid meson:
```meson
a = '''This string can't be simplified'''
```
which cannot be simplified because of the `'` in it, as
```meson
a = 'This string can't be simplified'
```
Is invalid.

Potentially we could convert that with escapes, but it seems reasonable
to me to leave this, since it may be desirable to not have lots of
escapes in a string. `'''I can't believe it's her's!'''` is much more
readable than `'I can\'t believe it\'s her\'s!'`, for example.

Closes: #13564