### PR TITLE
compilers: Pass `vs_module_defs` with `/DEF:` to LLD-LINK

### DIFF
--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -135,7 +135,7 @@ class ClangCompiler(GnuLikeCompiler):
             return []
 
     def gen_vs_module_defs_args(self, defsfile: str) -> T.List[str]:
-        if isinstance(self.linker, (MSVCDynamicLinker)):
+        if isinstance(self.linker, (ClangClDynamicLinker, MSVCDynamicLinker)):
             # With MSVC, DLLs only export symbols that are explicitly exported,
             # so if a module defs file is specified, we use that to export symbols
             return ['-Wl,/DEF:' + defsfile]


### PR DESCRIPTION
Recently, it is possible to install Clang with Visual Studio Installer. By default this Clang has a MSVC target, and invokes the Microsoft Linker; if `-fuse-ld=lld` is specified, it will invoke LLD-LINK. Both linkers take MSVC-style arguments, and take DEF files with `/DEF:<path>`.

Previously DEF files were passed in the GNU way, directly on the linker command line like an object file, which caused errors like

   lld-link: error: ..\my.def: unknown file type

While Clang-CL takes Unix-style options, it actually passes MSVC-style options to LINK or LLD-LINK with `-Wl,`. There is already a check for both linkers in `linker_to_compiler_args()`, so it's necessary to do the same in `gen_vs_module_defs_args()`.

This commit closes https://github.com/mesonbuild/meson/issues/13988.