### PR TITLE
Fix regression when using both libraries

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -31,7 +31,7 @@ from ..interpreterbase import InterpreterException, InvalidArguments, InvalidCod
 from ..interpreterbase import Disabler, disablerIfNotFound
 from ..interpreterbase import FeatureNew, FeatureDeprecated, FeatureBroken, FeatureNewKwargs
 from ..interpreterbase import ObjectHolder, ContextManagerObject
-from ..interpreterbase import stringifyUserArguments, resolve_second_level_holders
+from ..interpreterbase import stringifyUserArguments
 from ..modules import ExtensionModule, ModuleObject, MutableModuleObject, NewExtensionModule, NotFoundExtensionModule
 from ..optinterpreter import optname_regex
 
@@ -690,7 +690,6 @@ class Interpreter(InterpreterBase, HoldableObject):
         KwargInfo('version', (str, NoneType)),
         KwargInfo('objects', ContainerTypeInfo(list, build.ExtractedObjects), listify=True, default=[], since='1.1.0'),
     )
-    @noSecondLevelHolderResolving
     def func_declare_dependency(self, node: mparser.BaseNode, args: T.List[TYPE_var],
                                 kwargs: kwtypes.FuncDeclareDependency) -> dependencies.Dependency:
         deps = kwargs['dependencies']
@@ -1873,14 +1872,11 @@ class Interpreter(InterpreterBase, HoldableObject):
     def func_shared_lib(self, node: mparser.BaseNode,
                         args: T.Tuple[str, SourcesVarargsType],
                         kwargs: kwtypes.SharedLibrary) -> build.SharedLibrary:
-        holder = self.build_target(node, args, kwargs, build.SharedLibrary)
-        holder.shared_library_only = True
-        return holder
+        return self.build_target(node, args, kwargs, build.SharedLibrary)
 
     @permittedKwargs(known_library_kwargs)
     @typed_pos_args('both_libraries', str, varargs=SOURCES_VARARGS)
     @typed_kwargs('both_libraries', *LIBRARY_KWS, allow_unknown=True)
-    @noSecondLevelHolderResolving
     def func_both_lib(self, node: mparser.BaseNode,
                       args: T.Tuple[str, SourcesVarargsType],
                       kwargs: kwtypes.Library) -> build.BothLibraries:
@@ -1898,7 +1894,6 @@ class Interpreter(InterpreterBase, HoldableObject):
     @permittedKwargs(known_library_kwargs)
     @typed_pos_args('library', str, varargs=SOURCES_VARARGS)
     @typed_kwargs('library', *LIBRARY_KWS, allow_unknown=True)
-    @noSecondLevelHolderResolving
     def func_library(self, node: mparser.BaseNode,
                      args: T.Tuple[str, SourcesVarargsType],
                      kwargs: kwtypes.Library) -> build.Executable:
@@ -1916,15 +1911,12 @@ class Interpreter(InterpreterBase, HoldableObject):
     @permittedKwargs(known_build_target_kwargs)
     @typed_pos_args('build_target', str, varargs=SOURCES_VARARGS)
     @typed_kwargs('build_target', *BUILD_TARGET_KWS, allow_unknown=True)
-    @noSecondLevelHolderResolving
     def func_build_target(self, node: mparser.BaseNode,
                           args: T.Tuple[str, SourcesVarargsType],
                           kwargs: kwtypes.BuildTarget
                           ) -> T.Union[build.Executable, build.StaticLibrary, build.SharedLibrary,
                                        build.SharedModule, build.BothLibraries, build.Jar]:
         target_type = kwargs['target_type']
-        if target_type not in {'both_libraries', 'library'}:
-            args, kwargs = resolve_second_level_holders(args, kwargs)
 
         if target_type == 'executable':
             return self.build_target(node, args, kwargs, build.Executable)
@@ -2177,7 +2169,14 @@ class Interpreter(InterpreterBase, HoldableObject):
         name, deps = args
         if any(isinstance(d, build.RunTarget) for d in deps):
             FeatureNew.single_use('alias_target that depends on run_targets', '0.60.0', self.subproject)
-        tg = build.AliasTarget(name, deps, self.subdir, self.subproject, self.environment)
+        real_deps: T.List[build.Target] = []
+        for d in deps:
+            if isinstance(d, build.BothLibraries):
+                real_deps.append(d.shared)
+                real_deps.append(d.static)
+            else:
+                real_deps.append(d)
+        tg = build.AliasTarget(name, real_deps, self.subdir, self.subproject, self.environment)
         self.add_target(name, tg)
         return tg
 
@@ -3283,16 +3282,18 @@ class Interpreter(InterpreterBase, HoldableObject):
             # Keep only compilers used for linking
             static_lib.compilers = {k: v for k, v in static_lib.compilers.items() if k in compilers.clink_langs}
 
