### PR TITLE
Introducing Meson Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,4 +101,6 @@ interface][matrix_web]) or [OFTC IRC][oftc_irc].
 More information about the Meson build system can be found at the
 [project's home page](https://mesonbuild.com).
 
+You can also [Ask Meson Guru](https://gurubase.io/g/meson), it is a Meson-focused AI to answer your questions.
+
 Meson is a registered trademark of ***Jussi Pakkanen***.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Meson Guru](https://gurubase.io/g/meson) to Gurubase. Meson Guru uses the data from this repo and data from the [docs](https://mesonbuild.com/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Meson Guru", which highlights that Meson now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Meson Guru in Gurubase, just let me know that's totally fine.