### PR TITLE
Python: Work around missing rpath in Xcode python3-embed

### DIFF
--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -327,6 +327,12 @@ class PythonPkgConfigDependency(PkgConfigDependency, _PythonDependencyBase):
         if not self.link_libpython and mesonlib.version_compare(self.version, '< 3.8'):
             self.link_args = []
 
+        # But not Apple, because it's a framework
+        if self.env.machines.host.is_darwin() and 'PYTHONFRAMEWORKPREFIX' in self.variables:
+            framework_prefix = self.variables['PYTHONFRAMEWORKPREFIX']
+            # Add rpath, will be de-duplicated if necessary
+            if framework_prefix.startswith('/Applications/Xcode.app/'):
+                self.link_args += ['-rpath,' + framework_prefix]
 
 class PythonFrameworkDependency(ExtraFrameworkDependency, _PythonDependencyBase):
 


### PR DESCRIPTION
Hi all,

This PR enables generating Python bindings and linking against `python3-embed` without resorting to later `install_name_tool` changes, as the pkg-config module provided by Xcode doesn't say that Python3.framework requires a rpath entry:

    $ otool -L /Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Python3
    /Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Python3:
                @rpath/Python3.framework/Versions/3.9/Python3 (compatibility version 3.9.0, current version 3.9.0)
                /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1933.0.0)
                /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.0.0)

All feedback is appreciated.

cc @nirbheek 