### PR TITLE
linkers: fix rpath padding calculation for non-ascii

### DIFF
--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -720,8 +720,10 @@ class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
         # In order to avoid relinking for RPATH removal, the binary needs to contain just
         # enough space in the ELF header to hold the final installation RPATH.
         paths = ':'.join(all_paths)
-        if len(paths) < len(install_rpath):
-            padding = 'X' * (len(install_rpath) - len(paths))
+        paths_length = len(paths.encode('utf-8'))
+        install_rpath_length = len(install_rpath.encode('utf-8'))
+        if paths_length < install_rpath_length:
+            padding = 'X' * (install_rpath_length - paths_length)
             if not paths:
                 paths = padding
             else:
@@ -1488,8 +1490,10 @@ class SolarisDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
         # In order to avoid relinking for RPATH removal, the binary needs to contain just
         # enough space in the ELF header to hold the final installation RPATH.
         paths = ':'.join(all_paths)
-        if len(paths) < len(install_rpath):
-            padding = 'X' * (len(install_rpath) - len(paths))
+        paths_length = len(paths.encode('utf-8'))
+        install_rpath_length = len(install_rpath.encode('utf-8'))
+        if paths_length < install_rpath_length:
+            padding = 'X' * (install_rpath_length - paths_length)
             if not paths:
                 paths = padding
             else:

--- a/test cases/unit/10 build_rpath/meson.build
+++ b/test cases/unit/10 build_rpath/meson.build
@@ -8,6 +8,12 @@ executable('prog', 'prog.c',
   install : true,
   )
 
+executable('multibyte_rpath', 'prog.c',
+  link_with: l,
+  install_rpath: get_option('prefix') / '⢖⢖⢖⢖⢖',
+  install: true
+  )
+
 executable('progcxx', 'prog.cc',
   link_with : l,
   build_rpath : '/foo/bar',


### PR DESCRIPTION
rpaths are calculated in bytes, and that's also how depfixer processes them. We need to ensure that the ascii padding we use (bytes == unicode) is the correct offset for the install rpath - build rpath (both specified in unicode which then gets converted to bytes).

In the event of a unicode install_rpath, we can get into a situation where the install rpath is longer than the padding, since we assumed that the install_rpath was shorter than it actually is -- because we counted the length in characters instead of the length in bytes.

This then broke installation for people who e.g. install into a prefix inside their home directory, when their home directory contains multibyte unicode characters.

Bug: https://gitlab.gnome.org/GNOME/gnome-builder/-/issues/2280