### PR TITLE
[tools] Improve the Lexer of cmake2meson

### DIFF
--- a/tools/cmake2meson.py
+++ b/tools/cmake2meson.py
@@ -28,7 +28,7 @@ class Lexer:
             ('ignore', re.compile(r'[ \t]')),
             ('string', re.compile(r'"([^\\]|(\\.))*?"', re.M)),
             ('varexp', re.compile(r'\${[-_0-9a-z/A-Z.]+}')),
-            ('id', re.compile('''[,-><${}=+_0-9a-z/A-Z|@.*]+''')),
+            ('id', re.compile('''[,-><&${}=+_0-9a-z/A-Z|@.*]+''')),
             ('eol', re.compile(r'\n')),
             ('comment', re.compile(r'#.*')),
             ('lparen', re.compile(r'\(')),


### PR DESCRIPTION
the rccl CMakeLists.txt is https://github.com/ROCm/rccl/blob/rocm-6.2.0/CMakeLists.txt
the original Lexer will occur mistake because of the follow code:
```
COMMAND mkdir -p ${HIP_FILE_DIR} && $ ${hipify-perl_executable} -quiet-warnings ${CMAKE_SOURCE_DIR}/${SRC_FILE} -o ${HIP_FILE}
```
the Lexer cannot parse "&"