### PR TITLE
Mixed Swift/C++ targets support

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -67,7 +67,8 @@ if T.TYPE_CHECKING:
 # Languages that can mix with C or C++ but don't support unity builds yet
 # because the syntax we use for unity builds is specific to C/++/ObjC/++.
 # Assembly files cannot be unitified and neither can LLVM IR files
-LANGS_CANT_UNITY: T.FrozenSet[Language] = frozenset({'d', 'fortran', 'vala', 'rust'})
+
+LANGS_CANT_UNITY: T.FrozenSet[Language] = frozenset({'d', 'fortran', 'vala', 'rust', 'swift'})
 
 @dataclass(eq=False)
 class RegenInfo:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1096,8 +1096,16 @@ class NinjaBackend(backends.Backend):
                     swift_sources[path] = file
             for path in swift_sources:
                 del target_sources[path]
-            objs = self.generate_swift_compile(target, swift_sources, swift_generated_sources, target_sources, generated_source_files)
+            objs, swift_generated_header = self.generate_swift_compile(target, swift_sources, swift_generated_sources, target_sources, generated_source_files)
             obj_list.extend(objs)
+
+            if swift_generated_header and any(lang in target.compilers for lang in ['c', 'objc', 'cpp', 'objcpp']):
+                header_deps.append(swift_generated_header)
+
+        # For linking with a Swift target in a C-family target, include the Swift target's generated header.
+        if any(lang in target.compilers for lang in ['c', 'objc', 'cpp', 'objcpp']):
+            for header in self.determine_swift_dep_headers(target):
+                header_deps.append(header)
 
         # These are the generated source files that need to be built for use by
         # this target. We create the Ninja build file elements for this here
@@ -2367,6 +2375,10 @@ class NinjaBackend(backends.Backend):
         return os.path.join(self.get_target_private_dir(target),
                             target.swift_module_name + '.swiftmodule')
 
+    def swift_generated_header_file_name(self, target: build.BuildTarget) -> str:
+        return os.path.join(self.get_target_private_dir(target),
+                            target.swift_module_name + '-Swift.h')
+
     def determine_swift_dep_modules(self, target: build.BuildTarget) -> T.List[str]:
         result = []
         for l in target.link_targets:
@@ -2375,9 +2387,16 @@ class NinjaBackend(backends.Backend):
                 result.append(self.swift_module_file_name(l))
         return result
 
+    def determine_swift_dep_headers(self, target: build.BuildTarget):
+        result = []
+        for l in target.link_targets:
+            if self.is_swift_target(l):
+                result.append(self.swift_generated_header_file_name(l))
+        return result
+
     def generate_swift_compile(self, target: build.BuildTarget,
                                swift_sources: T.OrderedMapping[str, File], swift_generated_sources: T.List[File],
-                               sources: T.OrderedMapping[str, File], generated_sources: T.List[File]) -> T.List[str]:
+                               sources: T.OrderedMapping[str, File], generated_sources: T.List[File]) -> T.Tuple[T.List[str], T.Optional[File]]:
         if not swift_sources and not swift_generated_sources:
             return [], None
 
@@ -2457,6 +2476,7 @@ class NinjaBackend(backends.Backend):
 
         compile_rule = self.compiler_to_rule_name(swiftc)
         module_rule = self.get_compiler_rule_name(swiftc.get_language(), swiftc.for_machine, 'SWIFTMODULE')
+        header_rule = self.get_compiler_rule_name(swiftc.get_language(), swiftc.for_machine, 'HEADER')
 
         # Swiftc does not seem to be able to emit objects and module files in one go.
         elem = NinjaBuildElement(self.all_outputs, rel_objects, compile_rule, abssrc)
@@ -2478,9 +2498,19 @@ class NinjaBackend(backends.Backend):
         elem.add_item('RUNDIR', rundir)
         self.add_build(elem)
 
+        # Generate a header for importing into Obj-C/C++.
+        out_header_name = self.swift_generated_header_file_name(target)
+        elem = NinjaBuildElement(self.all_outputs, out_header_name, header_rule, [out_module_name])
+        elem.add_dep(in_module_files)
+        elem.add_item('ARGS', compile_args + module_includes)
+        self.add_build(elem)
+
+        out_header_name_path = PurePath(out_header_name)
+        generated_header = File(True, str(out_header_name_path.parent), out_header_name_path.name)
+
         # Introspection information
         self.create_target_source_introspection(target, swiftc, compile_args + header_imports + module_includes, relsrc, rel_generated)
