### PR TITLE
env2mfile: Add unit test coverage for dpkg -> Meson, and fix some obvious errors

### DIFF
--- a/mesonbuild/scripts/env2mfile.py
+++ b/mesonbuild/scripts/env2mfile.py
@@ -130,14 +130,20 @@ def get_args_from_envvars(infos: MachineInfo) -> None:
     if objcpp_link_args:
         infos.link_args['objcpp'] = objcpp_link_args
 
+# map from DEB_HOST_GNU_CPU to Meson machine.cpu_family()
 deb_cpu_family_map = {
     'mips64el': 'mips64',
     'i686': 'x86',
     'powerpc64le': 'ppc64',
 }
 
-deb_cpu_map = {
+# map from DEB_HOST_ARCH to Meson machine.cpu()
+deb_arch_cpu_map = {
     'armhf': 'arm7hlf',
+}
+
+# map from DEB_HOST_GNU_CPU to Meson machine.cpu()
+deb_cpu_map = {
     'mips64el': 'mips64',
     'powerpc64le': 'ppc64',
 }
@@ -202,7 +208,8 @@ def dpkg_architecture_to_machine_info(output: str, options: T.Any) -> MachineInf
     host_subsystem = host_os
     host_kernel = replace_special_cases(deb_kernel_map, data['DEB_HOST_ARCH_OS'])
     host_cpu_family = replace_special_cases(deb_cpu_family_map, data['DEB_HOST_GNU_CPU'])
-    host_cpu = replace_special_cases(deb_cpu_map, data['DEB_HOST_ARCH'])
+    host_cpu = deb_arch_cpu_map.get(data['DEB_HOST_ARCH'],
+                                    replace_special_cases(deb_cpu_map, data['DEB_HOST_GNU_CPU']))
     host_endian = data['DEB_HOST_ARCH_ENDIAN']
 
     compilerstems = [('c', 'gcc'),

--- a/mesonbuild/scripts/env2mfile.py
+++ b/mesonbuild/scripts/env2mfile.py
@@ -142,6 +142,13 @@ deb_cpu_map = {
     'powerpc64le': 'ppc64',
 }
 
+def replace_special_cases(special_cases: T.Mapping[str, str], name: str) -> str:
+    '''
+    If name is a key in special_cases, replace it with the value, or otherwise
+    pass it through unchanged.
+    '''
+    return special_cases.get(name, name)
+
 def deb_detect_cmake(infos: MachineInfo, data: T.Dict[str, str]) -> None:
     system_name_map = {'linux': 'Linux', 'kfreebsd': 'kFreeBSD', 'hurd': 'GNU'}
     system_processor_map = {'arm': 'armv7l', 'mips64el': 'mips64', 'powerpc64le': 'ppc64le'}
@@ -152,8 +159,7 @@ def deb_detect_cmake(infos: MachineInfo, data: T.Dict[str, str]) -> None:
     except KeyError:
         pass
     infos.cmake["CMAKE_SYSTEM_NAME"] = system_name_map[data['DEB_HOST_ARCH_OS']]
-    infos.cmake["CMAKE_SYSTEM_PROCESSOR"] = system_processor_map.get(data['DEB_HOST_GNU_CPU'],
-                                                                     data['DEB_HOST_GNU_CPU'])
+    infos.cmake["CMAKE_SYSTEM_PROCESSOR"] = replace_special_cases(system_processor_map, data['DEB_HOST_GNU_CPU'])
 
 def deb_compiler_lookup(infos: MachineInfo, compilerstems: T.List[T.Tuple[str, str]], host_arch: str, gccsuffix: str) -> None:
     for langname, stem in compilerstems:
@@ -185,10 +191,8 @@ def dpkg_architecture_to_machine_info(output: str, options: T.Any) -> MachineInf
     host_os = data['DEB_HOST_ARCH_OS']
     host_subsystem = host_os
     host_kernel = 'linux'
-    host_cpu_family = deb_cpu_family_map.get(data['DEB_HOST_GNU_CPU'],
-                                             data['DEB_HOST_GNU_CPU'])
-    host_cpu = deb_cpu_map.get(data['DEB_HOST_ARCH'],
-                               data['DEB_HOST_ARCH'])
+    host_cpu_family = replace_special_cases(deb_cpu_family_map, data['DEB_HOST_GNU_CPU'])
+    host_cpu = replace_special_cases(deb_cpu_map, data['DEB_HOST_ARCH'])
     host_endian = data['DEB_HOST_ARCH_ENDIAN']
 
     compilerstems = [('c', 'gcc'),

--- a/mesonbuild/scripts/env2mfile.py
+++ b/mesonbuild/scripts/env2mfile.py
@@ -147,6 +147,11 @@ deb_os_map = {
     'hurd': 'gnu',
 }
 
+# map from DEB_HOST_ARCH_OS to Meson machine.kernel()
+deb_kernel_map = {
+    'kfreebsd': 'freebsd',
+}
+
 def replace_special_cases(special_cases: T.Mapping[str, str], name: str) -> str:
     '''
     If name is a key in special_cases, replace it with the value, or otherwise
@@ -195,7 +200,7 @@ def dpkg_architecture_to_machine_info(output: str, options: T.Any) -> MachineInf
     host_arch = data['DEB_HOST_GNU_TYPE']
     host_os = replace_special_cases(deb_os_map, data['DEB_HOST_ARCH_OS'])
     host_subsystem = host_os
-    host_kernel = 'linux'
+    host_kernel = replace_special_cases(deb_kernel_map, data['DEB_HOST_ARCH_OS'])
     host_cpu_family = replace_special_cases(deb_cpu_family_map, data['DEB_HOST_GNU_CPU'])
     host_cpu = replace_special_cases(deb_cpu_map, data['DEB_HOST_ARCH'])
     host_endian = data['DEB_HOST_ARCH_ENDIAN']

--- a/mesonbuild/scripts/env2mfile.py
+++ b/mesonbuild/scripts/env2mfile.py
@@ -171,6 +171,9 @@ def detect_cross_debianlike(options: T.Any) -> MachineInfo:
         cmd = ['dpkg-architecture', '-a' + options.debarch]
     output = subprocess.check_output(cmd, universal_newlines=True,
                                      stderr=subprocess.DEVNULL)
+    return dpkg_architecture_to_machine_info(output, options)
+
+def dpkg_architecture_to_machine_info(output: str, options: T.Any) -> MachineInfo:
     data = {}
     for line in output.split('\n'):
         line = line.strip()

--- a/mesonbuild/scripts/env2mfile.py
+++ b/mesonbuild/scripts/env2mfile.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 import sys, os, subprocess, shutil
 import shlex
 import typing as T
@@ -47,21 +48,21 @@ def add_arguments(parser: 'argparse.ArgumentParser') -> None:
     parser.add_argument('--endian', default='little', choices=['big', 'little'],
                         help='Define endianness for cross compilation.')
 
+@dataclass
 class MachineInfo:
-    def __init__(self) -> None:
-        self.compilers: T.Dict[str, T.List[str]] = {}
-        self.binaries: T.Dict[str, T.List[str]] = {}
-        self.properties: T.Dict[str, T.Union[str, T.List[str]]] = {}
-        self.compile_args: T.Dict[str, T.List[str]] = {}
-        self.link_args: T.Dict[str, T.List[str]] = {}
-        self.cmake: T.Dict[str, T.Union[str, T.List[str]]] = {}
+    compilers: T.Dict[str, T.List[str]] = field(default_factory=dict)
+    binaries: T.Dict[str, T.List[str]] = field(default_factory=dict)
+    properties: T.Dict[str, T.Union[str, T.List[str]]] = field(default_factory=dict)
+    compile_args: T.Dict[str, T.List[str]] = field(default_factory=dict)
+    link_args: T.Dict[str, T.List[str]] = field(default_factory=dict)
+    cmake: T.Dict[str, T.Union[str, T.List[str]]] = field(default_factory=dict)
 
-        self.system: T.Optional[str] = None
-        self.subsystem: T.Optional[str] = None
-        self.kernel: T.Optional[str] = None
-        self.cpu: T.Optional[str] = None
-        self.cpu_family: T.Optional[str] = None
-        self.endian: T.Optional[str] = None
+    system: T.Optional[str] = None
+    subsystem: T.Optional[str] = None
+    kernel: T.Optional[str] = None
+    cpu: T.Optional[str] = None
+    cpu_family: T.Optional[str] = None
+    endian: T.Optional[str] = None
 
 #parser = argparse.ArgumentParser(description='''Generate cross compilation definition file for the Meson build system.
 #

--- a/mesonbuild/scripts/env2mfile.py
+++ b/mesonbuild/scripts/env2mfile.py
@@ -142,6 +142,11 @@ deb_cpu_map = {
     'powerpc64le': 'ppc64',
 }
 
+# map from DEB_HOST_ARCH_OS to Meson machine.system()
+deb_os_map = {
+    'hurd': 'gnu',
+}
+
 def replace_special_cases(special_cases: T.Mapping[str, str], name: str) -> str:
     '''
     If name is a key in special_cases, replace it with the value, or otherwise
@@ -188,7 +193,7 @@ def dpkg_architecture_to_machine_info(output: str, options: T.Any) -> MachineInf
         k, v = line.split('=', 1)
         data[k] = v
     host_arch = data['DEB_HOST_GNU_TYPE']
-    host_os = data['DEB_HOST_ARCH_OS']
+    host_os = replace_special_cases(deb_os_map, data['DEB_HOST_ARCH_OS'])
     host_subsystem = host_os
     host_kernel = 'linux'
     host_cpu_family = replace_special_cases(deb_cpu_family_map, data['DEB_HOST_GNU_CPU'])

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1933,10 +1933,8 @@ class InternalTests(unittest.TestCase):
                         'CMAKE_SYSTEM_NAME': 'GNU',
                         'CMAKE_SYSTEM_PROCESSOR': 'i686',
                     },
-                    # TODO: Currently hurd, but should be gnu as per
-                    # https://mesonbuild.com/Reference-tables.html
-                    system='TODO',
-                    subsystem='TODO',
+                    system='gnu',
+                    subsystem='gnu',
                     # TODO: Currently linux, but should be gnu/hurd/mach?
                     # https://github.com/mesonbuild/meson/issues/13740
                     kernel='TODO',

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1835,9 +1835,7 @@ class InternalTests(unittest.TestCase):
                     system='linux',
                     subsystem='linux',
                     kernel='linux',
-                    # TODO: In native builds we get x86_64, but in
-                    # cross-builds it's amd64
-                    cpu='TODO',
+                    cpu='x86_64',
                     cpu_family='x86_64',
                     endian='little',
                 ),
@@ -1940,8 +1938,7 @@ class InternalTests(unittest.TestCase):
                     # fail when kernel() is called.
                     # https://github.com/mesonbuild/meson/issues/13740
                     kernel='TODO',
-                    # TODO: Currently hurd-i386, but should be i686
-                    cpu='TODO',
+                    cpu='i686',
                     cpu_family='x86',
                     endian='little',
                 ),
@@ -1980,8 +1977,7 @@ class InternalTests(unittest.TestCase):
                     system='kfreebsd',
                     subsystem='kfreebsd',
                     kernel='freebsd',
-                    # TODO: Currently kfreebsd-amd64 but should be x86_64
-                    cpu='TODO',
+                    cpu='x86_64',
                     cpu_family='x86_64',
                     endian='little',
                 ),
@@ -2059,8 +2055,7 @@ class InternalTests(unittest.TestCase):
                     system='linux',
                     subsystem='linux',
                     kernel='linux',
-                    # TODO: Currently ppc64el, but native builds have ppc64le,
-                    # and maybe it should be ppc64 in both cases?
+                    # TODO: Currently ppc64, but native builds have ppc64le
                     # https://github.com/mesonbuild/meson/issues/13741
                     cpu='TODO',
                     cpu_family='ppc64',

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1935,7 +1935,9 @@ class InternalTests(unittest.TestCase):
                     },
                     system='gnu',
                     subsystem='gnu',
-                    # TODO: Currently linux, but should be gnu/hurd/mach?
+                    # TODO: Currently hurd; should match whatever happens
+                    # during native builds, but at the moment native builds
+                    # fail when kernel() is called.
                     # https://github.com/mesonbuild/meson/issues/13740
                     kernel='TODO',
                     # TODO: Currently hurd-i386, but should be i686
@@ -1977,8 +1979,7 @@ class InternalTests(unittest.TestCase):
                     },
                     system='kfreebsd',
                     subsystem='kfreebsd',
-                    # TODO: Currently linux but should be freebsd
-                    kernel='TODO',
+                    kernel='freebsd',
                     # TODO: Currently kfreebsd-amd64 but should be x86_64
                     cpu='TODO',
                     cpu_family='x86_64',


### PR DESCRIPTION
* env2mfile: Convert MachineInfo into a dataclass
    
    This will make it easier to unit-test functions that work with a
    MachineInfo, by constructing the expected object in a single call.

* env2mfile: Split detect_cross_debianlike()
    
    Separating the part that runs dpkg-architecture from the part that
    interprets its results will make it easier to unit-test the latter.

* unittests: Test env2mfile's dpkg_architecture_to_machine_info
    
    This test parses several possible outputs of dpkg-architecture and
    asserts that they produce the expected MachineInfo.
    
    To avoid depending on suitable cross-tools being installed, use
    unittest.mock to override locate_path with a version that pretends that
    all of the tools we're interested in are in /usr/bin.
    Similarly, use mock environment variables to exercise what happens
    when we have those set.
    
    The test data used here exercises most variations:
    
    * big- and little-endianness
    * GNU CPU (x86_64) differing from dpkg CPU (amd64)
    * Linux, kFreeBSD and Hurd
    * special-cased architectures: x86, arm, mips64el, ppc64el
    
    expected_compilers() intentionally doesn't assume that every compiler
    is gcc (even though they all are, right now), because #13721 proposes
    adding valac which does not take a gcc suffix.

* env2mfile: Add a function for mostly-identity mappings with special cases
    
    This makes the frequent pattern of things like "CPU families are the
    same as GNU CPUs, with a few known exceptions" less verbose.

* env2mfile: Map Debian GNU/Hurd to system() -> gnu
    
    As per <https://mesonbuild.com/Reference-tables.html>, and matching what
    happens when running Meson for a native build on Debian GNU/Hurd.

* env2mfile: Don't hard-code Debian as always being Linux
    
    All official Debian release architectures use the Linux kernel, but
    unofficial ports like hurd-i386 and kfreebsd-amd64 use the Hurd and
    FreeBSD kernel, respectively.
    
    Map Linux to 'linux' and kFreeBSD ports to 'freebsd' as per the
    reference tables in Meson's documentation. For now, use the Debian
    system name such as 'hurd' for anything else (see #13740 for the
    question of whether Hurd should identify its kernel differently).

* env2mfile: Base cpu on DEB_HOST_GNU_CPU unless DEB_HOST_ARCH is special
    
    `DEB_HOST_ARCH` encodes both the CPU family and the OS, so using it to
    get the CPU type gives the wrong answer for non-Linux ports.
    
    However, `DEB_HOST_GNU_CPU` gives less detailed information about the
    CPU: it's `arm` for all 32-bit ARM CPUs, and doesn't distinguish between
    the differing baselines of `armel` (ARMv5 softfloat) and `armhf`
    (ARMv7 hardfloat).
    
    When cross-compiling for x86_64 Linux, this changes the `cpu()` from
    `amd64` to `x86_64`, which is consistent with the answer we get during
    native builds on that architecture.
    
    When cross-compiling for `ppc64el`, this changes the `cpu()` from
    `ppc64el` to `ppc64`, which is a reasonable change but is still not
    consistent with what we see during native builds (which is `ppc64le`):
    see #13741 for that.
    
    Resolves: https://github.com/mesonbuild/meson/issues/13742

---

This is not a complete solution for #13740 and #13741, but would be a good starting point for fixing those afterwards.