### PR TITLE
Type safety for the VisualStudio Backend(s)

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -377,7 +377,10 @@ class Backend:
             dirname = 'meson-out'
         return dirname
 
-    def get_target_dir_relative_to(self, t: build.Target, o: build.Target) -> str:
+    def get_target_dir_relative_to(self,
+                                   t: T.Union[build.Target, build.CustomTargetIndex],
+                                   o: T.Union[build.Target, build.CustomTargetIndex],
+                                   ) -> str:
         '''Get a target dir relative to another target's directory'''
         target_dir = os.path.join(self.environment.get_build_dir(), self.get_target_dir(t))
         othert_dir = os.path.join(self.environment.get_build_dir(), self.get_target_dir(o))

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -342,7 +342,7 @@ class Backend:
                 curdir = '.'
         return compiler.get_include_args(curdir, False)
 
-    def get_target_filename_for_linking(self, target: T.Union[build.Target, build.CustomTargetIndex]) -> T.Optional[str]:
+    def get_target_filename_for_linking(self, target: build.BuildTargetTypes) -> T.Optional[str]:
         # On some platforms (msvc for instance), the file that is used for
         # dynamic linking is not the same as the dynamic library itself. This
         # file is called an import library, and we want to link against that.
@@ -361,7 +361,7 @@ class Backend:
             return Path(self.get_target_dir(target), target.get_filename()).as_posix()
         elif isinstance(target, build.Executable):
             if target.import_filename:
-                return Path(self.get_target_dir(target), target.get_import_filename()).as_posix()
+                return Path(self.get_target_dir(target), target.import_filename).as_posix()
             else:
                 return None
         raise AssertionError(f'BUG: Tried to link to {target!r} which is not linkable')

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1107,7 +1107,7 @@ class Backend:
                 commands += compiler.get_include_args(priv_dir, False)
         return commands
 
-    def build_target_link_arguments(self, compiler: 'Compiler', deps: T.List[build.Target]) -> T.List[str]:
+    def build_target_link_arguments(self, compiler: Compiler, deps: T.Iterable[build.BuildTargetTypes]) -> T.List[str]:
         args: T.List[str] = []
         for d in deps:
             if not d.is_linkable_target():

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -466,7 +466,7 @@ class Backend:
         return result
 
     @staticmethod
-    def relpath(todir: str, fromdir: str) -> str:
+    def relpath(todir: T.Union[os.PathLike[str], str], fromdir: T.Union[os.PathLike[str], str]) -> str:
         return os.path.relpath(os.path.join('dummyprefixdir', todir),
                                os.path.join('dummyprefixdir', fromdir))
 

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1515,7 +1515,11 @@ class Backend:
             srcs += fname
         return srcs
 
-    def get_target_depend_files(self, target: T.Union[build.CustomTarget, build.BuildTarget], absolute_paths: bool = False) -> T.List[str]:
+    def get_target_depend_files(
+            self,
+            target: T.Union[build.GeneratedTypes, build.RunTarget, build.BuildTarget],
+            absolute_paths: bool = False
+            ) -> T.List[str]:
         deps: T.List[str] = []
         for i in target.depend_files:
             if isinstance(i, mesonlib.File):
@@ -1526,9 +1530,9 @@ class Backend:
                     deps.append(i.rel_to_builddir(self.build_to_src))
             else:
                 if absolute_paths:
-                    deps.append(os.path.join(self.environment.get_source_dir(), target.subdir, i))
+                    deps.append(os.path.join(self.environment.get_source_dir(), target.get_subdir(), i))
                 else:
-                    deps.append(os.path.join(self.build_to_src, target.subdir, i))
+                    deps.append(os.path.join(self.build_to_src, target.get_subdir(), i))
         return deps
 
     def get_custom_target_output_dir(self, target: T.Union[build.Target, build.CustomTargetIndex]) -> str:

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -423,7 +423,7 @@ class Backend:
         osrc = f'{target.name}-unity{number}.{suffix}'
         return mesonlib.File.from_built_file(self.get_target_private_dir(target), osrc)
 
-    def generate_unity_files(self, target: build.BuildTarget, unity_src: str) -> T.List[mesonlib.File]:
+    def generate_unity_files(self, target: build.BuildTarget, unity_src: T.Iterable[mesonlib.FileOrString]) -> T.List[mesonlib.File]:
         abs_files: T.List[str] = []
         result: T.List[mesonlib.File] = []
         compsrcs = classify_unity_sources(target.compilers.values(), unity_src)

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1445,8 +1445,8 @@ class Backend:
             newargs.append(arg)
         return newargs
 
