### PR TITLE
minstall: help mypy out with our chown overriding

### DIFF
--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -139,7 +139,6 @@ def append_to_log(lf: T.TextIO, line: str) -> None:
         lf.write('\n')
     lf.flush()
 
-
 def set_chown(path: str, user: T.Union[str, int, None] = None,
               group: T.Union[str, int, None] = None,
               dir_fd: T.Optional[int] = None, follow_symlinks: bool = True) -> None:
@@ -150,10 +149,23 @@ def set_chown(path: str, user: T.Union[str, int, None] = None,
     # Not nice, but better than actually rewriting shutil.chown until
     # this python bug is fixed: https://bugs.python.org/issue18108
 
+    # This is running into a problem where this may not match any of signatures
+    # of `shtil.chown`, which (simplified) are:
+    #  chown(path: int | AnyPath, user: int | str, group: None = None)
+    #  chown(path: int | AnyPath, user: None, group: int | str)
+    # We cannot through easy coercion of the type system force it to say:
+    #  - user is non null and group is null
+    #  - user is null and group is non null
+    #  - user is non null and group is non null
+    #
+    # This is checked by the only (current) caller, but let's be sure that the
+    # call we're making to `shutil.chown` is actually valid.
+    assert user is not None or group is not None, 'ensure that calls to chown are valid'
+
     if sys.version_info >= (3, 13):
         # pylint: disable=unexpected-keyword-arg
         # cannot handle sys.version_info, https://github.com/pylint-dev/pylint/issues/9622
-        shutil.chown(path, user, group, dir_fd=dir_fd, follow_symlinks=follow_symlinks)
+        shutil.chown(path, user, group, dir_fd=dir_fd, follow_symlinks=follow_symlinks)  # type: ignore[call-overload]
     else:
         real_os_chown = os.chown
 


### PR DESCRIPTION
This is an annoying issue to look at, because shutil.chown has (for our purposes) three signatures:
```python
chown(path: int | AnyPathLike, uid: int | str, group: None = None) -> None: ...
chown(path: int | AnyPathLike, uid: None, group: int | str) -> None: ...
chown(path: int | AnyPathLike, uid: int | str, group: int | str) -> None: ...
```

This is a really difficult thing to guarantee from our code. We more or less depend on being able to pass two parameters of `None | int | str`, and it working. In our only caller we do ensure that at least one of the variables is not None, but convincing mypy of this is more work than it's worth.

This issue only shows up in CI with python >= 3.13. It also shows up with pyright (used in VSCode) for earlier versions because of an updated typeshed.