### PR TITLE
micro-optimizations for is_windows() et al.

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -350,7 +350,7 @@ class Backend:
         if isinstance(target, build.SharedLibrary):
             link_lib = target.get_import_filename() or target.get_filename()
             # In AIX, if we archive .so, the blibpath must link to archived shared library otherwise to the .so file.
-            if mesonlib.is_aix() and target.aix_so_archive:
+            if mesonlib.Platform.is_aix and target.aix_so_archive:
                 link_lib = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*', '.a', link_lib.replace('.so', '.a'))
             return Path(self.get_target_dir(target), link_lib).as_posix()
         elif isinstance(target, build.StaticLibrary):
@@ -587,7 +587,7 @@ class Backend:
         else:
             if exe_cmd[0].endswith('.jar'):
                 exe_cmd = ['java', '-jar'] + exe_cmd
-            elif exe_cmd[0].endswith('.exe') and not (mesonlib.is_windows() or mesonlib.is_cygwin() or mesonlib.is_wsl()):
+            elif exe_cmd[0].endswith('.exe') and not (mesonlib.Platform.is_windows or mesonlib.Platform.is_cygwin or mesonlib.Platform.is_wsl):
                 exe_cmd = ['mono'] + exe_cmd
             exe_wrapper = None
 

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -572,7 +572,7 @@ class Backend:
                 cmd_args.append(c)
 
         machine = self.environment.machines[exe_for_machine]
-        if machine.is_windows() or machine.is_cygwin():
+        if machine.is_windows or machine.is_cygwin:
             extra_paths = self.determine_windows_extra_paths(exe, extra_bdeps or [])
         else:
             extra_paths = []
@@ -1248,7 +1248,7 @@ class Backend:
             is_cross = self.environment.is_cross_build(test_for_machine)
             exe_wrapper = self.environment.get_exe_wrapper()
             machine = self.environment.machines[exe.for_machine]
-            if machine.is_windows() or machine.is_cygwin():
+            if machine.is_windows or machine.is_cygwin:
                 extra_bdeps: T.List[T.Union[build.BuildTarget, build.CustomTarget, build.CustomTargetIndex]] = []
                 if isinstance(exe, build.CustomTarget):
                     extra_bdeps = list(exe.get_transitive_build_target_deps())
@@ -1284,7 +1284,7 @@ class Backend:
                     raise MesonException('Bad object in test command.')
 
             t_env = copy.deepcopy(t.env)
-            if not machine.is_windows() and not machine.is_cygwin() and not machine.is_darwin():
+            if not machine.is_windows and not machine.is_cygwin and not machine.is_darwin:
                 ld_lib_path_libs: T.Set[build.SharedLibrary] = set()
                 for d in depends:
                     if isinstance(d, build.BuildTarget):
@@ -2017,7 +2017,7 @@ class Backend:
                 # so they get used by default instead of searching on system when
                 # in developer environment.
                 extra_paths.add(tdir)
-                if host_machine.is_windows() or host_machine.is_cygwin():
+                if host_machine.is_windows or host_machine.is_cygwin:
                     # On windows we cannot rely on rpath to run executables from build
                     # directory. We have to add in PATH the location of every DLL needed.
                     library_paths.update(self.determine_windows_extra_paths(t, []))

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1099,7 +1099,7 @@ class NinjaBackend(backends.Backend):
         self.add_build(elem)
         #In AIX, we archive shared libraries. If the instance is a shared library, we add a command to archive the shared library
         #object and create the build element.
-        if isinstance(target, build.SharedLibrary) and self.environment.machines[target.for_machine].is_aix():
+        if isinstance(target, build.SharedLibrary) and self.environment.machines[target.for_machine].is_aix:
             if target.aix_so_archive:
                 elem = NinjaBuildElement(self.all_outputs, linker.get_archive_name(outname), 'AIX_LINKER', [outname])
                 self.add_build(elem)
@@ -1281,7 +1281,7 @@ class NinjaBackend(backends.Backend):
             if not hasattr(target, 'compilers'):
                 continue
             for compiler in target.compilers.values():
