### PR TITLE
Fix pkgconfig.generate handling of BothLibraries dependencies

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -353,14 +353,14 @@ class InternalDependency(Dependency):
         new_dep.libraries = []
         return new_dep
 
-    def get_as_static(self, recursive: bool) -> Dependency:
+    def get_as_static(self, recursive: bool) -> InternalDependency:
         new_dep = copy.copy(self)
         new_dep.libraries = [lib.get('static') for lib in self.libraries]
         if recursive:
             new_dep.ext_deps = [dep.get_as_static(True) for dep in self.ext_deps]
         return new_dep
 
-    def get_as_shared(self, recursive: bool) -> Dependency:
+    def get_as_shared(self, recursive: bool) -> InternalDependency:
         new_dep = copy.copy(self)
         new_dep.libraries = [lib.get('shared') for lib in self.libraries]
         if recursive:

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -195,6 +195,13 @@ class DependenciesHelper:
                 if obj.found():
                     if obj.objects:
                         raise mesonlib.MesonException('.pc file cannot refer to individual object files.')
+
+                    # Ensure BothLibraries are resolved:
+                    if self.pub_libs and isinstance(self.pub_libs[0], build.StaticLibrary):
+                        obj = obj.get_as_static(recursive=True)
+                    else:
+                        obj = obj.get_as_shared(recursive=True)
+
                     processed_libs += obj.get_link_args()
                     processed_cflags += obj.get_compile_args()
                     self._add_lib_dependencies(obj.libraries, obj.whole_libraries, obj.ext_deps, public, private_external_deps=True)

--- a/test cases/common/278 pkgconfig-gen/meson.build
+++ b/test cases/common/278 pkgconfig-gen/meson.build
@@ -1,0 +1,19 @@
+project('pkgconfig-get', 'c')
+
+pkgg = import('pkgconfig')
+
+subdir('simple2')
+
+lib = library('simple', 'simple.c', dependencies: lib_dep)
+libver = '1.0'
+h = install_headers('simple.h')
+
+
+pkgg.generate(
+  lib,
+  version : libver,
+  name : 'libsimple',
+  filebase : 'simple',
+  description : 'A simple demo library.',
+  libraries: [lib_dep],
+)

--- a/test cases/common/278 pkgconfig-gen/simple.c
+++ b/test cases/common/278 pkgconfig-gen/simple.c
@@ -1,0 +1,6 @@
+#include"simple.h"
+#include <simple2.h>
+
+int simple_function(void) {
+    return simple_simple_function();
+}

--- a/test cases/common/278 pkgconfig-gen/simple.h
+++ b/test cases/common/278 pkgconfig-gen/simple.h
@@ -1,0 +1,6 @@
+#ifndef SIMPLE_H_
+#define SIMPLE_H_
+
+int simple_function(void);
+
+#endif

--- a/test cases/common/278 pkgconfig-gen/simple2/exports.def
+++ b/test cases/common/278 pkgconfig-gen/simple2/exports.def
@@ -1,0 +1,2 @@
+EXPORTS
+    simple_simple_function  @1

--- a/test cases/common/278 pkgconfig-gen/simple2/meson.build
+++ b/test cases/common/278 pkgconfig-gen/simple2/meson.build
@@ -1,0 +1,2 @@
+lib2 = library('simple2', 'simple2.c', vs_module_defs: 'exports.def')
+lib_dep = declare_dependency(link_with: lib2, include_directories: include_directories('.'))

--- a/test cases/common/278 pkgconfig-gen/simple2/simple2.c
+++ b/test cases/common/278 pkgconfig-gen/simple2/simple2.c
@@ -1,0 +1,5 @@
+#include"simple2.h"
+
+int simple_simple_function(void) {
+    return 42;
+}

--- a/test cases/common/278 pkgconfig-gen/simple2/simple2.h
+++ b/test cases/common/278 pkgconfig-gen/simple2/simple2.h
@@ -1,0 +1,6 @@
+#ifndef SIMPLE2_H_
+#define SIMPLE2_H_
+
+int simple_simple_function(void);
+
+#endif

--- a/test cases/common/278 pkgconfig-gen/test.json
+++ b/test cases/common/278 pkgconfig-gen/test.json
@@ -1,0 +1,15 @@
+{
+    "installed": [
+        { "type": "file", "file": "usr/include/simple.h"},
+        { "type": "file", "file": "usr/lib/pkgconfig/simple.pc"}
+    ],
+    "matrix": {
+        "options": {
+            "default_library": [
+                { "val": "shared" },
+                { "val": "static" },
+                { "val": "both" }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Was caused by 7b3169f. Fixes #13657.

I'm not sure about the new test. Ideally, it should be integrated with "44 pkgconfig-gen". However, I don't have the requirements to run it on my machine.