-    def get_build_by_default_targets(self) -> 'T.OrderedDict[str, T.Union[build.BuildTarget, build.CustomTarget]]':
-        result: 'T.OrderedDict[str, T.Union[build.BuildTarget, build.CustomTarget]]' = OrderedDict()
+    def get_build_by_default_targets(self) -> T.Dict[str, T.Union[build.BuildTarget, build.CustomTarget]]:
+        result: T.Dict[str, T.Union[build.BuildTarget, build.CustomTarget]] = {}
         # Get all build and custom targets that must be built by default
         for name, b in self.build.get_targets().items():
             if b.build_by_default:

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -40,7 +40,7 @@ if T.TYPE_CHECKING:
     from ..environment import Environment
     from ..interpreter import Interpreter, Test
     from ..linkers.linkers import StaticLinker
-    from ..mesonlib import FileMode, FileOrString
+    from ..mesonlib import FileMode
 
     from typing_extensions import TypedDict, NotRequired
 
@@ -851,10 +851,9 @@ class Backend:
             self,
             target: build.BuildTargetTypes,
             compiler: Compiler,
-            source: 'FileOrString',
+            source: File,
             targetdir: T.Optional[str] = None
             ) -> str:
-        assert isinstance(source, mesonlib.File)
         if isinstance(target, build.CompileTarget):
             return target.sources_map[source]
         build_dir = self.environment.get_build_dir()
@@ -912,7 +911,7 @@ class Backend:
                 raw_sources.append(File.from_built_relative(path))
 
         # Filter out headers and all non-source files
