### PR TITLE
Prototype support for PEP 739

### DIFF
--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -115,17 +115,27 @@ class PythonInstallation(_ExternalProgramHolder['PythonExternalProgram']):
         info = python.info
         prefix = self.interpreter.environment.coredata.get_option(OptionKey('prefix'))
         assert isinstance(prefix, str), 'for mypy'
+
+        if python.build_config:
+            self.version = python.build_config['version']
+            self.platform = python.build_config['platform']
+            self.suffix = python.build_config['abi']['extension_suffix']
+            self.limited_api_suffix = python.build_config['abi']['stable_abi_suffix']
+            self.link_libpython = python.build_config['libpython']['link_to_libpython']
+            self.is_pypy = python.build_config['implementation']['name'] == 'pypy'
+        else:
+            self.version = info['version']
+            self.platform = info['platform']
+            self.suffix = info['suffix']
+            self.limited_api_suffix = info['limited_api_suffix']
+            self.link_libpython = info['link_libpython']
+            self.is_pypy = info['is_pypy']
+
         self.variables = info['variables']
-        self.suffix = info['suffix']
-        self.limited_api_suffix = info['limited_api_suffix']
         self.paths = info['paths']
         self.pure = python.pure
         self.platlib_install_path = os.path.join(prefix, python.platlib)
         self.purelib_install_path = os.path.join(prefix, python.purelib)
-        self.version = info['version']
-        self.platform = info['platform']
-        self.is_pypy = info['is_pypy']
-        self.link_libpython = info['link_libpython']
         self.methods.update({
             'extension_module': self.extension_module_method,
             'dependency': self.dependency_method,
@@ -256,8 +266,12 @@ class PythonInstallation(_ExternalProgramHolder['PythonExternalProgram']):
         if dep is not None:
             return dep
 
+        build_config = self.interpreter.environment.coredata.get_option(OptionKey('python.build_config'))
+
         new_kwargs = kwargs.copy()
         new_kwargs['required'] = False
+        if build_config:
+            new_kwargs['build_config'] = build_config
         candidates = python_factory(self.interpreter.environment, for_machine, new_kwargs, self.held_object)
         dep = find_external_dependency('python', self.interpreter.environment, new_kwargs, candidates)
 

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -663,6 +663,8 @@ BUILTIN_CORE_OPTIONS: T.Dict['OptionKey', 'BuiltinOption'] = OrderedDict([
      BuiltinOption(UserStringOption, 'Directory for site-specific, non-platform-specific files.', '')),
     (OptionKey('python.allow_limited_api'),
      BuiltinOption(UserBooleanOption, 'Whether to allow use of the Python Limited API', True)),
+    (OptionKey('python.build_config'),
+     BuiltinOption(UserStringOption, 'Config file containing the build details for the target Python installation.', '')),
 ])
 
 BUILTIN_OPTIONS = OrderedDict(chain(BUILTIN_DIR_OPTIONS.items(), BUILTIN_CORE_OPTIONS.items()))


### PR DESCRIPTION
The overall goal is to support targeting Python installations without need for introspection, given all necessary information is given externally.

This is built upon:
- [PEP 739](https://peps.python.org/pep-0739/), for all information necessary for the build process
- A future PEP, for all information necessary for the installation paths
- https://github.com/python/cpython/issues/127178, for `py_installation.get_variable`/`py_installation.has_variable` support

This PR is just a prototype, as I work to get all necessary pieces finalized.