### PR TITLE
modules/rust: Add support for autolib field in the Cargo.toml

### DIFF
--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -146,6 +146,7 @@ class Package:
     publish: bool = True
     metadata: T.Dict[str, T.Any] = dataclasses.field(default_factory=dict)
     default_run: T.Optional[str] = None
+    autolib: bool = True
     autobins: bool = True
     autoexamples: bool = True
     autotests: bool = True

--- a/mesonbuild/cargo/manifest.py
+++ b/mesonbuild/cargo/manifest.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright © 2022-2023 Intel Corporation
+# Copyright © 2022-2024 Intel Corporation
 
 """Type definitions for cargo manifest files."""
 
@@ -33,6 +33,7 @@ Package = TypedDict(
         'publish': bool,
         'metadata': T.Dict[str, T.Dict[str, str]],
         'default-run': str,
+        'autolib': bool,
         'autobins': bool,
         'autoexamples': bool,
         'autotests': bool,
@@ -65,6 +66,7 @@ class FixedPackage(TypedDict, total=False):
     publish: bool
     metadata: T.Dict[str, T.Dict[str, str]]
     default_run: str
+    autolib: bool
     autobins: bool
     autoexamples: bool
     autotests: bool


### PR DESCRIPTION
This adds support for parsing the new `autolib` member (https://github.com/rust-lang/cargo/pull/14591).

This is a quick and easy fix, suitable for backport. A larger more involved fix will be to stop splatting out the cargo dictionaries, and instead pass the fields we know about 1 by 1, and warning the user if we come across unknown fields.

Fixes: #13826