### PR TITLE
Fix call to object_filename_from_source in vs2010

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1463,7 +1463,7 @@ class Vs2010Backend(backends.Backend):
                         if self.environment.is_source(src):
                             target_private_dir = self.relpath(self.get_target_private_dir(t),
                                                               self.get_target_dir(t))
-                            rel_obj = self.object_filename_from_source(t, src, target_private_dir)
+                            rel_obj = self.object_filename_from_source(t, compiler, src, target_private_dir)
                             extra_link_args.append(rel_obj)
 
                     extra_link_args.extend(self.flatten_object_list(t))


### PR DESCRIPTION
There was a missing parameter in one call.
This was caused by b95e1777ddbf0f8aebb56b84a6011468088c06ec