### PR TITLE
Reimplement several methods for Fortran compilers

### DIFF
--- a/docs/markdown/snippets/fixed_sizeof_and_find_library_for_fortran.md
+++ b/docs/markdown/snippets/fixed_sizeof_and_find_library_for_fortran.md
@@ -1,0 +1,8 @@
+## Fixed `sizeof` and `find_library` methods for Fortran compilers
+
+The implementation of the `.sizeof()` method has been fixed for Fortran
+compilers (it was previously broken since it would try to compile a C code
+snippet). Note that this functionality requires Fortran 2008 support.
+
+Incidentally this also fixes the `.find_library()` method for Fortran compilers
+when the `prefer_static` built-in option is set to true.


### PR DESCRIPTION
The output_is_64bit, sizeof, cross_sizeof, compute_int and cross_compute_int methods are reimplemented for Fortran compilers. Those inherited from CLikeCompiler do not work since they assume C or C++.

Note that those tests rely on Fortran 2008 features (notably the c_sizeof operator).

Closes #12757