### PR TITLE
Allow running doctests via rust.doctest()

### DIFF
--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -38,6 +38,7 @@ It also takes the following keyword arguments:
 
 - `dependencies`: a list of test-only Dependencies
 - `link_with`: a list of additional build Targets to link with (*since 1.2.0*)
+- `link_whole`: a list of additional build Targets to link with in their entirety (*since 1.8.0*)
 - `rust_args`: a list of extra arguments passed to the Rust compiler (*since 1.2.0*)
 
 This function  also accepts all of the keyword arguments accepted by the
@@ -59,6 +60,7 @@ It also takes the following keyword arguments:
 
 - `dependencies`: a list of test-only Dependencies
 - `link_with`: a list of additional build Targets to link with
+- `link_whole`: a list of additional build Targets to link with in their entirety
 - `rust_args`: a list of extra arguments passed to the Rust compiler
 
 The target is linked automatically into the doctests.

--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -24,6 +24,8 @@ like Meson, rather than Meson work more like rust.
 rustmod.test(name, target, ...)
 ```
 
+*Since 1.8.0*
+
 This function creates a new rust unittest target from an existing rust
 based target, which may be a library or executable. It does this by
 copying the sources and arguments passed to the original target and
@@ -40,6 +42,31 @@ It also takes the following keyword arguments:
 
 This function  also accepts all of the keyword arguments accepted by the
 [[test]] function except `protocol`, it will set that automatically.
+
+### doctest()
+
+```meson
+rustmod.doctest(name, target, ...)
+```
+
+This function creates a new `test()` target from an existing rust
+based library target. The test will use `rustdoc` to extract and run
+the doctests that are included in `target`'s sources.
+
+This function takes two positional arguments, the first is the name of the
+test and the second is the library or executable that is the rust based target.
+It also takes the following keyword arguments:
+
+- `dependencies`: a list of test-only Dependencies
+- `link_with`: a list of additional build Targets to link with
+- `rust_args`: a list of extra arguments passed to the Rust compiler
+
+The target is linked automatically into the doctests.
+
+This function  also accepts all of the keyword arguments accepted by the
+[[test]] function except `protocol`, it will set that automatically.
+However, arguments are limited to strings that do not contain spaces
+due to limitations of `rustdoc`.
 
 ### bindgen()
 

--- a/docs/markdown/snippets/rust-test-link-whole.md
+++ b/docs/markdown/snippets/rust-test-link-whole.md
@@ -1,0 +1,4 @@
+## `rust.test` now supports `link_whole`
+
+The `test` function in the `rust` module now supports the `link_whole`
+keyword argument in addition to `link_with` and `dependencies`.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -2078,9 +2078,8 @@ class Backend:
         Some backends don't support custom compilers. This is a convenience
         method to convert a Compiler to a Generator.
         '''
-        exelist = compiler.get_exelist()
-        exe = programs.ExternalProgram(exelist[0])
-        args = exelist[1:]
+        exe = programs.ExternalProgram(compiler.get_exe())
+        args = compiler.get_exe_args()
         commands = self.compiler_to_generator_args(target, compiler)
         generator = build.Generator(exe, args + commands.to_native(),
                                     [output_templ], depfile='@PLAINNAME@.d',

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -43,7 +43,7 @@ if T.TYPE_CHECKING:
     from .backend.backends import Backend
     from .compilers import Compiler
     from .interpreter.interpreter import SourceOutputs, Interpreter
-    from .interpreter.interpreterobjects import Test
+    from .interpreter.interpreterobjects import Test, Doctest
     from .interpreterbase import SubProject
     from .linkers.linkers import StaticLinker
     from .mesonlib import ExecutableSerialisation, FileMode, FileOrString
@@ -730,6 +730,7 @@ class BuildTarget(Target):
         self.name_prefix_set = False
         self.name_suffix_set = False
         self.filename = 'no_name'
+        self.doctests: T.Optional[Doctest] = None
         # The debugging information file this target will generate
         self.debug_filename = None
         # The list of all files outputted by this target. Useful in cases such

--- a/mesonbuild/cmake/toolchain.py
+++ b/mesonbuild/cmake/toolchain.py
@@ -9,6 +9,7 @@ from ..envconfig import CMakeSkipCompilerTest
 from .common import language_map, cmake_get_generator_args
 from .. import mlog
 
+import os.path
 import shutil
 import typing as T
 from enum import Enum
@@ -198,7 +199,7 @@ class CMakeToolchain:
         if compiler.get_argument_syntax() == 'msvc':
             return arg.startswith('/')
         else:
-            if compiler.exelist[0] == 'zig' and arg in {'ar', 'cc', 'c++', 'dlltool', 'lib', 'ranlib', 'objcopy', 'rc'}:
+            if os.path.basename(compiler.get_exe()) == 'zig' and arg in {'ar', 'cc', 'c++', 'dlltool', 'lib', 'ranlib', 'objcopy', 'rc'}:
                 return True
             return arg.startswith('-')
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -521,6 +521,12 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
     def get_modes(self) -> T.List[Compiler]:
         return self.modes
 
+    def get_exe(self) -> str:
+        return self.exelist[0]
+
+    def get_exe_args(self) -> T.List[str]:
+        return self.exelist[1:]
+
     def get_linker_id(self) -> str:
         # There is not guarantee that we have a dynamic linker instance, as
         # some languages don't have separate linkers and compilers. In those

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -1099,7 +1099,7 @@ def detect_rust_compiler(env: 'Environment', for_machine: MachineChoice) -> Rust
                 extra_args: T.Dict[str, T.Union[str, bool]] = {}
                 always_args: T.List[str] = []
                 if is_link_exe:
-                    compiler.extend(cls.use_linker_args(cc.linker.exelist[0], ''))
+                    compiler.extend(cls.use_linker_args(cc.linker.get_exe(), ''))
                     extra_args['direct'] = True
                     extra_args['machine'] = cc.linker.machine
                 else:
@@ -1131,7 +1131,7 @@ def detect_rust_compiler(env: 'Environment', for_machine: MachineChoice) -> Rust
                 # inserts the correct prefix itself.
                 assert isinstance(linker, linkers.VisualStudioLikeLinkerMixin)
                 linker.direct = True
-                compiler.extend(cls.use_linker_args(linker.exelist[0], ''))
+                compiler.extend(cls.use_linker_args(linker.get_exe(), ''))
             else:
                 # On linux and macos rust will invoke the c compiler for
                 # linking, on windows it will use lld-link or link.exe.

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -279,6 +279,8 @@ class RustCompiler(Compiler):
 
     def get_linker_always_args(self) -> T.List[str]:
         args: T.List[str] = []
+        # Rust is super annoying, calling -C link-arg foo does not work, it has
+        # to be -C link-arg=foo
         for a in super().get_linker_always_args():
             args.extend(['-C', f'link-arg={a}'])
         return args

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -340,7 +340,8 @@ class RustCompiler(Compiler):
             return None
 
         return RustdocTestCompiler(exelist, self.version, self.for_machine,
-                                   self.is_cross, self.info, linker=self.linker)
+                                   self.is_cross, self.info, full_version=self.full_version,
+                                   linker=self.linker)
 
 class ClippyRustCompiler(RustCompiler):
 

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -107,7 +107,7 @@ class RustCompiler(Compiler):
     def needs_static_linker(self) -> bool:
         return False
 
-    def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
+    def sanity_check(self, work_dir: str, environment: Environment) -> None:
         source_name = os.path.join(work_dir, 'sanity.rs')
         output_name = os.path.join(work_dir, 'rusttest')
         cmdlist = self.exelist.copy()
@@ -332,6 +332,15 @@ class RustCompiler(Compiler):
     def has_multi_link_arguments(self, args: T.List[str], env: Environment) -> T.Tuple[bool, bool]:
         args = self.linker.fatal_warnings() + args
         return self.compiles('fn main { std::process::exit(0) };\n', env, extra_args=args, mode=CompileCheckMode.LINK)
+
+    @functools.lru_cache(maxsize=None)
+    def get_rustdoc(self, env: 'Environment') -> T.Optional[RustdocTestCompiler]:
+        exelist = self.get_rust_tool('rustdoc', env)
+        if not exelist:
+            return None
+
+        return RustdocTestCompiler(exelist, self.version, self.for_machine,
+                                   self.is_cross, self.info, linker=self.linker)
 
 class ClippyRustCompiler(RustCompiler):
 

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -314,7 +314,7 @@ class RustCompiler(Compiler):
             exelist = rustup_exelist + [name]
         else:
             exelist = [name]
-            args = self.exelist[1:]
+            args = self.get_exe_args()
 
         from ..programs import find_external_program
         for prog in find_external_program(env, self.for_machine, exelist[0], exelist[0],

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -593,7 +593,7 @@ class JNISystemDependency(SystemDependency):
 
         self.java_home = environment.properties[self.for_machine].get_java_home()
         if not self.java_home:
-            self.java_home = pathlib.Path(shutil.which(self.javac.exelist[0])).resolve().parents[1]
+            self.java_home = pathlib.Path(shutil.which(self.javac.get_exe())).resolve().parents[1]
             if m.is_darwin():
                 problem_java_prefix = pathlib.Path('/System/Library/Frameworks/JavaVM.framework/Versions')
                 if problem_java_prefix in self.java_home.parents:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -798,13 +798,12 @@ class Interpreter(InterpreterBase, HoldableObject):
             if not cmd.found():
                 raise InterpreterException(f'command {cmd.get_name()!r} not found or not executable')
         elif isinstance(cmd, compilers.Compiler):
-            exelist = cmd.get_exelist()
-            cmd = exelist[0]
+            expanded_args = cmd.get_exe_args()
+            cmd = cmd.get_exe()
             prog = ExternalProgram(cmd, silent=True)
             if not prog.found():
                 raise InterpreterException(f'Program {cmd!r} not found or not executable')
             cmd = prog
-            expanded_args = exelist[1:]
         else:
             if isinstance(cmd, mesonlib.File):
                 cmd = cmd.absolute_path(srcdir, builddir)
@@ -823,7 +822,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                 expanded_args.append(a.get_path())
             elif isinstance(a, compilers.Compiler):
                 FeatureNew.single_use('Compiler object as a variadic argument to `run_command`', '0.61.0', self.subproject, location=self.current_node)
-                prog = ExternalProgram(a.exelist[0], silent=True)
+                prog = ExternalProgram(a.get_exe(), silent=True)
                 if not prog.found():
                     raise InterpreterException(f'Program {cmd!r} not found or not executable')
                 expanded_args.append(prog.get_path())

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -130,6 +130,7 @@ if T.TYPE_CHECKING:
 
     ProgramVersionFunc = T.Callable[[T.Union[ExternalProgram, build.Executable, OverrideProgram]], str]
 
+    TestClass = T.TypeVar('TestClass', bound=Test)
 
 def _project_version_validator(value: T.Union[T.List, str, mesonlib.File, None]) -> T.Optional[str]:
     if isinstance(value, list):
@@ -2212,7 +2213,8 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     def make_test(self, node: mparser.BaseNode,
                   args: T.Tuple[str, T.Union[build.Executable, build.Jar, ExternalProgram, mesonlib.File, build.CustomTarget, build.CustomTargetIndex]],
-                  kwargs: 'kwtypes.BaseTest') -> Test:
+                  kwargs: 'kwtypes.BaseTest',
+                  klass: T.Type[TestClass] = Test) -> TestClass:
         name = args[0]
         if ':' in name:
             mlog.deprecation(f'":" is not allowed in test name "{name}", it has been replaced with "_"',
@@ -2242,20 +2244,20 @@ class Interpreter(InterpreterBase, HoldableObject):
                 s = ':' + s
             suite.append(prj.replace(' ', '_').replace(':', '_') + s)
 
-        return Test(name,
-                    prj,
-                    suite,
-                    exe,
-                    kwargs['depends'],
-                    kwargs.get('is_parallel', False),
-                    kwargs['args'],
-                    env,
-                    kwargs['should_fail'],
-                    kwargs['timeout'],
-                    kwargs['workdir'],
-                    kwargs['protocol'],
-                    kwargs['priority'],
-                    kwargs['verbose'])
+        return klass(name,
+                     prj,
+                     suite,
+                     exe,
+                     kwargs['depends'],
+                     kwargs.get('is_parallel', False),
+                     kwargs['args'],
+                     env,
+                     kwargs['should_fail'],
+                     kwargs['timeout'],
+                     kwargs['workdir'],
+                     kwargs['protocol'],
+                     kwargs['priority'],
+                     kwargs['verbose'])
 
     def add_test(self, node: mparser.BaseNode,
                  args: T.Tuple[str, T.Union[build.Executable, build.Jar, ExternalProgram, mesonlib.File, build.CustomTarget, build.CustomTargetIndex]],

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -809,6 +809,11 @@ class Test(MesonInterpreterObject):
     def get_name(self) -> str:
         return self.name
 
+
+class Doctest(Test):
+    target: T.Optional[build.BuildTarget] = None
+
+
 class NullSubprojectInterpreter(HoldableObject):
     pass
 

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -19,6 +19,9 @@ from ..modules.cmake import CMakeSubprojectOptions
 from ..programs import ExternalProgram
 from .type_checking import PkgConfigDefineType, SourcesVarargsType
 
+if T.TYPE_CHECKING:
+    TestArgs = T.Union[str, File, build.Target, ExternalProgram]
+
 class FuncAddProjectArgs(TypedDict):
 
     """Keyword Arguments for the add_*_arguments family of arguments.
@@ -38,7 +41,6 @@ class BaseTest(TypedDict):
 
     """Shared base for the Rust module."""
 
-    args: T.List[T.Union[str, File, build.Target, ExternalProgram]]
     should_fail: bool
     timeout: int
     workdir: T.Optional[str]
@@ -52,6 +54,7 @@ class FuncBenchmark(BaseTest):
 
     """Keyword Arguments shared between `test` and `benchmark`."""
 
+    args: T.List[TestArgs]
     protocol: Literal['exitcode', 'tap', 'gtest', 'rust']
 
 

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -472,9 +472,7 @@ VARIABLES_KW: KwargInfo[T.Dict[str, str]] = KwargInfo(
 
 PRESERVE_PATH_KW: KwargInfo[bool] = KwargInfo('preserve_path', bool, default=False, since='0.63.0')
 
-TEST_KWS: T.List[KwargInfo] = [
-    KwargInfo('args', ContainerTypeInfo(list, (str, File, BuildTarget, CustomTarget, CustomTargetIndex, ExternalProgram)),
-              listify=True, default=[]),
+TEST_KWS_NO_ARGS: T.List[KwargInfo] = [
     KwargInfo('should_fail', bool, default=False),
     KwargInfo('timeout', int, default=30),
     KwargInfo('workdir', (str, NoneType), default=None,
@@ -489,6 +487,11 @@ TEST_KWS: T.List[KwargInfo] = [
     DEPENDS_KW.evolve(since='0.46.0'),
     KwargInfo('suite', ContainerTypeInfo(list, str), listify=True, default=['']),  # yes, a list of empty string
     KwargInfo('verbose', bool, default=False, since='0.62.0'),
+]
+
+TEST_KWS: T.List[KwargInfo] = TEST_KWS_NO_ARGS + [
+    KwargInfo('args', ContainerTypeInfo(list, (str, File, BuildTarget, CustomTarget, CustomTargetIndex, ExternalProgram)),
+              listify=True, default=[]),
 ]
 
 # Cannot have a default value because we need to check that rust_crate_type and

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -31,6 +31,9 @@ class StaticLinker:
     def get_id(self) -> str:
         return self.id
 
+    def get_exe(self) -> str:
+        return self.exelist[0]
+
     def compiler_args(self, args: T.Optional[T.Iterable[str]] = None) -> CompilerArgs:
         return CompilerArgs(self, args)
 
@@ -151,6 +154,9 @@ class DynamicLinker(metaclass=abc.ABCMeta):
 
     def get_id(self) -> str:
         return self.id
+
+    def get_exe(self) -> str:
+        return self.exelist[0]
 
     def get_version_string(self) -> str:
         return f'({self.id} {self.version})'

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -37,6 +37,7 @@ if T.TYPE_CHECKING:
 
     class FuncTest(_kwargs.BaseTest):
 
+        args: T.List[_kwargs.TestArgs]
         dependencies: T.List[T.Union[Dependency, ExternalLibrary]]
         is_parallel: bool
         link_with: T.List[LibTypes]

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -29,6 +29,7 @@ if T.TYPE_CHECKING:
     from ..interpreter import Interpreter
     from ..interpreter import kwargs as _kwargs
     from ..interpreter.interpreter import SourceInputs, SourceOutputs
+    from ..interpreter.interpreterobjects import Test
     from ..programs import OverrideProgram
     from ..interpreter.type_checking import SourcesVarargsType
 
@@ -188,7 +189,7 @@ class RustModule(ExtensionModule):
             new_target_kwargs
         )
 
-        test = self.interpreter.make_test(
+        test: Test = self.interpreter.make_test(
             self.interpreter.current_node, (name, new_target), tkwargs)
 
         return ModuleReturnValue(None, [new_target, test])

--- a/test cases/rust/9 unit tests/doctest1.rs
+++ b/test cases/rust/9 unit tests/doctest1.rs
@@ -7,6 +7,6 @@
 /// ```ignore
 /// this one will be skipped
 /// ```
