### PR TITLE
make the testsuite handle MSYS2's addition of cmd

### DIFF
--- a/test cases/common/33 run program/check-mingw.py
+++ b/test cases/common/33 run program/check-mingw.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+import os, sys, re
+
+if 'MSYSTEM' in os.environ and os.environ['MSYSTEM'] != '':
+    print(os.environ['MSYSTEM'])
+else:
+    match = re.search('[\\\\/](mingw32|mingw64|clang32|clang64|clangarm64|ucrt64)[\\\\/]', sys.executable, flags=re.IGNORECASE)
+    if match:
+        print(match.group(1).upper())

--- a/test cases/common/33 run program/meson.build
+++ b/test cases/common/33 run program/meson.build
@@ -1,6 +1,9 @@
 project('run command', version : run_command('get-version.py', check : true).stdout().strip(), meson_version: '>=0.1.0')
 
-if build_machine.system() == 'windows'
+check_mingw = run_command('check-mingw.py', check : true).stdout().strip()
+is_mingw = not (check_mingw == '' or check_mingw == 'MSYS')
+
+if build_machine.system() == 'windows' and not is_mingw
   c = run_command('cmd', '/c', 'echo', 'hello', check: false)
 else
   c = run_command('echo', 'hello', check: false)
@@ -45,7 +48,7 @@ endif
 # We should be able to have files() in argument
 f = files('meson.build')
 
-if build_machine.system() == 'windows'
+if build_machine.system() == 'windows' and not is_mingw
   c = run_command('cmd', '/c', 'echo', f, check: false)
 else
   c = run_command('echo', f, check: false)

--- a/unittests/windowstests.py
+++ b/unittests/windowstests.py
@@ -54,20 +54,20 @@ class WindowsTests(BasePlatformTests):
         PATH to point to a directory with Python scripts.
         '''
         testdir = os.path.join(self.platform_test_dir, '8 find program')
-        # Find `cmd` and `cmd.exe`
-        prog1 = ExternalProgram('cmd')
-        self.assertTrue(prog1.found(), msg='cmd not found')
-        prog2 = ExternalProgram('cmd.exe')
-        self.assertTrue(prog2.found(), msg='cmd.exe not found')
+        # Find `xcopy` and `xcopy.exe`
+        prog1 = ExternalProgram('xcopy')
+        self.assertTrue(prog1.found(), msg='xcopy not found')
+        prog2 = ExternalProgram('xcopy.exe')
+        self.assertTrue(prog2.found(), msg='xcopy.exe not found')
         self.assertPathEqual(prog1.get_path(), prog2.get_path())
-        # Find cmd.exe with args without searching
-        prog = ExternalProgram('cmd', command=['cmd', '/C'])
-        self.assertTrue(prog.found(), msg='cmd not found with args')
-        self.assertPathEqual(prog.get_command()[0], 'cmd')
-        # Find cmd with an absolute path that's missing the extension
-        cmd_path = prog2.get_path()[:-4]
-        prog = ExternalProgram(cmd_path)
-        self.assertTrue(prog.found(), msg=f'{cmd_path!r} not found')
+        # Find xcopy.exe with args without searching
+        prog = ExternalProgram('xcopy', command=['xcopy', '/?'])
+        self.assertTrue(prog.found(), msg='xcopy not found with args')
+        self.assertPathEqual(prog.get_command()[0], 'xcopy')
+        # Find xcopy with an absolute path that's missing the extension
+        xcopy_path = prog2.get_path()[:-4]
+        prog = ExternalProgram(xcopy_path)
+        self.assertTrue(prog.found(), msg=f'{xcopy_path!r} not found')
         # Finding a script with no extension inside a directory works
         prog = ExternalProgram(os.path.join(testdir, 'test-script'))
         self.assertTrue(prog.found(), msg='test-script not found')


### PR DESCRIPTION
This contains commits c21706e3f1d8094278ac4bd7eb367ecaf6a50ea1, 4d7de831c8465f268c2e5333ebd8b74b970ac8d8  pulled from #13886.

With _all_ the workflow runs currently consistently failing on 'msys' I think it may be worthwhile to look at these changes independently from the rest of that PR (which may or may not actually be a Python regression).

If the workflow runs can work reliably again, checks on PRs can sensibly provide feedback again.
