### PR TITLE
env2mfile: Generalize handling of architecture-prefixed tools on Debian derivatives

### DIFF
--- a/mesonbuild/scripts/env2mfile.py
+++ b/mesonbuild/scripts/env2mfile.py
@@ -229,10 +229,13 @@ def dpkg_architecture_to_machine_info(output: str, options: T.Any) -> MachineInf
         deb_detect_cmake(infos, data)
     except ValueError:
         pass
-    try:
-        infos.binaries['pkg-config'] = locate_path("%s-pkg-config" % host_arch)
-    except ValueError:
-        pass # pkg-config is optional
+    for tool in [
+        'pkg-config',
+    ]:
+        try:
+            infos.binaries[tool] = locate_path("%s-%s" % (host_arch, tool))
+        except ValueError:
+            pass    # optional
     try:
         infos.binaries['cups-config'] = locate_path("cups-config")
     except ValueError:

--- a/mesonbuild/scripts/env2mfile.py
+++ b/mesonbuild/scripts/env2mfile.py
@@ -242,6 +242,13 @@ def dpkg_architecture_to_machine_info(output: str, options: T.Any) -> MachineInf
             infos.binaries[tool] = locate_path("%s-%s" % (host_arch, tool))
         except ValueError:
             pass    # optional
+    for tool, exe in [
+        ('exe_wrapper', 'cross-exe-wrapper'),
+    ]:
+        try:
+            infos.binaries[tool] = locate_path("%s-%s" % (host_arch, exe))
+        except ValueError:
+            pass
     try:
         infos.binaries['cups-config'] = locate_path("cups-config")
     except ValueError:

--- a/mesonbuild/scripts/env2mfile.py
+++ b/mesonbuild/scripts/env2mfile.py
@@ -249,6 +249,13 @@ def dpkg_architecture_to_machine_info(output: str, options: T.Any) -> MachineInf
             infos.binaries[tool] = locate_path("%s-%s" % (host_arch, exe))
         except ValueError:
             pass
+    for tool, exe in [
+        ('vala', 'valac'),
+    ]:
+        try:
+            infos.compilers[tool] = locate_path("%s-%s" % (host_arch, exe))
+        except ValueError:
+            pass
     try:
         infos.binaries['cups-config'] = locate_path("cups-config")
     except ValueError:

--- a/mesonbuild/scripts/env2mfile.py
+++ b/mesonbuild/scripts/env2mfile.py
@@ -230,6 +230,12 @@ def dpkg_architecture_to_machine_info(output: str, options: T.Any) -> MachineInf
     except ValueError:
         pass
     for tool in [
+        'g-ir-annotation-tool',
+        'g-ir-compiler',
+        'g-ir-doc-tool',
+        'g-ir-generate',
+        'g-ir-inspect',
+        'g-ir-scanner',
         'pkg-config',
     ]:
         try:

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1750,6 +1750,7 @@ class InternalTests(unittest.TestCase):
                 'cmake': ['/usr/bin/cmake'],
                 'pkg-config': [f'/usr/bin/{gnu_tuple}-pkg-config'],
                 'cups-config': ['/usr/bin/cups-config'],
+                'exe_wrapper': [f'/usr/bin/{gnu_tuple}-cross-exe-wrapper'],
                 'g-ir-annotation-tool': [f'/usr/bin/{gnu_tuple}-g-ir-annotation-tool'],
                 'g-ir-compiler': [f'/usr/bin/{gnu_tuple}-g-ir-compiler'],
                 'g-ir-doc-tool': [f'/usr/bin/{gnu_tuple}-g-ir-doc-tool'],

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1750,6 +1750,12 @@ class InternalTests(unittest.TestCase):
                 'cmake': ['/usr/bin/cmake'],
                 'pkg-config': [f'/usr/bin/{gnu_tuple}-pkg-config'],
                 'cups-config': ['/usr/bin/cups-config'],
+                'g-ir-annotation-tool': [f'/usr/bin/{gnu_tuple}-g-ir-annotation-tool'],
+                'g-ir-compiler': [f'/usr/bin/{gnu_tuple}-g-ir-compiler'],
+                'g-ir-doc-tool': [f'/usr/bin/{gnu_tuple}-g-ir-doc-tool'],
+                'g-ir-generate': [f'/usr/bin/{gnu_tuple}-g-ir-generate'],
+                'g-ir-inspect': [f'/usr/bin/{gnu_tuple}-g-ir-inspect'],
+                'g-ir-scanner': [f'/usr/bin/{gnu_tuple}-g-ir-scanner'],
             }
 
         for title, dpkg_arch, gccsuffix, env, expected in [

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1739,6 +1739,7 @@ class InternalTests(unittest.TestCase):
                 'cpp': [f'/usr/bin/{gnu_tuple}-g++{gcc_suffix}'],
                 'objc': [f'/usr/bin/{gnu_tuple}-gobjc{gcc_suffix}'],
                 'objcpp': [f'/usr/bin/{gnu_tuple}-gobjc++{gcc_suffix}'],
+                'vala': [f'/usr/bin/{gnu_tuple}-valac'],
             }
 
         def expected_binaries(gnu_tuple: str) -> T.Dict[str, T.List[str]]:


### PR DESCRIPTION
Depends on #13722, for its test coverage.

* env2mfile: Generalize detection of pkg-config to have a list of tools
    
    Cross-tools on Debian generally follow the naming convention set by
    Autotools AC_CHECK_TOOL, where the name is prefixed with the GNU
    architecture tuple for the host architecture. env2mfile was already
    using this for pkg-config, but there are many other tools that can
    be detected in the same way.

* env2mfile: Use Debian cross-prefixed GObject-Introspection tools
    
    In Debian testing/unstable, there are wrappers available for various
    GObject-Introspection tools during cross-builds, using qemu internally.

* env2mfile: Automatically set exe_wrapper on Debian if possible
    
    Recent versions of the architecture-properties package provide a
    cross-exe-wrapper package containing
    ${DEB_HOST_GNU_TYPE}-cross-exe-wrapper, which is currently a wrapper
    around qemu-user but could use different emulators on each architecture
    if it becomes necessary in the future.

* env2mfile: Use a cross valac on Debian if possible
    
    This is functionally equivalent to the logic used to locate pkg-config,
    but puts it below the "Compilers" heading rather than "Other binaries".