### PR TITLE
Support lists for ObjC and ObjC++ standards

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -11,7 +11,7 @@ from .. import options
 from .. import mlog
 from ..mesonlib import MesonException, version_compare
 from .c_function_attributes import C_FUNC_ATTRIBUTES
-from .mixins.apple import AppleCompilerMixin
+from .mixins.apple import AppleCompilerMixin, AppleCStdsMixin
 from .mixins.clike import CLikeCompiler
 from .mixins.ccrx import CcrxCompiler
 from .mixins.xc16 import Xc16Compiler
@@ -157,17 +157,13 @@ class ArmLtdClangCCompiler(ClangCCompiler):
     id = 'armltdclang'
 
 
-class AppleClangCCompiler(AppleCompilerMixin, ClangCCompiler):
+class AppleClangCCompiler(AppleCompilerMixin, AppleCStdsMixin, ClangCCompiler):
 
     """Handle the differences between Apple Clang and Vanilla Clang.
 
     Right now this just handles the differences between the versions that new
     C standards were added.
     """
-
-    _C17_VERSION = '>=10.0.0'
-    _C18_VERSION = '>=11.0.0'
-    _C2X_VERSION = '>=11.0.0'
 
 
 class EmscriptenCCompiler(EmscriptenMixin, ClangCCompiler):

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -19,7 +19,7 @@ from .mixins.compcert import CompCertCompiler
 from .mixins.ti import TICompiler
 from .mixins.arm import ArmCompiler, ArmclangCompiler
 from .mixins.visualstudio import MSVCCompiler, ClangClCompiler
-from .mixins.gnu import GnuCompiler
+from .mixins.gnu import GnuCompiler, GnuCStds
 from .mixins.gnu import gnu_common_warning_args, gnu_c_warning_args
 from .mixins.intel import IntelGnuLikeCompiler, IntelVisualStudioLikeCompiler
 from .mixins.clang import ClangCompiler, ClangCStds
@@ -237,12 +237,8 @@ class ArmclangCCompiler(ArmclangCompiler, CCompiler):
         return []
 
 
-class GnuCCompiler(GnuCompiler, CCompiler):
+class GnuCCompiler(GnuCStds, GnuCompiler, CCompiler):
 
-    _C18_VERSION = '>=8.0.0'
-    _C2X_VERSION = '>=9.0.0'
-    _C23_VERSION = '>=14.0.0'
-    _C2Y_VERSION = '>=15.0.0'
     _INVALID_PCH_VERSION = ">=3.4.0"
 
     def __init__(self, ccache: T.List[str], exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
@@ -264,25 +260,12 @@ class GnuCCompiler(GnuCompiler, CCompiler):
                                          self.supported_warn_args(gnu_c_warning_args))}
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = CCompiler.get_options(self)
-        stds = ['c89', 'c99', 'c11']
-        if version_compare(self.version, self._C18_VERSION):
-            stds += ['c17', 'c18']
-        if version_compare(self.version, self._C2X_VERSION):
-            stds += ['c2x']
-        if version_compare(self.version, self._C23_VERSION):
-            stds += ['c23']
-        if version_compare(self.version, self._C2Y_VERSION):
-            stds += ['c2y']
-        key = self.form_compileropt_key('std')
-        std_opt = opts[key]
-        assert isinstance(std_opt, options.UserStdOption), 'for mypy'
-        std_opt.set_versions(stds, gnu=True)
+        opts = super().get_options()
         if self.info.is_windows() or self.info.is_cygwin():
             self.update_options(
                 opts,
                 self.create_option(options.UserArrayOption,
-                                   key.evolve('c_winlibs'),
+                                   self.form_compileropt_key('winlibs'),
                                    'Standard Windows libs to link against',
                                    gnu_winlibs),
             )

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2012-2020 The Meson development team
+# Copyright © 2024-2025 Intel Corporation
 
 from __future__ import annotations
 
@@ -47,9 +48,9 @@ if T.TYPE_CHECKING:
 else:
     CompilerMixinBase = object
 
-_ALL_STDS = ['c89', 'c9x', 'c90', 'c99', 'c1x', 'c11', 'c17', 'c18', 'c2x', 'c23', 'c2y']
-_ALL_STDS += [f'gnu{std[1:]}' for std in _ALL_STDS]
-_ALL_STDS += ['iso9899:1990', 'iso9899:199409', 'iso9899:1999', 'iso9899:2011', 'iso9899:2017', 'iso9899:2018']
+ALL_STDS = ['c89', 'c9x', 'c90', 'c99', 'c1x', 'c11', 'c17', 'c18', 'c2x', 'c23', 'c2y']
+ALL_STDS += [f'gnu{std[1:]}' for std in ALL_STDS]
+ALL_STDS += ['iso9899:1990', 'iso9899:199409', 'iso9899:1999', 'iso9899:2011', 'iso9899:2017', 'iso9899:2018']
 
 
 class CCompiler(CLikeCompiler, Compiler):
