### PR TITLE
docs: add Git to list of projects using meson

### DIFF
--- a/docs/markdown/Users.md
+++ b/docs/markdown/Users.md
@@ -53,6 +53,7 @@ topic](https://github.com/topics/meson).
  - [GameMode](https://github.com/FeralInteractive/gamemode), a daemon/lib combo for Linux that allows games to request a set of optimisations be temporarily applied to the host OS
  - [Geary](https://wiki.gnome.org/Apps/Geary), an email application built around conversations, for the GNOME 3 desktop
  - [GIMP](https://gitlab.gnome.org/GNOME/gimp), an image manipulation program (master branch)
+ - [git](https://git-scm.com/), needs no introduction
  - [GLib](https://gitlab.gnome.org/GNOME/glib), cross-platform C library used by GTK+ and GStreamer
  - [Glorytun](https://github.com/angt/glorytun), a multipath UDP tunnel
  - [GNOME Boxes](https://gitlab.gnome.org/GNOME/gnome-boxes), a GNOME hypervisor

--- a/docs/markdown/Users.md
+++ b/docs/markdown/Users.md
@@ -53,7 +53,7 @@ topic](https://github.com/topics/meson).
  - [GameMode](https://github.com/FeralInteractive/gamemode), a daemon/lib combo for Linux that allows games to request a set of optimisations be temporarily applied to the host OS
  - [Geary](https://wiki.gnome.org/Apps/Geary), an email application built around conversations, for the GNOME 3 desktop
  - [GIMP](https://gitlab.gnome.org/GNOME/gimp), an image manipulation program (master branch)
- - [git](https://git-scm.com/), needs no introduction
+ - [Git](https://git-scm.com/), ["the information manager from hell"](https://github.com/git/git/commit/e83c5163316f89bfbde7d9ab23ca2e25604af290)
  - [GLib](https://gitlab.gnome.org/GNOME/glib), cross-platform C library used by GTK+ and GStreamer
  - [Glorytun](https://github.com/angt/glorytun), a multipath UDP tunnel
  - [GNOME Boxes](https://gitlab.gnome.org/GNOME/gnome-boxes), a GNOME hypervisor


### PR DESCRIPTION
Git 2.48 introduced support for the Meson build system:

https://github.com/git/git/commit/904339edbd80ec5676616af6e072b41804c1c8eb

https://github.blog/open-source/git/highlights-from-git-2-48/