-        return rel_objects
+        return rel_objects, generated_header
 
     def _rsp_options(self, tool: T.Union['Compiler', 'StaticLinker']) -> NinjaRuleArgs:
         """Helper method to get rsp options.
@@ -2677,6 +2707,16 @@ class NinjaBackend(backends.Backend):
         ]
         description = 'Generating Swift module $out'
         self.add_rule(NinjaRule(rule, command, [], description, restat=True))
+
+        rule = self.get_compiler_rule_name(compiler.get_language(), compiler.for_machine, 'HEADER')
+        command = [
+            *compiler.get_exelist(), # don't need $RUNDIR for this one
+            *compiler.get_header_gen_args('$out'),
+            '$ARGS',
+            '$in'
+        ]
+        description = 'Generating C header for Swift module $in'
+        self.add_rule(NinjaRule(rule, command, [], description, extra='restat = 1'))
 
     def use_dyndeps_for_fortran(self) -> bool:
         '''Use the new Ninja feature for scanning dependencies during build,

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2375,6 +2375,12 @@ class NinjaBackend(backends.Backend):
         return os.path.join(self.get_target_private_dir(target),
                             target.swift_module_name + '.swiftmodule')
 
+    def swift_module_extra_output_files(self, target: build.BuildTarget) -> T.List[str]:
+        # -emit-module outputs these as well.
+        pd = self.get_target_private_dir(target)
+        return [os.path.join(pd, f'{target.swift_module_name}.{suffix}')
+                for suffix in ['swiftdoc', 'swiftsourceinfo']]
+
     def swift_generated_header_file_name(self, target: build.BuildTarget) -> str:
         return target.swift_module_name + '-Swift.h'
 
@@ -2495,7 +2501,7 @@ class NinjaBackend(backends.Backend):
         # Generate the module interface (for now: .swiftmodule and Obj-C header)
         out_header_name = self.swift_generated_header_file_name(target)
         out_header_rel_path = os.path.join(self.get_target_private_dir(target), out_header_name)
-        elem = NinjaBuildElement(self.all_outputs, [out_module_name, out_header_rel_path], interface_rule, abssrc)
+        elem = NinjaBuildElement(self.all_outputs, [out_module_name, out_header_rel_path, *self.swift_module_extra_output_files(target)], interface_rule, abssrc)
         elem.add_dep(in_module_files + rel_generated)
         elem.add_item('TARGET', target.name)
         elem.add_item('MODULE', target.swift_module_name)
@@ -3954,6 +3960,17 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             # For 'automagic' deps: Boost and GTest. Also dependency('threads').
             # pkg-config puts the thread flags itself via `Cflags:`
             commands += linker.get_target_link_args(target)
+
+            # Swiftc as a linker produces a  {module_name}.autolink file in the target private dir (presumably actually
+            # the base dir of all the object files). We can't handle this in the compiler class since that isn't aware
+            # of the files locations, so do it here... I'm not happy about this but don't have a better
+            # non-overengineered idea right now.
+            if linker.language == 'swift':
+                from ..compilers.swift import SwiftCompiler
+
+                if isinstance(linker, SwiftCompiler):
+                    implicit_outs.append(os.path.join(self.get_target_private_dir(target), f'{target.swift_module_name}.autolink'))
+
             # External deps must be last because target link libraries may depend on them.
             for dep in target.get_external_deps():
                 # Extend without reordering or de-dup to preserve `-L -l` sets

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1105,7 +1105,7 @@ class NinjaBackend(backends.Backend):
         # For linking with a Swift target in a C-family target, include the Swift target's generated header.
         if any(lang in target.compilers for lang in ['c', 'objc', 'cpp', 'objcpp']):
             for header in self.determine_swift_dep_headers(target):
-                header_deps.append(header)
+                header_deps.append(str(header))
 
         # These are the generated source files that need to be built for use by
         # this target. We create the Ninja build file elements for this here
@@ -2376,8 +2376,10 @@ class NinjaBackend(backends.Backend):
                             target.swift_module_name + '.swiftmodule')
 
     def swift_generated_header_file_name(self, target: build.BuildTarget) -> str:
-        return os.path.join(self.get_target_private_dir(target),
-                            target.swift_module_name + '-Swift.h')
+        return target.swift_module_name + '-Swift.h'
+
+    def swift_generated_header_path(self, target: build.BuildTarget) -> PurePath:
+        return PurePath(self.get_target_private_dir(target)) / self.swift_generated_header_file_name(target)
 
     def determine_swift_dep_modules(self, target: build.BuildTarget) -> T.List[str]:
         result = []
@@ -2387,11 +2389,11 @@ class NinjaBackend(backends.Backend):
                 result.append(self.swift_module_file_name(l))
         return result
 
-    def determine_swift_dep_headers(self, target: build.BuildTarget):
+    def determine_swift_dep_headers(self, target: build.BuildTarget) -> T.List[PurePath]:
         result = []
         for l in target.link_targets:
             if self.is_swift_target(l):
-                result.append(self.swift_generated_header_file_name(l))
+                result.append(self.swift_generated_header_path(l))
         return result
 
     def generate_swift_compile(self, target: build.BuildTarget,
@@ -2475,10 +2477,9 @@ class NinjaBackend(backends.Backend):
             module_includes += swiftc.get_include_args(x, False)
 
         compile_rule = self.compiler_to_rule_name(swiftc)
-        module_rule = self.get_compiler_rule_name(swiftc.get_language(), swiftc.for_machine, 'SWIFTMODULE')
-        header_rule = self.get_compiler_rule_name(swiftc.get_language(), swiftc.for_machine, 'HEADER')
+        interface_rule = self.get_compiler_rule_name(swiftc.get_language(), swiftc.for_machine, 'INTERFACE')
 
-        # Swiftc does not seem to be able to emit objects and module files in one go.
+        # Generate the object files.
         elem = NinjaBuildElement(self.all_outputs, rel_objects, compile_rule, abssrc)
         elem.add_dep(in_module_files + rel_generated)
         elem.add_dep(abs_headers)
@@ -2491,22 +2492,19 @@ class NinjaBackend(backends.Backend):
         # -g makes swiftc create a .o file with potentially the same name as one of the compile target generated ones.
         mod_gen_args = [el for el in compile_args if el != '-g']
 
-        elem = NinjaBuildElement(self.all_outputs, out_module_name, module_rule, abssrc)
+        # Generate the module interface (for now: .swiftmodule and Obj-C header)
+        out_header_name = self.swift_generated_header_file_name(target)
+        out_header_rel_path = os.path.join(self.get_target_private_dir(target), out_header_name)
+        elem = NinjaBuildElement(self.all_outputs, [out_module_name, out_header_rel_path], interface_rule, abssrc)
         elem.add_dep(in_module_files + rel_generated)
+        elem.add_item('TARGET', target.name)
         elem.add_item('MODULE', target.swift_module_name)
+        elem.add_item('HEADER', out_header_name)
         elem.add_item('ARGS', mod_gen_args + header_imports + abs_generated + module_includes)
         elem.add_item('RUNDIR', rundir)
         self.add_build(elem)
 
-        # Generate a header for importing into Obj-C/C++.
-        out_header_name = self.swift_generated_header_file_name(target)
-        elem = NinjaBuildElement(self.all_outputs, out_header_name, header_rule, [out_module_name])
-        elem.add_dep(in_module_files)
-        elem.add_item('ARGS', compile_args + module_includes)
-        self.add_build(elem)
-
-        out_header_name_path = PurePath(out_header_name)
-        generated_header = File(True, str(out_header_name_path.parent), out_header_name_path.name)
+        generated_header = File(True, self.get_target_private_dir(target), out_header_name)
 
         # Introspection information
         self.create_target_source_introspection(target, swiftc, compile_args + header_imports + module_includes, relsrc, rel_generated)
@@ -2697,26 +2695,17 @@ class NinjaBackend(backends.Backend):
         description = 'Compiling Swift sources for $TARGET'
         self.add_rule(NinjaRule(rule, command, [], description, restat=True))
 
-        rule = self.get_compiler_rule_name(compiler.get_language(), compiler.for_machine, 'SWIFTMODULE')
+        rule = self.get_compiler_rule_name(compiler.get_language(), compiler.for_machine, 'INTERFACE')
         command = [
             *invoc,
             *compiler.get_mod_gen_args(),
+            *compiler.get_header_gen_args('$HEADER'),
             *compiler.get_module_args('$MODULE'),
             '$ARGS',
             '$in'
         ]
-        description = 'Generating Swift module $out'
+        description = 'Generating Swift module interface for $TARGET'
         self.add_rule(NinjaRule(rule, command, [], description, restat=True))
-
-        rule = self.get_compiler_rule_name(compiler.get_language(), compiler.for_machine, 'HEADER')
-        command = [
-            *compiler.get_exelist(), # don't need $RUNDIR for this one
-            *compiler.get_header_gen_args('$out'),
-            '$ARGS',
-            '$in'
-        ]
-        description = 'Generating C header for Swift module $in'
-        self.add_rule(NinjaRule(rule, command, [], description, extra='restat = 1'))
 
     def use_dyndeps_for_fortran(self) -> bool:
         '''Use the new Ninja feature for scanning dependencies during build,

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1004,9 +1004,6 @@ class NinjaBackend(backends.Backend):
         if 'cs' in target.compilers:
             self.generate_cs_target(target)
             return
-        if 'swift' in target.compilers:
-            self.generate_swift_target(target)
-            return
 
         # CompileTarget compiles all its sources and does not do a final link.
         # This is, for example, a preprocessor.
@@ -1086,6 +1083,21 @@ class NinjaBackend(backends.Backend):
         # For D language, the object of generated source files are added
         # as order only deps because other files may depend on them
         d_generated_deps = []
+
+        # Swiftc wants a single compiler invocation for all of the source files. Filter out relevant
+        # sources here.
+        if 'swift' in target.compilers:
+            swiftc = target.compilers['swift']
+            swift_generated_sources = [file for file in generated_source_files if swiftc.can_compile(file)]
+            generated_source_files[:] = [file for file in generated_source_files if file not in swift_generated_sources]
+            swift_sources = {}
+            for path, file in target_sources.items():
+                if swiftc.can_compile(file):
+                    swift_sources[path] = file
+            for path in swift_sources:
+                del target_sources[path]
+            objs = self.generate_swift_compile(target, swift_sources, swift_generated_sources, target_sources, generated_source_files)
+            obj_list.extend(objs)
 
         # These are the generated source files that need to be built for use by
         # this target. We create the Ninja build file elements for this here
@@ -2363,25 +2375,36 @@ class NinjaBackend(backends.Backend):
                 result.append(self.swift_module_file_name(l))
         return result
 
-    def get_swift_link_deps(self, target: build.BuildTarget) -> T.List[str]:
-        result = []
-        for l in target.link_targets:
-            result.append(self.get_target_filename(l))
-        return result
+    def generate_swift_compile(self, target: build.BuildTarget,
+                               swift_sources: T.OrderedMapping[str, File], swift_generated_sources: T.List[File],
+                               sources: T.OrderedMapping[str, File], generated_sources: T.List[File]) -> T.List[str]:
+        if not swift_sources and not swift_generated_sources:
+            return [], None
 
-    def split_swift_generated_sources(self, target: build.BuildTarget) -> T.List[str]:
-        all_srcs = self.get_target_generated_sources(target)
-        srcs: T.List[str] = []
-        for i in all_srcs:
-            if i.endswith('.swift'):
-                srcs.append(i)
-        return srcs
-
-    def generate_swift_target(self, target: build.BuildTarget) -> None:
-        module_name = target.swift_module_name
         swiftc = T.cast('SwiftCompiler', target.compilers['swift'])
+
         abssrc = []
         relsrc = []
+        for i in swift_sources.values():
+            rels = i.rel_to_builddir(self.build_to_src)
+            abss = os.path.normpath(os.path.join(self.environment.get_build_dir(), rels))
+            relsrc.append(rels)
+            abssrc.append(abss)
+        abs_generated = []
+        rel_generated = []
+        for i in swift_generated_sources:
+            rels = i.rel_to_builddir(self.build_to_src)
+            abss = os.path.normpath(os.path.join(self.environment.get_build_dir(), rels))
+            rel_generated.append(rels)
+            abs_generated.append(abss)
+
+        # Swift outputs object files in the working directory (target's private dir), named after the input file
+        rel_objects = [] # Relative to build.ninja
+        for i in abssrc + abs_generated:
+            base = os.path.basename(i)
+            oname = os.path.splitext(base)[0] + '.o'
+            rel_objects.append(os.path.join(self.get_target_private_dir(target), oname))
+
         abs_headers = []
         header_imports = []
 
@@ -2398,25 +2421,21 @@ class NinjaBackend(backends.Backend):
                                      'Add "swift_interoperability_mode: \'cpp\'" to the definition of {0}.'
                                      .format(repr(target.name), target_word, first, and_word, last, enable_word))
 
-        for i in target.get_sources():
-            if swiftc.can_compile(i):
-                rels = i.rel_to_builddir(self.build_to_src)
-                abss = os.path.normpath(os.path.join(self.environment.get_build_dir(), rels))
-                relsrc.append(rels)
-                abssrc.append(abss)
-            elif compilers.is_header(i):
+        for i in itertools.chain(generated_sources, sources.values()):
+            if compilers.is_header(i):
                 relh = i.rel_to_builddir(self.build_to_src)
                 absh = os.path.normpath(os.path.join(self.environment.get_build_dir(), relh))
                 abs_headers.append(absh)
                 header_imports += swiftc.get_header_import_args(absh)
-            else:
-                raise InvalidArguments(f'Swift target {target.get_basename()} contains a non-swift source file.')
+        if header_imports != [] and not isinstance(target, build.Executable):
+            raise MesonException('C bridging headers are not supported in Swift library targets: {}. '
+                                 'Write a separate Clang module including the necessary headers and add it to this '
+                                 'target\'s include directories.'
+                                 .format(', '.join(repr(x) for x in header_imports)))
         os.makedirs(self.get_target_private_dir_abs(target), exist_ok=True)
+
         compile_args = self.generate_basic_compiler_args(target, swiftc)
-        compile_args += swiftc.get_module_args(module_name)
         compile_args += swiftc.get_cxx_interoperability_args(target)
-        compile_args += self.build.get_project_args(swiftc, target)
-        compile_args += self.build.get_global_args(swiftc, target.for_machine)
         if isinstance(target, (build.StaticLibrary, build.SharedLibrary)):
             # swiftc treats modules with a single source file, and the main.swift file in multi-source file modules
             # as top-level code. This is undesirable in library targets since it emits a main function. Add the
@@ -2428,68 +2447,40 @@ class NinjaBackend(backends.Backend):
             for path in i.abs_string_list(self.source_dir, self.build_dir):
                 compile_args.extend(swiftc.get_include_args(path, False))
         compile_args += target.get_extra_args('swift')
-        link_args = swiftc.get_output_args(os.path.join(self.environment.get_build_dir(), self.get_target_filename(target)))
-        link_args += self.build.get_project_link_args(swiftc, target)
-        link_args += self.build.get_global_link_args(swiftc, target.for_machine)
-        rundir = self.get_target_private_dir(target)
+        rundir = self.get_target_private_dir_abs(target)
         out_module_name = self.swift_module_file_name(target)
         in_module_files = self.determine_swift_dep_modules(target)
         abs_module_dirs = self.determine_swift_dep_dirs(target)
         module_includes = []
         for x in abs_module_dirs:
             module_includes += swiftc.get_include_args(x, False)
-        link_deps = self.get_swift_link_deps(target)
-        abs_link_deps = [os.path.join(self.environment.get_build_dir(), x) for x in link_deps]
-        for d in target.link_targets:
-            reldir = self.get_target_dir(d)
-            if reldir == '':
-                reldir = '.'
-            link_args += ['-L', os.path.normpath(os.path.join(self.environment.get_build_dir(), reldir))]
-        rel_generated = self.split_swift_generated_sources(target)
-        abs_generated = [os.path.join(self.environment.get_build_dir(), x) for x in rel_generated]
-        # We need absolute paths because swiftc needs to be invoked in a subdir
-        # and this is the easiest way about it.
-        objects = [] # Relative to swift invocation dir
-        rel_objects = [] # Relative to build.ninja
-        for i in abssrc + abs_generated:
-            base = os.path.basename(i)
-            oname = os.path.splitext(base)[0] + '.o'
-            objects.append(oname)
-            rel_objects.append(os.path.join(self.get_target_private_dir(target), oname))
 
-        rulename = self.compiler_to_rule_name(swiftc)
+        compile_rule = self.compiler_to_rule_name(swiftc)
+        module_rule = self.get_compiler_rule_name(swiftc.get_language(), swiftc.for_machine, 'SWIFTMODULE')
 
         # Swiftc does not seem to be able to emit objects and module files in one go.
-        elem = NinjaBuildElement(self.all_outputs, rel_objects, rulename, abssrc)
+        elem = NinjaBuildElement(self.all_outputs, rel_objects, compile_rule, abssrc)
         elem.add_dep(in_module_files + rel_generated)
         elem.add_dep(abs_headers)
-        elem.add_item('ARGS', swiftc.get_compile_only_args() + compile_args + header_imports + abs_generated + module_includes)
+        elem.add_item('TARGET', target.name)
+        elem.add_item('MODULE', target.swift_module_name)
+        elem.add_item('ARGS', compile_args + header_imports + abs_generated + module_includes)
         elem.add_item('RUNDIR', rundir)
         self.add_build(elem)
 
         # -g makes swiftc create a .o file with potentially the same name as one of the compile target generated ones.
         mod_gen_args = [el for el in compile_args if el != '-g']
 
-        elem = NinjaBuildElement(self.all_outputs, out_module_name, rulename, abssrc)
+        elem = NinjaBuildElement(self.all_outputs, out_module_name, module_rule, abssrc)
         elem.add_dep(in_module_files + rel_generated)
-        elem.add_item('ARGS', swiftc.get_mod_gen_args() + mod_gen_args + abs_generated + module_includes)
+        elem.add_item('MODULE', target.swift_module_name)
+        elem.add_item('ARGS', mod_gen_args + header_imports + abs_generated + module_includes)
         elem.add_item('RUNDIR', rundir)
         self.add_build(elem)
-        if isinstance(target, build.StaticLibrary):
-            elem = self.generate_link(target, self.get_target_filename(target),
-                                      rel_objects, self.build.static_linker[target.for_machine])
-            self.add_build(elem)
-        elif isinstance(target, build.Executable):
-            elem = NinjaBuildElement(self.all_outputs, self.get_target_filename(target), rulename, [])
-            elem.add_dep(rel_objects)
-            elem.add_dep(link_deps)
-            elem.add_item('ARGS', link_args + swiftc.get_std_exe_link_args() + objects + abs_link_deps)
-            elem.add_item('RUNDIR', rundir)
-            self.add_build(elem)
-        else:
-            raise MesonException('Swift supports only executable and static library targets.')
+
         # Introspection information
         self.create_target_source_introspection(target, swiftc, compile_args + header_imports + module_includes, relsrc, rel_generated)
+        return rel_objects
 
     def _rsp_options(self, tool: T.Union['Compiler', 'StaticLinker']) -> NinjaRuleArgs:
         """Helper method to get rsp options.
