### PR TITLE
Revert "meson: De-dup rpath arguments"

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -53,7 +53,7 @@ class CLikeCompilerArgs(arglist.CompilerArgs):
 
     # NOTE: not thorough. A list of potential corner cases can be found in
     # https://github.com/mesonbuild/meson/pull/4593#pullrequestreview-182016038
-    dedup1_prefixes = ('-l', '-Wl,-l', '-Wl,--export-dynamic', '-Wl,-rpath')
+    dedup1_prefixes = ('-l', '-Wl,-l', '-Wl,--export-dynamic')
     dedup1_suffixes = ('.lib', '.dll', '.so', '.dylib', '.a')
     dedup1_args = ('-c', '-S', '-E', '-pipe', '-pthread')
 


### PR DESCRIPTION
This reverts commit 8242187eb06adaabbd9c9dbb6e5d9a8c102ee6a2.

This same change was previously introduced in #12495 / commit 30ab9747ae03364ac2ccd4a8f508286c57ed54a5 and subsequently reverted in #12672 / commit 2fbc7b5ce3aced483b196dd10ca9eee1713b7494

Reintroduced in #13819 but it's still the same old problem. To repeat the problem:

This breaks at least:
- frameworks/17 mpi
- frameworks/30 scalapack

The problem is that openmpi's pkg-config emitted link arguments includes:

```
-Wl,-rpath -Wl,/path/to/libdir
```

The deduplication logic in meson doesn't contain sufficient information to tell when the compiler is passing an argument that requires values, and definitely cannot tell when that argument is split across argv. But for arguments that *can* do this, it is not possible to deduplicate a single argument as standalone, because it is not standalone.

The argument for deduplicating rpath here was that if you have multiple dependencies that all add the same rpath, the Apple ld64 emits a non-fatal warning "duplicate -rpath ignored". Since this is non-fatal, it's not a major issue. A major issue is when builds fatally error out with:

```
FAILED: scalapack_c
cc  -o scalapack_c scalapack_c.p/main.c.o -Wl,--as-needed -Wl,--no-undefined -Wl,--start-group /usr/lib64/libscalapack.so /usr/lib64/liblapack.so /usr/lib64/libblas.so -Wl,-rpath -Wl,/usr/lib64 -Wl,/usr/lib64 -Wl,--enable-new-dtags /usr/lib64/libmpi.so -Wl,--end-group
/usr/libexec/gcc/x86_64-pc-linux-gnu/ld: error: /usr/lib64: read: Is a directory
```

Today we have CI for this so the change actually caused our own unittest CI to go red.