### PR TITLE
Update release notes for 1.6.0

### DIFF
--- a/docs/markdown/snippets/add_support_for_ibm_clang_for_AIX.md
+++ b/docs/markdown/snippets/add_support_for_ibm_clang_for_AIX.md
@@ -1,0 +1,7 @@
+## Support for OpenXL compiler in AIX.
+
+The OpenXL compiler is now supported from Meson 1.6.0 onwards.
+So currently, in AIX Operating system we support GCC and openXL compilers for Meson build system.
+
+Both the compilers will archive shared libraries and generate a shared object
+for a shared module while using Meson in AIX.


### PR DESCRIPTION
Updating release notes to indicate openXL compiler is supported in AIX.