### PR TITLE
pylint: disable `too-many-positional-arguments`

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -66,6 +66,7 @@ disable=
     too-many-lines,
     too-many-locals,
     too-many-nested-blocks,
+    too-many-positional-arguments,
     too-many-public-methods,
     too-many-return-statements,
     too-many-statements,


### PR DESCRIPTION
Added in 3.3.0, split from `too-many-arguments`, which is disabled.