### PR TITLE
cmake/common: Add language map entry for nasm

### DIFF
--- a/mesonbuild/cmake/common.py
+++ b/mesonbuild/cmake/common.py
@@ -17,6 +17,7 @@ language_map = {
     'c': 'C',
     'cpp': 'CXX',
     'cuda': 'CUDA',
+    'nasm': 'ASM_NASM',
     'objc': 'OBJC',
     'objcpp': 'OBJCXX',
     'cs': 'CSharp',


### PR DESCRIPTION
When determining the CMake compilers state, a `CMakeLists.txt` with these languages would be written:
`project(CompInfo C NASM CXX)`
Unfortunately, `NASM` isn't a CMake language. But `ASM_NASM` is - so map to that.