### PR TITLE
modules/pkgconfig: use host machine to calculate install prefix

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -701,10 +701,11 @@ class PkgConfigModule(NewExtensionModule):
         pcfile = filebase + '.pc'
         pkgroot = pkgroot_name = kwargs['install_dir'] or default_install_dir
         if pkgroot is None:
-            if mesonlib.is_freebsd():
+            m = state.environment.machines.host
+            if m.is_freebsd():
                 pkgroot = os.path.join(_as_str(state.environment.coredata.get_option(OptionKey('prefix'))), 'libdata', 'pkgconfig')
                 pkgroot_name = os.path.join('{prefix}', 'libdata', 'pkgconfig')
-            elif mesonlib.is_haiku():
+            elif m.is_haiku():
                 pkgroot = os.path.join(_as_str(state.environment.coredata.get_option(OptionKey('prefix'))), 'develop', 'lib', 'pkgconfig')
                 pkgroot_name = os.path.join('{prefix}', 'develop', 'lib', 'pkgconfig')
             else:


### PR DESCRIPTION
The `mesonlib.is_*` functions are not correct to use here, since they are for the build machine, not the host machine. This means if the build machine if Linux but the host is Haiku, then pkg-config files willb e installed into $libdir/pkgconfig, instead of $prefix/develop/lib/pkgconfig