### PR TITLE
android: Added android_usecase kwargs to executable

### DIFF
--- a/docs/yaml/functions/executable.yaml
+++ b/docs/yaml/functions/executable.yaml
@@ -21,6 +21,17 @@ varargs_inherit: _build_target_base
 kwargs_inherit: _build_target_base
 
 kwargs:
+  android_exe_type:
+    type: str
+    default: "'executable'"
+    since: 1.8.0
+    description: |
+      Specifies the intended target of the executable. This can either be
+      `executable`, if the intended usecase is to run the executable using
+      fork + exec, or `application` if the executable is supposed to be
+      loaded as shared object by the android runtime.
+
+
   export_dynamic:
     type: bool
     since: 0.45.0

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2043,6 +2043,8 @@ class Executable(BuildTarget):
             else:
                 self.suffix = machine.get_exe_suffix()
         self.filename = self.name
+        if self.prefix:
+            self.filename = self.prefix + self.filename
         if self.suffix:
             self.filename += '.' + self.suffix
         self.outputs[0] = self.filename

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -112,7 +112,7 @@ known_build_target_kwargs = (
     rust_kwargs |
     cs_kwargs)
 
-known_exe_kwargs = known_build_target_kwargs | {'implib', 'export_dynamic', 'pie', 'vs_module_defs'}
+known_exe_kwargs = known_build_target_kwargs | {'implib', 'export_dynamic', 'pie', 'vs_module_defs', 'android_exe_type'}
 known_shlib_kwargs = known_build_target_kwargs | {'version', 'soversion', 'vs_module_defs', 'darwin_versions', 'rust_abi'}
 known_shmod_kwargs = known_build_target_kwargs | {'vs_module_defs', 'rust_abi'}
 known_stlib_kwargs = known_build_target_kwargs | {'pic', 'prelink', 'rust_abi'}
@@ -1996,6 +1996,7 @@ class Executable(BuildTarget):
         super().__init__(name, subdir, subproject, for_machine, sources, structured_sources, objects,
                          environment, compilers, kwargs)
         self.win_subsystem = kwargs.get('win_subsystem') or 'console'
+        assert kwargs.get('android_exe_type') is None or kwargs.get('android_exe_type') in {'application', 'executable'}
         # Check for export_dynamic
         self.export_dynamic = kwargs.get('export_dynamic', False)
         if not isinstance(self.export_dynamic, bool):

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -393,6 +393,7 @@ class Executable(_BuildTarget):
     pie: T.Optional[bool]
     vs_module_defs: T.Optional[T.Union[str, File, build.CustomTarget, build.CustomTargetIndex]]
     win_subsystem: T.Optional[str]
+    android_exe_type: T.Optional[Literal['application', 'executable']]
 
 
 class _StaticLibMixin(TypedDict):

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -701,6 +701,12 @@ _EXCLUSIVE_EXECUTABLE_KWS: T.List[KwargInfo] = [
         convertor=lambda x: x.lower() if isinstance(x, str) else None,
         validator=_validate_win_subsystem,
     ),
+    KwargInfo(
+        'android_exe_type',
+        (str, NoneType),
+        validator=in_set_validator({'application', 'executable'}),
+        since='1.8.0'
+    ),
 ]
 
 # The total list of arguments used by Executable

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -76,7 +76,7 @@ if T.TYPE_CHECKING:
         v: bool
 
 ALL_TESTS = ['cmake', 'common', 'native', 'warning-meson', 'failing-meson', 'failing-build', 'failing-test',
-             'keyval', 'platform-osx', 'platform-windows', 'platform-linux',
+             'keyval', 'platform-osx', 'platform-windows', 'platform-linux', 'platform-android',
              'java', 'C#', 'vala', 'cython', 'rust', 'd', 'objective c', 'objective c++',
              'fortran', 'swift', 'cuda', 'python3', 'python', 'fpga', 'frameworks', 'nasm', 'wasm', 'wayland',
              'format',
@@ -1123,6 +1123,8 @@ def detect_tests_to_run(only: T.Dict[str, T.List[str]], use_tmp: bool) -> T.List
         TestCategory('platform-osx', 'osx', not mesonlib.is_osx()),
         TestCategory('platform-windows', 'windows', not mesonlib.is_windows() and not mesonlib.is_cygwin()),
         TestCategory('platform-linux', 'linuxlike', mesonlib.is_osx() or mesonlib.is_windows()),
+        # FIXME, does not actually run in CI, change to run the test if an Android cross toolchain is detected.
+        TestCategory('platform-android', 'android', not mesonlib.is_android()),
         TestCategory('java', 'java', backend is not Backend.ninja or not have_java()),
         TestCategory('C#', 'csharp', skip_csharp(backend)),
         TestCategory('vala', 'vala', backend is not Backend.ninja or not shutil.which(os.environ.get('VALAC', 'valac'))),

--- a/test cases/android/1 exe_type/exe_type.c
+++ b/test cases/android/1 exe_type/exe_type.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+int main(void) {
+    return 0;
+}

--- a/test cases/android/1 exe_type/meson.build
+++ b/test cases/android/1 exe_type/meson.build
@@ -1,0 +1,15 @@
+project('android exe type', 'c')
+fs = import('fs')
+
+e = executable('executable', 'exe_type.c',
+  android_exe_type : 'executable')
+a = executable('application', 'exe_type.c',
+  android_exe_type : 'application')
+
+if fs.name(e.full_path()).contains('.')
+  error('Executable with exe_type `executable` did have expected filename')
+endif
+
+if not fs.name(a.full_path()).startswith('lib') or not fs.name(a.full_path()).endswith('.so')
+  error('Executable with exe_type `application` did not have expected filename')
+endif


### PR DESCRIPTION
This is the idea I've came up with in regards to https://github.com/mesonbuild/meson/discussions/13758

It doesn't do anything regarding application glue right now, as I'm unsure if and how to implement it, but I thought about it some more and belive having it would simplify things quite a bit.

---

By setting android_usecase to `application`, the executable gets actually built as a shared library instead of an executable. This makes it possible to use an application within an android application process.

https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/7555/ 