### PR TITLE
fix typos

### DIFF
--- a/data/shell-completions/bash/meson
+++ b/data/shell-completions/bash/meson
@@ -30,7 +30,7 @@ _subprojects() {
     local COMPREPLY=()
     _filedir
     # _filedir for whatever reason can't reason about symlinks, so -d will them.
-    # Filter out wrap files with this expresion.
+    # Filter out wrap files with this expression.
     IFS=$'\n' echo "${COMPREPLY[*]}" | grep -vE '\.wrap$' | xargs
   popd &>/dev/null
 }

--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -187,7 +187,7 @@ with previous meson versions), 'static', or 'auto'. With auto, the value from
 `default_library` option is used, unless it is 'both', in which case 'shared'
 is used instead.
 
-When `default_both_libraries` is 'auto', passing a [[@both_libs]] dependecy
+When `default_both_libraries` is 'auto', passing a [[@both_libs]] dependency
 in [[both_libraries]] will link the static dependency with the static lib,
 and the shared dependency with the shared lib.
 

--- a/docs/markdown/Release-notes-for-0.51.0.md
+++ b/docs/markdown/Release-notes-for-0.51.0.md
@@ -143,7 +143,7 @@ then invoke Meson as `meson setup builddir/ -Dcmake_prefix_path=/tmp/dep`
 You can tag a test as needing to fail like this:
 
 ```meson
-test('shoulfail', exe, should_fail: true)
+test('shouldfail', exe, should_fail: true)
 ```
 
 If the test passes the problem is reported in the error logs but due

--- a/docs/markdown/Release-notes-for-1.0.0.md
+++ b/docs/markdown/Release-notes-for-1.0.0.md
@@ -59,7 +59,7 @@ Any include paths in these dependencies will be passed to the underlying call to
 ## String arguments to the rust.bindgen include_directories argument
 
 Most other cases of include_directories accept strings as well as
-`IncludeDirectory` objects, so lets do that here too for consistency.
+`IncludeDirectory` objects, so let's do that here too for consistency.
 
 ## The Rust module is stable
 

--- a/docs/markdown/Release-notes-for-1.2.0.md
+++ b/docs/markdown/Release-notes-for-1.2.0.md
@@ -49,7 +49,7 @@ directory, instead of using Visual Studio's native engine.
 ## More data in introspection files
 
 - Used compilers are listed in `intro-compilers.json`
-- Informations about `host`, `build` and `target` machines 
+- Information about `host`, `build` and `target` machines 
   are lister in `intro-machines.json`
 - `intro-dependencies.json` now includes internal dependencies,
   and relations between dependencies.

--- a/docs/markdown/Release-notes-for-1.3.0.md
+++ b/docs/markdown/Release-notes-for-1.3.0.md
@@ -39,7 +39,7 @@ about its value.
 
 ## [[configure_file]] now has a `macro_name` parameter.
 
-This new paramater, `macro_name` allows C macro-style include guards to be added
+This new parameter, `macro_name` allows C macro-style include guards to be added
 to [[configure_file]]'s output when a template file is not given. This change
 simplifies the creation of configure files that define macros with dynamic names
 and want the C-style include guards.

--- a/docs/markdown/Release-notes-for-1.5.0.md
+++ b/docs/markdown/Release-notes-for-1.5.0.md
@@ -19,7 +19,7 @@ Cargo dependencies names are now in the format `<package_name>-<version>-rs`:
   * `x.y.z` -> 'x'
   * `0.x.y` -> '0.x'
   * `0.0.x` -> '0'
-  It allows to make different dependencies for uncompatible versions of the same
+  It allows to make different dependencies for incompatible versions of the same
   crate.
 - `-rs` suffix is added to distinguish from regular system dependencies, for
   example `gstreamer-1.0` is a system pkg-config dependency and `gstreamer-0.22-rs`

