### PR TITLE
Cleanup some issues (mostly typing) in dependency code

### DIFF
--- a/mesonbuild/dependencies/detect.py
+++ b/mesonbuild/dependencies/detect.py
@@ -59,10 +59,10 @@ def get_dep_identifier(name: str, kwargs: T.Dict[str, T.Any]) -> 'TV_DepID':
         # All keyword arguments are strings, ints, or lists (or lists of lists)
         if isinstance(value, list):
             for i in value:
-                assert isinstance(i, str)
+                assert isinstance(i, str), i
             value = tuple(frozenset(listify(value)))
         else:
-            assert isinstance(value, (str, bool, int))
+            assert isinstance(value, (str, bool, int)), value
         identifier = (*identifier, (key, value),)
     return identifier
 

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -584,7 +584,7 @@ class JNISystemDependency(SystemDependency):
                 self.is_found = False
                 return
 
-        if 'version' in kwargs and not version_compare(self.version, kwargs['version']):
+        if 'version' in kwargs and not version_compare_many(self.version, kwargs['version']):
             mlog.error(f'Incorrect JDK version found ({self.version}), wanted {kwargs["version"]}')
             self.is_found = False
             return

--- a/mesonbuild/dependencies/dub.py
+++ b/mesonbuild/dependencies/dub.py
@@ -328,7 +328,7 @@ class DubDependency(ExternalDependency):
         for lib in bs['libs']:
             if os.name != 'nt':
                 # trying to add system libraries by pkg-config
-                pkgdep = PkgConfigDependency(lib, environment, {'required': 'true', 'silent': 'true'})
+                pkgdep = PkgConfigDependency(lib, environment, {'required': True, 'silent': True})
                 if pkgdep.is_found:
                     for arg in pkgdep.get_compile_args():
                         self.compile_args.append(arg)

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -371,7 +371,7 @@ class CursesSystemDependency(SystemDependency):
                         req = kwargs.get('version')
                         if req:
                             if self.version:
-                                self.is_found = mesonlib.version_compare(self.version, req)
+                                self.is_found, *_ = mesonlib.version_compare_many(self.version, req)
                             else:
                                 mlog.warning('Cannot determine version of curses to compare against.')
 

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -29,7 +29,9 @@ def netcdf_factory(env: 'Environment',
                    for_machine: 'mesonlib.MachineChoice',
                    kwargs: T.Dict[str, T.Any],
                    methods: T.List[DependencyMethods]) -> T.List['DependencyGenerator']:
-    language = kwargs.get('language', 'c')
+    language = kwargs.get('language')
+    if language is None:
+        language = 'c'
     if language not in ('c', 'cpp', 'fortran'):
         raise DependencyException(f'Language {language} is not supported with NetCDF.')
 

--- a/mesonbuild/dependencies/mpi.py
+++ b/mesonbuild/dependencies/mpi.py
@@ -27,7 +27,9 @@ def mpi_factory(env: 'Environment',
                 for_machine: 'MachineChoice',
                 kwargs: T.Dict[str, T.Any],
                 methods: T.List[DependencyMethods]) -> T.List['DependencyGenerator']:
-    language = kwargs.get('language', 'c')
+    language = kwargs.get('language')
+    if language is None:
+        language = 'c'
     if language not in {'c', 'cpp', 'fortran'}:
         # OpenMPI doesn't work without any other languages
         return []

--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -417,6 +417,9 @@ def python_factory(env: 'Environment', for_machine: 'MachineChoice',
                     set_env('PKG_CONFIG_LIBDIR', old_pkg_libdir)
                     set_env('PKG_CONFIG_PATH', old_pkg_path)
 
+            # Otherwise this doesn't fulfill the interface requirements
+            wrap_in_pythons_pc_dir.log_tried = PythonPkgConfigDependency.log_tried  # type: ignore[attr-defined]
+
             candidates.append(functools.partial(wrap_in_pythons_pc_dir, pkg_name, env, kwargs, installation))
             # We only need to check both, if a python install has a LIBPC. It might point to the wrong location,
             # e.g. relocated / cross compilation, but the presence of LIBPC indicates we should definitely look for something.


### PR DESCRIPTION
This is the first bit of code split out of #13995

This contains generic cleanups to core dependency code (and to the python module around dependencies).

Theoretically, all of this could be tagged for backport, except maybe for the commit to make the assertions print a more helpful message.