### PR TITLE
Make the new options module fully type safe

### DIFF
--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -19,6 +19,7 @@ from .toolchain import CMakeToolchain, CMakeExecScope
 from .traceparser import CMakeTraceParser
 from .tracetargets import resolve_cmake_trace_targets
 from .. import mlog, mesonlib
+from .. import options
 from ..mesonlib import MachineChoice, OrderedSet, path_is_in_root, relative_to_if_possible
 from ..options import OptionKey
 from ..mesondata import DataFile
@@ -533,16 +534,11 @@ class ConverterTarget:
     @lru_cache(maxsize=None)
     def _all_lang_stds(self, lang: str) -> 'ImmutableListProtocol[str]':
         try:
-            res = self.env.coredata.optstore.get_value_object(OptionKey(f'{lang}_std', machine=MachineChoice.BUILD)).choices
+            opt = self.env.coredata.optstore.get_value_object(OptionKey(f'{lang}_std', machine=MachineChoice.BUILD))
+            assert isinstance(opt, (options.UserStdOption, options.UserComboOption)), 'for mypy'
+            return opt.choices or []
         except KeyError:
             return []
-
-        # TODO: Get rid of this once we have proper typing for options
-        assert isinstance(res, list)
-        for i in res:
-            assert isinstance(i, str)
-
-        return res
 
     def process_inter_target_dependencies(self) -> None:
         # Move the dependencies from all TRANSFER_DEPENDENCIES_FROM to the target

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -124,7 +124,7 @@ class ClangCCompiler(ClangCStds, ClangCompiler, CCompiler):
         opts = super().get_options()
         if self.info.is_windows() or self.info.is_cygwin():
             key = self.form_compileropt_key('winlibs')
