### PR TITLE
compilers/detect: remove unsupported -cpp flag for Clang preprocessor detection

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -1436,13 +1436,12 @@ def _get_clang_compiler_defines(compiler: T.List[str], lang: str) -> T.Dict[str,
         # based on the driver.
         lang = clang_lang_map[lang]
 
-        # The compiler may not infer the target language based on the driver name
-        # so first, try with '-cpp -x lang', then fallback without given it's less
-        # portable. We try with '-cpp' as GCC needs it for Fortran at least, and
-        # it seems to do no harm.
-        output = _try_obtain_compiler_defines(['-cpp', '-x', lang] + baseline_test_args)
+        # The compiler may not infer the target language based on the driver name.
+        # Try first with '-x lang' to supported systemwide language level overrides,
+        # then fallback to without since it's a more recent option.
+        output = _try_obtain_compiler_defines(['-x', lang] + baseline_test_args)
     except (EnvironmentException, KeyError):
-        mlog.debug(f'pre-processor extraction using -cpp -x {lang} failed, falling back w/o lang')
+        mlog.debug(f'pre-processor extraction using -x {lang} failed, falling back w/o lang')
         output = _try_obtain_compiler_defines(baseline_test_args)
 
     defines: T.Dict[str, str] = {}


### PR DESCRIPTION
Clang's resource files, e.g. /usr/share/clang/clang++.cfg, can be used to bump the default standard level across the system.  
However due to llvm/llvm-project#61641 `clang++ -std=c++17 -E -dM -` doesn't work. The workaround is to pass the language explicitly.  
4ad792e158b6059eb847dd0562aff9bd7029981f fixed the issue by passing the language explicitly, but started passing the `-cpp` flag, which Clang doesn't support.  
Basically Clang would always fallback to the second detection attempt as a result. Remove the unsupported flag and the above scenarios works now too. 🙂

See-also: https://github.com/llvm/llvm-project/issues/61641  
Fixes: 4ad792e158b6059eb847dd0562aff9bd7029981f