### PR TITLE
c: add -Wno-vla-larger-than to the exceptions for -Wno*

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -1285,10 +1285,16 @@ class CLikeCompiler(Compiler):
             # some compilers, e.g. GCC, don't warn for unsupported warning-disable
             # flags, so when we are testing a flag like "-Wno-forgotten-towel", also
             # check the equivalent enable flag too "-Wforgotten-towel".
-            # Make an exception for -Wno-attributes=x as -Wattributes=x is invalid
-            # for GCC at least.
-            if arg.startswith('-Wno-') and not arg.startswith('-Wno-attributes='):
-                new_args.append('-W' + arg[5:])
+            if arg.startswith('-Wno-'):
+                # Make an exception for -Wno-attributes=x as -Wattributes=x is invalid
+                # for GCC at least.  Also, the opposite of -Wno-vla-larger-than is
+                # -Wvla-larger-than=N
+                if arg.startswith('-Wno-attributes='):
+                    pass
+                elif arg == '-Wno-vla-larger-than':
+                    new_args.append('-Wvla-larger-than=1000')
+                else:
+                    new_args.append('-W' + arg[5:])
             if arg.startswith('-Wl,'):
                 mlog.warning(f'{arg} looks like a linker argument, '
                              'but has_argument and other similar methods only '

--- a/test cases/common/104 has arg/meson.build
+++ b/test cases/common/104 has arg/meson.build
@@ -56,6 +56,9 @@ if cpp.get_id() == 'gcc' and cpp.version().version_compare('>=12.1.0')
   # Handle special -Wno-attributes=foo where -Wattributes=foo is invalid
   # i.e. our usual -Wno-foo -Wfoo hack doesn't work for -Wattributes=foo.
   assert(cpp.has_argument('-Wno-attributes=meson::i_do_not_exist'))
+  # Likewise, the positive counterpart to -Wno-vla-larger-than is
+  # -Wvla-larger-than=N
+  assert(cpp.has_argument('-Wno-vla-larger-than'))
 endif
 
 if cc.get_id() == 'clang' and cc.version().version_compare('<=4.0.0')


### PR DESCRIPTION
When supplying -Wno-vla-larger-than to compiler.get_supported_arguments, meson will inject -Wvla-larger-than as an argument which considered invalid by GCC, as the converse argument is -Wvla-larger-than=<value>.

Just like CLikeCompiler._has_multi_arguments special-cases -Wno-attributes=, do the same for -Wno-vla-larger-than.

Resolves: https://github.com/mesonbuild/meson/issues/14208