### PR TITLE
refman: make man generator reproducible

### DIFF
--- a/docs/refman/generatorman.py
+++ b/docs/refman/generatorman.py
@@ -24,8 +24,10 @@ class ManPage:
 
     def title(self, name: str, section: int) -> None:
         import datetime
+        import time
+        from os import environ
 
-        date = datetime.date.today()
+        date = datetime.date.fromtimestamp(int(environ.get('SOURCE_DATE_EPOCH', time.time())))
         self.reset_font()
         self.text += f'.TH "{name}" "{section}" "{date}"\n'
 


### PR DESCRIPTION
The man backend of refman embeds the current date into the generated manpage, making the build not reproducible.

To fix this, honour the [SOURCE_DATE_EPOCH] environment variable, falling back to getting the current time.

[SOURCE_DATE_EPOCH]: https://reproducible-builds.org/docs/source-date-epoch/

Cc: @annacrombie