### PR TITLE
Check for uppercase 'head' when updating subprojects (fixes #12730)

### DIFF
--- a/docs/markdown/Wrap-dependency-system-manual.md
+++ b/docs/markdown/Wrap-dependency-system-manual.md
@@ -66,7 +66,7 @@ An example wrap-git will look like this:
 ```ini
 [wrap-git]
 url = https://github.com/libfoobar/libfoobar.git
-revision = head
+revision = HEAD
 depth = 1
 ```
 
@@ -124,7 +124,7 @@ case, the directory will be copied into `subprojects/` before applying patches.
 - `url` - name of the wrap-git repository to clone. Required.
 - `revision` - name of the revision to checkout. Must be either: a
   valid value (such as a git tag) for the VCS's `checkout` command, or
-  (for git) `head` to track upstream's default branch. Required.
+  (for git) `HEAD` to track upstream's default branch. Required.
 
 ### Specific to wrap-git
 - `depth` - shallowly clone the repository to X number of commits. This saves bandwidth and disk

--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -324,7 +324,8 @@ class Runner:
                 self.log('  -> Not a git repository.')
                 self.log('Pass --reset option to delete directory and redownload.')
                 return False
-        revision = self.wrap.values.get('revision')
+        revision_val = self.wrap.values.get('revision')
+        revision = revision_val if revision_val.upper() != 'HEAD' else 'HEAD'
         url = self.wrap.values.get('url')
         push_url = self.wrap.values.get('push-url')
         if not revision or not url:


### PR DESCRIPTION
This change may be more robust. I get these errors when using `head` for the value of `revision` in a wrap file and using 'checkout' or  'update' with the meson `subprojects` option:

```
$ meson subprojects checkout
Checkout head in decimal...
  -> Could not checkout head in subprojects/decimal
fatal: invalid reference: head
Git command failed: ['/usr/bin/git', 'checkout', '--ignore-other-worktrees', 'head', '--']
```

```
$ meson subprojects update
Updating decimal...
  -> Could not fetch revision head in subprojects/decimal
fatal: couldn't find remote ref head
Git command failed: ['/usr/bin/git', 'fetch', '--refmap', '+refs/heads/*:refs/remotes/origin/*', '--refmap', '+refs/tags/*:refs/tags/*', 'origin', 'head']
```

When I change the revision value to 'HEAD', there's no problem:

$ meson subprojects update
Updating decimal...
  -> 0d27065 (grafted, HEAD -> main, origin/main, origin/HEAD) Update installation document to state this project has now git submodules. [semihc]

EDIT:

fixes #12730
