### PR TITLE
Fix check for 32-bit clang-cl

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -309,7 +309,7 @@ def detect_windows_arch(compilers: CompilersDict) -> str:
     for compiler in compilers.values():
         if compiler.id == 'msvc' and (compiler.target in {'x86', '80x86'}):
             return 'x86'
-        if compiler.id == 'clang-cl' and compiler.target == 'x86':
+        if compiler.id == 'clang-cl' and (compiler.target in {'x86', 'i686'}):
             return 'x86'
         if compiler.id == 'gcc' and compiler.has_builtin_define('__i386__'):
             return 'x86'


### PR DESCRIPTION
Fixes #13643  (Architecture was being incorrectly detected for 32-bit clang-cl)

I am not sure how to write test for this. Also tests don't work for me in this case, due to #13645 .