### PR TITLE
interpreter: set shared_library_only for default_library='shared'

### DIFF
--- a/docs/markdown/Pkgconfig-module.md
+++ b/docs/markdown/Pkgconfig-module.md
@@ -94,7 +94,7 @@ basis, it might not work in all use-cases.
 
 The exact rules followed to find dependencies that are implicitly
 added into the pkg-config file have evolved over time. Here are the
-rules as of Meson *0.49.0*, previous versions might have slightly
+rules as of Meson *1.8.0*, previous versions might have slightly
 different behaviour.
 
 - Not found libraries or dependencies are ignored.
@@ -105,12 +105,13 @@ different behaviour.
 - Libraries and dependencies will be de-duplicated, if they are added in both
   public and private (e.g `Requires:` and `Requires.private:`) it will be removed
   from the private list.
-- Shared libraries (i.e. `shared_library()` and **NOT** `library()`) add only
-  `-lfoo` into `Libs:` or `Libs.private:` but their dependencies are not pulled.
-  This is because dependencies are only needed for static link.
-- Other libraries (i.e. `static_library()` or `library()`) add `-lfoo` into `Libs:`
-  or `Libs.private:` and recursively add their dependencies into `Libs.private:` or
-  `Requires.private:`.
+- Shared libraries (i.e. `shared_library()`, or `library()` when `default_library`
+  is `shared`) add only `-lfoo` into `Libs:` or `Libs.private:`, but their
+  dependencies are not pulled. This is because dependencies are only needed
+  for static link.
+- Other libraries (i.e. `static_library()`, or `library()` unless `default_library`
+  is `shared`) add `-lfoo` into `Libs:` or `Libs.private:` and recursively add
+  their dependencies into `Libs.private:` or `Requires.private:`.
 - Dependencies provided by pkg-config are added into `Requires:` or
   `Requires.private:`. If a version was specified when declaring that dependency
   it will be written into the generated file too.

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3284,7 +3284,9 @@ class Interpreter(InterpreterBase, HoldableObject):
         default_library = self.coredata.optstore.get_value_for(OptionKey('default_library', subproject=self.subproject))
         assert isinstance(default_library, str), 'for mypy'
         if default_library == 'shared':
-            return self.build_target(node, args, T.cast('kwtypes.SharedLibrary', kwargs), build.SharedLibrary)
+            holder = self.build_target(node, args, T.cast('kwtypes.SharedLibrary', kwargs), build.SharedLibrary)
+            holder.shared_library_only = True
+            return holder
         elif default_library == 'static':
             return self.build_target(node, args, T.cast('kwtypes.StaticLibrary', kwargs), build.StaticLibrary)
         elif default_library == 'both':

--- a/test cases/unit/76 as link whole/meson.build
+++ b/test cases/unit/76 as link whole/meson.build
@@ -2,8 +2,8 @@ project('as-link-whole', 'c')
 
 foo = static_library('foo', 'foo.c', install: true)
 dep = declare_dependency(link_with: foo)
-bar1 = library('bar1', 'bar.c', dependencies: dep)
-bar2 = library('bar2', 'bar.c', dependencies: dep.as_link_whole())
+bar1 = static_library('bar1', 'bar.c', dependencies: dep)
+bar2 = static_library('bar2', 'bar.c', dependencies: dep.as_link_whole())
 
 # bar1.pc should have -lfoo but not bar2.pc
 pkg = import('pkgconfig')


### PR DESCRIPTION
Hello, this fixes #3970, so that pc files generated by library when `default_library=shared` doesn't include `Requires.private`.

Thanks.