@@ -98,7 +99,7 @@ class CCompiler(CLikeCompiler, Compiler):
         opts = super().get_options()
         key = self.form_compileropt_key('std')
         opts.update({
-            key: options.UserStdOption('C', _ALL_STDS),
+            key: options.UserStdOption('C', ALL_STDS),
         })
         return opts
 

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -21,7 +21,7 @@ from .mixins.visualstudio import MSVCCompiler, ClangClCompiler
 from .mixins.gnu import GnuCompiler
 from .mixins.gnu import gnu_common_warning_args, gnu_c_warning_args
 from .mixins.intel import IntelGnuLikeCompiler, IntelVisualStudioLikeCompiler
-from .mixins.clang import ClangCompiler
+from .mixins.clang import ClangCompiler, ClangCStds
 from .mixins.elbrus import ElbrusCompiler
 from .mixins.pgi import PGICompiler
 from .mixins.emscripten import EmscriptenMixin
@@ -103,43 +103,7 @@ class CCompiler(CLikeCompiler, Compiler):
         return opts
 
 
-class _ClangCStds(CompilerMixinBase):
-
-    """Mixin class for clang based compilers for setting C standards.
-
-    This is used by both ClangCCompiler and ClangClCompiler, as they share
-    the same versions
-    """
-
-    _C17_VERSION = '>=6.0.0'
-    _C18_VERSION = '>=8.0.0'
-    _C2X_VERSION = '>=9.0.0'
-    _C23_VERSION = '>=18.0.0'
-    _C2Y_VERSION = '>=19.0.0'
-
-    def get_options(self) -> 'MutableKeyedOptionDictType':
-        opts = super().get_options()
-        stds = ['c89', 'c99', 'c11']
-        # https://releases.llvm.org/6.0.0/tools/clang/docs/ReleaseNotes.html
-        # https://en.wikipedia.org/wiki/Xcode#Latest_versions
-        if version_compare(self.version, self._C17_VERSION):
-            stds += ['c17']
-        if version_compare(self.version, self._C18_VERSION):
-            stds += ['c18']
-        if version_compare(self.version, self._C2X_VERSION):
-            stds += ['c2x']
-        if version_compare(self.version, self._C23_VERSION):
-            stds += ['c23']
-        if version_compare(self.version, self._C2Y_VERSION):
-            stds += ['c2y']
-        key = self.form_compileropt_key('std')
-        std_opt = opts[key]
-        assert isinstance(std_opt, options.UserStdOption), 'for mypy'
-        std_opt.set_versions(stds, gnu=True)
-        return opts
-
-
-class ClangCCompiler(_ClangCStds, ClangCompiler, CCompiler):
+class ClangCCompiler(ClangCStds, ClangCompiler, CCompiler):
 
     def __init__(self, ccache: T.List[str], exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo',
@@ -523,7 +487,7 @@ class VisualStudioCCompiler(MSVCCompiler, VisualStudioLikeCCompilerMixin, CCompi
         return args
 
 
-class ClangClCCompiler(_ClangCStds, ClangClCompiler, VisualStudioLikeCCompilerMixin, CCompiler):
+class ClangClCCompiler(ClangCStds, ClangClCompiler, VisualStudioLikeCCompilerMixin, CCompiler):
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice,
                  is_cross: bool, info: 'MachineInfo', target: str,
                  linker: T.Optional['DynamicLinker'] = None,

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -45,9 +45,9 @@ if T.TYPE_CHECKING:
 else:
     CompilerMixinBase = object
 
-_ALL_STDS = ['c++98', 'c++0x', 'c++03', 'c++1y', 'c++1z', 'c++11', 'c++14', 'c++17', 'c++2a', 'c++20', 'c++23', 'c++26']
-_ALL_STDS += [f'gnu{std[1:]}' for std in _ALL_STDS]
-_ALL_STDS += ['vc++11', 'vc++14', 'vc++17', 'vc++20', 'vc++latest', 'c++latest']
+ALL_STDS = ['c++98', 'c++0x', 'c++03', 'c++1y', 'c++1z', 'c++11', 'c++14', 'c++17', 'c++2a', 'c++20', 'c++23', 'c++26']
+ALL_STDS += [f'gnu{std[1:]}' for std in ALL_STDS]
+ALL_STDS += ['vc++11', 'vc++14', 'vc++17', 'vc++20', 'vc++latest', 'c++latest']
 
 
 def non_msvc_eh_options(eh: str, args: T.List[str]) -> None:
@@ -175,7 +175,7 @@ class CPPCompiler(CLikeCompiler, Compiler):
         opts = super().get_options()
         key = self.form_compileropt_key('std')
         opts.update({
-            key: options.UserStdOption('C++', _ALL_STDS),
+            key: options.UserStdOption('C++', ALL_STDS),
         })
         return opts
 

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -25,7 +25,7 @@ from .mixins.ccrx import CcrxCompiler
 from .mixins.ti import TICompiler
 from .mixins.arm import ArmCompiler, ArmclangCompiler
 from .mixins.visualstudio import MSVCCompiler, ClangClCompiler
-from .mixins.gnu import GnuCompiler, gnu_common_warning_args, gnu_cpp_warning_args
+from .mixins.gnu import GnuCompiler, GnuCPPStds, gnu_common_warning_args, gnu_cpp_warning_args
 from .mixins.intel import IntelGnuLikeCompiler, IntelVisualStudioLikeCompiler
 from .mixins.clang import ClangCompiler, ClangCPPStds
 from .mixins.elbrus import ElbrusCompiler
@@ -417,7 +417,7 @@ class ArmclangCPPCompiler(ArmclangCompiler, CPPCompiler):
         return []
 
 
-class GnuCPPCompiler(_StdCPPLibMixin, GnuCompiler, CPPCompiler):
+class GnuCPPCompiler(_StdCPPLibMixin, GnuCPPStds, GnuCompiler, CPPCompiler):
     def __init__(self, ccache: T.List[str], exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo',
                  linker: T.Optional['DynamicLinker'] = None,
@@ -437,7 +437,7 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCompiler, CPPCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         key = self.form_compileropt_key('std')
-        opts = CPPCompiler.get_options(self)
+        opts = super().get_options()
         self.update_options(
             opts,
             self.create_option(options.UserComboOption,
@@ -454,17 +454,6 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCompiler, CPPCompiler):
                                'STL debug mode',
                                False),
         )
-        cppstd_choices = [
-            'c++98', 'c++03', 'c++11', 'c++14', 'c++17', 'c++1z',
-            'c++2a', 'c++20',
-        ]
-        if version_compare(self.version, '>=11.0.0'):
-            cppstd_choices.append('c++23')
-        if version_compare(self.version, '>=14.0.0'):
-            cppstd_choices.append('c++26')
-        std_opt = opts[key]
-        assert isinstance(std_opt, options.UserStdOption), 'for mypy'
-        std_opt.set_versions(cppstd_choices, gnu=True)
         if self.info.is_windows() or self.info.is_cygwin():
             self.update_options(
                 opts,

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -19,7 +19,7 @@ from .compilers import (
     CompileCheckMode,
 )
 from .c_function_attributes import CXX_FUNC_ATTRIBUTES, C_FUNC_ATTRIBUTES
-from .mixins.apple import AppleCompilerMixin
+from .mixins.apple import AppleCompilerMixin, AppleCPPStdsMixin
 from .mixins.clike import CLikeCompiler
 from .mixins.ccrx import CcrxCompiler
 from .mixins.ti import TICompiler
@@ -325,10 +325,8 @@ class ArmLtdClangCPPCompiler(ClangCPPCompiler):
     id = 'armltdclang'
 
 
-class AppleClangCPPCompiler(AppleCompilerMixin, ClangCPPCompiler):
-
-    _CPP23_VERSION = '>=13.0.0'
-    _CPP26_VERSION = '>=16.0.0'
+class AppleClangCPPCompiler(AppleCompilerMixin, AppleCPPStdsMixin, ClangCPPCompiler):
+    pass
 
 
 class EmscriptenCPPCompiler(EmscriptenMixin, ClangCPPCompiler):

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -897,9 +897,13 @@ def _detect_objc_or_objcpp_compiler(env: 'Environment', lang: str, for_machine: 
             version = _get_gnu_version_from_defines(defines)
             comp = objc.GnuObjCCompiler if lang == 'objc' else objcpp.GnuObjCPPCompiler
             linker = guess_nix_linker(env, compiler, comp, version, for_machine)
-            return comp(
+            c = comp(
                 ccache, compiler, version, for_machine, is_cross, info,
                 defines, linker=linker)
+            if not c.compiles('int main(void) { return 0; }', env)[0]:
+                popen_exceptions[join_args(compiler)] = f'GCC was not built with support for {"objective-c" if lang == "objc" else "objective-c++"}'
+                continue
+            return c
         if 'clang' in out:
             linker = None
             defines = _get_clang_compiler_defines(compiler, lang)

--- a/mesonbuild/compilers/mixins/apple.py
+++ b/mesonbuild/compilers/mixins/apple.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright © 2024 Intel Corporation
+# Copyright © 2024-2025 Intel Corporation
 
 """Provides mixins for Apple compilers."""
 
@@ -59,3 +59,12 @@ class AppleCompilerMixin(Compiler):
     def get_prelink_args(self, prelink_name: str, obj_list: T.List[str]) -> T.Tuple[T.List[str], T.List[str]]:
         # The objects are prelinked through the compiler, which injects -lSystem
         return [prelink_name], ['-nostdlib', '-r', '-o', prelink_name] + obj_list
+
+
+class AppleCStdsMixin(Compiler):
+
+    """Provide version overrides for the Apple Compilers."""
+
+    _C17_VERSION = '>=10.0.0'
+    _C18_VERSION = '>=11.0.0'
+    _C2X_VERSION = '>=11.0.0'

--- a/mesonbuild/compilers/mixins/apple.py
+++ b/mesonbuild/compilers/mixins/apple.py
@@ -68,3 +68,11 @@ class AppleCStdsMixin(Compiler):
     _C17_VERSION = '>=10.0.0'
     _C18_VERSION = '>=11.0.0'
     _C2X_VERSION = '>=11.0.0'
+
+
+class AppleCPPStdsMixin(Compiler):
+
+    """Provide version overrides for the Apple C++ Compilers."""
+
+    _CPP23_VERSION = '>=13.0.0'
+    _CPP26_VERSION = '>=16.0.0'

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -247,3 +247,30 @@ class ClangCStds(CompilerMixinBase):
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
         std_opt.set_versions(stds, gnu=True)
         return opts
+
+
+class ClangCPPStds(CompilerMixinBase):
+
+    """Mixin class for clang based compilers for setting C++ standards.
+
+    This is used by the ClangCPPCompiler
+    """
+
+    _CPP23_VERSION = '>=12.0.0'
+    _CPP26_VERSION = '>=17.0.0'
+
+    def get_options(self) -> MutableKeyedOptionDictType:
+        opts = super().get_options()
+        stds = [
+            'c++98', 'c++03', 'c++11', 'c++14', 'c++17', 'c++1z', 'c++2a',
+            'c++20',
+        ]
+        if mesonlib.version_compare(self.version, self._CPP23_VERSION):
+            stds.append('c++23')
+        if mesonlib.version_compare(self.version, self._CPP26_VERSION):
+            stds.append('c++26')
+        key = self.form_compileropt_key('std')
+        std_opt = opts[key]
+        assert isinstance(std_opt, options.UserStdOption), 'for mypy'
+        std_opt.set_versions(stds, gnu=True)
+        return opts

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -10,6 +10,7 @@ import shutil
 import typing as T
 
 from ... import mesonlib
+from ... import options
 from ...linkers.linkers import AppleDynamicLinker, ClangClDynamicLinker, LLVMDynamicLinker, GnuGoldDynamicLinker, \
     MoldDynamicLinker, MSVCDynamicLinker
 from ...options import OptionKey
@@ -17,8 +18,14 @@ from ..compilers import CompileCheckMode
 from .gnu import GnuLikeCompiler
 
 if T.TYPE_CHECKING:
+    from ...coredata import MutableKeyedOptionDictType
     from ...environment import Environment
     from ...dependencies import Dependency  # noqa: F401
+    from ..compilers import Compiler
+
+    CompilerMixinBase = Compiler
+else:
+    CompilerMixinBase = object
 
 clang_color_args: T.Dict[str, T.List[str]] = {
     'auto': ['-fdiagnostics-color=auto'],
@@ -204,3 +211,39 @@ class ClangCompiler(GnuLikeCompiler):
                 raise mesonlib.MesonException('clang support for LTO threads requires clang >=4.0')
             args.append(f'-flto-jobs={threads}')
         return args
+
+
+class ClangCStds(CompilerMixinBase):
+
+    """Mixin class for clang based compilers for setting C standards.
+
+    This is used by both ClangCCompiler and ClangClCompiler, as they share
+    the same versions
+    """
+
+    _C17_VERSION = '>=6.0.0'
+    _C18_VERSION = '>=8.0.0'
+    _C2X_VERSION = '>=9.0.0'
+    _C23_VERSION = '>=18.0.0'
+    _C2Y_VERSION = '>=19.0.0'
+
+    def get_options(self) -> MutableKeyedOptionDictType:
+        opts = super().get_options()
+        stds = ['c89', 'c99', 'c11']
+        # https://releases.llvm.org/6.0.0/tools/clang/docs/ReleaseNotes.html
+        # https://en.wikipedia.org/wiki/Xcode#Latest_versions
+        if mesonlib.version_compare(self.version, self._C17_VERSION):
+            stds += ['c17']
+        if mesonlib.version_compare(self.version, self._C18_VERSION):
+            stds += ['c18']
+        if mesonlib.version_compare(self.version, self._C2X_VERSION):
+            stds += ['c2x']
+        if mesonlib.version_compare(self.version, self._C23_VERSION):
+            stds += ['c23']
+        if mesonlib.version_compare(self.version, self._C2Y_VERSION):
+            stds += ['c2y']
+        key = self.form_compileropt_key('std')
+        std_opt = opts[key]
+        assert isinstance(std_opt, options.UserStdOption), 'for mypy'
+        std_opt.set_versions(stds, gnu=True)
+        return opts

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -15,11 +15,12 @@ import typing as T
 
 from ... import mesonlib
 from ... import mlog
-from ...options import OptionKey
+from ...options import OptionKey, UserStdOption
 from mesonbuild.compilers.compilers import CompileCheckMode
 
 if T.TYPE_CHECKING:
     from ..._typing import ImmutableListProtocol
+    from ...coredata import MutableKeyedOptionDictType
     from ...environment import Environment
     from ..compilers import Compiler
 else:
@@ -629,3 +630,30 @@ class GnuCompiler(GnuLikeCompiler):
 
     def get_profile_use_args(self) -> T.List[str]:
         return super().get_profile_use_args() + ['-fprofile-correction']
+
+
+class GnuCStds(Compiler):
+
+    """Mixin class for gcc based compilers for setting C standards."""
+
+    _C18_VERSION = '>=8.0.0'
+    _C2X_VERSION = '>=9.0.0'
+    _C23_VERSION = '>=14.0.0'
+    _C2Y_VERSION = '>=15.0.0'
+
+    def get_options(self) -> MutableKeyedOptionDictType:
+        opts = super().get_options()
+        stds = ['c89', 'c99', 'c11']
+        if mesonlib.version_compare(self.version, self._C18_VERSION):
+            stds += ['c17', 'c18']
+        if mesonlib.version_compare(self.version, self._C2X_VERSION):
+            stds += ['c2x']
+        if mesonlib.version_compare(self.version, self._C23_VERSION):
+            stds += ['c23']
+        if mesonlib.version_compare(self.version, self._C2Y_VERSION):
+            stds += ['c2y']
+        key = self.form_compileropt_key('std')
+        std_opt = opts[key]
+        assert isinstance(std_opt, UserStdOption), 'for mypy'
+        std_opt.set_versions(stds, gnu=True)
+        return opts

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -657,3 +657,28 @@ class GnuCStds(Compiler):
         assert isinstance(std_opt, UserStdOption), 'for mypy'
         std_opt.set_versions(stds, gnu=True)
         return opts
+
+
+class GnuCPPStds(Compiler):
+
+    """Mixin class for GNU based compilers for setting CPP standards."""
+
+    _CPP23_VERSION = '>=11.0.0'
+    _CPP26_VERSION = '>=14.0.0'
+
+    def get_options(self) -> MutableKeyedOptionDictType:
+        opts = super().get_options()
+
+        stds = [
+            'c++98', 'c++03', 'c++11', 'c++14', 'c++17', 'c++1z',
+            'c++2a', 'c++20',
+        ]
+        if mesonlib.version_compare(self.version, self._CPP23_VERSION):
+            stds.append('c++23')
+        if mesonlib.version_compare(self.version, self._CPP26_VERSION):
+            stds.append('c++26')
+        key = self.form_compileropt_key('std')
+        std_opt = opts[key]
+        assert isinstance(std_opt, UserStdOption), 'for mypy'
+        std_opt.set_versions(stds, gnu=True)
+        return opts

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -9,6 +9,7 @@ from ..options import OptionKey, UserStdOption
 
 from .c import ALL_STDS
 from .compilers import Compiler
+from .mixins.apple import AppleCStdsMixin
 from .mixins.clang import ClangCompiler, ClangCStds
 from .mixins.clike import CLikeCompiler
 from .mixins.gnu import GnuCompiler, GnuCStds, gnu_common_warning_args, gnu_objc_warning_args
@@ -105,10 +106,6 @@ class ClangObjCCompiler(ClangCStds, ClangCompiler, ObjCCompiler):
             args.append('-std=' + std)
         return args
 
-class AppleClangObjCCompiler(ClangObjCCompiler):
+class AppleClangObjCCompiler(AppleCStdsMixin, ClangObjCCompiler):
 
     """Handle the differences between Apple's clang and vanilla clang."""
-
-    _C17_VERSION = '>=10.0.0'
-    _C18_VERSION = '>=11.0.0'
-    _C2X_VERSION = '>=11.0.0'

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -11,7 +11,7 @@ from .c import ALL_STDS
 from .compilers import Compiler
 from .mixins.clang import ClangCompiler, ClangCStds
 from .mixins.clike import CLikeCompiler
-from .mixins.gnu import GnuCompiler, gnu_common_warning_args, gnu_objc_warning_args
+from .mixins.gnu import GnuCompiler, GnuCStds, gnu_common_warning_args, gnu_objc_warning_args
 
 if T.TYPE_CHECKING:
     from .. import coredata
@@ -56,7 +56,7 @@ class ObjCCompiler(CLikeCompiler, Compiler):
         return super().form_compileropt_key(basename)
 
 
-class GnuObjCCompiler(GnuCompiler, ObjCCompiler):
+class GnuObjCCompiler(GnuCStds, GnuCompiler, ObjCCompiler):
     def __init__(self, ccache: T.List[str], exelist: T.List[str], version: str, for_machine: MachineChoice,
                  is_cross: bool, info: 'MachineInfo',
                  defines: T.Optional[T.Dict[str, str]] = None,
@@ -73,6 +73,13 @@ class GnuObjCCompiler(GnuCompiler, ObjCCompiler):
                           'everything': (default_warn_args + ['-Wextra', '-Wpedantic'] +
                                          self.supported_warn_args(gnu_common_warning_args) +
                                          self.supported_warn_args(gnu_objc_warning_args))}
+
+    def get_option_compile_args(self, options: 'coredata.KeyedOptionDictType') -> T.List[str]:
+        args = []
+        std = options.get_value(self.form_compileropt_key('std'))
+        if std != 'none':
+            args.append('-std=' + std)
+        return args
 
 
 class ClangObjCCompiler(ClangCStds, ClangCompiler, ObjCCompiler):

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -9,6 +9,7 @@ from ..options import OptionKey, UserStdOption
 
 from .cpp import ALL_STDS
 from .compilers import Compiler
+from .mixins.apple import AppleCPPStdsMixin
 from .mixins.gnu import GnuCompiler, GnuCPPStds, gnu_common_warning_args, gnu_objc_warning_args
 from .mixins.clang import ClangCompiler, ClangCPPStds
 from .mixins.clike import CLikeCompiler
@@ -107,6 +108,6 @@ class ClangObjCPPCompiler(ClangCPPStds, ClangCompiler, ObjCPPCompiler):
         return args
 
 
-class AppleClangObjCPPCompiler(ClangObjCPPCompiler):
+class AppleClangObjCPPCompiler(AppleCPPStdsMixin, ClangObjCPPCompiler):
 
     """Handle the differences between Apple's clang and vanilla clang."""

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -9,7 +9,7 @@ from ..options import OptionKey, UserStdOption
 
 from .cpp import ALL_STDS
 from .compilers import Compiler
-from .mixins.gnu import GnuCompiler, gnu_common_warning_args, gnu_objc_warning_args
+from .mixins.gnu import GnuCompiler, GnuCPPStds, gnu_common_warning_args, gnu_objc_warning_args
 from .mixins.clang import ClangCompiler, ClangCPPStds
 from .mixins.clike import CLikeCompiler
 
@@ -56,7 +56,7 @@ class ObjCPPCompiler(CLikeCompiler, Compiler):
         return opts
 
 
-class GnuObjCPPCompiler(GnuCompiler, ObjCPPCompiler):
+class GnuObjCPPCompiler(GnuCPPStds, GnuCompiler, ObjCPPCompiler):
     def __init__(self, ccache: T.List[str], exelist: T.List[str], version: str, for_machine: MachineChoice,
                  is_cross: bool, info: 'MachineInfo',
                  defines: T.Optional[T.Dict[str, str]] = None,
@@ -73,6 +73,13 @@ class GnuObjCPPCompiler(GnuCompiler, ObjCPPCompiler):
                           'everything': (default_warn_args + ['-Wextra', '-Wpedantic'] +
                                          self.supported_warn_args(gnu_common_warning_args) +
                                          self.supported_warn_args(gnu_objc_warning_args))}
+
+    def get_option_compile_args(self, options: 'coredata.KeyedOptionDictType') -> T.List[str]:
+        args = []
+        std = options.get_value(self.form_compileropt_key('std'))
+        if std != 'none':
+            args.append('-std=' + std)
+        return args
 
 
 class ClangObjCPPCompiler(ClangCPPStds, ClangCompiler, ObjCPPCompiler):

--- a/test cases/unit/116 c cpp stds/meson.build
+++ b/test cases/unit/116 c cpp stds/meson.build
@@ -1,6 +1,17 @@
-project('c cpp stds', 'c', 'cpp',
-    default_options: [
-        'c_std=gnu89,c89',
-        'cpp_std=gnu++98,vc++11',
-    ],
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2024 Intel Corporation
+
+project(
+  'c cpp stds',
+  default_options: [
+    'c_std=gnu89,c89',
+    'cpp_std=gnu++98,vc++11',
+  ],
 )
+
+if get_option('with-c')
+  add_languages('c', 'cpp', native : false)
+endif
+if get_option('with-objc')
+  add_languages('objc', 'objcpp', native : false)
+endif

--- a/test cases/unit/116 c cpp stds/meson.options
+++ b/test cases/unit/116 c cpp stds/meson.options
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2024 Intel Corporation
+
+option('with-c', type : 'boolean', value : false)
+option('with-objc', type : 'boolean', value : false)

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -5055,7 +5055,7 @@ class AllPlatformTests(BasePlatformTests):
             self.setconf('-Dc_std=c++11')
         env = get_fake_env()
         cc = detect_c_compiler(env, MachineChoice.HOST)
-        if cc.get_id() == 'msvc':
+        if cc.get_id() in {'msvc', 'clang-cl'}:
             # default_option should have selected those
             self.assertEqual(self.getconf('c_std'), 'c89')
             self.assertEqual(self.getconf('cpp_std'), 'vc++11')
@@ -5068,7 +5068,7 @@ class AllPlatformTests(BasePlatformTests):
             # The first supported std should be selected
             self.setconf('-Dcpp_std=gnu++11,vc++11,c++11')
             self.assertEqual(self.getconf('cpp_std'), 'vc++11')
-        elif cc.get_id() == 'gcc':
+        elif cc.get_id() == 'gcc' or (cc.get_id() == 'clang' and not is_windows()):
             # default_option should have selected those
             self.assertEqual(self.getconf('c_std'), 'gnu89')
             self.assertEqual(self.getconf('cpp_std'), 'gnu++98')

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -5043,9 +5043,11 @@ class AllPlatformTests(BasePlatformTests):
             olddata = newdata
             oldmtime = newmtime
 
-    def test_c_cpp_stds(self):
+    def __test_multi_stds(self, test_c: bool = True, test_objc: bool = False) -> None:
+        assert test_c or test_objc, 'must test something'
         testdir = os.path.join(self.unit_test_dir, '116 c cpp stds')
-        self.init(testdir)
+        self.init(testdir, extra_args=[f'-Dwith-c={str(test_c).lower()}',
+                                       f'-Dwith-objc={str(test_objc).lower()}'])
         # Invalid values should fail whatever compiler we have
         with self.assertRaises(subprocess.CalledProcessError):
             self.setconf('-Dc_std=invalid')
@@ -5054,7 +5056,19 @@ class AllPlatformTests(BasePlatformTests):
         with self.assertRaises(subprocess.CalledProcessError):
             self.setconf('-Dc_std=c++11')
         env = get_fake_env()
-        cc = detect_c_compiler(env, MachineChoice.HOST)
+        if test_c:
+            cc = detect_c_compiler(env, MachineChoice.HOST)
+        if test_objc:
+            objc = detect_compiler_for(env, 'objc', MachineChoice.HOST, True, '')
+            assert objc is not None
+            if test_c and cc.get_argument_syntax() != objc.get_argument_syntax():
+                # The test doesn't work correctly in this case because we can
+                # end up with incompatible stds, like gnu89 with cl.exe for C
+                # and clang.exe for ObjC
+                return
+            if not test_c:
+                cc = objc
+
         if cc.get_id() in {'msvc', 'clang-cl'}:
             # default_option should have selected those
             self.assertEqual(self.getconf('c_std'), 'c89')
@@ -5068,13 +5082,26 @@ class AllPlatformTests(BasePlatformTests):
             # The first supported std should be selected
             self.setconf('-Dcpp_std=gnu++11,vc++11,c++11')
             self.assertEqual(self.getconf('cpp_std'), 'vc++11')
-        elif cc.get_id() == 'gcc' or (cc.get_id() == 'clang' and not is_windows()):
+        elif cc.get_id() in {'gcc', 'clang'}:
             # default_option should have selected those
             self.assertEqual(self.getconf('c_std'), 'gnu89')
             self.assertEqual(self.getconf('cpp_std'), 'gnu++98')
             # The first supported std should be selected
             self.setconf('-Dcpp_std=c++11,gnu++11,vc++11')
             self.assertEqual(self.getconf('cpp_std'), 'c++11')
+
+    def test_c_cpp_stds(self) -> None:
+        self.__test_multi_stds()
+
+    @skip_if_not_language('objc')
+    @skip_if_not_language('objcpp')
+    def test_objc_objcpp_stds(self) -> None:
+        self.__test_multi_stds(test_c=False, test_objc=True)
+
+    @skip_if_not_language('objc')
+    @skip_if_not_language('objcpp')
+    def test_c_cpp_objc_objcpp_stds(self) -> None:
+        self.__test_multi_stds(test_objc=True)
 
     def test_rsp_support(self):
         env = get_fake_env()

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -42,7 +42,6 @@ from run_tests import (
 # e.g. for assertXXX helpers.
 __unittest = True
 
-@mock.patch.dict(os.environ)
 class BasePlatformTests(TestCase):
     prefix = '/usr'
     libdir = 'lib'
@@ -87,8 +86,17 @@ class BasePlatformTests(TestCase):
             # VS doesn't have a stable output when no changes are done
             # XCode backend is untested with unit tests, help welcome!
             cls.no_rebuild_stdout = [f'UNKNOWN BACKEND {cls.backend.name!r}']
+
+        cls.env_patch = mock.patch.dict(os.environ)
+        cls.env_patch.start()
+
         os.environ['COLUMNS'] = '80'
         os.environ['PYTHONIOENCODING'] = 'utf8'
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        super().tearDownClass()
+        cls.env_patch.stop()
 
     def setUp(self):
         super().setUp()

--- a/unittests/failuretests.py
+++ b/unittests/failuretests.py
@@ -241,19 +241,26 @@ class FailureTests(BasePlatformTests):
         '''
         self.assertMesonRaises(code, ".* is not a config-tool dependency")
 
-    def test_objc_cpp_detection(self):
+    def test_objc_detection(self) -> None:
         '''
         Test that when we can't detect objc or objcpp, we fail gracefully.
         '''
         env = get_fake_env()
         try:
             detect_objc_compiler(env, MachineChoice.HOST)
+        except EnvironmentException as e:
+            self.assertRegex(str(e), r"(Unknown compiler|GCC was not built with support)")
+        else:
+            raise unittest.SkipTest('Working objective-c Compiler found, cannot test error.')
+
+    def test_objcpp_detection(self) -> None:
+        env = get_fake_env()
+        try:
             detect_objcpp_compiler(env, MachineChoice.HOST)
-        except EnvironmentException:
-            code = "add_languages('objc')\nadd_languages('objcpp')"
-            self.assertMesonRaises(code, "Unknown compiler")
-            return
-        raise unittest.SkipTest("objc and objcpp found, can't test detection failure")
+        except EnvironmentException as e:
+            self.assertRegex(str(e), r"(Unknown compiler|GCC was not built with support)")
+        else:
+            raise unittest.SkipTest('Working objective-c++ Compiler found, cannot test error.')
 
     def test_subproject_variables(self):
         '''

--- a/unittests/failuretests.py
+++ b/unittests/failuretests.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016-2021 The Meson development team
 
+from __future__ import annotations
 import subprocess
 import tempfile
 import os
 import shutil
 import unittest
+import typing as T
 from contextlib import contextmanager
 
 from mesonbuild.mesonlib import (
@@ -75,12 +77,13 @@ class FailureTests(BasePlatformTests):
         super().tearDown()
         windows_proof_rmtree(self.srcdir)
 
-    def assertMesonRaises(self, contents, match, *,
-                          extra_args=None,
-                          langs=None,
-                          meson_version=None,
-                          options=None,
-                          override_envvars=None):
+    def assertMesonRaises(self, contents: str,
+                          match: T.Union[str, T.Pattern[str]], *,
+                          extra_args: T.Optional[T.List[str]] = None,
+                          langs: T.Optional[T.List[str]] = None,
+                          meson_version: T.Optional[str] = None,
+                          options: T.Optional[str] = None,
+                          override_envvars: T.Optional[T.MutableMapping[str, str]] = None) -> None:
         '''
         Assert that running meson configure on the specified @contents raises
         a error message matching regex @match.

--- a/unittests/machinefiletests.py
+++ b/unittests/machinefiletests.py
@@ -23,7 +23,7 @@ import mesonbuild.envconfig
 import mesonbuild.environment
 import mesonbuild.coredata
 import mesonbuild.modules.gnome
-
+from mesonbuild import mesonlib
 from mesonbuild import machinefile
 
 from mesonbuild.mesonlib import (
@@ -275,7 +275,12 @@ class NativeFileTests(BasePlatformTests):
             if not is_real_gnu_compiler(shutil.which('gcc')):
                 raise SkipTest('Only one compiler found, cannot test.')
             return 'gcc', 'gcc'
-        self.helper_for_compiler('objc', cb)
+        try:
+            self.helper_for_compiler('objc', cb)
+        except mesonlib.EnvironmentException as e:
+            if 'GCC was not built with support for objective-c' in str(e):
+                raise unittest.SkipTest("GCC doesn't support objective-c, test cannot run")
+            raise
 
     @skip_if_not_language('objcpp')
     @skip_if_env_set('OBJCXX')
@@ -288,7 +293,12 @@ class NativeFileTests(BasePlatformTests):
             if not is_real_gnu_compiler(shutil.which('g++')):
                 raise SkipTest('Only one compiler found, cannot test.')
             return 'g++', 'gcc'
-        self.helper_for_compiler('objcpp', cb)
+        try:
+            self.helper_for_compiler('objcpp', cb)
+        except mesonlib.EnvironmentException as e:
+            if 'GCC was not built with support for objective-c++' in str(e):
+                raise unittest.SkipTest("G++ doesn't support objective-c++, test cannot run")
+            raise
 
     @skip_if_not_language('d')
     @skip_if_env_set('DC')


### PR DESCRIPTION
Also, share the implementations between the C and ObjC, and C++ and OjbC++ instance of both Clang and GNU compilers, so that we update once, and only once for each compiler.

Mostly this just ends up moving code around.

Fixes: #13639