### PR TITLE
test cases: fix '8 flex' with C23

### DIFF
--- a/test cases/frameworks/8 flex/lexer.l
+++ b/test cases/frameworks/8 flex/lexer.l
@@ -3,11 +3,11 @@
 #include "parser.tab.h"
 
 extern int yylex(void);
-extern int yyerror();
+extern int yyerror(char *s);
 %}
 
 %option noyywrap nounput noinput
 
 %%
 ("true"|"false")    {return BOOLEAN;}
-. { yyerror(); }
+. { yyerror("Invalid value"); }

--- a/test cases/frameworks/8 flex/parser.y
+++ b/test cases/frameworks/8 flex/parser.y
@@ -1,6 +1,6 @@
 %{
 extern int yylex(void);
-extern int yyerror();
+extern int yyerror(char *s);
 %}
 
 %token BOOLEAN

--- a/test cases/frameworks/8 flex/prog.c
+++ b/test cases/frameworks/8 flex/prog.c
@@ -24,7 +24,7 @@ int yywrap(void) {
      return 0;
 }
 
-int yyerror(void) {
-     printf("Parse error\n");
+int yyerror(char* s) {
+     printf("Parse error: %s\n", s);
      exit(1);
 }


### PR DESCRIPTION
With C23 (as upcoming GCC 15 will default to), `void yyerror()` is the same as `void yyerror(void)`, i.e. `yyerror` takes no arguments.

Fix the prototype given we *do* call it with an error string:
```
pgen.p/parser.tab.c: In function ‘yyparse’:
pgen.p/parser.tab.c:1104:7: error: too many arguments to function ‘yyerror’
 1104 |       yyerror (YY_("syntax error"));
      |       ^~~~~~~
../test cases/frameworks/8 flex/parser.y:3:12: note: declared here
    3 | extern int yyerror();
      |            ^~~~~~~
pgen.p/parser.tab.c:1215:3: error: too many arguments to function ‘yyerror’
 1215 |   yyerror (YY_("memory exhausted"));
      |   ^~~~~~~
../test cases/frameworks/8 flex/parser.y:3:12: note: declared here
    3 | extern int yyerror();
      |            ^~~~~~~
```

Bug: https://bugs.gentoo.org/946625