### PR TITLE
Fix TI C2000 support 

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3554,6 +3554,17 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                             for t in target.link_depends])
         elem = NinjaBuildElement(self.all_outputs, outname, linker_rule, obj_list, implicit_outs=implicit_outs)
         elem.add_dep(dep_targets + custom_target_libraries)
+
+        # Compiler args must be included in TI C28x linker commands.
+        if linker.get_id() in {'c2000', 'c6000', 'ti'}:
+            compile_args = []
+            for for_machine in MachineChoice:
+                clist = self.environment.coredata.compilers[for_machine]
+                for langname, compiler in clist.items():
+                    if langname in {'c', 'cpp'} and compiler.get_id() in {'c2000', 'c6000', 'ti'}:
+                        compile_args += self.generate_basic_compiler_args(target, compiler)
+            elem.add_item('ARGS', compile_args)
+
         elem.add_item('LINK_ARGS', commands)
         self.create_target_linker_introspection(target, linker, commands)
         return elem

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -1034,8 +1034,8 @@ class CLikeCompiler(Compiler):
         elif env.machines[self.for_machine].is_cygwin():
             shlibext = ['dll', 'dll.a']
             prefixes = ['cyg'] + prefixes
-        elif self.id.lower() == 'c6000' or self.id.lower() == 'ti':
-            # TI C6000 compiler can use both extensions for static or dynamic libs.
+        elif self.id.lower() in {'c6000', 'c2000', 'ti'}:
+            # TI C28x compilers can use both extensions for static or dynamic libs.
             stlibext = ['a', 'lib']
             shlibext = ['dll', 'so']
         else:

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -26,6 +26,9 @@ class StaticLinker:
     def __init__(self, exelist: T.List[str]):
         self.exelist = exelist
 
+    def get_id(self) -> str:
+        return self.id
+
     def compiler_args(self, args: T.Optional[T.Iterable[str]] = None) -> CompilerArgs:
         return CompilerArgs(self, args)
 


### PR DESCRIPTION
## Summary
<!-- 

1. In one sentence, or as close as possible, summarize why the changes are
needed. Then, include any relevant links, such as Slack discussions or design
documents. 

2. In one sentence, or as close as possible, summarize how the changes achieve
the resolution of the issue.

3. Specify the number of the issue resolved by this PR below.

-->

The purpose of this PR is to enable building for TI C28x targets with Meson without workarounds and un-mesonic ways.

I've looked through the implementation of the support for TI C28x currently in Meson and it appears workarounds have been used to avoid dealing with these issues directly, like including the arg `-llibc.a` in the linker args in the cross file for the MSP430 and using linker command files that can include the runtime support library rather than doing it the Mesonic way.

