### PR TITLE
mformat: regenerate long lines even if they're already multiline

### DIFF
--- a/mesonbuild/mformat.py
+++ b/mesonbuild/mformat.py
@@ -769,9 +769,8 @@ class ComputeLineLengths(FullAstVisitor):
     def split_if_needed(self, node: mparser.ArgumentNode) -> None:
         if len(node) and not node.is_multiline and self.length > self.config.max_line_length:
             arg = self.argument_stack[self.level] if len(self.argument_stack) > self.level else node
-            if not arg.is_multiline:
-                arg.is_multiline = True
-                self.need_regenerate = True
+            arg.is_multiline = True
+            self.need_regenerate = True
 
     def visit_ArgumentNode(self, node: mparser.ArgumentNode) -> None:
         self.argument_stack.append(node)

--- a/test cases/format/4 config/indentation.meson
+++ b/test cases/format/4 config/indentation.meson
@@ -71,3 +71,18 @@ if meson.project_version().version_compare('>1.2')
     endforeach
   endif
 endif
+
+subproject(
+  '@0@-@1@-@2@-@3@'.format(
+    meson.project_name(),
+    meson.project_version(),
+    meson.project_build_root(),
+    meson.project_source_root(),
+  ),
+  default_options : [
+    'aaaaaaaa=bbbbbbbbbb',
+    'cccccccccccc=ddddddddddddd',
+    'eeeeeeeeeeeeeee=fffffffffffff',
+    'gggggggggggggggggggggg=hhhhhhhhhhhhhhhhhhhh',
+  ],
+)


### PR DESCRIPTION
If `kwargs_force_multiline` is enabled, an `ArgumentNode` in a kwarg value can already be marked multiline by the time we notice that the line needs to be broken for length.  Ensure we still break the line in this case.

Fixes: #13512