### PR TITLE
Add `-q` as alternative to `--quiet` for meson install

### DIFF
--- a/data/shell-completions/bash/meson
+++ b/data/shell-completions/bash/meson
@@ -408,6 +408,7 @@ _meson-install() {
   shortopts=(
     h
     n
+    q
     C
   )
 

--- a/data/shell-completions/zsh/_meson
+++ b/data/shell-completions/zsh/_meson
@@ -217,7 +217,7 @@ local -a meson_commands=(
     "$__meson_cd"
     '--no-rebuild[Do not rebuild before installing]'
     '--only-changed[Do not overwrite files that are older than the copied file]'
-    '--quiet[Do not print every file that was installed]'
+    '(--quiet -q)'{'--quiet','-q'}'[Do not print every file that was installed]'
   )
 _arguments \
   '(: -)'{'--help','-h'}'[show a help message and quit]' \

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -74,7 +74,7 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
                         help='Do not rebuild before installing.')
     parser.add_argument('--only-changed', default=False, action='store_true',
                         help='Only overwrite files that are older than the copied file.')
-    parser.add_argument('--quiet', default=False, action='store_true',
+    parser.add_argument('-q', '--quiet', default=False, action='store_true',
                         help='Do not print every file that was installed.')
     parser.add_argument('--destdir', default=None,
                         help='Sets or overrides DESTDIR environment. (Since 0.57.0)')

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -78,7 +78,7 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
                         help='Do not print every file that was installed.')
     parser.add_argument('--destdir', default=None,
                         help='Sets or overrides DESTDIR environment. (Since 0.57.0)')
-    parser.add_argument('--dry-run', '-n', action='store_true',
+    parser.add_argument('-n', '--dry-run', action='store_true',
                         help='Doesn\'t actually install, but print logs. (Since 0.57.0)')
     parser.add_argument('--skip-subprojects', nargs='?', const='*', default='',
                         help='Do not install files from given subprojects. (Since 0.58.0)')


### PR DESCRIPTION
Since `meson test` already has both `-q` and `--quiet` it makes a lot of
sense to add the short option to `meson install` too for reasons of
symmetry.

Also changes the output order of `-n` and `--dry-run` for consistency in a separate commit.