### PR TITLE
programs: Store the project version when overriding find_program

### DIFF
--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -334,7 +334,7 @@ class MesonMain(MesonInterpreterObject):
                                         self.interpreter.environment.build_dir)
             if not os.path.exists(abspath):
                 raise InterpreterException(f'Tried to override {name} with a file that does not exist.')
-            exe = OverrideProgram(name, [abspath])
+            exe = OverrideProgram(name, self.interpreter.project_version, command=[abspath])
         self.interpreter.add_find_program_override(name, exe)
 
     @typed_kwargs(

--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -340,6 +340,12 @@ class OverrideProgram(ExternalProgram):
 
     """A script overriding a program."""
 
+    def __init__(self, name: str, version: str, command: T.Optional[T.List[str]] = None,
+                 silent: bool = False, search_dir: T.Optional[str] = None,
+                 extra_search_dirs: T.Optional[T.List[str]] = None):
+        self.cached_version = version
+        super().__init__(name, command=command, silent=silent,
+                         search_dir=search_dir, extra_search_dirs=extra_search_dirs)
 
 def find_external_program(env: 'Environment', for_machine: MachineChoice, name: str,
                           display_name: str, default_names: T.List[str],


### PR DESCRIPTION
When we're using the output of `configure_file()` with `override_find_program()`, we weren't storing the version anywhere, so `get_version()` was trying to run the script during setup.

This is usually fine, except in cases where the `configure_file()` script actually has to import a library built as part of the project, and fails to run.

For built executables, we simply use the project version, and we now do the same here too.