-            opts[key] = options.UserArrayOption(
+            opts[key] = options.UserStringArrayOption(
                 self.make_option_name(key),
                 'Standard Windows libraries to link against',
                 gnu_winlibs)
@@ -257,7 +257,7 @@ class GnuCCompiler(GnuCStds, GnuCompiler, CCompiler):
         opts = super().get_options()
         if self.info.is_windows() or self.info.is_cygwin():
             key = self.form_compileropt_key('winlibs')
-            opts[key] = options.UserArrayOption(
+            opts[key] = options.UserStringArrayOption(
                 self.make_option_name(key),
                 'Standard Windows libraries to link against',
                 gnu_winlibs)
@@ -406,7 +406,7 @@ class VisualStudioLikeCCompilerMixin(CompilerMixinBase):
     def get_options(self) -> MutableKeyedOptionDictType:
         opts = super().get_options()
         key = self.form_compileropt_key('winlibs')
-        opts[key] = options.UserArrayOption(
+        opts[key] = options.UserStringArrayOption(
             self.make_option_name(key),
             'Standard Windows libraries to link against',
             msvc_winlibs)
@@ -733,9 +733,7 @@ class MetrowerksCCompilerARM(MetrowerksCompiler, CCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
-        c_stds = ['c99']
-        key = self.form_compileropt_key('std')
-        opts[key].choices = ['none'] + c_stds
+        self._update_language_stds(opts, ['c99'])
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
@@ -763,9 +761,7 @@ class MetrowerksCCompilerEmbeddedPowerPC(MetrowerksCompiler, CCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
-        c_stds = ['c99']
-        key = self.form_compileropt_key('std')
-        opts[key].choices = ['none'] + c_stds
+        self._update_language_stds(opts, ['c99'])
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -214,7 +214,7 @@ class ArmclangCCompiler(ArmclangCompiler, CCompiler):
                           'everything': ['-Weverything']}
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = CCompiler.get_options(self)
+        opts = super().get_options()
         key = self.form_compileropt_key('std')
         std_opt = opts[key]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
@@ -313,7 +313,7 @@ class NvidiaHPC_CCompiler(PGICompiler, CCompiler):
         PGICompiler.__init__(self)
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = CCompiler.get_options(self)
+        opts = super().get_options()
         cppstd_choices = ['c89', 'c90', 'c99', 'c11', 'c17', 'c18']
         std_opt = opts[self.form_compileropt_key('std')]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
@@ -332,7 +332,7 @@ class ElbrusCCompiler(ElbrusCompiler, CCompiler):
         ElbrusCompiler.__init__(self)
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = CCompiler.get_options(self)
+        opts = super().get_options()
         stds = ['c89', 'c9x', 'c99', 'gnu89', 'gnu9x', 'gnu99']
         stds += ['iso9899:1990', 'iso9899:199409', 'iso9899:1999']
         if version_compare(self.version, '>=1.20.00'):
@@ -379,7 +379,7 @@ class IntelCCompiler(IntelGnuLikeCompiler, CCompiler):
                           'everything': default_warn_args + ['-Wextra']}
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = CCompiler.get_options(self)
+        opts = super().get_options()
         stds = ['c89', 'c99']
         if version_compare(self.version, '>=16.0.0'):
             stds += ['c11']
@@ -536,7 +536,7 @@ class ArmCCompiler(ArmCompiler, CCompiler):
         ArmCompiler.__init__(self)
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = CCompiler.get_options(self)
+        opts = super().get_options()
         key = self.form_compileropt_key('std')
         std_opt = opts[key]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
@@ -566,7 +566,7 @@ class CcrxCCompiler(CcrxCompiler, CCompiler):
         return ['-nologo']
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = CCompiler.get_options(self)
+        opts = super().get_options()
         key = self.form_compileropt_key('std')
         std_opt = opts[key]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
@@ -614,7 +614,7 @@ class Xc16CCompiler(Xc16Compiler, CCompiler):
         Xc16Compiler.__init__(self)
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = CCompiler.get_options(self)
+        opts = super().get_options()
         key = self.form_compileropt_key('std')
         std_opt = opts[key]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
@@ -660,7 +660,7 @@ class CompCertCCompiler(CompCertCompiler, CCompiler):
         CompCertCompiler.__init__(self)
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = CCompiler.get_options(self)
+        opts = super().get_options()
         key = self.form_compileropt_key('std')
         std_opt = opts[key]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
@@ -698,7 +698,7 @@ class TICCompiler(TICompiler, CCompiler):
         return []
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = CCompiler.get_options(self)
+        opts = super().get_options()
         key = self.form_compileropt_key('std')
         std_opt = opts[key]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
@@ -738,7 +738,7 @@ class MetrowerksCCompilerARM(MetrowerksCompiler, CCompiler):
         return mwccarm_instruction_set_args.get(instruction_set, None)
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = CCompiler.get_options(self)
+        opts = super().get_options()
         c_stds = ['c99']
         key = self.form_compileropt_key('std')
         opts[key].choices = ['none'] + c_stds
@@ -768,7 +768,7 @@ class MetrowerksCCompilerEmbeddedPowerPC(MetrowerksCompiler, CCompiler):
         return mwcceppc_instruction_set_args.get(instruction_set, None)
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = CCompiler.get_options(self)
+        opts = super().get_options()
         c_stds = ['c99']
         key = self.form_compileropt_key('std')
         opts[key].choices = ['none'] + c_stds

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -99,7 +99,7 @@ class CCompiler(CLikeCompiler, Compiler):
         opts = super().get_options()
         key = self.form_compileropt_key('std')
         opts.update({
-            key: options.UserStdOption('C', ALL_STDS),
+            key: options.UserStdOption('c', ALL_STDS),
         })
         return opts
 

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -123,13 +123,11 @@ class ClangCCompiler(ClangCStds, ClangCompiler, CCompiler):
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
         if self.info.is_windows() or self.info.is_cygwin():
-            self.update_options(
-                opts,
-                self.create_option(options.UserArrayOption,
-                                   self.form_compileropt_key('winlibs'),
-                                   'Standard Windows libs to link against',
-                                   gnu_winlibs),
-            )
+            key = self.form_compileropt_key('winlibs')
+            opts[key] = options.UserArrayOption(
+                self.make_option_name(key),
+                'Standard Windows libraries to link against',
+                gnu_winlibs)
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
@@ -258,13 +256,11 @@ class GnuCCompiler(GnuCStds, GnuCompiler, CCompiler):
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
         if self.info.is_windows() or self.info.is_cygwin():
-            self.update_options(
-                opts,
-                self.create_option(options.UserArrayOption,
-                                   self.form_compileropt_key('winlibs'),
-                                   'Standard Windows libs to link against',
-                                   gnu_winlibs),
-            )
+            key = self.form_compileropt_key('winlibs')
+            opts[key] = options.UserArrayOption(
+                self.make_option_name(key),
+                'Standard Windows libraries to link against',
+                gnu_winlibs)
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
@@ -408,15 +404,13 @@ class VisualStudioLikeCCompilerMixin(CompilerMixinBase):
     """Shared methods that apply to MSVC-like C compilers."""
 
     def get_options(self) -> MutableKeyedOptionDictType:
-        return self.update_options(
-            super().get_options(),
-            self.create_option(
-                options.UserArrayOption,
-                self.form_compileropt_key('winlibs'),
-                'Standard Windows libs to link against',
-                msvc_winlibs,
-            ),
-        )
+        opts = super().get_options()
+        key = self.form_compileropt_key('winlibs')
+        opts[key] = options.UserArrayOption(
+            self.make_option_name(key),
+            'Standard Windows libraries to link against',
+            msvc_winlibs)
+        return opts
 
     def get_option_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         # need a TypeDict to make this work

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -35,7 +35,6 @@ if T.TYPE_CHECKING:
     from ..dependencies import Dependency
 
     CompilerType = T.TypeVar('CompilerType', bound='Compiler')
-    UserOptionType = T.TypeVar('UserOptionType', bound=options.UserOption)
 
 _T = T.TypeVar('_T')
 
@@ -592,7 +591,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         return f'{self.language}_{key.name}'
 
     @staticmethod
-    def update_options(options: MutableKeyedOptionDictType, *args: T.Tuple[OptionKey, UserOptionType]) -> MutableKeyedOptionDictType:
+    def update_options(options: MutableKeyedOptionDictType, *args: T.Tuple[OptionKey, options.AnyOptionType]) -> MutableKeyedOptionDictType:
         options.update(args)
         return options
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2012-2022 The Meson development team
-# Copyright © 2023-2024 Intel Corporation
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 
@@ -20,9 +20,7 @@ from ..mesonlib import (
     EnvironmentException, MesonException,
     Popen_safe_logged, LibType, TemporaryDirectoryWinProof,
 )
-
 from ..options import OptionKey
-
 from ..arglist import CompilerArgs
 
 if T.TYPE_CHECKING:
@@ -37,8 +35,9 @@ if T.TYPE_CHECKING:
     from ..dependencies import Dependency
 
     CompilerType = T.TypeVar('CompilerType', bound='Compiler')
-    _T = T.TypeVar('_T')
     UserOptionType = T.TypeVar('UserOptionType', bound=options.UserOption)
+
+_T = T.TypeVar('_T')
 
 """This file contains the data files of all compilers Meson knows
 about. To support a new compiler, add its information below.
@@ -216,18 +215,20 @@ clike_debug_args: T.Dict[bool, T.List[str]] = {
 
 MSCRT_VALS = ['none', 'md', 'mdd', 'mt', 'mtd']
 
+
 @dataclass
-class BaseOption(T.Generic[options._T, options._U]):
-    opt_type: T.Type[options._U]
+class BaseOption(T.Generic[_T]):
+    opt_type: T.Type[options.UserOption[_T]]
     description: str
     default: T.Any = None
     choices: T.Any = None
 
-    def init_option(self, name: OptionKey) -> options._U:
+    def init_option(self, name: OptionKey) -> options.UserOption[_T]:
         keywords = {'value': self.default}
         if self.choices:
             keywords['choices'] = self.choices
         return self.opt_type(name.name, self.description, **keywords)
+
 
 BASE_OPTIONS: T.Mapping[OptionKey, BaseOption] = {
     OptionKey('b_pch'): BaseOption(options.UserBooleanOption, 'Use precompiled headers', True),

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1359,6 +1359,15 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
     def form_compileropt_key(self, basename: str) -> OptionKey:
         return OptionKey(f'{self.language}_{basename}', machine=self.for_machine)
 
+    def _update_language_stds(self, opts: MutableKeyedOptionDictType, value: T.List[str]) -> None:
+        key = self.form_compileropt_key('std')
+        std = opts[key]
+        assert isinstance(std, (options.UserStdOption, options.UserComboOption)), 'for mypy'
+        if 'none' not in value:
+            value = ['none'] + value
+        std.choices = value
+
+
 def get_global_options(lang: str,
                        comp: T.Type[Compiler],
                        for_machine: MachineChoice,
@@ -1374,12 +1383,12 @@ def get_global_options(lang: str,
     comp_options = env.options.get(comp_key, [])
     link_options = env.options.get(largkey, [])
 
-    cargs = options.UserArrayOption(
+    cargs = options.UserStringArrayOption(
         f'{lang}_{argkey.name}',
         description + ' compiler',
         comp_options, split_args=True, allow_dups=True)
 
-    largs = options.UserArrayOption(
+    largs = options.UserStringArrayOption(
         f'{lang}_{largkey.name}',
         description + ' linker',
         link_options, split_args=True, allow_dups=True)

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -224,16 +224,16 @@ class BaseOption(T.Generic[_T]):
     choices: T.Any = None
 
     def init_option(self, name: OptionKey) -> options.UserOption[_T]:
-        keywords = {'value': self.default}
+        keywords = {}
         if self.choices:
             keywords['choices'] = self.choices
-        return self.opt_type(name.name, self.description, **keywords)
+        return self.opt_type(name.name, self.description, self.default, **keywords)
 
 
 BASE_OPTIONS: T.Mapping[OptionKey, BaseOption] = {
     OptionKey('b_pch'): BaseOption(options.UserBooleanOption, 'Use precompiled headers', True),
     OptionKey('b_lto'): BaseOption(options.UserBooleanOption, 'Use link time optimization', False),
-    OptionKey('b_lto_threads'): BaseOption(options.UserIntegerOption, 'Use multiple threads for Link Time Optimization', (None, None, 0)),
+    OptionKey('b_lto_threads'): BaseOption(options.UserIntegerOption, 'Use multiple threads for Link Time Optimization', 0),
     OptionKey('b_lto_mode'): BaseOption(options.UserComboOption, 'Select between different LTO modes.', 'default',
                                         choices=['default', 'thin']),
     OptionKey('b_thinlto_cache'): BaseOption(options.UserBooleanOption, 'Use LLVM ThinLTO caching for faster incremental builds', False),

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -588,8 +588,8 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         """
         return []
 
-    def create_option(self, option_type: T.Type[UserOptionType], option_key: OptionKey, *args: T.Any, **kwargs: T.Any) -> T.Tuple[OptionKey, UserOptionType]:
-        return option_key, option_type(f'{self.language}_{option_key.name}', *args, **kwargs)
+    def make_option_name(self, key: OptionKey) -> str:
+        return f'{self.language}_{key.name}'
 
     @staticmethod
     def update_options(options: MutableKeyedOptionDictType, *args: T.Tuple[OptionKey, UserOptionType]) -> MutableKeyedOptionDictType:

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -242,8 +242,8 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCPPStds, ClangCompiler, CPPCompiler
         opts[key] = options.UserComboOption(
             self.make_option_name(key),
             'C++ exception handling type.',
-            ['none', 'default', 'a', 's', 'sc'],
-            'default')
+            'default',
+            ['none', 'default', 'a', 's', 'sc'])
 
         key = self.form_compileropt_key('rtti')
         opts[key] = options.UserBooleanOption(
@@ -398,8 +398,8 @@ class ArmclangCPPCompiler(ArmclangCompiler, CPPCompiler):
         opts[key] = options.UserComboOption(
             self.make_option_name(key),
             'C++ exception handling type.',
-            ['none', 'default', 'a', 's', 'sc'],
-            'default')
+            'default',
+            ['none', 'default', 'a', 's', 'sc'])
 
         key = self.form_compileropt_key('std')
         std_opt = opts[key]
@@ -448,8 +448,8 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCPPStds, GnuCompiler, CPPCompiler):
         opts[key] = options.UserComboOption(
             self.make_option_name(key),
             'C++ exception handling type.',
-            ['none', 'default', 'a', 's', 'sc'],
-            'default')
+            'default',
+            ['none', 'default', 'a', 's', 'sc'])
 
         key = self.form_compileropt_key('rtti')
         opts[key] = options.UserBooleanOption(
@@ -577,8 +577,8 @@ class ElbrusCPPCompiler(ElbrusCompiler, CPPCompiler):
         opts[key] = options.UserComboOption(
             self.make_option_name(key),
             'C++ exception handling type.',
-            ['none', 'default', 'a', 's', 'sc'],
-            'default')
+            'default',
+            ['none', 'default', 'a', 's', 'sc'])
 
         key = self.form_compileropt_key('debugstl')
         opts[key] = options.UserBooleanOption(
@@ -660,8 +660,8 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
         opts[key] = options.UserComboOption(
             self.make_option_name(key),
             'C++ exception handling type.',
-            ['none', 'default', 'a', 's', 'sc'],
-            'default')
+            'default',
+            ['none', 'default', 'a', 's', 'sc'])
 
         key = self.form_compileropt_key('rtti')
         opts[key] = options.UserBooleanOption(
@@ -753,8 +753,8 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
         opts[key] = options.UserComboOption(
             self.make_option_name(key),
             'C++ exception handling type.',
-            ['none', 'default', 'a', 's', 'sc'],
-            'default')
+            'default',
+            ['none', 'default', 'a', 's', 'sc'])
 
         key = self.form_compileropt_key('rtti')
         opts[key] = options.UserBooleanOption(

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -175,7 +175,7 @@ class CPPCompiler(CLikeCompiler, Compiler):
         opts = super().get_options()
         key = self.form_compileropt_key('std')
         opts.update({
-            key: options.UserStdOption('C++', ALL_STDS),
+            key: options.UserStdOption('cpp', ALL_STDS),
         })
         return opts
 

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -390,7 +390,7 @@ class ArmclangCPPCompiler(ArmclangCompiler, CPPCompiler):
                           'everything': ['-Weverything']}
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = CPPCompiler.get_options(self)
+        opts = super().get_options()
         key = self.form_compileropt_key('std')
         self.update_options(
             opts,
@@ -545,7 +545,7 @@ class NvidiaHPC_CPPCompiler(PGICompiler, CPPCompiler):
         PGICompiler.__init__(self)
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = CPPCompiler.get_options(self)
+        opts = super().get_options()
         cppstd_choices = [
             'c++98', 'c++03', 'c++11', 'c++14', 'c++17', 'c++20', 'c++23',
             'gnu++98', 'gnu++03', 'gnu++11', 'gnu++14', 'gnu++17', 'gnu++20'
@@ -567,7 +567,7 @@ class ElbrusCPPCompiler(ElbrusCompiler, CPPCompiler):
         ElbrusCompiler.__init__(self)
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = CPPCompiler.get_options(self)
+        opts = super().get_options()
 
         cpp_stds = ['c++98']
         if version_compare(self.version, '>=1.20.00'):
@@ -649,7 +649,7 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
                           'everything': default_warn_args + ['-Wextra']}
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = CPPCompiler.get_options(self)
+        opts = super().get_options()
         # Every Unix compiler under the sun seems to accept -std=c++03,
         # with the exception of ICC. Instead of preventing the user from
         # globally requesting C++03, we transparently remap it to C++98
@@ -923,7 +923,7 @@ class ArmCPPCompiler(ArmCompiler, CPPCompiler):
         ArmCompiler.__init__(self)
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = CPPCompiler.get_options(self)
+        opts = super().get_options()
         std_opt = self.form_compileropt_key('std')
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
         std_opt.set_versions(['c++03', 'c++11'])
@@ -984,7 +984,7 @@ class TICPPCompiler(TICompiler, CPPCompiler):
         TICompiler.__init__(self)
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = CPPCompiler.get_options(self)
+        opts = super().get_options()
         key = self.form_compileropt_key('std')
         std_opt = opts[key]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
@@ -1027,7 +1027,7 @@ class MetrowerksCPPCompilerARM(MetrowerksCompiler, CPPCompiler):
         return mwccarm_instruction_set_args.get(instruction_set, None)
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = CPPCompiler.get_options(self)
+        opts = super().get_options()
         key = self.form_compileropt_key('std')
         opts[key].choices = ['none']
         return opts
@@ -1056,7 +1056,7 @@ class MetrowerksCPPCompilerEmbeddedPowerPC(MetrowerksCompiler, CPPCompiler):
         return mwcceppc_instruction_set_args.get(instruction_set, None)
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = CPPCompiler.get_options(self)
+        opts = super().get_options()
         key = self.form_compileropt_key('std')
         opts[key].choices = ['none']
         return opts

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -237,30 +237,32 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCPPStds, ClangCompiler, CPPCompiler
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
-        self.update_options(
-            opts,
-            self.create_option(options.UserComboOption,
-                               self.form_compileropt_key('eh'),
-                               'C++ exception handling type',
-                               ['none', 'default', 'a', 's', 'sc'],
-                               'default'),
-            self.create_option(options.UserBooleanOption,
-                               self.form_compileropt_key('rtti'),
-                               'Enable RTTI',
-                               True),
-            self.create_option(options.UserBooleanOption,
-                               self.form_compileropt_key('debugstl'),
-                               'STL debug mode',
-                               False),
-        )
+
+        key = self.form_compileropt_key('eh')
+        opts[key] = options.UserComboOption(
+            self.make_option_name(key),
+            'C++ exception handling type.',
+            ['none', 'default', 'a', 's', 'sc'],
+            'default')
+
+        key = self.form_compileropt_key('rtti')
+        opts[key] = options.UserBooleanOption(
+            self.make_option_name(key),
+            'Enable RTTI',
+            True)
+
+        key = self.form_compileropt_key('debugstl')
+        opts[key] = options.UserBooleanOption(
+            self.make_option_name(key),
+            'STL debug mode',
+            False)
+
         if self.info.is_windows() or self.info.is_cygwin():
-            self.update_options(
-                opts,
-                self.create_option(options.UserArrayOption,
-                                   self.form_compileropt_key('winlibs'),
-                                   'Standard Windows libs to link against',
-                                   gnu_winlibs),
-            )
+            key = self.form_compileropt_key('winlibs')
+            opts[key] = options.UserArrayOption(
+                self.make_option_name(key),
+                'Standard Win libraries to link against',
+                gnu_winlibs)
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
@@ -391,15 +393,15 @@ class ArmclangCPPCompiler(ArmclangCompiler, CPPCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
+
+        key = self.form_compileropt_key('eh')
+        opts[key] = options.UserComboOption(
+            self.make_option_name(key),
+            'C++ exception handling type.',
+            ['none', 'default', 'a', 's', 'sc'],
+            'default')
+
         key = self.form_compileropt_key('std')
-        self.update_options(
-            opts,
-            self.create_option(options.UserComboOption,
-                               key.evolve('eh'),
-                               'C++ exception handling type',
-                               ['none', 'default', 'a', 's', 'sc'],
-                               'default'),
-        )
         std_opt = opts[key]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
         std_opt.set_versions(['c++98', 'c++03', 'c++11', 'c++14', 'c++17'], gnu=True)
@@ -440,32 +442,34 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCPPStds, GnuCompiler, CPPCompiler):
                                          self.supported_warn_args(gnu_cpp_warning_args))}
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        key = self.form_compileropt_key('std')
         opts = super().get_options()
