### PR TITLE
Add support to override pkg-config with meson.override_find_program

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1638,6 +1638,9 @@ class Interpreter(InterpreterBase, HoldableObject):
         if name in self.build.find_overrides:
             raise InterpreterException(f'Tried to override executable "{name}" which has already been overridden.')
         self.build.find_overrides[name] = exe
+        if name == 'pkg-config' and isinstance(exe, ExternalProgram):
+            from ..dependencies.pkgconfig import PkgConfigInterface
+            PkgConfigInterface.set_program_override(exe, MachineChoice.HOST)
 
     def notfound_program(self, args: T.List[mesonlib.FileOrString]) -> ExternalProgram:
         return NonExistingExternalProgram(' '.join(

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -551,9 +551,14 @@ def validate_output(test: TestDef, stdo: str, stde: str) -> str:
 def clear_internal_caches() -> None:
     import mesonbuild.interpreterbase
     from mesonbuild.dependencies.cmake import CMakeDependency
+    from mesonbuild.dependencies.pkgconfig import PkgConfigInterface
     from mesonbuild.mesonlib import PerMachine
     mesonbuild.interpreterbase.FeatureNew.feature_registry = {}
     CMakeDependency.class_cmakeinfo = PerMachine(None, None)
+    PkgConfigInterface.class_impl = PerMachine(False, False)
+    PkgConfigInterface.class_cli_impl = PerMachine(False, False)
+    PkgConfigInterface.pkg_bin_per_machine = PerMachine(None, None)
+
 
 def run_test_inprocess(testdir: str) -> T.Tuple[int, str, str, str]:
     old_stdout = sys.stdout

--- a/test cases/common/279 pkgconfig override/meson.build
+++ b/test cases/common/279 pkgconfig override/meson.build
@@ -1,0 +1,8 @@
+project('override pkg-config', 'c')
+
+subproject('pkg-config')
+
+pkgconfig = find_program('pkg-config')
+
+# This dependency can only be found if pkg-config is overridden with our custom pkg-config.py
+gobj = dependency('test-package-0.0', version : '= 0.0.0')

--- a/test cases/common/279 pkgconfig override/subprojects/pkg-config.wrap
+++ b/test cases/common/279 pkgconfig override/subprojects/pkg-config.wrap
@@ -1,0 +1,5 @@
+[wrap-file]
+directory = pkg-config
+
+[provide]
+program_names = pkg-config

--- a/test cases/common/279 pkgconfig override/subprojects/pkg-config/bin/pkg-config.py
+++ b/test cases/common/279 pkgconfig override/subprojects/pkg-config/bin/pkg-config.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import sys
+
+if len(sys.argv) > 1:
+    if sys.argv[1] == "--modversion":
+        if sys.argv[2] == "test-package-0.0":
+            print("0.0.0")
+        else:
+            exit(-1)
+    elif sys.argv[1] == "--version":
+        print("0.0.0")
+        exit(0)

--- a/test cases/common/279 pkgconfig override/subprojects/pkg-config/meson.build
+++ b/test cases/common/279 pkgconfig override/subprojects/pkg-config/meson.build
@@ -1,0 +1,4 @@
+project('pkg-config')
+
+pkgconfig = find_program(meson.project_source_root() / 'bin' / 'pkg-config.py')
+meson.override_find_program('pkg-config', pkgconfig)


### PR DESCRIPTION
In the GStreamer monorepo, the goal is for users to build GStreamer and its dependencies out-of-the-box with meson, requiring a minimal setup. Some of the build dependencies such as `flex` `bison` or `nasm` are provided through subprojects that download the binary and override them via `find_program` like: `meson.override_find_program('bison', find_program(meson.project_source_root() / ret.stdout() / 'bin/bison'))`.

`pkg-config` is one of the build dependencies required to build `gobject-introspection`, but it's not possible to override it via ` meson.override_find_program`. The goal of this MR is to support this scenario to simplify the setup and provide a way to provide through an override like the rest of the dependencies. 

I am not sure this is the canonical way, but it allows providing the `pkg-config` binary as a subproject, allowing GStreamer's monorepo to build `gobject-introspection` without a `pkg-config` installed in the system. 