### PR TITLE
tests: Avoid modifying '17 prebuild shared' test dir

### DIFF
--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1766,7 +1766,7 @@ class AllPlatformTests(BasePlatformTests):
 
     def test_prebuilt_shared_lib(self):
         (cc, _, object_suffix, shared_suffix) = self.detect_prebuild_env()
-        tdir = os.path.join(self.unit_test_dir, '17 prebuilt shared')
+        tdir = self.copy_srcdir(os.path.join(self.unit_test_dir, '17 prebuilt shared'))
         source = os.path.join(tdir, 'alexandria.c')
         objectfile = os.path.join(tdir, 'alexandria.' + object_suffix)
         impfile = os.path.join(tdir, 'alexandria.lib')


### PR DESCRIPTION
Tests can tread on each other's toes when parallelism is high enough.

In this case, `test_prebuilt_shared_lib` creates an object file in the `17 prebuilt shared` test dir.

`test_prebuilt_shared_lib_rpath_same_prefix` uses `shutil.copytree` to copy that same test dir to a temporary location.

If the former test cleans up its object file while `copytree` is running, the copy can fail with a fatal ENOENT `shutil.Error`.

Use `copy_srcdir` to prevent this from happening.