### PR TITLE
Fix various incorrect uses of `its` vs `it's`.

### DIFF
--- a/docs/markdown/Qt6-module.md
+++ b/docs/markdown/Qt6-module.md
@@ -20,7 +20,7 @@ Compiles Qt's resources collection files (.qrc) into c++ files for compilation.
 It takes no positional arguments, and the following keyword arguments:
   - `name` (string | empty): if provided a single .cpp file will be generated,
     and the output of all qrc files will be combined in this file, otherwise
-    each qrc file be written to it's own cpp file.
+    each qrc file be written to its own cpp file.
   - `sources` (File | string | custom_target | custom_target index | generator_output)[]:
     A list of sources to be transpiled. Required, must have at least one source<br/>
     *New in 0.60.0*: support for custom_target, custom_target_index, and generator_output.
@@ -111,7 +111,7 @@ This method takes the following keyword arguments:
    directory. For instance, when a file called `subdir/one.input` is processed
    it generates a file `{target private directory}/subdir/one.out` when `true`,
    and `{target private directory}/one.out` when `false` (default).
-    
+
 It returns an array of targets and sources to pass to a compilation target.
 
 ## compile_translations

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -423,7 +423,7 @@ class XCodeBackend(backends.Backend):
             # generate id for our own target-name
             t.buildphasemap = {}
             t.buildphasemap[tname] = self.gen_id()
-            # each target can have it's own Frameworks/Sources/..., generate id's for those
+            # each target can have its own Frameworks/Sources/..., generate id's for those
             t.buildphasemap['Frameworks'] = self.gen_id()
             t.buildphasemap['Resources'] = self.gen_id()
             t.buildphasemap['Sources'] = self.gen_id()

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -280,7 +280,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
         compiler_name = os.path.basename(compiler[0])
 
         if any(os.path.basename(x) in {'cl', 'cl.exe', 'clang-cl', 'clang-cl.exe'} for x in compiler):
-            # Watcom C provides it's own cl.exe clone that mimics an older
+            # Watcom C provides its own cl.exe clone that mimics an older
             # version of Microsoft's compiler. Since Watcom's cl.exe is
             # just a wrapper, we skip using it if we detect its presence
             # so as not to confuse Meson when configuring for MSVC.
@@ -1026,7 +1026,7 @@ def detect_rust_compiler(env: 'Environment', for_machine: MachineChoice) -> Rust
         version = search_version(out)
         cls: T.Type[RustCompiler] = rust.RustCompiler
 
-        # Clippy is a wrapper around rustc, but it doesn't have rustc in it's
+        # Clippy is a wrapper around rustc, but it doesn't have rustc in its
         # output. We can otherwise treat it as rustc.
         if 'clippy' in out:
             # clippy returns its own version and not the rustc version by

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -157,7 +157,7 @@ class Dependency(HoldableObject):
         return self.compile_args
 
     def get_all_compile_args(self) -> T.List[str]:
-        """Get the compile arguments from this dependency and it's sub dependencies."""
+        """Get the compile arguments from this dependency and its sub dependencies."""
         return list(itertools.chain(self.get_compile_args(),
                                     *(d.get_all_compile_args() for d in self.ext_deps)))
 
@@ -167,7 +167,7 @@ class Dependency(HoldableObject):
         return self.link_args
 
     def get_all_link_args(self) -> T.List[str]:
-        """Get the link arguments from this dependency and it's sub dependencies."""
+        """Get the link arguments from this dependency and its sub dependencies."""
         return list(itertools.chain(self.get_link_args(),
                                     *(d.get_all_link_args() for d in self.ext_deps)))
 
@@ -213,7 +213,7 @@ class Dependency(HoldableObject):
             compile_args -- any compile args
             link_args -- any link args
 
-        Additionally the new dependency will have the version parameter of it's
+        Additionally the new dependency will have the version parameter of its
         parent (if any) and the requested values of any dependencies will be
         added as well.
         """

--- a/mesonbuild/dependencies/configtool.py
+++ b/mesonbuild/dependencies/configtool.py
@@ -22,7 +22,7 @@ class ConfigToolDependency(ExternalDependency):
 
     Takes the following extra keys in kwargs that it uses internally:
     :tools List[str]: A list of tool names to use
-    :version_arg str: The argument to pass to the tool to get it's version
+    :version_arg str: The argument to pass to the tool to get its version
     :skip_version str: The argument to pass to the tool to ignore its version
         (if ``version_arg`` fails, but it may start accepting it in the future)
         Because some tools are stupid and don't accept --version

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -71,7 +71,7 @@ class ExtractRequired(TypedDict):
     """Keyword Arguments consumed by the `extract_required_kwargs` function.
 
     Any function that uses the `required` keyword argument which accepts either
-    a boolean or a feature option should inherit it's arguments from this class.
+    a boolean or a feature option should inherit its arguments from this class.
     """
 
     required: T.Union[bool, options.UserFeatureOption]

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -141,7 +141,7 @@ class Conf:
 
         This prints the generated output in an aligned, pretty form. it aims
         for a total width of 160 characters, but will use whatever the tty
-        reports it's value to be. Though this is much wider than the standard
+        reports its value to be. Though this is much wider than the standard
         80 characters of terminals, and even than the newer 120, compressing
         it to those lengths makes the output hard to read.
 

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -86,7 +86,7 @@ class RustModule(ExtensionModule):
     def test(self, state: ModuleState, args: T.Tuple[str, BuildTarget], kwargs: FuncTest) -> ModuleReturnValue:
         """Generate a rust test target from a given rust target.
 
-        Rust puts it's unitests inside it's main source files, unlike most
+        Rust puts its unitests inside its main source files, unlike most
         languages that put them in external files. This means that normally
         you have to define two separate targets with basically the same
         arguments to get tests:
@@ -207,7 +207,7 @@ class RustModule(ExtensionModule):
         DEPENDENCIES_KW.evolve(since='1.0.0'),
     )
     def bindgen(self, state: ModuleState, args: T.List, kwargs: FuncBindgen) -> ModuleReturnValue:
-        """Wrapper around bindgen to simplify it's use.
+        """Wrapper around bindgen to simplify its use.
 
         The main thing this simplifies is the use of `include_directory`
         objects, instead of having to pass a plethora of `-I` arguments.

--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -119,7 +119,7 @@ class ExternalProgram(mesonlib.HoldableObject):
     @classmethod
     def from_bin_list(cls, env: 'Environment', for_machine: MachineChoice, name: str) -> 'ExternalProgram':
         # There is a static `for_machine` for this class because the binary
-        # always runs on the build platform. (It's host platform is our build
+        # always runs on the build platform. (Its host platform is our build
         # platform.) But some external programs have a target platform, so this
         # is what we are specifying here.
         command = env.lookup_binary_entry(for_machine, name)


### PR DESCRIPTION
These errors can make reading comments and documentation unnecessarily confusing for users and contributors who do not speak English as their first language.
