### PR TITLE
nasm: Avoid changing multipass optimization levels

### DIFF
--- a/mesonbuild/compilers/asm.py
+++ b/mesonbuild/compilers/asm.py
@@ -14,16 +14,6 @@ if T.TYPE_CHECKING:
     from ..mesonlib import MachineChoice
     from ..envconfig import MachineInfo
 
-nasm_optimization_args: T.Dict[str, T.List[str]] = {
-    'plain': [],
-    '0': ['-O0'],
-    'g': ['-O0'],
-    '1': ['-O1'],
-    '2': ['-Ox'],
-    '3': ['-Ox'],
-    's': ['-Ox'],
-}
-
 
 class NasmCompiler(Compiler):
     language = 'nasm'
@@ -82,7 +72,7 @@ class NasmCompiler(Compiler):
         return outargs
 
     def get_optimization_args(self, optimization_level: str) -> T.List[str]:
-        return nasm_optimization_args[optimization_level]
+        return []
 
     def get_debug_args(self, is_debug: bool) -> T.List[str]:
         if is_debug:


### PR DESCRIPTION
Currently the -O argument is set according to the meson optimization level, but this is a bad idea as it can break assembly code relying on certain instructions or offsets being a particular size.

There's not really any benefit of using a non-default value (if anything, debugging becomes more difficult when the output changes!), and the nasm manual even explicitly points out that it should be changed from the default "only if you need the finer programmer-level control of output".