@@ -2653,7 +2644,6 @@ class NinjaBackend(backends.Backend):
                                 depfile=depfile))
 
     def generate_swift_compile_rules(self, compiler: SwiftCompiler) -> None:
-        rule = self.compiler_to_rule_name(compiler)
         wd_args = compiler.get_working_directory_args('$RUNDIR')
 
         if wd_args is not None:
@@ -2666,8 +2656,26 @@ class NinjaBackend(backends.Backend):
             ]
             invoc = full_exe + compiler.get_exelist()
 
-        command = invoc + ['$ARGS', '$in']
-        description = 'Compiling Swift source $in'
+        rule = self.compiler_to_rule_name(compiler)
+        command = [
+            *invoc,
+            *compiler.get_compile_only_args(),
+            *compiler.get_module_args('$MODULE'),
+            '$ARGS',
+            '$in'
+        ]
+        description = 'Compiling Swift sources for $TARGET'
+        self.add_rule(NinjaRule(rule, command, [], description, restat=True))
+
+        rule = self.get_compiler_rule_name(compiler.get_language(), compiler.for_machine, 'SWIFTMODULE')
+        command = [
+            *invoc,
+            *compiler.get_mod_gen_args(),
+            *compiler.get_module_args('$MODULE'),
+            '$ARGS',
+            '$in'
+        ]
+        description = 'Generating Swift module $out'
         self.add_rule(NinjaRule(rule, command, [], description, restat=True))
 
     def use_dyndeps_for_fortran(self) -> bool:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1753,6 +1753,13 @@ class BuildTarget(Target):
     def uses_vala(self) -> bool:
         return 'vala' in self.compilers
 