-        sources: T.List['FileOrString'] = []
+        sources: T.List[File] = []
         for s in raw_sources:
             if self.environment.is_source(s):
                 sources.append(s)

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -530,7 +530,7 @@ class Backend:
     def get_executable_serialisation(
             self, cmd: T.Sequence[T.Union[programs.ExternalProgram, build.BuildTarget, build.CustomTarget, File, str]],
             workdir: T.Optional[str] = None,
-            extra_bdeps: T.Optional[T.List[build.BuildTarget]] = None,
+            extra_bdeps: T.Optional[T.Iterable[T.Union[build.BuildTarget, build.CustomTarget, build.CustomTargetIndex]]] = None,
             capture: T.Optional[str] = None,
             feed: T.Optional[str] = None,
             env: T.Optional[mesonlib.EnvironmentVariables] = None,
@@ -602,7 +602,7 @@ class Backend:
     def as_meson_exe_cmdline(self, exe: T.Union[str, mesonlib.File, build.BuildTarget, build.CustomTarget, programs.ExternalProgram],
                              cmd_args: T.Sequence[T.Union[str, mesonlib.File, build.BuildTarget, build.CustomTarget, programs.ExternalProgram]],
                              workdir: T.Optional[str] = None,
-                             extra_bdeps: T.Optional[T.List[build.BuildTarget]] = None,
+                             extra_bdeps: T.Optional[T.Iterable[T.Union[build.BuildTarget, build.CustomTarget, build.CustomTargetIndex]]] = None,
                              capture: T.Optional[str] = None,
                              feed: T.Optional[str] = None,
                              force_serialize: bool = False,
@@ -1206,7 +1206,7 @@ class Backend:
 
     def determine_windows_extra_paths(
             self, target: T.Union[build.BuildTarget, build.CustomTarget, build.CustomTargetIndex, programs.ExternalProgram, mesonlib.File, str],
-            extra_bdeps: T.Sequence[T.Union[build.BuildTarget, build.CustomTarget, build.CustomTargetIndex]]) -> T.List[str]:
+            extra_bdeps: T.Iterable[T.Union[build.BuildTarget, build.CustomTarget, build.CustomTargetIndex]]) -> T.List[str]:
         """On Windows there is no such thing as an rpath.
 
         We must determine all locations of DLLs that this exe

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -745,7 +745,7 @@ class Vs2010Backend(backends.Backend):
             # enough to emit the references to the other projects for them to
             # be built/run/..., if necessary.
             assert isinstance(target, build.AliasTarget)
-            assert len(depend_files) == 0
+            assert not depend_files
         else:
             assert not isinstance(target, build.AliasTarget)
 
@@ -1005,7 +1005,7 @@ class Vs2010Backend(backends.Backend):
                 return c
         # No source files, only objects, but we still need a compiler, so
         # return a found compiler
-        if len(target.objects) > 0:
+        if target.objects:
             for lang, c in self.environment.coredata.compilers[target.for_machine].items():
                 if lang in {'c', 'cpp'}:
                     return c
@@ -1407,7 +1407,7 @@ class Vs2010Backend(backends.Backend):
             else:  # 'sc' or 'default'
                 ET.SubElement(clconf, 'ExceptionHandling').text = 'Sync'
 
-        if len(target_args) > 0:
+        if target_args:
             target_args.append('%(AdditionalOptions)')
             ET.SubElement(clconf, "AdditionalOptions").text = ' '.join(target_args)
         ET.SubElement(clconf, 'AdditionalIncludeDirectories').text = ';'.join(target_inc_dirs)
@@ -1551,13 +1551,13 @@ class Vs2010Backend(backends.Backend):
         for lib in self.get_custom_target_provided_libraries(target):
             additional_links.append(self.relpath(lib, self.get_target_dir(target)))
 
-        if len(extra_link_args) > 0:
+        if extra_link_args:
             extra_link_args.append('%(AdditionalOptions)')
             ET.SubElement(link, "AdditionalOptions").text = ' '.join(extra_link_args)
-        if len(additional_libpaths) > 0:
+        if additional_libpaths:
             additional_libpaths.insert(0, '%(AdditionalLibraryDirectories)')
             ET.SubElement(link, 'AdditionalLibraryDirectories').text = ';'.join(additional_libpaths)
-        if len(additional_links) > 0:
+        if additional_links:
             additional_links.append('%(AdditionalDependencies)')
             ET.SubElement(link, 'AdditionalDependencies').text = ';'.join(additional_links)
         ofile = ET.SubElement(link, 'OutputFile')
@@ -1737,7 +1737,7 @@ class Vs2010Backend(backends.Backend):
                     pch_sources[lang] = (pch[0], None, lang, None)
 
         previous_includes: T.List[str] = []
-        if len(headers) + len(gen_hdrs) + len(target.extra_files) + len(pch_sources) > 0:
+        if headers or gen_hdrs or target.extra_files or pch_sources:
             if self.gen_lite and gen_hdrs:
                 # Although we're constructing our .vcxproj under our '..._vs' directory, we want to reference generated files
                 # in our concrete build directories (e.g. '..._debug'), where generated files will exist after building.
@@ -1761,7 +1761,7 @@ class Vs2010Backend(backends.Backend):
                     ET.SubElement(inc_hdrs, 'CLInclude', Include=path)
 
         previous_sources: T.List[str] = []
-        if len(sources) + len(gen_src) + len(pch_sources) > 0:
+        if sources or gen_src or pch_sources:
             if self.gen_lite:
                 # Get data to fill in intellisense fields for sources that can't reference the project-wide values
                 defs_paths_opts_per_lang_and_buildtype = get_non_primary_lang_intellisense_fields(
@@ -1833,7 +1833,7 @@ class Vs2010Backend(backends.Backend):
         explicit_link_gen_objs = [obj for obj in gen_objs if not obj.endswith(('.obj', '.res'))]
 
         previous_objects: T.List[str] = []
-        if len(objects) + len(additional_objects) + len(explicit_link_gen_objs) > 0:
+        if objects or additional_objects or explicit_link_gen_objs:
             inc_objs = ET.SubElement(root, 'ItemGroup')
             for s in objects:
                 relpath = os.path.join(proj_to_build_root, s.rel_to_builddir(self.build_to_src))

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -356,6 +356,7 @@ class Vs2010Backend(backends.Backend):
                     if isinstance(ldep, build.CustomTargetIndex):
                         all_deps[ldep.get_id()] = ldep.target
                     elif isinstance(ldep, File):
+                        # XXX: this this true? What if the file `is_built`?
                         # Already built, no target references needed
                         pass
                     else:

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -453,7 +453,7 @@ class Vs2010Backend(backends.Backend):
                 target = self.build.targets[prj[0]]
                 lang = 'default'
                 if hasattr(target, 'compilers') and target.compilers:
-                    for lang_out in target.compilers.keys():
+                    for lang_out in target.compilers:
                         lang = lang_out
                         break
                 prj_line = prj_templ % (
@@ -913,7 +913,7 @@ class Vs2010Backend(backends.Backend):
         # defs/dirs/opts that are set for the nominal 'primary' src type.
         ext = src.split('.')[-1]
         lang = compilers.compilers.SUFFIX_TO_LANG.get(ext, None)
-        if lang in defs_paths_opts_per_lang_and_buildtype.keys():
+        if lang in defs_paths_opts_per_lang_and_buildtype:
             # This is a non-primary src type for which can't simply reference the project's nmake fields;
             # we must laboriously fill in the fields for all buildtypes.
             for buildtype in coredata.get_genvs_default_buildtype_list():
@@ -1065,7 +1065,7 @@ class Vs2010Backend(backends.Backend):
                 file_args[l] += sargs
         # Compile args added from the env or cross file: CFLAGS/CXXFLAGS, etc. We want these
         # to override all the defaults, but not the per-target compile args.
-        for lang in file_args.keys():
+        for lang in file_args:
             _args = target.get_option(OptionKey(f'{lang}_args', machine=target.for_machine))
             assert isinstance(_args, list), 'for mypy'
             file_args[lang].extend(_args)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2014-2016 The Meson development team
+# Copyright © 2025 Intel Corporation
 
 from __future__ import annotations
 import copy
@@ -1839,7 +1840,7 @@ class Vs2010Backend(backends.Backend):
                 relpath = os.path.join(proj_to_build_root, s.rel_to_builddir(self.build_to_src))
                 if path_normalize_add(relpath, previous_objects):
                     ET.SubElement(inc_objs, 'Object', Include=relpath)
-            for f in additional_objects + explicit_link_gen_objs:
+            for f in itertools.chain(additional_objects, explicit_link_gen_objs):
                 if path_normalize_add(f, previous_objects):
                     ET.SubElement(inc_objs, 'Object', Include=f)
 

--- a/mesonbuild/backend/vs2017backend.py
+++ b/mesonbuild/backend/vs2017backend.py
@@ -12,6 +12,7 @@ from ..mesonlib import MesonException
 
 if T.TYPE_CHECKING:
     from ..build import Build
+    from ..arglist import CompilerArgs
     from ..interpreter import Interpreter
 
 
@@ -44,11 +45,11 @@ class Vs2017Backend(Vs2010Backend):
         if sdk_version:
             self.windows_target_platform_version = sdk_version.rstrip('\\')
 
-    def generate_debug_information(self, link):
+    def generate_debug_information(self, link: ET.Element) -> None:
         # valid values for vs2017 is 'false', 'true', 'DebugFastLink', 'DebugFull'
         ET.SubElement(link, 'GenerateDebugInformation').text = 'DebugFull'
 
-    def generate_lang_standard_info(self, file_args, clconf):
+    def generate_lang_standard_info(self, file_args: T.Dict[str, CompilerArgs], clconf: ET.Element) -> None:
         if 'cpp' in file_args:
             optargs = [x for x in file_args['cpp'] if x.startswith('/std:c++')]
             if optargs:

--- a/mesonbuild/backend/vs2019backend.py
+++ b/mesonbuild/backend/vs2019backend.py
@@ -10,6 +10,7 @@ import xml.etree.ElementTree as ET
 from .vs2010backend import Vs2010Backend
 
 if T.TYPE_CHECKING:
+    from ..arglist import CompilerArgs
     from ..build import Build
     from ..interpreter import Interpreter
 
@@ -39,11 +40,11 @@ class Vs2019Backend(Vs2010Backend):
         if sdk_version:
             self.windows_target_platform_version = sdk_version.rstrip('\\')
 
-    def generate_debug_information(self, link):
+    def generate_debug_information(self, link: ET.Element) -> None:
         # valid values for vs2019 is 'false', 'true', 'DebugFastLink', 'DebugFull'
         ET.SubElement(link, 'GenerateDebugInformation').text = 'DebugFull'
 
-    def generate_lang_standard_info(self, file_args, clconf):
+    def generate_lang_standard_info(self, file_args: T.Dict[str, CompilerArgs], clconf: ET.Element) -> None:
         if 'cpp' in file_args:
             optargs = [x for x in file_args['cpp'] if x.startswith('/std:c++')]
             if optargs:

--- a/mesonbuild/backend/vs2022backend.py
+++ b/mesonbuild/backend/vs2022backend.py
@@ -10,6 +10,7 @@ import xml.etree.ElementTree as ET
 from .vs2010backend import Vs2010Backend
 
 if T.TYPE_CHECKING:
+    from ..arglist import CompilerArgs
     from ..build import Build
     from ..interpreter import Interpreter
 
@@ -39,11 +40,11 @@ class Vs2022Backend(Vs2010Backend):
         if sdk_version:
             self.windows_target_platform_version = sdk_version.rstrip('\\')
 
-    def generate_debug_information(self, link):
+    def generate_debug_information(self, link: ET.Element) -> None:
         # valid values for vs2022 is 'false', 'true', 'DebugFastLink', 'DebugFull'
         ET.SubElement(link, 'GenerateDebugInformation').text = 'DebugFull'
 
-    def generate_lang_standard_info(self, file_args, clconf):
+    def generate_lang_standard_info(self, file_args: T.Dict[str, CompilerArgs], clconf: ET.Element) -> None:
         if 'cpp' in file_args:
             optargs = [x for x in file_args['cpp'] if x.startswith('/std:c++')]
             if optargs:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -49,6 +49,7 @@ if T.TYPE_CHECKING:
     from .mesonlib import ExecutableSerialisation, FileMode, FileOrString
     from .modules import ModuleState
     from .mparser import BaseNode
+    from .options import ElementaryOptionValues
 
     GeneratedTypes = T.Union['CustomTarget', 'CustomTargetIndex', 'GeneratedList']
     LibTypes = T.Union['SharedLibrary', 'StaticLibrary', 'CustomTarget', 'CustomTargetIndex']
@@ -679,10 +680,8 @@ class Target(HoldableObject, metaclass=abc.ABCMeta):
     def get_options(self) -> coredata.OptionsView:
         return self.options
 
-    def get_option(self, key: 'OptionKey') -> T.Union[str, int, bool]:
-        # TODO: if it's possible to annotate get_option or validate_option_value
-        # in the future we might be able to remove the cast here
-        return T.cast('T.Union[str, int, bool]', self.options.get_value(key))
+    def get_option(self, key: OptionKey) -> ElementaryOptionValues:
+        return self.options.get_value(key)
 
     @staticmethod
     def parse_overrides(kwargs: T.Dict[str, T.Any]) -> T.Dict[OptionKey, str]:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -3092,6 +3092,10 @@ class CustomTargetIndex(CustomTargetBase, HoldableObject):
     def get_option(self, key: OptionKey) -> ElementaryOptionValues:
         return self.target.get_option(key)
 
+    def get_basename(self) -> str:
+        return self.target.get_basename()
+
+
 class ConfigurationData(HoldableObject):
     def __init__(self, initial_values: T.Optional[T.Union[
                 T.Dict[str, T.Tuple[T.Union[str, int, bool], T.Optional[str]]],

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -749,7 +749,7 @@ class BuildTarget(Target):
         self.link_targets: T.List[LibTypes] = []
         self.link_whole_targets: T.List[T.Union[StaticLibrary, CustomTarget, CustomTargetIndex]] = []
         self.depend_files: T.List[File] = []
-        self.link_depends = []
+        self.link_depends: T.List[T.Union[File, CustomTarget, CustomTargetIndex, BuildTarget]] = []
         self.added_deps = set()
         self.name_prefix_set = False
         self.name_suffix_set = False
@@ -1034,7 +1034,7 @@ class BuildTarget(Target):
             langs = ', '.join(self.compilers.keys())
             raise InvalidArguments(f'Cannot mix those languages into a target: {langs}')
 
-    def process_link_depends(self, sources):
+    def process_link_depends(self, sources: T.Iterable[T.Union[str, File, CustomTarget, CustomTargetIndex, BuildTarget]]) -> None:
         """Process the link_depends keyword argument.
 
         This is designed to handle strings, Files, and the output of Custom

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -24,7 +24,7 @@ from .mesonlib import (
     File, MesonException, MachineChoice, PerMachine, OrderedSet, listify,
     extract_as_list, typeslistify, stringlistify, classify_unity_sources,
     get_filenames_templates_dict, substitute_values, has_path_sep,
-    PerMachineDefaultable,
+    PerMachineDefaultable, lazy_property,
     MesonBugException, EnvironmentVariables, pickle_load,
 )
 from .options import OptionKey
@@ -415,20 +415,26 @@ class ExtractedObjects(HoldableObject):
     '''
     Holds a list of sources for which the objects must be extracted
     '''
-    target: 'BuildTarget'
+    target: BuildTargetTypes
     srclist: T.List[File] = field(default_factory=list)
-    genlist: T.List['GeneratedTypes'] = field(default_factory=list)
-    objlist: T.List[T.Union[str, 'File', 'ExtractedObjects']] = field(default_factory=list)
+    genlist: T.List[GeneratedTypes] = field(default_factory=list)
+    objlist: T.List[T.Union[str, File, ExtractedObjects]] = field(default_factory=list)
     recursive: bool = True
     pch: bool = False
 
     def __post_init__(self) -> None:
-        if self.target.is_unity:
-            self.check_unity_compatible()
+        if isinstance(self.target, BuildTarget) and self.target.is_unity:
+            self.__check_unity_compatible()
 
     def __repr__(self) -> str:
         r = '<{0} {1!r}: {2}>'
         return r.format(self.__class__.__name__, self.target.name, self.srclist)
+
+    @lazy_property
+    def is_unity(self) -> bool:
+        if isinstance(self.target, BuildTarget):
+            return self.target.is_unity
+        return False
 
     @staticmethod
     def get_sources(sources: T.Sequence['FileOrString'], generated_sources: T.Sequence['GeneratedTypes']) -> T.List['FileOrString']:
@@ -446,9 +452,16 @@ class ExtractedObjects(HoldableObject):
 
     def classify_all_sources(self, sources: T.List[FileOrString], generated_sources: T.Sequence['GeneratedTypes']) -> T.Dict['Compiler', T.List['FileOrString']]:
         sources_ = self.get_sources(sources, generated_sources)
-        return classify_unity_sources(self.target.compilers.values(), sources_)
+        if isinstance(self.target, BuildTarget):
+            return classify_unity_sources(self.target.compilers.values(), sources_)
+        # This is currently unreachable, and difficult to implement
+        # CustomTarget classes don't have access to compilers, so we'd need oo
+        # have access to the Interpreter's list of compilers for this objects
+        # subproject.
+        raise MesonBugException('Attempted to call "classify_all_sources" on CustomTarget output. This is not currently supported.')
 
-    def check_unity_compatible(self) -> None:
+    def __check_unity_compatible(self) -> None:
+        assert isinstance(self.target, BuildTarget), 'This shouldnt have been called'
         # Figure out if the extracted object list is compatible with a Unity
         # build. When we're doing a Unified build, we go through the sources,
         # and create a single source file from each subset of the sources that
@@ -2614,6 +2627,9 @@ class CustomTargetBase:
     '''
 
     rust_crate_type = ''
+    name: str
+
+    def get_outputs(self) -> T.List[str]: ...
 
     def get_dependencies_recurse(self, result: OrderedSet[BuildTargetTypes], include_internals: bool = True) -> None:
         pass
@@ -2627,6 +2643,12 @@ class CustomTargetBase:
     def get(self, lib_type: T.Literal['static', 'shared'], recursive: bool = False) -> LibTypes:
         """Base case used by BothLibraries"""
         return self
+
+    def extract_all_objects(self, recursive: bool = True) -> ExtractedObjects:
+        self_as_child = T.cast('T.Union[CustomTarget, CustomTargetIndex]', self)
+        return ExtractedObjects(self_as_child, [], [self_as_child], [],
+                                recursive, pch=True)
+
 
 class CustomTarget(Target, CustomTargetBase, CommandBase):
 
@@ -2808,9 +2830,6 @@ class CustomTarget(Target, CustomTargetBase, CommandBase):
         if len(self.outputs) != 1:
             return False
         return CustomTargetIndex(self, self.outputs[0]).is_internal()
-
-    def extract_all_objects(self) -> T.List[T.Union[str, 'ExtractedObjects']]:
-        return self.get_outputs()
 
     def type_suffix(self):
         return "@cus"
@@ -3082,9 +3101,6 @@ class CustomTargetIndex(CustomTargetBase, HoldableObject):
         '''
         suf = os.path.splitext(self.output)[-1]
         return suf in {'.a', '.lib'} and not self.should_install()
-
-    def extract_all_objects(self) -> T.List[T.Union[str, 'ExtractedObjects']]:
-        return self.target.extract_all_objects()
 
     def get_custom_install_dir(self) -> T.List[T.Union[str, Literal[False]]]:
         return self.target.get_custom_install_dir()

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -3089,6 +3089,9 @@ class CustomTargetIndex(CustomTargetBase, HoldableObject):
     def get_custom_install_dir(self) -> T.List[T.Union[str, Literal[False]]]:
         return self.target.get_custom_install_dir()
 
+    def get_option(self, key: OptionKey) -> ElementaryOptionValues:
+        return self.target.get_option(key)
+
 class ConfigurationData(HoldableObject):
     def __init__(self, initial_values: T.Optional[T.Union[
                 T.Dict[str, T.Tuple[T.Union[str, int, bool], T.Optional[str]]],

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -3032,6 +3032,10 @@ class CustomTargetIndex(CustomTargetBase, HoldableObject):
     def name(self) -> str:
         return f'{self.target.name}[{self.output}]'
 
+    @property
+    def depend_files(self) -> T.List[File]:
+        return self.target.depend_files
+
     def __repr__(self):
         return '<CustomTargetIndex: {!r}[{}]>'.format(self.target, self.output)
 

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2013-2024 The Meson development team
-# Copyright © 2023-2024 Intel Corporation
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 
@@ -43,7 +43,7 @@ if T.TYPE_CHECKING:
     from .mesonlib import FileOrString
     from .cmake.traceparser import CMakeCacheEntry
     from .interpreterbase import SubProject
-    from .options import UserOption
+    from .options import UserOption, ElementaryOptionValues
 
     class SharedCMDOptions(Protocol):
 
@@ -442,7 +442,7 @@ class CoreData:
                 'Default project to execute in Visual Studio',
                 ''))
 
-    def get_option(self, key: OptionKey) -> T.Union[T.List[str], str, int, bool]:
+    def get_option(self, key: OptionKey) -> ElementaryOptionValues:
         try:
             v = self.optstore.get_value(key)
             return v
@@ -916,7 +916,7 @@ class OptionsView(abc.Mapping):
     # python 3.8 or typing_extensions
     original_options: T.Union[KeyedOptionDictType, 'dict[OptionKey, UserOption[Any]]']
     subproject: T.Optional[str] = None
-    overrides: T.Optional[T.Mapping[OptionKey, T.Union[str, int, bool, T.List[str]]]] = dataclasses.field(default_factory=dict)
+    overrides: T.Optional[T.Mapping[OptionKey, ElementaryOptionValues]] = dataclasses.field(default_factory=dict)
 
     def __getitem__(self, key: OptionKey) -> options.UserOption:
         # FIXME: This is fundamentally the same algorithm than interpreter.get_option_internal().
@@ -960,7 +960,7 @@ class OptionsView(abc.Mapping):
             key = OptionKey(key)
         return self[key].value
 
-    def set_value(self, key: T.Union[str, OptionKey], value: T.Union[str, int, bool, T.List[str]]):
+    def set_value(self, key: T.Union[str, OptionKey], value: ElementaryOptionValues):
         if isinstance(key, str):
             key = OptionKey(key)
         self.overrides[key] = value

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2012-2021 The Meson development team
-# Copyright © 2023-2024 Intel Corporation
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 
@@ -1668,7 +1668,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     # the host machine.
     def find_program_impl(self, args: T.List[mesonlib.FileOrString],
                           for_machine: MachineChoice = MachineChoice.HOST,
-                          default_options: T.Optional[T.Dict[OptionKey, T.Union[str, int, bool, T.List[str]]]] = None,
+                          default_options: T.Optional[T.Dict[OptionKey, options.ElementaryOptionValues]] = None,
                           required: bool = True, silent: bool = True,
                           wanted: T.Union[str, T.List[str]] = '',
                           search_dirs: T.Optional[T.List[str]] = None,
@@ -1699,7 +1699,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         return progobj
 
     def program_lookup(self, args: T.List[mesonlib.FileOrString], for_machine: MachineChoice,
-                       default_options: T.Optional[T.Dict[OptionKey, T.Union[str, int, bool, T.List[str]]]],
+                       default_options: T.Optional[T.Dict[OptionKey, options.ElementaryOptionValues]],
                        required: bool,
                        search_dirs: T.Optional[T.List[str]],
                        wanted: T.Union[str, T.List[str]],
@@ -1767,7 +1767,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         return True
 
     def find_program_fallback(self, fallback: str, args: T.List[mesonlib.FileOrString],
-                              default_options: T.Dict[OptionKey, T.Union[str, int, bool, T.List[str]]],
+                              default_options: T.Dict[OptionKey, options.ElementaryOptionValues],
                               required: bool, extra_info: T.List[mlog.TV_Loggable]
                               ) -> T.Optional[T.Union[ExternalProgram, build.Executable, OverrideProgram]]:
         mlog.log('Fallback to subproject', mlog.bold(fallback), 'which provides program',

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2190,6 +2190,10 @@ class Interpreter(InterpreterBase, HoldableObject):
                 raise InterpreterException(f'Tried to use non-existing executable {i.name!r}')
         if isinstance(all_args[0], str):
             all_args[0] = self.find_program_impl([all_args[0]])
+
+        if '@DEPFILE@' in all_args:
+            raise InterpreterException('run_target does not have support for @DEPFILE@')
+
         name = args[0]
         tg = build.RunTarget(name, all_args, kwargs['depends'], self.subdir, self.subproject, self.environment,
                              kwargs['env'])

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright © 2021 The Meson Developers
-# Copyright © 2021-2024 Intel Corporation
+# Copyright © 2021-2025 Intel Corporation
+# Copyright © 2021-2025 Intel Corporation
 from __future__ import annotations
 
 """Keyword Argument type annotations."""
@@ -209,7 +209,7 @@ class Project(TypedDict):
 
     version: T.Optional[FileOrString]
     meson_version: T.Optional[str]
-    default_options: T.Dict[OptionKey, T.Union[str, int, bool, T.List[str]]]
+    default_options: T.Dict[OptionKey, options.ElementaryOptionValues]
     license: T.List[str]
     license_files: T.List[str]
     subproject_dir: str
@@ -239,7 +239,7 @@ class Summary(TypedDict):
 
 class FindProgram(ExtractRequired, ExtractSearchDirs):
 
-    default_options: T.Dict[OptionKey, T.Union[str, int, bool, T.List[str]]]
+    default_options: T.Dict[OptionKey, options.ElementaryOptionValues]
     native: MachineChoice
     version: T.List[str]
 
@@ -312,13 +312,13 @@ class ConfigureFile(TypedDict):
 
 class Subproject(ExtractRequired):
 
-    default_options: T.Dict[OptionKey, T.Union[str, int, bool, T.List[str]]]
+    default_options: T.Dict[OptionKey, options.ElementaryOptionValues]
     version: T.List[str]
 
 
 class DoSubproject(ExtractRequired):
 
-    default_options: T.Dict[OptionKey, T.Union[str, int, bool, T.List[str]]]
+    default_options: T.Dict[OptionKey, options.ElementaryOptionValues]
     version: T.List[str]
     cmake_options: T.List[str]
     options: T.Optional[CMakeSubprojectOptions]
@@ -346,7 +346,7 @@ class _BaseBuildTarget(TypedDict):
     name_suffix: T.Optional[str]
     native: MachineChoice
     objects: T.List[build.ObjectTypes]
-    override_options: T.Dict[OptionKey, T.Union[str, int, bool, T.List[str]]]
+    override_options: T.Dict[OptionKey, options.ElementaryOptionValues]
     depend_files: NotRequired[T.List[File]]
     resources: T.List[str]
 

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright © 2021 Intel Corporation
+# Copyright © 2021-2025 Intel Corporation
 
 """Helpers for strict type checking."""
 
@@ -27,6 +27,7 @@ if T.TYPE_CHECKING:
 
     from ..build import ObjectTypes
     from ..interpreterbase import TYPE_var
+    from ..options import ElementaryOptionValues
     from ..mesonlib import EnvInitValueType
 
     _FullEnvInitValueType = T.Union[EnvironmentVariables, T.List[str], T.List[T.List[str]], EnvInitValueType, str, None]
@@ -292,11 +293,11 @@ COMMAND_KW: KwargInfo[T.List[T.Union[str, BuildTarget, CustomTarget, CustomTarge
     default=[],
 )
 
-def _override_options_convertor(raw: T.Union[str, T.List[str], T.Dict[str, T.Union[str, int, bool, T.List[str]]]]) -> T.Dict[OptionKey, T.Union[str, int, bool, T.List[str]]]:
+def _override_options_convertor(raw: T.Union[str, T.List[str], T.Dict[str, ElementaryOptionValues]]) -> T.Dict[OptionKey, ElementaryOptionValues]:
     if isinstance(raw, str):
         raw = [raw]
     if isinstance(raw, list):
-        output: T.Dict[OptionKey, T.Union[str, int, bool, T.List[str]]] = {}
+        output: T.Dict[OptionKey, ElementaryOptionValues] = {}
         for each in raw:
             k, v = split_equal_string(each)
             output[OptionKey.from_string(k)] = v
@@ -304,7 +305,7 @@ def _override_options_convertor(raw: T.Union[str, T.List[str], T.Dict[str, T.Uni
     return {OptionKey.from_string(k): v for k, v in raw.items()}
 
 
-OVERRIDE_OPTIONS_KW: KwargInfo[T.Union[str, T.Dict[str, T.Union[str, int, bool, T.List[str]]], T.List[str]]] = KwargInfo(
+OVERRIDE_OPTIONS_KW: KwargInfo[T.Union[str, T.Dict[str, ElementaryOptionValues], T.List[str]]] = KwargInfo(
     'override_options',
     (str, ContainerTypeInfo(list, str), ContainerTypeInfo(dict, (str, int, bool, list))),
     default={},

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -36,6 +36,7 @@ if T.TYPE_CHECKING:
         'UserBooleanOption', 'UserComboOption', 'UserFeatureOption',
         'UserIntegerOption', 'UserStdOption', 'UserStringArrayOption',
         'UserStringOption', 'UserUmaskOption']
+    ElementaryOptionValues: TypeAlias = T.Union[str, int, bool, T.List[str]]
 
     class ArgparseKWs(TypedDict, total=False):
 

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -50,6 +50,7 @@ if T.TYPE_CHECKING:
     # A generic type for pickle_load. This allows any type that has either a
     # .version or a .environment to be passed.
     _PL = T.TypeVar('_PL', bound=T.Union[_EnvPickleLoadable, _VerPickleLoadable])
+    FileTypes = T.TypeVar('FileTypes', 'File', str, T.Union['File', str])
 
 FileOrString = T.Union['File', str]
 
@@ -468,8 +469,8 @@ def get_compiler_for_source(compilers: T.Iterable['Compiler'], src: 'FileOrStrin
     raise MesonException(f'No specified compiler can handle file {src!s}')
 
 
-def classify_unity_sources(compilers: T.Iterable['Compiler'], sources: T.Sequence['FileOrString']) -> T.Dict['Compiler', T.List['FileOrString']]:
-    compsrclist: T.Dict['Compiler', T.List['FileOrString']] = {}
+def classify_unity_sources(compilers: T.Iterable[Compiler], sources: T.Iterable[FileTypes]) -> T.Dict[Compiler, T.List[FileTypes]]:
+    compsrclist: T.Dict['Compiler', T.List[FileTypes]] = {}
     for src in sources:
         comp = get_compiler_for_source(compilers, src)
         if comp not in compsrclist:

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -36,6 +36,7 @@ modules = [
     'mesonbuild/backend/vs2010backend.py',
     'mesonbuild/backend/vs2017backend.py',
     'mesonbuild/backend/vs2019backend.py',
+    'mesonbuild/backend/vs2022backend.py',
     # 'mesonbuild/coredata.py',
     'mesonbuild/depfile.py',
     'mesonbuild/envconfig.py',

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -35,6 +35,7 @@ modules = [
     'mesonbuild/backend/nonebackend.py',
     'mesonbuild/backend/vs2010backend.py',
     'mesonbuild/backend/vs2017backend.py',
+    'mesonbuild/backend/vs2019backend.py',
     # 'mesonbuild/coredata.py',
     'mesonbuild/depfile.py',
     'mesonbuild/envconfig.py',

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -33,6 +33,7 @@ modules = [
     'mesonbuild/arglist.py',
     'mesonbuild/backend/backends.py',
     'mesonbuild/backend/nonebackend.py',
+    'mesonbuild/backend/vs2010backend.py',
     # 'mesonbuild/coredata.py',
     'mesonbuild/depfile.py',
     'mesonbuild/envconfig.py',

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -34,6 +34,7 @@ modules = [
     'mesonbuild/backend/backends.py',
     'mesonbuild/backend/nonebackend.py',
     'mesonbuild/backend/vs2010backend.py',
+    'mesonbuild/backend/vs2017backend.py',
     # 'mesonbuild/coredata.py',
     'mesonbuild/depfile.py',
     'mesonbuild/envconfig.py',


### PR DESCRIPTION
~~This gets most of the VS backend type safe, with the exception of some of the object extraction stuff where there seems to be a real potential for things to explode.~~

This gets all of the VS Backends type safe. Thanks @bonzini for for help with the object stuff.

This turned up a lot of issues in the build module and in the base `backend` module.

It should be possible to merge pieces of this series incrementally.

It should be noted that this is untested on the vs2010 backend. I expect to find issues at runtime.