The existing support for TI C28x cross compilation (C2000, C6000, etc.) omits the compiler args that are required to be included in the linker command for TI C28x and formats the names of static libs incorrectly. An example that demonstrates the issue has been created as a [repo with a Docker image](https://github.com/EngJay/meson-minimal-ti-c28x-cgt).

### Compiler args not included in linker command

For example, the arg `--abi=eabi` is needed when compiling source files but also when linking since libraries being linked in and linker scripts have logic that depend on the macros set by the compiler / linker. If this arg is not included as a compiler arg when running the linker with the `-z` flag, linking fails since the linker fails to confirm the ABI is correct for everything and the wrong elements are included in some places since the ABI-related macros aren't set.

A conditional has been added to the `generate_link()` method to populate the Ninja `$ARGS` variable with the compiler args when generating the linking command for the TI C28x compilers. In order to get the ID of the linker, a getter for the ID has been added.

### Static libs not found and names are formatted incorrectly

When linking in static libraries, the TI C28x family of compilers requires the full name of the static library be included rather than just the name of the library with the preceding `lib` and suffix removed.

Currently, for the static lib `libc.a` with a TI C28x compiler, Meson adds the flag `-lc`, with which linking fails because the linker doesn't find the lib. Also, the runtime support libraries for this family use a suffix of `.lib` without `lib` prepended to the name. The format needed is `-llibc.a` or just `libc.a` for the linking command to work. When linking in a specific runtime support library rather than the `libc.a` index library, the arg needed is like this, `-lrts2800_fpu32_eabi.lib` or `rts2800_fpu32_eabi.lib`.

Meson's `find_library()` finds the lib but the linker fails to find it because of the format of the arg added by Meson.
```meson
# This is faulty because it adds a flag `-lc` at the end of the linker args but
# the C28x compiler expects it in the form `-llibc.a`.
#
cc = meson.get_compiler('c')
c2000_libc = cc.find_library('c', dirs: ti_c28x_c2000_cgt_dir / 'lib', static: true)
```

```bash
FAILED: src/example-i2c-ti-lp-f28379d-bme280.out 
cl2000 --c99 -O2 '--define=RELEASE -DNDEBUG' --cla_support=cla1 --float_support=fpu32 --tmu_support=tmu0 --vcu_support=vcu2 --diag_suppress=10063 --diag_warning=225 --diag_wrap=off --display_error_number --abi=eabi --define=F2837xD --define=CPU1 --issue_remarks -v28 -ml -mt -z --output_file=src/example-i2c-ti-lp-f28379d-bme280.out src/example-i2c-ti-lp-f28379d-bme280.out.p/i2c_ex3_external_loopback.c.o src/example-i2c-ti-lp-f28379d-bme280.out.p/device_F2837xD_CodeStartBranch.asm.o src/example-i2c-ti-lp-f28379d-bme280.out.p/device_device.c.o /Users/REDACTED/Projects/embedded-hal-c/examples/ti-lp-f28379d/bme280/src/2837xD_RAM_lnk_cpu1.cmd /Users/REDACTED/Projects/embedded-hal-c/examples/ti-lp-f28379d/bme280/subprojects/c2000ware-core-sdk/driverlib/f2837xd/driverlib/ccs/Release/driverlib_eabi.lib -mmain.map --heap_size=0x200 --stack_size=0x3F8 --warn_sections -i/Applications/ti/ti-cgt-c2000_22.6.1.LTS/lib -i/Applications/ti/ti-cgt-c2000_22.6.1.LTS/include --reread_libs --define=RAM --diag_wrap=off --display_error_number --xml_link_info=example-i2c-ti-f28379d-bme280_linkInfo.xml --entry_point=code_start --rom_model -lc
<Linking>
error #10008-D: cannot find file "c"

 undefined            first referenced                                                                                                                                                       
  symbol                  in file                                                                                                                                                            
 ---------            ----------------                                                                                                                                                       
 __TI_decompress_lzss                                                                                                                                                                        
 __TI_decompress_none                                                                                                                                                                        
 __c28xabi_divf       /Users/REDACTED/Projects/embedded-hal-c/examples/ti-lp-f28379d/bme280/subprojects/c2000ware-core-sdk/driverlib/f2837xd/driverlib/ccs/Release/driverlib_eabi.lib<sysctl.obj>
 _c_int00             src/example-i2c-ti-lp-f28379d-bme280.out.p/device_F2837xD_CodeStartBranch.asm.o  
```

Using Meson's `find_library()` fails, however, when trying to use it to find the runtime support libraries since they have a suffix of `.lib` and no prefix.
```meson
cc = meson.get_compiler('c')
c2000_rts_lib = cc.find_library('rts2800_fpu32_eabi', dirs: ti_c28x_c2000_cgt_dir / 'lib', static: true)
```

```bash
../src/meson.build:91:16: ERROR: C static library 'rts2800_fpu32_eabi' not found
```

The cause of this is `c2000` is missing from the conditional to set library naming in the `get_library_naming()` method on `CLikeCompiler` and I by chance have been using a C2000 compiler for this work.

To somewhat fix this, `c2000` has been added to the conditional for the other TI compilers in `get_library_naming()`, which enables the static libs to be found and included as with the other ostensibly supported TI compilers. This still depends on unintended behavior, as the warning produced indicates, `WARNING: find_library('libc') starting in "lib" only works by accident and is not portable`.

## Details
<!-- 

Describe the specific changes that have been made in this pull request. Provide
details on the approach taken to address the problem and any notable
implementation details. 

If the changes have visual elements or supporting visuals, like a change to a
user interface or images of signals on a scope, including screenshots or GIFs
can help reviewers understand them more easily. 

Also include any additional information that might be needed for verification
and validation.

-->

### Populating the compiler args for TI C28x linking 

I spent some time attempting to figure out how to get the compiler args into the `generate_link()` method but resorted to using the guts from the `generate_compile_rules()` method in `generate_link()`. I imagine there is a better way to do this but this got it working and I can go from here. 

An exception has been added to the `generate_link()` method of the Ninja backend to populate the `$ARGS` Ninja variable for the linking rule when the linker ID is `cl2000`, `cl6000`, or `ti`. 

Exception added to `generate_link()`.

```python
        # Compiler args must be included in TI C28x linker commands and static libs must go last.
        if linker.get_id() in {'c2000', 'c6000', 'ti'}:
            compile_args = []
            for for_machine in MachineChoice:
                clist = self.environment.coredata.compilers[for_machine]
                for langname, compiler in clist.items():
                    if langname in {'c', 'cpp'} and compiler.get_id() in {'c2000', 'c6000', 'ti'}:
                        compile_args += self.generate_basic_compiler_args(target, compiler)
            elem.add_item('ARGS', compile_args)
```

### Exception added to find and format static lib names in a manner that works for the TI C28x compilers.

C2000 was missing from the conditional in `get_library_naming()` for the other TI compilers from the same family.

```python
        elif self.id.lower() == 'c6000' or self.id.lower() == 'ti':
            # TI C6000 compiler can use both extensions for static or dynamic libs.
            stlibext = ['a', 'lib']
            shlibext = ['dll', 'so']
```

Adding `c2000` to this branch enables the static libs to be found and included as with the other ostensibly supported TI compilers but the behavior is still not quite correct.

```python
        elif self.id.lower() in {'c6000', 'c2000', 'ti'}:
            # TI C28x compilers can use both extensions for static or dynamic libs.
            stlibext = ['a', 'lib']
            shlibext = ['dll', 'so']
```

The behavior, then, is `libc.a` is found and added in a form that works when `libc` is passed to `find_library()`.

```meson
cc = meson.get_compiler('c')
c2000_libc = cc.find_library('libc', dirs: ti_c28x_c2000_cgt_dir / 'lib', static: true)
```

```bash
...

[4/4] cl2000 --c99 -O2 --cla_support=cla1 --float_support=fpu32 --tmu_support=tmu0 --vcu_support=vcu2 --diag_suppress=10063 --diag_warning=225 --diag_wrap=off --display_error_number --abi=eabi --define=F2837xD --define=CPU1 --issue_remarks -v28 -ml -mt -O2 '--define=RELEASE -DNDEBUG' -z --output_file=src/example-i2c-ti-lp-f28379d-bme280.out src/example-i2c-ti-lp-f28379d-bme280.out.p/i2c_ex3_external_loopback.c.o src/example-i2c-ti-lp-f28379d-bme280.out.p/device_F2837xD_CodeStartBranch.asm.o src/example-i2c-ti-lp-f28379d-bme280.out.p/device_device.c.o /Users/REDACTED/Projects/embedded-hal-c/examples/ti-lp-f28379d/bme280/src/2837xD_RAM_lnk_cpu1.cmd /Users/REDACTED/Projects/embedded-hal-c/examples/ti-lp-f28379d/bme280/subprojects/c2000ware-core-sdk/driverlib/f2837xd/driverlib/ccs/Release/driverlib_eabi.lib -mmain.map --heap_size=0x200 --stack_size=0x3F8 --warn_sections -i/Applications/ti/ti-cgt-c2000_22.6.1.LTS/lib -i/Applications/ti/ti-cgt-c2000_22.6.1.LTS/include --reread_libs --define=RAM --diag_wrap=off --display_error_number --xml_link_info=example-i2c-ti-f28379d-bme280_linkInfo.xml --entry_point=code_start --rom_model /Applications/ti/ti-cgt-c2000_22.6.1.LTS/lib/libc.a
<Linking>
remark #10205-D: automatic RTS selection:  linking in "rts2800_fpu32_eabi.lib" in place of index library "libc.a"
```

## Testing
<!--

Describe how the changes have been tested and how to reproduce the test results.

If no tests or testing is necessary, briefly state why.

-->

All tests pass locally except a couple that appear related to my environment. I did not find unit tests for the Ninja backend methods but the CI is passing and I have verified this works successfully with a minimal cross build with C2000. I could provide a self-contained example as a Docker image, if needed, so the minimal example can be run by a reviewer.
