### PR TITLE
docs: Use examples for build_machine.cpu() that genuinely exist

### DIFF
--- a/docs/yaml/builtins/build_machine.yaml
+++ b/docs/yaml/builtins/build_machine.yaml
@@ -22,7 +22,7 @@ methods:
 
 - name: cpu
   returns: str
-  description: Returns a more specific CPU name, such as `i686`, `amd64`, etc.
+  description: Returns a more specific CPU name, such as `i686`, `armv8l`, etc.
 
 - name: system
   returns: str


### PR DESCRIPTION
Previously, the documentation said that the CPU name might be amd64, but in fact x86_64 (AMD64) machines are detected as x86_64 in both cpu() and cpu_family() during native builds. Reference: https://buildd.debian.org/status/fetch.php?pkg=libglvnd&arch=amd64&ver=1.7.0-1%2Bb1&stamp=1714222481&raw=0

Instead, mention the only common case for more-specific CPU names other than 32-bit x86, namely 32-bit ARM. On Debian's autobuilders (which are running 32-bit user-space on a 64-bit-capable CPU), native builds genuinely do present as `armv8l`:
https://buildd.debian.org/status/fetch.php?pkg=libglvnd&arch=armhf&ver=1.7.0-1%2Bb1&stamp=1714223924&raw=0 On other machines, they might be some older CPU functionality level.

At the time of writing, cpu() *can* return amd64 when using `meson env2mfile` on Debian systems, but I think that's a bug in env2mfile (#13742).