### PR TITLE
Feature checks: fall back to reporting insufficiently portable features

### DIFF
--- a/docs/markdown/snippets/always_report_deprecations.md
+++ b/docs/markdown/snippets/always_report_deprecations.md
@@ -1,0 +1,29 @@
+## Default to printing deprecations when no minimum version is specified.
+
+For a long time, the [[project]] function has supported specifying the minimum
+`meson_version:` needed by a project. When this is used, deprecated features
+from before that version produce warnings, as do features which aren't
+available in all supported versions.
+
+When no minimum version was specified, meson didn't warn you even about
+deprecated functionality that might go away in an upcoming semver major release
+of meson.
+
+Now, meson will treat an unspecified minimum version following semver:
+
+- For new features introduced in the current meson semver major cycle
+  (currently: all features added since 1.0) a warning is printed. Features that
+  have been available since the initial 1.0 release are assumed to be widely
+  available.
+
+- For features that have been deprecated by any version of meson, a warning is
+  printed. Since no minimum version was specified, it is assumed that the
+  project wishes to follow the latest and greatest functionality.
+
+These warnings will overlap for functionality that was both deprecated and
+replaced with an alternative in the current release cycle. The combination
+means that projects without a minimum version specified are assumed to want
+broad compatibility with the current release cycle (1.x).
+
+Projects that specify a minimum `meson_version:` will continue to only receive
+actionable warnings based on their current minimum version.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1702,7 +1702,7 @@ class BuildTarget(Target):
                 else:
                     mlog.deprecation(f'target {self.name} links against shared module {link_target.name}, which is incorrect.'
                                      '\n             '
-                                     f'This will be an error in the future, so please use shared_library() for {link_target.name} instead.'
+                                     f'This will be an error in meson 2.0, so please use shared_library() for {link_target.name} instead.'
                                      '\n             '
                                      f'If shared_module() was used for {link_target.name} because it has references to undefined symbols,'
                                      '\n             '

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -694,7 +694,7 @@ class Environment:
                     key = OptionKey.from_string(k)
                     # If we're in the cross file, and there is a `build.foo` warn about that. Later we'll remove it.
                     if machine is MachineChoice.HOST and key.machine is not machine:
-                        mlog.deprecation('Setting build machine options in cross files, please use a native file instead, this will be removed in meson 0.60', once=True)
+                        mlog.deprecation('Setting build machine options in cross files, please use a native file instead, this will be removed in meson 2.0', once=True)
                     if key.subproject:
                         raise MesonException('Do not set subproject options in [built-in options] section, use [subproject:built-in options] instead.')
                     self.options[key.evolve(subproject=subproject, machine=machine)] = v

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -256,7 +256,7 @@ permitted_dependency_kwargs = {
 
 implicit_check_false_warning = """You should add the boolean check kwarg to the run_command call.
          It currently defaults to false,
-         but it will default to true in future releases of meson.
+         but it will default to true in meson 2.0.
          See also: https://github.com/mesonbuild/meson/issues/9300"""
 class Interpreter(InterpreterBase, HoldableObject):
 
@@ -2300,7 +2300,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             if kwargs['install_dir'] is not None:
                 raise InterpreterException('install_headers: cannot specify both "install_dir" and "subdir". Use only "install_dir".')
             if os.path.isabs(install_subdir):
-                mlog.deprecation('Subdir keyword must not be an absolute path. This will be a hard error in the next release.')
+                mlog.deprecation('Subdir keyword must not be an absolute path. This will be a hard error in meson 2.0.')
         else:
             install_subdir = ''
 
@@ -3157,7 +3157,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                 if not strict and s.startswith(self.environment.get_build_dir()):
                     results.append(s)
                     mlog.warning(f'Source item {s!r} cannot be converted to File object, because it is a generated file. '
-                                 'This will become a hard error in the future.', location=self.current_node)
+                                 'This will become a hard error in meson 2.0.', location=self.current_node)
                 else:
                     self.validate_within_subproject(self.subdir, s)
                     results.append(mesonlib.File.from_source_file(self.environment.source_dir, self.subdir, s))

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1178,6 +1178,8 @@ class Interpreter(InterpreterBase, HoldableObject):
         # for things like deprecation testing.
         if kwargs['meson_version']:
             self.handle_meson_version(kwargs['meson_version'], node)
+        else:
+            mesonlib.project_meson_versions[self.subproject] = mesonlib.NoProjectVersion()
 
         # Load "meson.options" before "meson_options.txt", and produce a warning if
         # it is being used with an old version. I have added check that if both

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -938,7 +938,7 @@ class BuildTargetHolder(ObjectHolder[_BuildTarget]):
                 extract_all_objects called without setting recursive
                 keyword argument. Meson currently defaults to
                 non-recursive to maintain backward compatibility but
-                the default will be changed in the future.
+                the default will be changed in meson 2.0.
             ''')
         )
     )

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -127,7 +127,7 @@ class DependenciesHelper:
                          'to generate() method instead of first positional '
                          'argument.', 'Adding', mlog.bold(data.display_name),
                          'to "Requires" field, but this is a deprecated '
-                         'behaviour that will change in a future version '
+                         'behaviour that will change in version 2.0 '
                          'of Meson. Please report the issue if this '
                          'warning cannot be avoided in your case.',
                          location=data.location)

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -362,7 +362,7 @@ class ArgumentNode(BaseNode):
     def set_kwarg(self, name: IdNode, value: BaseNode) -> None:
         if any((isinstance(x, IdNode) and name.value == x.value) for x in self.kwargs):
             mlog.warning(f'Keyword argument "{name.value}" defined multiple times.', location=self)
-            mlog.warning('This will be an error in future Meson releases.')
+            mlog.warning('This will be an error in Meson 2.0.')
         self.kwargs[name] = value
 
     def set_kwarg_no_check(self, name: BaseNode, value: BaseNode) -> None:

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -409,7 +409,7 @@ class UserArrayOption(UserOption[T.List[str]]):
 
         if not self.allow_dups and len(set(newvalue)) != len(newvalue):
             msg = 'Duplicated values in array option is deprecated. ' \
-                  'This will become a hard error in the future.'
+                  'This will become a hard error in meson 2.0.'
             mlog.deprecation(msg)
         for i in newvalue:
             if not isinstance(i, str):
@@ -500,7 +500,7 @@ class UserStdOption(UserComboOption):
                 mlog.deprecation(
                     f'None of the values {candidates} are supported by the {self.lang} compiler.\n' +
                     f'However, the deprecated {std} std currently falls back to {newstd}.\n' +
-                    'This will be an error in the future.\n' +
+                    'This will be an error in meson 2.0.\n' +
                     'If the project supports both GNU and MSVC compilers, a value such as\n' +
                     '"c_std=gnu11,c11" specifies that GNU is preferred but it can safely fallback to plain c11.')
                 return newstd

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -57,6 +57,7 @@ _U = T.TypeVar('_U')
 __all__ = [
     'GIT',
     'python_command',
+    'NoProjectVersion',
     'project_meson_versions',
     'SecondLevelHolder',
     'File',
@@ -157,10 +158,13 @@ __all__ = [
 ]
 
 
+class NoProjectVersion:
+    pass
+
 # TODO: this is such a hack, this really should be either in coredata or in the
 # interpreter
 # {subproject: project_meson_version}
-project_meson_versions: T.DefaultDict[str, str] = collections.defaultdict(str)
+project_meson_versions: T.Dict[str, T.Union[str, NoProjectVersion]] = {}
 
 
 from glob import glob

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -2464,7 +2464,7 @@ class AllPlatformTests(BasePlatformTests):
         tdir = os.path.join(self.unit_test_dir, '30 shared_mod linking')
         out = self.init(tdir)
         msg = ('''DEPRECATION: target prog links against shared module mymod, which is incorrect.
-             This will be an error in the future, so please use shared_library() for mymod instead.
+             This will be an error in meson 2.0, so please use shared_library() for mymod instead.
              If shared_module() was used for mymod because it has references to undefined symbols,
              use shared_library() with `override_options: ['b_lundef=false']` instead.''')
         self.assertIn(msg, out)


### PR DESCRIPTION
When projects do not specify a minimum meson version, we used to avoid giving them the benefit of the Feature checks framework. Instead:

- warn for features that were added after the most recent semver bump, since they aren't portable to the range of versions people might use these days

- warn for features that were deprecated before the upcoming semver bump, i.e. all deprecated features, since they aren't portable to upcoming semver-compatible versions people might be imminently upgrading to