### PR TITLE
rust: allow linking with dynamic libstd

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -303,6 +303,7 @@ or compiler being used:
 | cpp_thread_count | 4             | integer value ≥ 0                        | Number of threads to use with emcc when using threads |
 | cpp_winlibs      | see below     | free-form comma-separated list           | Standard Windows libs to link against |
 | fortran_std      | none          | [none, legacy, f95, f2003, f2008, f2018] | Fortran language standard to use |
+| rust_dynamic_std | false         | true, false                              | Whether to link dynamically to the Rust standard library *(Added in 1.9.0)* |
 | cuda_ccbindir    |               | filesystem path                          | CUDA non-default toolchain directory to use (-ccbin) *(Added in 0.57.1)* |
 
 The default values of `c_winlibs` and `cpp_winlibs` are in

--- a/docs/markdown/snippets/rust-dynamic-std.md
+++ b/docs/markdown/snippets/rust-dynamic-std.md
@@ -1,0 +1,7 @@
+## New experimental option `rust_dynamic_std`
+
+A new option `rust_dynamic_std` can be used to link Rust programs so
+that they use a dynamic library for the Rust `libstd`.
+
+Right now, `staticlib` crates cannot be produced if `rust_dynamic_std` is
+true, but this may change in the future.

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -241,6 +241,12 @@ class RustCompiler(Compiler):
             'none',
             choices=['none', '2015', '2018', '2021', '2024'])
 
+        key = self.form_compileropt_key('dynamic_std')
+        opts[key] = options.UserBooleanOption(
+            self.make_option_name(key),
+            'Whether to link Rust build targets to a dynamic libstd',
+            False)
+
         return opts
 
     def get_dependency_compile_args(self, dep: 'Dependency') -> T.List[str]:

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -200,15 +200,15 @@ class RustCompiler(Compiler):
     def build_rpath_args(self, env: 'Environment', build_dir: str, from_dir: str,
                          rpath_paths: T.Tuple[str, ...], build_rpath: str,
                          install_rpath: str) -> T.Tuple[T.List[str], T.Set[bytes]]:
-        args, to_remove = super().build_rpath_args(env, build_dir, from_dir, rpath_paths,
-                                                   build_rpath, install_rpath)
+        # add rustc's sysroot to account for rustup installations
+        args, to_remove = self.linker.build_rpath_args(env, build_dir, from_dir, rpath_paths,
+                                                       build_rpath, install_rpath,
+                                                       [self.get_target_libdir()])
 
-        # ... but then add rustc's sysroot to account for rustup
-        # installations
         rustc_rpath_args = []
         for arg in args:
             rustc_rpath_args.append('-C')
-            rustc_rpath_args.append(f'link-arg={arg}:{self.get_target_libdir()}')
+            rustc_rpath_args.append(f'link-arg={arg}')
         return rustc_rpath_args, to_remove
 
     def compute_parameters_with_absolute_paths(self, parameter_list: T.List[str],

--- a/test cases/rust/1 basic/meson.build
+++ b/test cases/rust/1 basic/meson.build
@@ -6,6 +6,12 @@ e = executable('rust-program', 'prog.rs',
 )
 test('rusttest', e)
 
+e = executable('rust-dynamic', 'prog.rs',
+  override_options: {'rust_dynamic_std': true},
+  install : true
+)
+test('rusttest-dynamic', e)
+
 subdir('subdir')
 
 # this should fail due to debug_assert

--- a/test cases/rust/1 basic/test.json
+++ b/test cases/rust/1 basic/test.json
@@ -3,6 +3,8 @@
     {"type": "exe", "file": "usr/bin/rust-program"},
     {"type": "pdb", "file": "usr/bin/rust-program"},
     {"type": "exe", "file": "usr/bin/rust-program2"},
-    {"type": "pdb", "file": "usr/bin/rust-program2"}
+    {"type": "pdb", "file": "usr/bin/rust-program2"},
+    {"type": "exe", "file": "usr/bin/rust-dynamic"},
+    {"type": "pdb", "file": "usr/bin/rust-dynamic"}
   ]
 }


### PR DESCRIPTION
As a first step towards fixing #8828, allow linking Rust bin crates with dynamic libstd.

staticlib crates cannot yet do this, but this can be extended later on; in the meanwhile, this PR creates the API with a minimal implementation.