### PR TITLE
Xcode backend: only use found appleframeworks

### DIFF
--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -526,7 +526,7 @@ class XCodeBackend(backends.Backend):
         self.native_frameworks_fileref = {}
         for t in self.build_targets.values():
             for dep in t.get_external_deps():
-                if dep.name == 'appleframeworks':
+                if dep.name == 'appleframeworks' and dep.found():
                     for f in dep.frameworks:
                         self.native_frameworks[f] = self.gen_id()
                         self.native_frameworks_fileref[f] = self.gen_id()
@@ -691,7 +691,7 @@ class XCodeBackend(backends.Backend):
     def generate_pbx_build_file(self, objects_dict: PbxDict) -> None:
         for tname, t in self.build_targets.items():
             for dep in t.get_external_deps():
-                if dep.name == 'appleframeworks':
+                if dep.name == 'appleframeworks' and dep.found():
                     for f in dep.frameworks:
                         fw_dict = PbxDict()
                         fwkey = self.native_frameworks[f]
@@ -848,7 +848,7 @@ class XCodeBackend(backends.Backend):
     def generate_pbx_file_reference(self, objects_dict: PbxDict) -> None:
         for tname, t in self.build_targets.items():
             for dep in t.get_external_deps():
-                if dep.name == 'appleframeworks':
+                if dep.name == 'appleframeworks' and dep.found():
                     for f in dep.frameworks:
                         fw_dict = PbxDict()
                         framework_fileref = self.native_frameworks_fileref[f]
@@ -1023,7 +1023,7 @@ class XCodeBackend(backends.Backend):
             file_list = PbxArray()
             bt_dict.add_item('files', file_list)
             for dep in t.get_external_deps():
-                if dep.name == 'appleframeworks':
+                if dep.name == 'appleframeworks' and dep.found():
                     for f in dep.frameworks:
                         file_list.add_item(self.native_frameworks[f], f'{f}.framework in Frameworks')
             bt_dict.add_item('runOnlyForDeploymentPostprocessing', 0)
@@ -1071,7 +1071,7 @@ class XCodeBackend(backends.Backend):
 
         for t in self.build_targets.values():
             for dep in t.get_external_deps():
-                if dep.name == 'appleframeworks':
+                if dep.name == 'appleframeworks' and dep.found():
                     for f in dep.frameworks:
                         frameworks_children.add_item(self.native_frameworks_fileref[f], f)
 


### PR DESCRIPTION
Add a check before using an `appleframeworks` to make sure it was found. This fixes an exception in meson while encountering an optional dep for the target.