### PR TITLE
Detect missing files with trailing space on Windows

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3179,6 +3179,8 @@ class Interpreter(InterpreterBase, HoldableObject):
         results: T.List['SourceOutputs'] = []
         for s in sources:
             if isinstance(s, str):
+                if s.endswith(' '):
+                    raise MesonException(f'{s!r} ends with a space. This is probably an error.')
                 if not strict and s.startswith(self.environment.get_build_dir()):
                     results.append(s)
                     mlog.warning(f'Source item {s!r} cannot be converted to File object, because it is a generated file. '

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -398,7 +398,7 @@ class File(HoldableObject):
 
     @staticmethod
     @lru_cache(maxsize=None)
-    def from_source_file(source_root: str, subdir: str, fname: str) -> 'File':
+    def from_source_file(source_root: str, subdir: str, fname: str) -> File:
         if not os.path.isfile(os.path.join(source_root, subdir, fname)):
             raise MesonException(f'File {fname} does not exist.')
         return File(False, subdir, fname)


### PR DESCRIPTION
On Windows, if you accidently add a space at the end of a file name, like `files('myfile.txt ')`, the file is not reported as missing, because of the normalization performed by the OS. However, ninja will reference it with the trailing space, and will fail because the file does not exist.

One solution is to prepend the file name with `\\?\` to prevent the normalization of the name.

See https://github.com/python/cpython/issues/115104 for reference.