### PR TITLE
Fix computation of rustc library directory

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2125,7 +2125,7 @@ class NinjaBackend(backends.Backend):
             # ... but then add rustc's sysroot to account for rustup
             # installations
             for rpath_arg in rpath_args:
-                args += ['-C', 'link-arg=' + rpath_arg + ':' + os.path.join(rustc.get_sysroot(), 'lib')]
+                args += ['-C', 'link-arg=' + rpath_arg + ':' + rustc.get_target_libdir()]
 
         proc_macro_dylib_path = None
         if getattr(target, 'rust_crate_type', '') == 'proc-macro':

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -142,8 +142,15 @@ class RustCompiler(Compiler):
     def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
         return ['--dep-info', outfile]
 
+    @functools.lru_cache(maxsize=None)
     def get_sysroot(self) -> str:
         cmd = self.get_exelist(ccache=False) + ['--print', 'sysroot']
+        p, stdo, stde = Popen_safe_logged(cmd)
+        return stdo.split('\n', maxsplit=1)[0]
+
+    @functools.lru_cache(maxsize=None)
+    def get_target_libdir(self) -> str:
+        cmd = self.get_exelist(ccache=False) + ['--print', 'target-libdir']
         p, stdo, stde = Popen_safe_logged(cmd)
         return stdo.split('\n', maxsplit=1)[0]
 


### PR DESCRIPTION
Using a rustup-based toolchain fails the "rust/2 sharedlib" test for me:

```
./prog: error while loading shared libraries: libstd-211931512faabf29.so: cannot open shared object file: No such file or directory
```

This happens because recent rustup places the standard library under SYSROOT/lib/rustlib/TARGET/lib.  Retrieve the right directory using "--print target-libdir".  This also provides a more accurate version for rustc installed in /usr.

Before:
```
$ echo $(/usr/bin/rustc --print sysroot)/lib
/usr/lib
```
After:
```
$ /usr/bin/rustc --print target-libdir
/usr/lib/rustlib/x86_64-unknown-linux-gnu/lib
```
While at it, cache the value to avoid repeated process invocation.