### PR TITLE
zsh: Add missing flags to 'meson install'

### DIFF
--- a/data/shell-completions/zsh/_meson
+++ b/data/shell-completions/zsh/_meson
@@ -215,9 +215,14 @@ local -a meson_commands=(
   local curcontext="$curcontext"
   local -a specs=(
     "$__meson_cd"
-    '--no-rebuild[Do not rebuild before installing]'
-    '--only-changed[Do not overwrite files that are older than the copied file]'
-    '(--quiet -q)'{'--quiet','-q'}'[Do not print every file that was installed]'
+    '--no-rebuild[do not rebuild before installing]'
+    '--only-changed[do not overwrite files that are older than the copied file]'
+    '(--quiet -q)'{'--quiet','-q'}'[do not print every file that was installed]'
+    '--destdir[set or override DESTDIR environment]: :_directories'
+    '(--dry-run -d)'{'--dry-run','-d'}'[do not actually install, only print logs]'
+    '--skip-subprojects[do not install files from given subprojects]: : '
+    '--tags[install only targets having one of the given tags]: :_values -s , tag devel runtime python-runtime man doc i18n typelib bin bin-devel tests systemtap'
+    '--strip[strip targets even if strip option was not set during configure]'
   )
 _arguments \
   '(: -)'{'--help','-h'}'[show a help message and quit]' \


### PR DESCRIPTION
All flags which don't have the `(Since 0.a.0)` comment in their description aren't currently completed by ZSH completions. This is pretty annoying, because I use `--destdir` and `--dry-run` often, so I wanted to fix this.

The `--skip-subprojects` flag introduced by this PR currently doesn't have suggestions.