### PR TITLE
New xgettext method to i18n module

### DIFF
--- a/docs/markdown/i18n-module.md
+++ b/docs/markdown/i18n-module.md
@@ -74,3 +74,50 @@ for normal keywords. In addition it accepts these keywords:
 * `mo_targets` *required*: mo file generation targets as returned by `i18n.gettext()`.
 
 *Added 0.62.0*
+
+
+### i18n.xgettext()
+
+``` meson
+i18n.xgettext(name, sources..., args: [...], recursive: false)
+```
+
+Invokes the `xgettext` program on given sources, to generate a `.pot` file.
+This function is to be used when the `gettext` function workflow it not suitable
+for your project. For example, it can be used to produce separate `.pot` files
+for each executable.
+
+Positional arguments are the following:
+
+* name `str`: the name of the resulting pot file.
+* sources `list[str|File|build_tgt|custom_tgt]`:
+          source files or targets. May be a list of `string`, `File`, [[@build_tgt]],
+          or [[@custom_tgt]] returned from other calls to this function.
+
+Keyword arguments are the following:
+
+- recursive `bool`:
+        if `true`, will merge the resulting pot file with extracted pot files
+        related to dependencies of the given source targets. For instance,
+        if you build an executable, then you may want to merge the executable
+        translations with the translations from the dependent libraries.
+- install `bool`: if `true`, will add the resulting pot file to install targets.
+- install_tag `str`: install tag to use for the install target.
+- install_dir `str`: directory where to install the resulting pot file.
+
+The `i18n.xgettext()` function returns a [[@custom_tgt]].
+
+Usually, you want to pass one build target as sources, and the list of header files
+for that target. If the number of source files would result in a command line that
+is too long, the list of source files is written to a file at config time, to be
+used as input for the `xgettext` program.
+
+The `recursive: true` argument is to be given to targets that will actually read
+the resulting `.mo` file. Each time you call the `i18n.xgettext()` function,
+it maps the source targets to the resulting pot file. When `recursive: true` is
+given, all generated pot files from dependencies of the source targets are
+included to generate the final pot file. Therefore, adding a dependency to
+source target will automatically add the translations of that dependency to the
+needed translations for that source target.
+
+*Added 1.8.0*

--- a/docs/markdown/snippets/i18n_xgettext.md
+++ b/docs/markdown/snippets/i18n_xgettext.md
@@ -1,0 +1,12 @@
+## i18n module xgettext
+
+There is a new `xgettext` function in `i18n` module that acts as a
+wrapper around `xgettext`. It allows to extract strings to translate from
+source files.
+
+This function is convenient, because:
+- It can find the sources files from a build target;
+- It will use an intermediate file when the number of source files is too
+  big to be handled directly from the command line;
+- It is able to get strings to translate from the dependencies of the given
+  targets.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -92,27 +92,8 @@ def gcc_rsp_quote(s: str) -> str:
 
     return quote_func(s)
 
-def get_rsp_threshold() -> int:
-    '''Return a conservative estimate of the commandline size in bytes
-    above which a response file should be used.  May be overridden for
-    debugging by setting environment variable MESON_RSP_THRESHOLD.'''
-
-    if mesonlib.is_windows():
-        # Usually 32k, but some projects might use cmd.exe,
-        # and that has a limit of 8k.
-        limit = 8192
-    else:
-        # Unix-like OSes usually have very large command line limits, (On Linux,
-        # for example, this is limited by the kernel's MAX_ARG_STRLEN). However,
-        # some programs place much lower limits, notably Wine which enforces a
-        # 32k limit like Windows. Therefore, we limit the command line to 32k.
-        limit = 32768
-    # Be conservative
-    limit = limit // 2
-    return int(os.environ.get('MESON_RSP_THRESHOLD', limit))
-
 # a conservative estimate of the command-line length limit
-rsp_threshold = get_rsp_threshold()
+rsp_threshold = mesonlib.get_rsp_threshold()
 
 # ninja variables whose value should remain unquoted. The value of these ninja
 # variables (or variables we use them in) is interpreted directly by ninja

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1350,7 +1350,7 @@ class BuildTarget(Target):
     def get_source_subdir(self):
         return self.subdir
 
-    def get_sources(self):
+    def get_sources(self) -> T.List[File]:
         return self.sources
 
     def get_objects(self) -> T.List[T.Union[str, 'File', 'ExtractedObjects']]:
@@ -2566,7 +2566,7 @@ class BothLibraries(SecondLevelHolder):
     def __repr__(self) -> str:
         return f'<BothLibraries: static={repr(self.static)}; shared={repr(self.shared)}>'
 
