### PR TITLE
zsh: Fix 'meson init --language' completion

### DIFF
--- a/data/shell-completions/zsh/_meson
+++ b/data/shell-completions/zsh/_meson
@@ -251,7 +251,7 @@ _arguments \
     '(-n --name)'{'-n','--name'}'=[the name of the project (defaults to directory name)]'
     '(-e --executable)'{'-e','--executable'}'=[the name of the executable target to create (defaults to project name)]'
     '(-d --deps)'{'-d','--deps'}'=[comma separated list of dependencies]'
-    '(-l --language)'{'-l','--language'}'=[comma separated list of languages (autodetected based on sources if unset)]:languages:_values , (c cpp cs cuda d fortran java objc objcpp rust)'
+    '(-l --language)'{'-l','--language'}'=[comma separated list of languages (autodetected based on sources if unset)]:languages:_values -s , language c cpp cs cuda d fortran java objc objcpp rust'
     '(-b --build)'{'-b','--build'}'[build the project immediately after generation]'
     '--builddir=[directory for building]:directory:_directories'
     '(-f --force)'{'-f','--force'}'[overwrite any existing files and directories]'


### PR DESCRIPTION
This PR fixes invalid syntax, which leads to

```
(eval):1: number expected
_arguments:465: command not found: _
```

when trying to complete `meson init --language=<TAB>`.