### PR TITLE
Fix internal dependency names

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1364,7 +1364,8 @@ class BuildTarget(Target):
                                                               [],
                                                               dep.get_compile_args(),
                                                               dep.get_link_args(),
-                                                              [], [], [], [], [], {}, [], [], [])
+                                                              [], [], [], [], [], {}, [], [], [],
+                                                              dep.name)
                     self.external_deps.append(extpart)
                 # Deps of deps.
                 self.add_deps(dep.ext_deps)

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -111,7 +111,7 @@ class Dependency(HoldableObject):
         # This allows two Dependencies to be compared even after being copied.
         # The purpose is to allow the name to be changed, but still have a proper comparison
         self._id = uuid.uuid4().int
-        self.name = f'dep{id(self)}'
+        self.name = f'dep{self._id}'
         self.version:  T.Optional[str] = None
         self.language: T.Optional[str] = None # None means C-like
         self.is_found = False
@@ -278,7 +278,8 @@ class InternalDependency(Dependency):
                  extra_files: T.Sequence[mesonlib.File],
                  ext_deps: T.List[Dependency], variables: T.Dict[str, str],
                  d_module_versions: T.List[T.Union[str, int]], d_import_dirs: T.List['IncludeDirs'],
-                 objects: T.List['ExtractedObjects']):
+                 objects: T.List['ExtractedObjects'],
+                 name: T.Optional[str] = None):
         super().__init__(DependencyTypeName('internal'), {})
         self.version = version
         self.is_found = True
@@ -296,6 +297,8 @@ class InternalDependency(Dependency):
             self.d_features['versions'] = d_module_versions
         if d_import_dirs:
             self.d_features['import_dirs'] = d_import_dirs
+        if name:
+            self.name = name
 
     def __deepcopy__(self, memo: T.Dict[int, 'InternalDependency']) -> 'InternalDependency':
         result = self.__class__.__new__(self.__class__)
@@ -335,7 +338,7 @@ class InternalDependency(Dependency):
         return InternalDependency(
             self.version, final_includes, final_compile_args,
             final_link_args, final_libraries, final_whole_libraries,
-            final_sources, final_extra_files, final_deps, self.variables, [], [], [])
+            final_sources, final_extra_files, final_deps, self.variables, [], [], [], self.name)
 
     def get_include_dirs(self) -> T.List['IncludeDirs']:
         return self.include_directories


### PR DESCRIPTION
Internal dependency names were generated from object id. This cause problem when objects are copied, especially when generating partial dependency, or when extracting shared or static dependencies from both_library, because dependency names in target and dependencies introspection files become unrelated.

This fixes that by generating the dependency name from the internal id, and by using that base name when generating partial dependencies.