### PR TITLE
programs: fix regex to match multi-digit major version

### DIFF
--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -123,7 +123,7 @@ class ExternalProgram(mesonlib.HoldableObject):
             if not output:
                 output = e.strip()
 
-            match = re.search(r'([0-9](\.[0-9]+)+)', output)
+            match = re.search(r'([0-9]+(\.[0-9]+)+)', output)
             if not match:
                 match = re.search(r'([0-9][0-9\.]+)', output)
             if not match:

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -689,6 +689,7 @@ class InternalTests(unittest.TestCase):
                     'foo 1.2.4.': '1.2.4',
                     'foo 1.2.4': '1.2.4',
                     'foo 1.2.4 bar': '1.2.4',
+                    'foo 10.0.0': '10.0.0',
                     '50 5.4.0': '5.4.0',
                     'This is perl 5, version 40, subversion 0 (v5.40.0)': '5.40.0',
                     'git version 2.48.0.rc1': '2.48.0',


### PR DESCRIPTION
In a3679a64e (programs: favor version numbers with dots, 2025-01-03) we have changed the regex used to extract version numbers to favor dotted versions. It was reported though that the regex doesn't match major version numbers that start with multiple digits correctly. Fix this.