### PR TITLE
compiler: fix leftover chars in compiler.links()

### DIFF
--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -587,7 +587,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
                     compiler = clist[SUFFIX_TO_LANG[suffix]]
 
         extra_args = functools.partial(self._determine_args, kwargs)
-        deps, msg = self._determine_dependencies(kwargs['dependencies'], compile_only=False)
+        deps, msg = self._determine_dependencies(kwargs['dependencies'], compile_only=False, endl=None)
         result, cached = self.compiler.links(code, self.environment,
                                              compiler=compiler,
                                              extra_args=extra_args,


### PR DESCRIPTION
This is my first code pull request to meson, so please be patient with me. I have done little to no testing for this PR, but the change is taken directly from [`mesonbuild/interpreter/compiler.py:541`](https://github.com/mesonbuild/meson/blob/83253cdbaa8afd268286ca06520ca1cf2095dd28/mesonbuild/interpreter/compiler.py#L541), the change looks reasonable and only logging is affected (no core functionality is modified).

The following log output:

```
Checking if "strnstr() available" : links: NO
```

now becomes:

```
Checking if "strnstr() available" links: NO
```

This is more consistent with the `compiles()` method.