### PR TITLE
ExternalProgram: Ensure that the path has no forward slashes on Windows

### DIFF
--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -310,7 +310,14 @@ class ExternalProgram(mesonlib.HoldableObject):
             paths = OrderedSet(path.split(os.pathsep)).difference(exclude_paths)
             path = os.pathsep.join(paths)
         command = shutil.which(name, path=path)
-        if mesonlib.is_windows():
+        if command is not None and mesonlib.is_windows():
+            # Some programs like cmd.exe do not expect forward slashes in the first part
+            # of GetCommandLineW() (the part corresponding to argv[0]) and confuse the
+            # slash for a command-line switch.
+            #
+            # Example: "C:\Windows\System32/cmd.exe /C echo hello world" fails with
+            # "syntax error".
+            command = command.replace('/', '\\')
             return self._search_windows_special_cases(name, command, exclude_paths)
         # On UNIX-like platforms, shutil.which() is enough to find
         # all executables whether in PATH or with an absolute path


### PR DESCRIPTION
Some programs like cmd.exe do not expect forward slashes in the first part of GetCommandLineW() (the part corresponding to argv[0]) and confuse the slash for a command-line switch.

This is a fix for [test cases\common\33 run program](https://github.com/mesonbuild/meson/tree/master/test%20cases/common/33%20run%20program). ~~Also helps https://github.com/mesonbuild/meson/issues/1526~~

Note: [shutil.which](https://docs.python.org/3/library/shutil.html#shutil.which) uses forward slash also on Windows. We may introduce a mesonlib.which() helper (see also commit [935aa452](https://github.com/python/cpython/commit/935aa452359ac3f79febefcdb4387b962cf528af))

https://github.com/python/cpython/blob/v3.13.0/Lib/shutil.py#L1503