### PR TITLE
Meson env fixes for icc-cl and msvc

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -551,10 +551,7 @@ class IntelClCCompiler(IntelVisualStudioLikeCompiler, VisualStudioLikeCCompilerM
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
         key = self.form_compileropt_key('std')
-        # To shut up mypy.
-        if isinstance(opts, dict):
-            raise RuntimeError('This is a transitory issue that should not happen. Please report with full backtrace.')
-        std_opt = opts.get_value_object(key)
+        std_opt = opts.get(key)
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
         std_opt.set_versions(['c89', 'c99', 'c11'])
         return opts

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -195,7 +195,7 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
     for linker in trials:
         linker_name = os.path.basename(linker[0])
 
-        if any(os.path.basename(x) in {'lib', 'lib.exe', 'llvm-lib', 'llvm-lib.exe', 'xilib', 'xilib.exe'} for x in linker):
+        if os.getenv('FORCE_MSVC_ARFLAGS') or any(os.path.basename(x) in {'lib', 'lib.exe', 'llvm-lib', 'llvm-lib.exe', 'xilib', 'xilib.exe'} for x in linker):
             arg = '/?'
         elif linker_name in {'ar2000', 'ar2000.exe', 'ar430', 'ar430.exe', 'armar', 'armar.exe', 'ar6x', 'ar6x.exe'}:
             arg = '?'
@@ -483,7 +483,9 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
             target = 'x86' if 'IA-32' in err else 'x86_64'
             cls = c.IntelClCCompiler if lang == 'c' else cpp.IntelClCPPCompiler
             env.coredata.add_lang_args(cls.language, cls, for_machine, env)
-            linker = linkers.XilinkDynamicLinker(for_machine, [], version=version)
+            linker_exe = env.lookup_binary_entry(for_machine, 'c_ld')
+            linker_exelist = [linker_exe] if linker_exe else None
+            linker = linkers.XilinkDynamicLinker(for_machine, [], version=version, exelist=linker_exelist)
             return cls(
                 compiler, version, for_machine, is_cross, info, target,
                 linker=linker)
@@ -492,7 +494,9 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
             target = 'x86' if 'IA-32' in err else 'x86_64'
             cls = c.IntelLLVMClCCompiler if lang == 'c' else cpp.IntelLLVMClCPPCompiler
             env.coredata.add_lang_args(cls.language, cls, for_machine, env)
-            linker = linkers.XilinkDynamicLinker(for_machine, [], version=version)
+            linker_exe = env.lookup_binary_entry(for_machine, 'c_ld')
+            linker_exelist = [linker_exe] if linker_exe else None
+            linker = linkers.XilinkDynamicLinker(for_machine, [], version=version, exelist=linker_exelist)
             return cls(
                 compiler, version, for_machine, is_cross, info, target,
                 linker=linker)

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -1433,7 +1433,8 @@ class XilinkDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
                  prefix: T.Union[str, T.List[str]] = '',
                  machine: str = 'x86', version: str = 'unknown version',
                  direct: bool = True):
-        super().__init__(['xilink.exe'], for_machine, '', always_args, version=version)
+        super().__init__(exelist or ['xilink.exe'], for_machine,
+                         prefix, always_args, machine=machine, version=version, direct=direct)
 
     def get_win_subsystem_args(self, value: str) -> T.List[str]:
         return self._apply_prefix([f'/SUBSYSTEM:{value.upper()}'])


### PR DESCRIPTION
fix for when lib.exe is not in meson's hardcoded list of names. fix so intel cl reads linker exe from env instead of relying on hardcoded string