### PR TITLE
Fix ci images

### DIFF
--- a/ci/ciimage/fedora/install.sh
+++ b/ci/ciimage/fedora/install.sh
@@ -12,7 +12,7 @@ pkgs=(
   boost-python3-devel
   itstool gtk3-devel java-latest-openjdk-devel gtk-doc llvm-devel clang-devel SDL2-devel graphviz-devel zlib zlib-devel zlib-static
   #hdf5-openmpi-devel hdf5-devel netcdf-openmpi-devel netcdf-devel netcdf-fortran-openmpi-devel netcdf-fortran-devel scalapack-openmpi-devel
-  doxygen vulkan-devel vulkan-validation-layers-devel openssh objfw mercurial gtk-sharp2-devel libpcap-devel gpgme-devel
+  doxygen vulkan-devel vulkan-validation-layers-devel openssh lksctp-tools-devel objfw mercurial gtk-sharp2-devel libpcap-devel gpgme-devel
   qt5-qtbase-devel qt5-qttools-devel qt5-linguist qt5-qtbase-private-devel
   libwmf-devel valgrind cmake openmpi-devel nasm gnustep-base-devel gettext-devel ncurses-devel
   libxml2-devel libxslt-devel libyaml-devel glib2-devel json-glib-devel libgcrypt-devel wayland-devel wayland-protocols-devel

--- a/test cases/frameworks/24 libgcrypt/test.json
+++ b/test cases/frameworks/24 libgcrypt/test.json
@@ -1,3 +1,3 @@
 {
-  "expect_skip_on_jobname": ["arch", "azure", "cygwin", "msys2"]
+  "expect_skip_on_jobname": ["arch", "azure", "cygwin", "msys2", "ubuntu-rolling"]
 }


### PR DESCRIPTION
I have no idea about the Arch failure:

```
2024-11-20T16:22:36.4765258Z [1/5] c++ -Isubprojects/cmMod/libcmModLib__.so.p -Isubprojects/cmMod '-I../test cases/cmake/1 basic/subprojects/cmMod' -Isubprojects/cmMod/__CMake_build '-I../test cases/cmake/1 basic/subprojects/cmMod/__CMake_build' -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=gnu++14 -O0 -g -fPIC -g -DDO_NOTHING_JUST_A_FLAG=1 -DMESON_MAGIC_FLAG=21 -DcmModLib___EXPORTS -MD -MQ subprojects/cmMod/libcmModLib__.so.p/cmMod.cpp.o -MF subprojects/cmMod/libcmModLib__.so.p/cmMod.cpp.o.d -o subprojects/cmMod/libcmModLib__.so.p/cmMod.cpp.o -c '../test cases/cmake/1 basic/subprojects/cmMod/cmMod.cpp'
2024-11-20T16:22:36.4771685Z [2/5] c++  -o subprojects/cmMod/libcmModLib__.so subprojects/cmMod/libcmModLib__.so.p/cmMod.cpp.o -Wl,--as-needed -Wl,--no-undefined -shared -fPIC -Wl,-soname,libcmModLib__.so -Wl,--dependency-file,CMakeFiles/cmModLib++.dir/link.d
2024-11-20T16:22:36.4773648Z FAILED: subprojects/cmMod/libcmModLib__.so 
2024-11-20T16:22:36.4775912Z c++  -o subprojects/cmMod/libcmModLib__.so subprojects/cmMod/libcmModLib__.so.p/cmMod.cpp.o -Wl,--as-needed -Wl,--no-undefined -shared -fPIC -Wl,-soname,libcmModLib__.so -Wl,--dependency-file,CMakeFiles/cmModLib++.dir/link.d
2024-11-20T16:22:36.4778166Z /usr/sbin/ld: cannot open dependency file CMakeFiles/cmModLib++.dir/link.d: no error
2024-11-20T16:22:36.4779121Z collect2: error: ld returned 1 exit status
2024-11-20T16:22:36.4783656Z [3/5] c++ -Imain.p -I. '-I../test cases/cmake/1 basic' -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O0 -g -DMESON_MAGIC_FLAG=42 '-isystem../test cases/cmake/1 basic/subprojects/cmMod' -isystemsubprojects/cmMod '-isystem../test cases/cmake/1 basic/subprojects/cmMod/__CMake_build' -isystemsubprojects/cmMod/__CMake_build -MD -MQ main.p/main.cpp.o -MF main.p/main.cpp.o.d -o main.p/main.cpp.o -c '../test cases/cmake/1 basic/main.cpp'
2024-11-20T16:22:36.4787314Z ninja: build stopped: subcommand failed.
```

but the Fedora and Ubuntu ones should be easy.