### PR TITLE
Add support for building Apple bundles

### DIFF
--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -62,7 +62,7 @@ Builds a default or a specified target of a configured Meson project.
 - `NAME`: name of the target from `meson.build` (e.g. `foo` from `executable('foo', ...)`).
 - `SUFFIX`: name of the suffix of the target from `meson.build` (e.g. `exe` from `executable('foo', suffix: 'exe', ...)`).
 - `PATH`: path to the target relative to the root `meson.build` file. Note: relative path for a target specified in the root `meson.build` is `./`.
-- `TYPE`: type of the target. Can be one of the following: 'executable', 'static_library', 'shared_library', 'shared_module', 'custom', 'alias', 'run', 'jar'.
+- `TYPE`: type of the target. Can be one of the following: 'executable', 'static_library', 'shared_library', 'shared_module', 'custom', 'alias', 'run', 'jar', 'nsapp', 'nsframework', 'nsbundle'.
 
 `PATH`, `SUFFIX`, and `TYPE` can all be omitted if the resulting `TARGET` can be
 used to uniquely identify the target in `meson.build`.

--- a/docs/markdown/NSBundle-module.md
+++ b/docs/markdown/NSBundle-module.md
@@ -1,0 +1,3 @@
+# NSBundle module
+
+TODO

--- a/docs/sitemap.txt
+++ b/docs/sitemap.txt
@@ -48,6 +48,7 @@ index.md
 			Icestorm-module.md
 			Java-module.md
 			Keyval-module.md
+			NSBundle-module.md
 			Pkgconfig-module.md
 			Python-3-module.md
 			Python-module.md

--- a/docs/theme/extra/templates/navbar_links.html
+++ b/docs/theme/extra/templates/navbar_links.html
@@ -18,6 +18,7 @@
             ("Icestorm-module.html","Icestorm"), \
             ("Java-module.html","Java"), \
             ("Keyval-module.html","Keyval"), \
+            ("NSBundle-module.html","NSBundle"), \
             ("Pkgconfig-module.html","Pkgconfig"), \
             ("Python-3-module.html","Python 3"), \
             ("Python-module.html","Python"), \

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -34,12 +34,15 @@ _TARGET_KWARGS: T.Mapping[str, set[str]] = {
     'shared module': {s.name for s in type_checking.SHARED_MOD_KWS},
     'static library': {s.name for s in type_checking.STATIC_LIB_KWS},
     'both libraries': {s.name for s in type_checking.LIBRARY_KWS},
+    'nsapp': {s.name for s in type_checking.NSAPP_KWS},
+    'nsframework': {s.name for s in type_checking.NSFRAMEWORK_KWS},
+    #'nsbundle': {s.name for s in type_checking.NSBUNDLE_KWS},
 }
 
 # TODO: it would be nice to not have to duplicate this
 BUILD_TARGET_FUNCTIONS = [
     'executable', 'jar', 'library', 'shared_library', 'shared_module',
-    'static_library', 'both_libraries'
+    'static_library', 'both_libraries', 'nsapp', 'nsframework', 'nsbundle'
 ]
 
 class IntrospectionHelper:

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -25,6 +25,7 @@ from .. import mesonlib
 from .. import mlog
 from .. import compilers
 from ..compilers import detect, lang_suffixes
+from ..compilers.mixins.clang import ClangCompiler
 from ..mesonlib import (
     File, MachineChoice, MesonException, MesonBugException, OrderedSet,
     ExecutableSerialisation, EnvironmentException, FileMode, InstallScriptFailure,
@@ -354,22 +355,30 @@ class Backend:
         return compiler.get_include_args(curdir, False)
 
     def get_target_filename_for_linking(self, target: build.AnyTargetType) -> T.Optional[str]:
+        if isinstance(target, (build.BuildTarget, build.CustomTarget, build.CustomTargetIndex)):
+            target_filename = target.get_filename()
+
+            if isinstance(target, build.BundleTargetBase):
+                # TODO: what's the difference linking a framework like this vs. the bespoke framework arg on macOS's ld?
+                # (this also has the advantage of working on other platforms!)
+                target_filename = os.path.join(target_filename, target.get_bundle_info().get_executable_path())
+
         # On some platforms (msvc for instance), the file that is used for
         # dynamic linking is not the same as the dynamic library itself. This
         # file is called an import library, and we want to link against that.
         # On all other platforms, we link to the library directly.
         if isinstance(target, build.SharedLibrary):
-            link_lib = target.get_import_filename() or target.get_filename()
+            link_lib = target.get_import_filename() or target_filename
             # In AIX, if we archive .so, the blibpath must link to archived shared library otherwise to the .so file.
             if mesonlib.is_aix() and target.aix_so_archive:
                 link_lib = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*', '.a', link_lib.replace('.so', '.a'))
             return Path(self.get_target_dir(target), link_lib).as_posix()
         elif isinstance(target, build.StaticLibrary):
-            return Path(self.get_target_dir(target), target.get_filename()).as_posix()
+            return Path(self.get_target_dir(target), target_filename).as_posix()
         elif isinstance(target, (build.CustomTarget, build.CustomTargetIndex)):
             if not target.is_linkable_target():
                 raise MesonException(f'Tried to link against custom target "{target.name}", which is not linkable.')
-            return Path(self.get_target_dir(target), target.get_filename()).as_posix()
+            return Path(self.get_target_dir(target), target_filename).as_posix()
         elif isinstance(target, build.Executable):
             if target.import_filename:
                 return Path(self.get_target_dir(target), target.get_import_filename()).as_posix()
@@ -1036,11 +1045,17 @@ class Backend:
                             break
                         commands += ['--target-glib', f'{glib_version[0]}.{glib_version[1]}']
 
-        # Fortran requires extra include directives.
-        if compiler.language == 'fortran':
-            for lt in chain(target.link_targets, target.link_whole_targets):
+        for lt in chain(target.link_targets, target.link_whole_targets):
+            # Fortran requires extra include directives.
+            if compiler.language == 'fortran':
                 priv_dir = self.get_target_private_dir(lt)
                 commands += compiler.get_include_args(priv_dir, False)
+
+            # Add linked frameworks to include path
+            if isinstance(lt, build.FrameworkBundle):
+                # TODO: Handle this in the compiler class?
+                assert isinstance(compiler, ClangCompiler), 'Linking against frameworks requires clang'
+                commands += [f'-F{self.get_target_dir(lt)}', '-framework', lt.get_basename()]
         return commands
 
     def build_target_link_arguments(self, compiler: Compiler, deps: T.Iterable[build.BuildTargetTypes]) -> T.List[str]:

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -315,6 +315,8 @@ class Backend:
             filename = t.get_outputs()[0]
         elif isinstance(t, build.CustomTargetIndex):
             filename = t.get_outputs()[0]
+        elif isinstance(t, build.BundleTarget):
+            filename = t.get_filename()
         else:
             assert isinstance(t, build.BuildTarget), t
             filename = t.get_filename()

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -4048,12 +4048,12 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             else:
                 self.implicit_meson_outs.append(aliasfile)
 
-    def generate_custom_target_clean(self, trees: T.List[str]) -> str:
+    def generate_dir_target_clean(self, trees: T.List[str]) -> str:
         e = self.create_phony_target('clean-ctlist', 'CUSTOM_COMMAND', 'PHONY')
         d = CleanTrees(self.environment.get_build_dir(), trees)
         d_file = os.path.join(self.environment.get_scratch_dir(), 'cleantrees.dat')
         e.add_item('COMMAND', self.environment.get_build_command() + ['--internal', 'cleantrees', d_file])
-        e.add_item('description', 'Cleaning custom target directories')
+        e.add_item('description', 'Cleaning directory target outputs')
         self.add_build(e)
         # Write out the data file passed to the script
         with open(d_file, 'wb') as ofile:
@@ -4260,16 +4260,15 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         # instead of files. This is needed because on platforms other than
         # Windows, Ninja only deletes directories while cleaning if they are
         # empty. https://github.com/mesonbuild/meson/issues/1220
-        ctlist = []
+        dir_output_list = []
         for t in self.build.get_targets().values():
-            if isinstance(t, build.CustomTarget):
-                # Create a list of all custom target outputs
-                for o in t.get_outputs():
-                    ctlist.append(os.path.join(self.get_target_dir(t), o))
+            for o in t.get_outputs():
+                if t.can_output_be_directory(o):
+                    dir_output_list.append(os.path.join(self.get_target_dir(t), o))
         # Also clean meson-dist directory created by `meson dist`
-        ctlist.append('meson-dist')
-        if ctlist:
-            elem.add_dep(self.generate_custom_target_clean(ctlist))
+        dir_output_list.append('meson-dist')
+        if dir_output_list:
+            elem.add_dep(self.generate_dir_target_clean(dir_output_list))
 
         if OptionKey('b_coverage') in self.environment.coredata.optstore and \
            self.environment.coredata.optstore.get_value_for('b_coverage'):

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1488,6 +1488,8 @@ class NinjaBackend(backends.Backend):
                                 restat=True))
         self.add_rule(NinjaRule('COPY_FILE', self.environment.get_build_command() + ['--internal', 'copy'],
                                 ['$in', '$out'], 'Copying $in to $out'))
