### PR TITLE
docs: Add windres to cross-compiling example

### DIFF
--- a/docs/markdown/Cross-compilation.md
+++ b/docs/markdown/Cross-compilation.md
@@ -14,6 +14,7 @@ targeting 64-bit Windows could be:
 c = 'x86_64-w64-mingw32-gcc'
 cpp = 'x86_64-w64-mingw32-g++'
 ar = 'x86_64-w64-mingw32-ar'
+windres = 'x86_64-w64-mingw32-windres'
 strip = 'x86_64-w64-mingw32-strip'
 exe_wrapper = 'wine64'
 


### PR DESCRIPTION
I wanted to suggest (or ask about) this. I don't know how common it is for windres to be required. My first time trying this and I got an error until I added this line.

If you want this change, would you also like me to add some brief info about windres to this page?

Also, what do you think about adding this example I found:

```
[binaries]
c = '/usr/bin/x86_64-w64-mingw32-gcc'
cpp = '/usr/bin/x86_64-w64-mingw32-g++'
fortran = '/usr/bin/x86_64-w64-mingw32-gfortran'
rust = ['rustc', '--target', 'x86_64-pc-windows-msvc', '-C', 'linker=/usr/bin/x86_64-w64-mingw32-gcc']
ar = '/usr/bin/x86_64-w64-mingw32-ar'
pkgconfig = '/usr/bin/x86_64-w64-mingw32-pkg-config'
ranlib = '/usr/bin/x86_64-w64-mingw32-ranlib'
strip = '/usr/bin/x86_64-w64-mingw32-strip'
windres = '/usr/bin/x86_64-w64-mingw32-windres'
dlltool = '/usr/bin/x86_64-w64-mingw32-dlltool'
libgcrypt-config = '/usr/x86_64-w64-mingw32/sys-root/mingw/bin/libgcrypt-config'
exe_wrapper = '/usr/bin/wine'

[properties]
root = '/usr/x86_64-w64-mingw32/sys-root/mingw'
needs_exe_wrapper = true

[host_machine]
system = 'windows'
cpu_family = 'x86_64'
cpu = 'x86_64'
endian = 'little'
```

I thought it might be appropriate to add it to the bottom of the page, noting something like "Here is a complex example used for cross-compiling gtk4 (used by https://github.com/MGlolenstine/gtk4-cross)...