### PR TITLE
Correct annotations in the options module

### DIFF
--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -141,7 +141,7 @@ class OptionKey:
     def __hash__(self) -> int:
         return self._hash
 
-    def _to_tuple(self) -> T.Tuple[str, str, str, MachineChoice, str]:
+    def _to_tuple(self) -> T.Tuple[str, MachineChoice, str]:
         return (self.subproject, self.machine, self.name)
 
     def __eq__(self, other: object) -> bool:

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -27,6 +27,16 @@ from .mesonlib import (
 )
 from . import mlog
 
+if T.TYPE_CHECKING:
+    from typing_extensions import TypedDict
+
+    class ArgparseKWs(TypedDict, total=False):
+
+        action: str
+        dest: str
+        default: str
+        choices: T.List
+
 DEFAULT_YIELDING = False
 
 # Can't bind this near the class method it seems, sadly.
@@ -566,7 +576,7 @@ class BuiltinOption(T.Generic[_T, _U]):
         return self.default
 
     def add_to_argparse(self, name: str, parser: argparse.ArgumentParser, help_suffix: str) -> None:
-        kwargs = OrderedDict()
+        kwargs: ArgparseKWs = {}
 
         c = self._argparse_choices()
         b = self._argparse_action()

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 from itertools import chain
 from functools import total_ordering
 import argparse
+import typing as T
 
 from .mesonlib import (
     HoldableObject,
@@ -23,11 +24,7 @@ from .mesonlib import (
     listify_array_value,
     MachineChoice,
 )
-
 from . import mlog
-
-import typing as T
-from typing import ItemsView
 
 DEFAULT_YIELDING = False
 
@@ -752,7 +749,7 @@ class OptionStore:
     def values(self):
         return self.d.values()
 
-    def items(self) -> ItemsView['OptionKey', 'UserOption[T.Any]']:
+    def items(self) -> T.ItemsView['OptionKey', 'UserOption[T.Any]']:
         return self.d.items()
 
     # FIXME: this method must be deleted and users moved to use "add_xxx_option"s instead.

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2013-2024 Contributors to the The Meson project
+# Copyright © 2019-2024 Intel Corporation
 
 from collections import OrderedDict
 from itertools import chain

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -671,16 +671,14 @@ BUILTIN_DIR_NOPREFIX_OPTIONS: T.Dict[OptionKey, T.Dict[str, str]] = {
 }
 
 class OptionStore:
-    def __init__(self):
+    def __init__(self) -> None:
         self.d: T.Dict['OptionKey', 'UserOption[T.Any]'] = {}
-        self.project_options = set()
-        self.all_languages = set()
-        self.module_options = set()
+        self.project_options: T.Set[OptionKey] = set()
+        self.module_options: T.Set[OptionKey] = set()
         from .compilers import all_languages
-        for lang in all_languages:
-            self.all_languages.add(lang)
+        self.all_languages = set(all_languages)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.d)
 
     def ensure_key(self, key: T.Union[OptionKey, str]) -> OptionKey:
@@ -694,29 +692,29 @@ class OptionStore:
     def get_value(self, key: T.Union[OptionKey, str]) -> 'T.Any':
         return self.get_value_object(key).value
 
-    def add_system_option(self, key: T.Union[OptionKey, str], valobj: 'UserOption[T.Any]'):
+    def add_system_option(self, key: T.Union[OptionKey, str], valobj: 'UserOption[T.Any]') -> None:
         key = self.ensure_key(key)
         if '.' in key.name:
             raise MesonException(f'Internal error: non-module option has a period in its name {key.name}.')
         self.add_system_option_internal(key, valobj)
 
-    def add_system_option_internal(self, key: T.Union[OptionKey, str], valobj: 'UserOption[T.Any]'):
+    def add_system_option_internal(self, key: T.Union[OptionKey, str], valobj: 'UserOption[T.Any]') -> None:
         key = self.ensure_key(key)
         assert isinstance(valobj, UserOption)
         self.d[key] = valobj
 
