### PR TITLE
Add support for .hg_archival.txt to detect_vcs

### DIFF
--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -773,6 +773,14 @@ def detect_vcs(source_dir: T.Union[str, Path]) -> T.Optional[T.Dict[str, str]]:
             'dep': '.hg/dirstate'
         },
         {
+            'name': 'mercurial',
+            'cmd': 'cat',
+            'repo_dir': '.',
+            'get_rev': 'cat .hg_archival.txt',
+            'rev_regex': 'node: (.*)\n',
+            'dep': '.hg_archival.txt'
+        },
+        {
             'name': 'subversion',
             'cmd': 'svn',
             'repo_dir': '.svn',


### PR DESCRIPTION
This allows `vcs_tag()` to work on a mercurial archived tarball so programs can display the revision at runtime.

I used cat for now which obviously won't work on windows but wasn't sure how else to handle that case. Thoughts?