### PR TITLE
modules/wayland: document that scan_xml can take any protocol.

### DIFF
--- a/docs/markdown/Wayland-module.md
+++ b/docs/markdown/Wayland-module.md
@@ -53,7 +53,8 @@ generated = wl_mod.scan_xml(
   include_core_only : true,
 )
 ```
-This function accepts one or more arguments of either string or file type.
+This function accepts one or more arguments of either string or file type, so
+it can be used in conjunction with `find_protocol` or not.
 
 It takes the following keyword arguments:
 - `public` Optional arg that specifies the scope of the generated code.
@@ -63,7 +64,7 @@ It takes the following keyword arguments:
 - `server` Optional arg that specifies if server side header file is
   generated. The default is false.
 - `include_core_only` Optional arg that specifies that generated headers only include
-  `wayland-<client|server>-core.h` instead of `wayland-<client|server>.h`. 
+  `wayland-<client|server>-core.h` instead of `wayland-<client|server>.h`.
   The default is true. Since *0.64.0*
 
 **Returns**: a list of [[@custom_tgt]] in the order source, client side header,


### PR DESCRIPTION
A lot of projects vendor protocols, since the ones they are using aren't available in default system directories. One example would be kanshi, where I am trying to use the wayland module (see <https://github.com/ericonr/kanshi/pull/2>).

Right now this PR has a few issues. The main one is that the first configuration works and the project can be built successfully, but then, when I touch any of the `meson.build` files, the reconfiguration fails:

```
../protocol/meson.build:3:31: ERROR: The file protocol/wlr-output-management-unstable-v1.xml does not exist.
```

I feel like I'm using a totally wrong way of getting the current source directory.

Furthermore, I don't think this is the ideal interface. A "directory" key might work better? For example in cases where people grab the protocol from a git submodule, so they can't have a `meson.build` in the same directory as the protocol definition. I would appreciate guidance on the interface definition and in actually implementing it.