### PR TITLE
Prioritise Apple's toolchain in project-tests-appleclang

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -110,7 +110,9 @@ jobs:
         # These cannot evaluate anything, so we cannot set PATH or SDKROOT here
       run: |
         export SDKROOT="$(xcodebuild -version -sdk macosx Path)"
-        export PATH="$HOME/tools:/opt/homebrew/opt/qt@5/bin:/opt/homebrew/opt/llvm/bin:/opt/homebrew/opt/ncurses/bin:$PATH"
+        # Append LLVM's bin directory to PATH to prioritise Apple Clang over Homebrew Clang.
+        # We need this to avoid objfw test failures.
+        export PATH="$HOME/tools:/opt/homebrew/opt/qt@5/bin:/opt/homebrew/opt/ncurses/bin:$PATH:/opt/homebrew/opt/llvm/bin"
         export PKG_CONFIG_PATH="/opt/homebrew/opt/qt@5/lib/pkgconfig:/opt/homebrew/opt/lapack/lib/pkgconfig:/opt/homebrew/opt/ncurses/lib/pkgconfig:$PKG_CONFIG_PATH"
         ./tools/run_with_cov.py ./run_project_tests.py --backend=ninja
 


### PR DESCRIPTION
Using Homebrew Clang leads to failures when testing objfw. We probably
want to ensure we use Apple Clang here given the workflow job name, in
any case.
