### PR TITLE
run_single_test.py: skip setup_symlinks() call on Windows

### DIFF
--- a/run_single_test.py
+++ b/run_single_test.py
@@ -48,7 +48,7 @@ def main() -> None:
 
     if not is_windows():
         scan_test_data_symlinks()
-    setup_symlinks()
+        setup_symlinks()
     setup_commands(args.backend)
     if not args.quick:
         detect_system_compiler(args)


### PR DESCRIPTION
This fixed `run_single_test.py` on my local development environment (base on MSYS2)