### PR TITLE
Skip symlinks in _make_tree_writable()

### DIFF
--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -1902,7 +1902,7 @@ def _make_tree_writable(topdir: T.Union[str, Path]) -> None:
         os.chmod(d, os.stat(d).st_mode | stat.S_IWRITE | stat.S_IREAD)
         for fname in files:
             fpath = os.path.join(d, fname)
-            if os.path.isfile(fpath):
+            if not os.path.islink(fpath) and os.path.isfile(fpath):
                 os.chmod(fpath, os.stat(fpath).st_mode | stat.S_IWRITE | stat.S_IREAD)
 
 


### PR DESCRIPTION
Trying to chmod a symlink results in trying to chmod the file or directory it points to, not the symlink itself which has no permissions. Either a symlink points to within the tree we're making writable in which case it'll be handled eventually by os.walk() or it points outside of the tree we're making writable in which case we don't want to touch it. Let's avoid touching files outside of the tree by simply skipping symlinks in _make_tree_writable().