### PR TITLE
rust: add 2024 edition

### DIFF
--- a/docs/markdown/snippets/rust-2024.md
+++ b/docs/markdown/snippets/rust-2024.md
@@ -1,0 +1,5 @@
+## Support for Rust 2024
+
+Meson can now request the compiler to use the 2024 edition of Rust.  Use
+`rust_std=2024` to activate it.  Rust 2024 requires the 1.85.0 version
+(or newer) of the compiler.

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -223,7 +223,7 @@ class RustCompiler(Compiler):
         return dict((self.create_option(options.UserComboOption,
                                         self.form_compileropt_key('std'),
                                         'Rust edition to use',
-                                        ['none', '2015', '2018', '2021'],
+                                        ['none', '2015', '2018', '2021', '2024'],
                                         'none'),))
 
     def get_dependency_compile_args(self, dep: 'Dependency') -> T.List[str]:


### PR DESCRIPTION
Rust edition 2024 is being released in February, add support for rust_std=2024.

Resolves: #14074