### PR TITLE
Add Accept Header to wrap requests

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -689,6 +689,7 @@ class Resolver:
         else:
             headers = {
                 'User-Agent': f'mesonbuild/{coredata.version}',
+                'Accept': '*/*',
                 'Accept-Language': '*',
                 'Accept-Encoding': '*',
             }


### PR DESCRIPTION
This is a follow on to the original change in b1abfa89d. curl also sets request headers to use this value by default, which can be helpful when trying to connect to sites with very strict content negotiation requirements