### PR TITLE
ci/ciimage: Lower nofile ulimit on containers that test D

### DIFF
--- a/ci/ciimage/opensuse/install.sh
+++ b/ci/ciimage/opensuse/install.sh
@@ -35,6 +35,9 @@ echo 'export PKG_CONFIG_PATH="/usr/lib64/mpi/gcc/openmpi3/lib64/pkgconfig:$PKG_C
 curl -fsS https://dlang.org/install.sh | bash -s dmd | tee dmd_out.txt
 cat dmd_out.txt | grep source | sed 's/^[^`]*`//g' | sed 's/`.*//g' >> /ci/env_vars.sh
 chmod +x /ci/env_vars.sh
+# Lower ulimit before running dub, otherwise there's a very high chance it will OOM.
+# See: https://github.com/dlang/phobos/pull/9048 and https://github.com/dlang/phobos/pull/8990
+echo 'ulimit -n -S 10000' >> /ci/env_vars.sh
 
 source /ci/env_vars.sh
 

--- a/ci/ciimage/ubuntu-rolling/install.sh
+++ b/ci/ciimage/ubuntu-rolling/install.sh
@@ -44,6 +44,10 @@ eatmydata apt-get -y install --no-install-recommends wine-stable  # Wine is spec
 
 install_python_packages hotdoc
 
+# Lower ulimit before running dub, otherwise there's a very high chance it will OOM.
+# See: https://github.com/dlang/phobos/pull/9048 and https://github.com/dlang/phobos/pull/8990
+echo 'ulimit -n -S 10000' >> /ci/env_vars.sh
+ulimit -n -S 10000
 # dub stuff
 dub_fetch urld
 dub build --deep urld --arch=x86_64 --compiler=gdc --build=debug


### PR DESCRIPTION
The D stdlib function std.process.spawnProcessPosix suffers from a bug that causes any program that calls it to OOM if the nofile ulimit is large.

This doesn't affect CI currently but trying to run or build the containers locally will most likely crash when calling dub as docker defaults to something like 1073741816 for both the hard limit and soft limit. Lowering the soft limit is enough to make dub behave.