### PR TITLE
CMake minimum version 3.10

### DIFF
--- a/mesonbuild/cmake/toolchain.py
+++ b/mesonbuild/cmake/toolchain.py
@@ -212,7 +212,7 @@ class CMakeToolchain:
         languages = list(self.compilers.keys())
         lang_ids = [language_map.get(x, x.upper()) for x in languages]
         cmake_content = dedent(f'''
-            cmake_minimum_required(VERSION 3.7)
+            cmake_minimum_required(VERSION 3.10)
             project(CompInfo {' '.join(lang_ids)})
         ''')
 

--- a/test cases/cmake/1 basic/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/1 basic/subprojects/cmMod/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
 
 project(cmMod)
 set (CMAKE_CXX_STANDARD 14)
@@ -12,7 +12,7 @@ target_compile_definitions(cmModLib++ PRIVATE MESON_MAGIC_FLAG=21)
 target_compile_definitions(cmModLib++ INTERFACE MESON_MAGIC_FLAG=42)
 
 # Test PCH support
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16.0")
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.16.0")
   target_precompile_headers(cmModLib++ PRIVATE "cpp_pch.hpp")
 endif()
 

--- a/test cases/cmake/10 header only/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/10 header only/subprojects/cmMod/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
 
 project(cmMod)
 set (CMAKE_CXX_STANDARD 14)

--- a/test cases/cmake/11 cmake_module_path/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/11 cmake_module_path/subprojects/cmMod/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
 
 project(cmMod)
 

--- a/test cases/cmake/12 generator expressions/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/12 generator expressions/subprojects/cmMod/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
 
 project(cmMod)
 set (CMAKE_CXX_STANDARD 14)

--- a/test cases/cmake/13 system includes/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/13 system includes/subprojects/cmMod/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
 
 project(cmMod)
 set (CMAKE_CXX_STANDARD 14)

--- a/test cases/cmake/16 threads/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/16 threads/subprojects/cmMod/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
 
 project(cmMod C CXX)
 set (CMAKE_CXX_STANDARD 14)

--- a/test cases/cmake/17 include path order/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/17 include path order/subprojects/cmMod/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
 
 project(cmMod)
 set (CMAKE_CXX_STANDARD 14)

--- a/test cases/cmake/18 skip include files/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/18 skip include files/subprojects/cmMod/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
 
 project(cmMod)
 set (CMAKE_CXX_STANDARD 14)

--- a/test cases/cmake/2 advanced/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/2 advanced/subprojects/cmMod/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
 
 project(cmMod)
 set(CMAKE_CXX_STANDARD 14)

--- a/test cases/cmake/21 shared module/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/21 shared module/subprojects/cmMod/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
 
 project(cmModule)
 

--- a/test cases/cmake/23 cmake toolchain/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/23 cmake toolchain/subprojects/cmMod/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
 
 project(cmMod NONE)
 

--- a/test cases/cmake/23 cmake toolchain/subprojects/cmModFortran/CMakeLists.txt
+++ b/test cases/cmake/23 cmake toolchain/subprojects/cmModFortran/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 project(cmMod NONE)
 

--- a/test cases/cmake/24 mixing languages/subprojects/cmTest/CMakeLists.txt
+++ b/test cases/cmake/24 mixing languages/subprojects/cmTest/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
 
 project(cmTest LANGUAGES C OBJC)
 

--- a/test cases/cmake/25 assembler/subprojects/cmTest/CMakeLists.txt
+++ b/test cases/cmake/25 assembler/subprojects/cmTest/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
 
 project(cmTest)
 

--- a/test cases/cmake/27 dependency fallback/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/27 dependency fallback/subprojects/cmMod/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
 
 project(cmMod VERSION 1.2.3)
 set(CMAKE_CXX_STANDARD 14)
@@ -12,7 +12,7 @@ target_compile_definitions(cmModLib++ PRIVATE MESON_MAGIC_FLAG=21)
 target_compile_definitions(cmModLib++ INTERFACE MESON_MAGIC_FLAG=42)
 
 # Test PCH support
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16.0")
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.16.0")
     target_precompile_headers(cmModLib++ PRIVATE "cpp_pch.hpp")
 endif()
 

--- a/test cases/cmake/27 dependency fallback/subprojects/cmake_subp/CMakeLists.txt
+++ b/test cases/cmake/27 dependency fallback/subprojects/cmake_subp/CMakeLists.txt
@@ -1,2 +1,2 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
 project(cmModDummy)

--- a/test cases/cmake/27 dependency fallback/subprojects/force_cmake/CMakeLists.txt
+++ b/test cases/cmake/27 dependency fallback/subprojects/force_cmake/CMakeLists.txt
@@ -1,2 +1,2 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
 project(cmModBoth)

--- a/test cases/cmake/3 advanced no dep/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/3 advanced no dep/subprojects/cmMod/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
 
 project(cmMod)
 set(CMAKE_CXX_STANDARD 14)

--- a/test cases/cmake/8 custom command/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
 
 project(cmMod)
 set (CMAKE_CXX_STANDARD 14)

--- a/test cases/failing build/3 cmake subproject isolation/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/failing build/3 cmake subproject isolation/subprojects/cmMod/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
 
 project(cmMod)
 set (CMAKE_CXX_STANDARD 14)

--- a/test cases/failing/109 cmake executable dependency/subprojects/cmlib/CMakeLists.txt
+++ b/test cases/failing/109 cmake executable dependency/subprojects/cmlib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
 
 project(cmlib)
 

--- a/test cases/failing/119 cmake subproject error/subprojects/cmlib/CMakeLists.txt
+++ b/test cases/failing/119 cmake subproject error/subprojects/cmlib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
 
 project(cmlib)
 

--- a/test cases/unit/1 soname/CMakeLists.txt
+++ b/test cases/unit/1 soname/CMakeLists.txt
@@ -7,7 +7,7 @@
 # soname to 1.2.3 but Autotools sets it to 1.
 
 project(vertest C)
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
 
 add_library(nover SHARED versioned.c)
 


### PR DESCRIPTION
This mitigates maintenance burden as CMake minimum version isn't
relevant for these tests. CMake >= 3.31 warns if CMake minimum version
is less than 3.10.

ref: https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9875