### PR TITLE
Hide warnings from Cargo downloaded subprojects

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -98,6 +98,8 @@ machine](#specifying-options-per-machine) section for details.
 | force_fallback_for                     | []            | Force fallback for those dependencies                          | no             | no                |
 | vsenv                                  | false         | Activate Visual Studio environment                             | no             | no                |
 
+(For the Rust language only, `warning_level=0` disables all warnings).
+
 #### Details for `backend`
 
 Several build file formats are supported as command runners to build the

--- a/docs/markdown/snippets/cargo_cap_lints.md
+++ b/docs/markdown/snippets/cargo_cap_lints.md
@@ -1,0 +1,8 @@
+## `--cap-lints allow` used for Cargo subprojects
+
+Similar to Cargo itself, all downloaded Cargo subprojects automatically
+add the `--cap-lints allow` compiler argument, thus hiding any warnings
+from the compiler.
+
+Related to this, `warning_level=0` now translates into `--cap-lints allow`
+for Rust targets instead of `-A warnings`.

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -69,7 +69,7 @@ class RustCompiler(Compiler):
     id = 'rustc'
 
     _WARNING_LEVELS: T.Dict[str, T.List[str]] = {
-        '0': ['-A', 'warnings'],
+        '0': ['--cap-lints', 'allow'],
         '1': [],
         '2': [],
         '3': ['-W', 'warnings'],

--- a/mesonbuild/scripts/clippy.py
+++ b/mesonbuild/scripts/clippy.py
@@ -41,14 +41,23 @@ class ClippyDriver:
 
                 cmdlist = list(clippy)
                 prev = None
+                lints_cap = None
                 for arg in src_block['parameters']:
-                    if prev:
+                    if prev == '--cap-lints':
+                        cmdlist.append(prev)
+                        lints_cap = arg
+                        prev = None
+                    elif prev:
                         prev = None
                         continue
-                    elif arg in {'--emit', '--out-dir'}:
+                    if arg in {'--emit', '--out-dir', '--cap-lints'}:
                         prev = arg
                     else:
                         cmdlist.append(arg)
+
+                # no use in running clippy if it wouldn't print anything anyway
+                if lints_cap == 'allow':
+                    break
 
                 cmdlist.extend(src_block['sources'])
                 # the default for --emit is to go all the way to linking,


### PR DESCRIPTION
In Rust, the equivalent of -W/-D options can be added inside the sources themselves (`#[warn]`, `#[deny]`) and therefore it's quite common for a crate to stop building with newer compilers.

To avoid this, Cargo hides warnings from non-path dependencies using the special flag `--cap-lints allow`. Do the same for downloaded Cargo subprojects by adding `warning_level=0` to the generated subproject's default options. While warning_level=0 generally means "compiler default", Rust has always used it for the similar but inferior option `-A warnings`, so just replace that with `--cap-lints allow`.

The question is what to do for pure-Meson Rust subprojects. Here I'm leaving them aside, because they can do the check themselves with `meson.is_subproject()` if they wanted and because in general I'm tending to treat pure-Meson Rust subprojects as if they follow more the C standards for diagnostics. Therefore I expect them to do something like "use werror when built from git and disable it for releases", or "use `#[deny]` sparingly and rely more on `#[warn]` and werror".