### PR TITLE
Fix minimum required Apple clang version for C++26

### DIFF
--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -341,9 +341,7 @@ class ArmLtdClangCPPCompiler(ClangCPPCompiler):
 class AppleClangCPPCompiler(AppleCompilerMixin, ClangCPPCompiler):
 
     _CPP23_VERSION = '>=13.0.0'
-    # TODO: We don't know which XCode version will include LLVM 17 yet, so
-    # use something absurd.
-    _CPP26_VERSION = '>=99.0.0'
+    _CPP26_VERSION = '>=16.0.0'
 
 
 class EmscriptenCPPCompiler(EmscriptenMixin, ClangCPPCompiler):


### PR DESCRIPTION
Fixes https://github.com/mesonbuild/meson/issues/14075.