### PR TITLE
compilers: allow combining address and leak sanitizers

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -225,8 +225,8 @@ available on all platforms or with all compilers:
 | b_vscrt             | from_buildtype       | none, md, mdd, mt, mtd, from_buildtype, static_from_buildtype | VS runtime library to use (since 0.48.0) (static_from_buildtype since 0.56.0)  |
 
 The value of `b_sanitize` can be one of: `none`, `address`, `thread`,
-`undefined`, `memory`, `leak`, `address,undefined`, but note that some
-compilers might not support all of them. For example Visual Studio
+`undefined`, `memory`, `leak`, `address,leak`, `address,undefined`, but note
+that some compilers might not support all of them. For example Visual Studio
 only supports the address sanitizer.
 
 \* < 0 means disable, == 0 means automatic selection, > 0 sets a specific number to use

--- a/docs/markdown/Configuring-a-build-directory.md
+++ b/docs/markdown/Configuring-a-build-directory.md
@@ -53,7 +53,7 @@ a sample output for a simple project.
       b_ndebug    false         [true, false, if-release]                                     Disable asserts
       b_pch       true          [true, false]                                                 Use precompiled headers
       b_pgo       off           [off, generate, use]                                          Use profile guided optimization
-      b_sanitize  none          [none, address, thread, undefined, leak, memory, address,undefined] Code sanitizer to use
+      b_sanitize  none          [none, address, thread, undefined, leak, memory, address,leak, address,undefined] Code sanitizer to use
       b_staticpic true          [true, false]                                                 Build static libraries as position independent
 
     Compiler options:

--- a/docs/markdown/snippets/sanitize-address-leak.md
+++ b/docs/markdown/snippets/sanitize-address-leak.md
@@ -1,0 +1,4 @@
+## `-b_sanitize` supports combining address and leak sanitizers
+
+The `-b_sanitize` option now supports combining the address and leak
+sanitizers with each other by passing `-b_sanitize=address,leak`.

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -237,7 +237,7 @@ BASE_OPTIONS: T.Mapping[OptionKey, BaseOption] = {
     OptionKey('b_thinlto_cache'): BaseOption(options.UserBooleanOption, 'Use LLVM ThinLTO caching for faster incremental builds', False),
     OptionKey('b_thinlto_cache_dir'): BaseOption(options.UserStringOption, 'Directory to store ThinLTO cache objects', ''),
     OptionKey('b_sanitize'): BaseOption(options.UserComboOption, 'Code sanitizer to use', 'none',
-                                        choices=['none', 'address', 'thread', 'undefined', 'memory', 'leak', 'address,undefined']),
+                                        choices=['none', 'address', 'thread', 'undefined', 'memory', 'leak', 'address,leak', 'address,undefined']),
     OptionKey('b_lundef'): BaseOption(options.UserBooleanOption, 'Use -Wl,--no-undefined when linking', True),
     OptionKey('b_asneeded'): BaseOption(options.UserBooleanOption, 'Use -Wl,--as-needed when linking', True),
     OptionKey('b_pgo'): BaseOption(options.UserComboOption, 'Use profile guided optimization', 'off',

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -318,6 +318,17 @@ class LinuxlikeTests(BasePlatformTests):
         self.init(testdir, extra_args=['-Db_sanitize=address', '-Db_lundef=false'])
         self.build()
 
+    @skip_if_not_base_option('b_sanitize')
+    def test_cpp_with_address_and_leak_sanitizer(self):
+        if is_cygwin():
+            raise SkipTest('asan not available on Cygwin')
+        if is_openbsd():
+            raise SkipTest('-fsanitize=address is not supported on OpenBSD')
+
+        testdir = os.path.join(self.common_test_dir, '2 cpp')
+        self.init(testdir, extra_args=['-Db_sanitize=address,leak', '-Db_lundef=false'])
+        self.build()
+
     def test_qt5dependency_no_lrelease(self):
         '''
         Test that qt5 detection with qmake works. This can't be an ordinary


### PR DESCRIPTION
We do not currently allow combining the address and leak sanitizers with one another. This mode is officially documented as supported by at least LLVm though, as documented in [1]:

    LeakSanitizer is a run-time memory leak detector. It can be combined
    with AddressSanitizer to get both memory error and leak detection,
    or used in a stand-alone mode.

Add the combination to the list of allowed sanitizers.

[1]: https://clang.llvm.org/docs/LeakSanitizer.html