### PR TITLE
compilers: Pass mode to determine_args, not its string value

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -417,7 +417,7 @@ class CLikeCompiler(Compiler):
         else:
             # TODO: we want to do this in the caller
             extra_args = mesonlib.listify(extra_args)
-        extra_args = mesonlib.listify([e(mode.value) if callable(e) else e for e in extra_args])
+        extra_args = mesonlib.listify([e(mode) if callable(e) else e for e in extra_args])
 
         if dependencies is None:
             dependencies = []


### PR DESCRIPTION
We always pass the string value of the mode to `determine_args`, which causes the check on the mode argument inside `determine_args` to always evaluate to false.

Fix this by passing the mode itself, not its value.

Discovered this while investigating #13610. I noticed that `determine_args` is always called with a string as its `mode` argument, causing the condition at line 275 to always evaluate to false:

https://github.com/amcn/meson/blob/2b80d4cca174916a4b6d0c47c54ad56795741bb6/mesonbuild/interpreter/compiler.py#L266-L280
