### PR TITLE
rust: avoid warnings from rust.test

### DIFF
--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -162,6 +162,9 @@ class RustModule(ExtensionModule):
         new_target_kwargs['dependencies'] = new_target_kwargs.get('dependencies', []) + kwargs['dependencies']
         new_target_kwargs['link_with'] = new_target_kwargs.get('link_with', []) + kwargs['link_with']
         del new_target_kwargs['rust_crate_type']
+        for kw in ['pic', 'prelink', 'rust_abi', 'version', 'soversion', 'darwin_versions']:
+            if kw in new_target_kwargs:
+                del new_target_kwargs[kw]
 
         lang_args = base_target.extra_args.copy()
         lang_args['rust'] = base_target.extra_args['rust'] + kwargs['rust_args'] + ['--test']

--- a/test cases/rust/9 unit tests/meson.build
+++ b/test cases/rust/9 unit tests/meson.build
@@ -1,4 +1,4 @@
-project('rust unit tests', 'rust')
+project('rust unit tests', 'rust', meson_version: '>=1.2.0')
 
 t = executable(
   'rust_test',
@@ -33,7 +33,7 @@ test(
 
 exe = executable('rust_exe', ['test2.rs', 'test.rs'], build_by_default : false)
 
-rust = import('unstable-rust')
+rust = import('rust')
 rust.test('rust_test_from_exe', exe, should_fail : true)
 
 lib = static_library('rust_static', ['test.rs'], build_by_default : false, rust_crate_type : 'lib')

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -4891,6 +4891,13 @@ class AllPlatformTests(BasePlatformTests):
                         'error: use of a disallowed/placeholder name `foo`' in cm.exception.stdout)
 
     @skip_if_not_language('rust')
+    def test_rust_test_warnings(self) -> None:
+        if self.backend is not Backend.ninja:
+            raise unittest.SkipTest('Rust is only supported with ninja currently')
+        testdir = os.path.join(self.rust_test_dir, '9 unit tests')
+        self.init(testdir, extra_args=['--fatal-meson-warnings'])
+
+    @skip_if_not_language('rust')
     def test_rust_rlib_linkage(self) -> None:
         if self.backend is not Backend.ninja:
             raise unittest.SkipTest('Rust is only supported with ninja currently')


### PR DESCRIPTION
Any argument from the base target is copied to the test target, but some keyword arguments for libraries are not available in executable. Remove them, and add a unit test that checks for it with --fatal-meson-warnings.