### PR TITLE
backend/ninja: Generate sysroot in rust-project.json

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -707,10 +707,11 @@ class NinjaBackend(backends.Backend):
             return
         with open(os.path.join(self.environment.get_build_dir(), 'rust-project.json'),
                   'w', encoding='utf-8') as f:
+            sysroot = self.environment.coredata.compilers.host['rust'].get_sysroot()
             json.dump(
                 {
-                    "sysroot_src": os.path.join(self.environment.coredata.compilers.host['rust'].get_sysroot(),
-                                                'lib/rustlib/src/rust/library/'),
+                    "sysroot": sysroot,
+                    "sysroot_src": os.path.join(sysroot, 'lib/rustlib/src/rust/library/'),
                     "crates": [c.to_json() for c in self.rust_crates.values()],
                 },
                 f, indent=4)


### PR DESCRIPTION
Rust-analyzer relies on sysroot to discover its proc-macro server [1] which is typically installed at <sysroot>/libexec/rust-analyzer-proc-macro-srv. When used with rust-project.json, rust-analyzer expects the json file to specify sysroot and fails to launch the proc-macro server otherwise.

So add sysroot to the meson-generated rust-project.json and point it to the sysroot of the detected rustc compiler.

[1] https://github.com/rust-lang/rust-analyzer/blob/2024-09-16/crates/project-model/src/sysroot.rs#L175