+    def uses_swift_objc_interop(self) -> bool:
+        # At this point, this is only available on Apple platforms, and enabled unconditionally there.
+        # In the -- perhaps futile -- hope of this changing in the future, let's handle this one like Swift/C++.
+        # (I'll just take a commenter on the Swift forums at their word that you can't build a Swift compiler for
+        # Apple platforms with Obj-C disabled, which simplifies the logic quite a bit here for now)
+        return 'swift' in self.compilers and self.environment.machines[self.for_machine].is_darwin()
+
     def uses_swift_cpp_interop(self) -> bool:
         return self.swift_interoperability_mode == 'cpp' and 'swift' in self.compilers
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1006,6 +1006,19 @@ class BuildTarget(Target):
             if self.vala_gir is not None:
                 self.outputs.append(self.vala_gir)
                 self.install_tag.append('devel')
+        # TODO: this is for purposes of calling Swift from C++. This check should probably be in the location where the
+        # header export target is generated instead of here, because obviously there is no issue with linking Swift code
+        # with C++ code in and of itself
+        if 'cpp' in self.compilers and \
+                any(t.uses_swift_cpp_interop()
+                    for t in itertools.chain([self], self.link_targets, self.link_whole_targets)):
+            from .compilers.cpp import CPPCompiler
+
+            cpp = self.compilers['cpp']
+            assert isinstance(cpp, CPPCompiler)
+            if not cpp.works_with_swift():
+                raise MesonException(f'target {self.name!r} tries to link Swift objects with C++ objects, '
+                                     'but the C++ and Swift compilers are incompatible')
 
         for compiler in self.compilers.values():
             self.single_compile_base_args[compiler] = self._generate_single_compile_base_args(compiler)

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -99,7 +99,7 @@ clib_langs = ('objcpp', 'cpp', 'objc', 'c', 'nasm', 'fortran')
 # List of languages that can be linked with C code directly by the linker
 # used in build.py:process_compilers() and build.py:get_dynamic_linker()
 # This must be sorted, see sort_clink().
