### PR TITLE
Fail gracefully when compiler cache is specified without compiler

### DIFF
--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -438,16 +438,19 @@ class BinaryTable:
 
     @classmethod
     def parse_entry(cls, entry: T.Union[str, T.List[str]]) -> T.Tuple[T.List[str], T.List[str]]:
-        compiler = mesonlib.stringlistify(entry)
+        parts = mesonlib.stringlistify(entry)
         # Ensure ccache exists and remove it if it doesn't
-        if compiler[0] == 'ccache':
-            compiler = compiler[1:]
+        if parts[0] == 'ccache':
+            compiler = parts[1:]
             ccache = cls.detect_ccache()
-        elif compiler[0] == 'sccache':
-            compiler = compiler[1:]
+        elif parts[0] == 'sccache':
+            compiler = parts[1:]
             ccache = cls.detect_sccache()
         else:
+            compiler = parts
             ccache = []
+        if not compiler:
+            raise EnvironmentException(f'Compiler cache specified without compiler: {parts[0]}')
         # Return value has to be a list of compiler 'choices'
         return compiler, ccache
 

--- a/unittests/failuretests.py
+++ b/unittests/failuretests.py
@@ -381,3 +381,8 @@ class FailureTests(BasePlatformTests):
     def test_error_func(self):
         self.assertMesonRaises("error('a', 'b', ['c', ['d', {'e': 'f'}]], 'g')",
                                r"Problem encountered: a b \['c', \['d', {'e' : 'f'}\]\] g")
+
+    def test_compiler_cache_without_compiler(self):
+        self.assertMesonRaises('',
+                               'Compiler cache specified without compiler: ccache',
+                               override_envvars={'CC': 'ccache'})


### PR DESCRIPTION
With

    CC=ccache meson ...

meson crashes with

    [...]
      File "/usr/lib/python3.10/site-packages/mesonbuild/compilers/detect.py", line 364, in _detect_c_or_cpp_compiler
        compiler_name = os.path.basename(compiler[0])
    IndexError: list index out of range

Improve this by throwing an `EnvironmentException` to fail gracefully when no compiler is specified.

Fixes #9933
Fixes #13589