### PR TITLE
modules/rust: allow customizing env vars on bindgen

### DIFF
--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -67,6 +67,7 @@ It takes the following keyword arguments
 - `dependencies`: a list of `Dependency` objects to pass to the underlying clang call (*since 1.0.0*)
 - `language`: A literal string value of `c` or `cpp`. When set this will force bindgen to treat a source as the given language. Defaults to checking based on the input file extension. *(since 1.4.0)*
 - `bindgen_version`: a list of string version values. When set the found bindgen binary must conform to these constraints. *(since 1.4.0)*
+- `env`: environment variables to set, such as {'NAME1': 'value1', 'NAME2': 'value2'} or ['NAME1=value1', 'NAME2=value2'], or an env object which allows more sophisticated environment juggling. *(since 1.6.0)*
 
 ```meson
 rust = import('unstable-rust')

--- a/docs/markdown/snippets/bindgen_allows_setting_environment_variables.md
+++ b/docs/markdown/snippets/bindgen_allows_setting_environment_variables.md
@@ -1,0 +1,7 @@
+## Bindgen now allows customizing environment variables
+
+Bindgen is configurable through environment variables on how it searches for
+clang and what extra arguments it passes to the compiler. The bindgen() function
+of the rust module now accepts an `env` keyword argument for customizing
+environment variables. The type of the argument is the same as `env` of
+[[custom_target]].

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -14,11 +14,13 @@ from ..build import (BothLibraries, BuildTarget, CustomTargetIndex, Executable, 
                      CustomTarget, InvalidArguments, Jar, StructuredSources, SharedLibrary)
 from ..compilers.compilers import are_asserts_disabled, lang_suffixes
 from ..interpreter.type_checking import (
-    DEPENDENCIES_KW, LINK_WITH_KW, SHARED_LIB_KWS, TEST_KWS, OUTPUT_KW,
+    DEPENDENCIES_KW, LINK_WITH_KW, SHARED_LIB_KWS, TEST_KWS, OUTPUT_KW, ENV_KW,
     INCLUDE_DIRECTORIES, SOURCES_VARARGS, NoneType, in_set_validator
 )
 from ..interpreterbase import ContainerTypeInfo, InterpreterException, KwargInfo, typed_kwargs, typed_pos_args, noPosargs, permittedKwargs
-from ..mesonlib import File
+from ..mesonlib import (
+    File, EnvironmentVariables,
+)
 from ..programs import ExternalProgram
 
 if T.TYPE_CHECKING:
@@ -49,6 +51,7 @@ if T.TYPE_CHECKING:
         output: str
         output_inline_wrapper: str
         dependencies: T.List[T.Union[Dependency, ExternalLibrary]]
+        env: T.Optional[EnvironmentVariables]
         language: T.Optional[Literal['c', 'cpp']]
         bindgen_version: T.List[str]
 
@@ -198,6 +201,7 @@ class RustModule(ExtensionModule):
         KwargInfo('bindgen_version', ContainerTypeInfo(list, str), default=[], listify=True, since='1.4.0'),
         INCLUDE_DIRECTORIES.evolve(since_values={ContainerTypeInfo(list, str): '1.0.0'}),
         OUTPUT_KW,
+        ENV_KW.evolve(since='1.6.0'),
         KwargInfo(
             'output_inline_wrapper',
             str,
@@ -330,6 +334,7 @@ class RustModule(ExtensionModule):
             extra_depends=depends,
             depend_files=depend_files,
             backend=state.backend,
+            env=kwargs['env'],
             description='Generating bindings for Rust {}',
         )
 

--- a/test cases/rust/12 bindgen/env/header.h
+++ b/test cases/rust/12 bindgen/env/header.h
@@ -1,0 +1,9 @@
+// SPDX-license-identifer: Apache-2.0
+
+# pragma once
+
+#include "other.h"
+
+#ifdef EXPOSE_API
+int32_t add(const int32_t, const int32_t);
+#endif

--- a/test cases/rust/12 bindgen/env/meson.build
+++ b/test cases/rust/12 bindgen/env/meson.build
@@ -1,0 +1,22 @@
+# SPDX-license-identifer: Apache-2.0
+
+gen_env = rust.bindgen(
+  input : 'header.h',
+  output : 'header.rs',
+  env : {'BINDGEN_EXTRA_CLANG_ARGS' : '-DEXPOSE_API'},
+  include_directories : inc,
+)
+
+f_env = configure_file(
+  input : '../src/main.rs',
+  output : 'main.rs',
+  copy : true,
+)
+
+rust_bin_env = executable(
+  'rust_bin_env',
+  [f_env, gen_env],
+  link_with : c_lib,
+)
+
+test('generate with custom environment variables', rust_bin_env)

--- a/test cases/rust/12 bindgen/meson.build
+++ b/test cases/rust/12 bindgen/meson.build
@@ -129,6 +129,7 @@ endif
 
 subdir('sub')
 subdir('dependencies')
+subdir('env')
 
 gp = rust.bindgen(
   input : 'src/global-project.h',


### PR DESCRIPTION
Bindgen is configurable through environment variables on how it searches for clang and what extra arguments it passes to the compiler. The former is the only way to change which clang or libclang bindgen will use, which is useful to work around the issue that bindgen uses clang and libclang of different versions on systems with multiple version of the compiler installed.

Add an env keyword argument to bindgen() of the rust module to allow customizing the environment variables when invoking bindgen. The argument has the same type as env of custom_target().