### PR TITLE
Add "objects" support to Rust targets

### DIFF
--- a/docs/markdown/snippets/rust-objects.md
+++ b/docs/markdown/snippets/rust-objects.md
@@ -1,0 +1,4 @@
+## `objects` added correctly to Rust executables
+
+Any objects included in a Rust executable were previously ignored.  They
+are now added correctly.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2023,7 +2023,7 @@ class NinjaBackend(backends.Backend):
         args += target.get_extra_args('rust')
         return args
 
-    def get_rust_compiler_deps_and_args(self, target: build.BuildTarget, rustc: Compiler) -> T.Tuple[T.List[str], T.List[RustDep], T.List[str]]:
+    def get_rust_compiler_deps_and_args(self, target: build.BuildTarget, rustc: Compiler) -> T.Tuple[T.List[str], T.List[str], T.List[RustDep], T.List[str]]:
         deps: T.List[str] = []
         project_deps: T.List[RustDep] = []
         args: T.List[str] = []
@@ -2054,6 +2054,12 @@ class NinjaBackend(backends.Backend):
             if modifiers:
                 type_ += ':' + ','.join(modifiers)
             args.append(f'-l{type_}={libname}')
+
+        objs, od = self.flatten_object_list(target)
+        for o in objs:
+            args.append(f'-Clink-arg={o}')
+            deps.append(o)
+        fortran_order_deps = self.get_fortran_order_deps(od)
 
         linkdirs = mesonlib.OrderedSet()
         external_deps = target.external_deps.copy()
@@ -2140,7 +2146,7 @@ class NinjaBackend(backends.Backend):
         if isinstance(target, build.SharedLibrary) or has_shared_deps:
             args += self.get_build_rpath_args(target, rustc)
 
-        return deps, project_deps, args
+        return deps, fortran_order_deps, project_deps, args
 
     def generate_rust_target(self, target: build.BuildTarget) -> None:
         rustc = T.cast('RustCompiler', target.compilers['rust'])
@@ -2164,7 +2170,7 @@ class NinjaBackend(backends.Backend):
         depfile = os.path.join(self.get_target_private_dir(target), target.name + '.d')
         args += self.get_rust_compiler_args(target, rustc, target.rust_crate_type, depfile)
 
-        deps, project_deps, deps_args = self.get_rust_compiler_deps_and_args(target, rustc)
+        deps, fortran_order_deps, project_deps, deps_args = self.get_rust_compiler_deps_and_args(target, rustc)
         args += deps_args
 
         proc_macro_dylib_path = None
@@ -2182,6 +2188,8 @@ class NinjaBackend(backends.Backend):
         element = NinjaBuildElement(self.all_outputs, target_name, compiler_name, main_rust_file)
         if orderdeps:
             element.add_orderdep(orderdeps)
+        if fortran_order_deps:
+            element.add_orderdep(fortran_order_deps)
         if deps:
             # dependencies need to cause a relink, they're not just for ordering
             element.add_dep(deps)
@@ -2197,7 +2205,7 @@ class NinjaBackend(backends.Backend):
             rustdoc = rustc.get_rustdoc(self.environment)
             args = rustdoc.get_exe_args()
             args += self.get_rust_compiler_args(target.doctests.target, rustdoc, target.rust_crate_type)
-            _, _, deps_args = self.get_rust_compiler_deps_and_args(target.doctests.target, rustdoc)
+            _, _, _, deps_args = self.get_rust_compiler_deps_and_args(target.doctests.target, rustdoc)
             args += deps_args
             target.doctests.cmd_args = args.to_native() + [main_rust_file] + target.doctests.cmd_args
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3458,6 +3458,8 @@ class Interpreter(InterpreterBase, HoldableObject):
 
         target = targetclass(name, self.subdir, self.subproject, for_machine, srcs, struct, objs,
                              self.environment, self.compilers[for_machine], kwargs)
+        if objs and target.uses_rust():
+            FeatureNew.single_use('objects in Rust targets', '1.8.0', self.subproject)
 
         self.add_target(name, target)
         self.project_args_frozen = True