-        self.update_options(
-            opts,
-            self.create_option(options.UserComboOption,
-                               self.form_compileropt_key('eh'),
-                               'C++ exception handling type',
-                               ['none', 'default', 'a', 's', 'sc'],
-                               'default'),
-            self.create_option(options.UserBooleanOption,
-                               self.form_compileropt_key('rtti'),
-                               'Enable RTTI',
-                               True),
-            self.create_option(options.UserBooleanOption,
-                               self.form_compileropt_key('debugstl'),
-                               'STL debug mode',
-                               False),
-        )
+
+        key = self.form_compileropt_key('eh')
+        opts[key] = options.UserComboOption(
+            self.make_option_name(key),
+            'C++ exception handling type.',
+            ['none', 'default', 'a', 's', 'sc'],
+            'default')
+
+        key = self.form_compileropt_key('rtti')
+        opts[key] = options.UserBooleanOption(
+            self.make_option_name(key),
+            'Enable RTTI',
+            True)
+
+        key = self.form_compileropt_key('debugstl')
+        opts[key] = options.UserBooleanOption(
+            self.make_option_name(key),
+            'STL debug mode',
+            False)
+
         if self.info.is_windows() or self.info.is_cygwin():
-            self.update_options(
-                opts,
-                self.create_option(options.UserArrayOption,
-                                   key.evolve('cpp_winlibs'),
-                                   'Standard Windows libs to link against',
-                                   gnu_winlibs),
-            )
+            key = key.evolve(name='cpp_winlibs')
+            opts[key] = options.UserArrayOption(
+                self.make_option_name(key),
+                'Standard Win libraries to link against',
+                gnu_winlibs)
+
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
@@ -569,6 +573,19 @@ class ElbrusCPPCompiler(ElbrusCompiler, CPPCompiler):
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
 
