### PR TITLE
Add a newline at the end of test files

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -805,6 +805,8 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
                                        'testfile.' + self.default_suffix)
                 with open(srcname, 'w', encoding='utf-8') as ofile:
                     ofile.write(code)
+                    if not code.endswith('\n'):
+                        ofile.write('\n')
                 # ccache would result in a cache miss
                 no_ccache = True
                 code_debug = f'Code:\n{code}'


### PR DESCRIPTION
When running in some settings, a C compiler may demand newlines at the end of each file.  Instead of modifying everywhere that writes out test files to incorporate newlines in each indivudual string, simply add a newline when writing it out.

An examples of when this is a problem is running with `CC=clang` and `CFLAGS="--std=c99 -pedantic-errors"` and meson.build contains (for example) the following:

```
project('myproject', 'c')
executable('myexecutable', 'main.c')
cc = meson.get_compiler('c')
sizeof_int = cc.sizeof('int')

```

sizeof_int will be -1, because the compile failed.  The meson logs contain the error `testfile.c:7:10: error: no newline at end of file`

Fixes https://github.com/mesonbuild/meson/issues/13684
