### PR TITLE
Fix #14072 symlinks not handled correctly by wrap patch.

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -870,4 +870,4 @@ class Resolver:
                     except PermissionError:
                         os.chmod(dst_file, stat.S_IWUSR)
                         os.remove(dst_file)
-                shutil.copy2(src_file, dst_dir)
+                shutil.copy2(src_file, dst_dir, follow_symlinks=False)


### PR DESCRIPTION
This fixes the problem described in the related issue https://github.com/mesonbuild/meson/issues/14072.