### PR TITLE
Support for UEFI target

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -168,6 +168,7 @@ These are provided by the `.system()` method call.
 | openbsd             | |
 | windows             | Native Windows (not Cygwin or MSYS2) |
 | sunos               | illumos and Solaris |
+| uefi                | |
 
 Any string not listed above is not guaranteed to remain stable in
 future releases.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2366,6 +2366,10 @@ class SharedLibrary(BuildTarget):
             suffix = 'so'
             # Android doesn't support shared_library versioning
             self.filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
+        elif self.environment.machines[self.for_machine].is_uefi():
+            prefix = 'lib'
+            suffix = 'lib'
+            self.filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
         else:
             prefix = 'lib'
             suffix = 'so'

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -366,12 +366,18 @@ class MachineInfo(HoldableObject):
         """Machine is IRIX?"""
         return self.system.startswith('irix')
 
+    def is_uefi(self) -> bool:
+        """Machine is UEFI?"""
+        return self.system == 'uefi'
+
     # Various prefixes and suffixes for import libraries, shared libraries,
     # static libraries, and executables.
     # Versioning is added to these names in the backends as-needed.
     def get_exe_suffix(self) -> str:
         if self.is_windows() or self.is_cygwin():
             return 'exe'
+        elif self.is_uefi():
+            return 'efi'
         else:
             return ''
 
@@ -382,7 +388,7 @@ class MachineInfo(HoldableObject):
             return 'o'
 
     def libdir_layout_is_win(self) -> bool:
-        return self.is_windows() or self.is_cygwin()
+        return self.is_windows() or self.is_cygwin() or self.is_uefi()
 
 class BinaryTable:
 

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -687,6 +687,9 @@ def is_qnx() -> bool:
 def is_aix() -> bool:
     return platform.system().lower() == 'aix'
 
+def is_uefi() -> bool:
+    return platform.system().lower() == 'uefi'
+
 @lru_cache(maxsize=None)
 def darwin_get_object_archs(objpath: str) -> 'ImmutableListProtocol[str]':
     '''

--- a/test cases/common/132 get define/meson.build
+++ b/test cases/common/132 get define/meson.build
@@ -13,6 +13,7 @@ system_define_map = {
   'openbsd'   : ['__OpenBSD__',   '1'],
   'gnu'       : ['__GNU__',       '1'],
   'sunos'     : ['__sun__',       '1'],
+  'uefi'      : ['__uefi__',      '1'],
 
   # The __FreeBSD__ define will be equal to the major version of the release
   # (ex, in FreeBSD 11.x, __FreeBSD__ == 11). To make the test robust when


### PR DESCRIPTION
Requires some new LLVM PR's to be merged - https://github.com/llvm/llvm-project/pull/120632

This PR introduces basic support for UEFI as an OS. The idea is to be able to support projects using Meson to be cross compiled to UEFI using LLVM and using LLVM libc. I likely haven't implemented everything needed but with grepping the source tree, this looks like a good start.