### PR TITLE
environment: Never require an exe_wrapper for native builds

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -991,6 +991,8 @@ class Environment:
         value = self.properties[for_machine].get('needs_exe_wrapper', None)
         if value is not None:
             return value
+        if not self.is_cross_build():
+            return False
         return not machine_info_can_run(self.machines[for_machine])
 
     def get_exe_wrapper(self) -> T.Optional[ExternalProgram]:


### PR DESCRIPTION
It is possible to run a container or chroot with one ABI on a CPU and kernel that would normally have a different ABI, most commonly by running a 32-bit container on a 64-bit CPU and kernel. When we do a native build in such an environment, the build and host architectures are both equal to the architecture of the container, and it is safe to assume that we can run executables from that architecture, because if we could not, we wouldn't be running Python successfully.

Until now, we have been handling this by adding explicit special cases in `machine_info_can_run()` for each known-good combination of the detected CPU and the host architecture: every x86_64 can run x86 binaries, and every mips64 is assumed to be able to run 32-bit mips binaries. However, the equivalent would not be true on ARM systems: *most* aarch64 CPUs can run arm binaries, but not all (according to Wikipedia, ARM Cortex-A34 is an example of a purely 64-bit CPU that cannot execute 32-bit instructions).

Instead, assume that if we are doing a native build (not a cross build), by definition we can run build-architecture executables, and since the host architecture is equal to the build architecture during a native build, this implies that we can run host-architecture executables too.

This makes the behaviour of `need_exe_wrapper()` consistent with `meson.can_run_host_binaries()`, which in turn avoids `Compiler.run()` failing with error message "Can not run test applications in this cross environment" during native builds even though `meson.can_run_host_binaries()` has previously succeeded.

Resolves: https://github.com/mesonbuild/meson/issues/13841