### PR TITLE
WIP: wrap: Implemented wraplock

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -28,6 +28,7 @@ from pathlib import Path, PurePath
 from functools import lru_cache
 
 from . import WrapMode
+from .wraplock import WrapLock
 from .. import coredata
 from ..mesonlib import quiet_git, GIT, ProgressBar, MesonException, windows_proof_rmtree, Popen_safe
 from ..interpreterbase import FeatureNew
@@ -304,6 +305,7 @@ class Resolver:
     def __post_init__(self) -> None:
         self.subdir_root = os.path.join(self.source_dir, self.subdir)
         self.cachedir = os.environ.get('MESON_PACKAGE_CACHE_DIR') or os.path.join(self.subdir_root, 'packagecache')
+        self.wraplock = WrapLock(self.subdir_root)
         self.wraps: T.Dict[str, PackageDefinition] = {}
         self.netrc: T.Optional[netrc] = None
         self.provided_deps: T.Dict[str, PackageDefinition] = {}
@@ -427,7 +429,7 @@ class Resolver:
                 return wrap_name
         return None
 
-    def resolve(self, packagename: str, force_method: T.Optional[Method] = None) -> T.Tuple[str, Method]:
+    def _resolve(self, packagename: str, force_method: T.Optional[Method]) -> T.Tuple[str, Method]:
         wrap = self.wraps.get(packagename)
         if wrap is None:
             wrap = self.get_from_wrapdb(packagename)
@@ -524,6 +526,10 @@ class Resolver:
         # reference.
         self.wrap.update_hash_cache(self.dirname)
         return rel_path, method
+
+    def resolve(self, packagename: str, force_method: T.Optional[Method] = None) -> T.Tuple[str, Method]:
+        with self.wraplock:
+            return self._resolve(packagename, force_method)
 
     def check_can_download(self) -> None:
         # Don't download subproject data based on wrap file if requested.

--- a/mesonbuild/wrap/wraplock.py
+++ b/mesonbuild/wrap/wraplock.py
@@ -2,32 +2,41 @@ from __future__ import annotations
 
 import os
 
-import fcntl
+try:
+    import fcntl
+except ImportError:
+    class WrapLock():
+        def __init__(self, subdir_root: str):
+            pass
+        def __enter__(self, *args, **kwargs) -> None:
+            pass
+        def __exit__(self, *args, **kwargs) -> None:
+            pass
+else:
+    class WrapLock():
+        def __init__(self, subdir_root: str):
+            self.lock_file = os.path.join(subdir_root, ".wraplock")
 
-class WrapLock():
-    def __init__(self, subdir_root: str):
-        self.lock_file = os.path.join(subdir_root, ".wraplock")
+        """Uses the :func:`fcntl.flock` to hard lock the lock file on unix systems."""
+        def __enter__(self, *args, **kwargs) -> None:
+            try:
+                self.fd = os.open(self.lock_file,
+                             os.O_RDWR | os.O_TRUNC | os.O_CREAT,
+                             0o644);
+            except FileNotFoundError:
+                self.fd = -1
+                return
+            fcntl.flock(self.fd, fcntl.LOCK_EX)
 
-    """Uses the :func:`fcntl.flock` to hard lock the lock file on unix systems."""
-    def __enter__(self, *args, **kwargs) -> None:
-        try:
-            self.fd = os.open(self.lock_file,
-                         os.O_RDWR | os.O_TRUNC | os.O_CREAT,
-                         0o644);
-        except FileNotFoundError:
+        def __exit__(self, *args, **kwargs) -> None:
+            if self.fd == -1:
+                return;
+            # Do not remove the lockfile:
+            #   https://github.com/tox-dev/py-filelock/issues/31
+            #   https://stackoverflow.com/questions/17708885/flock-removing-locked-file-without-race-condition
+            fcntl.flock(self.fd, fcntl.LOCK_UN)
+            os.close(self.fd)
             self.fd = -1
-            return
-        fcntl.flock(self.fd, fcntl.LOCK_EX)
-
-    def __exit__(self, *args, **kwargs) -> None:
-        if self.fd == -1:
-            return;
-        # Do not remove the lockfile:
-        #   https://github.com/tox-dev/py-filelock/issues/31
-        #   https://stackoverflow.com/questions/17708885/flock-removing-locked-file-without-race-condition
-        fcntl.flock(self.fd, fcntl.LOCK_UN)
-        os.close(self.fd)
-        self.fd = -1
 
 __all__ = [
     "WrapLock",

--- a/mesonbuild/wrap/wraplock.py
+++ b/mesonbuild/wrap/wraplock.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import os
+
+import fcntl
+
+class WrapLock():
+    def __init__(self, subdir_root: str):
+        self.lock_file = os.path.join(subdir_root, ".wraplock")
+
+    """Uses the :func:`fcntl.flock` to hard lock the lock file on unix systems."""
+    def __enter__(self, *args, **kwargs) -> None:
+        try:
+            self.fd = os.open(self.lock_file,
+                         os.O_RDWR | os.O_TRUNC | os.O_CREAT,
+                         0o644);
+        except FileNotFoundError:
+            self.fd = -1
+            return
+        fcntl.flock(self.fd, fcntl.LOCK_EX)
+
+    def __exit__(self, *args, **kwargs) -> None:
+        if self.fd == -1:
+            return;
+        # Do not remove the lockfile:
+        #   https://github.com/tox-dev/py-filelock/issues/31
+        #   https://stackoverflow.com/questions/17708885/flock-removing-locked-file-without-race-condition
+        fcntl.flock(self.fd, fcntl.LOCK_UN)
+        os.close(self.fd)
+        self.fd = -1
+
+__all__ = [
+    "WrapLock",
+]

--- a/test cases/unit/116 empty project/expected_mods.json
+++ b/test cases/unit/116 empty project/expected_mods.json
@@ -237,7 +237,8 @@
       "mesonbuild.utils.universal",
       "mesonbuild.utils.vsenv",
       "mesonbuild.wrap",
-      "mesonbuild.wrap.wrap"
+      "mesonbuild.wrap.wrap",
+      "mesonbuild.wrap.wraplock"
     ],
     "count": 69
   }


### PR DESCRIPTION
Mostly a POC looking for feedback, but:

As I've described in https://github.com/mesonbuild/meson/discussions/13758

When you start multiple meson setup instances at the same time, then during their attempted access of the same subproject, one instance manages to start the download, while the other attempts to evaluate a partially download subproject: `../meson.build:406:17: ERROR: Subproject exists but has no meson.build file.`

The current implementation is a heavily shortend/modified version of [tox-dev:filelock/UnixFileLock](https://github.com/tox-dev/filelock/blob/main/src/filelock/_unix.py). The issue with the current code is hower, that fcntl isn't cross-platform.

Unlike the filelock package, I was thinking of just providing the fnctl locking implementation and letting meson processes race into each other of systems that don't implement it.