+        key = self.form_compileropt_key('eh')
+        opts[key] = options.UserComboOption(
+            self.make_option_name(key),
+            'C++ exception handling type.',
+            ['none', 'default', 'a', 's', 'sc'],
+            'default')
+
+        key = self.form_compileropt_key('debugstl')
+        opts[key] = options.UserBooleanOption(
+            self.make_option_name(key),
+            'STL debug mode',
+            False)
+
         cpp_stds = ['c++98']
         if version_compare(self.version, '>=1.20.00'):
             cpp_stds += ['c++03', 'c++0x', 'c++11']
@@ -586,18 +603,6 @@ class ElbrusCPPCompiler(ElbrusCompiler, CPPCompiler):
             cpp_stds += ['c++20']
 
         key = self.form_compileropt_key('std')
-        self.update_options(
-            opts,
-            self.create_option(options.UserComboOption,
-                               self.form_compileropt_key('eh'),
-                               'C++ exception handling type',
-                               ['none', 'default', 'a', 's', 'sc'],
-                               'default'),
-            self.create_option(options.UserBooleanOption,
-                               self.form_compileropt_key('debugstl'),
-                               'STL debug mode',
-                               False),
-        )
         std_opt = opts[key]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
         std_opt.set_versions(cpp_stds, gnu=True)
@@ -650,6 +655,26 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
+
+        key = self.form_compileropt_key('eh')
+        opts[key] = options.UserComboOption(
+            self.make_option_name(key),
+            'C++ exception handling type.',
+            ['none', 'default', 'a', 's', 'sc'],
+            'default')
+
+        key = self.form_compileropt_key('rtti')
+        opts[key] = options.UserBooleanOption(
+            self.make_option_name(key),
+            'Enable RTTI',
+            True)
+
+        key = self.form_compileropt_key('debugstl')
+        opts[key] = options.UserBooleanOption(
+            self.make_option_name(key),
+            'STL debug mode',
+            False)
+
         # Every Unix compiler under the sun seems to accept -std=c++03,
         # with the exception of ICC. Instead of preventing the user from
         # globally requesting C++03, we transparently remap it to C++98
@@ -666,24 +691,7 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
             c_stds += ['c++2a']
             g_stds += ['gnu++2a']
 
-        key = self.form_compileropt_key('std')
-        self.update_options(
-            opts,
-            self.create_option(options.UserComboOption,
-                               self.form_compileropt_key('eh'),
-                               'C++ exception handling type',
-                               ['none', 'default', 'a', 's', 'sc'],
-                               'default'),
-            self.create_option(options.UserBooleanOption,
-                               self.form_compileropt_key('rtti'),
-                               'Enable RTTI',
-                               True),
-            self.create_option(options.UserBooleanOption,
-                               self.form_compileropt_key('debugstl'),
-                               'STL debug mode',
-                               False),
-        )
-        std_opt = opts[key]
+        std_opt = opts[self.form_compileropt_key('std')]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
         std_opt.set_versions(c_stds + g_stds)
         return opts
@@ -739,24 +747,28 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
         return T.cast('T.List[str]', options.get_value(key)[:])
 
     def _get_options_impl(self, opts: 'MutableKeyedOptionDictType', cpp_stds: T.List[str]) -> 'MutableKeyedOptionDictType':
-        key = self.form_compileropt_key('std')
-        self.update_options(
-            opts,
-            self.create_option(options.UserComboOption,
-                               self.form_compileropt_key('eh'),
-                               'C++ exception handling type',
-                               ['none', 'default', 'a', 's', 'sc'],
-                               'default'),
-            self.create_option(options.UserBooleanOption,
-                               self.form_compileropt_key('rtti'),
-                               'Enable RTTI',
-                               True),
-            self.create_option(options.UserArrayOption,
-                               self.form_compileropt_key('winlibs'),
-                               'Standard Windows libs to link against',
-                               msvc_winlibs),
-        )
-        std_opt = opts[key]
+        opts = super().get_options()
+
+        key = self.form_compileropt_key('eh')
+        opts[key] = options.UserComboOption(
+            self.make_option_name(key),
+            'C++ exception handling type.',
+            ['none', 'default', 'a', 's', 'sc'],
+            'default')
+
+        key = self.form_compileropt_key('rtti')
+        opts[key] = options.UserBooleanOption(
+            self.make_option_name(key),
+            'Enable RTTI',
+            True)
+
+        key = self.form_compileropt_key('winlibs')
+        opts[key] = options.UserArrayOption(
+            self.make_option_name(key),
+            'Standard Win libraries to link against',
+            msvc_winlibs)
+
+        std_opt = opts[self.form_compileropt_key('std')]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
         std_opt.set_versions(cpp_stds)
         return opts

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -243,7 +243,7 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCPPStds, ClangCompiler, CPPCompiler
             self.make_option_name(key),
             'C++ exception handling type.',
             'default',
-            ['none', 'default', 'a', 's', 'sc'])
+            choices=['none', 'default', 'a', 's', 'sc'])
 
         key = self.form_compileropt_key('rtti')
         opts[key] = options.UserBooleanOption(
@@ -259,7 +259,7 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCPPStds, ClangCompiler, CPPCompiler
 
         if self.info.is_windows() or self.info.is_cygwin():
             key = self.form_compileropt_key('winlibs')
-            opts[key] = options.UserArrayOption(
+            opts[key] = options.UserStringArrayOption(
                 self.make_option_name(key),
                 'Standard Win libraries to link against',
                 gnu_winlibs)
@@ -399,7 +399,7 @@ class ArmclangCPPCompiler(ArmclangCompiler, CPPCompiler):
             self.make_option_name(key),
             'C++ exception handling type.',
             'default',
-            ['none', 'default', 'a', 's', 'sc'])
+            choices=['none', 'default', 'a', 's', 'sc'])
 
         key = self.form_compileropt_key('std')
         std_opt = opts[key]
@@ -449,7 +449,7 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCPPStds, GnuCompiler, CPPCompiler):
             self.make_option_name(key),
             'C++ exception handling type.',
             'default',
-            ['none', 'default', 'a', 's', 'sc'])
+            choices=['none', 'default', 'a', 's', 'sc'])
 
         key = self.form_compileropt_key('rtti')
         opts[key] = options.UserBooleanOption(
@@ -465,7 +465,7 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCPPStds, GnuCompiler, CPPCompiler):
 
         if self.info.is_windows() or self.info.is_cygwin():
             key = key.evolve(name='cpp_winlibs')
-            opts[key] = options.UserArrayOption(
+            opts[key] = options.UserStringArrayOption(
                 self.make_option_name(key),
                 'Standard Win libraries to link against',
                 gnu_winlibs)
@@ -578,7 +578,7 @@ class ElbrusCPPCompiler(ElbrusCompiler, CPPCompiler):
             self.make_option_name(key),
             'C++ exception handling type.',
             'default',
-            ['none', 'default', 'a', 's', 'sc'])
+            choices=['none', 'default', 'a', 's', 'sc'])
 
         key = self.form_compileropt_key('debugstl')
         opts[key] = options.UserBooleanOption(
@@ -661,7 +661,7 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
             self.make_option_name(key),
             'C++ exception handling type.',
             'default',
-            ['none', 'default', 'a', 's', 'sc'])
+            choices=['none', 'default', 'a', 's', 'sc'])
 
         key = self.form_compileropt_key('rtti')
         opts[key] = options.UserBooleanOption(
@@ -691,9 +691,7 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
             c_stds += ['c++2a']
             g_stds += ['gnu++2a']
 
-        std_opt = opts[self.form_compileropt_key('std')]
-        assert isinstance(std_opt, options.UserStdOption), 'for mypy'
-        std_opt.set_versions(c_stds + g_stds)
+        self._update_language_stds(opts, c_stds + g_stds)
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
@@ -754,7 +752,7 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
             self.make_option_name(key),
             'C++ exception handling type.',
             'default',
-            ['none', 'default', 'a', 's', 'sc'])
+            choices=['none', 'default', 'a', 's', 'sc'])
 
         key = self.form_compileropt_key('rtti')
         opts[key] = options.UserBooleanOption(
@@ -763,7 +761,7 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
             True)
 
         key = self.form_compileropt_key('winlibs')
