### PR TITLE
Basic support for generating C++ header from Swift code

### DIFF
--- a/docs/markdown/snippets/swift_cxx_interoperability.md
+++ b/docs/markdown/snippets/swift_cxx_interoperability.md
@@ -1,0 +1,13 @@
+## Swift/C++ interoperability is now supported
+
+It is now possible to create Swift executables that can link to C++ or
+Objective-C++ libraries. Only specifying a bridging header for the Swift
+target is required.
+
+Swift 5.9 is required to use this feature. Xcode 15 is required if the
+Xcode backend is used.
+
+```meson
+lib = static_library('mylib', 'mylib.cpp')
+exe = executable('prog', 'main.swift', 'mylib.h', link_with: lib)
+```

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2220,6 +2220,10 @@ class NinjaBackend(backends.Backend):
         compile_args = self.generate_basic_compiler_args(target, swiftc)
         compile_args += swiftc.get_compile_only_args()
         compile_args += swiftc.get_module_args(module_name)
+        if mesonlib.version_compare(swiftc.version, '>=5.9'):
+            compile_args += swiftc.get_cxx_interoperability_args(target.compilers)
+        compile_args += self.build.get_project_args(swiftc, target.subproject, target.for_machine)
+        compile_args += self.build.get_global_args(swiftc, target.for_machine)
         for i in reversed(target.get_include_dirs()):
             basedir = i.get_curdir()
             for d in i.get_incdirs():

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -1596,6 +1596,7 @@ class XCodeBackend(backends.Backend):
             headerdirs = []
             bridging_header = ""
             is_swift = self.is_swift_target(target)
+            langs = set()
             for d in target.include_dirs:
                 for sd in d.incdirs:
                     cd = os.path.join(d.curdir, sd)
@@ -1714,6 +1715,7 @@ class XCodeBackend(backends.Backend):
                         lang = 'c'
                     elif lang == 'objcpp':
                         lang = 'cpp'
+                    langs.add(lang)
                     langname = LANGNAMEMAP[lang]
                     langargs.setdefault(langname, [])
                     langargs[langname] = cargs + cti_args + args
@@ -1775,6 +1777,8 @@ class XCodeBackend(backends.Backend):
             settings_dict.add_item('SECTORDER_FLAGS', '')
             if is_swift and bridging_header:
                 settings_dict.add_item('SWIFT_OBJC_BRIDGING_HEADER', bridging_header)
+                if self.objversion >= 60 and 'cpp' in langs:
+                    settings_dict.add_item('SWIFT_OBJC_INTEROP_MODE', 'objcxx')
             settings_dict.add_item('BUILD_DIR', symroot)
             settings_dict.add_item('OBJROOT', f'{symroot}/build')
             sysheader_arr = PbxArray()

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1156,6 +1156,9 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
     def get_compile_only_args(self) -> T.List[str]:
         return []
 
+    def get_cxx_interoperability_args(self, lang: T.Dict[str, Compiler]) -> T.List[str]:
+        raise EnvironmentException('This compiler does not support CXX interoperability')
+
     def get_preprocess_only_args(self) -> T.List[str]:
         raise EnvironmentException('This compiler does not have a preprocessor')
 

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -121,6 +121,12 @@ class SwiftCompiler(Compiler):
 
         return ['-working-directory', path]
 
+    def get_cxx_interoperability_args(self, lang: T.Dict[str, Compiler]) -> T.List[str]:
+        if 'cpp' in lang or 'objcpp' in lang:
+            return ['-cxx-interoperability-mode=default']
+        else:
+            return ['-cxx-interoperability-mode=off']
+
     def compute_parameters_with_absolute_paths(self, parameter_list: T.List[str],
                                                build_dir: str) -> T.List[str]:
         for idx, i in enumerate(parameter_list):

--- a/mesonbuild/modules/swift.py
+++ b/mesonbuild/modules/swift.py
@@ -35,8 +35,15 @@ class SwiftModule(NewExtensionModule):
             self.swiftc = None
 
         self.methods.update({
+            'get_library_path': self.get_library_path,
             'generate_cpp_header': self.generate_cpp_header,
         })
+
+    @typed_pos_args('swift.get_library_path')
+    @typed_kwargs('swift.get_library_path')
+    def get_library_path(self, state: ModuleState, args, kwargs) -> ModuleReturnValue:
+        paths = [*self.swiftc.dynamic_library_path, *self.swiftc.static_library_path]
+        return ModuleReturnValue(paths, [])
 
     @typed_pos_args('swift.generate_cpp_header', build.BuildTarget)
     @typed_kwargs('swift.generate_cpp_header')

