### PR TITLE
test: fix hang when running tests that need parsing with `--interactive`

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -924,7 +924,8 @@ class TestRun:
         return super().__new__(TestRun.PROTOCOL_TO_CLASS[test.protocol])
 
     def __init__(self, test: TestSerialisation, test_env: T.Dict[str, str],
-                 name: str, timeout: T.Optional[int], is_parallel: bool, verbose: bool):
+                 name: str, timeout: T.Optional[int], is_parallel: bool, verbose: bool,
+                 interactive: bool):
         self.res = TestResult.PENDING
         self.test = test
         self._num: T.Optional[int] = None
@@ -944,6 +945,7 @@ class TestRun:
         self.junit: T.Optional[et.ElementTree] = None
         self.is_parallel = is_parallel
         self.verbose = verbose
+        self.interactive = interactive
         self.warnings: T.List[str] = []
 
     def start(self, cmd: T.List[str]) -> None:
@@ -957,6 +959,15 @@ class TestRun:
             TestRun.TEST_NUM += 1
             self._num = TestRun.TEST_NUM
         return self._num
+
+    @property
+    def console_mode(self) -> ConsoleUser:
+        if self.interactive:
+            return ConsoleUser.INTERACTIVE
+        elif self.direct_stdout:
+            return ConsoleUser.STDOUT
+        else:
+            return ConsoleUser.LOGGER
 
     @property
     def direct_stdout(self) -> bool:
@@ -1450,14 +1461,11 @@ class SingleTestRunner:
 
         is_parallel = test.is_parallel and self.options.num_processes > 1 and not self.options.interactive
         verbose = (test.verbose or self.options.verbose) and not self.options.quiet
-        self.runobj = TestRun(test, env, name, timeout, is_parallel, verbose)
+        self.runobj = TestRun(test, env, name, timeout, is_parallel, verbose, self.options.interactive)
 
-        if self.options.interactive:
-            self.console_mode = ConsoleUser.INTERACTIVE
-        elif self.runobj.direct_stdout:
-            self.console_mode = ConsoleUser.STDOUT
-        else:
-            self.console_mode = ConsoleUser.LOGGER
+    @property
+    def console_mode(self) -> ConsoleUser:
+        return self.runobj.console_mode
 
     def _get_test_cmd(self) -> T.Optional[T.List[str]]:
         testentry = self.test.fname[0]

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -242,6 +242,7 @@ class TestResult(enum.Enum):
     EXPECTEDFAIL = 'EXPECTEDFAIL'
     UNEXPECTEDPASS = 'UNEXPECTEDPASS'
     ERROR = 'ERROR'
+    IGNORED = 'IGNORED'
 
     @staticmethod
     def maxlen() -> int:
@@ -263,7 +264,7 @@ class TestResult(enum.Enum):
     def colorize(self, s: str) -> mlog.AnsiDecorator:
         if self.is_bad():
             decorator = mlog.red
-        elif self in (TestResult.SKIP, TestResult.EXPECTEDFAIL):
+        elif self in (TestResult.SKIP, TestResult.IGNORED, TestResult.EXPECTEDFAIL):
             decorator = mlog.yellow
         elif self.is_finished():
             decorator = mlog.green
@@ -833,7 +834,8 @@ class JunitBuilder(TestLogger):
                                {TestResult.INTERRUPT, TestResult.ERROR})),
                 failures=str(sum(1 for r in test.results if r.result in
                                  {TestResult.FAIL, TestResult.UNEXPECTEDPASS, TestResult.TIMEOUT})),
-                skipped=str(sum(1 for r in test.results if r.result is TestResult.SKIP)),
+                skipped=str(sum(1 for r in test.results if r.result in
+                                {TestResult.SKIP, TestResult.IGNORED})),
                 time=str(test.duration),
             )
 
@@ -843,6 +845,9 @@ class JunitBuilder(TestLogger):
                 testcase = et.SubElement(suite, 'testcase', name=str(subtest), classname=suitename)
                 if subtest.result is TestResult.SKIP:
                     et.SubElement(testcase, 'skipped')
+                elif subtest.result is TestResult.IGNORED:
+                    skip = et.SubElement(testcase, 'skipped')
+                    skip.text = 'Test output was not parsed.'
                 elif subtest.result is TestResult.ERROR:
                     et.SubElement(testcase, 'error')
                 elif subtest.result is TestResult.FAIL:
@@ -877,6 +882,10 @@ class JunitBuilder(TestLogger):
                                      classname=test.project, time=str(test.duration))
             if test.res is TestResult.SKIP:
                 et.SubElement(testcase, 'skipped')
+                suite.attrib['skipped'] = str(int(suite.attrib['skipped']) + 1)
+            elif test.res is TestResult.IGNORED:
+                skip = et.SubElement(testcase, 'skipped')
+                skip.text = 'Test output was not parsed.'
                 suite.attrib['skipped'] = str(int(suite.attrib['skipped']) + 1)
             elif test.res is TestResult.ERROR:
                 et.SubElement(testcase, 'error')
@@ -977,7 +986,7 @@ class TestRun:
         if self.results:
             # running or succeeded
             passed = sum(x.result.is_ok() for x in self.results)
