### PR TITLE
ci: gentoo: install dev-qt/qttools

### DIFF
--- a/ci/ciimage/gentoo/install.sh
+++ b/ci/ciimage/gentoo/install.sh
@@ -40,8 +40,7 @@ pkgs_stable=(
   sci-libs/hdf5
   dev-qt/linguist-tools
   sys-devel/llvm
-  # qt6 unstable
-  #dev-qt/qttools
+  dev-qt/qttools
 
   # misc
   app-admin/sudo


### PR DESCRIPTION
Qt 6 now has stable keywords (and has for a while). Recent stabilisation of Plasma 6 now pulls in Qt 6 in the image builder so frameworks: 4 qt fails as qttools is missing.