### PR TITLE
coverage.py: Guard use of `--html-nested` behind version check.

### DIFF
--- a/mesonbuild/scripts/coverage.py
+++ b/mesonbuild/scripts/coverage.py
@@ -159,9 +159,14 @@ def coverage(outputs: T.List[str], source_root: str, subproject_root: str, build
             htmloutdir = os.path.join(log_dir, 'coveragereport')
             if not os.path.isdir(htmloutdir):
                 os.mkdir(htmloutdir)
+            # Use `--html-details` if gcovr version < 6.0, otherwise
+            # use `--html-nested`.
+            html_arg = '--html-details'
+            if mesonlib.version_compare(gcovr_version, '>=6.0'):
+                html_arg = '--html-nested'
             subprocess.check_call(gcovr_base_cmd + gcovr_config +
                                   ['--html',
-                                   '--html-nested',
+                                   html_arg,
                                    '--print-summary',
                                    '-o', os.path.join(htmloutdir, 'index.html'),
                                    ] + gcov_exe_args)


### PR DESCRIPTION
`--html-nested` was added to gcovr in version 6.0 so passing it to versions before this will result in gcovr complaining that it doesn't recognise the argument.

Added a version check to ensure that we pass a recognised argument for versions before 6.0

Fixes #13781