### PR TITLE
Enable GCC to find free-threaded python DLL library

### DIFF
--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -229,7 +229,10 @@ class _PythonDependencyBase(_Base):
                     elif imp_lower == 'pypy':
                         libpath = Path(f'libpypy{verdot}-c.dll')
                     else:
-                        libpath = Path(f'python{vernum}.dll')
+                        if self.is_freethreaded:
+                            libpath = Path(f'python{vernum}t.dll')
+                        else:
+                            libpath = Path(f'python{vernum}.dll')
                 else:
                     if self.is_freethreaded:
                         libpath = Path('libs') / f'python{vernum}t.lib'


### PR DESCRIPTION
This fixes a case not covered in PR #13338, which causes Meson not to locate the Python free-threaded DLL libraries, whose suffix ends in `t` when using GCC.

cc @rgommers 