### PR TITLE
modules/rust: Specify the compiler version to bindgen when possible

### DIFF
--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -62,6 +62,10 @@ class RustModule(ExtensionModule):
     def __init__(self, interpreter: Interpreter) -> None:
         super().__init__(interpreter)
         self._bindgen_bin: T.Optional[T.Union[ExternalProgram, Executable, OverrideProgram]] = None
+        if 'rust' in interpreter.compilers.host:
+            self._bindgen_rust_target: T.Optional[str] = interpreter.compilers.host['rust'].version
+        else:
+            self._bindgen_rust_target = None
         self.methods.update({
             'test': self.test,
             'bindgen': self.bindgen,
@@ -250,6 +254,15 @@ class RustModule(ExtensionModule):
 
         if self._bindgen_bin is None:
             self._bindgen_bin = state.find_program('bindgen', wanted=kwargs['bindgen_version'])
+            if self._bindgen_rust_target is not None:
+                # ExternalCommand.command's type is bonkers
+                _, _, err = mesonlib.Popen_safe(
+                    T.cast('T.List[str]', self._bindgen_bin.get_command()) +
+                    ['--rust-target', self._bindgen_rust_target])
+                # Sometimes this is "invalid Rust target" and sometimes "invalid
+                # rust target"
+                if 'Got an invalid' in err:
+                    self._bindgen_rust_target = None
 
         name: str
         if isinstance(header, File):
@@ -317,9 +330,13 @@ class RustModule(ExtensionModule):
                 '@INPUT@', '--output',
                 os.path.join(state.environment.build_dir, '@OUTPUT0@')
             ] + \
-            kwargs['args'] + inline_wrapper_args + ['--'] + \
-            kwargs['c_args'] + clang_args + \
-            ['-MD', '-MQ', '@INPUT@', '-MF', '@DEPFILE@']
+            kwargs['args'] + inline_wrapper_args
+        if self._bindgen_rust_target and '--rust-target' not in cmd:
+            cmd.extend(['--rust-target', self._bindgen_rust_target])
+        cmd.append('--')
+        cmd.extend(kwargs['c_args'])
+        cmd.extend(clang_args)
+        cmd.extend(['-MD', '-MQ', '@INPUT@', '-MF', '@DEPFILE@'])
 
         target = CustomTarget(
             f'rustmod-bindgen-{name}'.replace('/', '_'),


### PR DESCRIPTION
bindgen by default may output code that an older rustc cannot successfully consume. To avoid this, we check if bindgen supports the rustc version we're using, if so, and if the user didn't set the `--rust-target` option, we will supply it to ensure that bindgen writes out code our rustc can use. If it does not support that version explicitly, we leave it at the default, assuming that our compiler version is newer than bindgen.