### PR TITLE
Prevent raw exception during project()

### DIFF
--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -12,7 +12,7 @@ from .. import options
 from .. import build
 from .. import mlog
 
-from ..modules import ModuleReturnValue, ModuleObject, ModuleState, ExtensionModule
+from ..modules import ModuleReturnValue, ModuleObject, ModuleState, ExtensionModule, NewExtensionModule
 from ..backend.backends import TestProtocol
 from ..interpreterbase import (
                                ContainerTypeInfo, KwargInfo, MesonOperator,
@@ -872,6 +872,10 @@ class ModuleObjectHolder(ObjectHolder[ModuleObject]):
             args = flatten(args)
         if not getattr(method, 'no-second-level-holder-flattening', False):
             args, kwargs = resolve_second_level_holders(args, kwargs)
+        if not self.interpreter.active_projectname:
+            assert isinstance(modobj, (ExtensionModule, NewExtensionModule)), 'for mypy'
+            full_method_name = f'{modobj.INFO.name}.{method_name}'
+            raise mesonlib.MesonException(f'Module methods ({full_method_name}) cannot be invoked during project declaration.')
         state = ModuleState(self.interpreter)
         # Many modules do for example self.interpreter.find_program_impl(),
         # so we have to ensure they use the current interpreter and not the one

--- a/test cases/failing/132 module use inside project decl/meson.build
+++ b/test cases/failing/132 module use inside project decl/meson.build
@@ -1,0 +1,6 @@
+# GH issue 11393
+project('module use inside project decl', 'c',
+  version: run_command(
+    import('python').find_installation('python3')
+  )
+)

--- a/test cases/failing/132 module use inside project decl/test.json
+++ b/test cases/failing/132 module use inside project decl/test.json
@@ -1,0 +1,7 @@
+{
+    "stdout": [
+      {
+        "line": "test cases/failing/132 module use inside project decl/meson.build:4:21: ERROR: Module methods (python.find_installation) cannot be invoked during project declaration."
+      }
+    ]
+  }


### PR DESCRIPTION
If a user imports a module and invokes a method on it, a raw Python exception is raised to the user. This commit adds a check to ensure that in this case an appropriate exception is raised instead.

A test has been added to ensure that this exception is in fact raised on offending code.

Fixes #11393
Fixes #5134