### PR TITLE
Revert "interpreterbase: Add disabler exception for `get_variable` method

### DIFF
--- a/mesonbuild/interpreterbase/interpreterbase.py
+++ b/mesonbuild/interpreterbase/interpreterbase.py
@@ -542,7 +542,7 @@ class InterpreterBase:
         method_name = node.name.value
         (h_args, h_kwargs) = self.reduce_arguments(node.args)
         (args, kwargs) = self._unholder_args(h_args, h_kwargs)
-        if is_disabled(args, kwargs) and method_name != 'get_variable':
+        if is_disabled(args, kwargs):
             return Disabler()
         if not isinstance(obj, InterpreterObject):
             raise InvalidArguments(f'{object_display_name} is not callable.')

--- a/test cases/common/158 disabler/meson.build
+++ b/test cases/common/158 disabler/meson.build
@@ -151,8 +151,3 @@ foreach k, i : {'a': true, 'b': disabler(), 'c': true}
 endforeach
 assert(loops == 3, 'Disabler in foreach dict')
 assert(disablers == 1, 'Disabler in foreach dict')
-
-# https://github.com/mesonbuild/meson/issues/13717
-bar_subproject = subproject('bar')
-bar_dep = bar_subproject.get_variable('bar_dep', disabler())
-assert(not is_disabler(bar_dep))

--- a/test cases/common/158 disabler/subprojects/bar/meson.build
+++ b/test cases/common/158 disabler/subprojects/bar/meson.build
@@ -1,2 +1,0 @@
-project('bar')
-bar_dep = declare_dependency()


### PR DESCRIPTION
This needs to be dealt with one way or another before the final release.