### PR TITLE
haiku: fix devel lib install path

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1770,7 +1770,12 @@ class Backend:
                     d.targets.append(i)
 
                     for alias, to, tag in t.get_aliases():
-                        alias = os.path.join(first_outdir, alias)
+                        symlinkDir = first_outdir
+                        if tag == 'devel':
+                            symlinkDir = self.environment.get_import_lib_dir()
+                        alias = os.path.join(symlinkDir, alias)
+                        if first_outdir != symlinkDir:
+                            to = os.path.join(os.path.relpath(first_outdir, symlinkDir), to)
                         s = InstallSymlinkData(to, alias, first_outdir, t.subproject, tag, allow_missing=True)
                         d.symlinks.append(s)
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -913,6 +913,9 @@ class Environment:
 
     def get_import_lib_dir(self) -> str:
         "Install dir for the import library (library used for linking)"
+        m = self.machines.host
+        if m.is_haiku():
+            return 'develop/lib'
         return self.get_libdir()
 
     def get_shared_module_dir(self) -> str:
@@ -933,6 +936,9 @@ class Environment:
 
     def get_static_lib_dir(self) -> str:
         "Install dir for the static library"
+        m = self.machines.host
+        if m.is_haiku():
+            return 'develop/lib'
         return self.get_libdir()
 
     def get_prefix(self) -> str:

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -507,7 +507,10 @@ class PkgConfigModule(NewExtensionModule):
                     if optname == 'prefix':
                         ofile.write('prefix={}\n'.format(self._escape(prefix)))
                     else:
-                        dirpath = PurePath(_as_str(coredata.get_option(OptionKey(optname))))
+                        if optname == 'libdir':
+                            dirpath = PurePath(state.environment.get_import_lib_dir())
+                        else:
+                            dirpath = PurePath(_as_str(coredata.get_option(OptionKey(optname))))
                         ofile.write('{}={}\n'.format(optname, self._escape('${prefix}' / dirpath)))
             if uninstalled and not dataonly:
                 ofile.write('srcdir={}\n'.format(self._escape(srcdir)))


### PR DESCRIPTION
Haiku have separate install paths for libraries used by runtime loader and compiler. Runtime loader library search path is `$prefix/lib`. Compiler search path (for `ld -lXXX` argumets) is `$prefix/develop/lib`.