### PR TITLE
Speedup regex usage

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2012-2017 The Meson development team
-# Copyright © 2023-2024 Intel Corporation
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 
@@ -351,6 +351,7 @@ class NinjaBuildElement:
         if name == 'DEPFILE':
             self.elems.append((name + '_UNQUOTED', elems))
 
+    @mesonlib.lazy_property
     def _should_use_rspfile(self) -> bool:
         # 'phony' is a rule built-in to ninja
         if self.rulename == 'phony':
@@ -368,7 +369,7 @@ class NinjaBuildElement:
 
     def count_rule_references(self) -> None:
         if self.rulename != 'phony':
-            if self._should_use_rspfile():
+            if self._should_use_rspfile:
                 self.rule.rsprefcount += 1
             else:
                 self.rule.refcount += 1
@@ -381,7 +382,7 @@ class NinjaBuildElement:
         implicit_outs = ' '.join([ninja_quote(i, True) for i in self.implicit_outfilenames])
         if implicit_outs:
             implicit_outs = ' | ' + implicit_outs
-        use_rspfile = self._should_use_rspfile()
+        use_rspfile = self._should_use_rspfile
         if use_rspfile:
             rulename = self.rulename + '_RSP'
             mlog.debug(f'Command line for building {self.outfilenames} is long, using a response file')

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3520,6 +3520,8 @@ class Interpreter(InterpreterBase, HoldableObject):
     @noSecondLevelHolderResolving
     def func_set_variable(self, node: mparser.BaseNode, args: T.Tuple[str, object], kwargs: 'TYPE_kwargs') -> None:
         varname, value = args
+        if mparser.IDENT_RE.fullmatch(varname) is None:
+            raise InvalidCode('Invalid variable name: ' + varname)
         self.set_variable(varname, value, holderify=True)
 
     @typed_pos_args('get_variable', (str, Disabler), optargs=[object])

--- a/mesonbuild/interpreterbase/interpreterbase.py
+++ b/mesonbuild/interpreterbase/interpreterbase.py
@@ -655,8 +655,6 @@ class InterpreterBase:
                 raise mesonlib.MesonBugException(f'set_variable in InterpreterBase called with a non InterpreterObject {variable} of type {type(variable).__name__}')
         if not isinstance(varname, str):
             raise InvalidCode('First argument to set_variable must be a string.')
-        if re.match('[_a-zA-Z][_0-9a-zA-Z]*$', varname) is None:
-            raise InvalidCode('Invalid variable name: ' + varname)
         if varname in self.builtin:
             raise InvalidCode(f'Tried to overwrite internal variable "{varname}"')
         self.variables[varname] = variable

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -94,6 +94,9 @@ class Token(T.Generic[TV_TokenTypes]):
             return self.tid == other.tid
         return NotImplemented
 
+
+IDENT_RE = re.compile('[_a-zA-Z][_0-9a-zA-Z]*')
+
 class Lexer:
     def __init__(self, code: str):
         if code.startswith(codecs.BOM_UTF8.decode('utf-8')):
@@ -113,7 +116,7 @@ class Lexer:
             ('whitespace', re.compile(r'[ \t]+')),
             ('multiline_fstring', re.compile(r"f'''(.|\n)*?'''", re.M)),
             ('fstring', re.compile(r"f'([^'\\]|(\\.))*'")),
-            ('id', re.compile('[_a-zA-Z][_0-9a-zA-Z]*')),
+            ('id', IDENT_RE),
             ('number', re.compile(r'0[bB][01]+|0[oO][0-7]+|0[xX][0-9a-fA-F]+|0|[1-9]\d*')),
             ('eol_cont', re.compile(r'\\[ \t]*(#.*)?\n')),
             ('eol', re.compile(r'\n')),

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -828,21 +828,18 @@ def current_vs_supports_modules() -> bool:
         return True
     return vsver.startswith('16.9.0') and '-pre.' in vsver
 
+_VERSION_TOK_RE = re.compile(r'(\d+)|([a-zA-Z]+)')
+
 # a helper class which implements the same version ordering as RPM
 class Version:
     def __init__(self, s: str) -> None:
         self._s = s
 
-        # split into numeric, alphabetic and non-alphanumeric sequences
-        sequences1 = re.finditer(r'(\d+|[a-zA-Z]+|[^a-zA-Z\d]+)', s)
-
-        # non-alphanumeric separators are discarded
-        sequences2 = [m for m in sequences1 if not re.match(r'[^a-zA-Z\d]+', m.group(1))]
-
+        # extract numeric and alphabetic sequences
         # numeric sequences are converted from strings to ints
-        sequences3 = [int(m.group(1)) if m.group(1).isdigit() else m.group(1) for m in sequences2]
-
-        self._v = sequences3
+        self._v = [
+                int(m.group(1)) if m.group(1) else m.group(2)
+                for m in _VERSION_TOK_RE.finditer(s)]
 
     def __str__(self) -> str:
         return '{} (V={})'.format(self._s, str(self._v))

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -130,6 +130,7 @@ __all__ = [
     'is_wsl',
     'iter_regexin_iter',
     'join_args',
+    'lazy_property',
     'listify',
     'listify_array_value',
     'partition',
@@ -2379,3 +2380,22 @@ def first(iter: T.Iterable[_T], predicate: T.Callable[[_T], bool]) -> T.Optional
         if predicate(i):
             return i
     return None
+
+
+class lazy_property(T.Generic[_T]):
+    """Descriptor that replaces the function it wraps with the value generated.
+
+    This property will only be calculated the first time it's queried, and will
+    be cached and the cached value used for subsequent calls.
+
+    This works by shadowing itself with the calculated value, in the instance.
+    Due to Python's MRO that means that the calculated value will be found
+    before this property, speeding up subsequent lookups.
+    """
+    def __init__(self, func: T.Callable[[T.Any], _T]):
+        self.__func = func
+
+    def __get__(self, instance: object, cls: T.Type) -> _T:
+        value = self.__func(instance)
+        setattr(instance, self.__func.__name__, value)
+        return value


### PR DESCRIPTION
Optimize a few uses of uncompiled regex that amount to a visible % of meson's run time. Frequently used regexes should be either compiled, or removed altogether.

Version checks remain quite inefficient, taking about 2% of the runtime; but they're not easy to improve (e.g. by pre-building the Version objects) because most of them are of the compare_condition_with_min kind.

While these are small improvements, they pile up.