### PR TITLE
qt module: allow has_tools to specify which tools to check

### DIFF
--- a/docs/markdown/Qt6-module.md
+++ b/docs/markdown/Qt6-module.md
@@ -156,6 +156,9 @@ This method takes the following keyword arguments:
   `true` or an enabled [`feature`](Build-options.md#features) and some tools are
   missing Meson will abort.
 - `method` string: The method to use to detect Qt, see [[dependency]]
+- `tools`: string[]: *Since 1.6.0*. List of tools to check. Testable tools
+  are `moc`, `uic`, `rcc` and `lrelease`. By default `tools` is set to `['moc',
+  'uic', 'rcc', 'lrelease']`
 
 ## Dependencies
 

--- a/docs/markdown/snippets/qt_has_tools_ignore.md
+++ b/docs/markdown/snippets/qt_has_tools_ignore.md
@@ -1,0 +1,12 @@
+## Tools can be selected when calling `has_tools()` on the Qt modules
+
+When checking for the presence of Qt tools, you can now explictly ask Meson
+which tools you need. This is particularly useful when you do not need
+`lrelease` because you are not shipping any translations. For example:
+
+```meson
+qt6_mod = import('qt6')
+qt6_mod.has_tools(required: true, tools: ['moc', 'uic', 'rcc'])
+```
+
+valid tools are `moc`, `uic`, `rcc` and `lrelease`.

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -48,7 +48,13 @@ foreach qt : ['qt4', 'qt5', 'qt6']
   qtdep = dependency(qt, modules : qt_modules, main : true, private_headers: true, required : required, method : get_option('method'))
   if qtdep.found()
     qtmodule = import(qt)
-    assert(qtmodule.has_tools(), 'You may be missing a devel package. (qttools5-dev-tools on Debian based systems)')
+    if get_option('expect_lrelease')
+      assert(qtmodule.has_tools(), 'You may be missing a devel package. (qttools5-dev-tools on Debian based systems)')
+    else
+      assert(not qtmodule.has_tools(), 'Unexpectedly found lrelease')
+      assert(not qtmodule.has_tools(tools: ['lrelease']), 'Unexpectedly found lrelease')
+      assert(qtmodule.has_tools(tools: ['moc', 'uic', 'rcc']), 'You may be missing a devel package. (qttools5-dev-tools on Debian based systems)')
+    endif
 
     # Test that fetching a variable works and yields a non-empty value
     assert(qtdep.get_variable('prefix', configtool: 'QT_INSTALL_PREFIX') != '')
@@ -91,23 +97,25 @@ foreach qt : ['qt4', 'qt5', 'qt6']
     # qt4-rcc and qt5-rcc take different arguments, for example qt4: ['-compress', '3']; qt5: '--compress=3'
     qtmodule.preprocess(qt + 'testrccarg', qresources : files(['stuff.qrc', 'stuff2.qrc']), rcc_extra_arguments : '--compress=3', method : get_option('method'))
 
-    translations_cpp = qtmodule.compile_translations(qresource: qt+'_lang.qrc')
-    # unity builds suck and definitely cannot handle two qrc embeds in one compilation unit
-    unityproof_translations = static_library(qt+'unityproof_translations', translations_cpp, dependencies: qtdep)
+    if get_option('expect_lrelease')
+      translations_cpp = qtmodule.compile_translations(qresource: qt+'_lang.qrc')
+      # unity builds suck and definitely cannot handle two qrc embeds in one compilation unit
+      unityproof_translations = static_library(qt+'unityproof_translations', translations_cpp, dependencies: qtdep)
 
-    extra_cpp_args += '-DQT="@0@"'.format(qt)
-    qexe = executable(qt + 'app',
-      sources : ['main.cpp', 'mainWindow.cpp', # Sources that don't need preprocessing.
-      prep, prep_rcc],
-      dependencies : qtdep,
-      link_with: unityproof_translations,
-      cpp_args: extra_cpp_args,
-      gui_app : true)
+      extra_cpp_args += '-DQT="@0@"'.format(qt)
+      qexe = executable(qt + 'app',
+        sources : ['main.cpp', 'mainWindow.cpp', # Sources that don't need preprocessing.
+        prep, prep_rcc],
+        dependencies : qtdep,
+        link_with: unityproof_translations,
+        cpp_args: extra_cpp_args,
+        gui_app : true)
 
-    # We need a console test application because some test environments
-    # do not have an X server.
+      # We need a console test application because some test environments
+      # do not have an X server.
 
-    translations = qtmodule.compile_translations(ts_files : qt+'core_fr.ts', build_by_default : true)
+      translations = qtmodule.compile_translations(ts_files : qt+'core_fr.ts', build_by_default : true)
+    endif
 
     qtcore = dependency(qt, modules : 'Core', method : get_option('method'))
 

--- a/test cases/frameworks/4 qt/meson_options.txt
+++ b/test cases/frameworks/4 qt/meson_options.txt
@@ -1,2 +1,3 @@
 option('method', type : 'string', value : 'auto', description : 'The method to use to find Qt')
 option('required', type : 'string', value : 'qt5', description : 'The version of Qt which is required to be present')
+option('expect_lrelease', type: 'boolean', value: true)


### PR DESCRIPTION
This allows checking for tools that may not be available in older version of qt or avoiding requesting tools that may not be necessary for a given project

this MR supersed #13524 as discussed [here](https://github.com/mesonbuild/meson/pull/13524#issuecomment-2285522509)


