### PR TITLE
modules/gnome, modules/Python: Allow injecting RPATH flags through LDFLAGS if needed

### DIFF
--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -333,6 +333,7 @@ class PythonPkgConfigDependency(PkgConfigDependency, _PythonDependencyBase):
             # Add rpath, will be de-duplicated if necessary
             if framework_prefix.startswith('/Applications/Xcode.app/'):
                 self.link_args += ['-Wl,-rpath,' + framework_prefix]
+                self.raw_link_args += ['-Wl,-rpath,' + framework_prefix]
 
 class PythonFrameworkDependency(ExtraFrameworkDependency, _PythonDependencyBase):
 

--- a/test cases/frameworks/7 gnome/gir/meson-python-sample.c
+++ b/test cases/frameworks/7 gnome/gir/meson-python-sample.c
@@ -1,0 +1,51 @@
+#include "meson-python-sample.h"
+
+#include <Python.h>
+
+struct _MesonPythonSample
+{
+  GObject parent_instance;
+};
+
+G_DEFINE_TYPE (MesonPythonSample, meson_python_sample, G_TYPE_OBJECT)
+
+/**
+ * meson_python_sample_new:
+ *
+ * Allocates a new #MesonPythonSample.
+ *
+ * Returns: (transfer full): a #MesonPythonSample.
+ */
+MesonPythonSample *
+meson_python_sample_new (void)
+{
+  return g_object_new (MESON_TYPE_PYTHON_SAMPLE, NULL);
+}
+
+static void
+meson_python_sample_class_init (MesonPythonSampleClass *klass)
+{
+  if (!Py_IsInitialized ()) {
+    Py_Initialize ();
+    Py_Finalize ();
+  }
+}
+
+static void
+meson_python_sample_init (MesonPythonSample *self)
+{
+}
+
+/**
+ * meson_python_sample_print_message:
+ * @self: a #MesonSample2.
+ *
+ * Prints Hello.
+ *
+ * Returns: Nothing.
+ */
+void
+meson_python_sample_print_message (MesonPythonSample *self)
+{
+  g_print ("Message: Hello\n");
+}

--- a/test cases/frameworks/7 gnome/gir/meson-python-sample.def
+++ b/test cases/frameworks/7 gnome/gir/meson-python-sample.def
@@ -1,0 +1,4 @@
+EXPORTS
+    meson_python_sample_new
+    meson_python_sample_print_message
+    meson_python_sample_get_type

--- a/test cases/frameworks/7 gnome/gir/meson-python-sample.h
+++ b/test cases/frameworks/7 gnome/gir/meson-python-sample.h
@@ -1,0 +1,17 @@
+#ifndef MESON_PYTHON_SAMPLE_H
+#define MESON_PYTHON_SAMPLE_H
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define MESON_TYPE_PYTHON_SAMPLE (meson_python_sample_get_type())
+
+G_DECLARE_FINAL_TYPE (MesonPythonSample, meson_python_sample, MESON, SAMPLE, GObject)
+
+MesonPythonSample *meson_python_sample_new           (void);
+void               meson_python_sample_print_message (MesonPythonSample *self);
+
+G_END_DECLS
+
+#endif /* MESON_PYTHON_SAMPLE_H */

--- a/test cases/frameworks/7 gnome/gir/meson.build
+++ b/test cases/frameworks/7 gnome/gir/meson.build
@@ -2,6 +2,7 @@ subdir('dep1')
 
 libsources = ['meson-sample.c', 'meson-sample.h']
 lib2sources = ['meson-sample2.c', 'meson-sample2.h']
