### PR TITLE
compiler,rust: No native-static-libs for wasm after 1.84

### DIFF
--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -161,6 +161,9 @@ class RustCompiler(Compiler):
                 # no match and kernel == none (i.e. baremetal) is a valid use case.
                 # return and let native_static_libs list empty
                 return
+            if self.info.system == 'emscripten':
+                # no match and emscripten is valid after rustc 1.84
+                return
             raise EnvironmentException('Failed to find native-static-libs in Rust compiler output.')
         # Exclude some well known libraries that we don't need because they
         # are always part of C/C++ linkers. Rustc probably should not print


### PR DESCRIPTION
I am working on [adding support to gst-plugins-rs](https://github.com/fluendo/gst.wasm/issues/56) to `gst.wasm`. `gst.wasm` is a GStreamer port to WebAssembly where meson works correctly for all C/C++ projects. The last release of Rust, version 1.84, unblocks an issue with that language. Rust 1.84 [uses the latest emsdk 3.1.68](https://github.com/rust-lang/rust/pull/131533). Among many other things, it fixed an [issue with Emscripten dynamic linking and libc](https://github.com/rust-lang/libc/pull/4002). After that, no `native-static-libs` in the output if running:

```
rustc --target=wasm32-unknown-emscripten --crate-type staticlib --print native-static-libs - < /dev/null
```

Note:
```
[cerbero-web-wasm32] root@f4b4c9e2e3b8:/gst-plugins-rs# rustc --version
rustc 1.83.0 (90b35a623 2024-11-26)
[cerbero-web-wasm32] root@f4b4c9e2e3b8:/gst-plugins-rs# rustc --target=wasm32-unknown-emscripten --crate-type staticlib --print native-static-libs - < /dev/null
note: Link against the following native artifacts when linking against this static library. The order and any duplication can be significant on some platforms.

note: native-static-libs: -lc

[cerbero-web-wasm32] root@f4b4c9e2e3b8:/gst-plugins-rs# rustup default beta
info: using existing install for 'beta-x86_64-unknown-linux-gnu'
info: default toolchain set to 'beta-x86_64-unknown-linux-gnu'

  beta-x86_64-unknown-linux-gnu unchanged - rustc 	1.84.0-beta.5 (0857a8e32 2024-12-27)

[cerbero-web-wasm32] root@f4b4c9e2e3b8:/gst-plugins-rs# rustc --version
rustc 1.84.0-beta.5 (0857a8e32 2024-12-27)
[cerbero-web-wasm32] root@f4b4c9e2e3b8:/gst-plugins-rs# rustc --target=wasm32-unknown-emscripten --crate-type staticlib --print native-static-libs - < /dev/null
[cerbero-web-wasm32] root@f4b4c9e2e3b8:/gst-plugins-rs#
```
