### PR TITLE
external_project: workaround for MinGW

### DIFF
--- a/mesonbuild/modules/external_project.py
+++ b/mesonbuild/modules/external_project.py
@@ -19,7 +19,7 @@ from ..interpreterbase import FeatureNew
 from ..interpreter.type_checking import ENV_KW, DEPENDS_KW
 from ..interpreterbase.decorators import ContainerTypeInfo, KwargInfo, typed_kwargs, typed_pos_args
 from ..mesonlib import (EnvironmentException, MesonException, Popen_safe, MachineChoice,
-                        get_variable_regex, do_replacement, join_args)
+                        get_variable_regex, do_replacement, join_args, relpath)
 from ..options import OptionKey
 
 if T.TYPE_CHECKING:
@@ -93,10 +93,10 @@ class ExternalProject(NewExtensionModule):
         # will install files into "c:/bar/c:/foo" which is an invalid path.
         # Work around that issue by removing the drive from prefix.
         if self.prefix.drive:
-            self.prefix = self.prefix.relative_to(self.prefix.drive)
+            self.prefix = Path(relpath(self.prefix, self.prefix.drive))
 
         # self.prefix is an absolute path, so we cannot append it to another path.
-        self.rel_prefix = self.prefix.relative_to(self.prefix.root)
+        self.rel_prefix = Path(relpath(self.prefix, self.prefix.root))
 
         self._configure(state)
 

--- a/test cases/common/33 run program/check-mingw.py
+++ b/test cases/common/33 run program/check-mingw.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+import os, sys, re
+
+if 'MSYSTEM' in os.environ and os.environ['MSYSTEM'] != '':
+    print(os.environ['MSYSTEM'])
+else:
+    match = re.search(r'[\\/](mingw32|mingw64|clang32|clang64|clangarm64|ucrt64)[\\/]', sys.executable, flags=re.IGNORECASE)
+    if match:
+        print(match.group(1).upper())

--- a/test cases/common/33 run program/meson.build
+++ b/test cases/common/33 run program/meson.build
@@ -1,6 +1,9 @@
 project('run command', version : run_command('get-version.py', check : true).stdout().strip(), meson_version: '>=0.1.0')
 
-if build_machine.system() == 'windows'
+check_mingw = run_command('check-mingw.py', check : true).stdout().strip()
+is_mingw = not (check_mingw == '' or check_mingw == 'MSYS')
+
+if build_machine.system() == 'windows' and not is_mingw
   c = run_command('cmd', '/c', 'echo', 'hello', check: false)
 else
   c = run_command('echo', 'hello', check: false)
@@ -45,7 +48,7 @@ endif
 # We should be able to have files() in argument
 f = files('meson.build')
 
-if build_machine.system() == 'windows'
+if build_machine.system() == 'windows' and not is_mingw
   c = run_command('cmd', '/c', 'echo', f, check: false)
 else
   c = run_command('echo', f, check: false)

