### PR TITLE
Allow for cmake w-flags addition

### DIFF
--- a/mesonbuild/cmake/__init__.py
+++ b/mesonbuild/cmake/__init__.py
@@ -15,12 +15,13 @@ __all__ = [
     'TargetOptions',
     'language_map',
     'cmake_defines_to_args',
+    'cmake_warning_flags_to_args',
     'check_cmake_args',
     'cmake_is_debug',
     'resolve_cmake_trace_targets',
 ]
 
-from .common import CMakeException, TargetOptions, cmake_defines_to_args, language_map, check_cmake_args, cmake_is_debug
+from .common import CMakeException, TargetOptions, cmake_defines_to_args, cmake_warning_flags_to_args, language_map, check_cmake_args, cmake_is_debug
 from .executor import CMakeExecutor
 from .interpreter import CMakeInterpreter
 from .toolchain import CMakeToolchain, CMakeExecScope

--- a/mesonbuild/cmake/common.py
+++ b/mesonbuild/cmake/common.py
@@ -51,6 +51,9 @@ blacklist_cmake_defs = [
     'MESON_CMAKE_ROOT',
 ]
 
+blacklist_cmake_warning_flags = [
+]
+
 def cmake_is_debug(env: 'Environment') -> bool:
     if OptionKey('b_vscrt') in env.coredata.optstore:
         is_debug = env.coredata.get_option(OptionKey('buildtype')) == 'debug'
@@ -127,6 +130,20 @@ def cmake_defines_to_args(raw: T.List[T.Dict[str, TYPE_var]], permissive: bool =
                 res += [f'-D{key}={val_str}']
             else:
                 raise MesonException('Type "{}" of "{}" is not supported as for a CMake define value'.format(type(val).__name__, key))
+
+    return res
+
+def cmake_warning_flags_to_args(raw: T.List[str], permissive: bool = False) -> T.List[str]:
+    res: T.List[str] = []
+
+    for flag in raw:
+        if flag in blacklist_cmake_warning_flags:
+            # idk something something
+            #mlog.warning('Setting', mlog.bold(flag), 'is not supported. See the meson docs for cross compilation support:')
+            #mlog.warning('  - URL: https://mesonbuild.com/CMake-module.html#cross-compilation')
+            #mlog.warning('  --> Ignoring this option')
+            continue
+        res += [f'-W{flag}']
 
     return res
 

--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -11,7 +11,7 @@ from . import ExtensionModule, ModuleReturnValue, ModuleObject, ModuleInfo
 
 from .. import build, mesonlib, mlog, dependencies
 from ..options import OptionKey
-from ..cmake import TargetOptions, cmake_defines_to_args
+from ..cmake import TargetOptions, cmake_defines_to_args, cmake_warning_flags_to_args
 from ..interpreter import SubprojectHolder
 from ..interpreter.type_checking import REQUIRED_KW, INSTALL_DIR_KW, NoneType, in_set_validator
 from ..interpreterbase import (
@@ -191,6 +191,7 @@ class CMakeSubprojectOptions(ModuleObject):
         self.methods.update(
             {
                 'add_cmake_defines': self.add_cmake_defines,
+                'add_cmake_warning_flags': self.add_cmake_warning_flags,
                 'set_override_option': self.set_override_option,
                 'set_install': self.set_install,
                 'append_compile_args': self.append_compile_args,
@@ -208,6 +209,11 @@ class CMakeSubprojectOptions(ModuleObject):
     @noKwargs
     def add_cmake_defines(self, state: ModuleState, args: T.Tuple[T.List[T.Dict[str, TYPE_var]]], kwargs: TYPE_kwargs) -> None:
         self.cmake_options += cmake_defines_to_args(args[0])
+
+    @typed_pos_args('subproject_options.add_cmake_warning_flags', varargs=str)
+    @noKwargs
+    def add_cmake_warning_flags(self, state: ModuleState, args: T.Tuple[T.List[str]], kwargs: TYPE_kwargs) -> None:
+        self.cmake_options += cmake_warning_flags_to_args(args[0])
 
     @typed_pos_args('subproject_options.set_override_option', str, str)
     @typed_kwargs('subproject_options.set_override_option', _TARGET_KW)


### PR DESCRIPTION
Take this as a rough proposal - I've read the docs so I know there are more requirements, but I don't feel like spending that much time on something that is maybe not considered for a reason. I have no issues with adding all that is required afterwards.

During configuration of many 3rd party projects I'm getting a lot of messages meant for developers of those libraries which can be silenced using `-Wno-dev` flag passed to `cmake`. It cluttered the output so much I've started looking into it and spending better half a day on the issue I haven't found a way how to do it 'the right way'.

There are `cmake_options` that can be passed to `cmake.subproject` which I ended up with, but deprecated feature warning comes with it - still it's easier on the eyes than all the other unwanted output.

I've look around the documentation, many issues, conversations and finally source code and I haven't been able to find such option. I've tried even to 'hack' `add_cmake_defines` with something like `'DUMMYSTART=False -Wno-dev -DDUMMYEND' : false` but to no one's surprise, arguments are being passed properly 😄 

After all this I've come up with one solution myself and although it works, it is just that. Working proposal.

I don't know why it's not yet exposed, if there are some reasons to keep end user safe whatever just let me know. If it's something that could be implemented I'd gladly finish it, but I've come across the whole environment variables topic (python script to generate meson.options with resolved variables is working just great btw. but still), so I'm familiar with some forced limitations already. If this is one of those, feel free to close this PR.