### PR TITLE
interpreter: when overriding a dependency, override its name too, V2

### DIFF
--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2012-2021 The Meson development team
-# Copyright © 2021 Intel Corporation
+# Copyright © 2021-2024 Intel Corporation
 from __future__ import annotations
 
+import copy
 import os
 import typing as T
 
@@ -347,6 +348,16 @@ class MesonMain(MesonInterpreterObject):
         name, dep = args
         if not name:
             raise InterpreterException('First argument must be a string and cannot be empty')
+
+        # Make a copy since we're going to mutate.
+        #
+        #   dep = declare_dependency()
+        #   meson.override_dependency('foo', dep)
+        #   meson.override_dependency('foo-1.0', dep)
+        #   dep = dependency('foo')
+        #   dep.name() # == 'foo-1.0'
+        dep = copy.copy(dep)
+        dep.name = name
 
         optkey = OptionKey('default_library', subproject=self.interpreter.subproject)
         default_library = self.interpreter.coredata.get_option(optkey)

--- a/test cases/common/183 partial dependency/declare_dependency/meson.build
+++ b/test cases/common/183 partial dependency/declare_dependency/meson.build
@@ -1,4 +1,4 @@
-# Copyright © 2018 Intel Corporation
+# Copyright © 2018-2024 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,6 +27,14 @@ dec_exe = executable(
   'declare_dep',
   files('main.c', 'other.c'),
   dependencies : sub_dep,
+)
+
+# Ensure that two partial dependencies of the same dependency are applied, as
+# they may provide different values.
+dec2_exe = executable(
+  'declare_dep2',
+  files('main.c', 'other.c'),
+  dependencies : [sub_dep.partial_dependency(), sub_dep],
 )
 
 test('Declare Dependency', dec_exe)

--- a/test cases/common/183 partial dependency/external_dependency/header_only.c
+++ b/test cases/common/183 partial dependency/external_dependency/header_only.c
@@ -1,0 +1,8 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright © 2024 Intel Corporation
+ */
+
+#include <zlib.h>
+
+int main(void) { return 0; }

--- a/test cases/common/183 partial dependency/external_dependency/link.c
+++ b/test cases/common/183 partial dependency/external_dependency/link.c
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright © 2024 Intel Corporation
+ */
+
+#include <zlib.h>
+#include <string.h>
+
+int main(void) {
+    const char * zver = zlibVersion();
+    return strcmp(zver, ZLIB_VERSION);
+}

--- a/test cases/common/183 partial dependency/external_dependency/meson.build
+++ b/test cases/common/183 partial dependency/external_dependency/meson.build
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2024 Intel Corporation
+
+# TODO: don't use compile whenever we get includes and compile args separated
+dep_zlib_sub = dep_zlib.partial_dependency(compile_args : true, includes : true)
+
+executable(
+  'zlib header only test',
+  'header_only.c',
+  dependencies : dep_zlib_sub,
+)
+
+executable(
+  'zlib link test',
+  'link.c',
+  dependencies : [dep_zlib_sub, dep_zlib],
+)

--- a/test cases/common/183 partial dependency/meson.build
+++ b/test cases/common/183 partial dependency/meson.build
@@ -1,4 +1,4 @@
-# Copyright © 2018 Intel Corporation
+# Copyright © 2018-2024 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,3 +15,6 @@
 project('partial dependency', ['c', 'cpp'])
 
 subdir('declare_dependency')
+
+dep_zlib = dependency('zlib', required : false)
+subdir('external_dependency', if_found : dep_zlib)

--- a/test cases/common/98 subproject subdir/meson.build
+++ b/test cases/common/98 subproject subdir/meson.build
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2016-2023 The Meson Developers
+# Copyright © 2024 Intel Corporation
+
 project('proj', 'c')
 subproject('sub')
 libSub = dependency('sub', fallback: ['sub', 'libSub'])
@@ -6,7 +10,19 @@ exe = executable('prog', 'prog.c', dependencies: libSub)
 test('subproject subdir', exe)
 
 # Verify the subproject has placed dependency override.
-dependency('sub-1.0')
+d = dependency('sub-1.0')
+
+# verify that the name is the overridden name
+assert(d.name() == 'sub-1.0', 'name was not properly set, should have been "sub-1.0", but was @0@'.format(d.name()))
+
+# Verify that when a dependency object is used for two overrides, the correct
+# name is used
+meson.override_dependency('new-dep', d)
+d2 = dependency('new-dep')
+assert(d2.name() == 'new-dep', 'name was not properly set, should have been "new-dep", but was @0@'.format(d2.name()))
+
+# And that the old dependency wasn't changed
+assert(d.name() == 'sub-1.0', 'original dependency was mutated.')
 
 # Verify we can now take 'sub' dependency without fallback, but only version 1.0.
 dependency('sub')


### PR DESCRIPTION
 #12972 was reverted due to causing failures in libepoxy and a few other libraries.

This second spin identifies those issues as partial_dependency objects, where we *sometimes* would get a new id for the partial dependency (correct), but not in most cases. This respin replaces the `id()` based id with with `uuid.uuid4()` based one, and generates a new id for dependencies when they are `partial_dependency`'d, in all cases, not just those that happened to do so because of implementation.