### PR TITLE
cmake: pass clib_compiler to resolve_cmake_trace_targets()

### DIFF
--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -251,8 +251,6 @@ class ConverterTarget:
 
         self.generated_raw: T.List[Path] = []
 
-        self.clib_compiler = None
-
         for i in target.files:
             languages: T.Set[str] = set()
             src_suffixes: T.Set[str] = set()
@@ -278,10 +276,6 @@ class ConverterTarget:
             # Register the new languages and initialize the compile opts array
             for lang in languages:
                 self.languages.add(lang)
-
-                if self.clib_compiler is None:
-                    self.clib_compiler = self.env.coredata.compilers[self.for_machine].get(lang)
-
                 if lang not in self.compile_opts:
                     self.compile_opts[lang] = []
 
@@ -300,6 +294,17 @@ class ConverterTarget:
                 self.generated_raw += i.sources
             else:
                 self.sources += i.sources
+
+        self.clib_compiler = None
+        compilers = self.env.coredata.compilers[self.for_machine]
+
+        for lang in ['objcpp', 'cpp', 'objc', 'fortran', 'c']:
+            if lang in self.languages:
+                try:
+                    self.clib_compiler = compilers[lang]
+                    break
+                except KeyError:
+                    pass
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__}: {self.name}>'

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -251,6 +251,8 @@ class ConverterTarget:
 
         self.generated_raw: T.List[Path] = []
 
+        self.clib_compiler = None
+
         for i in target.files:
             languages: T.Set[str] = set()
             src_suffixes: T.Set[str] = set()
@@ -276,6 +278,10 @@ class ConverterTarget:
             # Register the new languages and initialize the compile opts array
             for lang in languages:
                 self.languages.add(lang)
+
+                if self.clib_compiler is None:
+                    self.clib_compiler = self.env.coredata.compilers[self.for_machine].get(lang)
+
                 if lang not in self.compile_opts:
                     self.compile_opts[lang] = []
 
@@ -346,7 +352,7 @@ class ConverterTarget:
         if tgt:
             self.depends_raw = trace.targets[self.cmake_name].depends
 
-            rtgt = resolve_cmake_trace_targets(self.cmake_name, trace, self.env)
+            rtgt = resolve_cmake_trace_targets(self.cmake_name, trace, self.env, clib_compiler=self.clib_compiler)
             self.includes += [Path(x) for x in rtgt.include_directories]
             self.link_flags += rtgt.link_flags
             self.public_link_flags += rtgt.public_link_flags


### PR DESCRIPTION
This is required to resolve ambiguous `LINK_LIBRARIES` passed as bare names.

Context: I'm trying to use SDL3 as a CMake subproject. It links correctly against the `SDL3-shared` target, but with `SDL3-static` it fails to link against system library and framework dependencies on Windows and macOS. Debugging the windows case has lead me here: the `SDL3-static` target has a bunch of windows system libraries listed in `LINK_LIBRARIES` without the `-l` prefix. This case is supposed to be handled in `resolve_cmake_trace_targets()` in the `reg_is_maybe_bare_lib` case, however, it requires the `clib_compiler` argument, which is never passed.

The cmake interpreter code is a very unfamiliar territory for me, so I'm not sure if this is the best way to detect an appropriate compiler.

I'm not sure what's going on with macOS frameworks; it's probably a different problem not fixed by this patch. I'll have to debug that later when I have access to a mac again.