### PR TITLE
Cleanup and modernize the templates and commands used by `meson init`

### DIFF
--- a/mesonbuild/templates/cpptemplates.py
+++ b/mesonbuild/templates/cpptemplates.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 

--- a/mesonbuild/templates/cpptemplates.py
+++ b/mesonbuild/templates/cpptemplates.py
@@ -21,14 +21,19 @@ int main(int argc, char **argv) {{
 }}
 '''
 
-hello_cpp_meson_template = '''project('{project_name}', 'cpp',
+hello_cpp_meson_template = '''project(
+  '{project_name}',
+  'cpp',
   version : '{version}',
   meson_version : '>= {meson_version}',
-  default_options : ['warning_level=3',
-                     'cpp_std=c++14'])
+  default_options : ['warning_level=3', 'cpp_std=c++14'],
+)
 
-exe = executable('{exe_name}', '{source_name}',
-  install : true)
+exe = executable(
+  '{exe_name}',
+  '{source_name}',
+  install : true,
+)
 
 test('basic', exe)
 '''
@@ -94,29 +99,38 @@ int main(int argc, char **argv) {{
 }}
 '''
 
-lib_cpp_meson_template = '''project('{project_name}', 'cpp',
+lib_cpp_meson_template = '''project(
+  '{project_name}',
+  'cpp',
   version : '{version}',
   meson_version : '>= {meson_version}',
-  default_options : ['warning_level=3', 'cpp_std=c++14'])
+  default_options : ['warning_level=3', 'cpp_std=c++14'],
+)
 
 # These arguments are only used to build the shared library
 # not the executables that use the library.
 lib_args = ['-DBUILDING_{utoken}']
 
-shlib = shared_library('{lib_name}', '{source_file}',
+shlib = shared_library(
+  '{lib_name}',
+  '{source_file}',
   install : true,
   cpp_args : lib_args,
   gnu_symbol_visibility : 'hidden',
 )
 
-test_exe = executable('{test_exe_name}', '{test_source_file}',
-  link_with : shlib)
+test_exe = executable(
+  '{test_exe_name}',
+  '{test_source_file}',
+  link_with : shlib,
+)
 test('{test_name}', test_exe)
 
 # Make this library usable as a Meson subproject.
 {ltoken}_dep = declare_dependency(
-  include_directories: include_directories('.'),
-  link_with : shlib)
+  include_directories : include_directories('.'),
+  link_with : shlib,
+)
 
 # Make this library usable from the system's
 # package manager.

--- a/mesonbuild/templates/cpptemplates.py
+++ b/mesonbuild/templates/cpptemplates.py
@@ -3,9 +3,12 @@
 # Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
+import typing as T
 
 from mesonbuild.templates.sampleimpl import FileHeaderImpl
 
+if T.TYPE_CHECKING:
+    from ..minit import Arguments
 
 hello_cpp_template = '''#include <iostream>
 
@@ -118,11 +121,11 @@ dependencies = [{dependencies}
 # not the executables that use the library.
 lib_args = ['-DBUILDING_{utoken}']
 
-shlib = shared_library(
+lib = library(
   '{lib_name}',
   '{source_file}',
   install : true,
-  cpp_args : lib_args,
+  cpp_shared_args : lib_args,
   gnu_symbol_visibility : 'hidden',
   dependencies : dependencies,
 )
@@ -131,7 +134,7 @@ test_exe = executable(
   '{test_exe_name}',
   '{test_source_file}',
   dependencies : dependencies,
-  link_with : shlib,
+  link_with : lib,
 )
 test('{test_name}', test_exe)
 
@@ -139,7 +142,7 @@ test('{test_name}', test_exe)
 {ltoken}_dep = declare_dependency(
   include_directories : include_directories('.'),
   dependencies : dependencies,
-  link_with : shlib,
+  link_with : lib,
 )
 meson.override_dependency('{project_name}', {ltoken}_dep)
 
@@ -149,7 +152,7 @@ install_headers('{header_file}', subdir : '{header_dir}')
 
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(
-  shlib,
+  lib,
   description : 'Meson sample project.',
   subdirs : '{header_dir}',
 )
@@ -166,3 +169,7 @@ class CppProject(FileHeaderImpl):
     lib_header_template = lib_hpp_template
     lib_test_template = lib_cpp_test_template
     lib_meson_template = lib_cpp_meson_template
+
+    def __init__(self, args: Arguments):
+        super().__init__(args)
+        self.meson_version = '1.3.0'

--- a/mesonbuild/templates/cpptemplates.py
+++ b/mesonbuild/templates/cpptemplates.py
@@ -141,6 +141,7 @@ test('{test_name}', test_exe)
   dependencies : dependencies,
   link_with : shlib,
 )
+meson.override_dependency('{project_name}', {ltoken}_dep)
 
 # Make this library usable from the system's
 # package manager.

--- a/mesonbuild/templates/cpptemplates.py
+++ b/mesonbuild/templates/cpptemplates.py
@@ -29,10 +29,14 @@ hello_cpp_meson_template = '''project(
   default_options : ['warning_level=3', 'cpp_std=c++14'],
 )
 
+dependencies = [{dependencies}
+]
+
 exe = executable(
   '{exe_name}',
   '{source_name}',
   install : true,
+  dependencies : dependencies,
 )
 
 test('basic', exe)
@@ -107,6 +111,9 @@ lib_cpp_meson_template = '''project(
   default_options : ['warning_level=3', 'cpp_std=c++14'],
 )
 
+dependencies = [{dependencies}
+]
+
 # These arguments are only used to build the shared library
 # not the executables that use the library.
 lib_args = ['-DBUILDING_{utoken}']
@@ -117,11 +124,13 @@ shlib = shared_library(
   install : true,
   cpp_args : lib_args,
   gnu_symbol_visibility : 'hidden',
+  dependencies : dependencies,
 )
 
 test_exe = executable(
   '{test_exe_name}',
   '{test_source_file}',
+  dependencies : dependencies,
   link_with : shlib,
 )
 test('{test_name}', test_exe)
@@ -129,6 +138,7 @@ test('{test_name}', test_exe)
 # Make this library usable as a Meson subproject.
 {ltoken}_dep = declare_dependency(
   include_directories : include_directories('.'),
+  dependencies : dependencies,
   link_with : shlib,
 )
 

--- a/mesonbuild/templates/cpptemplates.py
+++ b/mesonbuild/templates/cpptemplates.py
@@ -149,12 +149,9 @@ install_headers('{header_file}', subdir : '{header_dir}')
 
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(
-  name : '{project_name}',
-  filebase : '{ltoken}',
+  shlib,
   description : 'Meson sample project.',
   subdirs : '{header_dir}',
-  libraries : shlib,
-  version : '{version}',
 )
 '''
 

--- a/mesonbuild/templates/cpptemplates.py
+++ b/mesonbuild/templates/cpptemplates.py
@@ -23,6 +23,7 @@ int main(int argc, char **argv) {{
 
 hello_cpp_meson_template = '''project('{project_name}', 'cpp',
   version : '{version}',
+  meson_version : '>= {meson_version}',
   default_options : ['warning_level=3',
                      'cpp_std=c++14'])
 
@@ -95,6 +96,7 @@ int main(int argc, char **argv) {{
 
 lib_cpp_meson_template = '''project('{project_name}', 'cpp',
   version : '{version}',
+  meson_version : '>= {meson_version}',
   default_options : ['warning_level=3', 'cpp_std=c++14'])
 
 # These arguments are only used to build the shared library

--- a/mesonbuild/templates/cstemplates.py
+++ b/mesonbuild/templates/cstemplates.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 

--- a/mesonbuild/templates/cstemplates.py
+++ b/mesonbuild/templates/cstemplates.py
@@ -26,6 +26,7 @@ public class {class_name} {{
 
 hello_cs_meson_template = '''project('{project_name}', 'cs',
   version : '{version}',
+  meson_version : '>= {meson_version}',
   default_options : ['warning_level=3'])
 
 exe = executable('{exe_name}', '{source_name}',
@@ -63,6 +64,7 @@ public class {class_test} {{
 
 lib_cs_meson_template = '''project('{project_name}', 'cs',
   version : '{version}',
+  meson_version : '>= {meson_version}',
   default_options : ['warning_level=3'])
 
 stlib = shared_library('{lib_name}', '{source_file}',

--- a/mesonbuild/templates/cstemplates.py
+++ b/mesonbuild/templates/cstemplates.py
@@ -24,13 +24,19 @@ public class {class_name} {{
 
 '''
 
-hello_cs_meson_template = '''project('{project_name}', 'cs',
+hello_cs_meson_template = '''project(
+  '{project_name}',
+  'cs',
   version : '{version}',
   meson_version : '>= {meson_version}',
-  default_options : ['warning_level=3'])
+  default_options : ['warning_level=3'],
+)
 
-exe = executable('{exe_name}', '{source_name}',
-  install : true)
+exe = executable(
+  '{exe_name}',
+  '{source_name}',
+  install : true,
+)
 
 test('basic', exe)
 '''
@@ -62,23 +68,32 @@ public class {class_test} {{
 
 '''
 
-lib_cs_meson_template = '''project('{project_name}', 'cs',
+lib_cs_meson_template = '''project(
+  '{project_name}',
+  'cs',
   version : '{version}',
   meson_version : '>= {meson_version}',
-  default_options : ['warning_level=3'])
+  default_options : ['warning_level=3'],
+)
 
-stlib = shared_library('{lib_name}', '{source_file}',
+stlib = shared_library(
+  '{lib_name}',
+  '{source_file}',
   install : true,
 )
 
-test_exe = executable('{test_exe_name}', '{test_source_file}',
-  link_with : stlib)
+test_exe = executable(
+  '{test_exe_name}',
+  '{test_source_file}',
+  link_with : stlib,
+)
 test('{test_name}', test_exe)
 
 # Make this library usable as a Meson subproject.
 {ltoken}_dep = declare_dependency(
-  include_directories: include_directories('.'),
-  link_with : stlib)
+  include_directories : include_directories('.'),
+  link_with : stlib,
+)
 
 '''
 

--- a/mesonbuild/templates/cstemplates.py
+++ b/mesonbuild/templates/cstemplates.py
@@ -32,10 +32,14 @@ hello_cs_meson_template = '''project(
   default_options : ['warning_level=3'],
 )
 
+dependencies = [{dependencies}
+]
+
 exe = executable(
   '{exe_name}',
   '{source_name}',
   install : true,
+  dependencies : dependencies,
 )
 
 test('basic', exe)
@@ -76,15 +80,20 @@ lib_cs_meson_template = '''project(
   default_options : ['warning_level=3'],
 )
 
+dependencies = [{dependencies}
+]
+
 stlib = shared_library(
   '{lib_name}',
   '{source_file}',
+  dependencies : dependencies,
   install : true,
 )
 
 test_exe = executable(
   '{test_exe_name}',
   '{test_source_file}',
+  dependencies : dependencies,
   link_with : stlib,
 )
 test('{test_name}', test_exe)
@@ -92,6 +101,7 @@ test('{test_name}', test_exe)
 # Make this library usable as a Meson subproject.
 {ltoken}_dep = declare_dependency(
   include_directories : include_directories('.'),
+  dependencies : dependencies,
   link_with : stlib,
 )
 

--- a/mesonbuild/templates/cstemplates.py
+++ b/mesonbuild/templates/cstemplates.py
@@ -104,6 +104,7 @@ test('{test_name}', test_exe)
   dependencies : dependencies,
   link_with : stlib,
 )
+meson.override_dependency('{project_name}', {ltoken}_dep)
 
 '''
 

--- a/mesonbuild/templates/ctemplates.py
+++ b/mesonbuild/templates/ctemplates.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 

--- a/mesonbuild/templates/ctemplates.py
+++ b/mesonbuild/templates/ctemplates.py
@@ -52,29 +52,38 @@ int main(int argc, char **argv) {{
 }}
 '''
 
-lib_c_meson_template = '''project('{project_name}', 'c',
+lib_c_meson_template = '''project(
+  '{project_name}',
+  'c',
   version : '{version}',
   meson_version : '>= {meson_version}',
-  default_options : ['warning_level=3'])
+  default_options : ['warning_level=3'],
+)
 
 # These arguments are only used to build the shared library
 # not the executables that use the library.
 lib_args = ['-DBUILDING_{utoken}']
 
-shlib = shared_library('{lib_name}', '{source_file}',
+shlib = shared_library(
+  '{lib_name}',
+  '{source_file}',
   install : true,
   c_args : lib_args,
   gnu_symbol_visibility : 'hidden',
 )
 
-test_exe = executable('{test_exe_name}', '{test_source_file}',
-  link_with : shlib)
+test_exe = executable(
+  '{test_exe_name}',
+  '{test_source_file}',
+  link_with : shlib,
+)
 test('{test_name}', test_exe)
 
 # Make this library usable as a Meson subproject.
 {ltoken}_dep = declare_dependency(
-  include_directories: include_directories('.'),
-  link_with : shlib)
+  include_directories : include_directories('.'),
+  link_with : shlib,
+)
 
 # Make this library usable from the system's
 # package manager.
@@ -105,13 +114,19 @@ int main(int argc, char **argv) {{
 }}
 '''
 
-hello_c_meson_template = '''project('{project_name}', 'c',
+hello_c_meson_template = '''project(
+  '{project_name}',
+  'c',
   meson_version : '>= {meson_version}',
   version : '{version}',
-  default_options : ['warning_level=3'])
+  default_options : ['warning_level=3'],
+)
 
-exe = executable('{exe_name}', '{source_name}',
-  install : true)
+exe = executable(
+  '{exe_name}',
+  '{source_name}',
+  install : true,
+)
 
 test('basic', exe)
 '''

--- a/mesonbuild/templates/ctemplates.py
+++ b/mesonbuild/templates/ctemplates.py
@@ -3,8 +3,12 @@
 # Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
+import typing as T
 
 from mesonbuild.templates.sampleimpl import FileHeaderImpl
+
+if T.TYPE_CHECKING:
+    from ..minit import Arguments
 
 
 lib_h_template = '''#pragma once
@@ -67,11 +71,11 @@ lib_args = ['-DBUILDING_{utoken}']
 dependencies = [{dependencies}
 ]
 
-shlib = shared_library(
+lib = library(
   '{lib_name}',
   '{source_file}',
   install : true,
-  c_args : lib_args,
+  c_shared_args : lib_args,
   gnu_symbol_visibility : 'hidden',
   dependencies : dependencies,
 )
@@ -80,7 +84,7 @@ test_exe = executable(
   '{test_exe_name}',
   '{test_source_file}',
   dependencies : dependencies,
-  link_with : shlib,
+  link_with : lib,
 )
 test('{test_name}', test_exe)
 
@@ -88,7 +92,7 @@ test('{test_name}', test_exe)
 {ltoken}_dep = declare_dependency(
   include_directories : include_directories('.'),
   dependencies : dependencies,
-  link_with : shlib,
+  link_with : lib,
 )
 meson.override_dependency('{project_name}', {ltoken}_dep)
 
@@ -98,7 +102,7 @@ install_headers('{header_file}', subdir : '{header_dir}')
 
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(
-  shlib,
+  lib,
   description : 'Meson sample project.',
   subdirs : '{header_dir}',
 )
@@ -150,3 +154,7 @@ class CProject(FileHeaderImpl):
     lib_header_template = lib_h_template
     lib_test_template = lib_c_test_template
     lib_meson_template = lib_c_meson_template
+
+    def __init__(self, args: Arguments):
+        super().__init__(args)
+        self.meson_version = '1.3.0'

--- a/mesonbuild/templates/ctemplates.py
+++ b/mesonbuild/templates/ctemplates.py
@@ -64,17 +64,22 @@ lib_c_meson_template = '''project(
 # not the executables that use the library.
 lib_args = ['-DBUILDING_{utoken}']
 
+dependencies = [{dependencies}
+]
+
 shlib = shared_library(
   '{lib_name}',
   '{source_file}',
   install : true,
   c_args : lib_args,
   gnu_symbol_visibility : 'hidden',
+  dependencies : dependencies,
 )
 
 test_exe = executable(
   '{test_exe_name}',
   '{test_source_file}',
+  dependencies : dependencies,
   link_with : shlib,
 )
 test('{test_name}', test_exe)
@@ -82,6 +87,7 @@ test('{test_name}', test_exe)
 # Make this library usable as a Meson subproject.
 {ltoken}_dep = declare_dependency(
   include_directories : include_directories('.'),
+  dependencies : dependencies,
   link_with : shlib,
 )
 
@@ -122,9 +128,13 @@ hello_c_meson_template = '''project(
   default_options : ['warning_level=3'],
 )
 
+dependencies = [{dependencies}
+]
+
 exe = executable(
   '{exe_name}',
   '{source_name}',
+  dependencies : dependencies,
   install : true,
 )
 

--- a/mesonbuild/templates/ctemplates.py
+++ b/mesonbuild/templates/ctemplates.py
@@ -98,12 +98,9 @@ install_headers('{header_file}', subdir : '{header_dir}')
 
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(
-  name : '{project_name}',
-  filebase : '{ltoken}',
+  shlib,
   description : 'Meson sample project.',
   subdirs : '{header_dir}',
-  libraries : shlib,
-  version : '{version}',
 )
 '''
 

--- a/mesonbuild/templates/ctemplates.py
+++ b/mesonbuild/templates/ctemplates.py
@@ -54,6 +54,7 @@ int main(int argc, char **argv) {{
 
 lib_c_meson_template = '''project('{project_name}', 'c',
   version : '{version}',
+  meson_version : '>= {meson_version}',
   default_options : ['warning_level=3'])
 
 # These arguments are only used to build the shared library
@@ -105,6 +106,7 @@ int main(int argc, char **argv) {{
 '''
 
 hello_c_meson_template = '''project('{project_name}', 'c',
+  meson_version : '>= {meson_version}',
   version : '{version}',
   default_options : ['warning_level=3'])
 

--- a/mesonbuild/templates/ctemplates.py
+++ b/mesonbuild/templates/ctemplates.py
@@ -90,6 +90,7 @@ test('{test_name}', test_exe)
   dependencies : dependencies,
   link_with : shlib,
 )
+meson.override_dependency('{project_name}', {ltoken}_dep)
 
 # Make this library usable from the system's
 # package manager.

--- a/mesonbuild/templates/cudatemplates.py
+++ b/mesonbuild/templates/cudatemplates.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 

--- a/mesonbuild/templates/cudatemplates.py
+++ b/mesonbuild/templates/cudatemplates.py
@@ -29,9 +29,13 @@ hello_cuda_meson_template = '''project(
   default_options : ['warning_level=3', 'cpp_std=c++14'],
 )
 
+dependencies = [{dependencies}
+]
+
 exe = executable(
   '{exe_name}',
   '{source_name}',
+  dependencies : dependencies,
   install : true,
 )
 
@@ -111,24 +115,30 @@ lib_cuda_meson_template = '''project(
 # not the executables that use the library.
 lib_args = ['-DBUILDING_{utoken}']
 
+dependencies = [{dependencies}
+]
+
 shlib = shared_library(
   '{lib_name}',
   '{source_file}',
   install : true,
   cpp_args : lib_args,
   gnu_symbol_visibility : 'hidden',
+  dependencies : dependencies,
 )
 
 test_exe = executable(
   '{test_exe_name}',
   '{test_source_file}',
   link_with : shlib,
+  dependencies : dependencies,
 )
 test('{test_name}', test_exe)
 
 # Make this library usable as a Meson subproject.
 {ltoken}_dep = declare_dependency(
   include_directories : include_directories('.'),
+  dependencies : dependencies,
   link_with : shlib,
 )
 

--- a/mesonbuild/templates/cudatemplates.py
+++ b/mesonbuild/templates/cudatemplates.py
@@ -141,6 +141,7 @@ test('{test_name}', test_exe)
   dependencies : dependencies,
   link_with : shlib,
 )
+meson.override_dependency('{project_name}', {ltoken}_dep)
 
 # Make this library usable from the system's
 # package manager.

--- a/mesonbuild/templates/cudatemplates.py
+++ b/mesonbuild/templates/cudatemplates.py
@@ -21,14 +21,19 @@ int main(int argc, char **argv) {{
 }}
 '''
 
-hello_cuda_meson_template = '''project('{project_name}', ['cuda', 'cpp'],
+hello_cuda_meson_template = '''project(
+  '{project_name}',
+  ['cuda', 'cpp'],
   version : '{version}',
   meson_version : '>= {meson_version}',
-  default_options : ['warning_level=3',
-                     'cpp_std=c++14'])
+  default_options : ['warning_level=3', 'cpp_std=c++14'],
+)
 
-exe = executable('{exe_name}', '{source_name}',
-  install : true)
+exe = executable(
+  '{exe_name}',
+  '{source_name}',
+  install : true,
+)
 
 test('basic', exe)
 '''
@@ -94,29 +99,38 @@ int main(int argc, char **argv) {{
 }}
 '''
 
-lib_cuda_meson_template = '''project('{project_name}', ['cuda', 'cpp'],
+lib_cuda_meson_template = '''project(
+  '{project_name}',
+  ['cuda', 'cpp'],
   version : '{version}',
   meson_version : '>= {meson_version}',
-  default_options : ['warning_level=3'])
+  default_options : ['warning_level=3'],
+)
 
 # These arguments are only used to build the shared library
 # not the executables that use the library.
 lib_args = ['-DBUILDING_{utoken}']
 
-shlib = shared_library('{lib_name}', '{source_file}',
+shlib = shared_library(
+  '{lib_name}',
+  '{source_file}',
   install : true,
   cpp_args : lib_args,
   gnu_symbol_visibility : 'hidden',
 )
 
-test_exe = executable('{test_exe_name}', '{test_source_file}',
-  link_with : shlib)
+test_exe = executable(
+  '{test_exe_name}',
+  '{test_source_file}',
+  link_with : shlib,
+)
 test('{test_name}', test_exe)
 
 # Make this library usable as a Meson subproject.
 {ltoken}_dep = declare_dependency(
-  include_directories: include_directories('.'),
-  link_with : shlib)
+  include_directories : include_directories('.'),
+  link_with : shlib,
+)
 
 # Make this library usable from the system's
 # package manager.

--- a/mesonbuild/templates/cudatemplates.py
+++ b/mesonbuild/templates/cudatemplates.py
@@ -23,6 +23,7 @@ int main(int argc, char **argv) {{
 
 hello_cuda_meson_template = '''project('{project_name}', ['cuda', 'cpp'],
   version : '{version}',
+  meson_version : '>= {meson_version}',
   default_options : ['warning_level=3',
                      'cpp_std=c++14'])
 
@@ -95,6 +96,7 @@ int main(int argc, char **argv) {{
 
 lib_cuda_meson_template = '''project('{project_name}', ['cuda', 'cpp'],
   version : '{version}',
+  meson_version : '>= {meson_version}',
   default_options : ['warning_level=3'])
 
 # These arguments are only used to build the shared library

--- a/mesonbuild/templates/cudatemplates.py
+++ b/mesonbuild/templates/cudatemplates.py
@@ -149,12 +149,9 @@ install_headers('{header_file}', subdir : '{header_dir}')
 
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(
-  name : '{project_name}',
-  filebase : '{ltoken}',
+  shlib,
   description : 'Meson sample project.',
   subdirs : '{header_dir}',
-  libraries : shlib,
-  version : '{version}',
 )
 '''
 

--- a/mesonbuild/templates/cudatemplates.py
+++ b/mesonbuild/templates/cudatemplates.py
@@ -3,8 +3,12 @@
 # Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
+import typing as T
 
 from mesonbuild.templates.sampleimpl import FileHeaderImpl
+
+if T.TYPE_CHECKING:
+    from ..minit import Arguments
 
 
 hello_cuda_template = '''#include <iostream>
@@ -118,11 +122,11 @@ lib_args = ['-DBUILDING_{utoken}']
 dependencies = [{dependencies}
 ]
 
-shlib = shared_library(
+lib = library(
   '{lib_name}',
   '{source_file}',
   install : true,
-  cpp_args : lib_args,
+  cpp_shared_args : lib_args,
   gnu_symbol_visibility : 'hidden',
   dependencies : dependencies,
 )
@@ -130,7 +134,7 @@ shlib = shared_library(
 test_exe = executable(
   '{test_exe_name}',
   '{test_source_file}',
-  link_with : shlib,
+  link_with : lib,
   dependencies : dependencies,
 )
 test('{test_name}', test_exe)
@@ -139,7 +143,7 @@ test('{test_name}', test_exe)
 {ltoken}_dep = declare_dependency(
   include_directories : include_directories('.'),
   dependencies : dependencies,
-  link_with : shlib,
+  link_with : lib,
 )
 meson.override_dependency('{project_name}', {ltoken}_dep)
 
@@ -149,7 +153,7 @@ install_headers('{header_file}', subdir : '{header_dir}')
 
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(
-  shlib,
+  lib,
   description : 'Meson sample project.',
   subdirs : '{header_dir}',
 )
@@ -166,3 +170,7 @@ class CudaProject(FileHeaderImpl):
     lib_header_template = lib_h_template
     lib_test_template = lib_cuda_test_template
     lib_meson_template = lib_cuda_meson_template
+
+    def __init__(self, args: Arguments):
+        super().__init__(args)
+        self.meson_version = '1.3.0'

--- a/mesonbuild/templates/dlangtemplates.py
+++ b/mesonbuild/templates/dlangtemplates.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 

--- a/mesonbuild/templates/dlangtemplates.py
+++ b/mesonbuild/templates/dlangtemplates.py
@@ -32,9 +32,13 @@ hello_d_meson_template = '''project(
   default_options : ['warning_level=3'],
 )
 
+dependencies = [{dependencies}
+]
+
 exe = executable(
   '{exe_name}',
   '{source_name}',
+  dependencies : dependencies,
   install : true,
 )
 
@@ -77,23 +81,30 @@ lib_d_meson_template = '''project(
   default_options : ['warning_level=3'],
 )
 
+dependencies = [{dependencies}
+]
+
+
 stlib = static_library(
   '{lib_name}',
   '{source_file}',
   install : true,
   gnu_symbol_visibility : 'hidden',
+  dependencies : dependencies,
 )
 
 test_exe = executable(
   '{test_exe_name}',
   '{test_source_file}',
   link_with : stlib,
+  dependencies : dependencies,
 )
 test('{test_name}', test_exe)
 
 # Make this library usable as a Meson subproject.
 {ltoken}_dep = declare_dependency(
   include_directories : include_directories('.'),
+  dependencies : dependencies,
   link_with : stlib,
 )
 

--- a/mesonbuild/templates/dlangtemplates.py
+++ b/mesonbuild/templates/dlangtemplates.py
@@ -26,6 +26,7 @@ int main(string[] args) {{
 
 hello_d_meson_template = '''project('{project_name}', 'd',
     version : '{version}',
+    meson_version : '>= {meson_version}',
     default_options: ['warning_level=3'])
 
 exe = executable('{exe_name}', '{source_name}',
@@ -64,6 +65,7 @@ int main(string[] args) {{
 
 lib_d_meson_template = '''project('{project_name}', 'd',
   version : '{version}',
+  meson_version : '>= {meson_version}',
   default_options : ['warning_level=3'])
 
 stlib = static_library('{lib_name}', '{source_file}',

--- a/mesonbuild/templates/dlangtemplates.py
+++ b/mesonbuild/templates/dlangtemplates.py
@@ -107,6 +107,7 @@ test('{test_name}', test_exe)
   dependencies : dependencies,
   link_with : stlib,
 )
+meson.override_dependency('{project_name}', {ltoken}_dep)
 
 # Make this library usable from the Dlang
 # build system.

--- a/mesonbuild/templates/dlangtemplates.py
+++ b/mesonbuild/templates/dlangtemplates.py
@@ -24,13 +24,19 @@ int main(string[] args) {{
 }}
 '''
 
-hello_d_meson_template = '''project('{project_name}', 'd',
-    version : '{version}',
-    meson_version : '>= {meson_version}',
-    default_options: ['warning_level=3'])
+hello_d_meson_template = '''project(
+  '{project_name}',
+  'd',
+  version : '{version}',
+  meson_version : '>= {meson_version}',
+  default_options : ['warning_level=3'],
+)
 
-exe = executable('{exe_name}', '{source_name}',
-  install : true)
+exe = executable(
+  '{exe_name}',
+  '{source_name}',
+  install : true,
+)
 
 test('basic', exe)
 '''
@@ -63,32 +69,43 @@ int main(string[] args) {{
 }}
 '''
 
-lib_d_meson_template = '''project('{project_name}', 'd',
+lib_d_meson_template = '''project(
+  '{project_name}',
+  'd',
   version : '{version}',
   meson_version : '>= {meson_version}',
-  default_options : ['warning_level=3'])
+  default_options : ['warning_level=3'],
+)
 
-stlib = static_library('{lib_name}', '{source_file}',
+stlib = static_library(
+  '{lib_name}',
+  '{source_file}',
   install : true,
   gnu_symbol_visibility : 'hidden',
 )
 
-test_exe = executable('{test_exe_name}', '{test_source_file}',
-  link_with : stlib)
+test_exe = executable(
+  '{test_exe_name}',
+  '{test_source_file}',
+  link_with : stlib,
+)
 test('{test_name}', test_exe)
 
 # Make this library usable as a Meson subproject.
 {ltoken}_dep = declare_dependency(
-  include_directories: include_directories('.'),
-  link_with : stlib)
+  include_directories : include_directories('.'),
+  link_with : stlib,
+)
 
 # Make this library usable from the Dlang
 # build system.
 dlang_mod = import('dlang')
-if find_program('dub', required: false).found()
-  dlang_mod.generate_dub_file(meson.project_name().to_lower(), meson.source_root(),
+if find_program('dub', required : false).found()
+  dlang_mod.generate_dub_file(
+    meson.project_name().to_lower(),
+    meson.source_root(),
     name : meson.project_name(),
-    license: meson.project_license(),
+    license : meson.project_license(),
     sourceFiles : '{source_file}',
     description : 'Meson sample project.',
     version : '{version}',

--- a/mesonbuild/templates/fortrantemplates.py
+++ b/mesonbuild/templates/fortrantemplates.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 

--- a/mesonbuild/templates/fortrantemplates.py
+++ b/mesonbuild/templates/fortrantemplates.py
@@ -39,6 +39,7 @@ end program
 
 lib_fortran_meson_template = '''project('{project_name}', 'fortran',
   version : '{version}',
+  meson_version : '>= {meson_version}',
   default_options : ['warning_level=3'])
 
 # These arguments are only used to build the shared library
@@ -83,6 +84,7 @@ end program
 
 hello_fortran_meson_template = '''project('{project_name}', 'fortran',
   version : '{version}',
+  meson_version : '>= {meson_version}',
   default_options : ['warning_level=3'])
 
 exe = executable('{exe_name}', '{source_name}',

--- a/mesonbuild/templates/fortrantemplates.py
+++ b/mesonbuild/templates/fortrantemplates.py
@@ -3,8 +3,12 @@
 # Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
+import typing as T
 
 from mesonbuild.templates.sampleimpl import FileImpl
+
+if T.TYPE_CHECKING:
+    from ..minit import Arguments
 
 lib_fortran_template = '''
 ! This procedure will not be exported and is not
@@ -52,11 +56,11 @@ lib_args = ['-DBUILDING_{utoken}']
 dependencies = [{dependencies}
 ]
 
-shlib = shared_library(
+lib = library(
   '{lib_name}',
   '{source_file}',
   install : true,
-  fortran_args : lib_args,
+  fortran_shared_args : lib_args,
   gnu_symbol_visibility : 'hidden',
   dependencies : dependencies,
 )
@@ -64,7 +68,7 @@ shlib = shared_library(
 test_exe = executable(
   '{test_exe_name}',
   '{test_source_file}',
-  link_with : shlib,
+  link_with : lib,
   dependencies : dependencies,
 )
 test('{test_name}', test_exe)
@@ -73,13 +77,13 @@ test('{test_name}', test_exe)
 {ltoken}_dep = declare_dependency(
   include_directories : include_directories('.'),
   dependencies : dependencies,
-  link_with : shlib,
+  link_with : lib,
 )
 meson.override_dependency('{project_name}', {ltoken}_dep)
 
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(
-  shlib,
+  lib,
   description : 'Meson sample project.',
   subdirs : '{header_dir}',
 )
@@ -125,3 +129,7 @@ class FortranProject(FileImpl):
     lib_template = lib_fortran_template
     lib_meson_template = lib_fortran_meson_template
     lib_test_template = lib_fortran_test_template
+
+    def __init__(self, args: Arguments):
+        super().__init__(args)
+        self.meson_version = '1.3.0'

--- a/mesonbuild/templates/fortrantemplates.py
+++ b/mesonbuild/templates/fortrantemplates.py
@@ -37,29 +37,38 @@ print *,{function_name}()
 end program
 '''
 
-lib_fortran_meson_template = '''project('{project_name}', 'fortran',
+lib_fortran_meson_template = '''project(
+  '{project_name}',
+  'fortran',
   version : '{version}',
   meson_version : '>= {meson_version}',
-  default_options : ['warning_level=3'])
+  default_options : ['warning_level=3'],
+)
 
 # These arguments are only used to build the shared library
 # not the executables that use the library.
 lib_args = ['-DBUILDING_{utoken}']
 
-shlib = shared_library('{lib_name}', '{source_file}',
+shlib = shared_library(
+  '{lib_name}',
+  '{source_file}',
   install : true,
   fortran_args : lib_args,
   gnu_symbol_visibility : 'hidden',
 )
 
-test_exe = executable('{test_exe_name}', '{test_source_file}',
-  link_with : shlib)
+test_exe = executable(
+  '{test_exe_name}',
+  '{test_source_file}',
+  link_with : shlib,
+)
 test('{test_name}', test_exe)
 
 # Make this library usable as a Meson subproject.
 {ltoken}_dep = declare_dependency(
-  include_directories: include_directories('.'),
-  link_with : shlib)
+  include_directories : include_directories('.'),
+  link_with : shlib,
+)
 
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(
@@ -82,13 +91,19 @@ print *,"This is project ", PROJECT_NAME
 end program
 '''
 
-hello_fortran_meson_template = '''project('{project_name}', 'fortran',
+hello_fortran_meson_template = '''project(
+  '{project_name}',
+  'fortran',
   version : '{version}',
   meson_version : '>= {meson_version}',
-  default_options : ['warning_level=3'])
+  default_options : ['warning_level=3'],
+)
 
-exe = executable('{exe_name}', '{source_name}',
-  install : true)
+exe = executable(
+  '{exe_name}',
+  '{source_name}',
+  install : true,
+)
 
 test('basic', exe)
 '''

--- a/mesonbuild/templates/fortrantemplates.py
+++ b/mesonbuild/templates/fortrantemplates.py
@@ -79,12 +79,9 @@ meson.override_dependency('{project_name}', {ltoken}_dep)
 
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(
-  name : '{project_name}',
-  filebase : '{ltoken}',
+  shlib,
   description : 'Meson sample project.',
   subdirs : '{header_dir}',
-  libraries : shlib,
-  version : '{version}',
 )
 '''
 

--- a/mesonbuild/templates/fortrantemplates.py
+++ b/mesonbuild/templates/fortrantemplates.py
@@ -75,6 +75,7 @@ test('{test_name}', test_exe)
   dependencies : dependencies,
   link_with : shlib,
 )
+meson.override_dependency('{project_name}', {ltoken}_dep)
 
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(

--- a/mesonbuild/templates/fortrantemplates.py
+++ b/mesonbuild/templates/fortrantemplates.py
@@ -49,24 +49,30 @@ lib_fortran_meson_template = '''project(
 # not the executables that use the library.
 lib_args = ['-DBUILDING_{utoken}']
 
+dependencies = [{dependencies}
+]
+
 shlib = shared_library(
   '{lib_name}',
   '{source_file}',
   install : true,
   fortran_args : lib_args,
   gnu_symbol_visibility : 'hidden',
+  dependencies : dependencies,
 )
 
 test_exe = executable(
   '{test_exe_name}',
   '{test_source_file}',
   link_with : shlib,
+  dependencies : dependencies,
 )
 test('{test_name}', test_exe)
 
 # Make this library usable as a Meson subproject.
 {ltoken}_dep = declare_dependency(
   include_directories : include_directories('.'),
+  dependencies : dependencies,
   link_with : shlib,
 )
 
@@ -99,9 +105,13 @@ hello_fortran_meson_template = '''project(
   default_options : ['warning_level=3'],
 )
 
+dependencies = [{dependencies}
+]
+
 exe = executable(
   '{exe_name}',
   '{source_name}',
+  dependencies : dependencies,
   install : true,
 )
 

--- a/mesonbuild/templates/javatemplates.py
+++ b/mesonbuild/templates/javatemplates.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 

--- a/mesonbuild/templates/javatemplates.py
+++ b/mesonbuild/templates/javatemplates.py
@@ -32,10 +32,14 @@ hello_java_meson_template = '''project(
   default_options : ['warning_level=3'],
 )
 
+dependencies = [{dependencies}
+]
+
 exe = jar(
   '{exe_name}',
   '{source_name}',
   main_class : '{exe_name}',
+  dependencies : dependencies,
   install : true,
 )
 
@@ -79,9 +83,13 @@ lib_java_meson_template = '''project(
   default_options : ['warning_level=3'],
 )
 
+dependencies = [{dependencies}
+]
+
 jarlib = jar(
   '{class_name}',
   '{source_file}',
+  dependencies : dependencies,
   main_class : '{class_name}',
   install : true,
 )
@@ -90,6 +98,7 @@ test_jar = jar(
   '{class_test}',
   '{test_source_file}',
   main_class : '{class_test}',
+  dependencies : dependencies,
   link_with : jarlib,
 )
 test('{test_name}', test_jar)
@@ -97,6 +106,7 @@ test('{test_name}', test_jar)
 # Make this library usable as a Meson subproject.
 {ltoken}_dep = declare_dependency(
   include_directories : include_directories('.'),
+  dependencies : dependencies,
   link_with : jarlib,
 )
 '''

--- a/mesonbuild/templates/javatemplates.py
+++ b/mesonbuild/templates/javatemplates.py
@@ -24,14 +24,20 @@ public class {class_name} {{
 
 '''
 
-hello_java_meson_template = '''project('{project_name}', 'java',
+hello_java_meson_template = '''project(
+  '{project_name}',
+  'java',
   version : '{version}',
   meson_version : '>= {meson_version}',
-  default_options : ['warning_level=3'])
+  default_options : ['warning_level=3'],
+)
 
-exe = jar('{exe_name}', '{source_name}',
+exe = jar(
+  '{exe_name}',
+  '{source_name}',
   main_class : '{exe_name}',
-  install : true)
+  install : true,
+)
 
 test('basic', exe)
 '''
@@ -65,25 +71,34 @@ public class {class_test} {{
 
 '''
 
-lib_java_meson_template = '''project('{project_name}', 'java',
+lib_java_meson_template = '''project(
+  '{project_name}',
+  'java',
   version : '{version}',
   meson_version : '>= {meson_version}',
-  default_options : ['warning_level=3'])
+  default_options : ['warning_level=3'],
+)
 
-jarlib = jar('{class_name}', '{source_file}',
+jarlib = jar(
+  '{class_name}',
+  '{source_file}',
   main_class : '{class_name}',
   install : true,
 )
 
-test_jar = jar('{class_test}', '{test_source_file}',
+test_jar = jar(
+  '{class_test}',
+  '{test_source_file}',
   main_class : '{class_test}',
-  link_with : jarlib)
+  link_with : jarlib,
+)
 test('{test_name}', test_jar)
 
 # Make this library usable as a Meson subproject.
 {ltoken}_dep = declare_dependency(
-  include_directories: include_directories('.'),
-  link_with : jarlib)
+  include_directories : include_directories('.'),
+  link_with : jarlib,
+)
 '''
 
 

--- a/mesonbuild/templates/javatemplates.py
+++ b/mesonbuild/templates/javatemplates.py
@@ -26,6 +26,7 @@ public class {class_name} {{
 
 hello_java_meson_template = '''project('{project_name}', 'java',
   version : '{version}',
+  meson_version : '>= {meson_version}',
   default_options : ['warning_level=3'])
 
 exe = jar('{exe_name}', '{source_name}',
@@ -66,6 +67,7 @@ public class {class_test} {{
 
 lib_java_meson_template = '''project('{project_name}', 'java',
   version : '{version}',
+  meson_version : '>= {meson_version}',
   default_options : ['warning_level=3'])
 
 jarlib = jar('{class_name}', '{source_file}',

--- a/mesonbuild/templates/javatemplates.py
+++ b/mesonbuild/templates/javatemplates.py
@@ -109,6 +109,7 @@ test('{test_name}', test_jar)
   dependencies : dependencies,
   link_with : jarlib,
 )
+meson.override_dependency('{project_name}', {ltoken}_dep)
 '''
 
 

--- a/mesonbuild/templates/mesontemplates.py
+++ b/mesonbuild/templates/mesontemplates.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 

--- a/mesonbuild/templates/mesontemplates.py
+++ b/mesonbuild/templates/mesontemplates.py
@@ -52,9 +52,8 @@ def create_meson_build(options: Arguments) -> None:
                                             for x in options.deps.split(','))
         depspec += '],'
     if options.language != 'java':
-        language = f"'{options.language}'" if options.language != 'vala' else ['c', 'vala']
         content = meson_executable_template.format(project_name=options.name,
-                                                   language=language,
+                                                   language=options.language,
                                                    version=options.version,
                                                    meson_version='1.0.0',
                                                    executable=options.executable,

--- a/mesonbuild/templates/mesontemplates.py
+++ b/mesonbuild/templates/mesontemplates.py
@@ -61,5 +61,6 @@ def create_meson_build(options: Arguments) -> None:
                           sourcespec=sourcespec,
                           depspec=depspec,
                           default_options=formatted_default_options)
-    open('meson.build', 'w', encoding='utf-8').write(content)
+    with open('meson.build', 'w', encoding='utf-8') as f:
+        f.write(content)
     print('Generated meson.build file:\n\n' + content)

--- a/mesonbuild/templates/mesontemplates.py
+++ b/mesonbuild/templates/mesontemplates.py
@@ -11,6 +11,7 @@ if T.TYPE_CHECKING:
 
 meson_executable_template = '''project('{project_name}', {language},
   version : '{version}',
+  meson_version : '>= {meson_version}',
   default_options : [{default_options}])
 
 executable('{executable}',
@@ -21,6 +22,7 @@ executable('{executable}',
 
 meson_jar_template = '''project('{project_name}', '{language}',
   version : '{version}',
+  meson_version : '>= {meson_version}',
   default_options : [{default_options}])
 
 jar('{executable}',
@@ -54,6 +56,7 @@ def create_meson_build(options: Arguments) -> None:
         content = meson_executable_template.format(project_name=options.name,
                                                    language=language,
                                                    version=options.version,
+                                                   meson_version='1.0.0',
                                                    executable=options.executable,
                                                    sourcespec=sourcespec,
                                                    depspec=depspec,
@@ -62,6 +65,7 @@ def create_meson_build(options: Arguments) -> None:
         content = meson_jar_template.format(project_name=options.name,
                                             language=options.language,
                                             version=options.version,
+                                            meson_version='1.0.0' if options.language != 'rust' else '1.3.0',
                                             executable=options.executable,
                                             main_class=options.name,
                                             sourcespec=sourcespec,

--- a/mesonbuild/templates/mesontemplates.py
+++ b/mesonbuild/templates/mesontemplates.py
@@ -9,26 +9,38 @@ import typing as T
 if T.TYPE_CHECKING:
     from ..minit import Arguments
 
-meson_executable_template = '''project('{project_name}', {language},
+meson_executable_template = '''project(
+  '{project_name}',
+  {language},
   version : '{version}',
   meson_version : '>= {meson_version}',
-  default_options : [{default_options}])
+  default_options : [{default_options}],
+)
 
-executable('{executable}',
-           {sourcespec},{depspec}
-           install : true)
+executable(
+  '{executable}',
+  {sourcespec},{depspec}
+  install : true,
+)
+
 '''
 
 
-meson_jar_template = '''project('{project_name}', '{language}',
+meson_jar_template = '''project(
+  '{project_name}',
+  '{language}',
   version : '{version}',
   meson_version : '>= {meson_version}',
-  default_options : [{default_options}])
+  default_options : [{default_options}],
+)
 
-jar('{executable}',
-    {sourcespec},{depspec}
-    main_class: '{main_class}',
-    install : true)
+jar(
+  '{executable}',
+  {sourcespec},{depspec}
+  main_class : '{main_class}',
+  install : true,
+)
+
 '''
 
 

--- a/mesonbuild/templates/mesontemplates.py
+++ b/mesonbuild/templates/mesontemplates.py
@@ -51,24 +51,15 @@ def create_meson_build(options: Arguments) -> None:
         depspec += ',\n              '.join(f"dependency('{x}')"
                                             for x in options.deps.split(','))
         depspec += '],'
-    if options.language != 'java':
-        content = meson_executable_template.format(project_name=options.name,
-                                                   language=options.language,
-                                                   version=options.version,
-                                                   meson_version='1.0.0',
-                                                   executable=options.executable,
-                                                   sourcespec=sourcespec,
-                                                   depspec=depspec,
-                                                   default_options=formatted_default_options)
-    else:
-        content = meson_jar_template.format(project_name=options.name,
-                                            language=options.language,
-                                            version=options.version,
-                                            meson_version='1.0.0' if options.language != 'rust' else '1.3.0',
-                                            executable=options.executable,
-                                            main_class=options.name,
-                                            sourcespec=sourcespec,
-                                            depspec=depspec,
-                                            default_options=formatted_default_options)
+    tmpl = meson_executable_template if options.language != 'java' else meson_jar_template
+    content = tmpl.format(project_name=options.name,
+                          language=options.language,
+                          version=options.version,
+                          meson_version='1.0.0' if options.language != 'rust' else '1.3.0',
+                          main_class=options.name,
+                          executable=options.executable,
+                          sourcespec=sourcespec,
+                          depspec=depspec,
+                          default_options=formatted_default_options)
     open('meson.build', 'w', encoding='utf-8').write(content)
     print('Generated meson.build file:\n\n' + content)

--- a/mesonbuild/templates/mesontemplates.py
+++ b/mesonbuild/templates/mesontemplates.py
@@ -6,73 +6,15 @@ from __future__ import annotations
 
 import typing as T
 
+from .samplefactory import sample_generator
+
 if T.TYPE_CHECKING:
     from ..minit import Arguments
 
-meson_executable_template = '''project(
-  '{project_name}',
-  {language},
-  version : '{version}',
-  meson_version : '>= {meson_version}',
-  default_options : [{default_options}],
-)
-
-executable(
-  '{executable}',
-  {sourcespec},{depspec}
-  install : true,
-)
-
-'''
-
-
-meson_jar_template = '''project(
-  '{project_name}',
-  '{language}',
-  version : '{version}',
-  meson_version : '>= {meson_version}',
-  default_options : [{default_options}],
-)
-
-jar(
-  '{executable}',
-  {sourcespec},{depspec}
-  main_class : '{main_class}',
-  install : true,
-)
-
-'''
-
 
 def create_meson_build(options: Arguments) -> None:
-    if options.type != 'executable':
-        raise SystemExit('\nGenerating a meson.build file from existing sources is\n'
-                         'supported only for project type "executable".\n'
-                         'Run meson init in an empty directory to create a sample project.')
-    default_options = ['warning_level=3']
-    if options.language == 'cpp':
-        # This shows how to set this very common option.
-        default_options += ['cpp_std=c++14']
-    # If we get a meson.build autoformatter one day, this code could
-    # be simplified quite a bit.
-    formatted_default_options = ', '.join(f"'{x}'" for x in default_options)
-    sourcespec = ',\n           '.join(f"'{x}'" for x in options.srcfiles)
-    depspec = ''
-    if options.deps:
-        depspec = '\n           dependencies : [\n              '
-        depspec += ',\n              '.join(f"dependency('{x}')"
-                                            for x in options.deps.split(','))
-        depspec += '],'
-    tmpl = meson_executable_template if options.language != 'java' else meson_jar_template
-    content = tmpl.format(project_name=options.name,
-                          language=options.language,
-                          version=options.version,
-                          meson_version='1.0.0' if options.language != 'rust' else '1.3.0',
-                          main_class=options.name,
-                          executable=options.executable,
-                          sourcespec=sourcespec,
-                          depspec=depspec,
-                          default_options=formatted_default_options)
-    with open('meson.build', 'w', encoding='utf-8') as f:
-        f.write(content)
-    print('Generated meson.build file:\n\n' + content)
+    proj = sample_generator(options)
+    if options.type == 'executable':
+        proj.create_executable()
+    else:
+        proj.create_library()

--- a/mesonbuild/templates/objcpptemplates.py
+++ b/mesonbuild/templates/objcpptemplates.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 

--- a/mesonbuild/templates/objcpptemplates.py
+++ b/mesonbuild/templates/objcpptemplates.py
@@ -54,6 +54,7 @@ int main(int argc, char **argv) {{
 
 lib_objcpp_meson_template = '''project('{project_name}', 'objcpp',
   version : '{version}',
+  meson_version : '>= {meson_version}',
   default_options : ['warning_level=3'])
 
 # These arguments are only used to build the shared library
@@ -106,6 +107,7 @@ int main(int argc, char **argv) {{
 
 hello_objcpp_meson_template = '''project('{project_name}', 'objcpp',
   version : '{version}',
+  meson_version : '>= {meson_version}',
   default_options : ['warning_level=3'])
 
 exe = executable('{exe_name}', '{source_name}',

--- a/mesonbuild/templates/objcpptemplates.py
+++ b/mesonbuild/templates/objcpptemplates.py
@@ -60,6 +60,9 @@ lib_objcpp_meson_template = '''project(
   default_options : ['warning_level=3'],
 )
 
+dependencies = [{dependencies}
+]
+
 # These arguments are only used to build the shared library
 # not the executables that use the library.
 lib_args = ['-DBUILDING_{utoken}']
@@ -69,12 +72,14 @@ shlib = shared_library(
   '{source_file}',
   install : true,
   objcpp_args : lib_args,
+  dependencies : dependencies,
   gnu_symbol_visibility : 'hidden',
 )
 
 test_exe = executable(
   '{test_exe_name}',
   '{test_source_file}',
+  dependencies : dependencies,
   link_with : shlib,
 )
 test('{test_name}', test_exe)
@@ -82,6 +87,7 @@ test('{test_name}', test_exe)
 # Make this library usable as a Meson subproject.
 {ltoken}_dep = declare_dependency(
   include_directories : include_directories('.'),
+  dependencies : dependencies,
   link_with : shlib,
 )
 
@@ -122,9 +128,13 @@ hello_objcpp_meson_template = '''project(
   default_options : ['warning_level=3'],
 )
 
+dependencies = [{dependencies}
+]
+
 exe = executable(
   '{exe_name}',
   '{source_name}',
+  dependencies : dependencies,
   install : true,
 )
 

--- a/mesonbuild/templates/objcpptemplates.py
+++ b/mesonbuild/templates/objcpptemplates.py
@@ -3,8 +3,12 @@
 # Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
+import typing as T
 
 from mesonbuild.templates.sampleimpl import FileHeaderImpl
+
+if T.TYPE_CHECKING:
+    from ..minit import Arguments
 
 
 lib_h_template = '''#pragma once
@@ -67,11 +71,11 @@ dependencies = [{dependencies}
 # not the executables that use the library.
 lib_args = ['-DBUILDING_{utoken}']
 
-shlib = shared_library(
+lib = library(
   '{lib_name}',
   '{source_file}',
   install : true,
-  objcpp_args : lib_args,
+  objcpp_shared_args : lib_args,
   dependencies : dependencies,
   gnu_symbol_visibility : 'hidden',
 )
@@ -80,7 +84,7 @@ test_exe = executable(
   '{test_exe_name}',
   '{test_source_file}',
   dependencies : dependencies,
-  link_with : shlib,
+  link_with : lib,
 )
 test('{test_name}', test_exe)
 
@@ -88,7 +92,7 @@ test('{test_name}', test_exe)
 {ltoken}_dep = declare_dependency(
   include_directories : include_directories('.'),
   dependencies : dependencies,
-  link_with : shlib,
+  link_with : lib,
 )
 meson.override_dependency('{project_name}', {ltoken}_dep)
 
@@ -98,7 +102,7 @@ install_headers('{header_file}', subdir : '{header_dir}')
 
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(
-  shlib,
+  lib,
   description : 'Meson sample project.',
   subdirs : '{header_dir}',
 )
@@ -150,3 +154,7 @@ class ObjCppProject(FileHeaderImpl):
     lib_header_template = lib_h_template
     lib_test_template = lib_objcpp_test_template
     lib_meson_template = lib_objcpp_meson_template
+
+    def __init__(self, args: Arguments):
+        super().__init__(args)
+        self.meson_version = '1.3.0'

--- a/mesonbuild/templates/objcpptemplates.py
+++ b/mesonbuild/templates/objcpptemplates.py
@@ -98,12 +98,9 @@ install_headers('{header_file}', subdir : '{header_dir}')
 
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(
-  name : '{project_name}',
-  filebase : '{ltoken}',
+  shlib,
   description : 'Meson sample project.',
   subdirs : '{header_dir}',
-  libraries : shlib,
-  version : '{version}',
 )
 '''
 

--- a/mesonbuild/templates/objcpptemplates.py
+++ b/mesonbuild/templates/objcpptemplates.py
@@ -52,29 +52,38 @@ int main(int argc, char **argv) {{
 }}
 '''
 
-lib_objcpp_meson_template = '''project('{project_name}', 'objcpp',
+lib_objcpp_meson_template = '''project(
+ '{project_name}',
+ 'objcpp',
   version : '{version}',
   meson_version : '>= {meson_version}',
-  default_options : ['warning_level=3'])
+  default_options : ['warning_level=3'],
+)
 
 # These arguments are only used to build the shared library
 # not the executables that use the library.
 lib_args = ['-DBUILDING_{utoken}']
 
-shlib = shared_library('{lib_name}', '{source_file}',
+shlib = shared_library(
+  '{lib_name}',
+  '{source_file}',
   install : true,
   objcpp_args : lib_args,
   gnu_symbol_visibility : 'hidden',
 )
 
-test_exe = executable('{test_exe_name}', '{test_source_file}',
-  link_with : shlib)
+test_exe = executable(
+  '{test_exe_name}',
+  '{test_source_file}',
+  link_with : shlib,
+)
 test('{test_name}', test_exe)
 
 # Make this library usable as a Meson subproject.
 {ltoken}_dep = declare_dependency(
-  include_directories: include_directories('.'),
-  link_with : shlib)
+  include_directories : include_directories('.'),
+  link_with : shlib,
+)
 
 # Make this library usable from the system's
 # package manager.
@@ -105,13 +114,19 @@ int main(int argc, char **argv) {{
 }}
 '''
 
-hello_objcpp_meson_template = '''project('{project_name}', 'objcpp',
+hello_objcpp_meson_template = '''project(
+  '{project_name}',
+  'objcpp',
   version : '{version}',
   meson_version : '>= {meson_version}',
-  default_options : ['warning_level=3'])
+  default_options : ['warning_level=3'],
+)
 
-exe = executable('{exe_name}', '{source_name}',
-  install : true)
+exe = executable(
+  '{exe_name}',
+  '{source_name}',
+  install : true,
+)
 
 test('basic', exe)
 '''

--- a/mesonbuild/templates/objcpptemplates.py
+++ b/mesonbuild/templates/objcpptemplates.py
@@ -90,6 +90,7 @@ test('{test_name}', test_exe)
   dependencies : dependencies,
   link_with : shlib,
 )
+meson.override_dependency('{project_name}', {ltoken}_dep)
 
 # Make this library usable from the system's
 # package manager.

--- a/mesonbuild/templates/objctemplates.py
+++ b/mesonbuild/templates/objctemplates.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 

--- a/mesonbuild/templates/objctemplates.py
+++ b/mesonbuild/templates/objctemplates.py
@@ -60,6 +60,9 @@ lib_objc_meson_template = '''project(
   default_options : ['warning_level=3'],
 )
 
+dependencies = [{dependencies}
+]
+
 # These arguments are only used to build the shared library
 # not the executables that use the library.
 lib_args = ['-DBUILDING_{utoken}']
@@ -69,18 +72,21 @@ shlib = shared_library(
   '{source_file}',
   install : true,
   objc_args : lib_args,
+  dependencies : dependencies,
   gnu_symbol_visibility : 'hidden',
 )
 
 test_exe = executable(
   '{test_exe_name}',
   '{test_source_file}',
+  dependencies : dependencies,
   link_with : shlib)
 test('{test_name}', test_exe)
 
 # Make this library usable as a Meson subproject.
 {ltoken}_dep = declare_dependency(
   include_directories : include_directories('.'),
+  dependencies : dependencies,
   link_with : shlib,
 )
 
@@ -121,9 +127,13 @@ hello_objc_meson_template = '''project(
   default_options : ['warning_level=3'],
 )
 
+dependencies = [{dependencies}
+]
+
 exe = executable(
   '{exe_name}',
   '{source_name}',
+  dependencies : dependencies,
   install : true,
 )
 

--- a/mesonbuild/templates/objctemplates.py
+++ b/mesonbuild/templates/objctemplates.py
@@ -97,12 +97,9 @@ install_headers('{header_file}', subdir : '{header_dir}')
 
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(
-  name : '{project_name}',
-  filebase : '{ltoken}',
+  shlib,
   description : 'Meson sample project.',
   subdirs : '{header_dir}',
-  libraries : shlib,
-  version : '{version}',
 )
 '''
 

--- a/mesonbuild/templates/objctemplates.py
+++ b/mesonbuild/templates/objctemplates.py
@@ -54,6 +54,7 @@ int main(int argc, char **argv) {{
 
 lib_objc_meson_template = '''project('{project_name}', 'objc',
   version : '{version}',
+  meson_version : '>= {meson_version}',
   default_options : ['warning_level=3'])
 
 # These arguments are only used to build the shared library
@@ -106,6 +107,7 @@ int main(int argc, char **argv) {{
 
 hello_objc_meson_template = '''project('{project_name}', 'objc',
   version : '{version}',
+  meson_version : '>= {meson_version}',
   default_options : ['warning_level=3'])
 
 exe = executable('{exe_name}', '{source_name}',

--- a/mesonbuild/templates/objctemplates.py
+++ b/mesonbuild/templates/objctemplates.py
@@ -89,6 +89,7 @@ test('{test_name}', test_exe)
   dependencies : dependencies,
   link_with : shlib,
 )
+meson.override_dependency('{project_name}', {ltoken}_dep)
 
 # Make this library usable from the system's
 # package manager.

--- a/mesonbuild/templates/objctemplates.py
+++ b/mesonbuild/templates/objctemplates.py
@@ -52,29 +52,37 @@ int main(int argc, char **argv) {{
 }}
 '''
 
-lib_objc_meson_template = '''project('{project_name}', 'objc',
+lib_objc_meson_template = '''project(
+  '{project_name}',
+  'objc',
   version : '{version}',
   meson_version : '>= {meson_version}',
-  default_options : ['warning_level=3'])
+  default_options : ['warning_level=3'],
+)
 
 # These arguments are only used to build the shared library
 # not the executables that use the library.
 lib_args = ['-DBUILDING_{utoken}']
 
-shlib = shared_library('{lib_name}', '{source_file}',
+shlib = shared_library(
+  '{lib_name}',
+  '{source_file}',
   install : true,
   objc_args : lib_args,
   gnu_symbol_visibility : 'hidden',
 )
 
-test_exe = executable('{test_exe_name}', '{test_source_file}',
+test_exe = executable(
+  '{test_exe_name}',
+  '{test_source_file}',
   link_with : shlib)
 test('{test_name}', test_exe)
 
 # Make this library usable as a Meson subproject.
 {ltoken}_dep = declare_dependency(
-  include_directories: include_directories('.'),
-  link_with : shlib)
+  include_directories : include_directories('.'),
+  link_with : shlib,
+)
 
 # Make this library usable from the system's
 # package manager.
@@ -105,13 +113,19 @@ int main(int argc, char **argv) {{
 }}
 '''
 
-hello_objc_meson_template = '''project('{project_name}', 'objc',
+hello_objc_meson_template = '''project(
+  '{project_name}',
+  'objc',
   version : '{version}',
   meson_version : '>= {meson_version}',
-  default_options : ['warning_level=3'])
+  default_options : ['warning_level=3'],
+)
 
-exe = executable('{exe_name}', '{source_name}',
-  install : true)
+exe = executable(
+  '{exe_name}',
+  '{source_name}',
+  install : true,
+)
 
 test('basic', exe)
 '''

--- a/mesonbuild/templates/rusttemplates.py
+++ b/mesonbuild/templates/rusttemplates.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 

--- a/mesonbuild/templates/rusttemplates.py
+++ b/mesonbuild/templates/rusttemplates.py
@@ -37,21 +37,29 @@ mod tests {{
 '''
 
 
-lib_rust_meson_template = '''project('{project_name}', 'rust',
+lib_rust_meson_template = '''project(
+  '{project_name}',
+  'rust',
   version : '{version}',
   meson_version : '>= {meson_version}',
-  default_options : ['rust_std=2021', 'warning_level=3'])
+  default_options : ['rust_std=2021', 'warning_level=3'],
+)
 
 rust = import('rust')
 
-shlib = static_library('{lib_name}', '{source_file}', install : true)
+shlib = static_library(
+  '{lib_name}',
+  '{source_file}',
+  install : true,
+)
 
 rust.test('{test_name}', shlib)
 
 # Make this library usable as a Meson subproject.
 {ltoken}_dep = declare_dependency(
-  include_directories: include_directories('.'),
-  link_with : shlib)
+  include_directories : include_directories('.'),
+  link_with : shlib,
+)
 '''
 
 hello_rust_template = '''
@@ -61,13 +69,19 @@ fn main() {{
 }}
 '''
 
-hello_rust_meson_template = '''project('{project_name}', 'rust',
+hello_rust_meson_template = '''project(
+  '{project_name}',
+  'rust',
   version : '{version}',
   meson_version : '>= {meson_version}',
-  default_options : ['rust_std=2021', 'warning_level=3'])
+  default_options : ['rust_std=2021', 'warning_level=3'],
+)
 
-exe = executable('{exe_name}', '{source_name}',
-  install : true)
+exe = executable(
+  '{exe_name}',
+  '{source_name}',
+  install : true,
+)
 
 test('basic', exe)
 '''

--- a/mesonbuild/templates/rusttemplates.py
+++ b/mesonbuild/templates/rusttemplates.py
@@ -65,6 +65,7 @@ rust.test('{test_name}', shlib)
   dependencies : dependencies,
   link_with : shlib,
 )
+meson.override_dependency('{project_name}', {ltoken}_dep)
 '''
 
 hello_rust_template = '''

--- a/mesonbuild/templates/rusttemplates.py
+++ b/mesonbuild/templates/rusttemplates.py
@@ -47,9 +47,13 @@ lib_rust_meson_template = '''project(
 
 rust = import('rust')
 
+dependencies = [{dependencies}
+]
+
 shlib = static_library(
   '{lib_name}',
   '{source_file}',
+  dependencies : dependencies,
   install : true,
 )
 
@@ -58,6 +62,7 @@ rust.test('{test_name}', shlib)
 # Make this library usable as a Meson subproject.
 {ltoken}_dep = declare_dependency(
   include_directories : include_directories('.'),
+  dependencies : dependencies,
   link_with : shlib,
 )
 '''
@@ -77,9 +82,13 @@ hello_rust_meson_template = '''project(
   default_options : ['rust_std=2021', 'warning_level=3'],
 )
 
+dependencies = [{dependencies}
+]
+
 exe = executable(
   '{exe_name}',
   '{source_name}',
+  dependencies : dependencies,
   install : true,
 )
 

--- a/mesonbuild/templates/rusttemplates.py
+++ b/mesonbuild/templates/rusttemplates.py
@@ -8,6 +8,9 @@ import typing as T
 
 from mesonbuild.templates.sampleimpl import FileImpl
 
+if T.TYPE_CHECKING:
+    from ..minit import Arguments
+
 
 lib_rust_template = '''#![crate_name = "{crate_file}"]
 
@@ -35,7 +38,8 @@ mod tests {{
 
 
 lib_rust_meson_template = '''project('{project_name}', 'rust',
-  version : '{version}', meson_version: '>=1.3.0',
+  version : '{version}',
+  meson_version : '>= {meson_version}',
   default_options : ['rust_std=2021', 'warning_level=3'])
 
 rust = import('rust')
@@ -58,7 +62,8 @@ fn main() {{
 '''
 
 hello_rust_meson_template = '''project('{project_name}', 'rust',
-  version : '{version}', meson_version: '>=1.3.0',
+  version : '{version}',
+  meson_version : '>= {meson_version}',
   default_options : ['rust_std=2021', 'warning_level=3'])
 
 exe = executable('{exe_name}', '{source_name}',
@@ -76,6 +81,10 @@ class RustProject(FileImpl):
     lib_template = lib_rust_template
     lib_test_template = None
     lib_meson_template = lib_rust_meson_template
+
+    def __init__(self, args: Arguments):
+        super().__init__(args)
+        self.meson_version = '1.3.0'
 
     def lib_kwargs(self) -> T.Dict[str, str]:
         kwargs = super().lib_kwargs()

--- a/mesonbuild/templates/rusttemplates.py
+++ b/mesonbuild/templates/rusttemplates.py
@@ -50,20 +50,20 @@ rust = import('rust')
 dependencies = [{dependencies}
 ]
 
-shlib = static_library(
+lib = static_library(
   '{lib_name}',
   '{source_file}',
   dependencies : dependencies,
   install : true,
 )
 
-rust.test('{test_name}', shlib)
+rust.test('{test_name}', lib)
 
 # Make this library usable as a Meson subproject.
 {ltoken}_dep = declare_dependency(
   include_directories : include_directories('.'),
   dependencies : dependencies,
-  link_with : shlib,
+  link_with : lib,
 )
 meson.override_dependency('{project_name}', {ltoken}_dep)
 '''

--- a/mesonbuild/templates/samplefactory.py
+++ b/mesonbuild/templates/samplefactory.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 

--- a/mesonbuild/templates/sampleimpl.py
+++ b/mesonbuild/templates/sampleimpl.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 

--- a/mesonbuild/templates/sampleimpl.py
+++ b/mesonbuild/templates/sampleimpl.py
@@ -30,27 +30,33 @@ class SampleImpl(metaclass=abc.ABCMeta):
     def create_library(self) -> None:
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def exe_template(self) -> str:
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def exe_meson_template(self) -> str:
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def lib_template(self) -> str:
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def lib_test_template(self) -> T.Optional[str]:
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def lib_meson_template(self) -> str:
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def source_ext(self) -> str:
         pass
 
@@ -148,11 +154,13 @@ class FileImpl(SampleImpl):
 
 class FileHeaderImpl(FileImpl):
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def header_ext(self) -> str:
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def lib_header_template(self) -> str:
         pass
 

--- a/mesonbuild/templates/sampleimpl.py
+++ b/mesonbuild/templates/sampleimpl.py
@@ -23,6 +23,7 @@ class SampleImpl(metaclass=abc.ABCMeta):
         self.capitalized_token = self.lowercase_token.capitalize()
         self.meson_version = '1.0.0'
         self.force = args.force
+        self.dependencies = args.deps.split(',') if args.deps else []
 
     @abc.abstractmethod
     def create_executable(self) -> None:
@@ -62,6 +63,9 @@ class SampleImpl(metaclass=abc.ABCMeta):
     def source_ext(self) -> str:
         pass
 
+    def _format_dependencies(self) -> str:
+        return ''.join(f"\n  dependency('{d}')," for d in self.dependencies)
+
 
 class ClassImpl(SampleImpl):
 
@@ -79,7 +83,8 @@ class ClassImpl(SampleImpl):
                                                        exe_name=self.name,
                                                        source_name=source_name,
                                                        version=self.version,
-                                                       meson_version=self.meson_version))
+                                                       meson_version=self.meson_version,
+                                                       dependencies=self._format_dependencies()))
 
     def create_library(self) -> None:
         lib_name = f'{self.capitalized_token}.{self.source_ext}'
@@ -96,6 +101,7 @@ class ClassImpl(SampleImpl):
                   'test_name': self.lowercase_token,
                   'version': self.version,
                   'meson_version': self.meson_version,
+                  'dependencies': self._format_dependencies(),
                   }
         if not os.path.exists(lib_name):
             with open(lib_name, 'w', encoding='utf-8') as f:
@@ -123,7 +129,8 @@ class FileImpl(SampleImpl):
                                                        exe_name=self.name,
                                                        source_name=source_name,
                                                        version=self.version,
-                                                       meson_version=self.meson_version))
+                                                       meson_version=self.meson_version,
+                                                       dependencies=self._format_dependencies()))
 
     def lib_kwargs(self) -> T.Dict[str, str]:
         """Get Language specific keyword arguments
@@ -145,6 +152,7 @@ class FileImpl(SampleImpl):
             'test_name': self.lowercase_token,
             'version': self.version,
             'meson_version': self.meson_version,
+            'dependencies': self._format_dependencies(),
         }
 
     def create_library(self) -> None:

--- a/mesonbuild/templates/sampleimpl.py
+++ b/mesonbuild/templates/sampleimpl.py
@@ -20,6 +20,7 @@ class SampleImpl(metaclass=abc.ABCMeta):
         self.lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         self.uppercase_token = self.lowercase_token.upper()
         self.capitalized_token = self.lowercase_token.capitalize()
+        self.meson_version = '1.0.0'
 
     @abc.abstractmethod
     def create_executable(self) -> None:
@@ -67,7 +68,8 @@ class ClassImpl(SampleImpl):
             f.write(self.exe_meson_template.format(project_name=self.name,
                                                    exe_name=self.name,
                                                    source_name=source_name,
-                                                   version=self.version))
+                                                   version=self.version,
+                                                   meson_version=self.meson_version))
 
     def create_library(self) -> None:
         lib_name = f'{self.capitalized_token}.{self.source_ext}'
@@ -83,6 +85,7 @@ class ClassImpl(SampleImpl):
                   'lib_name': self.lowercase_token,
                   'test_name': self.lowercase_token,
                   'version': self.version,
+                  'meson_version': self.meson_version,
                   }
         with open(lib_name, 'w', encoding='utf-8') as f:
             f.write(self.lib_template.format(**kwargs))
@@ -105,7 +108,8 @@ class FileImpl(SampleImpl):
             f.write(self.exe_meson_template.format(project_name=self.name,
                                                    exe_name=self.name,
                                                    source_name=source_name,
-                                                   version=self.version))
+                                                   version=self.version,
+                                                   meson_version=self.meson_version))
 
     def lib_kwargs(self) -> T.Dict[str, str]:
         """Get Language specific keyword arguments
@@ -126,6 +130,7 @@ class FileImpl(SampleImpl):
             'lib_name': self.lowercase_token,
             'test_name': self.lowercase_token,
             'version': self.version,
+            'meson_version': self.meson_version,
         }
 
     def create_library(self) -> None:

--- a/mesonbuild/templates/valatemplates.py
+++ b/mesonbuild/templates/valatemplates.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019 The Meson development team
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 

--- a/mesonbuild/templates/valatemplates.py
+++ b/mesonbuild/templates/valatemplates.py
@@ -12,7 +12,7 @@ hello_vala_template = '''void main (string[] args) {{
 }}
 '''
 
-hello_vala_meson_template = '''project('{project_name}', ['c', 'vala'],
+hello_vala_meson_template = '''project('{project_name}', 'vala',
   meson_version : '>= {meson_version}',
   version : '{version}')
 
@@ -48,7 +48,7 @@ public void main() {{
 }}
 '''
 
-lib_vala_meson_template = '''project('{project_name}', ['c', 'vala'],
+lib_vala_meson_template = '''project('{project_name}', 'vala',
   meson_version : '>= {meson_version}',
   version : '{version}')
 

--- a/mesonbuild/templates/valatemplates.py
+++ b/mesonbuild/templates/valatemplates.py
@@ -13,6 +13,7 @@ hello_vala_template = '''void main (string[] args) {{
 '''
 
 hello_vala_meson_template = '''project('{project_name}', ['c', 'vala'],
+  meson_version : '>= {meson_version}',
   version : '{version}')
 
 dependencies = [
@@ -48,6 +49,7 @@ public void main() {{
 '''
 
 lib_vala_meson_template = '''project('{project_name}', ['c', 'vala'],
+  meson_version : '>= {meson_version}',
   version : '{version}')
 
 dependencies = [

--- a/mesonbuild/templates/valatemplates.py
+++ b/mesonbuild/templates/valatemplates.py
@@ -12,17 +12,24 @@ hello_vala_template = '''void main (string[] args) {{
 }}
 '''
 
-hello_vala_meson_template = '''project('{project_name}', 'vala',
+hello_vala_meson_template = '''project(
+  '{project_name}',
+  'vala',
   meson_version : '>= {meson_version}',
-  version : '{version}')
+  version : '{version}',
+)
 
 dependencies = [
-    dependency('glib-2.0'),
-    dependency('gobject-2.0'),
+  dependency('glib-2.0'),
+  dependency('gobject-2.0'),
 ]
 
-exe = executable('{exe_name}', '{source_name}', dependencies : dependencies,
-  install : true)
+exe = executable(
+  '{exe_name}',
+  '{source_name}',
+  dependencies : dependencies,
+  install : true,
+)
 
 test('basic', exe)
 '''
@@ -48,30 +55,42 @@ public void main() {{
 }}
 '''
 
-lib_vala_meson_template = '''project('{project_name}', 'vala',
+lib_vala_meson_template = '''project(
+  '{project_name}',
+  'vala',
   meson_version : '>= {meson_version}',
-  version : '{version}')
+  version : '{version}',
+)
 
 dependencies = [
-    dependency('glib-2.0'),
-    dependency('gobject-2.0'),
+  dependency('glib-2.0'),
+  dependency('gobject-2.0'),
 ]
 
 # These arguments are only used to build the shared library
 # not the executables that use the library.
-shlib = shared_library('foo', '{source_file}',
-               dependencies: dependencies,
-               install: true,
-               install_dir: [true, true, true])
+shlib = shared_library(
+  'foo',
+  '{source_file}',
+  dependencies : dependencies,
+  install : true,
+  install_dir : [true, true, true],
+)
 
-test_exe = executable('{test_exe_name}', '{test_source_file}', dependencies : dependencies,
-  link_with : shlib)
+test_exe = executable(
+  '{test_exe_name}',
+  '{test_source_file}',
+  dependencies : dependencies,
+  link_with : shlib,
+)
 test('{test_name}', test_exe)
 
 # Make this library usable as a Meson subproject.
 {ltoken}_dep = declare_dependency(
-  include_directories: include_directories('.'),
-  link_with : shlib)
+  include_directories : include_directories('.'),
+  link_with : shlib,
+)
+
 '''
 
 

--- a/mesonbuild/templates/valatemplates.py
+++ b/mesonbuild/templates/valatemplates.py
@@ -69,7 +69,7 @@ dependencies = [
 
 # These arguments are only used to build the shared library
 # not the executables that use the library.
-shlib = shared_library(
+lib = shared_library(
   'foo',
   '{source_file}',
   dependencies : dependencies,
@@ -81,7 +81,7 @@ test_exe = executable(
   '{test_exe_name}',
   '{test_source_file}',
   dependencies : dependencies,
-  link_with : shlib,
+  link_with : lib,
 )
 test('{test_name}', test_exe)
 
@@ -89,7 +89,7 @@ test('{test_name}', test_exe)
 {ltoken}_dep = declare_dependency(
   include_directories : include_directories('.'),
   dependencies : dependencies,
-  link_with : shlib,
+  link_with : lib,
 )
 meson.override_dependency('{project_name}', {ltoken}_dep)
 

--- a/mesonbuild/templates/valatemplates.py
+++ b/mesonbuild/templates/valatemplates.py
@@ -21,7 +21,7 @@ hello_vala_meson_template = '''project(
 
 dependencies = [
   dependency('glib-2.0'),
-  dependency('gobject-2.0'),
+  dependency('gobject-2.0'),{dependencies}
 ]
 
 exe = executable(
@@ -64,7 +64,7 @@ lib_vala_meson_template = '''project(
 
 dependencies = [
   dependency('glib-2.0'),
-  dependency('gobject-2.0'),
+  dependency('gobject-2.0'),{dependencies}
 ]
 
 # These arguments are only used to build the shared library
@@ -88,6 +88,7 @@ test('{test_name}', test_exe)
 # Make this library usable as a Meson subproject.
 {ltoken}_dep = declare_dependency(
   include_directories : include_directories('.'),
+  dependencies : dependencies,
   link_with : shlib,
 )
 

--- a/mesonbuild/templates/valatemplates.py
+++ b/mesonbuild/templates/valatemplates.py
@@ -91,6 +91,7 @@ test('{test_name}', test_exe)
   dependencies : dependencies,
   link_with : shlib,
 )
+meson.override_dependency('{project_name}', {ltoken}_dep)
 
 '''
 


### PR DESCRIPTION
There's a couple of changes here. There's some just plain code cleanups, there's some formatting work, some replacement of deprecated methods, and some work to combine the templates and make them more powerful.

On that work I've done the following:
  - combined the "brand new project" and "add Meson to a project" paths to use the same code, this has enhanced both paths
  - updating the pkg-config API usage to use the "lib as a positional argument" approach
  - updating the way Meson version is handled to allow each template to set its own minimum
  - call `meson.override_dependency()` when we create the dependency for subprojects
  - use library() and `<lang>_shared_args` instead of shared_library