### PR TITLE
do @ variable substitution when parsing cmake format

### DIFF
--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -1189,6 +1189,9 @@ def do_replacement(regex: T.Pattern[str], line: str,
         else:
             # Template variable to be replaced
             varname = match.group('variable')
+            if not varname:
+                varname = match.group('cmake_variable')
+
             var_str = ''
             if varname in confdata:
                 var, _ = confdata.get(varname)
@@ -1280,11 +1283,15 @@ def get_variable_regex(variable_format: Literal['meson', 'cmake', 'cmake@'] = 'm
         ''', re.VERBOSE)
     else:
         regex = re.compile(r'''
-            (?:\\\\)+(?=\\?\$)  # Match multiple backslashes followed by a dollar sign
+            (?:\\\\)+(?=\\?(\$|@))  # Match multiple backslashes followed by a dollar sign or an @ symbol
             |                  # OR
             \\\${              # Match a backslash followed by a dollar sign and an opening curly brace
             |                  # OR
-            \${(?P<variable>[-a-zA-Z0-9_]+)}  # Match a variable enclosed in curly braces and capture the variable name
+            \${(?P<cmake_variable>[-a-zA-Z0-9_]+)}  # Match a variable enclosed in curly braces and capture the variable name
+            |                  # OR
+            (?<!\\)@(?P<variable>[-a-zA-Z0-9_]+)@  # Match a variable enclosed in @ symbols and capture the variable name; no matches beginning with '\@'
+            |                  # OR
+            (?P<escaped>\\@[-a-zA-Z0-9_]+\\@)  # Match an escaped variable enclosed in @ symbols
         ''', re.VERBOSE)
     return regex
 

--- a/test cases/common/14 configure file/config10.h.in
+++ b/test cases/common/14 configure file/config10.h.in
@@ -1,0 +1,4 @@
+/* Should both be the same */
+#define MESSAGE1 "@var@"
+#define MESSAGE2 "${var}"
+

--- a/test cases/common/14 configure file/meson.build
+++ b/test cases/common/14 configure file/meson.build
@@ -331,6 +331,16 @@ configure_file(output : 'config9b.h',
 
 test('test9', executable('prog9', 'prog9.c'))
 
+# Test @ and curly braces at the same time with cmake format
+conf10 = configuration_data()
+conf10.set('var', 'foo')
+configure_file(
+  input : 'config10.h.in',
+  output : '@BASENAME@',
+  format : 'cmake',
+  configuration : conf10)
+test('test10', executable('prog10', 'prog10.c'))
+
 check_inputs = find_program('check_inputs.py')
 configure_file(output : 'check_inputs.txt',
   input : ['prog.c', files('prog2.c', 'prog4.c')],

--- a/test cases/common/14 configure file/prog10.c
+++ b/test cases/common/14 configure file/prog10.c
@@ -1,0 +1,7 @@
+#include <string.h>
+#include <config10.h>
+
+int main(void) {
+    return strcmp(MESSAGE1, "foo")
+        || strcmp(MESSAGE2, "foo");
+}

--- a/test cases/frameworks/7 gnome/mkenums/meson.build
+++ b/test cases/frameworks/7 gnome/mkenums/meson.build
@@ -140,12 +140,9 @@ test('enum test 5', enumexe5)
 
 # Generate template then use as input to mkenums
 
-# Simple trick to copy the file without substitutions, can be
-# removed when https://github.com/mesonbuild/meson/pull/3383 is fixed
 gen_h_template = configure_file(input: 'enums.h.in',
   output: 'enums6.h.in',
-  configuration: configuration_data(),
-  format: 'cmake')
+  copy: true)
 
 enums_h6 = gnome.mkenums('enums6',
   sources : 'meson-sample.h',


### PR DESCRIPTION
the upstream behavior of configure_file in cmake parses both @VAR@ and ${VAR} and only supports disabling the bracket variables through the `@ONLY` argument, meson needs to follow this behavior for compatibility

this is an ugly solution but I think its best considering the alternatives:
- calling `do_conf_str` twice with both formats
    - will break if the first iteration places substitutes that match the format of the second iteration
- adapt the existing bracket format regex to support @
    - the existing regex is unholy and broken in more ways than I am willing to list, it would be better to completely gut this part of the code and replace it with regular python code
 - rewrite the code to not use regex
     - this would be quite complex and I am not familiar enough with mesondefine to be able to find any regressions. The lack of specification on how its suppose to work does not help either