-        opts[key] = options.UserArrayOption(
+        opts[key] = options.UserStringArrayOption(
             self.make_option_name(key),
             'Standard Win libraries to link against',
             msvc_winlibs)
@@ -1040,8 +1038,7 @@ class MetrowerksCPPCompilerARM(MetrowerksCompiler, CPPCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
-        key = self.form_compileropt_key('std')
-        opts[key].choices = ['none']
+        self._update_language_stds(opts, [])
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
@@ -1069,8 +1066,7 @@ class MetrowerksCPPCompilerEmbeddedPowerPC(MetrowerksCompiler, CPPCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
-        key = self.form_compileropt_key('std')
-        opts[key].choices = ['none']
+        self._update_language_stds(opts, [])
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -648,12 +648,13 @@ class CudaCompiler(Compiler):
 
         opts = super().get_options()
 
+        # XXX: cpp_std is correct, the annotations are wrong
         key = self.form_compileropt_key('std')
         opts[key] = options.UserComboOption(
             self.make_option_name(key),
             'C++ language standard to use with CUDA',
-            cpp_stds,
-            'none')
+            'none',
+            cpp_stds)
 
         key = self.form_compileropt_key('ccbindir')
         opts[key] = options.UserStringOption(

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -646,18 +646,22 @@ class CudaCompiler(Compiler):
         if version_compare(self.version, self._CPP20_VERSION):
             cpp_stds += ['c++20']
 
-        return self.update_options(
-            super().get_options(),
-            self.create_option(options.UserComboOption,
-                               self.form_compileropt_key('std'),
-                               'C++ language standard to use with CUDA',
-                               cpp_stds,
-                               'none'),
-            self.create_option(options.UserStringOption,
-                               self.form_compileropt_key('ccbindir'),
-                               'CUDA non-default toolchain directory to use (-ccbin)',
-                               ''),
-        )
+        opts = super().get_options()
+
+        key = self.form_compileropt_key('std')
+        opts[key] = options.UserComboOption(
+            self.make_option_name(key),
+            'C++ language standard to use with CUDA',
+            cpp_stds,
+            'none')
+
+        key = self.form_compileropt_key('ccbindir')
+        opts[key] = options.UserStringOption(
+            self.make_option_name(key),
+            'CUDA non-default toolchain directory to use (-ccbin)',
+            '')
+
+        return opts
 
     def _to_host_compiler_options(self, master_options: 'KeyedOptionDictType') -> 'KeyedOptionDictType':
         """

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -648,13 +648,12 @@ class CudaCompiler(Compiler):
 
         opts = super().get_options()
 
-        # XXX: cpp_std is correct, the annotations are wrong
         key = self.form_compileropt_key('std')
         opts[key] = options.UserComboOption(
             self.make_option_name(key),
             'C++ language standard to use with CUDA',
             'none',
-            cpp_stds)
+            choices=cpp_stds)
 
         key = self.form_compileropt_key('ccbindir')
         opts[key] = options.UserStringOption(

--- a/mesonbuild/compilers/cython.py
+++ b/mesonbuild/compilers/cython.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright © 2021 Intel Corporation
+# Copyright © 2021-2024 Intel Corporation
 from __future__ import annotations
 
 """Abstraction for Cython language compilers."""
@@ -67,19 +67,23 @@ class CythonCompiler(Compiler):
         return new
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        return self.update_options(
-            super().get_options(),
-            self.create_option(options.UserComboOption,
-                               self.form_compileropt_key('version'),
-                               'Python version to target',
-                               ['2', '3'],
-                               '3'),
-            self.create_option(options.UserComboOption,
-                               self.form_compileropt_key('language'),
-                               'Output C or C++ files',
-                               ['c', 'cpp'],
-                               'c'),
-        )
+        opts = super().get_options()
+
+        key = self.form_compileropt_key('version')
+        opts[key] = options.UserComboOption(
+            self.make_option_name(key),
+            'Python version to target',
+            ['2', '3'],
+            '3')
+
+        key = self.form_compileropt_key('language')
+        opts[key] = options.UserComboOption(
+            self.make_option_name(key),
+            'Output C or C++ files',
+            ['c', 'cpp'],
+            'c')
+
+        return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args: T.List[str] = []

--- a/mesonbuild/compilers/cython.py
+++ b/mesonbuild/compilers/cython.py
@@ -73,15 +73,15 @@ class CythonCompiler(Compiler):
         opts[key] = options.UserComboOption(
             self.make_option_name(key),
             'Python version to target',
-            ['2', '3'],
-            '3')
+            '3',
+            ['2', '3'])
 
         key = self.form_compileropt_key('language')
         opts[key] = options.UserComboOption(
             self.make_option_name(key),
             'Output C or C++ files',
-            ['c', 'cpp'],
-            'c')
+            'c',
+            ['c', 'cpp'])
 
         return opts
 

--- a/mesonbuild/compilers/cython.py
+++ b/mesonbuild/compilers/cython.py
@@ -74,14 +74,14 @@ class CythonCompiler(Compiler):
             self.make_option_name(key),
             'Python version to target',
             '3',
-            ['2', '3'])
+            choices=['2', '3'])
 
         key = self.form_compileropt_key('language')
         opts[key] = options.UserComboOption(
             self.make_option_name(key),
             'Output C or C++ files',
             'c',
-            ['c', 'cpp'])
+            choices=['c', 'cpp'])
 
         return opts
 

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -120,8 +120,8 @@ class FortranCompiler(CLikeCompiler, Compiler):
         opts[key] = options.UserComboOption(
             self.make_option_name(key),
             'Fortran language standard to use',
-            ['none'],
-            'none')
+            'none',
+            ['none'])
 
         return opts
 

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -273,7 +273,7 @@ class GnuFortranCompiler(GnuCompiler, FortranCompiler):
                           'everything': default_warn_args + ['-Wextra', '-Wpedantic', '-fimplicit-none']}
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = FortranCompiler.get_options(self)
+        opts = super().get_options()
         fortran_stds = ['legacy', 'f95', 'f2003']
         if version_compare(self.version, '>=4.4.0'):
             fortran_stds += ['f2008']
@@ -335,7 +335,7 @@ class ElbrusFortranCompiler(ElbrusCompiler, FortranCompiler):
         ElbrusCompiler.__init__(self)
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = FortranCompiler.get_options(self)
+        opts = super().get_options()
         fortran_stds = ['f95', 'f2003', 'f2008', 'gnu', 'legacy', 'f2008ts']
         key = self.form_compileropt_key('std')
         opts[key].choices = ['none'] + fortran_stds
@@ -415,7 +415,7 @@ class IntelFortranCompiler(IntelGnuLikeCompiler, FortranCompiler):
                           'everything': ['-warn', 'all']}
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = FortranCompiler.get_options(self)
+        opts = super().get_options()
         key = self.form_compileropt_key('std')
         opts[key].choices = ['none', 'legacy', 'f95', 'f2003', 'f2008', 'f2018']
         return opts
@@ -470,7 +470,7 @@ class IntelClFortranCompiler(IntelVisualStudioLikeCompiler, FortranCompiler):
                           'everything': ['/warn:all']}
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = FortranCompiler.get_options(self)
+        opts = super().get_options()
         key = self.form_compileropt_key('std')
         opts[key].choices = ['none', 'legacy', 'f95', 'f2003', 'f2008', 'f2018']
         return opts

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -121,7 +121,7 @@ class FortranCompiler(CLikeCompiler, Compiler):
             self.make_option_name(key),
             'Fortran language standard to use',
             'none',
-            ['none'])
+            choices=['none'])
 
         return opts
 
@@ -281,8 +281,7 @@ class GnuFortranCompiler(GnuCompiler, FortranCompiler):
             fortran_stds += ['f2008']
         if version_compare(self.version, '>=8.0.0'):
             fortran_stds += ['f2018']
-        key = self.form_compileropt_key('std')
-        opts[key].choices = ['none'] + fortran_stds
+        self._update_language_stds(opts, fortran_stds)
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
@@ -338,9 +337,7 @@ class ElbrusFortranCompiler(ElbrusCompiler, FortranCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
-        fortran_stds = ['f95', 'f2003', 'f2008', 'gnu', 'legacy', 'f2008ts']
-        key = self.form_compileropt_key('std')
-        opts[key].choices = ['none'] + fortran_stds
+        self._update_language_stds(opts, ['f95', 'f2003', 'f2008', 'gnu', 'legacy', 'f2008ts'])
         return opts
 
     def get_module_outdir_args(self, path: str) -> T.List[str]:
@@ -418,8 +415,7 @@ class IntelFortranCompiler(IntelGnuLikeCompiler, FortranCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
-        key = self.form_compileropt_key('std')
-        opts[key].choices = ['none', 'legacy', 'f95', 'f2003', 'f2008', 'f2018']
+        self._update_language_stds(opts, ['none', 'legacy', 'f95', 'f2003', 'f2008', 'f2018'])
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
@@ -473,8 +469,7 @@ class IntelClFortranCompiler(IntelVisualStudioLikeCompiler, FortranCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
-        key = self.form_compileropt_key('std')
-        opts[key].choices = ['none', 'legacy', 'f95', 'f2003', 'f2008', 'f2018']
+        self._update_language_stds(opts, ['none', 'legacy', 'f95', 'f2003', 'f2008', 'f2018'])
         return opts
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -114,14 +114,16 @@ class FortranCompiler(CLikeCompiler, Compiler):
         return self._has_multi_link_arguments(args, env, 'stop; end program')
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        return self.update_options(
-            super().get_options(),
-            self.create_option(options.UserComboOption,
-                               self.form_compileropt_key('std'),
-                               'Fortran language standard to use',
-                               ['none'],
-                               'none'),
-        )
+        opts = super().get_options()
+
+        key = self.form_compileropt_key('std')
+        opts[key] = options.UserComboOption(
+            self.make_option_name(key),
+            'Fortran language standard to use',
+            ['none'],
+            'none')
+
+        return opts
 
     def _compile_int(self, expression: str, prefix: str, env: 'Environment',
                      extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]],

--- a/mesonbuild/compilers/mixins/emscripten.py
+++ b/mesonbuild/compilers/mixins/emscripten.py
@@ -57,15 +57,15 @@ class EmscriptenMixin(Compiler):
         return args
 
     def get_options(self) -> coredata.MutableKeyedOptionDictType:
-        return self.update_options(
-            super().get_options(),
-            self.create_option(
-                options.UserIntegerOption,
-                OptionKey(f'{self.language}_thread_count', machine=self.for_machine),
-                'Number of threads to use in web assembly, set to 0 to disable',
-                (0, None, 4),  # Default was picked at random
-            ),
-        )
+        opts = super().get_options()
+
+        key = OptionKey(f'{self.language}_thread_count', machine=self.for_machine)
+        opts[key] = options.UserIntegerOption(
+            self.make_option_name(key),
+            'Number of threads to use in web assembly, set to 0 to disable',
+            (0, None, 4))  # Default was picked at random
+
+        return opts
 
     @classmethod
     def native_args_to_unix(cls, args: T.List[str]) -> T.List[str]:

--- a/mesonbuild/compilers/mixins/emscripten.py
+++ b/mesonbuild/compilers/mixins/emscripten.py
@@ -63,7 +63,8 @@ class EmscriptenMixin(Compiler):
         opts[key] = options.UserIntegerOption(
             self.make_option_name(key),
             'Number of threads to use in web assembly, set to 0 to disable',
-            (0, None, 4))  # Default was picked at random
+            4,  # Default was picked at random
+            min_value=0)
 
         return opts
 

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -99,6 +99,16 @@ class ClangObjCCompiler(ClangCStds, ClangCompiler, ObjCCompiler):
                           '3': default_warn_args + ['-Wextra', '-Wpedantic'],
                           'everything': ['-Weverything']}
 
+    def form_compileropt_key(self, basename: str) -> OptionKey:
+        if basename == 'std':
+            return OptionKey('c_std', machine=self.for_machine)
+        return super().form_compileropt_key(basename)
+
+    def make_option_name(self, key: OptionKey) -> str:
+        if key.name == 'std':
+            return 'c_std'
+        return super().make_option_name(key)
+
     def get_option_compile_args(self, options: 'coredata.KeyedOptionDictType') -> T.List[str]:
         args = []
         std = options.get_value(self.form_compileropt_key('std'))

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -35,6 +35,16 @@ class ObjCPPCompiler(CLikeCompiler, Compiler):
                           linker=linker)
         CLikeCompiler.__init__(self)
 
+    def form_compileropt_key(self, basename: str) -> OptionKey:
+        if basename == 'std':
+            return OptionKey('cpp_std', machine=self.for_machine)
+        return super().form_compileropt_key(basename)
+
+    def make_option_name(self, key: OptionKey) -> str:
+        if key.name == 'std':
+            return 'cpp_std'
+        return super().make_option_name(key)
+
     @staticmethod
     def get_display_language() -> str:
         return 'Objective-C++'
@@ -42,11 +52,6 @@ class ObjCPPCompiler(CLikeCompiler, Compiler):
     def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
         code = '#import<stdio.h>\nclass MyClass;int main(void) { return 0; }\n'
         return self._sanity_check_impl(work_dir, environment, 'sanitycheckobjcpp.mm', code)
-
-    def form_compileropt_key(self, basename: str) -> OptionKey:
-        if basename == 'std':
-            return OptionKey(f'cpp_{basename}', machine=self.for_machine)
-        return super().form_compileropt_key(basename)
 
     def get_options(self) -> coredata.MutableKeyedOptionDictType:
         opts = super().get_options()

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -227,7 +227,7 @@ class RustCompiler(Compiler):
             self.make_option_name(key),
             'Rust edition to use',
             'none',
-            ['none', '2015', '2018', '2021', '2024'])
+            choices=['none', '2015', '2018', '2021', '2024'])
 
         return opts
 

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -220,11 +220,16 @@ class RustCompiler(Compiler):
     # use_linker_args method instead.
 
     def get_options(self) -> MutableKeyedOptionDictType:
-        return dict((self.create_option(options.UserComboOption,
-                                        self.form_compileropt_key('std'),
-                                        'Rust edition to use',
-                                        ['none', '2015', '2018', '2021', '2024'],
-                                        'none'),))
+        opts = super().get_options()
+
+        key = self.form_compileropt_key('std')
+        opts[key] = options.UserComboOption(
+            self.make_option_name(key),
+            'Rust edition to use',
+            ['none', '2015', '2018', '2021', '2024'],
+            'none')
+
+        return opts
 
     def get_dependency_compile_args(self, dep: 'Dependency') -> T.List[str]:
         # Rust doesn't have dependency compile arguments so simply return

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -226,8 +226,8 @@ class RustCompiler(Compiler):
         opts[key] = options.UserComboOption(
             self.make_option_name(key),
             'Rust edition to use',
-            ['none', '2015', '2018', '2021', '2024'],
-            'none')
+            'none',
+            ['none', '2015', '2018', '2021', '2024'])
 
         return opts
 

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -60,8 +60,8 @@ if T.TYPE_CHECKING:
         cross_file: T.List[str]
         native_file: T.List[str]
 
-    OptionDictType = T.Union[T.Dict[str, 'options.UserOption[T.Any]'], 'OptionsView']
-    MutableKeyedOptionDictType = T.Dict['OptionKey', 'options.UserOption[T.Any]']
+    OptionDictType = T.Union[T.Dict[str, options.AnyOptionType], 'OptionsView']
+    MutableKeyedOptionDictType = T.Dict['OptionKey', options.AnyOptionType]
     KeyedOptionDictType = T.Union['options.OptionStore', 'OptionsView']
     CompilerCheckCacheKey = T.Tuple[T.Tuple[str, ...], str, FileOrString, T.Tuple[str, ...], CompileCheckMode]
     # code, args

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -599,7 +599,7 @@ class CoreData:
             oldval = self.optstore.get_value_object(key)
             if type(oldval) is not type(value):
                 self.optstore.set_value(key, value.value)
-            elif oldval.choices != value.choices:
+            elif oldval.printable_choices() != value.printable_choices():
                 # If the choices have changed, use the new value, but attempt
                 # to keep the old options. If they are not valid keep the new
                 # defaults but warn.

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -599,7 +599,7 @@ class CoreData:
             oldval = self.optstore.get_value_object(key)
             if type(oldval) is not type(value):
                 self.optstore.set_value(key, value.value)
-            elif oldval.printable_choices() != value.printable_choices():
+            elif options.choices_are_different(oldval, value):
                 # If the choices have changed, use the new value, but attempt
                 # to keep the old options. If they are not valid keep the new
                 # defaults but warn.

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -434,7 +434,8 @@ class CoreData:
                 'backend_max_links',
                 'Maximum number of linker processes to run or 0 for no '
                 'limit',
-                (0, None, 0)))
+                0,
+                min_value=0))
         elif backend_name.startswith('vs'):
             self.optstore.add_system_option('backend_startup_project', options.UserStringOption(
                 'backend_startup_project',

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -868,10 +868,10 @@ def save(obj: CoreData, build_dir: str) -> str:
 
 def register_builtin_arguments(parser: argparse.ArgumentParser) -> None:
     for n, b in options.BUILTIN_OPTIONS.items():
-        b.add_to_argparse(str(n), parser, '')
+        b.add_to_argparse(n, parser, '')
     for n, b in options.BUILTIN_OPTIONS_PER_MACHINE.items():
-        b.add_to_argparse(str(n), parser, ' (just for host machine)')
-        b.add_to_argparse(str(n.as_build()), parser, ' (just for build machine)')
+        b.add_to_argparse(n, parser, ' (just for host machine)')
+        b.add_to_argparse(n.as_build(), parser, ' (just for build machine)')
     parser.add_argument('-D', action='append', dest='projectoptions', default=[], metavar="option",
                         help='Set the value of an option, can be used several times to set multiple options.')
 

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -240,7 +240,7 @@ class Conf:
                 printable_value = '<inherited from main project>'
             if isinstance(o, options.UserFeatureOption) and o.is_auto():
                 printable_value = auto.printable_value()
-            self.add_option(str(root), o.description, printable_value, o.choices)
+            self.add_option(str(root), o.description, printable_value, o.printable_choices())
 
     def print_conf(self, pager: bool) -> None:
         if pager:

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -26,8 +26,6 @@ from .optinterpreter import OptionInterpreter
 
 if T.TYPE_CHECKING:
     from typing_extensions import Protocol
-    from typing import Any
-    from .options import UserOption
     import argparse
 
     class CMDOptions(coredata.SharedCMDOptions, Protocol):
@@ -189,7 +187,7 @@ class Conf:
                 items = [l[i] if l[i] else ' ' * four_column[i] for i in range(4)]
                 mlog.log(*items)
 
-    def split_options_per_subproject(self, options: 'T.Union[dict[OptionKey, UserOption[Any]], coredata.KeyedOptionDictType]') -> T.Dict[str, 'coredata.MutableKeyedOptionDictType']:
+    def split_options_per_subproject(self, options: T.Union[coredata.MutableKeyedOptionDictType, coredata.KeyedOptionDictType]) -> T.Dict[str, 'coredata.MutableKeyedOptionDictType']:
         result: T.Dict[str, 'coredata.MutableKeyedOptionDictType'] = {}
         for k, o in options.items():
             if k.subproject:
@@ -227,7 +225,7 @@ class Conf:
         self._add_line(mlog.normal_yellow(section + ':'), '', '', '')
         self.print_margin = 2
 
-    def print_options(self, title: str, opts: 'T.Union[dict[OptionKey, UserOption[Any]], coredata.KeyedOptionDictType]') -> None:
+    def print_options(self, title: str, opts: T.Union[coredata.MutableKeyedOptionDictType, coredata.KeyedOptionDictType]) -> None:
         if not opts:
             return
         if title:

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -30,8 +30,6 @@ from .mparser import FunctionNode, ArrayNode, ArgumentNode, StringNode
 
 if T.TYPE_CHECKING:
     import argparse
-    from typing import Any
-    from .options import UserOption
 
     from .interpreter import Interpreter
     from .mparser import BaseNode
@@ -306,7 +304,7 @@ def list_buildoptions(coredata: cdata.CoreData, subprojects: T.Optional[T.List[s
                 for s in subprojects:
                     core_options[k.evolve(subproject=s)] = v
 
-    def add_keys(opts: 'T.Union[dict[OptionKey, UserOption[Any]], cdata.KeyedOptionDictType]', section: str) -> None:
+    def add_keys(opts: T.Union[cdata.MutableKeyedOptionDictType, cdata.KeyedOptionDictType], section: str) -> None:
         for key, opt in sorted(opts.items()):
             optdict = {'name': str(key), 'value': opt.value, 'section': section,
                        'machine': key.machine.get_lower_case_name() if coredata.is_per_machine_option(key) else 'any'}

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -315,14 +315,15 @@ def list_buildoptions(coredata: cdata.CoreData, subprojects: T.Optional[T.List[s
             elif isinstance(opt, options.UserBooleanOption):
                 typestr = 'boolean'
             elif isinstance(opt, options.UserComboOption):
-                optdict['choices'] = opt.choices
+                optdict['choices'] = opt.printable_choices()
                 typestr = 'combo'
             elif isinstance(opt, options.UserIntegerOption):
                 typestr = 'integer'
             elif isinstance(opt, options.UserArrayOption):
                 typestr = 'array'
-                if opt.choices:
-                    optdict['choices'] = opt.choices
+                c = opt.printable_choices()
+                if c:
+                    optdict['choices'] = c
             else:
                 raise RuntimeError("Unknown option type")
             optdict['type'] = typestr

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -317,7 +317,7 @@ def list_buildoptions(coredata: cdata.CoreData, subprojects: T.Optional[T.List[s
             elif isinstance(opt, options.UserComboOption):
                 optdict['choices'] = opt.printable_choices()
                 typestr = 'combo'
-            elif isinstance(opt, options.UserIntegerOption):
+            elif isinstance(opt, (options.UserIntegerOption, options.UserUmaskOption)):
                 typestr = 'integer'
             elif isinstance(opt, options.UserStringArrayOption):
                 typestr = 'array'
@@ -325,7 +325,7 @@ def list_buildoptions(coredata: cdata.CoreData, subprojects: T.Optional[T.List[s
                 if c:
                     optdict['choices'] = c
             else:
-                raise RuntimeError("Unknown option type")
+                raise RuntimeError('Unknown option type: ', repr(type(opt)))
             optdict['type'] = typestr
             optdict['description'] = opt.description
             optlist.append(optdict)

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -319,7 +319,7 @@ def list_buildoptions(coredata: cdata.CoreData, subprojects: T.Optional[T.List[s
                 typestr = 'combo'
             elif isinstance(opt, options.UserIntegerOption):
                 typestr = 'integer'
-            elif isinstance(opt, options.UserArrayOption):
+            elif isinstance(opt, options.UserStringArrayOption):
                 typestr = 'array'
                 c = opt.printable_choices()
                 if c:

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -69,7 +69,7 @@ class OptionInterpreter:
     def __init__(self, optionstore: 'OptionStore', subproject: 'SubProject') -> None:
         self.options: 'coredata.MutableKeyedOptionDictType' = {}
         self.subproject = subproject
-        self.option_types: T.Dict[str, T.Callable[..., options.UserOption]] = {
+        self.option_types: T.Dict[str, T.Callable[..., options.AnyOptionType]] = {
             'string': self.string_parser,
             'boolean': self.boolean_parser,
             'combo': self.combo_parser,

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -213,7 +213,7 @@ class OptionInterpreter:
         KwargInfo('value', str, default=''),
     )
     def string_parser(self, name: str, description: str, args: T.Tuple[bool, _DEPRECATED_ARGS], kwargs: StringArgs) -> options.UserOption:
-        return options.UserStringOption(name, description, kwargs['value'], *args)
+        return options.UserStringOption(name, description, kwargs['value'], None, *args)
 
     @typed_kwargs(
         'boolean option',
@@ -226,7 +226,8 @@ class OptionInterpreter:
         ),
     )
     def boolean_parser(self, name: str, description: str, args: T.Tuple[bool, _DEPRECATED_ARGS], kwargs: BooleanArgs) -> options.UserOption:
-        return options.UserBooleanOption(name, description, kwargs['value'], *args)
+        yielding, deprecated = args
+        return options.UserBooleanOption(name, description, kwargs['value'], yielding=yielding, deprecated=deprecated)
 
     @typed_kwargs(
         'combo option',
@@ -238,7 +239,7 @@ class OptionInterpreter:
         value = kwargs['value']
         if value is None:
             value = kwargs['choices'][0]
-        return options.UserComboOption(name, description, choices, value, *args)
+        return options.UserComboOption(name, description, value, choices, *args)
 
     @typed_kwargs(
         'integer option',
@@ -253,9 +254,8 @@ class OptionInterpreter:
         KwargInfo('max', (int, NoneType)),
     )
     def integer_parser(self, name: str, description: str, args: T.Tuple[bool, _DEPRECATED_ARGS], kwargs: IntegerArgs) -> options.UserOption:
-        value = kwargs['value']
-        inttuple = (kwargs['min'], kwargs['max'], value)
-        return options.UserIntegerOption(name, description, inttuple, *args)
+        return options.UserIntegerOption(
+            name, description, kwargs['value'], None, *args, min_value=kwargs['min'], max_value=kwargs['max'])
 
     @typed_kwargs(
         'string array option',
@@ -270,8 +270,10 @@ class OptionInterpreter:
                 FeatureDeprecated('String value for array option', '1.3.0').use(self.subproject)
             else:
                 raise mesonlib.MesonException('Value does not define an array: ' + value)
+        # XXX: the value of choices is correct, the annotation is wrong.
+        #      the annotation will be fixed in a later commit
         return options.UserArrayOption(name, description, value,
-                                       choices=choices,
+                                       choices=choices,  # type: ignore[arg-type]
                                        yielding=args[0],
                                        deprecated=args[1])
 

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -213,7 +213,7 @@ class OptionInterpreter:
         KwargInfo('value', str, default=''),
     )
     def string_parser(self, name: str, description: str, args: T.Tuple[bool, _DEPRECATED_ARGS], kwargs: StringArgs) -> options.UserOption:
-        return options.UserStringOption(name, description, kwargs['value'], None, *args)
+        return options.UserStringOption(name, description, kwargs['value'], *args)
 
     @typed_kwargs(
         'boolean option',
@@ -239,7 +239,7 @@ class OptionInterpreter:
         value = kwargs['value']
         if value is None:
             value = kwargs['choices'][0]
-        return options.UserComboOption(name, description, value, choices, *args)
+        return options.UserComboOption(name, description, value, *args, choices)
 
     @typed_kwargs(
         'integer option',
@@ -255,7 +255,7 @@ class OptionInterpreter:
     )
     def integer_parser(self, name: str, description: str, args: T.Tuple[bool, _DEPRECATED_ARGS], kwargs: IntegerArgs) -> options.UserOption:
         return options.UserIntegerOption(
-            name, description, kwargs['value'], None, *args, min_value=kwargs['min'], max_value=kwargs['max'])
+            name, description, kwargs['value'], *args, min_value=kwargs['min'], max_value=kwargs['max'])
 
     @typed_kwargs(
         'string array option',
@@ -270,12 +270,11 @@ class OptionInterpreter:
                 FeatureDeprecated('String value for array option', '1.3.0').use(self.subproject)
             else:
                 raise mesonlib.MesonException('Value does not define an array: ' + value)
-        # XXX: the value of choices is correct, the annotation is wrong.
-        #      the annotation will be fixed in a later commit
-        return options.UserArrayOption(name, description, value,
-                                       choices=choices,  # type: ignore[arg-type]
-                                       yielding=args[0],
-                                       deprecated=args[1])
+        return options.UserStringArrayOption(
+            name, description, value,
+            choices=choices,
+            yielding=args[0],
+            deprecated=args[1])
 
     @typed_kwargs(
         'feature option',

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -484,7 +484,31 @@ class UserFeatureOption(UserComboOption):
         return self.value == 'auto'
 
 
-@dataclasses.dataclass(init=False)
+_U = T.TypeVar('_U', bound=UserOption)
+
+
+def choices_are_different(a: _U, b: _U) -> bool:
+    """Are the choices between two options the same?
+
+    :param a: A UserOption[T]
+    :param b: A second UserOption[T]
+    :return: True if the choices have changed, otherwise False
+    """
+    if isinstance(a, EnumeratedUserOption):
+        # We expect `a` and `b` to be of the same type, but can't really annotate it that way.
+        assert isinstance(b, EnumeratedUserOption), 'for mypy'
+        return a.choices != b.choices
+    elif isinstance(a, UserArrayOption):
+        # We expect `a` and `b` to be of the same type, but can't really annotate it that way.
+        assert isinstance(b, UserArrayOption), 'for mypy'
+        return a.choices != b.choices
+    elif isinstance(a, _UserIntegerBase):
+        assert isinstance(b, _UserIntegerBase), 'for mypy'
+        return a.max_value != b.max_value or a.min_value != b.min_value
+
+    return False
+
+
 class UserStdOption(UserComboOption):
     '''
     UserOption specific to c_std and cpp_std options. User can set a list of

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -142,7 +142,7 @@ class OptionKey:
     def __hash__(self) -> int:
         return self._hash
 
-    def _to_tuple(self) -> T.Tuple[str, str, str, MachineChoice, str]:
+    def _to_tuple(self) -> T.Tuple[str, MachineChoice, str]:
         return (self.subproject, self.machine, self.name)
 
     def __eq__(self, other: object) -> bool:

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -589,7 +589,7 @@ class BuiltinOption(T.Generic[_T]):
             pass
         return self.default
 
-    def add_to_argparse(self, name: str, parser: argparse.ArgumentParser, help_suffix: str) -> None:
+    def add_to_argparse(self, name: OptionKey, parser: argparse.ArgumentParser, help_suffix: str) -> None:
         kwargs: ArgparseKWs = {}
 
         c = self._argparse_choices()
@@ -602,9 +602,9 @@ class BuiltinOption(T.Generic[_T]):
         if c and not b:
             kwargs['choices'] = c
         kwargs['default'] = argparse.SUPPRESS
-        kwargs['dest'] = name
+        kwargs['dest'] = str(name)
 
-        cmdline_name = self.argparse_name_to_arg(name)
+        cmdline_name = self.argparse_name_to_arg(str(name))
         parser.add_argument(cmdline_name, help=h + help_suffix, **kwargs)
 
 

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -283,8 +283,6 @@ class UserOption(T.Generic[_T], HoldableObject):
         self.value = self.validate_value(newvalue)
         return self.value != oldvalue
 
-_U = T.TypeVar('_U', bound=UserOption[_T])
-
 
 class UserStringOption(UserOption[str]):
     def __init__(self, name: str, description: str, value: T.Any, yielding: bool = DEFAULT_YIELDING,
@@ -525,14 +523,14 @@ class UserStdOption(UserComboOption):
                              f'Possible values for option "{self.name}" are {self.choices}')
 
 
-class BuiltinOption(T.Generic[_T, _U]):
+class BuiltinOption(T.Generic[_T]):
 
     """Class for a builtin option type.
 
     There are some cases that are not fully supported yet.
     """
 
-    def __init__(self, opt_type: T.Type[_U], description: str, default: T.Any, yielding: bool = True, *,
+    def __init__(self, opt_type: T.Type[UserOption[_T]], description: str, default: T.Any, yielding: bool = True, *,
                  choices: T.Any = None, readonly: bool = False):
         self.opt_type = opt_type
         self.description = description
@@ -541,7 +539,7 @@ class BuiltinOption(T.Generic[_T, _U]):
         self.yielding = yielding
         self.readonly = readonly
 
-    def init_option(self, name: 'OptionKey', value: T.Optional[T.Any], prefix: str) -> _U:
+    def init_option(self, name: 'OptionKey', value: T.Optional[T.Any], prefix: str) -> UserOption[_T]:
         """Create an instance of opt_type and return it."""
         if value is None:
             value = self.prefixed_default(name, prefix)

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2013-2024 Contributors to the The Meson project
-# Copyright © 2019-2024 Intel Corporation
+# Copyright © 2019-2025 Intel Corporation
 
 from __future__ import annotations
 from collections import OrderedDict
@@ -264,6 +264,13 @@ class UserOption(T.Generic[_T], HoldableObject):
     def printable_value(self) -> T.Union[str, int, bool, T.List[T.Union[str, int, bool]]]:
         assert isinstance(self.value, (str, int, bool, list))
         return self.value
+
+    def printable_choices(self) -> T.Optional[T.List[str]]:
+        if not self.choices:
+            return None
+        if isinstance(self.choices, str):
+            return [self.choices]
+        return [str(c) for c in self.choices]
 
     # Check that the input is a valid value and return the
     # "cleaned" or "native" version. For example the Boolean

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -79,6 +79,7 @@ modules = [
     'mesonbuild/msetup.py',
     'mesonbuild/mtest.py',
     'mesonbuild/optinterpreter.py',
+    'mesonbuild/options.py',
     'mesonbuild/programs.py',
 ]
 additional = [


### PR DESCRIPTION
This fixes all of the issues in the options module, as well as fixing type safety issues introduced by it. This really falls into four parts:

1. fix the pre-existing issues with the `UserOption` classes
2. clean up some uses of `Any` that would hide real issues
3. Correct annotations for the OptionKey type that were broken
4. add missing annotations to the `OptionStore` class.

This fully supersedes #13616