### PR TITLE
Warn when Cargo.toml contains keys we don't expect

### DIFF
--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -11,9 +11,7 @@ port will be required.
 
 from __future__ import annotations
 import dataclasses
-import glob
 import importlib
-import itertools
 import json
 import os
 import shutil
@@ -370,47 +368,6 @@ def _convert_manifest(raw_manifest: manifest.Manifest, subdir: str, path: str = 
          for k, v in raw_manifest.get('target', {}).items()},
         path,
     )
-
-
-def _load_manifests(subdir: str) -> T.Dict[str, Manifest]:
-    filename = os.path.join(subdir, 'Cargo.toml')
-    raw = load_toml(filename)
-
-    manifests: T.Dict[str, Manifest] = {}
-
-    raw_manifest: T.Union[manifest.Manifest, manifest.VirtualManifest]
-    if 'package' in raw:
-        raw_manifest = T.cast('manifest.Manifest', raw)
-        manifest_ = _convert_manifest(raw_manifest, subdir)
-        manifests[manifest_.package.name] = manifest_
-    else:
-        raw_manifest = T.cast('manifest.VirtualManifest', raw)
-
-    if 'workspace' in raw_manifest:
-        # XXX: need to verify that python glob and cargo globbing are the
-        # same and probably write  a glob implementation. Blarg
-
-        # We need to chdir here to make the glob work correctly
-        pwd = os.getcwd()
-        os.chdir(subdir)
-        members: T.Iterable[str]
-        try:
-            members = itertools.chain.from_iterable(
-                glob.glob(m) for m in raw_manifest['workspace']['members'])
-        finally:
-            os.chdir(pwd)
-        if 'exclude' in raw_manifest['workspace']:
-            members = (x for x in members if x not in raw_manifest['workspace']['exclude'])
-
-        for m in members:
-            filename = os.path.join(subdir, m, 'Cargo.toml')
-            raw = load_toml(filename)
-
-            raw_manifest = T.cast('manifest.Manifest', raw)
-            man = _convert_manifest(raw_manifest, subdir, m)
-            manifests[man.package.name] = man
-
-    return manifests
 
 
 def _version_to_api(version: str) -> str:

--- a/mesonbuild/cargo/manifest.py
+++ b/mesonbuild/cargo/manifest.py
@@ -195,7 +195,7 @@ class Workspace(TypedDict):
 Manifest = TypedDict(
     'Manifest',
     {
-        'package': Package,
+        'package': Required[Package],
         'badges': T.Dict[str, Badge],
         'dependencies': T.Dict[str, DependencyV],
         'dev-dependencies': T.Dict[str, DependencyV],

--- a/run_single_test.py
+++ b/run_single_test.py
@@ -13,10 +13,11 @@ import pathlib
 import typing as T
 
 from mesonbuild import mlog
+from mesonbuild.mesonlib import is_windows
 from run_tests import handle_meson_skip_test
 from run_project_tests import TestDef, load_test_json, run_test, BuildStep
 from run_project_tests import setup_commands, detect_system_compiler, detect_tools
-from run_project_tests import setup_symlinks, clear_transitive_files
+from run_project_tests import scan_test_data_symlinks, setup_symlinks, clear_transitive_files
 
 if T.TYPE_CHECKING:
     from run_project_tests import CompilerArgumentType
@@ -45,6 +46,8 @@ def main() -> None:
     parser.add_argument('--quick', action='store_true', help='Skip some compiler and tool checking')
     args = T.cast('ArgumentType', parser.parse_args())
 
+    if not is_windows():
+        scan_test_data_symlinks()
     setup_symlinks()
     setup_commands(args.backend)
     if not args.quick:

--- a/test cases/rust/22 cargo subproject/subprojects/bar-0.1-rs/Cargo.toml
+++ b/test cases/rust/22 cargo subproject/subprojects/bar-0.1-rs/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "bar"
 version = "0.1"
+flooob = "lolz"
 
 # This dependency does not exist, it is required by default but this subproject
 # is called with default-features=false.

--- a/test cases/rust/22 cargo subproject/test.json
+++ b/test cases/rust/22 cargo subproject/test.json
@@ -1,0 +1,8 @@
+{
+  "stdout": [
+    {
+      "line": "foo-0-rs| WARNING: Package entry bar has unexpected keys \"flooob\". This may (unlikely) be an error in the cargo manifest, or may be a missing implementation in Meson. If this issue can be reproduced with the latest version of Meson, please help us by opening an issue at https://github.com/mesonbuild/meson/issues. Please include the crate and version that is generating this warning if possible."
+    }
+  ]
+}
+


### PR DESCRIPTION
This prevents use from having uncaught python exceptions when a new key is added, as one recently was. The downside of course of warning is that we might configure incorrectly. At the moment I think that is the preferable way to go, especially since Cargo support is experimental and may fail anyway.