### PR TITLE
docs: do not require aiohttp to build

### DIFF
--- a/docs/meson.build
+++ b/docs/meson.build
@@ -1,7 +1,7 @@
 project('Meson documentation', version: '1.0')
 
 yaml_modname = get_option('unsafe_yaml') ? 'yaml' : 'strictyaml'
-py = import('python').find_installation('python3', modules: [yaml_modname, 'aiohttp'], required: false)
+py = import('python').find_installation('python3', modules: [yaml_modname], required: false)
 if not py.found()
     error(f'Cannot build documentation without yaml support')
 endif


### PR DESCRIPTION
It pulls in 22 (!!!) dependencies and is only needed in CI for a trivial lint of the HTML docs. This is a big problem for people that simply want to compile the manpage. Let the tests fail at test time if this dependency isn't available.

Fixes: 74aab8a42c479cdeeda9371dbd591a19d070c48e


/cc @dnicolodi @thesamesam 

This should fix Gentoo's from-git builds of meson.