--- a/test cases/rust/27 objects/lib1-dylib.rs
+++ b/test cases/rust/27 objects/lib1-dylib.rs
@@ -1,0 +1,15 @@
+extern "C" {
+    fn from_lib1();
+}
+
+#[no_mangle]
+extern "C" fn from_lib2()
+{
+    println!("hello world from rust");
+}
+
+#[no_mangle]
+pub extern "C" fn c_func()
+{
+    unsafe { from_lib1(); }
+}

--- a/test cases/rust/27 objects/lib1.c
+++ b/test cases/rust/27 objects/lib1.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include "lib1.h"
+#include "lib2.h"
+
+void from_lib2(void) {
+    printf("hello world from c\n");
+}
+
+void c_func(void) {
+    from_lib1();
+}

--- a/test cases/rust/27 objects/lib1.h
+++ b/test cases/rust/27 objects/lib1.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void from_lib2(void);
+void c_func(void);

--- a/test cases/rust/27 objects/lib2.c
+++ b/test cases/rust/27 objects/lib2.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include "lib1.h"
+#include "lib2.h"
+
+void from_lib1(void)
+{
+    from_lib2();
+}

--- a/test cases/rust/27 objects/lib2.h
+++ b/test cases/rust/27 objects/lib2.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void from_lib1(void);

--- a/test cases/rust/27 objects/main.rs
+++ b/test cases/rust/27 objects/main.rs
@@ -1,0 +1,9 @@
+extern "C" {
+    fn c_func();
+}
+
+fn main() {
+    unsafe {
+        c_func();
+    }
+}

--- a/test cases/rust/27 objects/meson.build
+++ b/test cases/rust/27 objects/meson.build
@@ -1,0 +1,18 @@
+project('staticlib group', 'c', 'rust', meson_version: '>=1.8.0')
+
+lib1 = static_library('lib1', 'lib1.c')
+dep1 = declare_dependency(objects: lib1.extract_all_objects(recursive: false))
+lib2 = static_library('lib2', 'lib2.c')
+dep2 = declare_dependency(objects: lib2.extract_all_objects(recursive: false))
+executable('lib1objs', 'main.rs',
+  objects: lib1.extract_all_objects(recursive: false),
+  link_with: lib2)
+executable('lib2objs', 'main.rs',
+  objects: lib2.extract_all_objects(recursive: false),
+  link_with: lib1)
+executable('lib1objs_as_dep', 'main.rs',
+  dependencies: dep1,
+  link_with: lib2)
+executable('lib2objs_as_dep', 'main.rs',
+  dependencies: dep2,
+  link_with: lib1)

--- a/test cases/rust/27 objects/meson.build
+++ b/test cases/rust/27 objects/meson.build
@@ -16,3 +16,13 @@ executable('lib1objs_as_dep', 'main.rs',
 executable('lib2objs_as_dep', 'main.rs',
   dependencies: dep2,
   link_with: lib1)
+
+lib12 = shared_library('dylib2objs', 'lib1-dylib.rs',
+  objects: lib2.extract_all_objects(recursive: false),
+  rust_abi: 'c')
+executable('dylib', 'main.rs', link_with: lib12)
+
+lib12 = shared_library('dylib2objs_as_dep', 'lib1-dylib.rs',
+  dependencies: dep2,
+  rust_abi: 'c')
+executable('dylib_as_dep', 'main.rs', link_with: lib12)


### PR DESCRIPTION
Because rustc does not support extract_objects, QEMU creates a static library
with all the C objects. It then passes this static library as link_whole,
together with another static library containing general purpose utility
functions which is passed as link_with.
    
However, this is brittle because the two have a circular dependency and
they cannot be merged because of the link_whole/link_with difference.
While lld seems to have the --start-group/--end-group semantics
automatically, ld.bfd can fail if these options are needed. This can
cause difference between distros depending on how Rust is packaged
(e.g. Ubuntu 22.04 and Debian bookworm seem to use ld.bfd).
    
The simplest solution is for Meson to implement "objects:" properly
for Rust.  Then QEMU can use the same internal dependency objects that it
already has in place for C programs.

To limit conflicts, this PR includes part of #13933.