--- a/mesonbuild/modules/swift.py
+++ b/mesonbuild/modules/swift.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Meson development team
+
+from __future__ import annotations
+
+import typing as T
+
+from . import NewExtensionModule, ModuleInfo
+
+if T.TYPE_CHECKING:
+    from mesonbuild.interpreter import Interpreter
+
+
+def initialize(*args: T.Any, **kwargs: T.Any) -> SwiftModule:
+    return SwiftModule(*args, **kwargs)
+
+
+class SwiftModule(NewExtensionModule):
+    INFO = ModuleInfo('swift', '1.7.99')
+
+    def __init__(self, interpreter: Interpreter):
+        super().__init__()
+        self.methods.update({
+        })

--- a/mesonbuild/modules/swift.py
+++ b/mesonbuild/modules/swift.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 
 import typing as T
 
-from . import NewExtensionModule, ModuleInfo
+from . import NewExtensionModule, ModuleInfo, ModuleReturnValue
+from mesonbuild import build
+from mesonbuild.compilers.swift import SwiftCompiler
+from mesonbuild.interpreterbase.decorators import typed_kwargs, typed_pos_args
 
 if T.TYPE_CHECKING:
+    from . import ModuleState
     from mesonbuild.interpreter import Interpreter
 
 
@@ -20,5 +24,36 @@ class SwiftModule(NewExtensionModule):
 
     def __init__(self, interpreter: Interpreter):
         super().__init__()
+        self.interpreter = interpreter
+        self.swiftc: T.Optional[SwiftCompiler]
+
+        try:
+            swiftc = interpreter.compilers.host['swift']
+            assert isinstance(swiftc, SwiftCompiler), 'swiftc is not an instance of SwiftCompiler'
+            self.swiftc = swiftc
+        except KeyError:
+            self.swiftc = None
+
         self.methods.update({
+            'generate_cpp_header': self.generate_cpp_header,
         })
+
+    @typed_pos_args('swift.generate_cpp_header', build.BuildTarget)
+    @typed_kwargs('swift.generate_cpp_header')
+    def generate_cpp_header(self, state: ModuleState, args: T.Tuple[build.BuildTarget], kwargs) -> ModuleReturnValue:
+        (module,) = args
+
+        header_name = f'{module.name}-Swift.h'
+        command = [
+            *self.swiftc.get_exelist(),
+            '@INPUT@',
+            *self.swiftc.get_module_args(module.name),
+            *self.swiftc.get_cxx_interoperability_args(self.interpreter.compilers.host),
+            '-emit-clang-header-path', '@OUTPUT@',
+        ]
+
+        tgt = build.CustomTarget(header_name, state.subdir, state.subproject, state.environment, command,
+                                 module.get_sources() + module.get_generated_sources(), [header_name],
+                                 backend=state.backend)
+
+        return ModuleReturnValue(tgt, [tgt])

--- a/test cases/swift/10 mixed cpp/main.swift
+++ b/test cases/swift/10 mixed cpp/main.swift
@@ -1,0 +1,6 @@
+testCallFromSwift()
+testCallWithParam("Calling C++ function from Swift with param is working")
+
+var test = Test()
+var testtwo = Test(1)
+test.testCallFromClass()

--- a/test cases/swift/10 mixed cpp/meson.build
+++ b/test cases/swift/10 mixed cpp/meson.build
@@ -1,0 +1,12 @@
+project('mixed cpp', 'cpp', 'swift')
+
+swiftc = meson.get_compiler('swift')
+
+# Testing C++ and Swift interoperability requires Swift 5.9
+if not swiftc.version().version_compare('>= 5.9')
+  error('MESON_SKIP_TEST Test requires Swift 5.9')
+endif
+
+lib = static_library('mylib', 'mylib.cpp')
+exe = executable('prog', 'main.swift', 'mylib.h', link_with: lib)
+test('cpp interface', exe)

--- a/test cases/swift/10 mixed cpp/mylib.cpp
+++ b/test cases/swift/10 mixed cpp/mylib.cpp
@@ -1,0 +1,22 @@
+#include "mylib.h"
+#include <iostream>
+
+Test::Test() {
+    std::cout << "Test initialized" << std::endl;
+}
+    
+Test::Test(int param) {
+    std::cout << "Test initialized with param " << param << std::endl;
+}
+
+void Test::testCallFromClass() {
+    std::cout << "Calling C++ class function from Swift is working" << std::endl;
+}
+
+void testCallFromSwift() {
+    std::cout << "Calling this C++ function from Swift is working" << std::endl;
+}
+
+void testCallWithParam(const std::string &param) {
+    std::cout << param << std::endl;
+}

--- a/test cases/swift/10 mixed cpp/mylib.h
+++ b/test cases/swift/10 mixed cpp/mylib.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <string>
+
+class Test {
+public:
+    Test();
+    Test(int param);
+
+    void testCallFromClass();
+};
+
+void testCallFromSwift();
+void testCallWithParam(const std::string &param);

