### PR TITLE
Add get_link_targets and get_link_whole_targets options to build targets

### DIFF
--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -909,6 +909,8 @@ class BuildTargetHolder(ObjectHolder[_BuildTarget]):
                              'path': self.path_method,
                              'found': self.found_method,
                              'private_dir_include': self.private_dir_include_method,
+                             'get_link_targets': self.get_link_targets_method,
+                             'get_link_whole_targets': self.get_link_whole_targets_method,
                              })
 
     def __repr__(self) -> str:
@@ -989,6 +991,18 @@ class BuildTargetHolder(ObjectHolder[_BuildTarget]):
     @noKwargs
     def name_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> str:
         return self._target_object.name
+
+    @FeatureNew('get_link_targets', '1.6.0')
+    @noPosargs
+    @noKwargs
+    def get_link_targets_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> T.List[build.LibTypes]:
+        return self._target_object.link_targets
+
+    @FeatureNew('get_link_whole_targets', '1.6.0')
+    @noPosargs
+    @noKwargs
+    def get_link_whole_targets_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> T.List[T.Union[build.StaticLibrary, build.CustomTarget, build.CustomTargetIndex]]:
+        return self._target_object.link_whole_targets
 
 class ExecutableHolder(BuildTargetHolder[build.Executable]):
     pass


### PR DESCRIPTION
After building gstreamer-full, we would like to override the dependencies' pkg-config files for all of the ones contained in the whole static library to point to gstreamer-full instead of themselves. Since [`gstreamer-rs`](https://gitlab.freedesktop.org/eerii/gstreamer-rs) uses [`system-deps`](https://github.com/gdesmott/system-deps) (a wrapper for `pkg-config`) for dependency resolution, it is very useful to have this `pkg-config` files already pointing to the right place.

In order to do so, we need to know all of the names of the libraries bundled inside gstreamer-full. As far as I could tell, there was no way of accessing this information from the `meson.build` file. If there is a better way of doing this, I'd love to know.