--- a/unittests/windowstests.py
+++ b/unittests/windowstests.py
@@ -54,20 +54,20 @@ class WindowsTests(BasePlatformTests):
         PATH to point to a directory with Python scripts.
         '''
         testdir = os.path.join(self.platform_test_dir, '8 find program')
-        # Find `cmd` and `cmd.exe`
-        prog1 = ExternalProgram('cmd')
-        self.assertTrue(prog1.found(), msg='cmd not found')
-        prog2 = ExternalProgram('cmd.exe')
-        self.assertTrue(prog2.found(), msg='cmd.exe not found')
+        # Find `xcopy` and `xcopy.exe`
+        prog1 = ExternalProgram('xcopy')
+        self.assertTrue(prog1.found(), msg='xcopy not found')
+        prog2 = ExternalProgram('xcopy.exe')
+        self.assertTrue(prog2.found(), msg='xcopy.exe not found')
         self.assertPathEqual(prog1.get_path(), prog2.get_path())
-        # Find cmd.exe with args without searching
-        prog = ExternalProgram('cmd', command=['cmd', '/C'])
-        self.assertTrue(prog.found(), msg='cmd not found with args')
-        self.assertPathEqual(prog.get_command()[0], 'cmd')
-        # Find cmd with an absolute path that's missing the extension
-        cmd_path = prog2.get_path()[:-4]
-        prog = ExternalProgram(cmd_path)
-        self.assertTrue(prog.found(), msg=f'{cmd_path!r} not found')
+        # Find xcopy.exe with args without searching
+        prog = ExternalProgram('xcopy', command=['xcopy', '/?'])
+        self.assertTrue(prog.found(), msg='xcopy not found with args')
+        self.assertPathEqual(prog.get_command()[0], 'xcopy')
+        # Find xcopy with an absolute path that's missing the extension
+        xcopy_path = prog2.get_path()[:-4]
+        prog = ExternalProgram(xcopy_path)
+        self.assertTrue(prog.found(), msg=f'{xcopy_path!r} not found')
         # Finding a script with no extension inside a directory works
         prog = ExternalProgram(os.path.join(testdir, 'test-script'))
         self.assertTrue(prog.found(), msg='test-script not found')


### PR DESCRIPTION
On Python 3.12, self.prefix.relative_to(self.prefix.drive) no longer works and raises error like:

ValueError: 'C:/msys64/mingw64' is not in the subpath of 'C:'

```
Traceback (most recent call last):
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/mesonmain.py", line 193, in run
    return options.run_func(options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/msetup.py", line 365, in run
    app.generate()
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/msetup.py", line 188, in generate
    return self._generate(env, capture, vslite_ctx)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/msetup.py", line 227, in _generate
    intr.run()
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreter/interpreter.py", line 3063, in run
    super().run()
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 169, in run
    self.evaluate_codeblock(self.ast, start=1)
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 195, in evaluate_codeblock
    raise e
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 187, in evaluate_codeblock
    self.evaluate_statement(cur)
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 219, in evaluate_statement
    return self.evaluate_if(cur)
           ^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 309, in evaluate_if
    self.evaluate_codeblock(i.block)
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 195, in evaluate_codeblock
    raise e
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 187, in evaluate_codeblock
    self.evaluate_statement(cur)
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 201, in evaluate_statement
    return self.function_call(cur)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 528, in function_call
    res = func(node, func_args, kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreterbase/decorators.py", line 237, in wrapper
    return f(*nargs, **wrapped_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreterbase/decorators.py", line 556, in wrapper
    return f(*wrapped_args, **wrapped_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreter/interpreter.py", line 869, in func_subproject
    return self.do_subproject(args[0], kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreter/interpreter.py", line 951, in do_subproject
    raise e
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreter/interpreter.py", line 939, in do_subproject
    return methods_map[method](subp_name, subdir, default_options, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreter/interpreter.py", line 990, in _do_subproject_meson
    subi.run()
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreter/interpreter.py", line 3063, in run
    super().run()
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 169, in run
    self.evaluate_codeblock(self.ast, start=1)
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 195, in evaluate_codeblock
    raise e
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 187, in evaluate_codeblock
    self.evaluate_statement(cur)
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 205, in evaluate_statement
    self.assignment(cur)
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 642, in assignment
    value = self.evaluate_statement(node.value)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 207, in evaluate_statement
    return self.method_call(cur)
           ^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 557, in method_call
    res = obj.method_call(method_name, args, kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreter/interpreterobjects.py", line 885, in method_call
    ret = method(state, args, kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreterbase/decorators.py", line 237, in wrapper
    return f(*nargs, **wrapped_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/interpreterbase/decorators.py", line 556, in wrapper
    return f(*wrapped_args, **wrapped_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/modules/external_project.py", line 296, in add_project
    project = ExternalProject(state,
              ^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.12/site-packages/mesonbuild/modules/external_project.py", line 93, in __init__
    self.prefix = self.prefix.relative_to(self.prefix.drive)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.12/pathlib.py", line 682, in relative_to
    raise ValueError(f"{str(self)!r} is not in the subpath of {str(other)!r}")
ValueError: 'C:/msys64/mingw64' is not in the subpath of 'C:'

D:/Users/parrot/git/ham/subprojects/eggs/meson.build:14:8: ERROR: Unhandled python exception

    This is a Meson bug and should be reported!
```