### PR TITLE
Add archiver to reference tables

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -386,6 +386,7 @@ machine](#Environment-variables-per-machine) section for details.
 | C#            | CSC      | CSC       | The linker is the compiler                  |
 | Cython        | CYTHON   |           |                                             |
 | nasm          | NASM     |           | Uses the C linker                           |
+| archiver      |          | AR        |                                             |
 
 *The old environment variables are still supported, but are deprecated
 and will be removed in a future version of Meson.


### PR DESCRIPTION
Meson allows to set the archiver via the `AR` environment variable and a native / cross file. Only the latter approach seems to be documented. This patch adds the `AR` environment variable to the reference tables next to the compilers.