### PR TITLE
Rewriter: Handle unknown write targets

### DIFF
--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -517,16 +517,21 @@ class Rewriter:
             arg_node = node.args
         elif cmd['function'] == 'target':
             tmp = self.find_target(cmd['id'])
-            if tmp:
-                node = tmp['node']
-                arg_node = node.args
+            if not tmp:
+                mlog.error('Unable to find the target', mlog.bold(cmd['id']), *self.on_error())
+                return self.handle_error()
+            node = tmp['node']
+            arg_node = node.args
         elif cmd['function'] == 'dependency':
             tmp = self.find_dependency(cmd['id'])
-            if tmp:
-                node = tmp['node']
-                arg_node = node.args
+            if not tmp:
+                mlog.error('Unable to find the dependency', mlog.bold(cmd['id']), *self.on_error())
+                return self.handle_error()
+            node = tmp['node']
+            arg_node = node.args
         if not node:
-            mlog.error('Unable to find the function node')
+            mlog.error('Unable to find the function node', *self.on_error())
+            return self.handle_error()
         assert isinstance(node, FunctionNode)
         assert isinstance(arg_node, ArgumentNode)
         # Transform the key nodes to plain strings


### PR DESCRIPTION
Add error checks for cases in which the write target is unknown and ensure all error cases indeed abort the execution to avoid internal crash.

Resolves #13502.