### PR TITLE
env2mfile: Fix a typo

### DIFF
--- a/mesonbuild/scripts/env2mfile.py
+++ b/mesonbuild/scripts/env2mfile.py
@@ -330,7 +330,7 @@ def detect_cross_system(infos: MachineInfo, options: T.Any) -> None:
 
 def detect_cross_env(options: T.Any) -> MachineInfo:
     if options.debarch:
-        print('Detecting cross environment via dpkg-reconfigure.')
+        print('Detecting cross environment via dpkg-architecture.')
         infos = detect_cross_debianlike(options)
     else:
         print('Detecting cross environment via environment variables.')


### PR DESCRIPTION
Debian cross architectures are detected via dpkg-architecture, not via dpkg-reconfigure.