--- a/test cases/swift/11 mixed objcpp/main.swift
+++ b/test cases/swift/11 mixed objcpp/main.swift
@@ -1,0 +1,2 @@
+var test: ObjCPPTest = ObjCPPTest()
+test.testCallToObjCPP()

--- a/test cases/swift/11 mixed objcpp/meson.build
+++ b/test cases/swift/11 mixed objcpp/meson.build
@@ -1,0 +1,12 @@
+project('mixed objcpp', 'objcpp', 'swift')
+
+swiftc = meson.get_compiler('swift')
+
+# Testing Objective-C++ and Swift interoperability requires Swift 5.9
+if not swiftc.version().version_compare('>= 5.9')
+  error('MESON_SKIP_TEST Test requires Swift 5.9')
+endif
+
+lib = static_library('mylib', 'mylib.mm')
+exe = executable('prog', 'main.swift', 'mylib.h', link_with: lib)
+test('objcpp interface', exe)

--- a/test cases/swift/11 mixed objcpp/mylib.h
+++ b/test cases/swift/11 mixed objcpp/mylib.h
@@ -1,0 +1,17 @@
+#pragma once
+#import <Foundation/Foundation.h>
+
+class Test {
+public:
+    Test();
+
+    void testCallFromClass();
+};
+
+@interface ObjCPPTest: NSObject {
+    @private Test *test;
+}
+- (id)init;
+- (void)dealloc;
+- (void)testCallToObjCPP;
+@end

--- a/test cases/swift/11 mixed objcpp/mylib.mm
+++ b/test cases/swift/11 mixed objcpp/mylib.mm
@@ -1,0 +1,29 @@
+#include "mylib.h"
+#include <iostream>
+
+Test::Test() {
+    std::cout << "Test initialized" << std::endl;
+}
+
+void Test::testCallFromClass() {
+    std::cout << "Calling Objective-C++ class function from Swift is working" << std::endl;
+}
+
+@implementation ObjCPPTest
+- (id)init {
+    self = [super init];
+    if (self) {
+        test = new Test();
+    }
+    return self;
+}
+
+- (void)dealloc {
+    delete test;
+    [super dealloc];
+}
+
+- (void)testCallToObjCPP {
+    test->testCallFromClass();
+}
+@end


### PR DESCRIPTION
(Requires/follow-up to #13317. [Actual diff of this PR without #13317](https://github.com/2xsaiko/meson/compare/swift-base...2xsaiko:meson:push-oyppxqklmzzt).)

Adds a new function to generate Swift to C++ bridging header in order to allow calling Swift code from C++.

Also adds a function to get the Swift library search paths, since linking a static Swift library into a C++ program does not automatically link against the Swift standard library.  [CMake doesn't seem to have this problem](https://gitlab.kitware.com/cmake/cmake/-/blob/master/Tests/SwiftMixLib/CMakeLists.txt?ref_type=heads#L15) but I don't know why. Maybe they use swiftc to link the final binary in this case instead of the C++ linker? I don't like this at all, would love suggestions for how to make this better.

Caveat: using this requires manually setting CXX to the Swift-bundled clang++ (on non-macOS), since it requires special support in the compiler which the normal clang doesn't come with. What would need to happen for this not to be necessary is Meson would have to detect that when a Swift-generated header is used in a C++ target it should automatically use the Swift-bundled clang++. Not sure if this is possible/desirable.

To do:

- [ ] Version checks (C++ bridging is available in 5.9 and above)
- [ ] Test cases
- [ ] Documentation

Ref: 
- https://github.com/apple/swift-cmake-examples/blob/e673cd1e4060089daaa2b3e2677fe82232bcb970/3_bidirectional_cxx_interop/cmake/modules/InitializeSwift.cmake
- https://www.swift.org/documentation/cxx-interop/project-build-setup/#generating-c-header-with-exposed-swift-apis

```meson
cxx = meson.get_compiler('cpp')

swift = import('swift')

swiftcore_dep = [
    cxx.find_library('swiftCore', dirs: swift.get_library_path()),
    cxx.find_library('swiftSwiftOnoneSupport', dirs: swift.get_library_path()),
]

swiftlib = static_library('swiftlib', 'swiftlib.swift', swift_args: ['-parse-as-library'])
swiftlib_h = swift.generate_cpp_header(swiftlib)
cpp_exe = executable('cpp_exe', 'main.cpp', swiftlib_h, link_with: [swiftlib], dependencies: [swiftcore_dep])
```

```cpp
// main.cpp

#include "swiftlib-Swift.h"

int main()
{
    swiftlib::callMe();
}
```

```swift
// swiftlib.swift

public func callMe() {
  print("Hello from Swift!")
}
```