-clink_langs = ('rust', 'd', 'cuda') + clib_langs
+clink_langs = ('rust', 'd', 'cuda', 'swift') + clib_langs
 
 SUFFIX_TO_LANG: T.Mapping[str, Language] = dict(itertools.chain(*(
     [(suffix, lang) for suffix in v] for lang, v in lang_suffixes.items())))

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -9,7 +9,7 @@ import typing as T
 
 from .. import options
 from .. import mlog
-from ..mesonlib import MesonException, version_compare, lazy_property
+from ..mesonlib import MesonBugException, MesonException, version_compare, lazy_property
 
 from .compilers import (
     gnu_winlibs,
@@ -70,6 +70,8 @@ class CPPCompiler(CLikeCompiler, Compiler):
     def __init__(self, ccache: T.List[str], exelist: T.List[str], version: str, for_machine: MachineChoice,
                  env: Environment, linker: T.Optional['DynamicLinker'] = None,
                  full_version: T.Optional[str] = None):
+        self._works_with_swift: T.Optional[bool] = None
+
         # If a child ObjCPP class has already set it, don't set it ourselves
         Compiler.__init__(self, ccache, exelist, version, for_machine, env,
                           linker=linker, full_version=full_version)
@@ -90,6 +92,49 @@ class CPPCompiler(CLikeCompiler, Compiler):
 
     def _sanity_check_source_code(self) -> str:
         return '#include <stddef.h>\nclass breakCCompiler;int main(void) { return 0; }\n'
+
+    def detect_works_with_swift(self) -> None:
+        from ..mesonlib import MachineChoice
+        from .swift import SwiftCompiler
+
+        compilers = self.environment.coredata.compilers[self.for_machine]
+
+        try:
+            swiftc = compilers['swift']
+        except KeyError:
+            raise MesonBugException('CPPCompiler.detect_works_with_swift called without a Swift compiler being present')
+
+        assert isinstance(swiftc, SwiftCompiler)
+
+        if not swiftc.supports_cxx_interoperability():
+            self._works_with_swift = False
+            return
+
+        header_name = 'swift-export.h'
+        include_dir = self.environment.get_scratch_dir()
+
+        swiftc.export_cpp_header_for_compat_detection(header_name, include_dir)
+
+        works, _ = self.compiles(f'#include "{header_name}"\nclass breakCCompiler;int main(void) {{ return 0; }}\n',
+                                 extra_args=[
+                                     # On macOS, the Swift header seems to need at least C++11 standard level. Just use
+                                     # whatever the project has defined as the default.
+                                     *self.get_option_compile_args(None, None),
+                                     *self.get_include_args(include_dir, False)],
+                                 disable_cache=True)
+
+        msg = ['C++ compiler', *[mlog.bold(el) for el in self.get_exelist()], 'compiles Swift-exported headers:']
+        verbose = self.for_machine == MachineChoice.HOST or self.environment.is_cross_build()
+        logger_fun = mlog.log if verbose else mlog.debug
+        logger_fun(*msg, mlog.green('YES') if works else mlog.red('NO'))
+
+        self._works_with_swift = works
+
+    def works_with_swift(self) -> bool:
+        if self._works_with_swift is None:
+            raise MesonBugException('Called CPPCompiler.works_with_swift() but compatibility was never checked')
+
+        return self._works_with_swift
 
     def get_compiler_check_args(self, mode: CompileCheckMode) -> T.List[str]:
         # -fpermissive allows non-conforming code to compile which is necessary

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -104,6 +104,9 @@ class SwiftCompiler(Compiler):
     def get_std_exe_link_args(self) -> T.List[str]:
         return ['-emit-executable']
 
+    def get_std_shared_lib_link_args(self) -> T.List[str]:
+        return ['-emit-library']
+
     def get_module_args(self, modname: str) -> T.List[str]:
         return ['-module-name', modname]
 

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -187,10 +187,23 @@ class SwiftCompiler(Compiler):
         if target is not None and not target.uses_swift_cpp_interop():
             return []
 
-        if version_compare(self.version, '<5.9'):
+        if not self.supports_cxx_interoperability():
             raise MesonException(f'Compiler {self} does not support C++ interoperability')
 
         return ['-cxx-interoperability-mode=default']
+
+    def supports_cxx_interoperability(self) -> bool:
+        return version_compare(self.version, '>=5.9')
+
+    def export_cpp_header_for_compat_detection(self, header_name: str, output_dir: str) -> None:
+        from ..mesonlib import Popen_safe_logged
+
+        if not self.supports_cxx_interoperability():
+            raise MesonException(f'Compiler {self} does not support C++ interoperability')
+
+        swift_command = [*self.get_exelist(), *self.get_header_gen_args(header_name), *self.get_library_args(),
+                         *self.get_module_args('Check'), *self.get_cxx_interoperability_args(), '-']
+        p, _, _ = Popen_safe_logged(swift_command, cwd=output_dir)
 
     def get_library_args(self) -> T.List[str]:
         return ['-parse-as-library']

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -14,6 +14,7 @@ from .compilers import Compiler, clike_debug_args, PrefixArgumentLinkerOptionSty
 
 if T.TYPE_CHECKING:
     from .. import build
+    from ..build import BuildTarget
     from ..compilers.compilers import Language
     from ..envconfig import MachineInfo
     from ..options import MutableKeyedOptionDictType
@@ -116,6 +117,11 @@ class SwiftCompiler(Compiler):
 
     def get_std_shared_lib_link_args(self) -> T.List[str]:
         return ['-emit-library']
+
+    def get_target_link_args(self, target: BuildTarget) -> T.List[str]:
+        # Add module name here because swiftc as a linker produces a {module_name}.autolink file which will be
+        # otherwise auto-inferred and not always predictable.
+        return [*self.get_module_args(target.swift_module_name), *super().get_target_link_args(target)]
 
     def get_module_args(self, modname: str) -> T.List[str]:
         return ['-module-name', modname]

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -31,6 +31,12 @@ swift_optimization_args: T.Dict[str, T.List[str]] = {
     's': ['-O'],
 }
 
+swiftc_color_args: T.Dict[str, T.List[str]] = {
+    'auto': [],
+    'always': ['-color-diagnostics'],
+    'never': ['-no-color-diagnostics'],
+}
+
 class SwiftCompiler(Compiler):
 
     LINKER_OPTION_STYLE = PrefixArgumentLinkerOptionStyle('-Xlinker')
@@ -97,6 +103,9 @@ class SwiftCompiler(Compiler):
 
     def get_header_import_args(self, headername: str) -> T.List[str]:
         return ['-import-objc-header', headername]
+
+    def get_colorout_args(self, colortype: str) -> T.List[str]:
+        return swiftc_color_args[colortype][:]
 
     def get_warn_args(self, level: str) -> T.List[str]:
         return []

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -15,6 +15,7 @@ from .compilers import Compiler, clike_debug_args, PrefixArgumentLinkerOptionSty
 if T.TYPE_CHECKING:
     from .. import build
     from ..compilers.compilers import Language
+    from ..envconfig import MachineInfo
     from ..options import MutableKeyedOptionDictType
     from ..dependencies import Dependency
     from ..environment import Environment
@@ -222,3 +223,16 @@ class SwiftCompiler(Compiler):
 
     def get_optimization_args(self, optimization_level: str) -> T.List[str]:
         return swift_optimization_args[optimization_level]
+
+    @classmethod
+    def _unix_args_to_native(cls, args: T.List[str], info: MachineInfo) -> T.List[str]:
+        result: T.List[str] = []
+        for arg in args:
+            if arg == '-pthread':
+                arg = '-lpthread'
+            elif arg.startswith('-isystem'):
+                arg = f'-I{arg.removeprefix('-isystem')}'
+            elif arg.startswith('-idirafter'):
+                arg = f'-I{arg.removeprefix('-idirafter')}'
+            result.append(arg)
+        return result

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -126,7 +126,7 @@ class SwiftCompiler(Compiler):
     def get_header_gen_args(self, header_name: str) -> T.List[str]:
         # Despite these options being named after Objective-C, the header that gets generated from here includes the
         # support for all C-family languages with enabled interoperability, including C++.
-        return ['-parse', '-emit-objc-header', '-emit-objc-header-path', header_name]
+        return ['-emit-objc-header', '-emit-objc-header-path', header_name]
 
     def get_include_args(self, path: str, is_system: bool) -> T.List[str]:
         return ['-I' + path]

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -3,12 +3,13 @@
 
 from __future__ import annotations
 
+import itertools
 import re
 import subprocess, os.path
 import typing as T
 
 from .. import mlog, options
-from ..mesonlib import first, MesonException, version_compare
+from ..mesonlib import MesonException, version_compare
 from .compilers import Compiler, clike_debug_args, PrefixArgumentLinkerOptionStyle
 
 if T.TYPE_CHECKING:
@@ -138,14 +139,23 @@ class SwiftCompiler(Compiler):
             args += ['-swift-version', std]
 
         # Pass C compiler -std=... arg to swiftc
-        c_langs: T.List[Language] = ['objc', 'c']
-        if target.uses_swift_cpp_interop():
-            c_langs = ['objcpp', 'cpp', *c_langs]
 
-        c_lang = first(c_langs, lambda x: x in target.compilers)
-        if c_lang is not None:
+        objc_interop = target.uses_swift_objc_interop()
+        cpp_interop = target.uses_swift_cpp_interop()
+
+        def consider(compiler: Language, conditions: bool = True) -> T.Iterable[Language]:
+            return [compiler] if conditions and compiler in target.compilers else []
+
+        try:
+            c_lang = next(itertools.chain(consider('objcpp', objc_interop and cpp_interop),
+                                          consider('cpp', cpp_interop),
+                                          consider('objc', objc_interop),
+                                          consider('c')))
+
             cc = target.compilers[c_lang]
             args.extend(arg for c_arg in cc.get_option_std_args(target, subproject) for arg in ['-Xcc', c_arg])
+        except StopIteration:
+            pass
 
         return args
 

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -153,7 +153,7 @@ class SwiftCompiler(Compiler):
 
         return opts
 
-    def get_option_std_args(self, target: build.BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: T.Optional[build.BuildTarget], subproject: T.Optional[str] = None) -> T.List[str]:
         args: T.List[str] = []
 
         std = self.get_compileropt_value('std', target, subproject)
@@ -163,6 +163,10 @@ class SwiftCompiler(Compiler):
             args += ['-swift-version', std]
 
         # Pass C compiler -std=... arg to swiftc
+
+        # TODO: What do we do if target is None? (e.g. when called by compiler.compiles())
+        if target is None:
+            return args
 
         objc_interop = target.uses_swift_objc_interop()
         cpp_interop = target.uses_swift_cpp_interop()

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -123,6 +123,11 @@ class SwiftCompiler(Compiler):
     def get_mod_gen_args(self) -> T.List[str]:
         return ['-emit-module']
 
+    def get_header_gen_args(self, header_name: str) -> T.List[str]:
+        # Despite these options being named after Objective-C, the header that gets generated from here includes the
+        # support for all C-family languages with enabled interoperability, including C++.
+        return ['-parse', '-emit-objc-header', '-emit-objc-header-path', header_name]
+
     def get_include_args(self, path: str, is_system: bool) -> T.List[str]:
         return ['-I' + path]
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1609,6 +1609,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     def add_languages_for(self, args: T.List[Language], required: bool, for_machine: MachineChoice) -> bool:
         langs = set(self.compilers[for_machine])
         langs.update(args)
+        new_langs = set()
 
         # Some languages are added only as implementation details of other
         # languages. When that happens, we don't want to add those languages to
@@ -1690,8 +1691,25 @@ class Interpreter(InterpreterBase, HoldableObject):
             self.build.ensure_static_linker(comp)
             if lang not in internal:
                 self.compilers[for_machine][lang] = comp
+                new_langs.add(lang)
+
+        if new_langs:
+            self.did_add_languages_for(for_machine, new_langs)
 
         return success
+
+    def did_add_languages_for(self, for_machine: MachineChoice, new_languages: T.Set[str]):
+        from mesonbuild.compilers.cpp import CPPCompiler
+
+        swift_and_cpp = {'swift', 'cpp'}
+
+        # call this once, after both have been added
+        if all(name in self.compilers[for_machine] for name in swift_and_cpp) and \
+                new_languages.intersection(swift_and_cpp):
+            compilers = self.compilers[for_machine]
+            cpp = compilers['cpp']
+            assert isinstance(cpp, CPPCompiler)
+            cpp.detect_works_with_swift()
 
     def program_from_file_for(self, for_machine: MachineChoice, prognames: T.List[mesonlib.FileOrString]
                               ) -> T.Optional[ExternalProgram]:

--- a/test cases/swift/17 call swift from cpp/lib.swift
+++ b/test cases/swift/17 call swift from cpp/lib.swift
@@ -1,0 +1,3 @@
+public func callMe(input: String) -> String {
+    return "\(input), and back"
+}

--- a/test cases/swift/17 call swift from cpp/main.cpp
+++ b/test cases/swift/17 call swift from cpp/main.cpp
@@ -1,0 +1,10 @@
+#include "Library-Swift.h"
+#include <stdio.h>
+
+int main()
+{
+    if (std::string(Library::callMe("To Swift")) != "To Swift, and back") {
+        fprintf(stderr, "got wrong return value\n");
+        abort();
+    }
+}

--- a/test cases/swift/17 call swift from cpp/meson.build
+++ b/test cases/swift/17 call swift from cpp/meson.build
@@ -1,0 +1,16 @@
+project(
+  'call swift from cpp',
+  ['swift', 'cpp'],
+  # Swift headers contain noexcept, which was introduced in C++11
+  default_options: 'cpp_std=c++11',
+)
+
+swiftc = meson.get_compiler('swift')
+
+# Testing C++ and Swift interoperability requires Swift 5.9
+if not swiftc.version().version_compare('>= 5.9')
+  error('MESON_SKIP_TEST Test requires Swift 5.9')
+endif
+
+lib = shared_library('Library', 'lib.swift', swift_interoperability_mode: 'cpp')
+executable('program', 'main.cpp', link_with: [lib], include_directories: [lib.private_dir_include()])

--- a/test cases/swift/18 mixed c single target/callme.c
+++ b/test cases/swift/18 mixed c single target/callme.c
@@ -1,0 +1,6 @@
+#include "callme.h"
+
+const char *callMe()
+{
+    return "Value from C";
+}

--- a/test cases/swift/18 mixed c single target/callme.h
+++ b/test cases/swift/18 mixed c single target/callme.h
@@ -1,0 +1,3 @@
+#pragma once
+
+const char *callMe();

--- a/test cases/swift/18 mixed c single target/main.swift
+++ b/test cases/swift/18 mixed c single target/main.swift
@@ -1,0 +1,1 @@
+precondition(String(cString: callMe()) == "Value from C")

--- a/test cases/swift/18 mixed c single target/meson.build
+++ b/test cases/swift/18 mixed c single target/meson.build
@@ -1,0 +1,3 @@
+project('mixed c single target', 'swift', 'c')
+
+executable('program', 'main.swift', 'callme.h', 'callme.c')

--- a/test cases/swift/19 shared library/lib.swift
+++ b/test cases/swift/19 shared library/lib.swift
@@ -1,0 +1,1 @@
+public func callMe() {}

--- a/test cases/swift/19 shared library/main.swift
+++ b/test cases/swift/19 shared library/main.swift
@@ -1,0 +1,3 @@
+import Library
+
+callMe()

--- a/test cases/swift/19 shared library/meson.build
+++ b/test cases/swift/19 shared library/meson.build
@@ -1,0 +1,4 @@
+project('shared library', 'swift')
+
+lib = shared_library('Library', 'lib.swift')
+executable('program', 'main.swift', link_with: [lib])

--- a/test cases/swift/20 call swift from objc/lib.swift
+++ b/test cases/swift/20 call swift from objc/lib.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+@objc
+public class TestObject: NSObject {
+    @objc
+    public func callMe(input: String) -> String {
+        return "\(input), and back"
+    }
+}

--- a/test cases/swift/20 call swift from objc/main.m
+++ b/test cases/swift/20 call swift from objc/main.m
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+
+#import "Library-Swift.h"
+
+int main()
+{
+    TestObject *obj = [[TestObject alloc] init];
+
+    if (![[obj callMeWithInput: @"To Swift"] isEqualToString: @"To Swift, and back"]) {
+        fprintf(stderr, "got wrong return value\n");
+        abort();
+    }
+
+    [obj release];
+}

--- a/test cases/swift/20 call swift from objc/meson.build
+++ b/test cases/swift/20 call swift from objc/meson.build
@@ -1,0 +1,9 @@
+project(
+  'call swift from objc',
+  ['swift', 'objc'],
+)
+
+swiftc = meson.get_compiler('swift')
+
+lib = shared_library('Library', 'lib.swift')
+executable('program', 'main.m', link_with: [lib], include_directories: [lib.private_dir_include()])


### PR DESCRIPTION
Closes #13203.

Makes Swift target generation use the main code path. This allows mixing Swift and C++ sources inside of a single target. (All Swift sources are still compiled with one swiftc invocation since [per-file compilation is not supported](https://github.com/swiftlang/sourcekit-lsp/issues/1980#issuecomment-2660422475).)

This also adds support for shared library Swift targets.

Also creates a Ninja target for a C++/Obj-C exported header, which those languages can use to call Swift code. This header is automatically added as a dependency to targets that can use it.

~~Caveat: using this to call Swift code from C++ requires manually setting CXX to the Swift-bundled clang++ (on non-macOS), since it requires special support in the compiler which the normal clang doesn't come with. Meson would automatically have to switch to using the Swift-bundled clang when a project uses both Swift and C/C++/Obj-C. Not sure if that is desirable or even doable. Could maybe throw an error instead when the mismatch is detected.~~ After thinking about it some more, CXX should just be set correctly by the user for this.

To do:
- [x] Test on macOS, specifically with Obj-C
- [x] Version checks (C++ bridging is available in 5.9 and above)
- [x] Test cases
- Documentation (#15575)

```meson
# Linking Swift lib with C++ executable
swiftlib = static_library('swiftlib', 'swiftlib.swift', swift_args: ['-parse-as-library'])
cpp_exe = executable('cpp_exe', 'main.cpp', link_with: [swiftlib], include_directories: [swiftlib.private_dir_include()])

# Single Swift/C++ target
combined_swift_cpp = executable('combined', 'combined.swift', 'combined.h', 'combined.cpp')
```
