### PR TITLE
Add a new target "ninja clippy" for Rust projects

### DIFF
--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -93,12 +93,20 @@ can provide code completion for all source files.
 ```json
 {
     "language": "language ID",
+    "machine": "build" / "host",
     "compiler": ["The", "compiler", "command"],
     "parameters": ["list", "of", "compiler", "parameters"],
     "sources": ["list", "of", "all", "source", "files", "for", "this", "language"],
     "generated_sources": ["list", "of", "all", "source", "files", "that", "where", "generated", "somewhere", "else"]
 }
 ```
+
+*(New in 1.7.0)* The `machine` and `language` keys make it possible to
+to access further information about the compiler in the `compilers`
+introspection information.  `machine` can be absent if `language` is
+`unknown`.  In this case, information about the compiler is not
+available; Meson is therefore unable to know if the output relates
+to either the build of the host machine.
 
 It should be noted that the compiler parameters stored in the
 `parameters` differ from the actual parameters used to compile the

--- a/docs/markdown/Unit-tests.md
+++ b/docs/markdown/Unit-tests.md
@@ -83,15 +83,17 @@ possible.
 
 By default Meson uses as many concurrent processes as there are cores
 on the test machine. You can override this with the environment
-variable `MESON_TESTTHREADS` like this.
+variable `MESON_TESTTHREADS` or, *since 1.7.0*, `MESON_NUM_PROCESSES`:
 
 ```console
-$ MESON_TESTTHREADS=5 meson test
+$ MESON_NUM_PROCESSES=5 meson test
 ```
 
