### PR TITLE
Clean up testsuite intermediate files

### DIFF
--- a/run_meson_command_tests.py
+++ b/run_meson_command_tests.py
@@ -206,12 +206,12 @@ class CommandTests(unittest.TestCase):
         with open(script_file, 'w') as f:
             f.write('#!/usr/bin/env python3\n\n')
             f.write(f'{test_command}\n')
+        self.addCleanup(os.remove, script_file)
 
         for cmd in [['-c', test_command, 'fake argument'], [script_file, 'fake argument']]:
             pyout = self._run(python_command + cmd)
             mesonout = self._run(python_command + [meson_command, 'runpython'] + cmd, env=env)
             self.assertEqual(pyout, mesonout)
-
 
 if __name__ == '__main__':
     print('Meson build system', meson_version, 'Command Tests')

--- a/run_single_test.py
+++ b/run_single_test.py
@@ -16,6 +16,7 @@ from mesonbuild import mlog
 from run_tests import handle_meson_skip_test
 from run_project_tests import TestDef, load_test_json, run_test, BuildStep
 from run_project_tests import setup_commands, detect_system_compiler, detect_tools
+from run_project_tests import setup_symlinks, clear_transitive_files
 
 if T.TYPE_CHECKING:
     from run_project_tests import CompilerArgumentType
@@ -44,6 +45,7 @@ def main() -> None:
     parser.add_argument('--quick', action='store_true', help='Skip some compiler and tool checking')
     args = T.cast('ArgumentType', parser.parse_args())
 
+    setup_symlinks()
     setup_commands(args.backend)
     if not args.quick:
         detect_system_compiler(args)
@@ -95,6 +97,7 @@ def main() -> None:
                 mlog.log(cmd_res)
             mlog.log(result.stde)
 
+    clear_transitive_files()
     exit(1 if failed else 0)
 
 if __name__ == "__main__":


### PR DESCRIPTION
I've been running the testsuite locally for various in-flight things and I noticed that it can pollute the repo with intermediate files in some cases.

The changes in this PR address this such that running the suite no longer produces these intermediate files.