### PR TITLE
gnome: Added 'executable' method for GTK Android

### DIFF
--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -429,3 +429,11 @@ It takes the following keyword arguments:
   MIME types handled by desktop files in `<prefix>/<datadir>/applications`.
 - `update_mime_database`: *Since 0.64.0* If set to `true`, update cache of
   MIME types in `<prefix>/<datadir>/mime`.
+
+### gnome.executable()
+
+*Since 1.7.0*
+
+Wrapper for executable explicitly targeting applications utilizing GTK. It
+takes the same arguments as
+[executable](Reference-manual_functions.md#executable).

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1343,7 +1343,7 @@ class BuildTarget(Target):
     def get_include_dirs(self) -> T.List['IncludeDirs']:
         return self.include_dirs
 
-    def add_deps(self, deps):
+    def add_deps(self, deps: T.Sequence[dependencies.Dependency]):
         deps = listify(deps)
         for dep in deps:
             if dep in self.added_deps:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -525,6 +525,7 @@ class Target(HoldableObject, metaclass=abc.ABCMeta):
     build_always_stale: bool = False
     extra_files: T.List[File] = field(default_factory=list)
     override_options: InitVar[T.Optional[T.Dict[OptionKey, str]]] = None
+    introspection_flags: T.Optional[T.List[str]] = None
 
     @abc.abstractproperty
     def typename(self) -> str:
@@ -636,6 +637,12 @@ class Target(HoldableObject, metaclass=abc.ABCMeta):
             # preserve myid for better debuggability
             return subdir_part + '@@' + my_id
         return my_id
+
+    def add_introspection_flag(self, flag: str) -> None:
+        if self.introspection_flags is None:
+            self.introspection_flags = [flag]
+        else:
+            self.introspection_flags.append(flag)
 
     def get_id(self) -> str:
         name = self.name

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3362,6 +3362,12 @@ class Interpreter(InterpreterBase, HoldableObject):
     def build_target(self, node: mparser.BaseNode, args: T.Tuple[str, SourcesVarargsType],
                      kwargs: kwtypes.Jar, targetclass: T.Type[build.Jar]) -> build.Jar: ...
 
+    @T.overload
+    def build_target(self, node: mparser.BaseNode, args: T.Tuple[str, SourcesVarargsType],
+                     kwargs: T.Union[kwtypes.Executable, kwtypes.StaticLibrary, kwtypes.SharedLibrary, kwtypes.SharedModule, kwtypes.Jar],
+                     targetclass: T.Type[T.Union[build.Executable, build.StaticLibrary, build.SharedModule, build.SharedLibrary, build.Jar]]
+                     ) -> T.Union[build.Executable, build.StaticLibrary, build.SharedModule, build.SharedLibrary, build.Jar]: ...
+
     def build_target(self, node: mparser.BaseNode, args: T.Tuple[str, SourcesVarargsType],
                      kwargs: T.Union[kwtypes.Executable, kwtypes.StaticLibrary, kwtypes.SharedLibrary, kwtypes.SharedModule, kwtypes.Jar],
                      targetclass: T.Type[T.Union[build.Executable, build.StaticLibrary, build.SharedModule, build.SharedLibrary, build.Jar]]

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -263,6 +263,9 @@ def list_targets(builddata: build.Build, installdata: backends.InstallData, back
             'depends': [lib.get_id() for lib in getattr(target, 'dependencies', [])]
         }
 
+        if target.introspection_flags:
+            t['flags'] = target.introspection_flags
+
         vs_module_defs = getattr(target, 'vs_module_defs', None)
         if vs_module_defs is not None:
             t['vs_module_defs'] = vs_module_defs.relative_name()

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -15,8 +15,10 @@ from ..mesonlib import relpath, HoldableObject, MachineChoice
 from ..programs import ExternalProgram
 
 if T.TYPE_CHECKING:
+    from ..interpreter import kwargs as kwtypes
     from ..interpreter import Interpreter
     from ..interpreter.interpreter import ProgramVersionFunc
+    from ..interpreter.type_checking import SourcesVarargsType
     from ..interpreterbase import TYPE_var, TYPE_kwargs
     from ..programs import OverrideProgram
     from ..dependencies import Dependency
@@ -156,6 +158,28 @@ class ModuleState:
 
     def add_language(self, lang: str, for_machine: MachineChoice) -> None:
         self._interpreter.add_languages([lang], True, for_machine)
+
+    @T.overload
+    def add_target(self, args: T.Tuple[str, SourcesVarargsType],
+                   kwargs: kwtypes.Executable, targetclass: T.Type[build.Executable]) -> build.Executable: ...
+
+    @T.overload
+    def add_target(self, args: T.Tuple[str, SourcesVarargsType],
+                   kwargs: kwtypes.StaticLibrary, targetclass: T.Type[build.StaticLibrary]) -> build.StaticLibrary: ...
+
+    @T.overload
+    def add_target(self, args: T.Tuple[str, SourcesVarargsType],
+                   kwargs: kwtypes.SharedModule, targetclass: T.Type[build.SharedModule]) -> build.SharedModule: ...
+
+    @T.overload
+    def add_target(self, args: T.Tuple[str, SourcesVarargsType],
+                   kwargs: kwtypes.SharedLibrary, targetclass: T.Type[build.SharedLibrary]) -> build.SharedLibrary: ...
+
+    def add_target(self, args: T.Tuple[str, SourcesVarargsType],
+                   kwargs: T.Union[kwtypes.Executable, kwtypes.StaticLibrary, kwtypes.SharedLibrary, kwtypes.SharedModule, kwtypes.Jar],
+                   targetclass: T.Type[T.Union[build.Executable, build.StaticLibrary, build.SharedModule, build.SharedLibrary, build.Jar]]
+                   ) -> T.Union[build.Executable, build.StaticLibrary, build.SharedModule, build.SharedLibrary, build.Jar]:
+        return self._interpreter.build_target(self.current_node, args, kwargs, targetclass)
 
 class ModuleObject(HoldableObject):
     """Base class for all objects returned by modules

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -24,8 +24,8 @@ from .. import mlog
 from ..build import CustomTarget, CustomTargetIndex, Executable, GeneratedList, InvalidArguments
 from ..dependencies import Dependency, InternalDependency
 from ..dependencies.pkgconfig import PkgConfigDependency, PkgConfigInterface
-from ..interpreter.type_checking import DEPENDS_KW, DEPEND_FILES_KW, ENV_KW, INSTALL_DIR_KW, INSTALL_KW, NoneType, DEPENDENCY_SOURCES_KW, in_set_validator
-from ..interpreterbase import noPosargs, noKwargs, FeatureNew, FeatureDeprecated
+from ..interpreter.type_checking import DEPENDS_KW, DEPEND_FILES_KW, ENV_KW, EXECUTABLE_KWS, INSTALL_DIR_KW, INSTALL_KW, SOURCES_VARARGS, NoneType, DEPENDENCY_SOURCES_KW, in_set_validator
+from ..interpreterbase import noPosargs, noKwargs, permittedKwargs, FeatureNew, FeatureDeprecated
 from ..interpreterbase import typed_kwargs, KwargInfo, ContainerTypeInfo
 from ..interpreterbase.decorators import typed_pos_args
 from ..mesonlib import (
@@ -41,7 +41,9 @@ if T.TYPE_CHECKING:
     from . import ModuleState
     from ..build import BuildTarget
     from ..compilers import Compiler
+    from ..interpreter import kwargs as kwtypes
     from ..interpreter import Interpreter
+    from ..interpreter.type_checking import SourcesVarargsType
     from ..interpreterbase import TYPE_var, TYPE_kwargs
     from ..mesonlib import FileOrString
     from ..programs import ExternalProgram
@@ -274,6 +276,7 @@ class GnomeModule(ExtensionModule):
             'mkenums_simple': self.mkenums_simple,
             'genmarshal': self.genmarshal,
             'generate_vapi': self.generate_vapi,
+            'executable': self.executable,
         })
 
     def _get_native_glib_version(self, state: 'ModuleState') -> str:
@@ -2204,6 +2207,24 @@ class GnomeModule(ExtensionModule):
         rv = InternalDependency(None, incs, [], [], link_with, [], sources, [], [], {}, [], [], [])
         created_values.append(rv)
         return ModuleReturnValue(rv, created_values)
+
+    @permittedKwargs(build.known_exe_kwargs)
+    @typed_pos_args('gnome.executable', str, varargs=SOURCES_VARARGS)
+    @typed_kwargs('gnome.executable', *EXECUTABLE_KWS, allow_unknown=True)
+    def executable(self, state: 'ModuleState', args: T.Tuple[str, SourcesVarargsType], kwargs: kwtypes.Executable) -> ModuleReturnValue:
+        target: T.Union[build.Executable, build.SharedLibrary]
+        if state.environment.machines.host.is_android():
+            kwargs["gui_app"] = None
+            kwargs["win_subsystem"] = None
+            if T.TYPE_CHECKING:
+                target = state.add_target(args, T.cast(kwtypes.SharedLibrary, kwargs), build.SharedLibrary)
+            else:
+                target = state.add_target(args, kwargs, build.SharedLibrary)
+            glue = state.dependency('gtk4-android-glue')
+            target.add_deps([glue])
+        else:
+            target = state.add_target(args, kwargs, build.Executable)
+        return ModuleReturnValue(target, [])
 
 def initialize(interp: 'Interpreter') -> GnomeModule:
     mod = GnomeModule(interp)

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -2222,6 +2222,7 @@ class GnomeModule(ExtensionModule):
                 target = state.add_target(args, kwargs, build.SharedLibrary)
             glue = state.dependency('gtk4-android-glue')
             target.add_deps([glue])
+            target.add_introspection_flag('gnome:has-android-glue')
         else:
             target = state.add_target(args, kwargs, build.Executable)
         return ModuleReturnValue(target, [])


### PR DESCRIPTION
A new concept for #13767, this time more specifically tailored to GNOME/GTK.

I think having the "gtk4-android-glue" depname hardcoded is fine for now but it makes sense in the future to extend by scanning whether the user is depending on gtk4, 5, ... once there are different possibilities.