### PR TITLE
clang-tidy-fix: Avoid spawning too many threads

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3666,10 +3666,11 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         self.generate_clangtool('format', 'check')
 
     def generate_clangtidy(self) -> None:
-        import shutil
-        if not shutil.which('clang-tidy'):
+        if not environment.detect_clangtidy():
             return
         self.generate_clangtool('tidy')
+        if not environment.detect_clangapply():
+            return
         self.generate_clangtool('tidy', 'fix')
 
     def generate_tags(self, tool: str, target_name: str) -> None:

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -275,6 +275,32 @@ def detect_clangformat() -> T.List[str]:
             return [path]
     return []
 
+def detect_clangtidy() -> T.List[str]:
+    """ Look for clang-tidy binary on build platform
+
+    Return: a single-element list of the found clang-tidy binary ready to be
+        passed to Popen()
+    """
+    tools = get_llvm_tool_names('clang-tidy')
+    for tool in tools:
+        path = shutil.which(tool)
+        if path is not None:
+            return [path]
+    return []
+
+def detect_clangapply() -> T.List[str]:
+    """ Look for clang-apply-replacements binary on build platform
+
+    Return: a single-element list of the found clang-apply-replacements binary
+        ready to be passed to Popen()
+    """
+    tools = get_llvm_tool_names('clang-apply-replacements')
+    for tool in tools:
+        path = shutil.which(tool)
+        if path is not None:
+            return [path]
+    return []
+
 def detect_windows_arch(compilers: CompilersDict) -> str:
     """
     Detecting the 'native' architecture of Windows is not a trivial task. We


### PR DESCRIPTION
The `clang-tidy-fix` target spawns an excessive number of threads, because on top of Meson's thread pool `run-clang-tidy` also spawns a thread pool with `os.cpu_count()` threads. On a system with 96 CPU threads this results in over 3000 threads in practice, and if the number of threads is limited (e.g. [in a container](https://docs.podman.io/en/latest/markdown/podman-run.1.html#pids-limit-limit)) this causes errors at runtime.

This PR rewrites the `clang-tidy-fix` target to avoid `run-clang-tidy`, more specifically it performs the same task but exclusively on Meson's thread pool. In practice this means `clang-tidy` is invoked in parallel as normal but "fix-it" snippets are exported to `meson-private/clang-tidy-fix/`. Once the parallel phase is complete (to avoid filesystem races) the fixes are applied with a single invocation of `clang-apply-replacements`.

The search for both `clang-tidy` and `clang-apply-replacements` has been enhanced to attempt all binaries produced by `environment.get_llvm_tool_names`, identical to how `clang-format` is found. This allows the `clang-tidy` targets to be available even if only a versioned `clang-tidy` or `clang-apply-replacements` binary is available (e.g. on Debian/Ubuntu `clang-tidy-replacements` is only available with a version suffix).