### PR TITLE
curses: Ignore /usr/bin/ncurses5.4-config on macOS

### DIFF
--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -312,7 +312,14 @@ class CursesConfigToolDependency(ConfigToolDependency):
     tools = ['ncursesw6-config', 'ncursesw5-config', 'ncurses6-config', 'ncurses5-config', 'ncurses5.4-config']
 
     def __init__(self, name: str, env: 'Environment', kwargs: T.Dict[str, T.Any], language: T.Optional[str] = None):
-        super().__init__(name, env, kwargs, language)
+        exclude_paths = None
+        # macOS mistakenly ships /usr/bin/ncurses5.4-config and a man page for
+        # it, but none of the headers or libraries. Ignore /usr/bin because it
+        # can only contain this broken configtool script.
+        # Homebrew is /usr/local or /opt/homebrew.
+        if env.machines.build and env.machines.build.system == 'darwin':
+            exclude_paths = ['/usr/bin']
+        super().__init__(name, env, kwargs, language, exclude_paths=exclude_paths)
         if not self.is_found:
             return
         self.compile_args = self.get_config_value(['--cflags'], 'compile_args')

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -68,7 +68,7 @@ class GnuStepDependency(ConfigToolDependency):
             ['--gui-libs' if 'gui' in self.modules else '--base-libs'],
             'link_args'))
 
-    def find_config(self, versions: T.Optional[T.List[str]] = None, returncode: int = 0) -> T.Tuple[T.Optional[T.List[str]], T.Optional[str]]:
+    def find_config(self, versions: T.Optional[T.List[str]] = None, returncode: int = 0, exclude_paths: T.Optional[T.List[str]] = None) -> T.Tuple[T.Optional[T.List[str]], T.Optional[str]]:
         tool = [self.tools[0]]
         try:
             p, out = Popen_safe(tool + ['--help'])[:2]

--- a/unittests/failuretests.py
+++ b/unittests/failuretests.py
@@ -34,10 +34,10 @@ def no_pkgconfig():
     old_which = shutil.which
     old_search = ExternalProgram._search
 
-    def new_search(self, name, search_dir):
+    def new_search(self, name, search_dirs, exclude_paths):
         if name == 'pkg-config':
             return [None]
-        return old_search(self, name, search_dir)
+        return old_search(self, name, search_dirs, exclude_paths)
 
     def new_which(cmd, *kwargs):
         if cmd == 'pkg-config':


### PR DESCRIPTION
macOS mistakenly ships `/usr/bin/ncurses5.4-config` and a man page for it, but none of the headers or libraries are available in the location advertised by it. Ignore `/usr/bin` because it can only contain this broken configtool script. Homebrew is /usr/local or `/opt/homebrew`.

Xcode's command-line tools SDK does include curses, but the configtool in there is wrong too, and anyway we can't just randomly pick it up since the user must explicitly select that as a target by using a native file. The MacOSX SDK itself does not include curses.

We also can't ignore ncurses5.4-config entirely because it might be available in a different prefix.