### PR TITLE
Allow setting build_by_default to False when install is True

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -650,7 +650,7 @@ class Target(HoldableObject, metaclass=abc.ABCMeta):
             if not isinstance(self.build_by_default, bool):
                 raise InvalidArguments('build_by_default must be a boolean value.')
 
-        if not self.build_by_default and kwargs.get('install', False):
+        elif not self.build_by_default and kwargs.get('install', False):
             # For backward compatibility, if build_by_default is not explicitly
             # set, use the value of 'install' if it's enabled.
             self.build_by_default = True

--- a/test cases/common/129 build by default/meson.build
+++ b/test cases/common/129 build by default/meson.build
@@ -9,6 +9,7 @@ executable('fooprog', 'foo.c',
 
 executable('barprog', 'foo.c',
     build_by_default : false,
+    install : true,
 )
 
 comp = files('mygen.py')


### PR DESCRIPTION
Allow setting build_by_default to False even when install is True. An improper code check for the default case accidently covered also the case in which the value is explicitly being passed by the user, causing the user's value to be ignored.

Resolves #13498.