-Setting `MESON_TESTTHREADS` to 0 enables the default behavior (core
+Setting `MESON_NUM_PROCESSES` to 0 enables the default behavior (core
 count), whereas setting an invalid value results in setting the job
 count to 1.
+
+If both environment variables are present, `MESON_NUM_PROCESSES` prevails.
 
 ## Priorities
 

--- a/docs/markdown/howtox.md
+++ b/docs/markdown/howtox.md
@@ -239,6 +239,26 @@ And then pass it through the variable (remember to use absolute path):
 $ SCANBUILD=$(pwd)/my-scan-build.sh ninja -C builddir scan-build
 ```
 
+## Use clippy
+
+If your project includes Rust targets, you can invoke clippy like this:
+
+```console
+$ meson setup builddir
+$ ninja -C builddir clippy
+```
+
+Clippy will also obey the `werror` [builtin option](Builtin-options.md#core-options).
+
+By default Meson uses as many concurrent processes as there are cores
+on the test machine. You can override this with the environment
+variable `MESON_NUM_PROCESSES`.
+
+Meson will look for `clippy-driver` in the same directory as `rustc`,
+or try to invoke it using `rustup` if `rustc` points to a `rustup`
+binary.  If `clippy-driver` is not detected properly, you can add it to
+a [machine file](Machine-files.md).
+
 ## Use profile guided optimization
 
 Using profile guided optimization with GCC is a two phase

--- a/docs/markdown/snippets/clippy.md
+++ b/docs/markdown/snippets/clippy.md
@@ -1,0 +1,5 @@
+## Meson can run "clippy" on Rust projects
+
+Meson now defines a `clippy` target if the project uses the Rust programming
+language.  The target runs clippy on all Rust sources, using the `clippy-driver`
+program from the same Rust toolchain as the `rustc` compiler.

--- a/docs/markdown/snippets/clippy.md
+++ b/docs/markdown/snippets/clippy.md
@@ -3,3 +3,6 @@
 Meson now defines a `clippy` target if the project uses the Rust programming
 language.  The target runs clippy on all Rust sources, using the `clippy-driver`
 program from the same Rust toolchain as the `rustc` compiler.
+
+Using `clippy-driver` as the Rust compiler will now emit a warning, as it
+is not meant to be a general-purpose compiler front-end.

--- a/docs/markdown/snippets/introspect_machine.md
+++ b/docs/markdown/snippets/introspect_machine.md
@@ -1,0 +1,5 @@
+## "machine" entry in target introspection data
+
+The JSON data returned by `meson introspect --targets` now has a `machine`
+entry in each `target_sources` block.  The new entry can be one of `build`
+or `host` for compiler-built targets, or absent for `custom_target` targets.

--- a/docs/markdown/snippets/num-processes.md
+++ b/docs/markdown/snippets/num-processes.md
@@ -4,4 +4,5 @@ Previously, `meson test` checked the `MESON_TESTTHREADS` variable to control
 the amount of parallel jobs to run; this was useful when `meson test` is
 invoked through `ninja test` for example.  With this version, a new variable
 `MESON_NUM_PROCESSES` is supported with a broader scope: in addition to
-`meson test`, it is also used by the `external_project` module.
+`meson test`, it is also used by the `external_project` module and by
+Ninja targets that invoke `clang-tidy` and `clang-format`.

--- a/docs/markdown/snippets/num-processes.md
+++ b/docs/markdown/snippets/num-processes.md
@@ -5,4 +5,4 @@ the amount of parallel jobs to run; this was useful when `meson test` is
 invoked through `ninja test` for example.  With this version, a new variable
 `MESON_NUM_PROCESSES` is supported with a broader scope: in addition to
 `meson test`, it is also used by the `external_project` module and by
-Ninja targets that invoke `clang-tidy` and `clang-format`.
+Ninja targets that invoke `clang-tidy`, `clang-format` and `clippy`.

--- a/docs/markdown/snippets/num-processes.md
+++ b/docs/markdown/snippets/num-processes.md
@@ -1,0 +1,7 @@
+## Control the number of child processes with an environment variable
+
+Previously, `meson test` checked the `MESON_TESTTHREADS` variable to control
+the amount of parallel jobs to run; this was useful when `meson test` is
+invoked through `ninja test` for example.  With this version, a new variable
+`MESON_NUM_PROCESSES` is supported with a broader scope: in addition to
+`meson test`, it is also used by the `external_project` module.

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -283,7 +283,7 @@ class IntrospectionInterpreter(AstInterpreter):
         kwargs_reduced = {k: v for k, v in kwargs.items() if k in targetclass.known_kwargs and k in {'install', 'build_by_default', 'build_always'}}
         kwargs_reduced = {k: v.value if isinstance(v, ElementaryNode) else v for k, v in kwargs_reduced.items()}
         kwargs_reduced = {k: v for k, v in kwargs_reduced.items() if not isinstance(v, BaseNode)}
-        for_machine = MachineChoice.HOST
+        for_machine = MachineChoice.BUILD if kwargs.get('native', False) else MachineChoice.HOST
         objects: T.List[T.Any] = []
         empty_sources: T.List[T.Any] = []
         # Passing the unresolved sources list causes errors
@@ -294,6 +294,7 @@ class IntrospectionInterpreter(AstInterpreter):
 
         new_target = {
             'name': target.get_basename(),
+            'machine': target.for_machine.get_lower_case_name(),
             'id': target.get_id(),
             'type': target.get_typename(),
             'defined_in': os.path.normpath(os.path.join(self.source_root, self.subdir, environment.build_filename)),

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -2040,6 +2040,12 @@ class Backend:
         commands += [input]
         return commands
 
+    def have_language(self, langname: str) -> bool:
+        for for_machine in MachineChoice:
+            if langname in self.environment.coredata.compilers[for_machine]:
+                return True
+        return False
+
     def compiler_to_generator(self, target: build.BuildTarget,
                               compiler: 'Compiler',
                               sources: _ALL_SOURCES_TYPE,

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -41,13 +41,14 @@ if T.TYPE_CHECKING:
     from ..linkers.linkers import StaticLinker
     from ..mesonlib import FileMode, FileOrString
 
-    from typing_extensions import TypedDict
+    from typing_extensions import TypedDict, NotRequired
 
     _ALL_SOURCES_TYPE = T.List[T.Union[File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList]]
 
     class TargetIntrospectionData(TypedDict):
 
         language: str
+        machine: NotRequired[str]
         compiler: T.List[str]
         parameters: T.List[str]
         sources: T.List[str]

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3659,6 +3659,9 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         if extra_arg:
             target_name += f'-{extra_arg}'
             extra_args.append(f'--{extra_arg}')
+        colorout = self.environment.coredata.optstore.get_value('b_colorout') \
+            if OptionKey('b_colorout') in self.environment.coredata.optstore else 'always'
+        extra_args.extend(['--color', colorout])
         if not os.path.exists(os.path.join(self.environment.source_dir, '.clang-' + name)) and \
                 not os.path.exists(os.path.join(self.environment.source_dir, '_clang-' + name)):
             return

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -837,6 +837,7 @@ class NinjaBackend(backends.Backend):
             # The new entry
             src_block = {
                 'language': lang,
+                'machine': comp.for_machine.get_lower_case_name(),
                 'compiler': comp.get_exelist(),
                 'parameters': parameters,
                 'sources': [],

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -1042,6 +1042,10 @@ def detect_rust_compiler(env: 'Environment', for_machine: MachineChoice) -> Rust
             version = search_version(out)
 
             cls = rust.ClippyRustCompiler
+            mlog.deprecation(
+                'clippy-driver is not intended as a general purpose compiler. '
+                'You can use "ninja clippy" in order to run clippy on a '
+                'meson project.')
 
         if 'rustc' in out:
             # On Linux and mac rustc will invoke gcc (clang for mac

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import abc
 import functools
 import os
-import multiprocessing
 import pathlib
 import re
 import subprocess
@@ -617,8 +616,9 @@ class GnuCompiler(GnuLikeCompiler):
         if threads == 0:
             if self._has_lto_auto_support:
                 return ['-flto=auto']
-            # This matches clang's behavior of using the number of cpus
-            return [f'-flto={multiprocessing.cpu_count()}']
+            # This matches clang's behavior of using the number of cpus, but
+            # obeying meson's MESON_NUM_PROCESSES convention.
+            return [f'-flto={mesonlib.determine_worker_count()}']
         elif threads > 0:
             return [f'-flto={threads}']
         return super().get_lto_compile_args(threads=threads)

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -211,6 +211,7 @@ def list_targets_from_source(intr: IntrospectionInterpreter) -> T.List[T.Dict[st
             'build_by_default': i['build_by_default'],
             'target_sources': [{
                 'language': 'unknown',
+                'machine': i['machine'],
                 'compiler': [],
                 'parameters': [],
                 'sources': [str(x) for x in sources],

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -38,7 +38,6 @@ from .coredata import version as coredata_version
 from .mesonlib import (MesonException, OrderedSet, RealPathAction,
                        get_wine_shortpath, join_args, split_args, setup_vsenv)
 from .options import OptionKey
-from .mintro import get_infodir, load_info_file
 from .programs import ExternalProgram
 from .backend.backends import TestProtocol, TestSerialisation
 
@@ -2158,10 +2157,14 @@ def rebuild_deps(ninja: T.List[str], wd: str, tests: T.List[TestSerialisation]) 
 
     assert len(ninja) > 0
 
+    targets_file = os.path.join(wd, 'meson-info/intro-targets.json')
+    with open(targets_file, encoding='utf-8') as fp:
+        targets_info = json.load(fp)
+
     depends: T.Set[str] = set()
     targets: T.Set[str] = set()
     intro_targets: T.Dict[str, T.List[str]] = {}
-    for target in load_info_file(get_infodir(wd), kind='targets'):
+    for target in targets_info:
         intro_targets[target['id']] = [
             convert_path_to_target(f)
             for f in target['filename']]

--- a/mesonbuild/scripts/clangformat.py
+++ b/mesonbuild/scripts/clangformat.py
@@ -8,7 +8,7 @@ import subprocess
 from pathlib import Path
 import sys
 
-from .run_tool import run_tool
+from .run_tool import run_clang_tool
 from ..environment import detect_clangformat
 from ..mesonlib import version_compare
 from ..programs import ExternalProgram
@@ -57,4 +57,4 @@ def run(args: T.List[str]) -> int:
     else:
         cformat_ver = None
 
-    return run_tool('clang-format', srcdir, builddir, run_clang_format, exelist, options, cformat_ver)
+    return run_clang_tool('clang-format', srcdir, builddir, run_clang_format, exelist, options, cformat_ver)

--- a/mesonbuild/scripts/clangtidy.py
+++ b/mesonbuild/scripts/clangtidy.py
@@ -26,6 +26,7 @@ def run_clang_tidy(fname: Path, tidyexe: list, builddir: Path, fixesdir: T.Optio
 def run(args: T.List[str]) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('--fix', action='store_true')
+    parser.add_argument('--color', default='always')
     parser.add_argument('sourcedir')
     parser.add_argument('builddir')
     options = parser.parse_args(args)
@@ -37,6 +38,9 @@ def run(args: T.List[str]) -> int:
     if not tidyexe:
         print(f'Could not execute clang-tidy "{" ".join(tidyexe)}"')
         return 1
+
+    if options.color == 'always' or options.color == 'auto' and sys.stdout.isatty():
+        tidyexe += ['--use-color']
 
     fixesdir: T.Optional[Path] = None
     if options.fix:

--- a/mesonbuild/scripts/clangtidy.py
+++ b/mesonbuild/scripts/clangtidy.py
@@ -11,17 +11,17 @@ import os
 import shutil
 import sys
 
-from .run_tool import run_clang_tool
+from .run_tool import run_clang_tool, run_with_buffered_output
 from ..environment import detect_clangtidy, detect_clangapply
 import typing as T
 
-def run_clang_tidy(fname: Path, tidyexe: list, builddir: Path, fixesdir: T.Optional[Path]) -> subprocess.CompletedProcess:
+async def run_clang_tidy(fname: Path, tidyexe: list, builddir: Path, fixesdir: T.Optional[Path]) -> int:
     args = []
     if fixesdir is not None:
         handle, name = tempfile.mkstemp(prefix=fname.name + '.', suffix='.yaml', dir=fixesdir)
         os.close(handle)
         args.extend(['-export-fixes', name])
-    return subprocess.run(tidyexe + args + ['-quiet', '-p', str(builddir), str(fname)])
+    return await run_with_buffered_output(tidyexe + args + ['-quiet', '-p', str(builddir), str(fname)])
 
 def run(args: T.List[str]) -> int:
     parser = argparse.ArgumentParser()

--- a/mesonbuild/scripts/clangtidy.py
+++ b/mesonbuild/scripts/clangtidy.py
@@ -11,7 +11,7 @@ import os
 import shutil
 import sys
 
-from .run_tool import run_tool
+from .run_tool import run_clang_tool
 from ..environment import detect_clangtidy, detect_clangapply
 import typing as T
 
@@ -56,7 +56,7 @@ def run(args: T.List[str]) -> int:
             fixesdir.unlink()
         fixesdir.mkdir(parents=True)
 
-    tidyret = run_tool('clang-tidy', srcdir, builddir, run_clang_tidy, tidyexe, builddir, fixesdir)
+    tidyret = run_clang_tool('clang-tidy', srcdir, builddir, run_clang_tidy, tidyexe, builddir, fixesdir)
     if fixesdir is not None:
         print('Applying fix-its...')
         applyret = subprocess.run(applyexe + ['-format', '-style=file', '-ignore-insert-conflict', fixesdir]).returncode

--- a/mesonbuild/scripts/clippy.py
+++ b/mesonbuild/scripts/clippy.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 The Meson development team
+
+from __future__ import annotations
+from collections import defaultdict
+import os
+import tempfile
+import typing as T
+
+from .run_tool import run_tool_on_targets, run_with_buffered_output
+from .. import build, mlog
+from ..mesonlib import MachineChoice, PerMachine
+
+if T.TYPE_CHECKING:
+    from ..compilers.rust import RustCompiler
+
+class ClippyDriver:
+    def __init__(self, build: build.Build, tempdir: str):
+        self.tools: PerMachine[T.List[str]] = PerMachine([], [])
+        self.warned: T.DefaultDict[str, bool] = defaultdict(lambda: False)
+        self.tempdir = tempdir
+        for machine in MachineChoice:
+            compilers = build.environment.coredata.compilers[machine]
+            if 'rust' in compilers:
+                compiler = T.cast('RustCompiler', compilers['rust'])
+                self.tools[machine] = compiler.get_rust_tool('clippy-driver', build.environment)
+
+    def warn_missing_clippy(self, machine: str) -> None:
+        if self.warned[machine]:
+            return
+        mlog.warning(f'clippy-driver not found for {machine} machine')
+        self.warned[machine] = True
+
+    def __call__(self, target: T.Dict[str, T.Any]) -> T.Iterable[T.Coroutine[None, None, int]]:
+        for src_block in target['target_sources']:
+            if src_block['language'] == 'rust':
+                clippy = getattr(self.tools, src_block['machine'])
+                if not clippy:
+                    self.warn_missing_clippy(src_block['machine'])
+                    continue
+
+                cmdlist = list(clippy)
+                prev = None
+                for arg in src_block['parameters']:
+                    if prev:
+                        prev = None
+                        continue
+                    elif arg in {'--emit', '--out-dir'}:
+                        prev = arg
+                    else:
+                        cmdlist.append(arg)
+
+                cmdlist.extend(src_block['sources'])
+                # the default for --emit is to go all the way to linking,
+                # and --emit dep-info= is not enough for clippy to do
+                # enough analysis, so use --emit metadata.
+                cmdlist.append('--emit')
+                cmdlist.append('metadata')
+                cmdlist.append('--out-dir')
+                cmdlist.append(self.tempdir)
+                yield run_with_buffered_output(cmdlist)
+
+def run(args: T.List[str]) -> int:
+    os.chdir(args[0])
+    build_data = build.load(os.getcwd())
+    with tempfile.TemporaryDirectory() as d:
+        return run_tool_on_targets(ClippyDriver(build_data, d))

--- a/mesonbuild/scripts/externalproject.py
+++ b/mesonbuild/scripts/externalproject.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 
 import os
 import argparse
-import multiprocessing
 import subprocess
 from pathlib import Path
 import typing as T
 
-from ..mesonlib import Popen_safe, split_args
+from ..mesonlib import Popen_safe, split_args, determine_worker_count
 
 class ExternalProject:
     def __init__(self, options: argparse.Namespace):
@@ -48,7 +47,7 @@ class ExternalProject:
     def build(self) -> int:
         make_cmd = self.make.copy()
         if self.supports_jobs_flag():
-            make_cmd.append(f'-j{multiprocessing.cpu_count()}')
+            make_cmd.append(f'-j{determine_worker_count()}')
         rc = self._run('build', make_cmd)
         if rc != 0:
             return rc

--- a/mesonbuild/scripts/run_tool.py
+++ b/mesonbuild/scripts/run_tool.py
@@ -3,17 +3,85 @@
 
 from __future__ import annotations
 
-import itertools
+import asyncio.subprocess
 import fnmatch
-import concurrent.futures
+import itertools
+import signal
+import sys
 from pathlib import Path
 
+from .. import mlog
 from ..compilers import lang_suffixes
-from ..mesonlib import quiet_git
+from ..mesonlib import quiet_git, join_args, determine_worker_count
+from ..mtest import complete_all
 import typing as T
 
-if T.TYPE_CHECKING:
-    import subprocess
+Info = T.TypeVar("Info")
+
+async def run_with_buffered_output(cmdlist: T.List[str]) -> int:
+    """Run the command in cmdlist, buffering the output so that it is
+       not mixed for multiple child processes.  Kill the child on
+       cancellation."""
+    quoted_cmdline = join_args(cmdlist)
+    p: T.Optional[asyncio.subprocess.Process] = None
+    try:
+        p = await asyncio.create_subprocess_exec(*cmdlist,
+                                                 stdin=asyncio.subprocess.DEVNULL,
+                                                 stdout=asyncio.subprocess.PIPE,
+                                                 stderr=asyncio.subprocess.STDOUT)
+        stdo, _ = await p.communicate()
+    except FileNotFoundError as e:
+        print(mlog.blue('>>>'), quoted_cmdline, file=sys.stderr)
+        print(mlog.red('not found:'), e.filename, file=sys.stderr)
+        return 1
+    except asyncio.CancelledError:
+        if p:
+            p.kill()
+            await p.wait()
+            return p.returncode or 1
+        else:
+            return 0
+
+    if stdo:
+        print(mlog.blue('>>>'), quoted_cmdline, flush=True)
+        sys.stdout.buffer.write(stdo)
+    return p.returncode
+
+async def _run_workers(infos: T.Iterable[Info],
+                       fn: T.Callable[[Info], T.Iterable[T.Coroutine[None, None, int]]]) -> int:
+    futures: T.List[asyncio.Future[int]] = []
+    semaphore = asyncio.Semaphore(determine_worker_count())
+
+    async def run_one(worker_coro: T.Coroutine[None, None, int]) -> int:
+        try:
+            async with semaphore:
+                return await worker_coro
+        except asyncio.CancelledError as e:
+            worker_coro.throw(e)
+            return await worker_coro
+
+    def sigterm_handler() -> None:
+        for f in futures:
+            f.cancel()
+
+    if sys.platform != 'win32':
+        loop = asyncio.get_running_loop()
+        loop.add_signal_handler(signal.SIGINT, sigterm_handler)
+        loop.add_signal_handler(signal.SIGTERM, sigterm_handler)
+
+    for i in infos:
+        futures.extend((asyncio.ensure_future(run_one(x)) for x in fn(i)))
+    if not futures:
+        return 0
+
+    try:
+        await complete_all(futures)
+    except BaseException:
+        for f in futures:
+            f.cancel()
+        raise
+
+    return max(f.result() for f in futures if f.done() and not f.cancelled())
 
 def parse_pattern_file(fname: Path) -> T.List[str]:
     patterns = []
@@ -27,7 +95,7 @@ def parse_pattern_file(fname: Path) -> T.List[str]:
         pass
     return patterns
 
-def run_clang_tool(name: str, srcdir: Path, builddir: Path, fn: T.Callable[..., subprocess.CompletedProcess], *args: T.Any) -> int:
+def all_clike_files(name: str, srcdir: Path, builddir: Path) -> T.Iterable[Path]:
     patterns = parse_pattern_file(srcdir / f'.{name}-include')
     globs: T.Union[T.List[T.List[Path]], T.List[T.Generator[Path, None, None]]]
     if patterns:
@@ -44,29 +112,17 @@ def run_clang_tool(name: str, srcdir: Path, builddir: Path, fn: T.Callable[..., 
     suffixes = set(lang_suffixes['c']).union(set(lang_suffixes['cpp']))
     suffixes.add('h')
     suffixes = {f'.{s}' for s in suffixes}
-    futures = []
-    returncode = 0
-    e = concurrent.futures.ThreadPoolExecutor()
-    try:
-        for f in itertools.chain(*globs):
-            strf = str(f)
-            if f.is_dir() or f.suffix not in suffixes or \
-                    any(fnmatch.fnmatch(strf, i) for i in ignore):
-                continue
-            futures.append(e.submit(fn, f, *args))
-        concurrent.futures.wait(
-            futures,
-            return_when=concurrent.futures.FIRST_EXCEPTION
-        )
-    finally:
-        # We try to prevent new subprocesses from being started by canceling
-        # the futures, but this is not water-tight: some may have started
-        # between the wait being interrupted or exited and the futures being
-        # canceled. (A fundamental fix would probably require the ability to
-        # terminate such subprocesses upon cancellation of the future.)
-        for x in futures: # Python >=3.9: e.shutdown(cancel_futures=True)
-            x.cancel()
-        e.shutdown()
-    if futures:
-        returncode = max(x.result().returncode for x in futures)
-    return returncode
+    for f in itertools.chain.from_iterable(globs):
+        strf = str(f)
+        if f.is_dir() or f.suffix not in suffixes or \
+                any(fnmatch.fnmatch(strf, i) for i in ignore):
+            continue
+        yield f
+
+def run_clang_tool(name: str, srcdir: Path, builddir: Path, fn: T.Callable[..., T.Coroutine[None, None, int]], *args: T.Any) -> int:
+    if sys.platform == 'win32':
+        asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+
+    def wrapper(path: Path) -> T.Iterable[T.Coroutine[None, None, int]]:
+        yield fn(path, *args)
+    return asyncio.run(_run_workers(all_clike_files(name, srcdir, builddir), wrapper))

--- a/mesonbuild/scripts/run_tool.py
+++ b/mesonbuild/scripts/run_tool.py
@@ -27,7 +27,7 @@ def parse_pattern_file(fname: Path) -> T.List[str]:
         pass
     return patterns
 
-def run_tool(name: str, srcdir: Path, builddir: Path, fn: T.Callable[..., subprocess.CompletedProcess], *args: T.Any) -> int:
+def run_clang_tool(name: str, srcdir: Path, builddir: Path, fn: T.Callable[..., subprocess.CompletedProcess], *args: T.Any) -> int:
     patterns = parse_pattern_file(srcdir / f'.{name}-include')
     globs: T.Union[T.List[T.List[Path]], T.List[T.Generator[Path, None, None]]]
     if patterns:

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -473,6 +473,10 @@ def classify_unity_sources(compilers: T.Iterable['Compiler'], sources: T.Sequenc
     return compsrclist
 
 
+MACHINE_NAMES = ['build', 'host']
+MACHINE_PREFIXES = ['build.', '']
+
+
 class MachineChoice(enum.IntEnum):
 
     """Enum class representing one of the two abstract machine names used in
@@ -486,10 +490,10 @@ class MachineChoice(enum.IntEnum):
         return f'{self.get_lower_case_name()} machine'
 
     def get_lower_case_name(self) -> str:
-        return PerMachine('build', 'host')[self]
+        return MACHINE_NAMES[self.value]
 
     def get_prefix(self) -> str:
-        return PerMachine('build.', '')[self]
+        return MACHINE_PREFIXES[self.value]
 
 
 class PerMachine(T.Generic[_T]):
@@ -498,10 +502,7 @@ class PerMachine(T.Generic[_T]):
         self.host = host
 
     def __getitem__(self, machine: MachineChoice) -> _T:
-        return {
-            MachineChoice.BUILD:  self.build,
-            MachineChoice.HOST:   self.host,
-        }[machine]
+        return [self.build, self.host][machine.value]
 
     def __setitem__(self, machine: MachineChoice, val: _T) -> None:
         setattr(self, machine.get_lower_case_name(), val)

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -4892,6 +4892,24 @@ class AllPlatformTests(BasePlatformTests):
         # When clippy is used, we should get an exception since a variable named
         # "foo" is used, but is on our denylist
         testdir = os.path.join(self.rust_test_dir, '1 basic')
+        self.init(testdir)
+        self.build('clippy')
+
+        self.wipe()
+        self.init(testdir, extra_args=['--werror', '-Db_colorout=never'])
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            self.build('clippy')
+        self.assertTrue('error: use of a blacklisted/placeholder name `foo`' in cm.exception.stdout or
+                        'error: use of a disallowed/placeholder name `foo`' in cm.exception.stdout)
+
+    @skip_if_not_language('rust')
+    @unittest.skipIf(not shutil.which('clippy-driver'), 'Test requires clippy-driver')
+    def test_rust_clippy_as_rustc(self) -> None:
+        if self.backend is not Backend.ninja:
+            raise unittest.SkipTest('Rust is only supported with ninja currently')
+        # When clippy is used, we should get an exception since a variable named
+        # "foo" is used, but is on our denylist
+        testdir = os.path.join(self.rust_test_dir, '1 basic')
         self.init(testdir, extra_args=['--werror'], override_envvars={'RUSTC': 'clippy-driver'})
         with self.assertRaises(subprocess.CalledProcessError) as cm:
             self.build()

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -3333,13 +3333,17 @@ class AllPlatformTests(BasePlatformTests):
             ('win_subsystem', (str, None)),
         ]
 
-        targets_sources_typelist = [
+        targets_sources_unknown_lang_typelist = [
             ('language', str),
             ('compiler', list),
             ('parameters', list),
             ('sources', list),
             ('generated_sources', list),
             ('unity_sources', (list, None)),
+        ]
+
+        targets_sources_typelist = targets_sources_unknown_lang_typelist + [
+            ('machine', str),
         ]
 
         target_sources_linker_typelist = [
@@ -3456,7 +3460,10 @@ class AllPlatformTests(BasePlatformTests):
                 targets_to_find.pop(i['name'], None)
             for j in i['target_sources']:
                 if 'compiler' in j:
-                    assertKeyTypes(targets_sources_typelist, j)
+                    if j['language'] == 'unknown':
+                        assertKeyTypes(targets_sources_unknown_lang_typelist, j)
+                    else:
+                        assertKeyTypes(targets_sources_typelist, j)
                     self.assertEqual(j['sources'], [os.path.normpath(f) for f in tgt[4]])
                 else:
                     assertKeyTypes(target_sources_linker_typelist, j)
@@ -3558,6 +3565,7 @@ class AllPlatformTests(BasePlatformTests):
                 sources += j.get('sources', [])
             i['target_sources'] = [{
                 'language': 'unknown',
+                'machine': 'host',
                 'compiler': [],
                 'parameters': [],
                 'sources': sources,


### PR DESCRIPTION
Running clippy by setting a custom rustc compiler that points to "clippy-driver" is suboptimal, because it requires reconfiguration. Similar to the "ninja scan-build" target for C, add a clippy internal tool that runs clippy-driver on all crates in the project.

This also provide infrastructure to find sibling tools to rustc, such as "clippy-driver" itself or rustdoc, when using the "rustup run TOOLCHAIN rustc" to invoke rustc. Adding rustfmt for example is trivial.

A few extra new features are included as a bonus :angel: 
* `MESON_NUM_PROCESSES` respected every time Meson invokes multiple processes in parallel (supersedes `MESON_TESTTHREADS`
* clang-tidy targets respect `b_colorout`
* clang-tidy target do not mix output from multiple files
* target introspection gains a `machine` entry for each sources group, allowing cross lookup from targets to compilers