### PR TITLE
Add support for LLVM 19 in Debian.

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -196,6 +196,8 @@ def get_llvm_tool_names(tool: str) -> T.List[str]:
     # unless it becomes a stable release.
     suffixes = [
         '', # base (no suffix)
+        '-19.1', '19.1',
+        '-19',  '19',
         '-18.1', '18.1',
         '-18',  '18',
         '-17',  '17',
@@ -217,7 +219,6 @@ def get_llvm_tool_names(tool: str) -> T.List[str]:
         '-3.7', '37',
         '-3.6', '36',
         '-3.5', '35',
-        '-19',    # Debian development snapshot
         '-devel', # FreeBSD development snapshot
     ]
     names: T.List[str] = []


### PR DESCRIPTION
Originally from here:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1080463