### PR TITLE
CI: Use a tagged version of cygwin-install-action

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -53,7 +53,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: cygwin/cygwin-install-action@master
+      - uses: cygwin/cygwin-install-action@v5
         with:
           platform: ${{ matrix.ARCH }}
           packages: |


### PR DESCRIPTION
Use a tagged version of cygwin-install-action, rather than whatever happens to be master at the moment.

This should help isolate meson CI from random breakage there.