### PR TITLE
uninstall: handle elevation to root like minstall

### DIFF
--- a/mesonbuild/scripts/uninstall.py
+++ b/mesonbuild/scripts/uninstall.py
@@ -4,7 +4,18 @@
 from __future__ import annotations
 
 import os
+import selectors
+import shutil
+import sys
 import typing as T
+
+from ..mesonlib import (is_windows)
+try:
+    from __main__ import __file__ as main_file
+except ImportError:
+    # Happens when running as meson.exe which is native Windows.
+    # This is only used for pkexec which is not, so this is fine.
+    main_file = None
 
 logfile = 'meson-logs/install-log.txt'
 
@@ -22,6 +33,36 @@ def do_uninstall(log: str) -> None:
                 os.unlink(fname)
             print('Deleted:', fname)
             successes += 1
+        except PermissionError:
+            if is_windows() or not os.isatty(sys.stdout.fileno()) or not os.isatty(sys.stderr.fileno()):
+                # can't elevate to root except in an interactive unix environment *and* when not doing a destdir install
+                raise
+            rootcmd = os.environ.get('MESON_ROOT_CMD') or shutil.which('sudo') or shutil.which('doas')
+            pkexec = shutil.which('pkexec')
+            if rootcmd is None and pkexec is not None and 'PKEXEC_UID' not in os.environ:
+                rootcmd = pkexec
+
+            if rootcmd is not None:
+                print('Uninstall failed due to insufficient permissions.')
+                s = selectors.DefaultSelector()
+                s.register(sys.stdin, selectors.EVENT_READ)
+                ans = None
+                for attempt in range(5):
+                    print(f'Attempt to use {rootcmd} to gain elevated privileges? [y/n] ', end='', flush=True)
+                    if s.select(30):
+                        # we waited on sys.stdin *only*
+                        ans = sys.stdin.readline().rstrip('\n')
+                    else:
+                        print()
+                        break
+                    if ans in {'y', 'n'}:
+                        break
+                else:
+                    if ans is not None:
+                        raise MesonException('Answer not one of [y/n]')
+                if ans == 'y':
+                    os.execlp(rootcmd, rootcmd, sys.executable, main_file, *sys.argv[1:])
+            raise
         except Exception as e:
             print(f'Could not delete {fname}: {e}.')
             failures += 1


### PR DESCRIPTION
For better consistency and because it can often come in handy.

---

Supersedes https://github.com/mesonbuild/meson/pull/8846 by following the approach of https://github.com/mesonbuild/meson/pull/11366 