### PR TITLE
tests: use statx instead of sendmmsg in has_function test

### DIFF
--- a/test cases/common/36 has function/meson.build
+++ b/test cases/common/36 has function/meson.build
@@ -98,12 +98,11 @@ foreach cc : compilers
   # For some functions one needs to define _GNU_SOURCE before including the
   # right headers to get them picked up. Make sure we can detect these functions
   # as well without any prefix
-  if cc.has_header_symbol('sys/socket.h', 'recvmmsg',
+  if cc.has_header_symbol('sys/stat.h', 'statx',
                           prefix : '#define _GNU_SOURCE',
                           args : unit_test_args)
-    # We assume that if recvmmsg exists sendmmsg does too
-    assert (cc.has_function('sendmmsg', args : unit_test_args),
-            'Failed to detect function "sendmmsg" (should always exist).')
+    assert (cc.has_function('statx', args : unit_test_args),
+            'Failed to detect function "statx" (should always exist).')
   endif
 
   # We should be able to find GCC and Clang __builtin functions


### PR DESCRIPTION
Both recvmmsg/sendmmsg and statx require the `_GNU_SOURCE` symbol to be defined to be shown in headers, but statx has the additional property of being defined on all glibc systems ([ref1][1]), unlike recvmmsg which isn't implemented on Hurd([ref2][2], [ref3][3]).

With this fix, all tests now pass on Hurd.

    $ cat meson.build
    project('test', 'c')
    cc = meson.get_compiler('c')
    cc.has_header_symbol('sys/stat.h', 'statx')
    cc.has_header_symbol('sys/stat.h', 'statx', prefix: '#define _GNU_SOURCE')
    cc.has_function('statx')

    $ meson setup build
    The Meson build system
    Version: 1.5.1
    Source dir: /tmp/tmp.XcWk4fMra4
    Build dir: /tmp/tmp.XcWk4fMra4/build
    Build type: native build
    Project name: test
    Project version: undefined
    C compiler for the host machine: cc (gcc 14.2.0 "cc (Debian 14.2.0-3) 14.2.0")
    C linker for the host machine: cc ld.bfd 2.43.1
    Host machine cpu family: x86_64
    Host machine cpu: x86_64
    Header "sys/stat.h" has symbol "statx" : NO
    Header "sys/stat.h" has symbol "statx" : YES
    Checking for function "statx" : YES
    Build targets in project: 0

[1]: https://sourceware.org/git/?p=glibc.git;a=blob;f=io/statx_generic.c;h=93faf12297cfcd37ba005a02e991eab351d74174;hb=HEAD
[2]: https://www.gnu.org/software/hurd/open_issues/glibc.html#recvmmsg
[3]: https://github.com/mesonbuild/meson/pull/4351