### PR TITLE
Allow specifying exe suffix of cross host machine

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1999,8 +1999,10 @@ class Executable(BuildTarget):
         if not hasattr(self, 'prefix'):
             self.prefix = ''
         if not hasattr(self, 'suffix'):
-            # Executable for Windows or C#/Mono
-            if machine.is_windows() or machine.is_cygwin() or 'cs' in self.compilers:
+            suffix = machine.get_exe_suffix()
+            if suffix:
+                self.suffix = suffix
+            elif 'cs' in self.compilers:
                 self.suffix = 'exe'
             elif machine.system.startswith('wasm') or machine.system == 'emscripten':
                 self.suffix = 'js'

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -261,6 +261,7 @@ class MachineInfo(HoldableObject):
     endian: str
     kernel: T.Optional[str]
     subsystem: T.Optional[str]
+    exe_suffix: T.Optional[str]
 
     def __post_init__(self) -> None:
         self.is_64_bit: bool = self.cpu_family in CPU_FAMILIES_64_BIT
@@ -287,8 +288,9 @@ class MachineInfo(HoldableObject):
         system = literal['system']
         kernel = literal.get('kernel', None)
         subsystem = literal.get('subsystem', None)
+        exe_suffix = literal.get('exe_suffix', None)
 
-        return cls(system, cpu_family, literal['cpu'], endian, kernel, subsystem)
+        return cls(system, cpu_family, literal['cpu'], endian, kernel, subsystem, exe_suffix)
 
     def is_windows(self) -> bool:
         """
@@ -370,7 +372,9 @@ class MachineInfo(HoldableObject):
     # static libraries, and executables.
     # Versioning is added to these names in the backends as-needed.
     def get_exe_suffix(self) -> str:
-        if self.is_windows() or self.is_cygwin():
+        if self.exe_suffix:
+            return self.exe_suffix
+        elif self.is_windows() or self.is_cygwin():
             return 'exe'
         else:
             return ''

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -528,7 +528,8 @@ def detect_machine_info(compilers: T.Optional[CompilersDict] = None) -> MachineI
         detect_cpu(compilers) if compilers is not None else None,
         sys.byteorder,
         detect_kernel(system),
-        detect_subsystem(system))
+        detect_subsystem(system),
+        None)
 
 # TODO make this compare two `MachineInfo`s purely. How important is the
 # `detect_cpu_family({})` distinction? It is the one impediment to that.


### PR DESCRIPTION
implements #9857

adds support for an optional `exe_suffix` field in the `host_machine` section of cross file
that property will then end up being used as the executable suffix.

the `name_suffix` property of executable() will override this just like it overwrote the default suffix.

Here is the cross file I've used to test this:
```
[binaries]
c = 'gcc'

[host_machine]
system = 'linux'
cpu_family = 'x86_64'
cpu = 'x86'
endian = 'little'
exe_suffix = 'bla'
```
