### PR TITLE
Add DIA SDK dependency

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -849,6 +849,34 @@ version.
 
 *New in 0.54.0* the `system` method.
 
+## DIA SDK
+
+*(added 1.6.0)*
+
+Microsoft's Debug Interface Access SDK (DIA SDK) is available only on Windows,
+when using msvc, clang-cl or clang compiler from Microsoft Visual Studio.
+
+The DIA SDK runtime is not statically linked to target. The default usage
+method requires the runtime DLL (msdiaXXX.dll) to be manually registered in the
+OS with `regsrv32.exe` command, so it can be loaded using `CoCreateInstance`
+Windows function.
+
+Alternatively, you can use meson to copy the DIA runtime DLL to your build
+directory, and load it dynamically using `NoRegCoCreate` function provided by
+the DIA SDK. To facilitate this, you can read DLL path from dependency's
+variable 'dll' and use fs module to copy it. Example:
+
+```meson
+dia = dependency('diasdk', required: true)
+fs = import('fs')
+fs.copyfile(dia.get_variable('dll'))
+
+conf = configuration_data()
+conf.set('msdia_dll_name', fs.name(dia_dll_name))
+```
+
+Only the major version is available (eg. version is `14` for msdia140.dll).
+
 <hr>
 <a name="footnote1">1</a>: They may appear to be case-insensitive, if the
     underlying file system happens to be case-insensitive.

