### PR TITLE
When subproject() fails because downloading is disabled, say what failed

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -916,10 +916,16 @@ class Interpreter(InterpreterBase, HoldableObject):
         try:
             subdir, method = r.resolve(subp_name, force_method)
         except wrap.WrapException as e:
+            if force_method is not None:
+                prefix = force_method.title() + ' subproject'
+            else:
+                prefix = 'Subproject'
+            msg = [prefix, mlog.bold(subp_name), 'is buildable:', mlog.red('NO')]
             if not required:
                 mlog.log(e)
-                mlog.log('Subproject ', mlog.bold(subp_name), 'is buildable:', mlog.red('NO'), '(disabling)')
+                mlog.log(*msg, '(disabling)')
                 return self.disabled_subproject(subp_name, exception=e)
+            mlog.error(*msg)
             raise e
 
         os.makedirs(os.path.join(self.build.environment.get_build_dir(), subdir), exist_ok=True)


### PR DESCRIPTION
It's not especially explanatory to say:

```
meson.build:357:34: ERROR: Automatic wrap-based subproject downloading is disabled
```

But if we instead say this:

```
ERROR: Subproject libsamplerate is buildable: NO

meson.build:357:34: ERROR: Automatic wrap-based subproject downloading is disabled
```

It becomes a lot clearer to casual inspection, why it failed. And it matches the way we otherwise report errors for an unbuildable subproject (configure errors).

Bug: https://github.com/jacktrip/jacktrip/issues/1380