### PR TITLE
Can make deprecations into hard errors based on version.

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2298,7 +2298,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             if kwargs['install_dir'] is not None:
                 raise InterpreterException('install_headers: cannot specify both "install_dir" and "subdir". Use only "install_dir".')
             if os.path.isabs(install_subdir):
-                mlog.deprecation('Subdir keyword must not be an absolute path. This will be a hard error in the next release.')
+                mlog.deprecation('Subdir keyword must not be an absolute path.', error_since='1.6.99')
         else:
             install_subdir = ''
 

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -699,7 +699,7 @@ class FeatureNew(FeatureCheckBase):
         ]
         if self.extra_message:
             args.append(self.extra_message)
-        mlog.warning(*args, location=location)
+        mlog.deprecation(*args, location=location)
 
 class FeatureDeprecated(FeatureCheckBase):
     """Checks for deprecated features"""

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -346,7 +346,22 @@ class _Logger:
                     once: bool = False, fatal: bool = True,
                     location: T.Optional[BaseNode] = None,
                     nested: bool = True, sep: T.Optional[str] = None,
-                    end: T.Optional[str] = None) -> None:
+                    end: T.Optional[str] = None,
+                    error_since: T.Optional[str] = None) -> None:
+        if error_since is not None:
+            from .coredata import version
+            from .mesonlib import version_compare
+            from .mesonlib import MesonException
+            cmpstr = '>=' + error_since
+            if version_compare(version, cmpstr):
+                self._log_error(_Severity.ERROR, *args, once=once, fatal=True, location=location,
+                                nested=nested, sep=sep, end=end, is_error=True)
+                raise MesonException(f'\n  This deprecated functionality became an error in Meson {version}.')
+
+            else:
+                args = args + (f'\n  This will become a hard error in Meson version {version}.',)
+                self._log_error(_Severity.DEPRECATION, *args, once=once, fatal=fatal, location=location,
+                                nested=nested, sep=sep, end=end, is_error=True)
         return self._log_error(_Severity.DEPRECATION, *args, once=once, fatal=fatal, location=location,
                                nested=nested, sep=sep, end=end, is_error=True)
 


### PR DESCRIPTION
Add functionality to make deprecated features into hard errors "in the future". The basic idea is to give each deprecation a runway so that people can get their projects fixed with sufficient time, but also that the error will eventually happen without anyone having to remember to go back in the code and turn it into a hard error.

The default time should maybe be one year, so four releases? Dunno, comments welcome on that.

The example I converted was originally from 2022. People should have had that fixed by now.