### PR TITLE
docs: Add missing release snippet for the TASKING compiler support

### DIFF
--- a/docs/markdown/snippets/tasking_compiler.md
+++ b/docs/markdown/snippets/tasking_compiler.md
@@ -1,0 +1,3 @@
+## Support TASKING VX-Toolset
+
+Meson now supports the TASKING VX-Toolset compiler family for the Tricore cpu family.


### PR DESCRIPTION
I missed adding a release snippet for the TASKING compiler in #12342