### PR TITLE
Remove get_id() hotspot

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -25,7 +25,7 @@ from .mesonlib import (
     extract_as_list, typeslistify, stringlistify, classify_unity_sources,
     get_filenames_templates_dict, substitute_values, has_path_sep,
     PerMachineDefaultable,
-    MesonBugException, EnvironmentVariables, pickle_load,
+    MesonBugException, EnvironmentVariables, pickle_load, lazy_property,
 )
 from .options import OptionKey
 
@@ -639,12 +639,16 @@ class Target(HoldableObject, metaclass=abc.ABCMeta):
             return subdir_part + '@@' + my_id
         return my_id
 
-    def get_id(self) -> str:
+    @lazy_property
+    def id(self) -> str:
         name = self.name
         if getattr(self, 'name_suffix_set', False):
             name += '.' + self.suffix
         return self.construct_id_from_path(
             self.subdir, name, self.type_suffix())
+
+    def get_id(self) -> str:
+        return self.id
 
     def process_kwargs_base(self, kwargs: T.Dict[str, T.Any]) -> None:
         if 'build_by_default' in kwargs:

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -2379,10 +2379,17 @@ class lazy_property(T.Generic[_T]):
     Due to Python's MRO that means that the calculated value will be found
     before this property, speeding up subsequent lookups.
     """
-    def __init__(self, func: T.Callable[[T.Any], _T]):
+    def __init__(self, func: T.Callable[[T.Any], _T]) -> None:
+        self.__name: T.Optional[str] = None
         self.__func = func
+
+    def __set_name__(self, owner: T.Any, name: str) -> None:
+        if self.__name is None:
+            self.__name = name
+        else:
+            assert name == self.__name
 
     def __get__(self, instance: object, cls: T.Type) -> _T:
         value = self.__func(instance)
-        setattr(instance, self.__func.__name__, value)
+        setattr(instance, self.__name, value)
         return value


### PR DESCRIPTION
Use lazy_property for get_id(). To avoid touching code all over the place, keep get_id() but make it access the actual lazy property (which will be simply an entry in self.__dict__)
