### PR TITLE
docs: fix description of `py.install_sources` arguments

### DIFF
--- a/docs/markdown/Python-module.md
+++ b/docs/markdown/Python-module.md
@@ -121,7 +121,7 @@ Additionally, the following diverge from [[shared_module]]'s default behavior:
 - `gnu_symbol_visibility`: if unset, it will default to `'hidden'` on versions
   of Python that support this (the python headers define `PyMODINIT_FUNC` has
   default visibility).
-  
+
 Note that Cython support uses `extension_module`, see [the reference for Cython](Cython.md).
 
 *since 0.63.0* `extension_module` automatically adds a dependency to the library
@@ -158,11 +158,8 @@ void py_installation.install_sources(list_of_files, ...)
 
 Install actual python sources (`.py`).
 
-All positional and keyword arguments are the same as for
-[[install_data]], with the addition of the following:
-
-*Since 0.60.0* `python.platlibdir` and `python.purelibdir` options can be used
-to control the default installation path. See [Python module options](Builtin-options.md#python-module).
+Source files to install are given as positional argument, in the same way as for
+[[install_data]]. Supported keyword arguments are:
 
 - `pure`: On some platforms, architecture independent files are
   expected to be placed in a separate directory. However, if the
@@ -176,6 +173,12 @@ to control the default installation path. See [Python module options](Builtin-op
 
 - `install_tag` *(since 0.60.0)*: A string used by `meson install --tags` command
   to install only a subset of the files. By default it has the tag `python-runtime`.
+
+- `preserve_path`: if `true`, disable stripping child-directories from data
+  files when installing. Default is `false`. *(since 0.64.0)*
+
+*Since 0.60.0* `python.platlibdir` and `python.purelibdir` options can be used
+to control the default installation path. See [Python module options](Builtin-options.md#python-module).
 
 #### `get_install_dir()`
 


### PR DESCRIPTION
There is actually very little overlap between `install_sources` and `install_data` in arguments they accept: only 2/7 keywords for `install_data` apply to `install_sources`.

Closes gh-12601