### PR TITLE
Remove GCC's -Wunsuffixed-float-constants from warnings

### DIFF
--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -203,6 +203,7 @@ gnu_common_warning_args: T.Dict[str, T.List[str]] = {
 #   -Wdeclaration-after-statement
 #   -Wtraditional
 #   -Wtraditional-conversion
+#   -Wunsuffixed-float-constants
 gnu_c_warning_args: T.Dict[str, T.List[str]] = {
     "0.0.0": [
         "-Wbad-function-cast",
@@ -216,9 +217,6 @@ gnu_c_warning_args: T.Dict[str, T.List[str]] = {
     ],
     "4.1.0": [
         "-Wc++-compat",
-    ],
-    "4.5.0": [
-        "-Wunsuffixed-float-constants",
     ],
 }
 


### PR DESCRIPTION
This inclusion was a misunderstanding on my part: this warning isn't generally applicable to standard C (it prevents using double literals whatsoever since C doesn't have a suffix for them), but exists to support a GNU C extension.  It also has no counterpart in clang.  So, remove it, since warning_level=everything doesn't include such things.