### PR TITLE
compilers/clang++: Add `-fpch-instantiate-templates` flag to speed up clang++ builds

### DIFF
--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -332,6 +332,12 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCompiler, CPPCompiler):
 
         return []
 
+    def get_pch_use_args(self, pch_dir: str, header: str) -> T.List[str]:
+        args = super().get_pch_use_args(pch_dir, header)
+        if version_compare(self.version, '>=11'):
+            return ['-fpch-instantiate-templates'] + args
+        return args
+
 
 class ArmLtdClangCPPCompiler(ClangCPPCompiler):
 


### PR DESCRIPTION
This PR adds a non-configurable flag to clang++ PCH builds: `-fpch-instantiate-templates` which in my own tests with a medium sized project (~1m loc) cuts build times in half.

see:
- https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5168
- https://reviews.llvm.org/D69585

I ran `CXX=clang CXX_LD=mold ./run-tests.py` locally and all relevant tests passed, but I'm not a python dev so I have very little idea of what I'm doing when I touch python, please be patient with me.