### PR TITLE
Add GNU/Hurd kernel results

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -182,6 +182,7 @@ Native names as returned by the `.kernel()` method.
 | freebsd | |
 | openbsd | |
 | netbsd  | |
+| gnu     | GNU Hurd |
 | nt      | |
 | xnu                 | Kernel of various Apple OSes    |
 | illumos             | Kernel derived from OpenSolaris by community efforts |

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -476,6 +476,7 @@ KERNEL_MAPPINGS: T.Mapping[str, str] = {'freebsd': 'freebsd',
                                         'darwin': 'xnu',
                                         'dragonfly': 'dragonfly',
                                         'haiku': 'haiku',
+                                        'gnu': 'gnu',
                                         }
 
 def detect_kernel(system: str) -> T.Optional[str]:

--- a/mesonbuild/scripts/env2mfile.py
+++ b/mesonbuild/scripts/env2mfile.py
@@ -156,6 +156,7 @@ deb_os_map = {
 # map from DEB_HOST_ARCH_OS to Meson machine.kernel()
 deb_kernel_map = {
     'kfreebsd': 'freebsd',
+    'hurd': 'gnu',
 }
 
 def replace_special_cases(special_cases: T.Mapping[str, str], name: str) -> str:

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1933,11 +1933,7 @@ class InternalTests(unittest.TestCase):
                     },
                     system='gnu',
                     subsystem='gnu',
-                    # TODO: Currently hurd; should match whatever happens
-                    # during native builds, but at the moment native builds
-                    # fail when kernel() is called.
-                    # https://github.com/mesonbuild/meson/issues/13740
-                    kernel='TODO',
+                    kernel='gnu',
                     cpu='i686',
                     cpu_family='x86',
                     endian='little',


### PR DESCRIPTION
uname -s does return gnu there.

Resolves: https://github.com/mesonbuild/meson/issues/13740