-fn my_func()
+pub fn my_func()
 {
 }

--- a/test cases/rust/9 unit tests/meson.build
+++ b/test cases/rust/9 unit tests/meson.build
@@ -49,7 +49,7 @@ exe = executable('rust_exe', ['test2.rs', 'test.rs'], build_by_default : false)
 rust = import('rust')
 rust.test('rust_test_from_exe', exe, should_fail : true)
 
-lib = static_library('rust_static', ['test.rs'], build_by_default : false, rust_crate_type : 'lib')
+lib = static_library('rust_static', ['test.rs'], build_by_default : false, rust_abi: 'c')
 rust.test('rust_test_from_static', lib, args: ['--skip', 'test_add_intentional_fail'])
 
 lib = shared_library('rust_shared', ['test.rs'], build_by_default : false)

--- a/test cases/rust/9 unit tests/meson.build
+++ b/test cases/rust/9 unit tests/meson.build
@@ -1,4 +1,4 @@
-project('rust unit tests', 'rust', meson_version: '>=1.2.0')
+project('rust unit tests', 'rust', meson_version: '>=1.8.0')
 
 t = executable(
   'rust_test',
@@ -31,14 +31,12 @@ test(
   suite : ['foo'],
 )
 
+rust = import('rust')
+
 rustdoc = find_program('rustdoc', required: false)
 if rustdoc.found()
-  # rustdoc is invoked mostly like rustc.  This is a simple example
-  # where it is easy enough to invoke it by hand.
-  test(
-    'rust doctest',
-    rustdoc,
-    args : ['--test', '--crate-name', 'doctest1', '--crate-type', 'lib', files('doctest1.rs')],
+  doclib = static_library('rust_doc_lib', ['doctest1.rs'], build_by_default : false)
+  rust.doctest('rust doctests', doclib,
     protocol : 'rust',
     suite : ['doctests'],
   )
@@ -46,7 +44,6 @@ endif
 
 exe = executable('rust_exe', ['test2.rs', 'test.rs'], build_by_default : false)
 
-rust = import('rust')
 rust.test('rust_test_from_exe', exe, should_fail : true)
 
 lib = static_library('rust_static', ['test.rs'], build_by_default : false, rust_abi: 'c')


### PR DESCRIPTION
Most of the series is refactoring that avoids duplicating the code that creates arguments to rustc. The integration with build.BuildTarget is a bit rust-specific, so I am willing to change things if you guys don't like it.