+pythonsources = ['meson-python-sample.c', 'meson-python-sample.h']
 
 gen_source = custom_target(
   'meson_sample3.h',
@@ -26,6 +27,23 @@ girlib2 = shared_library(
   install : true
 )
 
+if get_option('b_sanitize') == 'none'
+  py3_dep = py3.dependency(embed: true)
+else
+  warning('Python 3 test not supported with b_sanitize')
+  py3_dep = disabler()
+endif
+
+if py3_dep.found()
+  pythongirlib = shared_library(
+    'python_gir_lib',
+    sources: pythonsources,
+    dependencies: [gobj, py3_dep],
+    vs_module_defs: 'meson-python-sample.def',
+    install: true
+  )
+endif
+
 girexe = executable(
   'girprog',
   sources : 'prog.c',
@@ -36,17 +54,30 @@ girexe = executable(
 
 fake_dep = dependency('no-way-this-exists', required: false)
 
+# g-ir-scanner ignores CFLAGS for MSVC
+flags_dep_for_msvc = declare_dependency(
+  compile_args: ['-DMESON_TEST_2']
+)
+
+girs = [girlib, girlib2]
+girs_sources = [libsources, lib2sources, gen_source]
+# dep1_dep pulls in dep2_dep for us
+girs_deps = [fake_dep, dep1_dep, flags_dep_for_msvc]
+if py3_dep.found()
+  girs += [pythongirlib]
+  girs_sources += [pythonsources]
+  girs_deps += [py3_dep]
+endif
+
 gnome.generate_gir(
-  girlib, girlib2,
-  sources : [libsources, lib2sources, gen_source],
-  env : {'CPPFLAGS': '-DMESON_TEST_2'},
+  girs,
+  sources : girs_sources,
   nsversion : '1.0',
   namespace : 'Meson',
   symbol_prefix : 'meson',
   identifier_prefix : 'Meson',
   includes : ['GObject-2.0', 'MesonDep1-1.0'],
-  # dep1_dep pulls in dep2_dep for us
-  dependencies : [[fake_dep, dep1_dep]],
+  dependencies : girs_deps,
   doc_format: 'gtk-doc-markdown',
   install : true,
   build_by_default : true,

--- a/test cases/frameworks/7 gnome/meson.build
+++ b/test cases/frameworks/7 gnome/meson.build
@@ -1,4 +1,4 @@
-project('gobject-introspection', 'c')
+project('gobject-introspection', 'c', meson_version: '>= 1.2.0')
 
 copyfile = find_program('copyfile.py')
 copyfile_gen = generator(copyfile,
@@ -15,8 +15,8 @@ if not gir.found()
   error('MESON_SKIP_TEST gobject-introspection not found.')
 endif
 
-python3 = import('python3')
-py3 = python3.find_python()
+python3 = import('python')
+py3 = python3.find_installation()
 if run_command(py3, '-c', 'import gi;', check: false).returncode() != 0
     error('MESON_SKIP_TEST python3-gi not found')
 endif
@@ -30,7 +30,6 @@ if cc.get_id() == 'intel'
   add_global_arguments('-wd2282', language : 'c')
 endif
 
-py3 = import('python3').find_python()
 pycode = '''import os, sys
 if "MESON_UNIT_TEST_PRETEND_GLIB_OLD" in os.environ:
   sys.exit(0)

--- a/test cases/frameworks/7 gnome/resources-data/meson.build
+++ b/test cases/frameworks/7 gnome/resources-data/meson.build
@@ -1,7 +1,5 @@
 subdir('subdir')
 
-python3 = import('python3').find_python()
-
 fake_generator_script = '''
 import os, sys
 assert os.path.exists(sys.argv[1]), "File %s not found" % sys.argv[1]
@@ -13,6 +11,6 @@ print("This is a generated resource.")
 res3_txt = custom_target('res3',
   input: 'res3.txt.in',
   output: 'res3.txt',
-  command: [python3, '-c', fake_generator_script, '@INPUT@'],
+  command: [py3, '-c', fake_generator_script, '@INPUT@'],
   capture: true,
 )

--- a/test cases/frameworks/7 gnome/test.json
+++ b/test cases/frameworks/7 gnome/test.json
@@ -12,6 +12,7 @@
     {"type": "file", "file": "usr/include/subdir-3/marshaller-3.h"},
     {"type": "file", "file": "usr/include/subdir-4/marshaller-4.h"},
     {"type": "file", "file": "usr/include/subdir-5/marshaller-5.h"},
+    {"type": "expr", "file": "usr/lib/?libpython_gir_lib.so"},
     {"type": "expr", "file": "usr/lib/?libgir_lib.so"},
     {"type": "file", "platform": "cygwin", "file": "usr/lib/libgir_lib.dll.a"},
     {"type": "expr", "file": "usr/lib/?libgir_lib2.so"},


### PR DESCRIPTION
Fixes communicating the RPATH to g-i-scanner in macOS.

See #14169

cc @nirbheek 