--- a/docs/markdown/Wrap-dependency-system-manual.md
+++ b/docs/markdown/Wrap-dependency-system-manual.md
@@ -323,7 +323,7 @@ name:
   * `x.y.z` -> 'x'
   * `0.x.y` -> '0.x'
   * `0.0.x` -> '0'
-  It allows to make different dependencies for uncompatible versions of the same
+  It allows to make different dependencies for incompatible versions of the same
   crate.
 - `-rs` suffix is added to distinguish from regular system dependencies, for
   example `gstreamer-1.0` is a system pkg-config dependency and `gstreamer-0.22-rs`
@@ -359,7 +359,7 @@ the main project depends on `foo-1-rs` and `bar-1-rs`, and they both depend on
 configure `common-rs` with a set of features. Later, when `bar-1-rs` does a lookup
 for `common-1-rs` it has already been configured and the set of features cannot be
 changed. If `bar-1-rs` wants extra features from `common-1-rs`, Meson will error out.
-It is currently the responsability of the main project to resolve those
+It is currently the responsibility of the main project to resolve those
 issues by enabling extra features on each subproject:
 ```meson
 project(...,

--- a/docs/refman/generatormd.py
+++ b/docs/refman/generatormd.py
@@ -94,7 +94,7 @@ class GeneratorMD(GeneratorBase):
 
     def _link_to_object(self, obj: T.Union[Function, Object], in_code_block: bool = False) -> str:
         '''
-            Generate a palaceholder tag for the function/method/object documentation.
+            Generate a placeholder tag for the function/method/object documentation.
             This tag is then replaced in the custom hotdoc plugin.
         '''
         prefix = '#' if in_code_block else ''

--- a/docs/yaml/functions/build_target.yaml
+++ b/docs/yaml/functions/build_target.yaml
@@ -32,7 +32,7 @@ description: |
 
   The returned object also has methods that are documented in [[@build_tgt]].
 
-  *"jar" is deprecated because it is fundementally a different thing than the
+  *"jar" is deprecated because it is fundamentally a different thing than the
   other build_target types.
 
 posargs_inherit: _build_target_base

--- a/docs/yaml/functions/install_data.yaml
+++ b/docs/yaml/functions/install_data.yaml
@@ -13,7 +13,7 @@ varargs:
 warnings:
   - the `install_mode` kwarg ignored integer values between 0.59.0 -- 1.1.0.
   - an omitted `install_dir` kwarg did not work correctly inside of a subproject until 1.3.0.
-  - an omitted `install_dir` kwarg did not work correctly when combined with the `preserve_path` kwarg untill 1.3.0.
+  - an omitted `install_dir` kwarg did not work correctly when combined with the `preserve_path` kwarg until 1.3.0.
 
 kwargs:
   install_dir:

--- a/docs/yaml/objects/compiler.yaml
+++ b/docs/yaml/objects/compiler.yaml
@@ -612,7 +612,7 @@ methods:
   # kwargs:
   #   checked:
   #     type: str
-  #     sinec: 0.59.0
+  #     since: 0.59.0
   #     default: "'off'"
   #     description: |
   #       Supported values:

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1135,7 +1135,7 @@ class Backend:
 
         if p.is_file():
             p = p.parent
-        # Heuristic: replace *last* occurence of '/lib'
+        # Heuristic: replace *last* occurrence of '/lib'
         binpath = Path('/bin'.join(p.as_posix().rsplit('/lib', maxsplit=1)))
         for _ in binpath.glob('*.dll'):
             return str(binpath)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -101,7 +101,7 @@ def get_rsp_threshold() -> int:
         # and that has a limit of 8k.
         limit = 8192
     else:
-        # Unix-like OSes usualy have very large command line limits, (On Linux,
+        # Unix-like OSes usually have very large command line limits, (On Linux,
         # for example, this is limited by the kernel's MAX_ARG_STRLEN). However,
         # some programs place much lower limits, notably Wine which enforces a
         # 32k limit like Windows. Therefore, we limit the command line to 32k.
@@ -3135,7 +3135,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
 
     # Fortran is a bit weird (again). When you link against a library, just compiling a source file
     # requires the mod files that are output when single files are built. To do this right we would need to
-    # scan all inputs and write out explicit deps for each file. That is stoo slow and too much effort so
+    # scan all inputs and write out explicit deps for each file. That is too slow and too much effort so
     # instead just have an ordered dependency on the library. This ensures all required mod files are created.
     # The real deps are then detected via dep file generation from the compiler. This breaks on compilers that
     # produce incorrect dep files but such is life.

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -879,7 +879,7 @@ class Vs2010Backend(backends.Backend):
                 ET.SubElement(parent_node, 'PreprocessorDefinitions', Condition=condition).text = defs
                 ET.SubElement(parent_node, 'AdditionalIncludeDirectories', Condition=condition).text = paths
                 ET.SubElement(parent_node, 'AdditionalOptions', Condition=condition).text = opts
-        else: # Can't find bespoke nmake defs/dirs/opts fields for this extention, so just reference the project's fields
+        else: # Can't find bespoke nmake defs/dirs/opts fields for this extension, so just reference the project's fields
             ET.SubElement(parent_node, 'PreprocessorDefinitions').text = '$(NMakePreprocessorDefinitions)'
             ET.SubElement(parent_node, 'AdditionalIncludeDirectories').text = '$(NMakeIncludeSearchPath)'
             ET.SubElement(parent_node, 'AdditionalOptions').text = '$(AdditionalOptions)'
@@ -1542,7 +1542,7 @@ class Vs2010Backend(backends.Backend):
     # the solution's configurations.  Similarly, 'ItemGroup' also doesn't support 'Condition'.  So, without knowing
     # a better (simple) alternative, for now, we'll repoint these generated sources (which will be incorrectly
     # pointing to non-existent files under our '[builddir]_vs' directory) to the appropriate location under one of
-    # our buildtype build directores (e.g. '[builddir]_debug').
+    # our buildtype build directories (e.g. '[builddir]_debug').
     # This will at least allow the user to open the files of generated sources listed in the solution explorer,
     # once a build/compile has generated these sources.
     #

--- a/mesonbuild/cargo/builder.py
+++ b/mesonbuild/cargo/builder.py
@@ -133,7 +133,7 @@ class Builder:
 
         :param lhs: The left hand side of the equal
         :param rhs: the right hand side of the equal
-        :return: A compraison node
+        :return: A comparison node
         """
         return mparser.ComparisonNode('==', lhs, self._symbol('=='), rhs)
 
@@ -142,7 +142,7 @@ class Builder:
 
         :param lhs: The left hand side of the "!="
         :param rhs: the right hand side of the "!="
-        :return: A compraison node
+        :return: A comparison node
         """
         return mparser.ComparisonNode('!=', lhs, self._symbol('!='), rhs)
 
@@ -151,7 +151,7 @@ class Builder:
 
         :param lhs: The left hand side of the "in"
         :param rhs: the right hand side of the "in"
-        :return: A compraison node
+        :return: A comparison node
         """
         return mparser.ComparisonNode('in', lhs, self._symbol('in'), rhs)
 
@@ -160,7 +160,7 @@ class Builder:
 
         :param lhs: The left hand side of the "not in"
         :param rhs: the right hand side of the "not in"
-        :return: A compraison node
+        :return: A comparison node
         """
         return mparser.ComparisonNode('notin', lhs, self._symbol('not in'), rhs)
 

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -106,7 +106,7 @@ def _fixup_raw_mappings(d: T.Union[manifest.BuildTarget, manifest.LibTarget, man
     This does the following:
     * replaces any `-` with `_`, cargo likes the former, but python dicts make
       keys with `-` in them awkward to work with
-    * Convert Dependndency versions from the cargo format to something meson
+    * Convert Dependency versions from the cargo format to something meson
       understands
 
     :param d: The mapping to fix
@@ -732,7 +732,7 @@ def interpret(subp_name: str, subdir: str, env: Environment) -> T.Tuple[mparser.
     ast += _create_meson_subdir(cargo, build)
 
     # Libs are always auto-discovered and there's no other way to handle them,
-    # which is unfortunate for reproducability
+    # which is unfortunate for reproducibility
     if os.path.exists(os.path.join(env.source_dir, cargo.subdir, cargo.path, cargo.lib.path)):
         for crate_type in cargo.lib.crate_type:
             ast.extend(_create_lib(cargo, build, crate_type))

--- a/mesonbuild/cmake/generator.py
+++ b/mesonbuild/cmake/generator.py
@@ -20,7 +20,7 @@ def parse_generator_expressions(
     '''Parse CMake generator expressions
 
     Most generator expressions are simply ignored for
-    simplicety, however some are required for some common
+    simplicity, however some are required for some common
     use cases.
     '''
 

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -487,7 +487,7 @@ class ConverterTarget:
             source_files = [x.name for x in i.sources + i.generated]
             for j in stem:
                 # On some platforms (specifically looking at you Windows with vs20xy backend) CMake does
-                # not produce object files with the format `foo.cpp.obj`, instead it skipps the language
+                # not produce object files with the format `foo.cpp.obj`, instead it skips the language
                 # suffix and just produces object files like `foo.obj`. Thus we have to do our best to
                 # undo this step and guess the correct language suffix of the object file. This is done
                 # by trying all language suffixes meson knows and checking if one of them fits.

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -39,7 +39,7 @@ defaults: T.Dict[str, T.List[str]] = {}
 if is_windows():
     # Intel C and C++ compiler is icl on Windows, but icc and icpc elsewhere.
     # Search for icl before cl, since Intel "helpfully" provides a
-    # cl.exe that returns *exactly the same thing* that microsofts
+    # cl.exe that returns *exactly the same thing* that Microsoft's
     # cl.exe does, and if icl is present, it's almost certainly what
     # you want.
     defaults['c'] = ['icl', 'cl', 'cc', 'gcc', 'clang', 'clang-cl', 'pgcc']
@@ -181,7 +181,7 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
             else:
                 trials = default_linkers
         elif compiler.id == 'intel-cl' and compiler.language == 'c': # why not cpp? Is this a bug?
-            # Intel has its own linker that acts like microsoft's lib
+            # Intel has its own linker that acts like Microsoft's lib
             trials = [['xilib']]
         elif is_windows() and compiler.id == 'pgi': # this handles cpp / nvidia HPC, in addition to just c/fortran
             trials = [['ar']]  # For PGI on Windows, "ar" is just a wrapper calling link/lib.
@@ -585,7 +585,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
                 lnk = linkers.MetrowerksLinkerEmbeddedPowerPC
 
             mwcc_ver_match = re.search(r'Version (\d+)\.(\d+)\.?(\d+)? build (\d+)', out)
-            assert mwcc_ver_match is not None, 'for mypy'  # because mypy *should* be complaning that this could be None
+            assert mwcc_ver_match is not None, 'for mypy'  # because mypy *should* be complaining that this could be None
             compiler_version = '.'.join(x for x in mwcc_ver_match.groups() if x is not None)
 
             env.coredata.add_lang_args(cls.language, cls, for_machine, env)
@@ -595,7 +595,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
                 _, o_ld, _ = Popen_safe(ld + ['--version'])
 
                 mwld_ver_match = re.search(r'Version (\d+)\.(\d+)\.?(\d+)? build (\d+)', o_ld)
-                assert mwld_ver_match is not None, 'for mypy'  # because mypy *should* be complaning that this could be None
+                assert mwld_ver_match is not None, 'for mypy'  # because mypy *should* be complaining that this could be None
                 linker_version = '.'.join(x for x in mwld_ver_match.groups() if x is not None)
 
                 linker = lnk(ld, for_machine, version=linker_version)

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -56,7 +56,7 @@ if T.TYPE_CHECKING:
 # Mac   / homebrew: libboost_<module>.dylib + libboost_<module>-mt.dylib    (location = /usr/local/lib)
 # Mac   / macports: libboost_<module>.dylib + libboost_<module>-mt.dylib    (location = /opt/local/lib)
 #
-# Its not clear that any other abi tags (e.g. -gd) are used in official packages.
+# It's not clear that any other abi tags (e.g. -gd) are used in official packages.
 #
 # On Linux systems, boost libs have multithreading support enabled, but without the -mt tag.
 #

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -329,7 +329,7 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
     """
     Python is inconsistent in its platform module.
     It returns different values for the same cpu.
-    For x86 it might return 'x86', 'i686' or somesuch.
+    For x86 it might return 'x86', 'i686' or some such.
     Do some canonicalization.
     """
     if mesonlib.is_windows():
@@ -466,7 +466,7 @@ def detect_kernel(system: str) -> T.Optional[str]:
             raise MesonException('Failed to run "/usr/bin/uname -o"')
         out = out.lower().strip()
         if out not in {'illumos', 'solaris'}:
-            mlog.warning(f'Got an unexpected value for kernel on a SunOS derived platform, expcted either "illumos" or "solaris", but got "{out}".'
+            mlog.warning(f'Got an unexpected value for kernel on a SunOS derived platform, expected either "illumos" or "solaris", but got "{out}".'
                          "Please open a Meson issue with the OS you're running and the value detected for your kernel.")
             return None
         return out

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3453,7 +3453,7 @@ class Interpreter(InterpreterBase, HoldableObject):
 
             if kwargs['implib']:
                 if kwargs['export_dynamic'] is False:
-                    FeatureDeprecated.single_use('implib overrides explict export_dynamic off', '1.3.0', self.subproject,
+                    FeatureDeprecated.single_use('implib overrides explicit export_dynamic off', '1.3.0', self.subproject,
                                                  'Do not set ths if want export_dynamic disabled if implib is enabled',
                                                  location=node)
                 kwargs['export_dynamic'] = True

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -113,7 +113,7 @@ class ModuleState:
         if wanted:
             kwargs['version'] = wanted
         # FIXME: Even if we fix the function, mypy still can't figure out what's
-        # going on here. And we really dont want to call interpreter
+        # going on here. And we really don't want to call interpreter
         # implementations of meson functions anyway.
         return self._interpreter.func_dependency(self.current_node, [depname], kwargs) # type: ignore
 

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -354,7 +354,7 @@ def run(options: T.Union[CMDOptions, T.List[str]]) -> int:
     coredata.parse_cmd_line_options(options)
 
     # Msetup doesn't actually use this option, but we pass msetup options to
-    # mconf, and it does. We won't actally hit the path that uses it, but don't
+    # mconf, and it does. We won't actually hit the path that uses it, but don't
     # lie
     options.pager = False
 

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -110,7 +110,7 @@ class OptionKey:
     def __init__(self, name: str, subproject: str = '',
                  machine: MachineChoice = MachineChoice.HOST):
         # the _type option to the constructor is kinda private. We want to be
-        # able tos ave the state and avoid the lookup function when
+        # able to save the state and avoid the lookup function when
         # pickling/unpickling, but we need to be able to calculate it when
         # constructing a new OptionKey
         object.__setattr__(self, 'name', name)

--- a/test cases/format/5 transform/genexpected.cmd
+++ b/test cases/format/5 transform/genexpected.cmd
@@ -1,6 +1,6 @@
 @echo off
 REM This script generates the expected files
-REM Please double-check the contents of those files before commiting them!!!
+REM Please double-check the contents of those files before committing them!!!
 
 python ../../../meson.py format -o default.expected.meson source.meson
 python ../../../meson.py format -c muon.ini -o muon.expected.meson source.meson

--- a/test cases/rust/5 polyglot static/meson.build
+++ b/test cases/rust/5 polyglot static/meson.build
@@ -19,7 +19,7 @@ e = executable('prog', 'prog.c',
 test('polyglottest', e)
 
 # Create a version that has overflow-checks on, then run a test to ensure that
-# the overflow-checks is larger than the other version by some ammount
+# the overflow-checks is larger than the other version by some amount
 r2 = static_library('stuff2', 'stuff.rs', rust_crate_type : 'staticlib', rust_args : ['-C', 'overflow-checks=on'])
 l2 = static_library('clib2', 'clib.c')
 e2 = executable('prog2', 'prog.c', link_with : [r2, l2])

--- a/test cases/rust/9 unit tests/test3.rs
+++ b/test cases/rust/9 unit tests/test3.rs
@@ -8,7 +8,7 @@ mod tests {
 
         use super::*;
 
-        // This is an intentinally broken test that should be turned off by extra rust arguments
+        // This is an intentionally broken test that should be turned off by extra rust arguments
         #[cfg(not(broken = "false"))]
         #[test]
         fn test_broken() {

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -496,13 +496,13 @@ class BasePlatformTests(TestCase):
 
         ensures that the copied tree is deleted after running.
 
-        :param srcdir: The locaiton of the source tree to copy
+        :param srcdir: The location of the source tree to copy
         :return: The location of the copy
         """
         dest = tempfile.mkdtemp()
         self.addCleanup(windows_proof_rmtree, dest)
 
-        # shutil.copytree expects the destinatin directory to not exist, Once
+        # shutil.copytree expects the destination directory to not exist, Once
         # python 3.8 is required the `dirs_exist_ok` parameter negates the need
         # for this
         dest = os.path.join(dest, 'subdir')

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1348,8 +1348,8 @@ class InternalTests(unittest.TestCase):
     def test_typed_kwarg_since(self) -> None:
         @typed_kwargs(
             'testfunc',
-            KwargInfo('input', str, since='1.0', since_message='Its awesome, use it',
-                      deprecated='2.0', deprecated_message='Its terrible, dont use it')
+            KwargInfo('input', str, since='1.0', since_message='It\'s awesome, use it',
+                      deprecated='2.0', deprecated_message='It\'s terrible, don\'t use it')
         )
         def _(obj, node, args: T.Tuple, kwargs: T.Dict[str, str]) -> None:
             self.assertIsInstance(kwargs['input'], str)
@@ -1360,8 +1360,8 @@ class InternalTests(unittest.TestCase):
                 mock.patch('mesonbuild.mesonlib.project_meson_versions', {'': '0.1'}):
             # With Meson 0.1 it should trigger the "introduced" warning but not the "deprecated" warning
             _(None, mock.Mock(subproject=''), [], {'input': 'foo'})
-            self.assertRegex(out.getvalue(), r'WARNING:.*introduced.*input arg in testfunc. Its awesome, use it')
-            self.assertNotRegex(out.getvalue(), r'WARNING:.*deprecated.*input arg in testfunc. Its terrible, dont use it')
+            self.assertRegex(out.getvalue(), r'WARNING:.*introduced.*input arg in testfunc. It\'s awesome, use it')
+            self.assertNotRegex(out.getvalue(), r'WARNING:.*deprecated.*input arg in testfunc. It\'s terrible, don\'t use it')
 
         with self.subTest('no warnings should be triggered'), \
                 mock.patch('sys.stdout', io.StringIO()) as out, \
@@ -1375,8 +1375,8 @@ class InternalTests(unittest.TestCase):
                 mock.patch('mesonbuild.mesonlib.project_meson_versions', {'': '2.0'}):
             # With Meson 2.0 it should trigger the "deprecated" warning but not the "introduced" warning
             _(None, mock.Mock(subproject=''), [], {'input': 'foo'})
-            self.assertRegex(out.getvalue(), r'WARNING:.*deprecated.*input arg in testfunc. Its terrible, dont use it')
-            self.assertNotRegex(out.getvalue(), r'WARNING:.*introduced.*input arg in testfunc. Its awesome, use it')
+            self.assertRegex(out.getvalue(), r'WARNING:.*deprecated.*input arg in testfunc. It\'s terrible, don\'t use it')
+            self.assertNotRegex(out.getvalue(), r'WARNING:.*introduced.*input arg in testfunc. It\'s awesome, use it')
 
     def test_typed_kwarg_validator(self) -> None:
         @typed_kwargs(
@@ -1408,7 +1408,7 @@ class InternalTests(unittest.TestCase):
         @typed_kwargs(
             'testfunc',
             KwargInfo('input', ContainerTypeInfo(list, str), listify=True, default=[], deprecated_values={'foo': '0.9'}, since_values={'bar': '1.1'}),
-            KwargInfo('output', ContainerTypeInfo(dict, str), default={}, deprecated_values={'foo': '0.9', 'foo2': ('0.9', 'dont use it')}, since_values={'bar': '1.1', 'bar2': ('1.1', 'use this')}),
+            KwargInfo('output', ContainerTypeInfo(dict, str), default={}, deprecated_values={'foo': '0.9', 'foo2': ('0.9', 'don\'t use it')}, since_values={'bar': '1.1', 'bar2': ('1.1', 'use this')}),
             KwargInfo('install_dir', (bool, str, NoneType), deprecated_values={False: '0.9'}),
             KwargInfo(
                 'mode',
@@ -1443,7 +1443,7 @@ class InternalTests(unittest.TestCase):
 
         with self.subTest('deprecated dict string value with msg'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'output': {'foo2': 'a'}})
-            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '1.0'.*deprecated since '0.9': "testfunc" keyword argument "output" value "foo2" in dict keys. dont use it.*""")
+            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '1.0'.*deprecated since '0.9': "testfunc" keyword argument "output" value "foo2" in dict keys. don't use it.*""")
 
         with self.subTest('new dict string value'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'output': {'bar': 'b'}})

--- a/unittests/machinefiletests.py
+++ b/unittests/machinefiletests.py
@@ -330,7 +330,7 @@ class NativeFileTests(BasePlatformTests):
             elif comp.id == 'gcc':
                 if shutil.which('ifort'):
                     # There is an ICC for windows (windows build, linux host),
-                    # but we don't support that ATM so lets not worry about it.
+                    # but we don't support that ATM so let's not worry about it.
                     if is_windows():
                         return 'ifort', 'intel-cl'
                     return 'ifort', 'intel'
@@ -634,7 +634,7 @@ class NativeFileTests(BasePlatformTests):
 
         testcase = os.path.join(self.rust_test_dir, '12 bindgen')
         config = self.helper_create_native_file({
-            'properties': {'bindgen_clang_arguments': 'sentinal'}
+            'properties': {'bindgen_clang_arguments': 'sentinel'}
         })
 
         self.init(testcase, extra_args=['--native-file', config])
@@ -642,10 +642,10 @@ class NativeFileTests(BasePlatformTests):
         for t in targets:
             if t['id'].startswith('rustmod-bindgen'):
                 args: T.List[str] = t['target_sources'][0]['compiler']
-                self.assertIn('sentinal', args, msg="Did not find machine file value")
+                self.assertIn('sentinel', args, msg="Did not find machine file value")
                 cargs_start = args.index('--')
-                sent_arg = args.index('sentinal')
-                self.assertLess(cargs_start, sent_arg, msg='sentinal argument does not come after "--"')
+                sent_arg = args.index('sentinel')
+                self.assertLess(cargs_start, sent_arg, msg='sentinel argument does not come after "--"')
                 break
         else:
             self.fail('Did not find a bindgen target')


### PR DESCRIPTION
Closes https://github.com/mesonbuild/meson/issues/13652

@dcbaker 

unittests/internaltests.py

before merging please clarify from line 1446

whether the apostrophe on don't  factually needs to be escaped

```diff
-             self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '1.0'.*deprecated since '0.9': "testfunc" keyword argument "output" value "foo2" in dict keys. dont use it.*""")
+             self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '1.0'.*deprecated since '0.9': "testfunc" keyword argument "output" value "foo2" in dict keys. don\'t use it.*""")
```