### PR TITLE
qt module: temporary disable OpenSuse QML tests

### DIFF
--- a/test cases/frameworks/39 qt qml/test.json
+++ b/test cases/frameworks/39 qt qml/test.json
@@ -18,5 +18,5 @@
     {"type": "file", "file": "usr/qml/My/Module5/qmldir"},
     {"type": "file", "file": "usr/qml/My/Module5/My_Module5.qmltypes"}
   ],
-  "expect_skip_on_jobname": ["cygwin", "msys2", "azure", "bionic", "macos"]
+  "expect_skip_on_jobname": ["cygwin", "msys2", "azure", "bionic", "macos", "opensuse"]
 }


### PR DESCRIPTION
OpenSuse CI image can't be updated at the moment. Disable QML tests that depend on new system packages.