-                if compiler.get_id() == 'clang' and not compiler.info.is_darwin():
+                if compiler.get_id() == 'clang' and not compiler.info.is_darwin:
                     use_llvm_cov = True
                     break
         elem.add_item('COMMAND', self.environment.get_build_command() +
@@ -2390,7 +2390,7 @@ class NinjaBackend(backends.Backend):
 
                 options = self._rsp_options(compiler)
                 self.add_rule(NinjaRule(rule, command, args, description, **options, extra=pool))
-            if self.environment.machines[for_machine].is_aix() and complist:
+            if self.environment.machines[for_machine].is_aix and complist:
                 rule = 'AIX_LINKER{}'.format(self.get_rule_suffix(for_machine))
                 description = 'Archiving AIX shared library'
                 cmdlist = compiler.get_command_to_archive_shlib()
@@ -3297,7 +3297,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
     def generate_shsym(self, target) -> None:
         target_file = self.get_target_filename(target)
         if isinstance(target, build.SharedLibrary) and target.aix_so_archive:
-            if self.environment.machines[target.for_machine].is_aix():
+            if self.environment.machines[target.for_machine].is_aix:
                 linker, stdlib_args = target.get_clink_dynamic_linker_and_stdlibs()
                 target.get_outputs()[0] = linker.get_archive_name(target.get_outputs()[0])
                 target_file = target.get_outputs()[0]
@@ -3361,7 +3361,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             # libraries (such as SDL2) add -mwindows to their link flags.
             m = self.environment.machines[target.for_machine]
 
-            if m.is_windows() or m.is_cygwin():
+            if m.is_windows or m.is_cygwin:
                 commands += linker.get_win_subsystem_args(target.win_subsystem)
         return commands
 
@@ -3815,7 +3815,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 # they are all built
                 #Add archive file if shared library in AIX for build all.
                 if isinstance(t, build.SharedLibrary) and t.aix_so_archive:
-                    if self.environment.machines[t.for_machine].is_aix():
+                    if self.environment.machines[t.for_machine].is_aix:
                         linker, stdlib_args = t.get_clink_dynamic_linker_and_stdlibs()
                         t.get_outputs()[0] = linker.get_archive_name(t.get_outputs()[0])
                 targetlist.append(os.path.join(self.get_target_dir(t), t.get_outputs()[0]))

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -72,7 +72,7 @@ def cmd_quote(arg: str) -> str:
 
 # How ninja executes command lines differs between Unix and Windows
 # (see https://ninja-build.org/manual.html#ref_rule_command)
-if mesonlib.is_windows():
+if mesonlib.Platform.is_windows:
     quote_func = cmd_quote
     execute_wrapper = ['cmd', '/c']  # unused
     rmfile_prefix = ['del', '/f', '/s', '/q', '{}', '&&']
@@ -96,7 +96,7 @@ def get_rsp_threshold() -> int:
     above which a response file should be used.  May be overridden for
     debugging by setting environment variable MESON_RSP_THRESHOLD.'''
 
-    if mesonlib.is_windows():
+    if mesonlib.Platform.is_windows:
         # Usually 32k, but some projects might use cmd.exe,
         # and that has a limit of 8k.
         limit = 8192
@@ -405,7 +405,7 @@ class NinjaBuildElement:
         # do not require quoting, unless explicitly specified, which is necessary for
         # the csc compiler.
         line = line.replace('\\', '/')
-        if mesonlib.is_windows():
+        if mesonlib.Platform.is_windows:
             # Support network paths as backslash, otherwise they are interpreted as
             # arguments for compile/link commands when using MSVC
             line = ' '.join(
@@ -550,7 +550,7 @@ class NinjaBackend(backends.Backend):
             # IFort / masm on windows is MSVC like, but doesn't have /showincludes
             if compiler.language in {'fortran', 'masm'}:
                 continue
-            if compiler.id == 'pgi' and mesonlib.is_windows():
+            if compiler.id == 'pgi' and mesonlib.Platform.is_windows:
                 # for the purpose of this function, PGI doesn't act enough like MSVC
                 return open(tempfilename, 'a', encoding='utf-8')
             if compiler.get_argument_syntax() == 'msvc':
@@ -2339,7 +2339,7 @@ class NinjaBackend(backends.Backend):
             #        them out to fix this properly on Windows. See:
             # https://github.com/mesonbuild/meson/issues/1517
             # https://github.com/mesonbuild/meson/issues/1526
-            if isinstance(static_linker, ArLikeLinker) and not mesonlib.is_windows():
+            if isinstance(static_linker, ArLikeLinker) and not mesonlib.Platform.is_windows:
                 # `ar` has no options to overwrite archives. It always appends,
                 # which is never what we want. Delete an existing library first if
                 # it exists. https://github.com/mesonbuild/meson/issues/1355
@@ -2423,7 +2423,7 @@ class NinjaBackend(backends.Backend):
         args = ['$ARGS', '$in']
         description = 'Compiling C Sharp target $out'
         self.add_rule(NinjaRule(rule, command, args, description,
-                                rspable=mesonlib.is_windows(),
+                                rspable=mesonlib.Platform.is_windows,
                                 rspfile_quote_style=compiler.rsp_file_syntax()))
 
     def generate_vala_compile_rules(self, compiler) -> None:
@@ -2478,7 +2478,7 @@ class NinjaBackend(backends.Backend):
         if self.use_dyndeps_for_fortran():
             return
         rule = f'FORTRAN_DEP_HACK{crstr}'
-        if mesonlib.is_windows():
+        if mesonlib.Platform.is_windows:
             cmd = ['cmd', '/C']
         else:
             cmd = ['true']

--- a/mesonbuild/cmake/executor.py
+++ b/mesonbuild/cmake/executor.py
@@ -10,7 +10,7 @@ import re
 import os
 
 from .. import mlog
-from ..mesonlib import PerMachine, Popen_safe, version_compare, is_windows
+from ..mesonlib import PerMachine, Popen_safe, version_compare, Platform
 from ..options import OptionKey
 from ..programs import find_external_program, NonExistingExternalProgram
 
@@ -108,7 +108,7 @@ class CMakeExecutor:
             return None
         except PermissionError:
             msg = 'Found CMake {!r} but didn\'t have permissions to run it.'.format(' '.join(cmd))
-            if not is_windows():
+            if not Platform.is_windows:
                 msg += '\n\nOn Unix-like systems this is often caused by scripts that are not executable.'
             mlog.warning(msg)
             return None

--- a/mesonbuild/compilers/asm.py
+++ b/mesonbuild/compilers/asm.py
@@ -54,10 +54,10 @@ class NasmCompiler(Compiler):
 
     def get_always_args(self) -> T.List[str]:
         cpu = '64' if self.info.is_64_bit else '32'
-        if self.info.is_windows() or self.info.is_cygwin():
+        if self.info.is_windows or self.info.is_cygwin:
             plat = 'win'
             define = f'WIN{cpu}'
-        elif self.info.is_darwin():
+        elif self.info.is_darwin:
             plat = 'macho'
             define = 'MACHO'
         else:
@@ -122,7 +122,7 @@ class NasmCompiler(Compiler):
     # require this, otherwise it'll fail to find
     # _WinMain or _DllMainCRTStartup.
     def get_crt_link_args(self, crt_val: str, buildtype: str) -> T.List[str]:
-        if not self.info.is_windows():
+        if not self.info.is_windows:
             return []
         return self.crt_args[self.get_crt_val(crt_val, buildtype)]
 
@@ -140,9 +140,9 @@ class YasmCompiler(NasmCompiler):
 
     def get_debug_args(self, is_debug: bool) -> T.List[str]:
         if is_debug:
-            if self.info.is_windows() and self.links_with_msvc:
+            if self.info.is_windows and self.links_with_msvc:
                 return ['-g', 'cv8']
-            elif self.info.is_darwin():
+            elif self.info.is_darwin:
                 return ['-g', 'null']
             else:
                 return ['-g', 'dwarf2']

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -122,7 +122,7 @@ class ClangCCompiler(ClangCStds, ClangCompiler, CCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
-        if self.info.is_windows() or self.info.is_cygwin():
+        if self.info.is_windows or self.info.is_cygwin:
             self.update_options(
                 opts,
                 self.create_option(options.UserArrayOption,
@@ -141,7 +141,7 @@ class ClangCCompiler(ClangCStds, ClangCompiler, CCompiler):
         return args
 
     def get_option_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
-        if self.info.is_windows() or self.info.is_cygwin():
+        if self.info.is_windows or self.info.is_cygwin:
             # without a typedict mypy can't understand this.
             key = self.form_compileropt_key('winlibs')
             libs = options.get_value(key).copy()
@@ -257,7 +257,7 @@ class GnuCCompiler(GnuCStds, GnuCompiler, CCompiler):
 
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
-        if self.info.is_windows() or self.info.is_cygwin():
+        if self.info.is_windows or self.info.is_cygwin:
             self.update_options(
                 opts,
                 self.create_option(options.UserArrayOption,
@@ -276,7 +276,7 @@ class GnuCCompiler(GnuCStds, GnuCompiler, CCompiler):
         return args
 
     def get_option_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
-        if self.info.is_windows() or self.info.is_cygwin():
+        if self.info.is_windows or self.info.is_cygwin:
             # without a typeddict mypy can't figure this out
             key = self.form_compileropt_key('winlibs')
             libs: T.List[str] = options.get_value(key).copy()

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1112,7 +1112,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
 
     def get_largefile_args(self) -> T.List[str]:
         '''Enable transparent large-file-support for 32-bit UNIX systems'''
-        if not (self.get_argument_syntax() == 'msvc' or self.info.is_darwin()):
+        if not (self.get_argument_syntax() == 'msvc' or self.info.is_darwin):
             # Enable large-file support unconditionally on all platforms other
             # than macOS and MSVC. macOS is now 64-bit-only so it doesn't
             # need anything special, and MSVC doesn't have automatic LFS.

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -253,7 +253,7 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCPPStds, ClangCompiler, CPPCompiler
                                'STL debug mode',
                                False),
         )
-        if self.info.is_windows() or self.info.is_cygwin():
+        if self.info.is_windows or self.info.is_cygwin:
             self.update_options(
                 opts,
                 self.create_option(options.UserArrayOption,
@@ -290,7 +290,7 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCPPStds, ClangCompiler, CPPCompiler
         return args
 
     def get_option_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
-        if self.info.is_windows() or self.info.is_cygwin():
+        if self.info.is_windows or self.info.is_cygwin:
             # without a typedict mypy can't understand this.
             key = self.form_compileropt_key('winlibs')
             libs = options.get_value(key).copy()
@@ -458,7 +458,7 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCPPStds, GnuCompiler, CPPCompiler):
                                'STL debug mode',
                                False),
         )
-        if self.info.is_windows() or self.info.is_cygwin():
+        if self.info.is_windows or self.info.is_cygwin:
             self.update_options(
                 opts,
                 self.create_option(options.UserArrayOption,
@@ -489,7 +489,7 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCPPStds, GnuCompiler, CPPCompiler):
         return args
 
     def get_option_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
-        if self.info.is_windows() or self.info.is_cygwin():
+        if self.info.is_windows or self.info.is_cygwin:
             # without a typedict mypy can't understand this.
             key = self.form_compileropt_key('winlibs')
             libs = options.get_value(key).copy()

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -135,7 +135,7 @@ class VisualStudioCsCompiler(CsCompiler):
 
     def get_debug_args(self, is_debug: bool) -> T.List[str]:
         if is_debug:
-            return ['-debug'] if self.info.is_windows() else ['-debug:portable']
+            return ['-debug'] if self.info.is_windows else ['-debug:portable']
         else:
             return []
 

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -13,7 +13,7 @@ from .. import options
 from .. import mlog
 from ..mesonlib import (
     EnvironmentException, Popen_safe,
-    is_windows, LibType, version_compare
+    Platform, LibType, version_compare
 )
 from ..options import OptionKey
 from .compilers import Compiler
@@ -677,7 +677,7 @@ class CudaCompiler(Compiler):
         # On Windows, the version of the C++ standard used by nvcc is dictated by
         # the combination of CUDA version and MSVC version; the --std= is thus ignored
         # and attempting to use it will result in a warning: https://stackoverflow.com/a/51272091/741027
-        if not is_windows():
+        if not Platform.is_windows:
             key = self.form_compileropt_key('std')
             std = options.get_value(key)
             if std != 'none':

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -12,7 +12,7 @@ from .. import mesonlib
 from ..arglist import CompilerArgs
 from ..linkers import RSPFileSyntax
 from ..mesonlib import (
-    EnvironmentException, version_compare, is_windows
+    EnvironmentException, version_compare, Platform
 )
 from ..options import OptionKey
 
@@ -786,7 +786,7 @@ class LLVMDCompiler(DmdLikeCompilerMixin, DCompiler):
         # We use `mesonlib.is_windows` here because we want to know what the
         # build machine is, not the host machine. This really means we would
         # have the Environment not the MachineInfo in the compiler.
-        return RSPFileSyntax.MSVC if is_windows() else RSPFileSyntax.GCC
+        return RSPFileSyntax.MSVC if Platform.is_windows else RSPFileSyntax.GCC
 
 
 class DmdDCompiler(DmdLikeCompilerMixin, DCompiler):

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -163,7 +163,7 @@ class DmdLikeCompilerMixin(CompilerMixinBase):
         return []
 
     def get_pic_args(self) -> T.List[str]:
-        if self.info.is_windows():
+        if self.info.is_windows:
             return []
         return ['-fPIC']
 
@@ -178,7 +178,7 @@ class DmdLikeCompilerMixin(CompilerMixinBase):
     def build_rpath_args(self, env: 'Environment', build_dir: str, from_dir: str,
                          rpath_paths: T.Tuple[str, ...], build_rpath: str,
                          install_rpath: str) -> T.Tuple[T.List[str], T.Set[bytes]]:
-        if self.info.is_windows():
+        if self.info.is_windows:
             return ([], set())
 
         # GNU ld, solaris ld, and lld acting like GNU ld
@@ -217,9 +217,9 @@ class DmdLikeCompilerMixin(CompilerMixinBase):
         for arg in args:
             # Translate OS specific arguments first.
             osargs: T.List[str] = []
-            if info.is_windows():
+            if info.is_windows:
                 osargs = cls.translate_arg_to_windows(arg)
-            elif info.is_darwin():
+            elif info.is_darwin:
                 osargs = cls._translate_arg_to_osx(arg)
             if osargs:
                 dcargs.extend(osargs)
@@ -307,7 +307,7 @@ class DmdLikeCompilerMixin(CompilerMixinBase):
                     continue
 
                 # linker flag such as -L=/DEBUG must pass through
-                if info.is_windows() and link_id == 'link' and suffix.startswith('/'):
+                if info.is_windows and link_id == 'link' and suffix.startswith('/'):
                     dcargs.append(arg)
                     continue
 
@@ -373,7 +373,7 @@ class DmdLikeCompilerMixin(CompilerMixinBase):
         return clike_debug_args[is_debug] + ddebug_args
 
     def _get_crt_args(self, crt_val: str, buildtype: str) -> T.List[str]:
-        if not self.info.is_windows():
+        if not self.info.is_windows:
             return []
         return self.mscrt_args[self.get_crt_val(crt_val, buildtype)]
 
@@ -404,7 +404,7 @@ class DmdLikeCompilerMixin(CompilerMixinBase):
 
     def get_allow_undefined_link_args(self) -> T.List[str]:
         args = self.linker.get_allow_undefined_args()
-        if self.info.is_darwin():
+        if self.info.is_darwin:
             # On macOS we're passing these options to the C compiler, but
             # they're linker options and need -Wl, so clang/gcc knows what to
             # do with them. I'm assuming, but don't know for certain, that
@@ -473,7 +473,7 @@ class DCompiler(Compiler):
         return 'deps'
 
     def get_pic_args(self) -> T.List[str]:
-        if self.info.is_windows():
+        if self.info.is_windows:
             return []
         return ['-fPIC']
 
@@ -553,7 +553,7 @@ class DCompiler(Compiler):
     def _get_target_arch_args(self) -> T.List[str]:
         # LDC2 on Windows targets to current OS architecture, but
         # it should follow the target specified by the MSVC toolchain.
-        if self.info.is_windows():
+        if self.info.is_windows:
             if self.is_cross:
                 return [f'-mtriple={self.arch}-windows-msvc']
             elif self.arch == 'x86_64':
@@ -703,7 +703,7 @@ class GnuDCompiler(GnuCompiler, DCompiler):
 
     def get_linker_always_args(self) -> T.List[str]:
         args = super().get_linker_always_args()
-        if self.info.is_windows():
+        if self.info.is_windows:
             return args
         return args + ['-shared-libphobos']
 
@@ -773,7 +773,7 @@ class LLVMDCompiler(DmdLikeCompilerMixin, DCompiler):
 
     def get_linker_always_args(self) -> T.List[str]:
         args = super().get_linker_always_args()
-        if self.info.is_windows():
+        if self.info.is_windows:
             return args
         return args + ['-link-defaultlib-shared']
 
@@ -810,7 +810,7 @@ class DmdDCompiler(DmdLikeCompilerMixin, DCompiler):
         return []
 
     def get_std_exe_link_args(self) -> T.List[str]:
-        if self.info.is_windows():
+        if self.info.is_windows:
             # DMD links against D runtime only when main symbol is found,
             # so these needs to be inserted when linking static D libraries.
             if self.arch == 'x86_64':
@@ -822,7 +822,7 @@ class DmdDCompiler(DmdLikeCompilerMixin, DCompiler):
 
     def get_std_shared_lib_link_args(self) -> T.List[str]:
         libname = 'libphobos2.so'
-        if self.info.is_windows():
+        if self.info.is_windows:
             if self.arch == 'x86_64':
                 libname = 'phobos64.lib'
             elif self.arch == 'x86_mscoff':
@@ -835,7 +835,7 @@ class DmdDCompiler(DmdLikeCompilerMixin, DCompiler):
         # DMD32 and DMD64 on 64-bit Windows defaults to 32-bit (OMF).
         # Force the target to 64-bit in order to stay consistent
         # across the different platforms.
-        if self.info.is_windows():
+        if self.info.is_windows:
             if self.arch == 'x86_64':
                 return ['-m64']
             elif self.arch == 'x86_mscoff':
@@ -859,7 +859,7 @@ class DmdDCompiler(DmdLikeCompilerMixin, DCompiler):
 
     def get_linker_always_args(self) -> T.List[str]:
         args = super().get_linker_always_args()
-        if self.info.is_windows():
+        if self.info.is_windows:
             return args
         return args + ['-defaultlib=phobos2', '-debuglib=phobos2']
 

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -463,7 +463,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
             else:
                 cls = c.ClangCCompiler if lang == 'c' else cpp.ClangCPPCompiler
 
-            if 'windows' in out or env.machines[for_machine].is_windows():
+            if 'windows' in out or env.machines[for_machine].is_windows:
                 # If we're in a MINGW context this actually will use a gnu
                 # style ld, but for clang on "real" windows we'll use
                 # either link.exe or lld-link.exe
@@ -814,7 +814,7 @@ def detect_fortran_compiler(env: 'Environment', for_machine: MachineChoice) -> C
 
             def _get_linker_try_windows(cls: T.Type['Compiler']) -> T.Optional['DynamicLinker']:
                 linker = None
-                if 'windows' in out or env.machines[for_machine].is_windows():
+                if 'windows' in out or env.machines[for_machine].is_windows:
                     # If we're in a MINGW context this actually will use a gnu
                     # style ld, but for flang on "real" windows we'll use
                     # either link.exe or lld-link.exe
@@ -914,7 +914,7 @@ def _detect_objc_or_objcpp_compiler(env: 'Environment', lang: str, for_machine: 
                 comp = objc.AppleClangObjCCompiler if lang == 'objc' else objcpp.AppleClangObjCPPCompiler
             else:
                 comp = objc.ClangObjCCompiler if lang == 'objc' else objcpp.ClangObjCPPCompiler
-            if 'windows' in out or env.machines[for_machine].is_windows():
+            if 'windows' in out or env.machines[for_machine].is_windows:
                 # If we're in a MINGW context this actually will use a gnu style ld
                 try:
                     linker = guess_win_linker(env, compiler, comp, version, for_machine)
@@ -1196,7 +1196,7 @@ def detect_d_compiler(env: 'Environment', for_machine: MachineChoice) -> Compile
             os.close(o)
 
             try:
-                if info.is_windows() or info.is_cygwin():
+                if info.is_windows or info.is_cygwin:
                     objfile = os.path.basename(f)[:-1] + 'obj'
                     extra_args = [f]
                     if is_cross:
@@ -1241,7 +1241,7 @@ def detect_d_compiler(env: 'Environment', for_machine: MachineChoice) -> Compile
             arch_arg = '-m64' if arch == 'x86_64' else '-m32'
 
             try:
-                if info.is_windows() or info.is_cygwin():
+                if info.is_windows or info.is_cygwin:
                     objfile = os.path.basename(f)[:-1] + 'obj'
                     linker = guess_win_linker(env,
                                               exelist, cls, full_version, for_machine,

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -977,10 +977,10 @@ class CLikeCompiler(Compiler):
         '''
         m = env.machines[self.for_machine]
         # Darwin always uses the underscore prefix, not matter what
-        if m.is_darwin():
+        if m.is_darwin:
             return True
         # Windows uses the underscore prefix on x86 (32bit) only
-        if m.is_windows() or m.is_cygwin():
+        if m.is_windows or m.is_cygwin:
             return m.cpu_family == 'x86'
         return None
 
@@ -1008,7 +1008,7 @@ class CLikeCompiler(Compiler):
         for p in prefixes:
             for s in suffixes:
                 patterns.append(p + '{}.' + s)
-        if shared and env.machines[self.for_machine].is_openbsd():
+        if shared and env.machines[self.for_machine].is_openbsd:
             # Shared libraries on OpenBSD can be named libfoo.so.X.Y:
             # https://www.openbsd.org/faq/ports/specialtopics.html#SharedLibs
             #
@@ -1035,9 +1035,9 @@ class CLikeCompiler(Compiler):
         else:
             prefixes = ['lib', '']
         # Library suffixes and prefixes
-        if env.machines[self.for_machine].is_darwin():
+        if env.machines[self.for_machine].is_darwin:
             shlibext = ['dylib', 'so']
-        elif env.machines[self.for_machine].is_windows():
+        elif env.machines[self.for_machine].is_windows:
             # FIXME: .lib files can be import or static so we should read the
             # file, figure out which one it is, and reject the wrong kind.
             if isinstance(self, VisualStudioLikeCompiler):
@@ -1046,7 +1046,7 @@ class CLikeCompiler(Compiler):
                 shlibext = ['dll.a', 'lib', 'dll']
             # Yep, static libraries can also be foo.lib
             stlibext += ['lib']
-        elif env.machines[self.for_machine].is_cygwin():
+        elif env.machines[self.for_machine].is_cygwin:
             shlibext = ['dll', 'dll.a']
             prefixes = ['cyg'] + prefixes
         elif self.id.lower() in {'c6000', 'c2000', 'ti'}:
@@ -1110,7 +1110,7 @@ class CLikeCompiler(Compiler):
         for p in paths:
             if p.is_file():
 
-                if env.machines.host.is_darwin() and env.machines.build.is_darwin():
+                if env.machines.host.is_darwin and env.machines.build.is_darwin:
                     # Run `lipo` and check if the library supports the arch we want
                     archs = mesonlib.darwin_get_object_archs(str(p))
                     if not archs or env.machines.host.cpu_family not in archs:
@@ -1268,7 +1268,7 @@ class CLikeCompiler(Compiler):
     def thread_flags(self, env: 'Environment') -> T.List[str]:
         # TODO: does this belong here or in GnuLike or maybe PosixLike?
         host_m = env.machines[self.for_machine]
-        if host_m.is_haiku() or host_m.is_darwin():
+        if host_m.is_haiku or host_m.is_darwin:
             return []
         return ['-pthread']
 
@@ -1334,7 +1334,7 @@ class CLikeCompiler(Compiler):
         # Just assume that if we're not on windows that dllimport and dllexport
         # don't work
         m = env.machines[self.for_machine]
-        if not (m.is_windows() or m.is_cygwin()):
+        if not (m.is_windows or m.is_cygwin):
             if name in {'dllimport', 'dllexport'}:
                 return False, False
 

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -361,18 +361,18 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
         self.base_options = {
             OptionKey(o) for o in ['b_pch', 'b_lto', 'b_pgo', 'b_coverage',
                                    'b_ndebug', 'b_staticpic', 'b_pie']}
-        if not (self.info.is_windows() or self.info.is_cygwin() or self.info.is_openbsd()):
+        if not (self.info.is_windows or self.info.is_cygwin or self.info.is_openbsd):
             self.base_options.add(OptionKey('b_lundef'))
-        if not self.info.is_windows() or self.info.is_cygwin():
+        if not self.info.is_windows or self.info.is_cygwin:
             self.base_options.add(OptionKey('b_asneeded'))
-        if not self.info.is_hurd():
+        if not self.info.is_hurd:
             self.base_options.add(OptionKey('b_sanitize'))
         # All GCC-like backends can do assembly
         self.can_compile_suffixes.add('s')
         self.can_compile_suffixes.add('sx')
 
     def get_pic_args(self) -> T.List[str]:
-        if self.info.is_windows() or self.info.is_cygwin() or self.info.is_darwin():
+        if self.info.is_windows or self.info.is_cygwin or self.info.is_darwin:
             return [] # On Window and OS X, pic is always on.
         return ['-fPIC']
 
@@ -413,7 +413,7 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
             raise RuntimeError('Module definitions file should be str')
         # On Windows targets, .def files may be specified on the linker command
         # line like an object file.
-        if self.info.is_windows() or self.info.is_cygwin():
+        if self.info.is_windows or self.info.is_cygwin:
             return [defsfile]
         # For other targets, discard the .def file.
         return []

--- a/mesonbuild/compilers/mixins/islinker.py
+++ b/mesonbuild/compilers/mixins/islinker.py
@@ -13,7 +13,7 @@ classes for those cases.
 
 import typing as T
 
-from ...mesonlib import EnvironmentException, MesonException, is_windows
+from ...mesonlib import EnvironmentException, MesonException, Platform
 
 if T.TYPE_CHECKING:
     from ...coredata import KeyedOptionDictType
@@ -44,7 +44,7 @@ class BasicLinkerIsCompilerMixin(Compiler):
         return []
 
     def can_linker_accept_rsp(self) -> bool:
-        return is_windows()
+        return Platform.is_windows
 
     def get_linker_exelist(self) -> T.List[str]:
         return self.exelist.copy()

--- a/mesonbuild/compilers/mixins/pgi.py
+++ b/mesonbuild/compilers/mixins/pgi.py
@@ -47,7 +47,7 @@ class PGICompiler(Compiler):
 
     def get_pic_args(self) -> T.List[str]:
         # PGI -fPIC is Linux only.
-        if self.info.is_linux():
+        if self.info.is_linux:
             return ['-fPIC']
         return []
 

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -595,7 +595,7 @@ class BoostDependency(SystemDependency):
         # mlog.debug('    - vscrt: {}'.format(vscrt))
         libs = [x for x in libs if x.static == self.static or not self.explicit_static]
         libs = [x for x in libs if x.mt == self.multithreading]
-        if not self.env.machines[self.for_machine].is_openbsd():
+        if not self.env.machines[self.for_machine].is_openbsd:
             libs = [x for x in libs if x.version_matches(lib_vers)]
         libs = [x for x in libs if x.arch_matches(self.arch)]
         libs = [x for x in libs if x.vscrt_matches(vscrt)]
@@ -678,7 +678,7 @@ class BoostDependency(SystemDependency):
 
         m = self.env.machines[self.for_machine]
         # Add system paths
-        if m.is_windows():
+        if m.is_windows:
             # Where boost built from source actually installs it
             c_root = Path('C:/Boost')
             if c_root.is_dir():
@@ -700,7 +700,7 @@ class BoostDependency(SystemDependency):
             tmp: T.List[Path] = []
 
             # Add some default system paths
-            if m.is_darwin():
+            if m.is_darwin:
                 tmp.extend([
                     Path('/opt/homebrew/'),        # for Apple Silicon MacOS
                     Path('/usr/local/opt/boost'),  # for Intel Silicon MacOS

--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -321,7 +321,7 @@ class CMakeDependency(ExternalDependency):
                     return True
 
             # Mac framework support
-            if machine.is_darwin():
+            if machine.is_darwin:
                 for j in [f'{lname}.framework', f'{lname}.app']:
                     for k in content:
                         if k[1] != j:

--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from .base import ExternalDependency, DependencyException, DependencyTypeName
-from ..mesonlib import is_windows, MesonException, PerMachine, stringlistify, extract_as_list
+from ..mesonlib import Platform, MesonException, PerMachine, stringlistify, extract_as_list
 from ..cmake import CMakeExecutor, CMakeTraceParser, CMakeException, CMakeToolchain, CMakeExecScope, check_cmake_args, resolve_cmake_trace_targets, cmake_is_debug
 from .. import mlog
 import importlib.resources
@@ -188,7 +188,7 @@ class CMakeDependency(ExternalDependency):
             return None
 
         def process_paths(l: T.List[str]) -> T.Set[str]:
-            if is_windows():
+            if Platform.is_windows:
                 # Cannot split on ':' on Windows because its in the drive letter
                 tmp = [x.split(os.pathsep) for x in l]
             else:

--- a/mesonbuild/dependencies/cuda.py
+++ b/mesonbuild/dependencies/cuda.py
@@ -214,17 +214,17 @@ class CudaDependency(SystemDependency):
         arch = detect_cpu_family(self.env.coredata.compilers.host)
         machine = self.env.machines[self.for_machine]
         msg = '{} architecture is not supported in {} version of the CUDA Toolkit.'
-        if machine.is_windows():
+        if machine.is_windows:
             libdirs = {'x86': 'Win32', 'x86_64': 'x64'}
             if arch not in libdirs:
                 raise DependencyException(msg.format(arch, 'Windows'))
             return os.path.join('lib', libdirs[arch])
-        elif machine.is_linux():
+        elif machine.is_linux:
             libdirs = {'x86_64': 'lib64', 'ppc64': 'lib', 'aarch64': 'lib64', 'loongarch64': 'lib64'}
             if arch not in libdirs:
                 raise DependencyException(msg.format(arch, 'Linux'))
             return libdirs[arch]
-        elif machine.is_darwin():
+        elif machine.is_darwin:
             libdirs = {'x86_64': 'lib64'}
             if arch not in libdirs:
                 raise DependencyException(msg.format(arch, 'macOS'))
@@ -239,7 +239,7 @@ class CudaDependency(SystemDependency):
             args = self.clib_compiler.find_library(module, self.env, [self.libdir])
             if module == 'cudart_static' and self.language != 'cuda':
                 machine = self.env.machines[self.for_machine]
-                if machine.is_linux():
+                if machine.is_linux:
                     # extracted by running
                     #   nvcc -v foo.o
                     args += ['-lrt', '-lpthread', '-ldl']
@@ -254,7 +254,7 @@ class CudaDependency(SystemDependency):
         return all_found
 
     def _is_windows(self) -> bool:
-        return self.env.machines[self.for_machine].is_windows()
+        return self.env.machines[self.for_machine].is_windows
 
     @T.overload
     def _report_dependency_error(self, msg: str) -> None: ...

--- a/mesonbuild/dependencies/detect.py
+++ b/mesonbuild/dependencies/detect.py
@@ -211,7 +211,7 @@ def _build_external_dependency_list(name: str, env: 'Environment', for_machine: 
 
     # On OSX only, try framework dependency detector.
     if 'extraframework' in methods:
-        if env.machines[for_machine].is_darwin():
+        if env.machines[for_machine].is_darwin:
             from .framework import ExtraFrameworkDependency
             candidates.append(functools.partial(ExtraFrameworkDependency, name, env, kwargs))
 

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -45,9 +45,9 @@ def get_shared_library_suffix(environment: 'Environment', for_machine: MachineCh
     code, not for languages like C# that use a bytecode and always end in .dll
     """
     m = environment.machines[for_machine]
-    if m.is_windows():
+    if m.is_windows:
         return '.dll'
-    elif m.is_darwin():
+    elif m.is_darwin:
         return '.dylib'
     return '.so'
 
@@ -533,8 +533,8 @@ class ZlibSystemDependency(SystemDependency):
 
         # I'm not sure this is entirely correct. What if we're cross compiling
         # from something to macOS?
-        if ((m.is_darwin() and isinstance(self.clib_compiler, (AppleClangCCompiler, AppleClangCPPCompiler))) or
-                m.is_freebsd() or m.is_dragonflybsd() or m.is_android()):
+        if ((m.is_darwin and isinstance(self.clib_compiler, (AppleClangCCompiler, AppleClangCPPCompiler))) or
+                m.is_freebsd or m.is_dragonflybsd or m.is_android):
             # No need to set includes,
             # on macos xcode/clang will do that for us.
             # on freebsd zlib.h is in /usr/include
@@ -592,7 +592,7 @@ class JNISystemDependency(SystemDependency):
         self.java_home = environment.properties[self.for_machine].get_java_home()
         if not self.java_home:
             self.java_home = pathlib.Path(shutil.which(self.javac.exelist[0])).resolve().parents[1]
-            if m.is_darwin():
+            if m.is_darwin:
                 problem_java_prefix = pathlib.Path('/System/Library/Frameworks/JavaVM.framework/Versions')
                 if problem_java_prefix in self.java_home.parents:
                     res = subprocess.run(['/usr/libexec/java_home', '--failfast', '--arch', m.cpu_family],
@@ -618,7 +618,7 @@ class JNISystemDependency(SystemDependency):
         self.compile_args.append(f'-I{java_home_include / platform_include_dir}')
 
         if modules:
-            if m.is_windows():
+            if m.is_windows:
                 java_home_lib = self.java_home / 'lib'
                 java_home_lib_server = java_home_lib
             else:
@@ -666,21 +666,21 @@ class JNISystemDependency(SystemDependency):
         platform-dependent directory that must be on the target's include path in addition to the
         parent `include/` directory.
         '''
-        if m.is_linux():
+        if m.is_linux:
             return 'linux'
-        elif m.is_windows():
+        elif m.is_windows:
             return 'win32'
-        elif m.is_darwin():
+        elif m.is_darwin:
             return 'darwin'
-        elif m.is_sunos():
+        elif m.is_sunos:
             return 'solaris'
-        elif m.is_freebsd():
+        elif m.is_freebsd:
             return 'freebsd'
-        elif m.is_netbsd():
+        elif m.is_netbsd:
             return 'netbsd'
-        elif m.is_openbsd():
+        elif m.is_openbsd:
             return 'openbsd'
-        elif m.is_dragonflybsd():
+        elif m.is_dragonflybsd:
             return 'dragonfly'
 
         return None

--- a/mesonbuild/dependencies/dub.py
+++ b/mesonbuild/dependencies/dub.py
@@ -320,7 +320,7 @@ class DubDependency(ExternalDependency):
         for flag in bs['lflags']:
             self.link_args.append(flag)
 
-        is_windows = self.env.machines.host.is_windows()
+        is_windows = self.env.machines.host.is_windows
         if is_windows:
             winlibs = ['kernel32', 'user32', 'gdi32', 'winspool', 'shell32', 'ole32',
                        'oleaut32', 'uuid', 'comdlg32', 'advapi32', 'ws2_32']

--- a/mesonbuild/dependencies/factory.py
+++ b/mesonbuild/dependencies/factory.py
@@ -111,7 +111,7 @@ class DependencyFactory:
         """
         # Extra frameworks are only valid for macOS and other apple products
         if (method is DependencyMethods.EXTRAFRAMEWORK and
-                not env.machines[for_machine].is_darwin()):
+                not env.machines[for_machine].is_darwin):
             return False
         return True
 

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -184,7 +184,7 @@ class BlocksDependency(SystemDependency):
         self.name = 'blocks'
         self.is_found = False
 
-        if self.env.machines[self.for_machine].is_darwin():
+        if self.env.machines[self.for_machine].is_darwin:
             self.compile_args = []
             self.link_args = []
         else:
@@ -540,7 +540,7 @@ def curses_factory(env: 'Environment',
     # There are path handling problems with these methods on msys, and they
     # don't apply to windows otherwise (cygwin is handled separately from
     # windows)
-    if not env.machines[for_machine].is_windows():
+    if not env.machines[for_machine].is_windows:
         if DependencyMethods.CONFIG_TOOL in methods:
             candidates.append(functools.partial(CursesConfigToolDependency, 'curses', env, kwargs))
 

--- a/mesonbuild/dependencies/mpi.py
+++ b/mesonbuild/dependencies/mpi.py
@@ -57,7 +57,7 @@ def mpi_factory(env: 'Environment',
         tool_names = [t for t in tool_names if t]  # remove empty environment variables
 
         if compiler_is_intel:
-            if env.machines[for_machine].is_windows():
+            if env.machines[for_machine].is_windows:
                 nwargs['returncode_value'] = 3
 
             if language == 'c':
@@ -79,7 +79,7 @@ def mpi_factory(env: 'Environment',
         candidates.append(functools.partial(
             MPIConfigToolDependency, tool_names[0], env, nwargs, language=language))
 
-    if DependencyMethods.SYSTEM in methods and env.machines[for_machine].is_windows():
+    if DependencyMethods.SYSTEM in methods and env.machines[for_machine].is_windows:
         candidates.append(functools.partial(
             MSMPIDependency, 'msmpi', env, kwargs, language=language))
 
@@ -222,7 +222,7 @@ class MSMPIDependency(SystemDependency):
             self.is_found = False
             return
         # MSMPI is only for windows, obviously
-        if not self.env.machines[self.for_machine].is_windows():
+        if not self.env.machines[self.for_machine].is_windows:
             return
 
         incdir = os.environ.get('MSMPI_INC')

--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -247,7 +247,7 @@ class PkgConfigCLI(PkgConfigInterface):
             return None
         except PermissionError:
             msg = f'Found pkg-config {command_as_string!r} but didn\'t have permissions to run it.'
-            if not self.env.machines.build.is_windows():
+            if not self.env.machines.build.is_windows:
                 msg += '\n\nOn Unix-like systems this is often caused by scripts that are not executable.'
             mlog.warning(msg)
             return None
@@ -342,7 +342,7 @@ class PkgConfigDependency(ExternalDependency):
         with / like /home/foo so leave them as-is so that the user gets an
         error/warning from the compiler/linker.
         '''
-        if not self.env.machines.build.is_windows():
+        if not self.env.machines.build.is_windows:
             return args.copy()
         converted = []
         for arg in args:
@@ -562,7 +562,7 @@ class PkgConfigDependency(ExternalDependency):
 
         # Darwin uses absolute paths where possible; since the libtool files never
         # contain absolute paths, use the libdir field
-        if self.env.machines[self.for_machine].is_darwin():
+        if self.env.machines[self.for_machine].is_darwin:
             dlbasename = os.path.basename(dlname)
             libdir = self.extract_libdir_field(la_file)
             if libdir is None:

--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -169,7 +169,7 @@ class _PythonDependencyBase(_Base):
         # pyconfig.h is shared between regular and free-threaded builds in the
         # Windows installer from python.org, and hence does not define
         # Py_GIL_DISABLED correctly. So do it here:
-        if mesonlib.is_windows() and self.is_freethreaded:
+        if mesonlib.Platform.is_windows and self.is_freethreaded:
             self.compile_args += ['-DPy_GIL_DISABLED']
 
     def find_libpy(self, environment: 'Environment') -> None:
@@ -346,7 +346,7 @@ class PythonSystemDependency(SystemDependency, _PythonDependencyBase):
         # match pkg-config behavior
         if self.link_libpython:
             # link args
-            if mesonlib.is_windows():
+            if mesonlib.Platform.is_windows:
                 self.find_libpy_windows(environment, limited_api=False)
             else:
                 self.find_libpy(environment)
@@ -363,7 +363,7 @@ class PythonSystemDependency(SystemDependency, _PythonDependencyBase):
 
         # https://sourceforge.net/p/mingw-w64/mailman/message/30504611/
         # https://github.com/python/cpython/pull/100137
-        if mesonlib.is_windows() and self.get_windows_python_arch().endswith('64') and mesonlib.version_compare(self.version, '<3.12'):
+        if mesonlib.Platform.is_windows and self.get_windows_python_arch().endswith('64') and mesonlib.version_compare(self.version, '<3.12'):
             self.compile_args += ['-DMS_WIN64=']
 
         if not self.clib_compiler.has_header('Python.h', '', environment, extra_args=self.compile_args)[0]:

--- a/mesonbuild/dependencies/qt.py
+++ b/mesonbuild/dependencies/qt.py
@@ -71,16 +71,16 @@ def get_qmake_host_libexecs(qvars: T.Dict[str, str]) -> T.Optional[str]:
 def _get_modules_lib_suffix(version: str, info: 'MachineInfo', is_debug: bool) -> str:
     """Get the module suffix based on platform and debug type."""
     suffix = ''
-    if info.is_windows():
+    if info.is_windows:
         if is_debug:
             suffix += 'd'
         if version.startswith('4'):
             suffix += '4'
-    if info.is_darwin():
+    if info.is_darwin:
         if is_debug:
             suffix += '_debug'
     if mesonlib.version_compare(version, '>= 5.14.0'):
-        if info.is_android():
+        if info.is_android:
             if info.cpu_family == 'x86':
                 suffix += '_x86'
             elif info.cpu_family == 'x86_64':
@@ -203,7 +203,7 @@ class QtPkgConfigDependency(_QtBase, PkgConfigDependency, metaclass=abc.ABCMeta)
                     mod.compile_args.append('-I' + directory)
             self._add_sub_dependency([lambda: mod])
 
-        if self.env.machines[self.for_machine].is_windows() and self.qtmain:
+        if self.env.machines[self.for_machine].is_windows and self.qtmain:
             # Check if we link with debug binaries
             debug_lib_name = self.qtpkgname + 'Core' + _get_modules_lib_suffix(self.version, self.env.machines[self.for_machine], True)
             is_debug = False
@@ -279,7 +279,7 @@ class QmakeQtDependency(_QtBase, ConfigToolDependency, metaclass=abc.ABCMeta):
             qvars[k] = v
         # Qt on macOS uses a framework, but Qt for iOS/tvOS does not
         xspec = qvars.get('QMAKE_XSPEC', '')
-        if self.env.machines.host.is_darwin() and not any(s in xspec for s in ['ios', 'tvos']):
+        if self.env.machines.host.is_darwin and not any(s in xspec for s in ['ios', 'tvos']):
             mlog.debug("Building for macOS, looking for framework")
             self._framework_detect(qvars, self.requested_modules, kwargs)
             # Sometimes Qt is built not as a framework (for instance, when using conan pkg manager)
@@ -332,7 +332,7 @@ class QmakeQtDependency(_QtBase, ConfigToolDependency, metaclass=abc.ABCMeta):
                 break
             self.link_args.append(libfile)
 
-        if self.env.machines[self.for_machine].is_windows() and self.qtmain:
+        if self.env.machines[self.for_machine].is_windows and self.qtmain:
             if not self._link_with_qt_winmain(is_debug, libdir):
                 self.is_found = False
 

--- a/mesonbuild/dependencies/scalapack.py
+++ b/mesonbuild/dependencies/scalapack.py
@@ -65,7 +65,7 @@ class MKLPkgConfigDependency(PkgConfigDependency):
         super().__init__(name, env, kwargs, language=language)
 
         # Doesn't work with gcc on windows, but does on Linux
-        if (not self.__mklroot or (env.machines[self.for_machine].is_windows()
+        if (not self.__mklroot or (env.machines[self.for_machine].is_windows
                                    and self.clib_compiler.id == 'gcc')):
             self.is_found = False
 
@@ -98,7 +98,7 @@ class MKLPkgConfigDependency(PkgConfigDependency):
     def _set_libs(self) -> None:
         super()._set_libs()
 
-        if self.env.machines[self.for_machine].is_windows():
+        if self.env.machines[self.for_machine].is_windows:
             suffix = '.lib'
         elif self.static:
             suffix = '.a'
@@ -121,7 +121,7 @@ class MKLPkgConfigDependency(PkgConfigDependency):
                 i = j + 1
             elif j > 3:
                 break
-        if self.env.machines[self.for_machine].is_windows() or self.static:
+        if self.env.machines[self.for_machine].is_windows or self.static:
             self.link_args.insert(
                 i, str(libdir / ('mkl_scalapack_lp64' + suffix))
             )

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -200,7 +200,7 @@ class VulkanDependencySystem(SystemDependency):
             lib_name = 'vulkan'
             lib_dir = 'lib'
             inc_dir = 'include'
-            if mesonlib.is_windows():
+            if mesonlib.Platform.is_windows:
                 lib_name = 'vulkan-1'
                 lib_dir = 'Lib32'
                 inc_dir = 'Include'

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -30,13 +30,13 @@ class GLDependencySystem(SystemDependency):
     def __init__(self, name: str, environment: 'Environment', kwargs: T.Dict[str, T.Any]) -> None:
         super().__init__(name, environment, kwargs)
 
-        if self.env.machines[self.for_machine].is_darwin():
+        if self.env.machines[self.for_machine].is_darwin:
             self.is_found = True
             # FIXME: Use AppleFrameworks dependency
             self.link_args = ['-framework', 'OpenGL']
             # FIXME: Detect version using self.clib_compiler
             return
-        elif self.env.machines[self.for_machine].is_windows():
+        elif self.env.machines[self.for_machine].is_windows:
             self.is_found = True
             # FIXME: Use self.clib_compiler.find_library()
             self.link_args = ['-lopengl32']

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -9,7 +9,7 @@ import typing as T
 from enum import Enum
 
 from . import mesonlib
-from .mesonlib import EnvironmentException, HoldableObject, lazy_property
+from .mesonlib import EnvironmentException, HoldableObject
 from . import mlog
 from pathlib import Path
 
@@ -266,6 +266,23 @@ class MachineInfo(HoldableObject):
     def __post_init__(self) -> None:
         self.is_64_bit: bool = self.cpu_family in CPU_FAMILIES_64_BIT
 
+        self.is_windows: bool = self.system == 'windows'
+        self.is_cygwin: bool = self.system == 'cygwin'
+        self.is_linux: bool = self.system == 'linux'
+        # Machine is Darwin (iOS/tvOS/OS X)?
+        self.is_darwin: bool = self.system in {'darwin', 'ios', 'tvos'}
+        self.is_android: bool = self.system == 'android'
+        self.is_haiku: bool = self.system == 'haiku'
+        self.is_netbsd: bool = self.system == 'netbsd'
+        self.is_openbsd: bool = self.system == 'openbsd'
+        self.is_dragonflybsd: bool = self.system == 'dragonfly'
+        self.is_freebsd: bool = self.system == 'freebsd'
+        # Machine is illumos or Solaris?
+        self.is_sunos: bool = self.system == 'sunos'
+        self.is_hurd: bool = self.system == 'gnu'
+        self.is_aix: bool = self.system == 'aix'
+        self.is_irix: bool = self.system.startswith('irix')
+
     def __repr__(self) -> str:
         return f'<MachineInfo: {self.system} {self.cpu_family} ({self.cpu})>'
 
@@ -291,99 +308,10 @@ class MachineInfo(HoldableObject):
 
         return cls(system, cpu_family, literal['cpu'], endian, kernel, subsystem)
 
-    @lazy_property
-    def is_windows(self) -> bool:
-        """
-        Machine is windows?
-        """
-        return self.system == 'windows'
-
-    @lazy_property
-    def is_cygwin(self) -> bool:
-        """
-        Machine is cygwin?
-        """
-        return self.system == 'cygwin'
-
-    @lazy_property
-    def is_linux(self) -> bool:
-        """
-        Machine is linux?
-        """
-        return self.system == 'linux'
-
-    @lazy_property
-    def is_darwin(self) -> bool:
-        """
-        Machine is Darwin (iOS/tvOS/OS X)?
-        """
-        return self.system in {'darwin', 'ios', 'tvos'}
-
-    @lazy_property
-    def is_android(self) -> bool:
-        """
-        Machine is Android?
-        """
-        return self.system == 'android'
-
-    @lazy_property
-    def is_haiku(self) -> bool:
-        """
-        Machine is Haiku?
-        """
-        return self.system == 'haiku'
-
-    @lazy_property
-    def is_netbsd(self) -> bool:
-        """
-        Machine is NetBSD?
-        """
-        return self.system == 'netbsd'
-
-    @lazy_property
-    def is_openbsd(self) -> bool:
-        """
-        Machine is OpenBSD?
-        """
-        return self.system == 'openbsd'
-
-    @lazy_property
-    def is_dragonflybsd(self) -> bool:
-        """Machine is DragonflyBSD?"""
-        return self.system == 'dragonfly'
-
-    @lazy_property
-    def is_freebsd(self) -> bool:
-        """Machine is FreeBSD?"""
-        return self.system == 'freebsd'
-
-    @lazy_property
-    def is_sunos(self) -> bool:
-        """Machine is illumos or Solaris?"""
-        return self.system == 'sunos'
-
-    @lazy_property
-    def is_hurd(self) -> bool:
-        """
-        Machine is GNU/Hurd?
-        """
-        return self.system == 'gnu'
-
-    @lazy_property
-    def is_aix(self) -> bool:
-        """
-        Machine is aix?
-        """
-        return self.system == 'aix'
-
-    @lazy_property
-    def is_irix(self) -> bool:
-        """Machine is IRIX?"""
-        return self.system.startswith('irix')
-
     # Various prefixes and suffixes for import libraries, shared libraries,
     # static libraries, and executables.
     # Versioning is added to these names in the backends as-needed.
+
     def get_exe_suffix(self) -> str:
         if self.is_windows or self.is_cygwin:
             return 'exe'

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -9,7 +9,7 @@ import typing as T
 from enum import Enum
 
 from . import mesonlib
-from .mesonlib import EnvironmentException, HoldableObject
+from .mesonlib import EnvironmentException, HoldableObject, lazy_property
 from . import mlog
 from pathlib import Path
 
@@ -291,78 +291,92 @@ class MachineInfo(HoldableObject):
 
         return cls(system, cpu_family, literal['cpu'], endian, kernel, subsystem)
 
+    @lazy_property
     def is_windows(self) -> bool:
         """
         Machine is windows?
         """
         return self.system == 'windows'
 
+    @lazy_property
     def is_cygwin(self) -> bool:
         """
         Machine is cygwin?
         """
         return self.system == 'cygwin'
 
+    @lazy_property
     def is_linux(self) -> bool:
         """
         Machine is linux?
         """
         return self.system == 'linux'
 
+    @lazy_property
     def is_darwin(self) -> bool:
         """
         Machine is Darwin (iOS/tvOS/OS X)?
         """
         return self.system in {'darwin', 'ios', 'tvos'}
 
+    @lazy_property
     def is_android(self) -> bool:
         """
         Machine is Android?
         """
         return self.system == 'android'
 
+    @lazy_property
     def is_haiku(self) -> bool:
         """
         Machine is Haiku?
         """
         return self.system == 'haiku'
 
+    @lazy_property
     def is_netbsd(self) -> bool:
         """
         Machine is NetBSD?
         """
         return self.system == 'netbsd'
 
+    @lazy_property
     def is_openbsd(self) -> bool:
         """
         Machine is OpenBSD?
         """
         return self.system == 'openbsd'
 
+    @lazy_property
     def is_dragonflybsd(self) -> bool:
         """Machine is DragonflyBSD?"""
         return self.system == 'dragonfly'
 
+    @lazy_property
     def is_freebsd(self) -> bool:
         """Machine is FreeBSD?"""
         return self.system == 'freebsd'
 
+    @lazy_property
     def is_sunos(self) -> bool:
         """Machine is illumos or Solaris?"""
         return self.system == 'sunos'
 
+    @lazy_property
     def is_hurd(self) -> bool:
         """
         Machine is GNU/Hurd?
         """
         return self.system == 'gnu'
 
+    @lazy_property
     def is_aix(self) -> bool:
         """
         Machine is aix?
         """
         return self.system == 'aix'
 
+    @lazy_property
     def is_irix(self) -> bool:
         """Machine is IRIX?"""
         return self.system.startswith('irix')
@@ -371,19 +385,19 @@ class MachineInfo(HoldableObject):
     # static libraries, and executables.
     # Versioning is added to these names in the backends as-needed.
     def get_exe_suffix(self) -> str:
-        if self.is_windows() or self.is_cygwin():
+        if self.is_windows or self.is_cygwin:
             return 'exe'
         else:
             return ''
 
     def get_object_suffix(self) -> str:
-        if self.is_windows():
+        if self.is_windows:
             return 'obj'
         else:
             return 'o'
 
     def libdir_layout_is_win(self) -> bool:
-        return self.is_windows() or self.is_cygwin()
+        return self.is_windows or self.is_cygwin
 
 class BinaryTable:
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -759,7 +759,7 @@ class Environment:
                 # these may contain duplicates, which must be removed, else
                 # a duplicates-in-array-option warning arises.
                 if keyname == 'cmake_prefix_path':
-                    if self.machines[for_machine].is_windows():
+                    if self.machines[for_machine].is_windows:
                         # Cannot split on ':' on Windows because its in the drive letter
                         _p_env = p_env.split(os.pathsep)
                     else:
@@ -923,7 +923,7 @@ class Environment:
         "Install dir for the shared library"
         m = self.machines.host
         # Windows has no RPATH or similar, so DLLs must be next to EXEs.
-        if m.is_windows() or m.is_cygwin():
+        if m.is_windows or m.is_cygwin:
             return self.get_bindir()
         return self.get_libdir()
 
@@ -1005,7 +1005,7 @@ class Environment:
 
     def get_env_for_paths(self, library_paths: T.Set[str], extra_paths: T.Set[str]) -> mesonlib.EnvironmentVariables:
         env = mesonlib.EnvironmentVariables()
-        need_wine = not self.machines.build.is_windows() and self.machines.host.is_windows()
+        need_wine = not self.machines.build.is_windows and self.machines.host.is_windows
         if need_wine:
             # Executable paths should be in both PATH and WINEPATH.
             # - Having them in PATH makes bash completion find it,
@@ -1015,9 +1015,9 @@ class Environment:
         if library_paths:
             if need_wine:
                 env.prepend('WINEPATH', list(library_paths), separator=';')
-            elif self.machines.host.is_windows() or self.machines.host.is_cygwin():
+            elif self.machines.host.is_windows or self.machines.host.is_cygwin:
                 extra_paths.update(library_paths)
-            elif self.machines.host.is_darwin():
+            elif self.machines.host.is_darwin:
                 env.prepend('DYLD_LIBRARY_PATH', list(library_paths))
             else:
                 env.prepend('LD_LIBRARY_PATH', list(library_paths))

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -359,9 +359,9 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
     For x86 it might return 'x86', 'i686' or some such.
     Do some canonicalization.
     """
-    if mesonlib.is_windows():
+    if mesonlib.Platform.is_windows:
         trial = detect_windows_arch(compilers)
-    elif mesonlib.is_freebsd() or mesonlib.is_netbsd() or mesonlib.is_openbsd() or mesonlib.is_qnx() or mesonlib.is_aix():
+    elif mesonlib.Platform.is_freebsd or mesonlib.Platform.is_netbsd or mesonlib.Platform.is_openbsd or mesonlib.Platform.is_qnx or mesonlib.Platform.is_aix:
         trial = platform.processor().lower()
     else:
         trial = platform.machine().lower()
@@ -425,9 +425,9 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
     return trial
 
 def detect_cpu(compilers: CompilersDict) -> str:
-    if mesonlib.is_windows():
+    if mesonlib.Platform.is_windows:
         trial = detect_windows_arch(compilers)
-    elif mesonlib.is_freebsd() or mesonlib.is_netbsd() or mesonlib.is_openbsd() or mesonlib.is_aix():
+    elif mesonlib.Platform.is_freebsd or mesonlib.Platform.is_netbsd or mesonlib.Platform.is_openbsd or mesonlib.Platform.is_aix:
         trial = platform.processor().lower()
     else:
         trial = platform.machine().lower()

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -81,7 +81,7 @@ def extract_search_dirs(kwargs: 'kwargs.ExtractSearchDirs') -> T.List[str]:
     search_dirs_str = mesonlib.stringlistify(kwargs.get('dirs', []))
     search_dirs = [Path(d).expanduser() for d in search_dirs_str]
     for d in search_dirs:
-        if mesonlib.is_windows() and d.root.startswith('\\'):
+        if mesonlib.Platform.is_windows and d.root.startswith('\\'):
             # a Unix-path starting with `/` that is not absolute on Windows.
             # discard without failing for end-user ease of cross-platform directory arrays
             continue

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -36,7 +36,7 @@ class StaticLinker:
         """
         Determines whether the linker can accept arguments using the @rsp syntax.
         """
-        return mesonlib.is_windows()
+        return mesonlib.Platform.is_windows
 
     def get_base_link_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         """Like compilers.get_base_link_args, but for the static linker."""
@@ -156,7 +156,7 @@ class DynamicLinker(metaclass=abc.ABCMeta):
     def get_accepts_rsp(self) -> bool:
         # rsp files are only used when building on Windows because we want to
         # avoid issues with quoting and max argument length
-        return mesonlib.is_windows()
+        return mesonlib.Platform.is_windows
 
     def rsp_file_syntax(self) -> RSPFileSyntax:
         """The format of the RSP file that this compiler supports.
@@ -419,7 +419,7 @@ class DLinker(StaticLinker):
         return ['-of=' + target]
 
     def get_linker_always_args(self) -> T.List[str]:
-        if mesonlib.is_windows():
+        if mesonlib.Platform.is_windows:
             if self.arch == 'x86_64':
                 return ['-m64']
             elif self.arch == 'x86_mscoff' and self.id == 'dmd':
@@ -709,7 +709,7 @@ class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
                 rpath_dirs_to_remove.add(p.encode('utf8'))
 
         # TODO: should this actually be "for (dragonfly|open)bsd"?
-        if mesonlib.is_dragonflybsd() or mesonlib.is_openbsd():
+        if mesonlib.Platform.is_dragonflybsd or mesonlib.Platform.is_openbsd:
             # This argument instructs the compiler to record the value of
             # ORIGIN in the .dynamic section of the elf. On Linux this is done
             # by default, but is not on dragonfly/openbsd for some reason. Without this
@@ -733,7 +733,7 @@ class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
         # TODO: should this actually be "for solaris/sunos"?
         # NOTE: Remove the zigcc check once zig support "-rpath-link"
         # See https://github.com/ziglang/zig/issues/18713
-        if mesonlib.is_sunos() or self.id == 'ld.zigcc':
+        if mesonlib.Platform.is_sunos or self.id == 'ld.zigcc':
             return (args, rpath_dirs_to_remove)
 
         # Rpaths to use while linking must be absolute. These are not
@@ -1255,9 +1255,9 @@ class PGIDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
 
     def get_std_shared_lib_args(self) -> T.List[str]:
         # PGI -shared is Linux only.
-        if mesonlib.is_windows():
+        if mesonlib.Platform.is_windows:
             return ['-Bdynamic', '-Mmakedll']
-        elif mesonlib.is_linux():
+        elif mesonlib.Platform.is_linux:
             return ['-shared']
         return []
 

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -387,8 +387,8 @@ class ArLinker(ArLikeLinker, StaticLinker):
         # on Mac OS X, Solaris, or illumos, so don't build them on those OSes.
         # OS X ld rejects with: "file built for unknown-unsupported file format"
         # illumos/Solaris ld rejects with: "unknown file type"
-        if is_thin and not env.machines[self.for_machine].is_darwin() \
-          and not env.machines[self.for_machine].is_sunos():
+        if is_thin and not env.machines[self.for_machine].is_darwin \
+          and not env.machines[self.for_machine].is_sunos:
             return self.std_thin_args
         else:
             return self.std_args
@@ -657,7 +657,7 @@ class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
 
     def export_dynamic_args(self, env: 'Environment') -> T.List[str]:
         m = env.machines[self.for_machine]
-        if m.is_windows() or m.is_cygwin():
+        if m.is_windows or m.is_cygwin:
             return self._apply_prefix('--export-all-symbols')
         return self._apply_prefix('-export-dynamic')
 
@@ -665,7 +665,7 @@ class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
         return self._apply_prefix('--out-implib=' + implibname)
 
     def thread_flags(self, env: 'Environment') -> T.List[str]:
-        if env.machines[self.for_machine].is_haiku():
+        if env.machines[self.for_machine].is_haiku:
             return []
         return ['-pthread']
 
@@ -678,7 +678,7 @@ class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
     def get_soname_args(self, env: 'Environment', prefix: str, shlib_name: str,
                         suffix: str, soversion: str, darwin_versions: T.Tuple[str, str]) -> T.List[str]:
         m = env.machines[self.for_machine]
-        if m.is_windows() or m.is_cygwin():
+        if m.is_windows or m.is_cygwin:
             # For PE/COFF the soname argument has no effect
             return []
         sostr = '' if soversion is None else '.' + soversion
@@ -688,7 +688,7 @@ class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
                          rpath_paths: T.Tuple[str, ...], build_rpath: str,
                          install_rpath: str) -> T.Tuple[T.List[str], T.Set[bytes]]:
         m = env.machines[self.for_machine]
-        if m.is_windows() or m.is_cygwin():
+        if m.is_windows or m.is_cygwin:
             return ([], set())
         if not rpath_paths and not install_rpath and not build_rpath:
             return ([], set())
@@ -1264,7 +1264,7 @@ class PGIDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
     def build_rpath_args(self, env: 'Environment', build_dir: str, from_dir: str,
                          rpath_paths: T.Tuple[str, ...], build_rpath: str,
                          install_rpath: str) -> T.Tuple[T.List[str], T.Set[bytes]]:
-        if not env.machines[self.for_machine].is_windows():
+        if not env.machines[self.for_machine].is_windows:
             return (['-R' + os.path.join(build_dir, p) for p in rpath_paths], set())
         return ([], set())
 

--- a/mesonbuild/mdevenv.py
+++ b/mesonbuild/mdevenv.py
@@ -9,7 +9,7 @@ import typing as T
 
 from pathlib import Path
 from . import build, minstall
-from .mesonlib import (EnvironmentVariables, MesonException, join_args, is_windows, setup_vsenv,
+from .mesonlib import (EnvironmentVariables, MesonException, join_args, Platform, setup_vsenv,
                        get_wine_shortpath, MachineChoice, relpath)
 from .options import OptionKey
 from . import mlog
@@ -102,7 +102,7 @@ def add_gdb_auto_load(autoload_path: Path, gdb_helper: str, fname: Path) -> None
     destdir = autoload_path / fname.parent
     destdir.mkdir(parents=True, exist_ok=True)
     try:
-        if is_windows():
+        if Platform.is_windows:
             shutil.copy(gdb_helper, str(destdir / os.path.basename(gdb_helper)))
         else:
             os.symlink(gdb_helper, str(destdir / os.path.basename(gdb_helper)))
@@ -196,7 +196,7 @@ def run(options: argparse.Namespace) -> int:
         # Prefer $SHELL in a MSYS2 bash despite it being Windows
         if shell_env and os.path.exists(shell_env):
             args = [shell_env]
-        elif is_windows():
+        elif Platform.is_windows:
             shell = get_windows_shell()
             if not shell:
                 mlog.warning('Failed to determine Windows shell, fallback to cmd.exe')

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -701,10 +701,10 @@ class PkgConfigModule(NewExtensionModule):
         pcfile = filebase + '.pc'
         pkgroot = pkgroot_name = kwargs['install_dir'] or default_install_dir
         if pkgroot is None:
-            if mesonlib.is_freebsd():
+            if mesonlib.Platform.is_freebsd:
                 pkgroot = os.path.join(_as_str(state.environment.coredata.get_option(OptionKey('prefix'))), 'libdata', 'pkgconfig')
                 pkgroot_name = os.path.join('{prefix}', 'libdata', 'pkgconfig')
-            elif mesonlib.is_haiku():
+            elif mesonlib.Platform.is_haiku:
                 pkgroot = os.path.join(_as_str(state.environment.coredata.get_option(OptionKey('prefix'))), 'develop', 'lib', 'pkgconfig')
                 pkgroot_name = os.path.join('{prefix}', 'develop', 'lib', 'pkgconfig')
             else:

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -447,7 +447,7 @@ class PythonModule(ExtensionModule):
             tmp_python = ExternalProgram.from_entry(display_name, name_or_path)
             python = PythonExternalProgram(display_name, ext_prog=tmp_python)
 
-            if not python.found() and mesonlib.is_windows():
+            if not python.found() and mesonlib.Platform.is_windows:
                 pythonpath = self._get_win_pythonpath(name_or_path)
                 if pythonpath is not None:
                     name_or_path = pythonpath

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -187,7 +187,7 @@ class PythonInstallation(_ExternalProgramHolder['PythonExternalProgram']):
 
             # On Windows, the limited API DLL is python3.dll, not python3X.dll.
             for_machine = kwargs['native']
-            if self.interpreter.environment.machines[for_machine].is_windows():
+            if self.interpreter.environment.machines[for_machine].is_windows:
                 pydep_copy = copy.copy(pydep)
                 pydep_copy.find_libpy_windows(self.env, limited_api=True)
                 if not pydep_copy.found():

--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -45,7 +45,7 @@ class ExternalProgram(mesonlib.HoldableObject):
         self.version_arg = '--version'
         if command is not None:
             self.command = mesonlib.listify(command)
-            if mesonlib.is_windows():
+            if mesonlib.Platform.is_windows:
                 cmd = self.command[0]
                 args = self.command[1:]
                 # Check whether the specified cmd is a path to a script, in
@@ -197,7 +197,7 @@ class ExternalProgram(mesonlib.HoldableObject):
                 # the single argument to pass to that command. So we must split
                 # exactly once.
                 commands = first_line[2:].split('#')[0].strip().split(maxsplit=1)
-                if mesonlib.is_windows():
+                if mesonlib.Platform.is_windows:
                     # Windows does not have UNIX paths so remove them,
                     # but don't remove Windows paths
                     if commands[0].startswith('/'):
@@ -207,7 +207,7 @@ class ExternalProgram(mesonlib.HoldableObject):
                     # Windows does not ship python3.exe, but we know the path to it
                     if len(commands) > 0 and commands[0] == 'python3':
                         commands = mesonlib.python_command + commands[1:]
-                elif mesonlib.is_haiku():
+                elif mesonlib.Platform.is_haiku:
                     # Haiku does not have /usr, but a lot of scripts assume that
                     # /usr/bin/env always exists. Detect that case and run the
                     # script with the interpreter after it.
@@ -231,7 +231,7 @@ class ExternalProgram(mesonlib.HoldableObject):
     def _is_executable(self, path: str) -> bool:
         suffix = os.path.splitext(path)[-1].lower()[1:]
         execmask = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
-        if mesonlib.is_windows():
+        if mesonlib.Platform.is_windows:
             if suffix in self.windows_exts:
                 return True
         elif os.stat(path).st_mode & execmask:
@@ -250,7 +250,7 @@ class ExternalProgram(mesonlib.HoldableObject):
             # b) we are on windows so they can't be directly executed.
             return self._shebang_to_cmd(trial)
         else:
-            if mesonlib.is_windows():
+            if mesonlib.Platform.is_windows:
                 for ext in self.windows_exts:
                     trial_ext = f'{trial}.{ext}'
                     if os.path.exists(trial_ext):
@@ -316,13 +316,13 @@ class ExternalProgram(mesonlib.HoldableObject):
             return [None]
         # Do a standard search in PATH
         path = os.environ.get('PATH', os.defpath)
-        if mesonlib.is_windows() and path:
+        if mesonlib.Platform.is_windows and path:
             path = self._windows_sanitize_path(path)
         if exclude_paths:
             paths = OrderedSet(path.split(os.pathsep)).difference(exclude_paths)
             path = os.pathsep.join(paths)
         command = shutil.which(name, path=path)
-        if mesonlib.is_windows():
+        if mesonlib.Platform.is_windows:
             return self._search_windows_special_cases(name, command, exclude_paths)
         # On UNIX-like platforms, shutil.which() is enough to find
         # all executables whether in PATH or with an absolute path

--- a/mesonbuild/scripts/coverage.py
+++ b/mesonbuild/scripts/coverage.py
@@ -98,7 +98,7 @@ def coverage(outputs: T.List[str], source_root: str, subproject_root: str, build
                 lcov_subpoject_exclude.append(os.path.join(subproject_root, '*'))
             if use_llvm_cov:
                 # Create a shim to allow using llvm-cov as a gcov tool.
-                if mesonlib.is_windows():
+                if mesonlib.Platform.is_windows:
                     llvm_cov_shim_path = os.path.join(log_dir, 'llvm-cov.bat')
                     with open(llvm_cov_shim_path, 'w', encoding='utf-8') as llvm_cov_bat:
                         llvm_cov_bat.write(f'@"{llvm_cov_exe}" gcov %*')

--- a/mesonbuild/scripts/gtkdochelper.py
+++ b/mesonbuild/scripts/gtkdochelper.py
@@ -7,7 +7,7 @@ import sys, os
 import subprocess
 import shutil
 import argparse
-from ..mesonlib import MesonException, Popen_safe, is_windows, is_cygwin, split_args
+from ..mesonlib import MesonException, Popen_safe, Platform, split_args
 from . import destdir_join
 import typing as T
 
@@ -47,7 +47,7 @@ def gtkdoc_run_check(cmd: T.List[str], cwd: str, library_paths: T.Optional[T.Lis
         library_paths = []
 
     env = dict(os.environ)
-    if is_windows() or is_cygwin():
+    if Platform.is_windows or Platform.is_cygwin:
         if 'PATH' in env:
             library_paths.extend(env['PATH'].split(os.pathsep))
         env['PATH'] = os.pathsep.join(library_paths)
@@ -56,7 +56,7 @@ def gtkdoc_run_check(cmd: T.List[str], cwd: str, library_paths: T.Optional[T.Lis
             library_paths.extend(env['LD_LIBRARY_PATH'].split(os.pathsep))
         env['LD_LIBRARY_PATH'] = os.pathsep.join(library_paths)
 
-    if is_windows():
+    if Platform.is_windows:
         cmd.insert(0, sys.executable)
 
     # Put stderr into stdout since we want to print it out anyway.

--- a/mesonbuild/scripts/symbolextractor.py
+++ b/mesonbuild/scripts/symbolextractor.py
@@ -270,31 +270,31 @@ def gen_symbols(libfilename: str, impfilename: str, outfilename: str, cross_host
         # determine the correct toolset, but we would need to use the correct
         # `nm`, `readelf`, etc, from the cross info which requires refactoring.
         dummy_syms(outfilename)
-    elif mesonlib.is_linux() or mesonlib.is_hurd():
+    elif mesonlib.Platform.is_linux or mesonlib.Platform.is_hurd:
         gnu_syms(libfilename, outfilename)
-    elif mesonlib.is_osx():
+    elif mesonlib.Platform.is_osx:
         osx_syms(libfilename, outfilename)
-    elif mesonlib.is_openbsd():
+    elif mesonlib.Platform.is_openbsd:
         openbsd_syms(libfilename, outfilename)
-    elif mesonlib.is_freebsd():
+    elif mesonlib.Platform.is_freebsd:
         freebsd_syms(libfilename, outfilename)
-    elif mesonlib.is_netbsd():
+    elif mesonlib.Platform.is_netbsd:
         freebsd_syms(libfilename, outfilename)
-    elif mesonlib.is_windows():
+    elif mesonlib.Platform.is_windows:
         if os.path.isfile(impfilename):
             windows_syms(impfilename, outfilename)
         else:
             # No import library. Not sure how the DLL is being used, so just
             # rebuild everything that links to it every time.
             dummy_syms(outfilename)
-    elif mesonlib.is_cygwin():
+    elif mesonlib.Platform.is_cygwin:
         if os.path.isfile(impfilename):
             cygwin_syms(impfilename, outfilename)
         else:
             # No import library. Not sure how the DLL is being used, so just
             # rebuild everything that links to it every time.
             dummy_syms(outfilename)
-    elif mesonlib.is_sunos():
+    elif mesonlib.Platform.is_sunos:
         solaris_syms(libfilename, outfilename)
     else:
         if not os.path.exists(TOOL_WARNING_FILE):

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -110,24 +110,6 @@ __all__ = [
     'get_wine_shortpath',
     'git',
     'has_path_sep',
-    'is_aix',
-    'is_android',
-    'is_ascii_string',
-    'is_cygwin',
-    'is_debianlike',
-    'is_dragonflybsd',
-    'is_freebsd',
-    'is_haiku',
-    'is_hurd',
-    'is_irix',
-    'is_linux',
-    'is_netbsd',
-    'is_openbsd',
-    'is_osx',
-    'is_qnx',
-    'is_sunos',
-    'is_windows',
-    'is_wsl',
     'iter_regexin_iter',
     'join_args',
     'lazy_property',
@@ -136,6 +118,7 @@ __all__ = [
     'partition',
     'path_is_in_root',
     'pickle_load',
+    'Platform',
     'Popen_safe',
     'Popen_safe_logged',
     'quiet_git',
@@ -260,7 +243,7 @@ def check_direntry_issues(direntry_array: T.Union[T.Iterable[T.Union[str, bytes]
     # There is no way to reset both the preferred encoding and the filesystem
     # encoding, so we can just warn about it.
     e = locale.getpreferredencoding()
-    if e.upper() != 'UTF-8' and not is_windows():
+    if e.upper() != 'UTF-8' and not Platform.is_windows:
         if isinstance(direntry_array, (str, bytes)):
             direntry_array = [direntry_array]
         for de in direntry_array:
@@ -629,68 +612,6 @@ class PerThreeMachineDefaultable(PerMachineDefaultable[T.Optional[_T]], PerThree
         return f'PerThreeMachineDefaultable({self.build!r}, {self.host!r}, {self.target!r})'
 
 
-def is_sunos() -> bool:
-    return platform.system().lower() == 'sunos'
-
-
-def is_osx() -> bool:
-    return platform.system().lower() == 'darwin'
-
-
-def is_linux() -> bool:
-    return platform.system().lower() == 'linux'
-
-
-def is_android() -> bool:
-    return platform.system().lower() == 'android'
-
-
-def is_haiku() -> bool:
-    return platform.system().lower() == 'haiku'
-
-
-def is_openbsd() -> bool:
-    return platform.system().lower() == 'openbsd'
-
-
-def is_windows() -> bool:
-    platname = platform.system().lower()
-    return platname == 'windows'
-
-def is_wsl() -> bool:
-    return is_linux() and 'microsoft' in platform.release().lower()
-
-def is_cygwin() -> bool:
-    return sys.platform == 'cygwin'
-
-
-def is_debianlike() -> bool:
-    return os.path.isfile('/etc/debian_version')
-
-
-def is_dragonflybsd() -> bool:
-    return platform.system().lower() == 'dragonfly'
-
-
-def is_netbsd() -> bool:
-    return platform.system().lower() == 'netbsd'
-
-
-def is_freebsd() -> bool:
-    return platform.system().lower() == 'freebsd'
-
-def is_irix() -> bool:
-    return platform.system().startswith('irix')
-
-def is_hurd() -> bool:
-    return platform.system().lower() == 'gnu'
-
-def is_qnx() -> bool:
-    return platform.system().lower() == 'qnx'
-
-def is_aix() -> bool:
-    return platform.system().lower() == 'aix'
-
 @lru_cache(maxsize=None)
 def darwin_get_object_archs(objpath: str) -> 'ImmutableListProtocol[str]':
     '''
@@ -1026,7 +947,7 @@ def search_version(text: str) -> str:
 
 
 def default_libdir() -> str:
-    if is_debianlike():
+    if Platform.is_debianlike:
         try:
             pc = subprocess.Popen(['dpkg-architecture', '-qDEB_HOST_MULTIARCH'],
                                   stdout=subprocess.PIPE,
@@ -1037,7 +958,7 @@ def default_libdir() -> str:
                 return 'lib/' + archpath
         except Exception:
             pass
-    if is_freebsd() or is_irix():
+    if Platform.is_freebsd or Platform.is_irix:
         return 'lib'
     if os.path.isdir('/usr/lib64') and not os.path.islink('/usr/lib64'):
         return 'lib64'
@@ -1045,58 +966,58 @@ def default_libdir() -> str:
 
 
 def default_libexecdir() -> str:
-    if is_haiku():
+    if Platform.is_haiku:
         return 'lib'
     # There is no way to auto-detect this, so it must be set at build time
     return 'libexec'
 
 
 def default_prefix() -> str:
-    if is_windows():
+    if Platform.is_windows:
         return 'c:/'
-    if is_haiku():
+    if Platform.is_haiku:
         return '/boot/system/non-packaged'
     return '/usr/local'
 
 
 def default_datadir() -> str:
-    if is_haiku():
+    if Platform.is_haiku:
         return 'data'
     return 'share'
 
 
 def default_includedir() -> str:
-    if is_haiku():
+    if Platform.is_haiku:
         return 'develop/headers'
     return 'include'
 
 
 def default_infodir() -> str:
-    if is_haiku():
+    if Platform.is_haiku:
         return 'documentation/info'
     return 'share/info'
 
 
 def default_localedir() -> str:
-    if is_haiku():
+    if Platform.is_haiku:
         return 'data/locale'
     return 'share/locale'
 
 
 def default_mandir() -> str:
-    if is_haiku():
+    if Platform.is_haiku:
         return 'documentation/man'
     return 'share/man'
 
 
 def default_sbindir() -> str:
-    if is_haiku():
+    if Platform.is_haiku:
         return 'bin'
     return 'sbin'
 
 
 def default_sysconfdir() -> str:
-    if is_haiku():
+    if Platform.is_haiku:
         return 'settings'
     return 'etc'
 
@@ -1126,85 +1047,13 @@ def determine_worker_count(varnames: T.Optional[T.List[str]] = None) -> int:
             num_workers = 1
     return num_workers
 
+
 def has_path_sep(name: str, sep: str = '/\\') -> bool:
     'Checks if any of the specified @sep path separators are in @name'
     for each in sep:
         if each in name:
             return True
     return False
-
-
-if is_windows():
-    # shlex.split is not suitable for splitting command line on Window (https://bugs.python.org/issue1724822);
-    # shlex.quote is similarly problematic. Below are "proper" implementations of these functions according to
-    # https://docs.microsoft.com/en-us/cpp/c-language/parsing-c-command-line-arguments and
-    # https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
-
-    _whitespace = ' \t\n\r'
-    _find_unsafe_char = re.compile(fr'[{_whitespace}"]').search
-
-    def quote_arg(arg: str) -> str:
-        if arg and not _find_unsafe_char(arg):
-            return arg
-
-        result = '"'
-        num_backslashes = 0
-        for c in arg:
-            if c == '\\':
-                num_backslashes += 1
-            else:
-                if c == '"':
-                    # Escape all backslashes and the following double quotation mark
-                    num_backslashes = num_backslashes * 2 + 1
-
-                result += num_backslashes * '\\' + c
-                num_backslashes = 0
-
-        # Escape all backslashes, but let the terminating double quotation
-        # mark we add below be interpreted as a metacharacter
-        result += (num_backslashes * 2) * '\\' + '"'
-        return result
-
-    def split_args(cmd: str) -> T.List[str]:
-        result: T.List[str] = []
-        arg = ''
-        num_backslashes = 0
-        num_quotes = 0
-        in_quotes = False
-        for c in cmd:
-            if c == '\\':
-                num_backslashes += 1
-            else:
-                if c == '"' and not num_backslashes % 2:
-                    # unescaped quote, eat it
-                    arg += (num_backslashes // 2) * '\\'
-                    num_quotes += 1
-                    in_quotes = not in_quotes
-                elif c in _whitespace and not in_quotes:
-                    if arg or num_quotes:
-                        # reached the end of the argument
-                        result.append(arg)
-                        arg = ''
-                        num_quotes = 0
-                else:
-                    if c == '"':
-                        # escaped quote
-                        num_backslashes = (num_backslashes - 1) // 2
-
-                    arg += num_backslashes * '\\' + c
-
-                num_backslashes = 0
-
-        if arg or num_quotes:
-            result.append(arg)
-
-        return result
-else:
-    def quote_arg(arg: str) -> str:
-        return shlex.quote(arg)
-
-    def split_args(cmd: str) -> T.List[str]:
-        return shlex.split(cmd)
 
 
 def join_args(args: T.Iterable[str]) -> str:
@@ -2399,3 +2248,151 @@ class lazy_property(T.Generic[_T]):
         value = self.__func(instance)
         setattr(instance, self.__func.__name__, value)
         return value
+
+
+class MetaPlatform(type):
+
+    @lazy_property
+    def is_sunos(cls) -> bool:
+        return platform.system().lower() == 'sunos'
+
+    @lazy_property
+    def is_osx(cls) -> bool:
+        return platform.system().lower() == 'darwin'
+
+    @lazy_property
+    def is_linux(cls) -> bool:
+        return platform.system().lower() == 'linux'
+
+    @lazy_property
+    def is_android(cls) -> bool:
+        return platform.system().lower() == 'android'
+
+    @lazy_property
+    def is_haiku(cls) -> bool:
+        return platform.system().lower() == 'haiku'
+
+    @lazy_property
+    def is_openbsd(cls) -> bool:
+        return platform.system().lower() == 'openbsd'
+
+    @lazy_property
+    def is_windows(cls) -> bool:
+        return platform.system().lower() == 'windows'
+
+    @lazy_property
+    def is_wsl(cls) -> bool:
+        return cls.is_linux and 'microsoft' in platform.release().lower()
+
+    @lazy_property
+    def is_cygwin(cls) -> bool:
+        return sys.platform == 'cygwin'
+
+    @lazy_property
+    def is_debianlike(cls) -> bool:
+        return os.path.isfile('/etc/debian_version')
+
+    @lazy_property
+    def is_dragonflybsd(cls) -> bool:
+        return platform.system().lower() == 'dragonfly'
+
+    @lazy_property
+    def is_netbsd(cls) -> bool:
+        return platform.system().lower() == 'netbsd'
+
+    @lazy_property
+    def is_freebsd(cls) -> bool:
+        return platform.system().lower() == 'freebsd'
+
+    @lazy_property
+    def is_irix(cls) -> bool:
+        return platform.system().startswith('irix')
+
+    @lazy_property
+    def is_hurd(cls) -> bool:
+        return platform.system().lower() == 'gnu'
+
+    @lazy_property
+    def is_qnx(cls) -> bool:
+        return platform.system().lower() == 'qnx'
+
+    @lazy_property
+    def is_aix(cls) -> bool:
+        return platform.system().lower() == 'aix'
+
+
+class Platform(metaclass=MetaPlatform):
+    ...
+
+
+if Platform.is_windows:
+    # shlex.split is not suitable for splitting command line on Window (https://bugs.python.org/issue1724822);
+    # shlex.quote is similarly problematic. Below are "proper" implementations of these functions according to
+    # https://docs.microsoft.com/en-us/cpp/c-language/parsing-c-command-line-arguments and
+    # https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
+
+    _whitespace = ' \t\n\r'
+    _find_unsafe_char = re.compile(fr'[{_whitespace}"]').search
+
+    def quote_arg(arg: str) -> str:
+        if arg and not _find_unsafe_char(arg):
+            return arg
+
+        result = '"'
+        num_backslashes = 0
+        for c in arg:
+            if c == '\\':
+                num_backslashes += 1
+            else:
+                if c == '"':
+                    # Escape all backslashes and the following double quotation mark
+                    num_backslashes = num_backslashes * 2 + 1
+
+                result += num_backslashes * '\\' + c
+                num_backslashes = 0
+
+        # Escape all backslashes, but let the terminating double quotation
+        # mark we add below be interpreted as a metacharacter
+        result += (num_backslashes * 2) * '\\' + '"'
+        return result
+
+    def split_args(cmd: str) -> T.List[str]:
+        result: T.List[str] = []
+        arg = ''
+        num_backslashes = 0
+        num_quotes = 0
+        in_quotes = False
+        for c in cmd:
+            if c == '\\':
+                num_backslashes += 1
+            else:
+                if c == '"' and not num_backslashes % 2:
+                    # unescaped quote, eat it
+                    arg += (num_backslashes // 2) * '\\'
+                    num_quotes += 1
+                    in_quotes = not in_quotes
+                elif c in _whitespace and not in_quotes:
+                    if arg or num_quotes:
+                        # reached the end of the argument
+                        result.append(arg)
+                        arg = ''
+                        num_quotes = 0
+                else:
+                    if c == '"':
+                        # escaped quote
+                        num_backslashes = (num_backslashes - 1) // 2
+
+                    arg += num_backslashes * '\\' + c
+
+                num_backslashes = 0
+
+        if arg or num_quotes:
+            result.append(arg)
+
+        return result
+else:
+    def quote_arg(arg: str) -> str:
+        return shlex.quote(arg)
+
+    def split_args(cmd: str) -> T.List[str]:
+        return shlex.split(cmd)

--- a/mesonbuild/utils/vsenv.py
+++ b/mesonbuild/utils/vsenv.py
@@ -10,7 +10,7 @@ import locale
 
 from .. import mlog
 from .core import MesonException
-from .universal import is_windows, windows_detect_native_arch
+from .universal import Platform, windows_detect_native_arch
 
 
 __all__ = [
@@ -30,7 +30,7 @@ SET
 # set it to be runnable. In this way Meson can be directly invoked
 # from any shell, VS Code etc.
 def _setup_vsenv(force: bool) -> bool:
-    if not is_windows():
+    if not Platform.is_windows:
         return False
     if os.environ.get('OSTYPE') == 'cygwin':
         return False

--- a/run_meson_command_tests.py
+++ b/run_meson_command_tests.py
@@ -10,7 +10,7 @@ import zipapp
 import sysconfig
 from pathlib import Path
 
-from mesonbuild.mesonlib import windows_proof_rmtree, python_command, is_windows
+from mesonbuild.mesonlib import windows_proof_rmtree, python_command, Platform
 from mesonbuild.coredata import version as meson_version
 
 scheme = None
@@ -111,7 +111,7 @@ class CommandTests(unittest.TestCase):
         stdo = self._run(meson_command + [self.testdir, builddir])
         self.assertMesonCommandIs(stdo.split('\n')[0], resolved_meson_command)
         # Symlink to meson.py
-        if is_windows():
+        if Platform.is_windows:
             # Symlinks require admin perms
             return
         os.chdir(str(self.src_root))
@@ -170,7 +170,7 @@ class CommandTests(unittest.TestCase):
         meson_command = python_command + meson_setup + self.meson_args
         stdo = self._run(meson_command + [self.testdir, builddir])
         self.assertMesonCommandIs(stdo.split('\n')[0], resolved_meson_command)
-        if is_windows():
+        if Platform.is_windows:
             # Next part requires a shell
             return
         # `meson` is a wrapper to `meson.real`
@@ -189,7 +189,7 @@ class CommandTests(unittest.TestCase):
         raise unittest.SkipTest('NOT IMPLEMENTED')
 
     def test_meson_zipapp(self):
-        if is_windows():
+        if Platform.is_windows:
             raise unittest.SkipTest('NOT IMPLEMENTED')
         source = Path(__file__).resolve().parent
         target = self.tmpdir / 'meson.pyz'

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -490,7 +490,7 @@ def _compare_output(expected: T.List[T.Dict[str, str]], output: str, desc: str) 
             #
             # (There should probably be a way to turn this off for more complex
             # cases which don't fit this)
-            if mesonlib.is_windows():
+            if mesonlib.Platform.is_windows:
                 if how != "re":
                     sub = r'\\'
                 else:
@@ -666,7 +666,7 @@ def _run_test(test: TestDef,
     # Configure in-process
     gen_args = ['setup']
     if 'prefix' not in test.do_not_set_opts:
-        gen_args += ['--prefix', 'x:/usr'] if mesonlib.is_windows() else ['--prefix', '/usr']
+        gen_args += ['--prefix', 'x:/usr'] if mesonlib.Platform.is_windows else ['--prefix', '/usr']
     if 'libdir' not in test.do_not_set_opts:
         gen_args += ['--libdir', 'lib']
     gen_args += [test.path.as_posix(), test_build_dir] + backend_flags + extra_args
@@ -1018,7 +1018,7 @@ def skip_dont_care(t: TestDef) -> bool:
     if not t.category.endswith('frameworks'):
         return True
 
-    if mesonlib.is_osx() and '6 gettext' in str(t.path):
+    if mesonlib.Platform.is_osx and '6 gettext' in str(t.path):
         return True
 
     return False
@@ -1067,13 +1067,13 @@ def should_skip_rust(backend: Backend) -> bool:
         return True
     if backend is not Backend.ninja:
         return True
-    if mesonlib.is_windows():
+    if mesonlib.Platform.is_windows:
         if has_broken_rustc():
             return True
     return False
 
 def should_skip_wayland() -> bool:
-    if mesonlib.is_windows() or mesonlib.is_osx():
+    if mesonlib.Platform.is_windows or mesonlib.Platform.is_osx:
         return True
     if not shutil.which('wayland-scanner'):
         return True
@@ -1120,9 +1120,9 @@ def detect_tests_to_run(only: T.Dict[str, T.List[str]], use_tmp: bool) -> T.List
         TestCategory('failing-build', 'failing build'),
         TestCategory('failing-test',  'failing test'),
         TestCategory('keyval', 'keyval'),
-        TestCategory('platform-osx', 'osx', not mesonlib.is_osx()),
-        TestCategory('platform-windows', 'windows', not mesonlib.is_windows() and not mesonlib.is_cygwin()),
-        TestCategory('platform-linux', 'linuxlike', mesonlib.is_osx() or mesonlib.is_windows()),
+        TestCategory('platform-osx', 'osx', not mesonlib.Platform.is_osx),
+        TestCategory('platform-windows', 'windows', not mesonlib.Platform.is_windows and not mesonlib.Platform.is_cygwin),
+        TestCategory('platform-linux', 'linuxlike', mesonlib.Platform.is_osx or mesonlib.Platform.is_windows),
         TestCategory('java', 'java', backend is not Backend.ninja or not have_java()),
         TestCategory('C#', 'csharp', skip_csharp(backend)),
         TestCategory('vala', 'vala', backend is not Backend.ninja or not shutil.which(os.environ.get('VALAC', 'valac'))),
@@ -1669,10 +1669,10 @@ if __name__ == '__main__':
     if options.native_file:
         options.extra_args += ['--native-file', options.native_file]
 
-    if not mesonlib.is_windows():
+    if not mesonlib.Platform.is_windows:
         scan_test_data_symlinks()
     clear_transitive_files()
-    if not mesonlib.is_windows():
+    if not mesonlib.Platform.is_windows:
         setup_symlinks()
     mesonlib.set_meson_command(get_meson_script())
 

--- a/run_single_test.py
+++ b/run_single_test.py
@@ -13,7 +13,7 @@ import pathlib
 import typing as T
 
 from mesonbuild import mlog
-from mesonbuild.mesonlib import is_windows
+from mesonbuild.mesonlib import Platform
 from run_tests import handle_meson_skip_test
 from run_project_tests import TestDef, load_test_json, run_test, BuildStep
 from run_project_tests import setup_commands, detect_system_compiler, detect_tools
@@ -46,7 +46,7 @@ def main() -> None:
     parser.add_argument('--quick', action='store_true', help='Skip some compiler and tool checking')
     args = T.cast('ArgumentType', parser.parse_args())
 
-    if not is_windows():
+    if not Platform.is_windows:
         scan_test_data_symlinks()
         setup_symlinks()
     setup_commands(args.backend)

--- a/run_tests.py
+++ b/run_tests.py
@@ -84,7 +84,7 @@ def guess_backend(backend_str: str, msbuild_exe: str) -> T.Tuple['Backend', T.Li
     # Auto-detect backend if unspecified
     backend_flags = []
     if backend_str is None:
-        if msbuild_exe is not None and (mesonlib.is_windows() and not _using_intelcl()):
+        if msbuild_exe is not None and (mesonlib.Platform.is_windows and not _using_intelcl()):
             backend_str = 'vs' # Meson will auto-detect VS version to use
         else:
             backend_str = 'ninja'
@@ -110,7 +110,7 @@ def _using_intelcl() -> bool:
     Sufficient evidence of intent is that user is working in the Intel compiler
     shell environment, otherwise this function returns False
     """
-    if not mesonlib.is_windows():
+    if not mesonlib.Platform.is_windows:
         return False
     # handle where user tried to "blank" MKLROOT and left space(s)
     if not os.environ.get('MKLROOT', '').strip():
@@ -178,7 +178,7 @@ if 'MESON_EXE' in os.environ:
 else:
     meson_exe = None
 
-if mesonlib.is_windows() or mesonlib.is_cygwin():
+if mesonlib.Platform.is_windows or mesonlib.Platform.is_cygwin:
     exe_suffix = '.exe'
 else:
     exe_suffix = ''
@@ -352,7 +352,7 @@ def main():
     _, backend_flags = guess_backend(options.backend, shutil.which('msbuild'))
     no_unittests = options.no_unittests
     # Running on a developer machine? Be nice!
-    if not mesonlib.is_windows() and not mesonlib.is_haiku() and 'CI' not in os.environ:
+    if not mesonlib.Platform.is_windows and not mesonlib.Platform.is_haiku and 'CI' not in os.environ:
         os.nice(20)
     # Appveyor sets the `platform` environment variable which completely messes
     # up building with the vs2010 and vs2015 backends.

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1753,7 +1753,7 @@ class AllPlatformTests(BasePlatformTests):
                 '/NOLOGO', '/DLL', '/DEBUG', '/IMPLIB:' + impfile,
                 '/OUT:' + outfile, objectfile]
         else:
-            if not (compiler.info.is_windows() or compiler.info.is_cygwin() or compiler.info.is_darwin()):
+            if not (compiler.info.is_windows or compiler.info.is_cygwin or compiler.info.is_darwin):
                 extra_args += ['-fPIC']
             link_cmd = compiler.get_exelist() + ['-shared', '-o', outfile, objectfile]
             if not Platform.is_osx:

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -25,7 +25,7 @@ import mesonbuild.environment
 import mesonbuild.coredata
 import mesonbuild.modules.gnome
 from mesonbuild.mesonlib import (
-    is_cygwin, join_args, split_args, windows_proof_rmtree, python_command
+    join_args, split_args, windows_proof_rmtree, python_command
 )
 import mesonbuild.modules.pkgconfig
 

--- a/unittests/darwintests.py
+++ b/unittests/darwintests.py
@@ -8,7 +8,7 @@ import platform
 import unittest
 
 from mesonbuild.mesonlib import (
-    MachineChoice, is_osx, version_compare
+    MachineChoice, Platform, version_compare
 )
 from mesonbuild.compilers import (
     detect_c_compiler
@@ -22,7 +22,7 @@ from run_tests import (
 from .baseplatformtests import BasePlatformTests
 from .helpers import *
 
-@unittest.skipUnless(is_osx(), "requires Darwin")
+@unittest.skipUnless(Platform.is_osx, "requires Darwin")
 class DarwinTests(BasePlatformTests):
     '''
     Tests that should run on macOS

--- a/unittests/failuretests.py
+++ b/unittests/failuretests.py
@@ -11,7 +11,7 @@ import typing as T
 from contextlib import contextmanager
 
 from mesonbuild.mesonlib import (
-    MachineChoice, is_windows, is_osx, windows_proof_rmtree, windows_proof_rm
+    MachineChoice, Platform, windows_proof_rmtree, windows_proof_rm
 )
 from mesonbuild.compilers import (
     detect_objc_compiler, detect_objcpp_compiler
@@ -157,14 +157,14 @@ class FailureTests(BasePlatformTests):
             self.assertMesonRaises(contents, match)
 
     def test_apple_frameworks_dependency(self):
-        if not is_osx():
+        if not Platform.is_osx:
             raise unittest.SkipTest('only run on macOS')
         self.assertMesonRaises("dependency('appleframeworks')",
                                "requires at least one module")
 
     def test_extraframework_dependency_method(self):
         code = "dependency('metal', method : 'extraframework')"
-        if not is_osx():
+        if not Platform.is_osx:
             self.assertMesonRaises(code, self.dnf)
         else:
             # metal framework is always available on macOS
@@ -382,7 +382,7 @@ class FailureTests(BasePlatformTests):
                                "meson.override_dependency('foo', declare_dependency())",
                                """Tried to override dependency 'foo' which has already been resolved or overridden""")
 
-    @unittest.skipIf(is_windows(), 'zlib is not available on Windows')
+    @unittest.skipIf(Platform.is_windows, 'zlib is not available on Windows')
     def test_override_resolved_dependency(self):
         self.assertMesonRaises("dependency('zlib')\n" +
                                "meson.override_dependency('zlib', declare_dependency())",

--- a/unittests/helpers.py
+++ b/unittests/helpers.py
@@ -16,7 +16,7 @@ from unittest import mock
 
 from mesonbuild.compilers import detect_c_compiler, compiler_from_language
 from mesonbuild.mesonlib import (
-    MachineChoice, is_osx, is_cygwin, EnvironmentException, MachineChoice,
+    MachineChoice, Platform, EnvironmentException, MachineChoice,
     OrderedSet
 )
 from mesonbuild.options import OptionKey
@@ -158,7 +158,7 @@ def chdir(path: str) -> T.Iterator[None]:
 
 
 def get_dynamic_section_entry(fname: str, entry: str) -> T.Optional[str]:
-    if is_cygwin() or is_osx():
+    if Platform.is_cygwin or Platform.is_osx:
         raise unittest.SkipTest('Test only applicable to ELF platforms')
 
     try:

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -596,12 +596,16 @@ class InternalTests(unittest.TestCase):
         else:
             self._test_all_naming(cc, env, patterns, 'linux')
             env.machines.host.system = 'openbsd'
+            env.machines.host.__post_init__()
             self._test_all_naming(cc, env, patterns, 'openbsd')
             env.machines.host.system = 'darwin'
+            env.machines.host.__post_init__()
             self._test_all_naming(cc, env, patterns, 'darwin')
             env.machines.host.system = 'cygwin'
+            env.machines.host.__post_init__()
             self._test_all_naming(cc, env, patterns, 'cygwin')
             env.machines.host.system = 'windows'
+            env.machines.host.__post_init__()
             self._test_all_naming(cc, env, patterns, 'windows-mingw')
 
     @skipIfNoPkgconfig

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -34,15 +34,14 @@ from mesonbuild.linkers import linkers
 from mesonbuild.interpreterbase import typed_pos_args, InvalidArguments, ObjectHolder
 from mesonbuild.interpreterbase import typed_pos_args, InvalidArguments, typed_kwargs, ContainerTypeInfo, KwargInfo
 from mesonbuild.mesonlib import (
-    LibType, MachineChoice, PerMachine, Version, is_windows, is_osx,
-    is_cygwin, is_openbsd, search_version, MesonException, python_command,
+    LibType, MachineChoice, Platform, Version,
+    search_version, MesonException, python_command,
 )
 from mesonbuild.options import OptionKey
 from mesonbuild.interpreter.type_checking import in_set_validator, NoneType
 from mesonbuild.dependencies.pkgconfig import PkgConfigDependency, PkgConfigInterface, PkgConfigCLI
 from mesonbuild.programs import ExternalProgram
 import mesonbuild.modules.pkgconfig
-from mesonbuild import utils
 
 
 from run_tests import (
@@ -583,16 +582,16 @@ class InternalTests(unittest.TestCase):
                                       'static': msvc_static}}
         env = get_fake_env()
         cc = detect_c_compiler(env, MachineChoice.HOST)
-        if is_osx():
+        if Platform.is_osx:
             self._test_all_naming(cc, env, patterns, 'darwin')
-        elif is_cygwin():
+        elif Platform.is_cygwin:
             self._test_all_naming(cc, env, patterns, 'cygwin')
-        elif is_windows():
+        elif Platform.is_windows:
             if cc.get_argument_syntax() == 'msvc':
                 self._test_all_naming(cc, env, patterns, 'windows-msvc')
             else:
                 self._test_all_naming(cc, env, patterns, 'windows-mingw')
-        elif is_openbsd():
+        elif Platform.is_openbsd:
             self._test_all_naming(cc, env, patterns, 'openbsd')
         else:
             self._test_all_naming(cc, env, patterns, 'linux')
@@ -613,7 +612,7 @@ class InternalTests(unittest.TestCase):
         https://github.com/mesonbuild/meson/issues/3951
         '''
         def create_static_lib(name):
-            if not is_osx():
+            if not Platform.is_osx:
                 name.open('w', encoding='utf-8').close()
                 return
             src = name.with_suffix('.c')
@@ -848,7 +847,7 @@ class InternalTests(unittest.TestCase):
     def test_split_args(self):
         split_args = mesonbuild.mesonlib.split_args
         join_args = mesonbuild.mesonlib.join_args
-        if is_windows():
+        if Platform.is_windows:
             test_data = [
                 # examples from https://docs.microsoft.com/en-us/cpp/c-language/parsing-c-command-line-arguments
                 (r'"a b c" d e', ['a b c', 'd', 'e'], True),
@@ -912,7 +911,7 @@ class InternalTests(unittest.TestCase):
     def test_quote_arg(self):
         split_args = mesonbuild.mesonlib.split_args
         quote_arg = mesonbuild.mesonlib.quote_arg
-        if is_windows():
+        if Platform.is_windows:
             test_data = [
                 ('', '""'),
                 ('arg1', 'arg1'),

--- a/unittests/linuxcrosstests.py
+++ b/unittests/linuxcrosstests.py
@@ -6,9 +6,7 @@ import shutil
 import unittest
 import platform
 
-from mesonbuild.mesonlib import (
-    is_windows, is_cygwin
-)
+from mesonbuild.mesonlib import Platform
 from mesonbuild.mesonlib import MesonException
 
 
@@ -25,7 +23,7 @@ class BaseLinuxCrossTests(BasePlatformTests):
 def should_run_cross_arm_tests():
     return shutil.which('arm-linux-gnueabihf-gcc') and not platform.machine().lower().startswith('arm')
 
-@unittest.skipUnless(not is_windows() and should_run_cross_arm_tests(), "requires ability to cross compile to ARM")
+@unittest.skipUnless(not Platform.is_windows and should_run_cross_arm_tests(), "requires ability to cross compile to ARM")
 class LinuxCrossArmTests(BaseLinuxCrossTests):
     '''
     Tests that cross-compilation to Linux/ARM works
@@ -116,9 +114,9 @@ class LinuxCrossArmTests(BaseLinuxCrossTests):
 
 
 def should_run_cross_mingw_tests():
-    return shutil.which('x86_64-w64-mingw32-gcc') and not (is_windows() or is_cygwin())
+    return shutil.which('x86_64-w64-mingw32-gcc') and not (Platform.is_windows or Platform.is_cygwin)
 
-@unittest.skipUnless(not is_windows() and should_run_cross_mingw_tests(), "requires ability to cross compile with MinGW")
+@unittest.skipUnless(not Platform.is_windows and should_run_cross_mingw_tests(), "requires ability to cross compile with MinGW")
 class LinuxCrossMingwTests(BaseLinuxCrossTests):
     '''
     Tests that cross-compilation to Windows/MinGW works

--- a/unittests/platformagnostictests.py
+++ b/unittests/platformagnostictests.py
@@ -16,13 +16,13 @@ from pathlib import Path
 
 from .baseplatformtests import BasePlatformTests
 from .helpers import is_ci
-from mesonbuild.mesonlib import EnvironmentVariables, ExecutableSerialisation, MesonException, is_linux, python_command, windows_proof_rmtree
+from mesonbuild.mesonlib import EnvironmentVariables, ExecutableSerialisation, MesonException, Platform, python_command, windows_proof_rmtree
 from mesonbuild.mformat import Formatter, match_path
 from mesonbuild.optinterpreter import OptionInterpreter, OptionException
 from mesonbuild.options import OptionStore
 from run_tests import Backend
 
-@skipIf(is_ci() and not is_linux(), "Run only on fast platforms")
+@skipIf(is_ci() and not Platform.is_linux, "Run only on fast platforms")
 class PlatformAgnosticTests(BasePlatformTests):
     '''
     Tests that does not need to run on all platforms during CI

--- a/unittests/pythontests.py
+++ b/unittests/pythontests.py
@@ -11,7 +11,7 @@ from .allplatformstests import git_init
 from .baseplatformtests import BasePlatformTests
 from .helpers import *
 
-from mesonbuild.mesonlib import MachineChoice, TemporaryDirectoryWinProof, is_windows
+from mesonbuild.mesonlib import MachineChoice, TemporaryDirectoryWinProof, Platform
 from mesonbuild.modules.python import PythonModule
 
 class PythonTests(BasePlatformTests):
@@ -88,7 +88,7 @@ python = pymod.find_installation('python3', required: true)
         self._test_bytecompile()
 
     def test_limited_api_linked_correct_lib(self):
-        if not is_windows():
+        if not Platform.is_windows:
             return self.skipTest('Test only run on Windows.')
 
         testdir = os.path.join(self.src_root, 'test cases', 'python', '9 extmodule limited api')

--- a/unittests/windowstests.py
+++ b/unittests/windowstests.py
@@ -16,7 +16,7 @@ import mesonbuild.environment
 import mesonbuild.coredata
 import mesonbuild.modules.gnome
 from mesonbuild.mesonlib import (
-    MachineChoice, is_windows, is_cygwin, python_command, version_compare,
+    MachineChoice, Platform, python_command, version_compare,
     EnvironmentException
 )
 from mesonbuild.options import OptionKey
@@ -35,7 +35,7 @@ from run_tests import (
 from .baseplatformtests import BasePlatformTests
 from .helpers import *
 
-@skipUnless(is_windows() or is_cygwin(), "requires Windows (or Windows via Cygwin)")
+@skipUnless(Platform.is_windows or Platform.is_cygwin, "requires Windows (or Windows via Cygwin)")
 class WindowsTests(BasePlatformTests):
     '''
     Tests that should run on Cygwin, MinGW, and MSVC
@@ -45,7 +45,7 @@ class WindowsTests(BasePlatformTests):
         super().setUp()
         self.platform_test_dir = os.path.join(self.src_root, 'test cases/windows')
 
-    @skipIf(is_cygwin(), 'Test only applicable to Windows')
+    @skipIf(Platform.is_cygwin, 'Test only applicable to Windows')
     @mock.patch.dict(os.environ)
     def test_find_program(self):
         '''
@@ -175,7 +175,7 @@ class WindowsTests(BasePlatformTests):
             return
         self.build()
 
-    @skipIf(is_cygwin(), 'Test only applicable to Windows')
+    @skipIf(Platform.is_cygwin, 'Test only applicable to Windows')
     def test_genvslite(self):
         # The test framework itself might be forcing a specific, non-ninja backend across a set of tests, which
         # includes this test. E.g. -
@@ -450,7 +450,7 @@ class WindowsTests(BasePlatformTests):
         self.init(testdir, extra_args=['-Dtest-failure=true'])
         self.assertRaises(subprocess.CalledProcessError, self.build)
 
-    @unittest.skipIf(is_cygwin(), "Needs visual studio")
+    @unittest.skipIf(Platform.is_cygwin, "Needs visual studio")
     def test_vsenv_option(self):
         if self.backend is not Backend.ninja:
             raise SkipTest('Only ninja backend is valid for test')


### PR DESCRIPTION
Use the `lazy_property` decorator to replace the `is_windows()` function with attribute lookup. Since those functions are used everywhere in many loops, this may lead to a small performance improvement.