+        self.add_rule(NinjaRule('SYMLINK_FILE', self.environment.get_build_command() + ['--internal', 'symlink'],
+                                ['$TARGET', '$out'], 'Creating symlink $out -> $TARGET'))
         self.add_rule(NinjaRule('MERGE_PLIST', self.environment.get_build_command() + ['--internal', 'merge-plist'],
                                 ['$out', '$in'], 'Merging plist $in to $out'))
 
@@ -1976,6 +1978,12 @@ class NinjaBackend(backends.Backend):
             instr = src
         elem = NinjaBuildElement(self.all_outputs, [str(output)], 'COPY_FILE', [instr])
         elem.add_orderdep(instr)
+        self.add_build(elem)
+
+    def _generate_symlink_target(self, src: str, output: Path) -> None:
+        """Create a target to create a symbolic link."""
+        elem = NinjaBuildElement(self.all_outputs, [str(output)], 'SYMLINK_FILE', [])
+        elem.add_item('TARGET', src)
         self.add_build(elem)
 
     def __generate_sources_structure(self, root: Path, structured_sources: build.StructuredSources,

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -979,6 +979,9 @@ class NinjaBackend(backends.Backend):
         if isinstance(target, build.RunTarget):
             self.generate_run_target(target)
             return
+        if isinstance(target, build.BundleTarget):
+            self.generate_bundle_target3(target)
+            return
         assert isinstance(target, build.BuildTarget)
         os.makedirs(self.get_target_private_dir_abs(target), exist_ok=True)
         compiled_sources: T.List[str] = []
@@ -1670,6 +1673,10 @@ class NinjaBackend(backends.Backend):
                     make_relative_link(contents_dir / n, path / n)
 
         self.add_build(elem)
+
+    def generate_bundle_target3(self, target: build.BundleTarget) -> None:
+        main_exe = os.path.join(self.get_target_dir(target.main_exe), target.main_exe.get_filename())
+        self.generate_bundle_target(target, main_exe)
 
     def generate_cs_resource_tasks(self, target: build.BuildTarget) -> T.Tuple[T.List[str], T.List[str]]:
         args = []

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1488,6 +1488,8 @@ class NinjaBackend(backends.Backend):
                                 restat=True))
         self.add_rule(NinjaRule('COPY_FILE', self.environment.get_build_command() + ['--internal', 'copy'],
                                 ['$in', '$out'], 'Copying $in to $out'))
+        self.add_rule(NinjaRule('MERGE_PLIST', self.environment.get_build_command() + ['--internal', 'merge-plist'],
+                                ['$out', '$in'], 'Merging plist $in to $out'))
 
         c = self.environment.get_build_command() + \
             ['--internal',
@@ -3627,6 +3629,18 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         if self.environment.is_cross_build():
             elem.add_item('CROSS', '--cross-host=' + self.environment.machines[target.for_machine].system)
         self.add_build(elem)
+
+    def generate_merge_plist(self, target: build.BuildTarget, out_name: str, in_files: T.List[File]) -> File:
+        out_path = os.path.join(self.get_target_private_dir(target), out_name)
+        elem = NinjaBuildElement(
+            self.all_outputs,
+            out_path,
+            'MERGE_PLIST',
+            [f.rel_to_builddir(self.build_to_src) for f in in_files],
+        )
+        self.add_build(elem)
+
+        return File(True, self.get_target_private_dir(target), out_name)
 
     def get_import_filename(self, target: build.Executable | build.SharedLibrary) -> str:
         return os.path.join(self.get_target_dir(target), target.import_filename)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -24,6 +24,7 @@ from .. import modules
 from .. import mesonlib
 from .. import build
 from .. import mlog
+from .. import nsbundle
 from .. import compilers
 from .. import tooldetect
 from ..arglist import CompilerArgs
@@ -1576,6 +1577,100 @@ class NinjaBackend(backends.Backend):
         # Create introspection information
         self.create_target_source_introspection(target, compiler, compile_args, src_list, gen_src_list)
 
+    def generate_bundle_target(self, target: build.BundleTargetBase, main_exe: str) -> None:
+        bi: nsbundle.BundleInfo = target.get_bundle_info()
+
+        main_exe_dir, main_exe_fname = os.path.split(main_exe)
+        bundle_rel = self.get_target_filename(target)
+
+        presets_path = os.path.join(self.get_target_private_dir(target), 'Presets', 'Info.plist')
+        presets_fullpath = os.path.join(self.environment.get_build_dir(), presets_path)
+        os.makedirs(os.path.dirname(presets_fullpath), exist_ok=True)
+
+        with open(presets_fullpath, 'wb') as fp:
+            import plistlib
+
+            d = bi.get_configured_info_dict()
+            plistlib.dump(d, fp)
+
+        presets_file = File(True, *os.path.split(presets_path))
+
+        if bi.info_dict_file:
+            info_plist = self.generate_merge_plist(target, 'Info.plist', [presets_file, bi.info_dict_file])
+        else:
+            info_plist = presets_file
+
+        layout = build.StructuredSources()
+        layout.sources[str(bi.get_executable_folder_path())] += [File(True, main_exe_dir, main_exe_fname)]
+        layout.sources[str(bi.get_infoplist_path())] += [info_plist]
+
+        if bi.resources is not None:
+            for k, v in bi.resources.sources.items():
+                layout.sources[str(bi.get_unlocalized_resources_folder_path() / k)] += v
+
+        if bi.contents is not None:
+            for k, v in bi.contents.sources.items():
+                layout.sources[str(bi.get_contents_folder_path() / k)] += v
+
+        if bi.headers is not None:
+            for k, v in bi.headers.sources.items():
+                layout.sources[str(bi.get_public_headers_folder_path() / k)] += v
+
+        if bi.extra_binaries is not None:
+            for v in bi.extra_binaries:
+                layout.sources[str(bi.get_executable_folder_path())] += v
+
+        for file in layout.as_list():
+            if isinstance(file, GeneratedList):
+                self.generate_genlist_for_target(file, target)
+
+        elem = NinjaBuildElement(self.all_outputs, bundle_rel, 'phony', [])
+        elem.add_orderdep(self.__generate_sources_structure(Path(bundle_rel), layout, target=target)[0])
+
+        # Create links for versioned bundles (frameworks only)
+        def make_relative_link(src: PurePath, dst: PurePath):
+            src_rel = src.relative_to(dst.parent, walk_up=True)
+            dst_path = Path(bundle_rel) / dst
+            elem.add_orderdep(str(dst_path))
+            self._generate_symlink_target(str(src_rel), dst_path)
+
+        contents_dir = bi.get_contents_folder_path()
+
+        for path in bi.get_paths_to_link_contents():
+            can_link_whole_dir = True
+
+            for d in layout.sources.keys():
+                if PurePath(d).is_relative_to(path):
+                    can_link_whole_dir = False
+                    break
+
+            if can_link_whole_dir:
+                make_relative_link(contents_dir, path)
+            else:
+                names = set()
+
+                for d in layout.sources.keys():
+                    d = PurePath(d)
+
+                    if not d.parent.is_relative_to(contents_dir):
+                        continue
+
+                    d = d.relative_to(contents_dir).parts[0]
+                    names.add(d)
+
+                for file in layout.sources[str(contents_dir)]:
+                    if isinstance(file, File):
+                        names.add(PurePath(file.fname).parts[0])
+                    else:
+                        names.update(file.get_outputs())
+
+                for n in names:
+                    assert n != '.'
+
+                    make_relative_link(contents_dir / n, path / n)
+
+        self.add_build(elem)
+
     def generate_cs_resource_tasks(self, target: build.BuildTarget) -> T.Tuple[T.List[str], T.List[str]]:
         args = []
         deps = []
@@ -1988,6 +2083,7 @@ class NinjaBackend(backends.Backend):
 
     def __generate_sources_structure(self, root: Path, structured_sources: build.StructuredSources,
                                      main_file_ext: T.Union[str, T.Tuple[str, ...]] = tuple(),
+                                     target: T.Optional[build.Target] = None,
                                      ) -> T.Tuple[T.List[str], T.Optional[str]]:
         first_file: T.Optional[str] = None
         orderdeps: T.List[str] = []
@@ -2001,11 +2097,19 @@ class NinjaBackend(backends.Backend):
                     if first_file is None and out_s.endswith(main_file_ext):
                         first_file = out_s
                 else:
+                    if isinstance(file, GeneratedList):
+                        if target is None:
+                            raise MesonBugException('Encountered GeneratedList in StructuredSources with None target')
+
+                        srcdir = Path(self.get_target_private_dir(target))
+                    else:
+                        srcdir = Path(file.subdir)
+
                     for f in file.get_outputs():
                         out = root / path / f
                         out_s = str(out)
                         orderdeps.append(out_s)
-                        self._generate_copy_target(str(Path(file.subdir) / f), out)
+                        self._generate_copy_target(str(srcdir / f), out)
                         if first_file is None and out_s.endswith(main_file_ext):
                             first_file = out_s
         return orderdeps, first_file
@@ -4240,6 +4344,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                     if self.environment.machines[t.for_machine].is_aix():
                         linker, stdlib_args = t.get_clink_dynamic_linker_and_stdlibs()
                         t.get_outputs()[0] = linker.get_archive_name(t.get_outputs()[0])
+
                 targetlist.append(os.path.join(self.get_target_dir(t), t.get_outputs()[0]))
 
                 # Add an import library if shared library in OS/2 for build all

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1040,7 +1040,11 @@ class NinjaBackend(backends.Backend):
         self.scan_fortran_module_outputs(target)
 
         # Generate rules for building the remaining source files in this target
-        outname = self.get_target_filename(target)
+        if isinstance(target, build.BundleTargetBase):
+            outname = os.path.join(self.get_target_private_dir(target), target.get_executable_name())
+        else:
+            outname = self.get_target_filename(target)
+
         obj_list = []
         is_unity = self.is_unity(target)
         header_deps = []
@@ -1204,6 +1208,9 @@ class NinjaBackend(backends.Backend):
             if target.aix_so_archive:
                 elem = NinjaBuildElement(self.all_outputs, linker.get_archive_name(outname), 'AIX_LINKER', [outname])
                 self.add_build(elem)
+
+        if isinstance(target, build.BundleTargetBase):
+            self.generate_bundle_target(target, elem.outfilenames[0])
 
     def should_use_dyndeps_for_target(self, target: build.BuildTargetTypes) -> bool:
         if not self.ninja_has_dyndeps:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1973,7 +1973,7 @@ class NinjaBackend(backends.Backend):
     def _generate_copy_target(self, src: FileOrString, output: Path) -> None:
         """Create a target to copy a source file from one location to another."""
         if isinstance(src, File):
-            instr = src.absolute_path(self.environment.source_dir, self.environment.build_dir)
+            instr = src.rel_to_builddir(self.build_to_src)
         else:
             instr = src
         elem = NinjaBuildElement(self.all_outputs, [str(output)], 'COPY_FILE', [instr])

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3485,6 +3485,15 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         if not self.use_dyndeps_for_fortran():
             for i in self.get_fortran_module_deps(target, compiler):
                 element.add_dep(i)
+
+        for lt in itertools.chain(target.link_targets, target.link_whole_targets):
+            # Linking against frameworks also pulls in its headers, therefore wait for it to be assembled. This is not
+            # exactly ideal, since it will also wait for the library to be linked, but it's better than no dep at all.
+            # TODO: check whether linking against framework is possible when only headers have been installed into the
+            # bundle
+            if isinstance(lt, build.FrameworkBundle):
+                element.add_orderdep(self.get_target_filename(lt))
+
         if dep_file:
             element.add_item('DEPFILE', dep_file)
         if compiler.get_language() == 'cuda':
@@ -3954,6 +3963,11 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                                                            self.get_target_dir(target))
         else:
             target_slashname_workaround_dir = self.get_target_dir(target)
