### PR TITLE
print out which command needs an exe_wrapper

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -573,7 +573,7 @@ class Backend:
         is_cross_built = not self.environment.machines.matches_build_machine(exe_for_machine)
         if is_cross_built and self.environment.need_exe_wrapper():
             if not self.environment.has_exe_wrapper():
-                msg = 'An exe_wrapper is needed but was not found. Please define one ' \
+                msg = 'An exe_wrapper is needed for ' + exe_cmd[0] + ' but was not found. Please define one ' \
                       'in cross file and check the command and/or add it to PATH.'
                 raise MesonException(msg)
             exe_wrapper = self.environment.get_exe_wrapper()

--- a/test cases/failing/126 generator host binary/test.json
+++ b/test cases/failing/126 generator host binary/test.json
@@ -1,5 +1,8 @@
 {
   "stdout": [
-    { "line": "ERROR: An exe_wrapper is needed but was not found. Please define one in cross file and check the command and/or add it to PATH." }
+    {
+      "match": "re",
+      "line": "ERROR: An exe_wrapper is needed for .* but was not found. Please define one in cross file and check the command and/or add it to PATH."
+    }
   ]
 }

--- a/unittests/linuxcrosstests.py
+++ b/unittests/linuxcrosstests.py
@@ -146,7 +146,7 @@ class LinuxCrossMingwTests(BaseLinuxCrossTests):
         self.meson_cross_files = [os.path.join(testdir, 'broken-cross.txt')]
         # Force tracebacks so we can detect them properly
         env = {'MESON_FORCE_BACKTRACE': '1'}
-        error_message = "An exe_wrapper is needed but was not found. Please define one in cross file and check the command and/or add it to PATH."
+        error_message = "An exe_wrapper is needed for " + self.builddir + "/prog.exe but was not found. Please define one in cross file and check the command and/or add it to PATH."
 
         with self.assertRaises(MesonException) as cm:
             # Must run in-process or we'll get a generic CalledProcessError


### PR DESCRIPTION
It's not the first time I run into an issue with an intentionally missing exe_wrapper during cross compilation. In pretty much all the cases the project I tried to build already had code available to not need one in the first place. Print out what command was actually the culprit to make debugging this easier.