-            ran = sum(x.result is not TestResult.SKIP for x in self.results)
+            ran = sum(x.result not in {TestResult.SKIP, TestResult.IGNORED} for x in self.results)
             if passed == ran:
                 return f'{passed} subtests passed'
             else:
@@ -997,6 +1006,8 @@ class TestRun:
     def _complete(self) -> None:
         if self.res == TestResult.RUNNING:
             self.res = TestResult.OK
+        if self.needs_parsing and self.console_mode is ConsoleUser.INTERACTIVE:
+            self.res = TestResult.IGNORED
         assert isinstance(self.res, TestResult)
         if self.should_fail and self.res in (TestResult.OK, TestResult.FAIL):
             self.res = TestResult.UNEXPECTEDPASS if self.res is TestResult.OK else TestResult.EXPECTEDFAIL
@@ -1614,6 +1625,7 @@ class TestHarness:
         self.unexpectedpass_count = 0
         self.success_count = 0
         self.skip_count = 0
+        self.ignored_count = 0
         self.timeout_count = 0
         self.test_count = 0
         self.name_max_len = 0
@@ -1757,6 +1769,8 @@ class TestHarness:
             self.timeout_count += 1
         elif result.res is TestResult.SKIP:
             self.skip_count += 1
+        elif result.res is TestResult.IGNORED:
+            self.ignored_count += 1
         elif result.res is TestResult.OK:
             self.success_count += 1
         elif result.res in {TestResult.FAIL, TestResult.ERROR, TestResult.INTERRUPT}:
@@ -1821,6 +1835,7 @@ class TestHarness:
           'Fail:              ': self.fail_count,
           'Unexpected Pass:   ': self.unexpectedpass_count,
           'Skipped:           ': self.skip_count,
+          'Ignored:           ': self.ignored_count,
           'Timeout:           ': self.timeout_count,
         }
 

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1597,7 +1597,7 @@ class SingleTestRunner:
                                        env=self.runobj.env,
                                        cwd=self.test.workdir)
 
-        if self.runobj.needs_parsing:
+        if self.runobj.needs_parsing and self.console_mode is not ConsoleUser.INTERACTIVE:
             parse_coro = self.runobj.parse(harness, p.stdout_lines())
             parse_task = asyncio.ensure_future(parse_coro)
         else:

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -23,7 +23,6 @@ import signal
 import subprocess
 import shlex
 import sys
-import textwrap
 import time
 import typing as T
 import unicodedata
@@ -1808,15 +1807,21 @@ class TestHarness:
         return prefix + left + middle + right
 
     def summary(self) -> str:
-        return textwrap.dedent('''
-            Ok:                 {:<4}
-            Expected Fail:      {:<4}
-            Fail:               {:<4}
-            Unexpected Pass:    {:<4}
-            Skipped:            {:<4}
-            Timeout:            {:<4}
-            ''').format(self.success_count, self.expectedfail_count, self.fail_count,
-                        self.unexpectedpass_count, self.skip_count, self.timeout_count)
+        results = {
+          'Ok:                ': self.success_count,
+          'Expected Fail:     ': self.expectedfail_count,
+          'Fail:              ': self.fail_count,
+          'Unexpected Pass:   ': self.unexpectedpass_count,
+          'Skipped:           ': self.skip_count,
+          'Timeout:           ': self.timeout_count,
+        }
+
+        summary = []
+        for result, count in results.items():
+            if count > 0 or result.startswith('Ok:') or result.startswith('Fail:'):
+                summary.append(result + '{:<4}'.format(count))
+
+        return '\n{}\n'.format('\n'.join(summary))
 
     def total_failure_count(self) -> int:
         return self.fail_count + self.unexpectedpass_count + self.timeout_count

--- a/test cases/unit/124 interactive tap/meson.build
+++ b/test cases/unit/124 interactive tap/meson.build
@@ -1,0 +1,4 @@
+project('interactive TAP output')
+
+test_script = find_program('script.py')
+test('main', test_script, protocol: 'tap')

--- a/test cases/unit/124 interactive tap/script.py
+++ b/test cases/unit/124 interactive tap/script.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+print('''1..2
+ok 1
+not ok 2''')

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -5148,3 +5148,11 @@ class AllPlatformTests(BasePlatformTests):
         testdir = os.path.join(self.common_test_dir, '1 trivial')
         self.init(testdir, extra_args=['-Dc_args=-DSOMETHING'])
         self.init(testdir, extra_args=['--wipe'])
+
+    def test_interactive_tap(self):
+        testdir = os.path.join(self.unit_test_dir, '124 interactive tap')
+        self.init(testdir, extra_args=['--wrap-mode=forcefallback'])
+        output = self._run(self.mtest_command + ['--interactive'])
+        self.assertRegex(output, r'Ok:\s*0')
+        self.assertRegex(output, r'Fail:\s*0')
+        self.assertRegex(output, r'Ignored:\s*1')


### PR DESCRIPTION
When running tests with `--interactive` we don't redirect stdin, stdout or stderr and instead pass them on to the user's console. This redirect causes us to hang in case the test in question needs parsing, like it is the case for TAP output, because we cannot read the process's stdout.

Fix this hang by not parsing output when running in interactive mode.