-    def get(self, lib_type: T.Literal['static', 'shared']) -> LibTypes:
+    def get(self, lib_type: T.Literal['static', 'shared']) -> T.Union[StaticLibrary, SharedLibrary]:
         if lib_type == 'static':
             return self.static
         if lib_type == 'shared':

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -106,6 +106,7 @@ __all__ = [
     'generate_list',
     'get_compiler_for_source',
     'get_filenames_templates_dict',
+    'get_rsp_threshold',
     'get_variable_regex',
     'get_wine_shortpath',
     'git',
@@ -2388,6 +2389,27 @@ def first(iter: T.Iterable[_T], predicate: T.Callable[[_T], bool]) -> T.Optional
         if predicate(i):
             return i
     return None
+
+
+def get_rsp_threshold() -> int:
+    '''Return a conservative estimate of the commandline size in bytes
+    above which a response file should be used.  May be overridden for
+    debugging by setting environment variable MESON_RSP_THRESHOLD.'''
+
+    if is_windows():
+        # Usually 32k, but some projects might use cmd.exe,
+        # and that has a limit of 8k.
+        limit = 8192
+    else:
+        # Unix-like OSes usually have very large command line limits, (On Linux,
+        # for example, this is limited by the kernel's MAX_ARG_STRLEN). However,
+        # some programs place much lower limits, notably Wine which enforces a
+        # 32k limit like Windows. Therefore, we limit the command line to 32k.
+        limit = 32768
+
+    # Be conservative
+    limit = limit // 2
+    return int(os.environ.get('MESON_RSP_THRESHOLD', limit))
 
 
 class lazy_property(T.Generic[_T]):

--- a/test cases/frameworks/38 gettext extractor/meson.build
+++ b/test cases/frameworks/38 gettext extractor/meson.build
@@ -1,0 +1,15 @@
+project(
+    'gettext extractor',
+    'c',
+    default_options: {'default_library': 'static'},
+    meson_version: '1.8.0',
+)
+
+if not find_program('xgettext', required: false).found()
+    error('MESON_SKIP_TEST xgettext command not found')
+endif
+
+i18n = import('i18n')
+xgettext_args = ['-ktr', '--add-comments=TRANSLATOR:', '--from-code=UTF-8']
+
+subdir('src')

--- a/test cases/frameworks/38 gettext extractor/src/lib1/lib1.c
+++ b/test cases/frameworks/38 gettext extractor/src/lib1/lib1.c
@@ -1,0 +1,10 @@
+#include "lib1.h"
+
+#include <stdio.h>
+
+#define tr(STRING) (STRING)
+
+void say_something(void)
+{
+    printf("%s\n", tr("Something!"));
+}

--- a/test cases/frameworks/38 gettext extractor/src/lib1/lib1.h
+++ b/test cases/frameworks/38 gettext extractor/src/lib1/lib1.h
@@ -1,0 +1,6 @@
+#ifndef LIB1_H
+#define LIB1_H
+
+void say_something(void);
+
+#endif

--- a/test cases/frameworks/38 gettext extractor/src/lib1/meson.build
+++ b/test cases/frameworks/38 gettext extractor/src/lib1/meson.build
@@ -1,0 +1,3 @@
+lib1 = library('mylib1', 'lib1.c')
+lib1_pot = i18n.xgettext('lib1', lib1, args: xgettext_args)
+lib1_includes = include_directories('.')

--- a/test cases/frameworks/38 gettext extractor/src/lib2/lib2.c
+++ b/test cases/frameworks/38 gettext extractor/src/lib2/lib2.c
@@ -1,0 +1,13 @@
+#include "lib2.h"
+
+#include <lib1.h>
+
+#include <stdio.h>
+
+#define tr(STRING) (STRING)
+
+void say_something_else(void)
+{
+    say_something();
+    printf("%s\n", tr("Something else!"));
+}

--- a/test cases/frameworks/38 gettext extractor/src/lib2/lib2.h
+++ b/test cases/frameworks/38 gettext extractor/src/lib2/lib2.h
@@ -1,0 +1,6 @@
+#ifndef LIB2_H
+#define LIB2_H
+
+void say_something_else(void);
+
+#endif

--- a/test cases/frameworks/38 gettext extractor/src/lib2/meson.build
+++ b/test cases/frameworks/38 gettext extractor/src/lib2/meson.build
@@ -1,0 +1,3 @@
+lib2 = library('mylib2', 'lib2.c', include_directories: lib1_includes, link_with: lib1)
+lib2_pot = i18n.xgettext('lib2', lib2, args: xgettext_args)
+lib2_includes = include_directories('.')

--- a/test cases/frameworks/38 gettext extractor/src/main.c
+++ b/test cases/frameworks/38 gettext extractor/src/main.c
@@ -1,0 +1,8 @@
+#include <lib2.h>
+
+int main(void)
+{
+    say_something_else();
+
+    return 0;
+}

--- a/test cases/frameworks/38 gettext extractor/src/meson.build
+++ b/test cases/frameworks/38 gettext extractor/src/meson.build
@@ -1,0 +1,6 @@
+subdir('lib1')
+subdir('lib2')
+
+main = executable('say', 'main.c', link_with: [lib2], include_directories: lib2_includes)
+
+main_pot = i18n.xgettext('main', main, args: xgettext_args, install: true, install_dir: 'intl', install_tag: 'intl', recursive: true)

--- a/test cases/frameworks/38 gettext extractor/test.json
+++ b/test cases/frameworks/38 gettext extractor/test.json
@@ -1,0 +1,6 @@
+{
+    "installed": [
+        { "type": "file", "file": "usr/intl/main.pot" }
+    ],
+    "expect_skip_on_jobname": ["azure", "cygwin"]
+}


### PR DESCRIPTION
This method call xgettext to extract translatable
string from source files into a .pot translation template.

It differs from a plain CustomTarget in three ways:
- It accepts build targets as sources, and automatically resolves source
  files from those build targets;
- It detects command lines that are too long, and writes, at config
  time, the list of source files into a text file to be consumed by the
  xgettext command;
- It detects dependencies between pot extraction targets, based on the
  dependencies between source targets.


This does the specific thing I need for my project, that I was trying to implement in a more generic way in #12272 and #11822.