### PR TITLE
Add cache to OptionKey

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -594,7 +594,7 @@ class CoreData:
                 # refactor they will get per-subproject values.
                 really_unknown = []
                 for uo in unknown_options:
-                    topkey = uo.evolve(subproject='')
+                    topkey = uo.as_root()
                     if topkey not in self.optstore:
                         really_unknown.append(uo)
                 unknown_options = really_unknown
@@ -696,7 +696,7 @@ class CoreData:
             # adding languages and setting backend.
             if self.optstore.is_compiler_option(k) or self.optstore.is_backend_option(k):
                 continue
-            if self.optstore.is_base_option(k) and k.as_root() in base_options:
+            if self.optstore.is_base_option(k) and (k in base_options or k.as_root() in base_options):
                 # set_options will report unknown base options
                 continue
             options[k] = v

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 from collections import OrderedDict
 from itertools import chain
-from functools import total_ordering
 import argparse
 import dataclasses
 import itertools
@@ -106,7 +105,6 @@ _BAD_VALUE = 'Qwert Zuiopü'
 _optionkey_cache: T.Dict[T.Tuple[str, str, MachineChoice], OptionKey] = {}
 
 
-@total_ordering
 class OptionKey:
 
     """Represents an option key in the various option dictionaries.
@@ -183,6 +181,11 @@ class OptionKey:
             return self._to_tuple() == other._to_tuple()
         return NotImplemented
 
+    def __ne__(self, other: object) -> bool:
+        if isinstance(other, OptionKey):
+            return self._to_tuple() != other._to_tuple()
+        return NotImplemented
+
     def __lt__(self, other: object) -> bool:
         if isinstance(other, OptionKey):
             if self.subproject is None:
@@ -190,6 +193,33 @@ class OptionKey:
             elif other.subproject is None:
                 return False
             return self._to_tuple() < other._to_tuple()
+        return NotImplemented
+
+    def __le__(self, other: object) -> bool:
+        if isinstance(other, OptionKey):
+            if self.subproject is None and other.subproject is not None:
+                return True
+            elif self.subproject is not None and other.subproject is None:
+                return False
+            return self._to_tuple() <= other._to_tuple()
+        return NotImplemented
+
+    def __gt__(self, other: object) -> bool:
+        if isinstance(other, OptionKey):
+            if other.subproject is None:
+                return self.subproject is not None
+            elif self.subproject is None:
+                return False
+            return self._to_tuple() > other._to_tuple()
+        return NotImplemented
+
+    def __ge__(self, other: object) -> bool:
+        if isinstance(other, OptionKey):
+            if self.subproject is None and other.subproject is not None:
+                return False
+            elif self.subproject is not None and other.subproject is None:
+                return True
+            return self._to_tuple() >= other._to_tuple()
         return NotImplemented
 
     def __str__(self) -> str:


### PR DESCRIPTION
OptionKey objects are used extensively. We want them with a simple API, but they also need to be optimized to not compromise meson performances.

Since this is an immutable object, it is possible to cache the OptionKey object creation. We need to do it using the __new__ to make the caching mechanism transparent.

Fixes #14245