+        # Cross reference them to implement as_shared() and as_static() methods.
+        shared_lib.set_static(static_lib)
+        static_lib.set_shared(shared_lib)
+
         return build.BothLibraries(shared_lib, static_lib, preferred_library)
 
     def build_library(self, node: mparser.BaseNode, args: T.Tuple[str, SourcesVarargsType], kwargs: kwtypes.Library):
         default_library = self.coredata.get_option(OptionKey('default_library', subproject=self.subproject))
         assert isinstance(default_library, str), 'for mypy'
         if default_library == 'shared':
-            args, kwargs = resolve_second_level_holders(args, kwargs)
             return self.build_target(node, args, T.cast('kwtypes.StaticLibrary', kwargs), build.SharedLibrary)
         elif default_library == 'static':
-            args, kwargs = resolve_second_level_holders(args, kwargs)
             return self.build_target(node, args, T.cast('kwtypes.SharedLibrary', kwargs), build.StaticLibrary)
         elif default_library == 'both':
             return self.build_both_libraries(node, args, kwargs)

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -1001,8 +1001,6 @@ class SharedLibraryHolder(BuildTargetHolder[build.SharedLibrary]):
 
 class BothLibrariesHolder(BuildTargetHolder[build.BothLibraries]):
     def __init__(self, libs: build.BothLibraries, interp: 'Interpreter'):
-        # FIXME: This build target always represents the shared library, but
-        # that should be configurable.
         super().__init__(libs, interp)
         self.methods.update({'get_shared_lib': self.get_shared_lib_method,
                              'get_static_lib': self.get_static_lib_method,

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -210,7 +210,7 @@ class DependenciesHelper:
                 if obj.found():
                     processed_libs += obj.get_link_args()
                     processed_cflags += obj.get_compile_args()
-            elif isinstance(obj, build.SharedLibrary) and obj.shared_library_only:
+            elif isinstance(obj, build.SharedLibrary) and obj.static_library is None:
                 # Do not pull dependencies for shared libraries because they are
                 # only required for static linking. Adding private requires has
                 # the side effect of exposing their cflags, which is the

--- a/test cases/frameworks/38 gir both_libraries/bar.c
+++ b/test cases/frameworks/38 gir both_libraries/bar.c
@@ -1,0 +1,7 @@
+#include "bar.h"
+#include "foo.h"
+
+int bar_func(void)
+{
+    return foo_func() + 42;
+}

--- a/test cases/frameworks/38 gir both_libraries/bar.h
+++ b/test cases/frameworks/38 gir both_libraries/bar.h
@@ -1,0 +1,1 @@
+int bar_func(void);

--- a/test cases/frameworks/38 gir both_libraries/foo.c
+++ b/test cases/frameworks/38 gir both_libraries/foo.c
@@ -1,0 +1,6 @@
+#include "foo.h"
+
+int foo_func(void)
+{
+    return 42;
+}

--- a/test cases/frameworks/38 gir both_libraries/foo.h
+++ b/test cases/frameworks/38 gir both_libraries/foo.h
@@ -1,0 +1,1 @@
+int foo_func(void);

--- a/test cases/frameworks/38 gir both_libraries/meson.build
+++ b/test cases/frameworks/38 gir both_libraries/meson.build
@@ -1,0 +1,37 @@
+project('gir both libraries', 'c')
+
+gir = dependency('gobject-introspection-1.0', required: false)
+if not gir.found()
+  error('MESON_SKIP_TEST gobject-introspection not found.')
+endif
+
+gnome = import('gnome')
+
+# Regression test simulating how GStreamer generate its GIRs.
+# Generated gobject-introspection binaries for every GStreamer libraries must
+# first call gst_init() defined in the main libgstreamer, which means they need
+# to link on that lib.
+# A regression caused by https://github.com/mesonbuild/meson/pull/12632 made
+# Meson not link the binary generated for bar with libfoo in the case it uses
+# both_libraries().
+
+libfoo = both_libraries('foo', 'foo.c')
+foo_gir = gnome.generate_gir(libfoo,
+  namespace: 'foo',
+  nsversion: '1.0',
+  sources: ['foo.c', 'foo.h'],
+)
+foo_dep = declare_dependency(
+  link_with: libfoo,
+  #link_with: libfoo.get_shared_lib(),
+  sources: foo_gir,
+)
+
+libbar = both_libraries('bar', 'bar.c', dependencies: foo_dep)
+gnome.generate_gir(libbar,
+  namespace: 'bar',
+  nsversion: '1.0',
+  sources: ['bar.c', 'bar.h'],
+  extra_args: '--add-init-section=extern void foo_func(void);foo_func();',
+  dependencies: foo_dep,
+)


### PR DESCRIPTION
    This partly reverts #12632 and provide an alternative implementation.
    The issue is we cannot propagate BothLibraries objects beyond the
    interpreter because it breaks many isinstance(obj, SharedLibrary) cases.
    
    Instead make SharedLibrary and StaticLibrary cross reference each other
    so we can take their brother library in as_static() and as_shared()
    methods.