+
+        if isinstance(target, build.BundleTargetBase):
+            target_slashname_workaround_dir = str(PurePath() / target_slashname_workaround_dir / target.get_filename() /
+                                                  target.get_bundle_info().get_executable_folder_path())
+
         (rpath_args, target.rpath_dirs_to_remove) = (
             linker.build_rpath_args(self.environment.get_build_dir(),
                                     target_slashname_workaround_dir,

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -29,7 +29,7 @@ from .mesonlib import (
     MesonBugException, EnvironmentVariables, pickle_load, lazy_property,
     unwrap,
 )
-from .nsbundle import BundleInfo, BundleType
+from .nsbundle import BundleInfo, BundleLayout, BundleType
 from .options import OptionKey
 
 from .compilers import (
@@ -1816,12 +1816,7 @@ class BuildTarget(Target):
             return
 
         self.link_depends.append(path)
-        if isinstance(path, File):
-            # When passing a generated file.
-            self.vs_module_defs = path
-        else:
-            # When passing output of a Custom Target
-            self.vs_module_defs = File.from_built_file(path.get_builddir(), path.get_filename())
+        self.vs_module_defs = _source_input_to_file(self, 'vs_module_defs', path)
 
     def _default_library_type(self) -> _LibraryType:
         bl_type = self.environment.coredata.optstore.get_value_for(OptionKey('default_both_libraries'))
@@ -1975,6 +1970,15 @@ class BuildTarget(Target):
             return 'darwin'
         else:
             return 'unix'
+
+
+def _source_input_to_file(t: Target, kw: str, source: T.Union[File, CustomTarget, CustomTargetIndex]) -> File:
+    if isinstance(source, File):
+        # When passing a generated file.
+        return source
+    else:
+        # When passing output of a Custom Target
+        return File.from_built_file(source.get_builddir(), source.get_filename())
 
 
 class LinkableTarget(metaclass=SimpleABC):
@@ -3410,6 +3414,104 @@ class BundleTargetBase(Target):
     @abc.abstractmethod
     def get_executable_name(self) -> str:
         pass
+
+
+def _fill_bundle_info_from_kwargs(tgt: BundleTargetBase, kwargs) -> None:
+    bi = tgt.get_bundle_info()
+    bi.resources = kwargs['bundle_resources']
+    bi.contents = kwargs['bundle_contents']
+    bi.extra_binaries = kwargs['bundle_extra_binaries']
+
+    info_plist = kwargs.get('info_plist')
+    if info_plist is not None:
+        bi.info_dict_file = _source_input_to_file(tgt, 'info_plist', info_plist)
+
+
+class AppBundle(Executable, BundleTargetBase):
+    typename = 'nsapp'
+
+    def __init__(self, name: str, subdir: str, subproject: SubProject, for_machine: MachineChoice,
+                 sources: T.List[SourceOutputs], structured_sources: T.Optional[StructuredSources],
+                 objects: T.List[ObjectTypes], environment: Environment, compilers: T.Dict[str, Compiler],
+                 kwargs):
+        super().__init__(name, subdir, subproject, for_machine, sources, structured_sources, objects, environment,
+                         compilers, kwargs)
+
+        self.bundle_info = BundleInfo(self)
+        _fill_bundle_info_from_kwargs(self, kwargs)
+
+        if kwargs['bundle_layout'] is not None:
+            try:
+                self.bundle_info.layout = BundleLayout(kwargs['bundle_layout'])
+            except ValueError:
+                raise MesonException('{!r} is not a valid value for bundle_layout'.format(kwargs['bundle_layout']))
+        if kwargs['bundle_exe_dir_name'] is not None:
+            self.bundle_info.executable_folder_name: T.Optional[str] = kwargs['bundle_exe_dir_name']
+
+    def type_suffix(self) -> str:
+        return '@nsapp'
+
+    def post_init(self) -> None:
+        super().post_init()
+        self.outputs[0] = self.get_filename()
+
+    def get_filename(self) -> str:
+        return self.bundle_info.get_wrapper_name()
+
+    def get_bundle_info(self) -> BundleInfo:
+        return self.bundle_info
+
+    def get_bundle_type(self) -> BundleType:
+        return BundleType.APPLICATION
+
+    def get_executable_name(self) -> str:
+        return self.filename
+
+    def can_output_be_directory(self, output: str) -> bool:
+        return output == self.get_filename()
+
+    def get_default_install_dir(self) -> T.Union[T.Tuple[str, str], T.Tuple[None, None]]:
+        return self.environment.get_app_dir(), '{appdir}'
+
+
+class FrameworkBundle(SharedLibrary, BundleTargetBase):
+    typename = 'nsframework'
+
+    def __init__(self, name: str, subdir: str, subproject: SubProject, for_machine: MachineChoice,
+                 sources: T.List[SourceOutputs], structured_sources: T.Optional[StructuredSources],
+                 objects: T.List[ObjectTypes], environment: Environment, compilers: T.Dict[str, Compiler],
+                 kwargs):
+        super().__init__(name, subdir, subproject, for_machine, sources, structured_sources, objects, environment,
+                         compilers, kwargs)
+
+        self.bundle_info = BundleInfo(self)
+        _fill_bundle_info_from_kwargs(self, kwargs)
+        self.bundle_info.headers = kwargs['framework_headers']
+
+    def type_suffix(self) -> str:
+        return '@nsframework'
+
+    def post_init(self) -> None:
+        super().post_init()
+        self.outputs[0] = self.get_filename()
+
+    def get_filename(self) -> str:
+        return self.bundle_info.get_wrapper_name()
+
+    def get_bundle_info(self) -> BundleInfo:
+        return self.bundle_info
+
+    def get_bundle_type(self) -> BundleType:
+        return BundleType.FRAMEWORK
+
+    def get_executable_name(self) -> str:
+        return self.filename
+
+    def can_output_be_directory(self, output: str) -> bool:
+        return output == self.get_filename()
+
+    def get_default_install_dir(self) -> T.Union[T.Tuple[str, str], T.Tuple[None, None]]:
+        return self.environment.get_framework_dir(), '{frameworkdir}'
 
 
 @dataclass(eq=False)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -29,6 +29,7 @@ from .mesonlib import (
     MesonBugException, EnvironmentVariables, pickle_load, lazy_property,
     unwrap,
 )
+from .nsbundle import BundleInfo, BundleType
 from .options import OptionKey
 
 from .compilers import (
@@ -3395,6 +3396,21 @@ class Jar(BuildTarget):
 
     def get_default_install_dir(self) -> T.Tuple[str, str]:
         return self.environment.get_jar_dir(), '{jardir}'
+
+
+class BundleTargetBase(Target):
+    @abc.abstractmethod
+    def get_bundle_info(self) -> BundleInfo:
+        pass
+
+    @abc.abstractmethod
+    def get_bundle_type(self) -> BundleType:
+        pass
+
+    @abc.abstractmethod
+    def get_executable_name(self) -> str:
+        pass
+
 
 @dataclass(eq=False)
 class CustomTargetIndex(CustomTargetBase, HoldableObject):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -777,6 +777,9 @@ class Target(HoldableObject, metaclass=SimpleABC):
     def get_outputs(self) -> T.List[str]:
         return []
 
+    def can_output_be_directory(self, output: str) -> bool:
+        return False
+
     def should_install(self) -> bool:
         return False
 
@@ -3123,6 +3126,9 @@ class CustomTarget(Target, CustomTargetBase):
 
     def get_outputs(self) -> T.List[str]:
         return self.outputs
+
+    def can_output_be_directory(self, output: str) -> bool:
+        return True
 
     def get_filename(self) -> str:
         return self.outputs[0]

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -3412,6 +3412,75 @@ class BundleTargetBase(Target):
         pass
 
 
+class BundleTarget(BundleTargetBase):
+    def __init__(self, name: str, subdir: str, subproject: str, environment: Environment, main_exe: T.Union[Executable, SharedLibrary], bundle_type: BundleType):
+        super().__init__(name, subdir, subproject, True, main_exe.for_machine, environment)
+
+        self.main_exe: T.Union[Executable, SharedLibrary] = main_exe
+        self.bundle_type: BundleType = bundle_type
+        self.install_dir: T.Optional[str] = None
+
+        self.bundle_info: BundleInfo = BundleInfo(self)
+
+        if bundle_type == BundleType.APPLICATION:
+            assert isinstance(main_exe, Executable)
+        elif bundle_type == BundleType.FRAMEWORK:
+            assert isinstance(main_exe, SharedLibrary)
+
+    def __repr__(self):
+        repr_str = "<{0} {1}: {2}>"
+        return repr_str.format(self.__class__.__name__, self.get_id(), self.get_filename())
+
+    def __str__(self):
+        return f"{self.name}"
+
+    def get_default_install_dir(self) -> T.Union[T.Tuple[str, str], T.Tuple[None, None]]:
+        if self.bundle_type == BundleType.APPLICATION:
+            return self.environment.get_app_dir(), '{appdir}'
+        elif self.bundle_type == BundleType.FRAMEWORK:
+            return self.environment.get_framework_dir(), '{frameworkdir}'
+        else:
+            return (None, None)
+
+    def get_custom_install_dir(self) -> T.List[T.Union[str, Literal[False]]]:
+        return self.install_dir
+
+    def type_suffix(self) -> str:
+        if self.bundle_type == BundleType.APPLICATION:
+            return '@nsapp'
+        elif self.bundle_type == BundleType.FRAMEWORK:
+            return '@nsframework'
+        else:
+            return '@nsbundle'
+
+    @property
+    def typename(self) -> str:
+        if self.bundle_type == BundleType.APPLICATION:
+            return 'nsapp'
+        elif self.bundle_type == BundleType.FRAMEWORK:
+            return 'nsframework'
+        else:
+            return 'nsbundle'
+
+    def get_bundle_info(self) -> BundleInfo:
+        return self.bundle_info
+
+    def get_bundle_type(self) -> BundleType:
+        return self.bundle_type
+
+    def get_executable_name(self) -> str:
+        return self.main_exe.get_filename()
+
+    def get_filename(self) -> str:
+        return self.bundle_info.get_wrapper_name()
+
+    def can_output_be_directory(self, output: str) -> bool:
+        return output == self.get_filename()
+
+    def get_outputs(self) -> T.List[str]:
+        return [self.get_filename()]
+
+
 @dataclass(eq=False)
 class CustomTargetIndex(CustomTargetBase, HoldableObject):
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2231,7 +2231,7 @@ class Executable(BuildTarget, LinkableTarget):
             # Executable for Windows or C#/Mono
             if machine.is_windows() or machine.is_cygwin() or 'cs' in self.compilers:
                 self.suffix = 'exe'
-            elif machine.system.startswith('wasm') or machine.system == 'emscripten':
+            elif machine.is_wasm():
                 self.suffix = 'js'
             elif ('c' in self.compilers and self.compilers['c'].get_id().startswith('armclang') or
                   'cpp' in self.compilers and self.compilers['cpp'].get_id().startswith('armclang')):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1357,7 +1357,10 @@ class BuildTarget(Target):
     def get_link_dep_subdirs(self) -> T.AbstractSet[str]:
         result: OrderedSet[str] = OrderedSet()
         for i in self.link_targets:
-            if not isinstance(i, StaticLibrary):
+            if isinstance(i, FrameworkBundle):
+                result.add(str(pathlib.PurePath() / i.get_builddir() / i.get_filename() /
+                               i.get_bundle_info().get_executable_folder_path()))
+            elif not isinstance(i, StaticLibrary):
                 result.add(i.get_builddir())
             result.update(i.get_link_dep_subdirs())
         return result
@@ -1852,6 +1855,7 @@ class BuildTarget(Target):
             # Need a copy here
             result = OrderedSet(self.get_link_dep_subdirs())
         else:
+            # TODO: Bundle handling
             result = OrderedSet()
             result.add('meson-out')
         result.update(self.rpaths_for_non_system_absolute_shared_libraries())

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -338,6 +338,12 @@ class MachineInfo(HoldableObject):
         """
         return self.system in {'darwin', 'ios', 'tvos', 'visionos', 'watchos'}
 
+    def is_macos(self) -> bool:
+        """
+        Machine is macOS?
+        """
+        return self.system == 'darwin' and self.subsystem == 'macos'
+
     def is_android(self) -> bool:
         """
         Machine is Android?

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -416,6 +416,12 @@ class MachineInfo(HoldableObject):
     def is_fuchsia(self) -> bool:
         return self.system == 'fuchsia'
 
+    def is_wasm(self) -> bool:
+        """
+        Machine is WASM?
+        """
+        return self.system.startswith('wasm') or self.system == 'emscripten'
+
     # Various prefixes and suffixes for import libraries, shared libraries,
     # static libraries, and executables.
     # Versioning is added to these names in the backends as-needed.

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -520,6 +520,14 @@ class Environment:
         "Install dir for the static library"
         return self.get_libdir()
 
+    def get_app_dir(self) -> str:
+        """Install dir for application bundles"""
+        return f"{self.get_prefix()}/Applications"
+
+    def get_framework_dir(self) -> str:
+        """Install dir for framework bundles"""
+        return f"{self.get_prefix()}/Library/Frameworks"
+
     def get_prefix(self) -> str:
         return _as_str(self.coredata.optstore.get_value_for(OptionKey('prefix')))
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -464,6 +464,8 @@ class Interpreter(InterpreterBase, HoldableObject):
             build.SharedModule: OBJ.SharedModuleHolder,
             build.Executable: OBJ.ExecutableHolder,
             build.Jar: OBJ.JarHolder,
+            build.AppBundle: OBJ.AppBundleHolder,
+            build.FrameworkBundle: OBJ.FrameworkBundleHolder,
             build.CustomTarget: OBJ.CustomTargetHolder,
             build.CustomTargetIndex: OBJ.CustomTargetIndexHolder,
             build.Generator: OBJ.GeneratorHolder,
@@ -3757,6 +3759,12 @@ class Interpreter(InterpreterBase, HoldableObject):
                     final[f'{key}_dir'] = action  # type: ignore[literal-required]
             final['install_dir'] = [kwargs['install_dir'][0] if kwargs['install_dir'] else True]
 
+    def __convert_bundle_shared_kwargs(self, kwargs: kwtypes.BundleShared, final: build.BuildTargetKeywordArguments) -> None:
+        for arg in ('bundle_resources', 'bundle_contents', 'bundle_extra_binaries'):
+            final[arg] = kwargs[arg]
+
+        final['info_plist'] = self.source_string_to_file(kwargs['info_plist'])
+
     def __convert_executable_kwargs(self, node: mparser.BaseNode, kwargs: kwtypes.Executable) -> build.ExecutableKeywordArguments:
         """Convert Executable arguments from DSL form to the build layer form.
 
@@ -3817,6 +3825,25 @@ class Interpreter(InterpreterBase, HoldableObject):
 
         return final
 
+    def __convert_app_bundle_kwargs(self, node: mparser.BaseNode, kwargs: kwtypes.AppBundle) -> build.ExecutableKeywordArguments:
+        """Convert AppBundle arguments from DSL form to the build layer form.
+
+        :param node: The Node being evaluated
+        :param kwargs: The DSL keyword arguments
+        :raises InvalidArguments: If both gui_app and win_subsystem are set
+        :raises InvalidArguments: If implib is false and export_dynamic is true
+        :raises InvalidArguments: If the rust_crate_type is set to anything except bin
+        :return: The keyword arguments as the Build layer expects
+        """
+
+        final = self.__convert_executable_kwargs(node, kwargs)
+        self.__convert_bundle_shared_kwargs(kwargs, final)
+
+        for arg in ('bundle_layout', 'bundle_exe_dir_name'):
+            final[arg] = kwargs[arg]
+
+        return final
+
     def __convert_static_library_kwargs(self, node: mparser.BaseNode, kwargs: kwtypes.StaticLibrary) -> build.StaticLibraryKeywordArguments:
         """Convert StaticLibrary arguments to the Build format.
 
@@ -3863,6 +3890,24 @@ class Interpreter(InterpreterBase, HoldableObject):
             build.SharedLibrary.typename, extra_valid_types={'proc-macro'})
 
         final['win_subsystem'] = kwargs['win_subsystem'] or 'console'
+
+        return final
+
+    def __convert_framework_bundle_kwargs(self, node: mparser.BaseNode, kwargs: kwtypes.FrameworkBundle) -> build.ExecutableKeywordArguments:
+        """Convert FrameworkBundle arguments from DSL form to the build layer form.
+
+        :param node: The Node being evaluated
+        :param kwargs: The DSL keyword arguments
+        :raises InvalidArguments: If both gui_app and win_subsystem are set
+        :raises InvalidArguments: If implib is false and export_dynamic is true
+        :raises InvalidArguments: If the rust_crate_type is set to anything except bin
+        :return: The keyword arguments as the Build layer expects
+        """
+
+        final = self.__convert_shared_library_kwargs(node, kwargs)
+        self.__convert_bundle_shared_kwargs(kwargs, final)
+
+        final['framework_headers'] = kwargs['framework_headers']
 
         return final
 
@@ -3958,7 +4003,8 @@ class Interpreter(InterpreterBase, HoldableObject):
     def create_build_target(self, node: mparser.BaseNode, args: T.Tuple[str, SourcesVarargsType],
                             kwargs: T.Dict[str, TYPE_var], targetclass: T.Type[BT],
                             shared_library_only: bool) -> BT:
-        if targetclass not in {build.Executable, build.SharedLibrary, build.SharedModule, build.StaticLibrary, build.Jar}:
+        if targetclass not in {build.Executable, build.SharedLibrary, build.SharedModule, build.StaticLibrary,
+                               build.Jar, build.AppBundle, build.FrameworkBundle}:
             mlog.debug('Unknown target type:', str(targetclass))
             raise RuntimeError('Unreachable code')
 
@@ -4037,6 +4083,11 @@ class Interpreter(InterpreterBase, HoldableObject):
                 node, T.cast('kwtypes.Executable', kwargs))
             target = build.Executable(name, self.subdir, for_machine, srcs, struct, objs,
                                       self.environment, self.compilers[for_machine], self.current_build_project(), nkwargs)
+        elif targetclass is build.AppBundle:
+            nkwargs = self.__convert_app_bundle_kwargs(
+                node, T.cast('kwtypes.AppBundle', kwargs))
+            target = build.AppBundle(name, self.subdir, for_machine, srcs, struct, objs,
+                                     self.environment, self.compilers[for_machine], self.current_build_project(), nkwargs)
         elif targetclass is build.StaticLibrary:
             nkwargs = self.__convert_static_library_kwargs(
                 node, T.cast('kwtypes.StaticLibrary', kwargs))
@@ -4047,6 +4098,12 @@ class Interpreter(InterpreterBase, HoldableObject):
                 node, T.cast('kwtypes.SharedLibrary', kwargs))
             target = build.SharedLibrary(name, self.subdir, for_machine, srcs, struct, objs,
                                          self.environment, self.compilers[for_machine], self.current_build_project(), nkwargs)
+            target.shared_library_only = shared_library_only
+        elif targetclass is build.FrameworkBundle:
+            nkwargs = self.__convert_framework_bundle_kwargs(
+                node, T.cast('kwtypes.FrameworkBundle', kwargs))
+            target = build.FrameworkBundle(name, self.subdir, for_machine, srcs, struct, objs,
+                                           self.environment, self.compilers[for_machine], self.current_build_project(), nkwargs)
             target.shared_library_only = shared_library_only
         elif targetclass is build.SharedModule:
             nkwargs = self.__convert_shared_module_kwargs(

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -144,6 +144,8 @@ if T.TYPE_CHECKING:
 
     TestClass = T.TypeVar('TestClass', bound=Test)
 
+BT = T.TypeVar('BT', bound=build.BuildTarget)
+
 def _project_version_validator(value: T.Union[T.List, str, mesonlib.File, None]) -> T.Optional[str]:
     if isinstance(value, list):
         if len(value) != 1:
@@ -3519,6 +3521,9 @@ class Interpreter(InterpreterBase, HoldableObject):
         if idname not in self.coredata.target_guids:
             self.coredata.target_guids[idname] = str(uuid.uuid4()).upper()
 
+        if isinstance(tobj, build.BuildTarget):
+            self.project_args_frozen = True
+
     @FeatureNew('both_libraries', '0.46.0')
     def build_both_libraries(self, node: mparser.BaseNode, args: T.Tuple[str, SourcesVarargsType], kwargs: kwtypes.Library) -> build.BothLibraries:
         shared_lib = self.build_target(node, args, kwargs, build.SharedLibrary, shared_library_only=False)
@@ -3946,6 +3951,13 @@ class Interpreter(InterpreterBase, HoldableObject):
                      targetclass: T.Type[T.Union[build.Executable, build.StaticLibrary, build.SharedModule, build.SharedLibrary, build.Jar]],
                      shared_library_only: bool = True
                      ) -> T.Union[build.Executable, build.StaticLibrary, build.SharedModule, build.SharedLibrary, build.Jar]:
+        target = self.create_build_target(node, args, kwargs, targetclass, shared_library_only)
+        self.add_target(target.name, target)
+        return target
+
+    def create_build_target(self, node: mparser.BaseNode, args: T.Tuple[str, SourcesVarargsType],
+                            kwargs: T.Dict[str, TYPE_var], targetclass: T.Type[BT],
+                            shared_library_only: bool) -> BT:
         if targetclass not in {build.Executable, build.SharedLibrary, build.SharedModule, build.StaticLibrary, build.Jar}:
             mlog.debug('Unknown target type:', str(targetclass))
             raise RuntimeError('Unreachable code')
@@ -4051,8 +4063,6 @@ class Interpreter(InterpreterBase, HoldableObject):
         if objs and target.uses_rust():
             FeatureNew.single_use('objects in Rust targets', '1.8.0', self.subproject)
 
-        self.add_target(name, target)
-        self.project_args_frozen = True
         return target
 
     def add_stdlib_info(self, target: build.BuildTarget) -> None:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -462,6 +462,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             build.SharedModule: OBJ.SharedModuleHolder,
             build.Executable: OBJ.ExecutableHolder,
             build.Jar: OBJ.JarHolder,
+            build.BundleTarget: OBJ.BundleTargetHolder,
             build.CustomTarget: OBJ.CustomTargetHolder,
             build.CustomTargetIndex: OBJ.CustomTargetIndexHolder,
             build.Generator: OBJ.GeneratorHolder,

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -1170,6 +1170,9 @@ class SharedModuleHolder(BuildTargetHolder[build.SharedModule]):
 class JarHolder(BuildTargetHolder[build.Jar]):
     pass
 
+class BundleTargetHolder(ObjectHolder[build.BundleTarget]):
+    pass
+
 class CustomTargetIndexHolder(ObjectHolder[build.CustomTargetIndex]):
     def __init__(self, target: build.CustomTargetIndex, interp: 'Interpreter'):
         super().__init__(target, interp)

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -1170,6 +1170,12 @@ class SharedModuleHolder(BuildTargetHolder[build.SharedModule]):
 class JarHolder(BuildTargetHolder[build.Jar]):
     pass
 
+class AppBundleHolder(BuildTargetHolder[build.AppBundle]):
+    pass
+
+class FrameworkBundleHolder(BuildTargetHolder[build.FrameworkBundle]):
+    pass
+
 class CustomTargetIndexHolder(ObjectHolder[build.CustomTargetIndex]):
     def __init__(self, target: build.CustomTargetIndex, interp: 'Interpreter'):
         super().__init__(target, interp)

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -516,6 +516,25 @@ class Library(BuildTarget, _SharedLibMixin, _StaticLibMixin, _LibraryMixin, _Lin
     masm_shared_args: NotRequired[T.List[str]]
 
 
+class BundleShared(TypedDict):
+
+    bundle_resources: T.Optional[build.StructuredSources]
+    bundle_contents: T.Optional[build.StructuredSources]
+    bundle_extra_binaries: T.List[build.BuildTargetTypes]
+    info_plist: T.Optional[T.Union[str, File, build.CustomTarget, build.CustomTargetIndex]]
+
+
+class AppBundle(Executable, BundleShared):
+
+    bundle_exe_dir_name: T.Optional[str]
+    bundle_layout: T.Optional[str]
+
+
+class FrameworkBundle(SharedLibrary, BundleShared):
+
+    pass
+
+
 class _JarMixin(TypedDict):
 
     main_class: str

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -1011,6 +1011,38 @@ JAR_KWS = [
       for a in _LANGUAGE_KWS],
 ]
 
+_BUNDLE_KWS: T.List[KwargInfo] = [
+    KwargInfo('bundle_resources', (StructuredSources, NoneType)),
+    KwargInfo('bundle_contents', (StructuredSources, NoneType)),
+    KwargInfo('bundle_extra_binaries', ContainerTypeInfo(list, (CustomTarget, CustomTargetIndex, BuildTarget)), listify=True, default=[]),
+    KwargInfo('info_plist', (str, File, CustomTarget, CustomTargetIndex, NoneType), default=None),
+]
+
+_EXCLUSIVE_NSAPP_KWS: T.List[KwargInfo] = [
+    KwargInfo('bundle_layout', (str, NoneType)),
+    KwargInfo('bundle_exe_dir_name', (StructuredSources, NoneType)),
+]
+
+_EXCLUSIVE_NSFRAMEWORK_KWS: T.List[KwargInfo] = [
+    KwargInfo('framework_headers', (StructuredSources, NoneType)),
+]
+
+NSAPP_KWS: T.List[KwargInfo] = [
+    *EXECUTABLE_KWS,
+    *_BUNDLE_KWS,
+    *_EXCLUSIVE_NSAPP_KWS,
+    INCLUDE_DIRECTORIES,
+    DEPENDENCIES_KW,
+]
+
+NSFRAMEWORK_KWS: T.List[KwargInfo] = [
+    *SHARED_LIB_KWS,
+    *_BUNDLE_KWS,
+    *_EXCLUSIVE_NSFRAMEWORK_KWS,
+    INCLUDE_DIRECTORIES,
+    DEPENDENCIES_KW,
+]
+
 _SHARED_STATIC_ARGS: T.List[KwargInfo[T.List[str | File]]] = [
     *[l.evolve(name=l.name.replace('_', '_static_'), since='1.3.0')
       for l in _LANGUAGE_KWS],
@@ -1038,6 +1070,8 @@ BUILD_TARGET_KWS = [
     *_EXCLUSIVE_SHARED_MOD_KWS,
     *_EXCLUSIVE_STATIC_LIB_KWS,
     *EXCLUSIVE_EXECUTABLE_KWS,
+    *_EXCLUSIVE_NSAPP_KWS,
+    *_EXCLUSIVE_NSFRAMEWORK_KWS,
     *_SHARED_STATIC_ARGS,
     _VS_MODULE_DEFS_KW,
     _WIN_SUBSYSTEM_KW.evolve(since='1.12.0'),

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -91,6 +91,9 @@ class ParsedTargetName:
             'alias',
             'run',
             'jar',
+            'nsapp',
+            'nsframework',
+            'nsbundle',
         }
         return type in allowed_types
 

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -218,7 +218,8 @@ def run_script_command(script_name: str, script_args: T.List[str]) -> int:
                   'delsuffix': 'delwithsuffix',
                   'gtkdoc': 'gtkdochelper',
                   'hotdoc': 'hotdochelper',
-                  'regencheck': 'regen_checker'}
+                  'regencheck': 'regen_checker',
+                  'merge-plist': 'merge_plist'}
     module_name = script_map.get(script_name, script_name)
 
     try:

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -20,10 +20,14 @@ if T.TYPE_CHECKING:
     from ..dependencies.base import DependencyObjectKWs
     from ..interpreter import Interpreter
     from ..interpreter.interpreter import ProgramVersionFunc
