### PR TITLE
dependencies/dev: prepend sysroot when searching for GTest sources

### DIFF
--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -56,7 +56,9 @@ class GTestDependencySystem(SystemDependency):
     def __init__(self, name: str, environment: 'Environment', kwargs: T.Dict[str, T.Any]) -> None:
         super().__init__(name, environment, kwargs, language='cpp')
         self.main = kwargs.get('main', False)
-        self.src_dirs = ['/usr/src/gtest/src', '/usr/src/googletest/googletest/src']
+
+        sysroot = environment.properties[self.for_machine].get_sys_root() or ''
+        self.src_dirs = [sysroot + '/usr/src/gtest/src', sysroot + '/usr/src/googletest/googletest/src']
         if not self._add_sub_dependency(threads_factory(environment, self.for_machine, {})):
             self.is_found = False
             return


### PR DESCRIPTION
Don't hardcode paths in /usr when looking for the GTest sources, as in cross-compile or other builds with a sysroot this will find the host sources, not ones that we want to use in the sysroot.

Closes #12690.