### PR TITLE
mtest: rust: allow parsing doctest output

### DIFF
--- a/test cases/rust/9 unit tests/doctest1.rs
+++ b/test cases/rust/9 unit tests/doctest1.rs
@@ -1,0 +1,12 @@
+//! This is a doctest
+//!
+//! ```
+//! assert_eq!(2+2, 4)
+//! ```
+
+/// ```ignore
+/// this one will be skipped
+/// ```
+fn my_func()
+{
+}

--- a/test cases/rust/9 unit tests/meson.build
+++ b/test cases/rust/9 unit tests/meson.build
@@ -31,6 +31,19 @@ test(
   suite : ['foo'],
 )
 
+rustdoc = find_program('rustdoc', required: false)
+if rustdoc.found()
+  # rustdoc is invoked mostly like rustc.  This is a simple example
+  # where it is easy enough to invoke it by hand.
+  test(
+    'rust doctest',
+    rustdoc,
+    args : ['--test', '--crate-name', 'doctest1', '--crate-type', 'lib', files('doctest1.rs')],
+    protocol : 'rust',
+    suite : ['doctests'],
+  )
+endif
+
 exe = executable('rust_exe', ['test2.rs', 'test.rs'], build_by_default : false)
 
 rust = import('rust')


### PR DESCRIPTION
Doctests have a slightly different output compared to what "protocol: rust" supports:

```
running 2 tests
test rust/qemu-api/libqemu_api.rlib.p/structured/lib.rs - QemuAllocator (line 49) ... ignored
test rust/qemu-api/libqemu_api.rlib.p/structured/zeroable.rs - zeroable::Zeroable (line 9) ... ok

test result: ok. 1 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.11s
```

Add a little more parsing in order to parse this correctly.  I plan to contribute an extension of the rust module to invoke doctests, for now this allows running rustdoc --test with "protocol: rust" and get information about the subtests:

```
2/3 qemu:unit+rust / rust-qemu-api-doctests           RUNNING
...
▶ 2/3 test rust/qemu-api/libqemu_api.rlib.p/structured/lib.rs:QemuAllocator:49 SKIP
▶ 2/3 test rust/qemu-api/libqemu_api.rlib.p/structured/zeroable.rs:zeroable.Zeroable:9 OK
2/3 qemu:unit+rust / rust-qemu-api-doctests           OK              1.20s   1 subtests passed
```