### PR TITLE
mdist: correctly detect dirty hg repos with non-English locale, redux

### DIFF
--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -254,6 +254,9 @@ class HgDist(Dist):
         '''Check whether there are uncommitted changes in hg'''
         env = os.environ.copy()
         env['LC_ALL'] = 'C'
+        # cpython's gettext has a bug and uses LANGUAGE to override LC_ALL,
+        # contrary to the gettext spec
+        env.pop('LANGUAGE', None)
         out = subprocess.check_output(['hg', '-R', self.src_root, 'summary'], env=env)
         return b'commit: (clean)' not in out
 


### PR DESCRIPTION
https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html

GNU Gettext defines a feature, whereby for translation purposes, if LC_ALL / LANG are *not* set to C, but rather define an active translation, the LANGUAGE variable can be used to specify fallback languages in a colon-separated list wherein the first option is the primary language and the rest are fallbacks.

CPython, instead, checks the LANGUAGE variable first, and the first variable that has a non-null value is treated as the canonical language specification, splitted, and iterated over. LC_ALL=C is therefore totally ignored, which is a major problem, and the variables aren't checked for consistency, which is a less major problem.

GNU libc documents the same behavior CPython does -- which is broken as it makes LC_ALL=C useless.

POSIX issue 8 standardizes on option 3: do like GNU Gettext, except do not require the primary language in $LANGUAGE to be consistent with LANG / LC_ALL.

Thus, we sanitize the environment even harder. What an absolute disaster. Even if this was fixed tomorrow we would need to maintain this hack until 2030.

Bug: https://bugs.gentoo.org/936670