### PR TITLE
mtest: Extend MESON_TESTTHREADS usage

### DIFF
--- a/docs/markdown/Unit-tests.md
+++ b/docs/markdown/Unit-tests.md
@@ -89,6 +89,10 @@ variable `MESON_TESTTHREADS` like this.
 $ MESON_TESTTHREADS=5 meson test
 ```
 
+Setting `MESON_TESTTHREADS` to 0 enables the default behavior (core
+count), whereas setting an invalid value results in setting the job
+count to 1.
+
 ## Priorities
 
 *(added in version 0.52.0)*

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -99,13 +99,17 @@ def uniwidth(s: str) -> int:
 
 def determine_worker_count() -> int:
     varname = 'MESON_TESTTHREADS'
+    num_workers = 0
     if varname in os.environ:
         try:
             num_workers = int(os.environ[varname])
+            if num_workers < 0:
+                raise ValueError
         except ValueError:
             print(f'Invalid value in {varname}, using 1 thread.')
             num_workers = 1
-    else:
+
+    if num_workers == 0:
         try:
             # Fails in some weird environments such as Debian
             # reproducible build.


### PR DESCRIPTION
Previously, setting `MESON_TESTTHREADS` to a number lower than 1 resulted in unexpected behavior. This commit introduces test for negative value (with fallback to 1), and fallback to core count in case it is set to 0.

It improves experience in job-matrix type of CI workflows, where some jobs within the matrix require single job execution, whereas others can default to taking core count as the job count.