### PR TITLE
programs: favor version numbers with dots

### DIFF
--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -113,7 +113,10 @@ class ExternalProgram(mesonlib.HoldableObject):
             output = o.strip()
             if not output:
                 output = e.strip()
-            match = re.search(r'([0-9][0-9\.]+)', output)
+
+            match = re.search(r'([0-9](\.[0-9]+)+)', output)
+            if not match:
+                match = re.search(r'([0-9][0-9\.]+)', output)
             if not match:
                 raise mesonlib.MesonException(f'Could not find a version number in output of {raw_cmd!r}')
             self.cached_version = match.group(1)

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -35,7 +35,7 @@ from mesonbuild.interpreterbase import typed_pos_args, InvalidArguments, ObjectH
 from mesonbuild.interpreterbase import typed_pos_args, InvalidArguments, typed_kwargs, ContainerTypeInfo, KwargInfo
 from mesonbuild.mesonlib import (
     LibType, MachineChoice, PerMachine, Version, is_windows, is_osx,
-    is_cygwin, is_openbsd, search_version, MesonException,
+    is_cygwin, is_openbsd, search_version, MesonException, python_command,
 )
 from mesonbuild.options import OptionKey
 from mesonbuild.interpreter.type_checking import in_set_validator, NoneType
@@ -673,6 +673,33 @@ class InternalTests(unittest.TestCase):
                     for link_arg in link_args:
                         for lib in ('pthread', 'm', 'c', 'dl', 'rt'):
                             self.assertNotIn(f'lib{lib}.a', link_arg, msg=link_args)
+
+    def test_program_version(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            script_path = Path(tmpdir) / 'script.py'
+            script_path.write_text('import sys\nprint(sys.argv[1])\n', encoding='utf-8')
+            script_path.chmod(0o755)
+
+            for output, expected in {
+                    '': None,
+                    '1': None,
+                    '1.2.4': '1.2.4',
+                    '1 1.2.4': '1.2.4',
+                    'foo version 1.2.4': '1.2.4',
+                    'foo 1.2.4.': '1.2.4',
+                    'foo 1.2.4': '1.2.4',
+                    'foo 1.2.4 bar': '1.2.4',
+                    '50 5.4.0': '5.4.0',
+                    'This is perl 5, version 40, subversion 0 (v5.40.0)': '5.40.0',
+                    'git version 2.48.0.rc1': '2.48.0',
+            }.items():
+                prog = ExternalProgram('script', command=[python_command, str(script_path), output], silent=True)
+
+                if expected is None:
+                    with self.assertRaisesRegex(MesonException, 'Could not find a version number'):
+                        prog.get_version()
+                else:
+                    self.assertEqual(prog.get_version(), expected)
 
     def test_version_compare(self):
         comparefunc = mesonbuild.mesonlib.version_compare_many


### PR DESCRIPTION
When using `find_program('perl')` we misdetect its version number:

    Program perl found: YES 40 40 (/usr/bin/perl)

This is caused by Perl outputting the version information in a somewhat weird format:

    $ perl --version

    This is perl 5, version 40, subversion 0 (v5.40.0) built for x86_64-linux-thread-multi

    ...

The problem here is that our version number detection picks the first match of at one digit followed by at least one more digit and/or dot. Consequently, as "40" matches that regular expression, we'd return its value as the version number.

Naturally, the version number detection we perform is best-effort, only, as there is no standardized format used by all programs. That being said, we can do better here by first trying to match a dotted version number so that we'd match the "5.40.0" string, not the "40". And given that most projects use dotted version numbers this should be a strict improvement in cases where we have multiple digits in-text. The old behaviour continues to be used as a fallback though in case we weren't able to match anything to not regress functionality.

The new regex also fixes another case: when the version information ends with a trailing dot, like "foo version 1.2.3.", then we'd also have matched that trailing dot. This can be for example the case when version numbers end with ".rc1" or something similar. While we'd ideally include such suffixes into the detected version, that issue is left for another day.

Add a couple of tests.