+    from ..interpreter.type_checking import SourcesVarargsType
     from ..interpreterbase import TYPE_var, TYPE_kwargs
     from ..programs import Program
     from ..dependencies import Dependency
     from ..options import ElementaryOptionValues
+
+BT = T.TypeVar('BT', bound=build.BuildTarget)
+
 
 class ModuleState:
     """Object passed to all module methods.
@@ -187,6 +191,14 @@ class ModuleState:
 
     def add_language(self, lang: Language, for_machine: MachineChoice) -> None:
         self._interpreter.add_languages([lang], True, for_machine)
+
+    # TODO: is this fine?
+    def create_build_target(self, targetclass: T.Type[BT], args: T.Tuple[str, SourcesVarargsType],
+                            kwargs: T.Dict[str, TYPE_var], shared_library_only: bool = True) -> BT:
+        """
+        Instantiate (but don't add) a target deriving from BuildTarget.
+        """
+        return self._interpreter.create_build_target(self.current_node, args, kwargs, targetclass, shared_library_only)
 
 class ModuleObject(HoldableObject):
     """Base class for all objects returned by modules

--- a/mesonbuild/modules/nsbundle.py
+++ b/mesonbuild/modules/nsbundle.py
@@ -5,10 +5,15 @@ from __future__ import annotations
 
 import typing as T
 
-from . import NewExtensionModule, ModuleInfo
+from . import NewExtensionModule, ModuleInfo, ModuleReturnValue
+from mesonbuild.build import AppBundle, FrameworkBundle
+from mesonbuild.interpreter.type_checking import NSAPP_KWS, NSFRAMEWORK_KWS, SOURCES_VARARGS
+from mesonbuild.interpreterbase.decorators import FeatureNew, typed_kwargs, typed_pos_args
 
 if T.TYPE_CHECKING:
-    from mesonbuild.interpreter import Interpreter
+    from . import ModuleState
+    from mesonbuild.interpreter.type_checking import SourcesVarargsType
+    from mesonbuild.interpreter import Interpreter, kwargs as kwtypes
 
 
 def initialize(*args: T.Any, **kwargs: T.Any) -> NSBundleModule:
@@ -21,4 +26,22 @@ class NSBundleModule(NewExtensionModule):
     def __init__(self, interpreter: Interpreter):
         super().__init__()
         self.methods.update({
+            'application': self.application,
+            'framework': self.framework,
         })
+
+    @FeatureNew('nsbundle.application', '1.7.99')
+    @typed_pos_args('nsbundle.application', (str,), varargs=SOURCES_VARARGS)
+    @typed_kwargs('nsbundle.application', *NSAPP_KWS, allow_unknown=True)
+    def application(self, state: ModuleState, args: T.Tuple[str, SourcesVarargsType], kwargs: kwtypes.AppBundle
+                    ) -> ModuleReturnValue:
+        tgt = state.create_build_target(AppBundle, args, kwargs)
+        return ModuleReturnValue(tgt, [tgt])
+
+    @FeatureNew('nsbundle.framework', '1.7.99')
+    @typed_pos_args('nsbundle.framework', (str,), varargs=SOURCES_VARARGS)
+    @typed_kwargs('nsbundle.framework', *NSFRAMEWORK_KWS, allow_unknown=True)
+    def framework(self, state: ModuleState, args: T.Tuple[str, SourcesVarargsType], kwargs: kwtypes.FrameworkBundle
+                  ) -> ModuleReturnValue:
+        tgt = state.create_build_target(FrameworkBundle, args, kwargs)
+        return ModuleReturnValue(tgt, [tgt])

--- a/mesonbuild/modules/nsbundle.py
+++ b/mesonbuild/modules/nsbundle.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 Marco Rebhan <me@dblsaiko.net>
+
+from __future__ import annotations
+
+import typing as T
+
+from . import NewExtensionModule, ModuleInfo
+
+if T.TYPE_CHECKING:
+    from mesonbuild.interpreter import Interpreter
+
+
+def initialize(*args: T.Any, **kwargs: T.Any) -> NSBundleModule:
+    return NSBundleModule(*args, **kwargs)
+
+
+class NSBundleModule(NewExtensionModule):
+    INFO = ModuleInfo('nsbundle', '1.7.99')
+
+    def __init__(self, interpreter: Interpreter):
+        super().__init__()
+        self.methods.update({
+        })

--- a/mesonbuild/modules/nsbundle.py
+++ b/mesonbuild/modules/nsbundle.py
@@ -5,10 +5,51 @@ from __future__ import annotations
 
 import typing as T
 
-from . import NewExtensionModule, ModuleInfo
+from . import NewExtensionModule, ModuleInfo, ModuleReturnValue
+from mesonbuild import build, dependencies
+from mesonbuild.interpreter.type_checking import KwargInfo, NoneType
+from mesonbuild.interpreterbase.decorators import ContainerTypeInfo, FeatureNew, typed_kwargs, typed_pos_args
+from mesonbuild.mesonlib import MesonException
+from mesonbuild.nsbundle import BundleType
 
 if T.TYPE_CHECKING:
+    from typing_extensions import TypedDict
+
+    from . import ModuleState
     from mesonbuild.interpreter import Interpreter
+
+    class CommonKws(TypedDict):
+        contents: T.Optional[build.StructuredSources]
+        resources: T.Optional[build.StructuredSources]
+        extra_binaries: T.List[T.Union[str, build.File, build.Executable, build.CustomTarget, build.CustomTargetIndex]]
+        info_plist: T.List[T.Union[str, build.File, build.CustomTarget, build.CustomTargetIndex]]
+
+    class ApplicationKws(CommonKws):
+        layout: T.Optional[str]
+        executable_folder_name: T.Optional[str]
+
+    class FrameworkKws(CommonKws):
+        headers: T.Optional[build.StructuredSources]
+
+
+COMMON_KWS: T.List[KwargInfo] = [
+    KwargInfo('contents', (NoneType, build.StructuredSources)),
+    KwargInfo('resources', (NoneType, build.StructuredSources)),
+    KwargInfo('extra_binaries', ContainerTypeInfo(list, (str, build.File, build.Executable, build.CustomTarget,
+                                                         build.CustomTargetIndex)), default=[], listify=True),
+    KwargInfo('info_plist', ContainerTypeInfo(list, (NoneType, str, build.File, build.CustomTarget, build.CustomTargetIndex)), default=[], listify=True)
+]
+
+APPLICATION_KWS: T.List[KwargInfo] = [
+    *COMMON_KWS,
+    KwargInfo('layout', (NoneType, str)),
+    KwargInfo('executable_folder_name', (NoneType, str)),
+]
+
+FRAMEWORK_KWS: T.List[KwargInfo] = [
+    *COMMON_KWS,
+    KwargInfo('headers', (NoneType, build.StructuredSources)),
+]
 
 
 def initialize(*args: T.Any, **kwargs: T.Any) -> NSBundleModule:
@@ -21,4 +62,41 @@ class NSBundleModule(NewExtensionModule):
     def __init__(self, interpreter: Interpreter):
         super().__init__()
         self.methods.update({
+            'wrap_application': self.wrap_application,
+            'wrap_framework': self.wrap_framework,
         })
+
+    @FeatureNew('nsbundle.wrap_application', '1.7.99')
+    @typed_pos_args('nsbundle.wrap_application', build.Executable)
+    @typed_kwargs('nsbundle.wrap_application', *APPLICATION_KWS)
+    def wrap_application(self, state: ModuleState, args: T.Tuple[build.Executable], kwargs: ApplicationKws
+                         ) -> ModuleReturnValue:
+        (main_exe,) = args
+
+        tgt = build.BundleTarget(main_exe.name, state.subdir, state.subproject, state.environment, main_exe, BundleType.APPLICATION)
+        tgt.bundle_info.resources = kwargs['resources']
+        tgt.bundle_info.contents = kwargs['contents']
+        tgt.bundle_info.extra_binaries = kwargs['extra_binaries']
+        tgt.bundle_info.layout = kwargs['layout']
+
+        if len(kwargs['info_plist']) > 1:
+            raise MesonException('Cannot specify more than one file for info_plist')
+        elif kwargs['info_plist'] != []:
+            tgt.bundle_info.info_dict_file = build._source_input_to_file(tgt, 'info_plist', kwargs['info_plist'][0])
+
+        return ModuleReturnValue(tgt, [tgt])
+
+    @FeatureNew('nsbundle.wrap_framework', '1.7.99')
+    @typed_pos_args('nsbundle.wrap_framework', (build.SharedLibrary, dependencies.InternalDependency))
+    @typed_kwargs('nsbundle.wrap_framework', *FRAMEWORK_KWS)
+    def wrap_framework(self, state: ModuleState,
+                       args: T.Tuple[T.Union[build.SharedLibrary, dependencies.InternalDependency]],
+                       kwargs: FrameworkKws) -> ModuleReturnValue:
+        (main_lib,) = args
+
+        # TODO
+        if not isinstance(main_lib, dependencies.InternalDependency):
+            main_lib = dependencies.InternalDependency(state.project_version, [], [], [], [main_lib], [], [], [], [],
+                                                       {}, [], [], [])
+
+        return ModuleReturnValue(main_lib, [])

--- a/mesonbuild/nsbundle.py
+++ b/mesonbuild/nsbundle.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 Marco Rebhan <me@dblsaiko.net>
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import PurePath
+
+from .envconfig import MachineInfo
+from .mesonlib import File, MachineChoice
+
+import typing as T
+
+if T.TYPE_CHECKING:
+    from .build import BuildTargetTypes, BundleTargetBase, StructuredSources
+
+
+PlistDataType = T.Union[str, bool, T.List['PlistDataType'], T.Dict[str, 'PlistDataType']]
+
+# https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/XcodeBuildSettingRef/1-Build_Setting_Reference/build_setting_ref.html
+# https://developer.apple.com/documentation/xcode/build-settings-reference
+
+
+class BundleLayout(Enum):
+    """
+    Names for these slightly named after their CoreFoundation names.
+    'oldstyle' is bundles with the executable in the top directory and a Resources folder, as used in Framework bundles
+    and GNUstep,
+    'contents' is the standard macOS application bundle layout with everything under a Contents directory,
+    'flat' is the iOS-style bundle with every file in the root directory of the bundle.
+    """
+
+    OLDSTYLE = 'oldstyle'
+    FLAT = 'flat'
+    CONTENTS = 'contents'
+
+
+class BundleType(Enum):
+    """
+    Subset of Xcode "product types". Affect the bundle defaults.
+    """
+
+    APPLICATION = 'application'
+    FRAMEWORK = 'framework'
+    BUNDLE = 'bundle'
+
+
+@dataclass(eq=False)
+class BundleInfo:
+    """
+    Backend-agnostic bundle info.
+    """
+
+    # How exactly bundle paths etc. are realized depends on the target.
+    owner: BundleTargetBase = field(repr=False, hash=False, compare=False)
+
+    # Layout settings
+    layout: T.Optional[BundleLayout] = None
+    version: T.Optional[str] = None
+    executable_folder_name: T.Optional[str] = None
+
+    # Info.plist settings
+    info_dict: T.Dict[str, PlistDataType] = field(default_factory=dict)
+    info_dict_file: T.Optional[File] = None
+
+    # Contents
+    resources: T.Optional[StructuredSources] = None
+    contents: T.Optional[StructuredSources] = None
+    headers: T.Optional[StructuredSources] = None
+    extra_binaries: T.List[BuildTargetTypes] = field(default_factory=list)
+
+    def _m(self) -> MachineInfo:
+        return self.owner.environment.machines[self.owner.for_machine]
+
+    def _type(self) -> BundleType:
+        return self.owner.get_bundle_type()
+
+    def get_layout(self) -> BundleLayout:
+        if self.layout is not None:
+            return self.layout
+
+        if self._type() == BundleType.FRAMEWORK:
+            return BundleLayout.OLDSTYLE
+
+        m = self._m()
+
+        if m.is_darwin() and not m.is_macos():
+            return BundleLayout.FLAT
+
+        return BundleLayout.CONTENTS
+
+    def get_version(self) -> T.Optional[str]:
+        # Versioned bundles contain symlinks, don't build them on Windows
+        if self.owner.environment.machines[MachineChoice.HOST].is_windows():
+            return None
+
+        # Only support frameworks as versioned bundles.
+        if self._type() != BundleType.FRAMEWORK:
+            return None
+
+        if self.version is not None:
+            version = self.version
+        else:
+            version = 'A'
+
+        return version
+
+    def get_configured_info_dict(self) -> T.Dict[str, PlistDataType]:
+        """
+        Returns Info.plist contents known at configure time (without the user-supplied Info.plist data merged)
+        """
+
+        d = {'CFBundleInfoDictionaryVersion': '6.0'}
+
+        t = self._type()
+
+        if t == BundleType.APPLICATION:
+            m = self._m()
+
+            if m.is_darwin() and not m.is_macos():
+                principal_class = 'UIApplication'
+            else:
+                principal_class = 'NSApplication'
+
+            d.update({
+                'CFBundleExecutable': self.get_executable_name(),
+                'CFBundlePackageType': 'APPL',
+                'NSPrincipalClass': principal_class,
+            })
+        elif t == BundleType.FRAMEWORK:
+            d.update({
+                'CFBundleExecutable': self.get_executable_name(),
+                'CFBundlePackageType': 'FMWK',
+            })
+        else:
+            d.update({
+                'CFBundlePackageType': 'BNDL',
+            })
+
+        d.update(self.info_dict)
+        return d
+
+    def get_paths_to_link_contents(self) -> T.List[PurePath]:
+        version = self.get_version()
+
+        if version is None:
+            return []
+
+        assert version != 'Current'
+
+        return [
+            PurePath(),
+            PurePath() / 'Versions' / 'Current'
+        ]
+
+    def get_contents_folder_path(self) -> PurePath:
+        p = PurePath()
+
+        version = self.get_version()
+
+        if version is not None:
+            p = p / 'Versions' / version
+
+        if self.get_layout() == BundleLayout.CONTENTS:
+            p = p / 'Contents'
+
+        return p
+
+    def get_unlocalized_resources_folder_path(self) -> PurePath:
+        contents = self.get_contents_folder_path()
+
+        if self.get_layout() == BundleLayout.FLAT:
+            return contents
+        else:
+            return contents / 'Resources'
+
+    def get_executable_folder_name(self) -> str:
+        if self.get_layout() != BundleLayout.CONTENTS:
+            return ''
+
+        if self.executable_folder_name is not None:
+            return self.executable_folder_name
+
+        m = self._m()
+
+        # As in _CFBundleGetPlatformExecutablesSubdirectoryName (CoreFoundation)
+        if m.is_darwin():
+            return 'MacOS'
+        elif m.is_windows():
+            return 'Windows'
+        elif m.is_sunos():
+            return 'Solaris'
+        elif m.is_cygwin():
+            return 'Cygwin'
+        elif m.is_linux():
+            return 'Linux'
+        elif m.is_freebsd():
+            return 'FreeBSD'
+        elif m.is_wasm():
+            return 'WASI'
+        else:
+            return ''
+
+    def get_executable_folder_path(self) -> PurePath:
+        return self.get_contents_folder_path() / self.get_executable_folder_name()
+
+    def get_executable_name(self) -> str:
+        return self.owner.get_executable_name()
+
+    def get_executable_path(self) -> PurePath:
+        return self.get_executable_folder_path() / self.get_executable_name()
+
+    def get_infoplist_path(self) -> PurePath:
+        if self.get_layout() == BundleLayout.OLDSTYLE:
+            return self.get_unlocalized_resources_folder_path()
+        else:
+            return self.get_contents_folder_path()
+
+    def get_public_headers_folder_path(self) -> PurePath:
+        return self.get_contents_folder_path() / 'Headers'
+
+    def get_private_headers_folder_path(self) -> PurePath:
+        return self.get_contents_folder_path() / 'PrivateHeaders'
+
+    def get_modules_folder_path(self) -> PurePath:
+        return self.get_contents_folder_path() / 'Modules'
+
+    def get_wrapper_extension(self) -> str:
+        t = self._type()
+
+        if t == BundleType.APPLICATION:
+            m = self._m()
+
+            if m.is_darwin() and not m.is_macos():
+                return 'ipa'
+            else:
+                return 'app'
+        elif t == BundleType.FRAMEWORK:
+            return 'framework'
+        else:
+            return 'bundle'
+
+    def get_wrapper_name(self) -> str:
+        return f'{self.owner.name}.{self.get_wrapper_extension()}'

--- a/mesonbuild/scripts/merge_plist.py
+++ b/mesonbuild/scripts/merge_plist.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 Marco Rebhan <me@dblsaiko.net>
+
+from __future__ import annotations
+
+"""
+Helper script to merge two plist files.
+"""
+
+import plistlib
+import typing as T
+
+
+def run(args: T.List[str]) -> int:
+    if len(args) < 1:
+        return 1
+
+    [out, *inputs] = args
+
+    data: T.Any = {}
+
+    for path in inputs:
+        try:
+            fp = open(path, 'rb')
+        except OSError as e:
+            print(f'merge-plist: cannot open \'{path}\': {e.strerror}')
+            return 1
+
+        with fp:
+            try:
+                new_data = plistlib.load(fp)
+            except plistlib.InvalidFileException as e:
+                print(f'merge-plist: cannot parse \'{path}\': {e}')
+                return 1
+            except OSError as e:
+                print(f'merge-plist: cannot read \'{path}\': {e}')
+                return 1
+
+            data = merge(data, new_data)
+
+    try:
+        ofp = open(out, 'wb')
+    except OSError as e:
+        print(f'merge-plist: cannot create \'{out}\': {e.strerror}')
+        return 1
+
+    with ofp:
+        try:
+            plistlib.dump(data, ofp)
+        except OSError as e:
+            print(f'merge-plist: cannot write \'{path}\': {e}')
+            return 1
+
+    return 0
+
+
+def merge(prev: T.Any, next: T.Any) -> T.Any:
+    if isinstance(prev, dict) and isinstance(next, dict):
+        out = prev.copy()
+
+        for k, v in next.items():
+            if k in out:
+                out[k] = merge(out[k], v)
+            else:
+                out[k] = v
+        return out
+    elif isinstance(prev, list) and isinstance(next, list):
+        return prev + next
+    else:
+        return next

--- a/mesonbuild/scripts/symlink.py
+++ b/mesonbuild/scripts/symlink.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 Marco Rebhan <me@dblsaiko.net>
+
+from __future__ import annotations
+
+"""
+Helper script to link files at build time.
+"""
+
+import os
+import typing as T
+
+
+def run(args: T.List[str]) -> int:
+    if len(args) != 2:
+        return 1
+
+    src, dst = args
+
+    try:
+        try:
+            os.remove(dst)
+        except FileNotFoundError:
+            pass
+
+        os.symlink(src, dst)
+    except OSError as e:
+        print(f'symlink: cannot create link \'{dst}\' -> \'{src}\': {e.strerror}')
+        return 1
+
+    return 0


### PR DESCRIPTION
Adds macOS (, Swift, GNUstep, whatever else) bundle support.

Still WIP but it can build a simple bundle at this point.

Right now, this contains two variants, of the API, the tip of the branch is a merge commit. One of them will go. These are the two variants:

```meson
nsbundle = module('nsbundle')

exe = executable(
  'Example App',
  'main.m',
  dependencies: [
    dependency('appleframeworks', modules: ['Foundation', 'AppKit']),
  ],
)

app = nsbundle.wrap_application(
  exe,
  resources: structured_sources('icon.icns'),
  info_plist: 'Info.plist', # gets merged with some default generated options
)
```


```meson
nsbundle = module('nsbundle')

tgt = nsbundle.application(
  'Example App',
  'main.m',
  dependencies: [
    dependency('appleframeworks', modules: ['Foundation', 'AppKit']),
  ],
  bundle_resources: structured_sources('icon.icns'),
  info_plist: 'Info.plist', # gets merged with some default generated options
)
```

Sample project: https://git.dblsaiko.net/MesonBundlesTest/

TODO:

- [ ] Framework bundle support
- [ ] Maybe other bundle (.bundle) support
- [ ] Xcode backend support
- [ ] The code is probably sucky because I have no idea how this codebase works
- [ ] Tests
- [ ] Documentation
- [ ] (whatever I can't think of at the moment)

Maybe:

- [ ] Nested framework support (Contents/Frameworks, Contents/Shared Frameworks) & rpath patching on the built executable

Don't plan on writing:

- VS backend support (don't have Windows so can't test it)

Closes  #48. 🎉 