### PR TITLE
Discard swiftc linker detect output

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -1248,7 +1248,7 @@ def detect_swift_compiler(env: 'Environment', for_machine: MachineChoice) -> Com
             cls = SwiftCompiler
             linker = guess_nix_linker(env,
                                       exelist, cls, version, for_machine,
-                                      extra_args=[f.name])
+                                      extra_args=[f.name, '-o /dev/null'])
         return cls(
             exelist, version, for_machine, is_cross, info, linker=linker)
 


### PR DESCRIPTION
`meson setup build` in swift project runs `swiftc -Xlinker -v some_tmp.swift` command to detect linker.
This leaves bunch of junk files like 'tmpc90jgpg7' in working directory. PR forwards output of command to /dev/null.