### PR TITLE
symbolextractor: detect DLL name with llvm-nm/nm

### DIFF
--- a/mesonbuild/scripts/symbolextractor.py
+++ b/mesonbuild/scripts/symbolextractor.py
@@ -220,6 +220,17 @@ def _get_implib_dllname(impfilename: str) -> T.Tuple[T.List[str], str]:
     if output:
         return [output], None
     all_stderr += e
+    # Next, try llvm-nm.exe provided by LLVM, then nm.exe provided by MinGW
+    for nm in ('llvm-nm', 'nm'):
+        output, e = call_tool_nowarn(get_tool(nm) + ['--extern-only', '--defined-only',
+                                                     '--format=posix', impfilename])
+        if output:
+            e = 'dll not found with {!r}\n'.format(nm)
+            first = output.split('\n')[1]
+            if first.endswith(':'):
+                output = first[:-1]
+                return [output], None
+        all_stderr += e
     return ([], all_stderr)
 
 def _get_implib_exports(impfilename: str) -> T.Tuple[T.List[str], str]:


### PR DESCRIPTION
`lib.exe`, `llvm-lib` and `dlltool` may not be available (as in llvm-mingw), the LLVM nm tool may be available. It lists the DLL for each export symbol, so we can get the DLL name from there.