### PR TITLE
interpreterbase: Add disabler exception for `get_variable` method

### DIFF
--- a/mesonbuild/interpreterbase/interpreterbase.py
+++ b/mesonbuild/interpreterbase/interpreterbase.py
@@ -542,7 +542,7 @@ class InterpreterBase:
         method_name = node.name.value
         (h_args, h_kwargs) = self.reduce_arguments(node.args)
         (args, kwargs) = self._unholder_args(h_args, h_kwargs)
-        if is_disabled(args, kwargs):
+        if is_disabled(args, kwargs) and method_name != 'get_variable':
             return Disabler()
         if not isinstance(obj, InterpreterObject):
             raise InvalidArguments(f'{object_display_name} is not callable.')

--- a/test cases/common/158 disabler/meson.build
+++ b/test cases/common/158 disabler/meson.build
@@ -151,3 +151,8 @@ foreach k, i : {'a': true, 'b': disabler(), 'c': true}
 endforeach
 assert(loops == 3, 'Disabler in foreach dict')
 assert(disablers == 1, 'Disabler in foreach dict')
+
+# https://github.com/mesonbuild/meson/issues/13717
+bar_subproject = subproject('bar')
+bar_dep = bar_subproject.get_variable('bar_dep', disabler())
+assert(not is_disabler(bar_dep))

--- a/test cases/common/158 disabler/subprojects/bar/meson.build
+++ b/test cases/common/158 disabler/subprojects/bar/meson.build
@@ -1,0 +1,2 @@
+project('bar')
+bar_dep = declare_dependency()


### PR DESCRIPTION
Add an exception to the disabler check to allow objects with a `get_variable` method to not always pick a disabler if their arguments contain one. This mimics the behaviour already in place for calls to functions, which has a set of excepted functions.

Fixes #13717