### PR TITLE
Fix spurious error message so its clear using get_option() as a parameter to project() is prohibited

### DIFF
--- a/test cases/common/281 get_option in project function/meson.build
+++ b/test cases/common/281 get_option in project function/meson.build
@@ -1,0 +1,2 @@
+# Project
+project('test', 'c', version: '1.0' + get_option('append_to_version'))

--- a/test cases/common/281 get_option in project function/meson.options
+++ b/test cases/common/281 get_option in project function/meson.options
@@ -1,0 +1,1 @@
+option('append_to_version', type : 'string', value : '.0001', description : 'append to version')

--- a/test cases/common/281 get_option in project function/test.json
+++ b/test cases/common/281 get_option in project function/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "DEPRECATION: Project uses feature that was always broken, and is now deprecated since '1.7': Reading meson.options or a meson -Dopt=value parameter by using get_option() as a parameter to project() isn't allowed. Instead use something similar to run_command('./get_value.py', check: true).stdout().strip()"
+    }
+  ]
+}


### PR DESCRIPTION
Calling get_option() from within project() fails because the meson.options file hasn’t be read yet. Reading the options file from within func_get_option fixes the issue.

