### PR TITLE
Fix broken both_libraries transitive dependencies

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -6,6 +6,7 @@ from collections import defaultdict, OrderedDict
 from dataclasses import dataclass, field, InitVar
 from functools import lru_cache
 import abc
+import copy
 import hashlib
 import itertools, pathlib
 import os
@@ -1757,7 +1758,7 @@ class BuildTarget(Target):
                 lib_list.append(lib)
         return lib_list
 
-    def get(self, lib_type: T.Literal['static', 'shared', 'auto']) -> LibTypes:
+    def get(self, lib_type: T.Literal['static', 'shared']) -> LibTypes:
         """Base case used by BothLibraries"""
         return self
 
@@ -2211,12 +2212,16 @@ class StaticLibrary(BuildTarget):
         return not self.install
 
     def set_shared(self, shared_library: SharedLibrary) -> None:
-        self.both_lib = shared_library
+        self.both_lib = copy.copy(shared_library)
+        self.both_lib.both_lib = None
 
-    def get(self, lib_type: T.Literal['static', 'shared', 'auto']) -> LibTypes:
+    def get(self, lib_type: T.Literal['static', 'shared'], recursive: bool = False) -> LibTypes:
+        result = self
         if lib_type == 'shared':
-            return self.both_lib or self
-        return self
+            result = self.both_lib or self
+        if recursive:
+            result.link_targets = [t.get(lib_type, True) for t in self.link_targets]
+        return result
 
 class SharedLibrary(BuildTarget):
     known_kwargs = known_shlib_kwargs
@@ -2485,12 +2490,16 @@ class SharedLibrary(BuildTarget):
         return True
 
     def set_static(self, static_library: StaticLibrary) -> None:
-        self.both_lib = static_library
+        self.both_lib = copy.copy(static_library)
+        self.both_lib.both_lib = None
 
-    def get(self, lib_type: T.Literal['static', 'shared']) -> LibTypes:
+    def get(self, lib_type: T.Literal['static', 'shared'], recursive: bool = False) -> LibTypes:
+        result = self
         if lib_type == 'static':
-            return self.both_lib or self
-        return self
+            result = self.both_lib or self
+        if recursive:
+            result.link_targets = [t.get(lib_type, True) for t in self.link_targets]
+        return result
 
 # A shared library that is meant to be used with dlopen rather than linking
 # into something else.
@@ -2537,7 +2546,7 @@ class BothLibraries(SecondLevelHolder):
     def __repr__(self) -> str:
         return f'<BothLibraries: static={repr(self.static)}; shared={repr(self.shared)}>'
 
-    def get(self, lib_type: T.Literal['static', 'shared', 'auto']) -> LibTypes:
+    def get(self, lib_type: T.Literal['static', 'shared']) -> LibTypes:
         if lib_type == 'static':
             return self.static
         if lib_type == 'shared':
@@ -2611,7 +2620,7 @@ class CustomTargetBase:
     def get_internal_static_libraries_recurse(self, result: OrderedSet[BuildTargetTypes]) -> None:
         pass
 
-    def get(self, lib_type: T.Literal['static', 'shared', 'auto']) -> LibTypes:
+    def get(self, lib_type: T.Literal['static', 'shared'], recursive: bool = False) -> LibTypes:
         """Base case used by BothLibraries"""
         return self
 

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -371,14 +371,14 @@ class InternalDependency(Dependency):
 
     def get_as_static(self, recursive: bool) -> InternalDependency:
         new_dep = copy.copy(self)
-        new_dep.libraries = [lib.get('static') for lib in self.libraries]
+        new_dep.libraries = [lib.get('static', recursive) for lib in self.libraries]
         if recursive:
             new_dep.ext_deps = [dep.get_as_static(True) for dep in self.ext_deps]
         return new_dep
 
     def get_as_shared(self, recursive: bool) -> InternalDependency:
         new_dep = copy.copy(self)
-        new_dep.libraries = [lib.get('shared') for lib in self.libraries]
+        new_dep.libraries = [lib.get('shared', recursive) for lib in self.libraries]
         if recursive:
             new_dep.ext_deps = [dep.get_as_shared(True) for dep in self.ext_deps]
         return new_dep

--- a/test cases/common/273 both libraries/meson.build
+++ b/test cases/common/273 both libraries/meson.build
@@ -111,3 +111,32 @@ if get_option('default_library') == 'both' and get_option('default_both_librarie
     )
     test('test shared', main_shared)
 endif
+
+# Test case for https://github.com/mesonbuild/meson/pull/14098
+if get_option('default_library') == 'shared'
+
+    if get_option('use_dep')
+        lib_deps = [with_bl_dep.as_static(recursive: true)]
+        lib_links = []
+    else
+        lib_deps = []
+        lib_links = [with_bl.get_static_lib()]
+    endif
+
+    lib_with_static_dep = library(
+        'lib_with_static_dep',
+        files('src/library.c'),
+        c_shared_args: ['-DEXPORT'],
+        link_with: lib_links,
+        dependencies: lib_deps,
+    )
+
+    main_with_static_dep = executable(
+        'main_with_static_dep',
+        files('src/main.c'),
+        c_args: [f'-DEXPECTED=1'],
+        link_with: lib_with_static_dep,
+    )
+    test('test static dep', main_with_static_dep)
+
+endif


### PR DESCRIPTION
 #13837 broke both_lib transitive deps, because the
`as_static` and `as_shared` functions return libraries that still contain references to the other lib type.