--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -80,8 +80,8 @@ var = foo_dep.get_variable(cmake : 'CMAKE_VAR', pkgconfig : 'pkg-config-var', co
 ```
 
 It accepts the keywords 'cmake', 'pkgconfig', 'pkgconfig_define',
-'configtool', 'internal', and 'default_value'. 'pkgconfig_define'
-works just like the 'define_variable' argument to
+'configtool', 'internal', 'system', and 'default_value'.
+'pkgconfig_define' works just like the 'define_variable' argument to
 `get_pkgconfig_variable`. When this method is invoked the keyword
 corresponding to the underlying type of the dependency will be used to
 look for a variable. If that variable cannot be found or if the caller

--- a/docs/markdown/snippets/dia_sdk.md
+++ b/docs/markdown/snippets/dia_sdk.md
@@ -1,0 +1,3 @@
+## Support for DIA SDK
+
+Added support for Windows Debug Interface Access SDK (DIA SDK) dependency. It allows reading with MSVC debugging information (.PDB format). This dependency can only be used on Windows, with msvc, clang or clang-cl compiler.

--- a/docs/markdown/snippets/system_variable_in_dep.md
+++ b/docs/markdown/snippets/system_variable_in_dep.md
@@ -1,0 +1,3 @@
+## Support for variable in system dependencies
+
+System Dependency method `get_variable()` now supports `system` variable.

--- a/docs/yaml/objects/dep.yaml
+++ b/docs/yaml/objects/dep.yaml
@@ -191,7 +191,7 @@ methods:
         since: 0.58.0
         description: |
           This argument is used as a default value
-          for `cmake`, `pkgconfig`, `configtool` and `internal` keyword
+          for `cmake`, `pkgconfig`, `configtool`, `internal` and `system` keyword
           arguments. It is useful in the common case where `pkgconfig` and `internal`
           use the same variable name, in which case it's easier to write `dep.get_variable('foo')`
           instead of `dep.get_variable(pkgconfig: 'foo', internal: 'foo')`.
@@ -213,6 +213,11 @@ methods:
         type: str
         since: 0.54.0
         description: The internal variable name
+
+      system:
+        type: str
+        since: 1.6.0
+        description: The system variable name
 
       default_value:
         type: str

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -195,6 +195,7 @@ packages.defaults.update({
     'zlib': 'dev',
     'jni': 'dev',
     'jdk': 'dev',
+    'diasdk': 'dev',
 
     'boost': 'boost',
     'cuda': 'cuda',

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -237,7 +237,7 @@ class Dependency(HoldableObject):
 
     def get_variable(self, *, cmake: T.Optional[str] = None, pkgconfig: T.Optional[str] = None,
                      configtool: T.Optional[str] = None, internal: T.Optional[str] = None,
-                     default_value: T.Optional[str] = None,
+                     system: T.Optional[str] = None, default_value: T.Optional[str] = None,
                      pkgconfig_define: PkgConfigDefineType = None) -> str:
         if default_value is not None:
             return default_value
@@ -321,7 +321,7 @@ class InternalDependency(Dependency):
 
     def get_variable(self, *, cmake: T.Optional[str] = None, pkgconfig: T.Optional[str] = None,
                      configtool: T.Optional[str] = None, internal: T.Optional[str] = None,
-                     default_value: T.Optional[str] = None,
+                     system: T.Optional[str] = None, default_value: T.Optional[str] = None,
                      pkgconfig_define: PkgConfigDefineType = None) -> str:
         val = self.variables.get(internal, default_value)
         if val is not None:

--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -617,7 +617,7 @@ class CMakeDependency(ExternalDependency):
 
     def get_variable(self, *, cmake: T.Optional[str] = None, pkgconfig: T.Optional[str] = None,
                      configtool: T.Optional[str] = None, internal: T.Optional[str] = None,
-                     default_value: T.Optional[str] = None,
+                     system: T.Optional[str] = None, default_value: T.Optional[str] = None,
                      pkgconfig_define: PkgConfigDefineType = None) -> str:
         if cmake and self.traceparser is not None:
             try:

--- a/mesonbuild/dependencies/configtool.py
+++ b/mesonbuild/dependencies/configtool.py
@@ -150,7 +150,7 @@ class ConfigToolDependency(ExternalDependency):
 
     def get_variable(self, *, cmake: T.Optional[str] = None, pkgconfig: T.Optional[str] = None,
                      configtool: T.Optional[str] = None, internal: T.Optional[str] = None,
-                     default_value: T.Optional[str] = None,
+                     system: T.Optional[str] = None, default_value: T.Optional[str] = None,
                      pkgconfig_define: PkgConfigDefineType = None) -> str:
         if configtool:
             p, out, _ = Popen_safe(self.config + self.get_variable_args(configtool))

--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -557,7 +557,7 @@ class PkgConfigDependency(ExternalDependency):
 
     def get_variable(self, *, cmake: T.Optional[str] = None, pkgconfig: T.Optional[str] = None,
                      configtool: T.Optional[str] = None, internal: T.Optional[str] = None,
-                     default_value: T.Optional[str] = None,
+                     system: T.Optional[str] = None, default_value: T.Optional[str] = None,
                      pkgconfig_define: PkgConfigDefineType = None) -> str:
         if pkgconfig:
             try:

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -539,6 +539,7 @@ class DependencyHolder(ObjectHolder[Dependency]):
         KwargInfo('pkgconfig', (str, NoneType)),
         KwargInfo('configtool', (str, NoneType)),
         KwargInfo('internal', (str, NoneType), since='0.54.0'),
+        KwargInfo('system', (str, NoneType), since='1.6.0'),
         KwargInfo('default_value', (str, NoneType)),
         PKGCONFIG_DEFINE_KW,
     )
@@ -555,6 +556,7 @@ class DependencyHolder(ObjectHolder[Dependency]):
             pkgconfig=kwargs['pkgconfig'] or default_varname,
             configtool=kwargs['configtool'] or default_varname,
             internal=kwargs['internal'] or default_varname,
+            system=kwargs['system'] or default_varname,
             default_value=kwargs['default_value'],
             pkgconfig_define=kwargs['pkgconfig_define'],
         )

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -268,6 +268,7 @@ class DependencyGetVariable(TypedDict):
     pkgconfig: T.Optional[str]
     configtool: T.Optional[str]
     internal: T.Optional[str]
+    system: T.Optional[str]
     default_value: T.Optional[str]
     pkgconfig_define: PkgConfigDefineType
 

--- a/test cases/windows/23 diasdk/dia_registered.cpp
+++ b/test cases/windows/23 diasdk/dia_registered.cpp
@@ -1,0 +1,30 @@
+// Loads DIA SDK from system registry using CoCreateInstance().
+// The corresponding msdiaXXX.dll must be registered in system registry
+//   (eg. run `regsvr32.exe msdia140.dll` as administrator)
+
+#include <dia2.h>
+#include <windows.h>
+#include <stdexcept>
+#include <iostream>
+
+int main()
+{
+    try {
+
+    HRESULT hr = CoInitialize(NULL);
+    if (FAILED(hr))
+        throw std::runtime_error("Failed to initialize COM library");
+
+    IDiaDataSource* datasrc;
+    hr = CoCreateInstance( CLSID_DiaSource, NULL, CLSCTX_INPROC_SERVER, __uuidof(IDiaDataSource), (void **)&datasrc);
+    if (FAILED(hr))
+        throw std::runtime_error("Can't create IDiaDataSource. You must register msdia*.dll with regsvr32.exe.");
+
+    std::cout << "DIA was successfully loaded\n";
+    return 0;
+
+    } catch (std::exception& err) {
+        std::cerr << err.what() << std::endl;
+        return 1;
+    }
+}

--- a/test cases/windows/23 diasdk/meson.build
+++ b/test cases/windows/23 diasdk/meson.build
@@ -1,0 +1,13 @@
+project('diatest', 'cpp')
+
+if host_machine.system() != 'windows'
+  error('MESON_SKIP_TEST: unsupported platform')
+endif
+cpp = meson.get_compiler('cpp', native: false)
+is_msvc_clang = cpp.get_id() == 'clang' and cpp.get_define('_MSC_VER') != ''
+if not ['msvc', 'clang-cl'].contains(cpp.get_id()) and not is_msvc_clang
+  error('MESON_SKIP_TEST: unsupported compiler')
+endif
+
+dia = dependency('diasdk', required: true)
+executable('dia_registered', ['dia_registered.cpp'], dependencies:[dia])

--- a/test cases/windows/24 diasdk copy dll/config.h.in
+++ b/test cases/windows/24 diasdk copy dll/config.h.in
@@ -1,0 +1,3 @@
+#pragma once
+
+#define MSDIA_DLL_NAME L"@msdia_dll_name@"

--- a/test cases/windows/24 diasdk copy dll/dia_from_dll.cpp
+++ b/test cases/windows/24 diasdk copy dll/dia_from_dll.cpp
@@ -1,0 +1,32 @@
+// Loads msdiaXXX.dll from current directory using NoRegCoCreate.
+// File name is set in config.h symbol MSDIA_DLL_NAME.
+
+#include <dia2.h>
+#include <diacreate.h>
+#include <windows.h>
+#include <stdexcept>
+#include <iostream>
+
+#include "config.h"
+
+int main()
+{
+    try {
+
+    HRESULT hr = CoInitialize(NULL);
+    if (FAILED(hr))
+        throw std::runtime_error("Failed to initialize COM library");
+
+    IDiaDataSource* datasrc;
+    hr = NoRegCoCreate(MSDIA_DLL_NAME, CLSID_DiaSource, __uuidof(IDiaDataSource), (void**)&datasrc);
+    if (FAILED(hr))
+        throw std::runtime_error("Can't open DIA DLL");
+
+    std::cout << "DIA was successfully loaded\n";
+    return 0;
+
+    } catch (std::exception& err) {
+        std::cerr << err.what() << std::endl;
+        return 1;
+    }
+}

--- a/test cases/windows/24 diasdk copy dll/meson.build
+++ b/test cases/windows/24 diasdk copy dll/meson.build
@@ -1,0 +1,21 @@
+project('diatest', 'cpp')
+
+if host_machine.system() != 'windows'
+  error('MESON_SKIP_TEST: unsupported platform')
+endif
+cpp = meson.get_compiler('cpp', native: false)
+is_msvc_clang = cpp.get_id() == 'clang' and cpp.get_define('_MSC_VER') != ''
+if not ['msvc', 'clang-cl'].contains(cpp.get_id()) and not is_msvc_clang
+  error('MESON_SKIP_TEST: unsupported compiler')
+endif
+
+dia = dependency('diasdk', required: true)
+dia_dll_name = dia.get_variable('dll')
+fs = import('fs')
+fs.copyfile( dia_dll_name )
+
+conf = configuration_data()
+conf.set('msdia_dll_name', fs.name(dia_dll_name))
+configure_file(input: 'config.h.in', output: 'config.h', configuration: conf)
+
+executable('dia_from_dll', ['dia_from_dll.cpp'], dependencies: [dia])


### PR DESCRIPTION
Solves: https://github.com/mesonbuild/meson/issues/13627

Tested on Windows with [msvc, clang_cl], building [x86, x86_64, arm, aarch64] targets (latter two via cross-compiling). AFAIK this is all that DIA SDK supports.

Possible issues:

1. Version of dependency is not provided. The only way I could find would require us to drag in some library for parsing the version out of msdiaXXX.dll resources. 

2. Should the dependency be named 'dia' or 'diasdk'? I am afraid the name 'dia' may be too generic and may conflict with something else in future. This library in particular is very commonly called 'DIA SDK', including the 'SDK' part, maybe for the very same reason.

3. Trickiest part is how to allow users to copy the runtime DLL to build directory, if they want to. This is not strictly required, but a very nice practical feature, without which an application must ask its users to manually register some DLL somewhere inside Program Files from admin console. To provide a better option, the dependency needs to return DLL path to meson.build script. I may have abused dependency variables here a bit. Currently this dependency returns a "internal" variable 'dll' (despite "internal" variables being only used with internal dependencies?). I am not aware of any other way to return such value from dependency. It works like this:

```meson
dia = dependency('diasdk', required: true)
dia_dll_name = dia.get_variable(internal: 'dll')
fs = import('fs')
fs.copyfile( dia_dll_name )

conf = configuration_data()
conf.set('msdia_dll_name', fs.name(dia_dll_name))
configure_file(input: 'config.h.in', output: 'config.h', configuration: conf)

executable('dia_from_dll', ['dia_from_dll.cpp'], dependencies: [dia])
```

Not sure if this is tolerable, or if there is some better way. 