-    def add_compiler_option(self, language: str, key: T.Union[OptionKey, str], valobj: 'UserOption[T.Any]'):
+    def add_compiler_option(self, language: str, key: T.Union[OptionKey, str], valobj: 'UserOption[T.Any]') -> None:
         key = self.ensure_key(key)
         if not key.name.startswith(language + '_'):
             raise MesonException(f'Internal error: all compiler option names must start with language prefix. ({key.name} vs {language}_)')
         self.add_system_option(key, valobj)
 
-    def add_project_option(self, key: T.Union[OptionKey, str], valobj: 'UserOption[T.Any]'):
+    def add_project_option(self, key: T.Union[OptionKey, str], valobj: 'UserOption[T.Any]') -> None:
         key = self.ensure_key(key)
         self.d[key] = valobj
         self.project_options.add(key)
 
-    def add_module_option(self, modulename: str, key: T.Union[OptionKey, str], valobj: 'UserOption[T.Any]'):
+    def add_module_option(self, modulename: str, key: T.Union[OptionKey, str], valobj: 'UserOption[T.Any]') -> None:
         key = self.ensure_key(key)
         if key.name.startswith('build.'):
             raise MesonException('FATAL internal error: somebody goofed option handling.')
@@ -730,38 +728,38 @@ class OptionStore:
         return self.d[key].set_value(new_value)
 
     # FIXME, this should be removed.or renamed to "change_type_of_existing_object" or something like that
-    def set_value_object(self, key: T.Union[OptionKey, str], new_object: 'UserOption[T.Any]') -> bool:
+    def set_value_object(self, key: T.Union[OptionKey, str], new_object: 'UserOption[T.Any]') -> None:
         key = self.ensure_key(key)
         self.d[key] = new_object
 
-    def remove(self, key):
+    def remove(self, key: OptionKey) -> None:
         del self.d[key]
 
-    def __contains__(self, key):
+    def __contains__(self, key: OptionKey) -> bool:
         key = self.ensure_key(key)
         return key in self.d
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return repr(self.d)
 
-    def keys(self):
+    def keys(self) -> T.KeysView[OptionKey]:
         return self.d.keys()
 
-    def values(self):
+    def values(self) -> T.ValuesView[UserOption[T.Any]]:
         return self.d.values()
 
     def items(self) -> T.ItemsView['OptionKey', 'UserOption[T.Any]']:
         return self.d.items()
 
     # FIXME: this method must be deleted and users moved to use "add_xxx_option"s instead.
-    def update(self, *args, **kwargs):
-        return self.d.update(*args, **kwargs)
+    def update(self, **kwargs: UserOption[T.Any]) -> None:
+        self.d.update(**kwargs)
 
-    def setdefault(self, k, o):
+    def setdefault(self, k: OptionKey, o: UserOption[T.Any]) -> UserOption[T.Any]:
         return self.d.setdefault(k, o)
 
-    def get(self, *args, **kwargs) -> UserOption:
-        return self.d.get(*args, **kwargs)
+    def get(self, o: OptionKey, default: T.Optional[UserOption[T.Any]] = None) -> T.Optional[UserOption[T.Any]]:
+        return self.d.get(o, default)
 
     def is_project_option(self, key: OptionKey) -> bool:
         """Convenience method to check if this is a project option."""

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -2,6 +2,7 @@
 # Copyright 2013-2024 Contributors to the The Meson project
 # Copyright © 2019-2024 Intel Corporation
 
+from __future__ import annotations
 from collections import OrderedDict
 from itertools import chain
 from functools import total_ordering


### PR DESCRIPTION
This fixes the `OptionKey` type, as well as the `OptionStore` type. I have in mind a solution for the `UserOption` type, but it will be  a refactor rather than simply fixing annotations