### PR TITLE
.github/workflows/os_comp.yml: set HOME to /root on OpenSUSE

### DIFF
--- a/.github/workflows/os_comp.yml
+++ b/.github/workflows/os_comp.yml
@@ -60,7 +60,14 @@ jobs:
       # All environment variables are stored inside the docker image in /ci/env_vars.sh
       # They are defined in the `env` section in each image.json. CI_ARGS should be set
       # via the `args` array ub the image.json
-      run: bash -c 'source /ci/env_vars.sh; cd $GITHUB_WORKSPACE; ./tools/run_with_cov.py ./run_tests.py $CI_ARGS'
+      shell: bash
+      run: |
+        # dmd is installed under /root on OpenSUSE
+        [[ ${{ matrix.cfg.id }} == opensuse ]] && export HOME=/root
+
+        source /ci/env_vars.sh
+        cd $GITHUB_WORKSPACE
+        ./tools/run_with_cov.py ./run_tests.py $CI_ARGS
 
     - name: Aggregate coverage reports
       run: ./ci/combine_cov.sh


### PR DESCRIPTION
D tests in CI are currently skipped on OpenSUSE:
```
2024-09-13T05:41:49.5905706Z ##[group]Run bash -c 'source /ci/env_vars.sh; cd $GITHUB_WORKSPACE; ./tools/run_with_cov.py ./run_tests.py $CI_ARGS'
2024-09-13T05:41:49.5906827Z bash -c 'source /ci/env_vars.sh; cd $GITHUB_WORKSPACE; ./tools/run_with_cov.py ./run_tests.py $CI_ARGS'
2024-09-13T05:41:49.5910232Z shell: sh -e {0}
2024-09-13T05:41:49.5910719Z env:
2024-09-13T05:41:49.5911076Z   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
2024-09-13T05:41:49.5911543Z   MESON_CI_JOBNAME: linux-opensuse-gcc
2024-09-13T05:41:49.5912026Z ##[endgroup]
2024-09-13T05:41:49.6638977Z /ci/env_vars.sh: line 12: /github/home/dlang/dmd-2.109.1/activate: No such file or directory
2024-09-13T05:41:50.2631396Z Meson build system 1.5.99 Project and Unit Tests
#### <snip>
2024-09-13T05:51:49.9153096Z  [SKIPPED]   failing: 80 dub library
2024-09-13T05:51:49.9154187Z Reason: test requires D compiler
2024-09-13T05:51:49.9160901Z  [SKIPPED]   failing: 81 dub executable
2024-09-13T05:51:49.9162680Z Reason: test requires D compiler
2024-09-13T05:51:49.9173974Z  [SKIPPED]   failing: 82 dub compiler    (warning_level=1)
2024-09-13T05:51:49.9175726Z Reason: not run because preconditions were not met
#### <snip>
2024-09-13T05:53:50.7814038Z 
2024-09-13T05:53:50.7814564Z Not running d tests.
2024-09-13T05:53:50.7814992Z 
```