### PR TITLE
mtest: list the first N log lines rather than the last N

### DIFF
--- a/docs/markdown/Unit-tests.md
+++ b/docs/markdown/Unit-tests.md
@@ -280,7 +280,7 @@ other useful information as the environmental variables. This is
 useful, for example, when you run the tests on Travis-CI, Jenkins and
 the like.
 
-By default, the output from tests will be limited to the last 100 lines. The
+By default, the output from tests will be limited to the first 100 lines. The
 maximum number of lines to show can be configured with the `--max-lines` option
 *(added 1.5.0)*:
 

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -657,7 +657,7 @@ class ConsoleLogger(TestLogger):
         if len(lines) < self.max_lines:
             return log
         else:
-            return str(mlog.bold(f'Listing only the last {self.max_lines} lines from a long log.\n')) + '\n'.join(lines[-self.max_lines:])
+            return str(mlog.bold(f'Listing only the first {self.max_lines} lines from a long log.\n')) + '\n'.join(lines[:self.max_lines])
 
     def print_log(self, harness: 'TestHarness', result: 'TestRun') -> None:
         if not result.verbose:


### PR DESCRIPTION
In most cases, the most useful log lines from a failing test are the first N lines. This is, of course, open to discussion—if we think configurability is needed, I'm happy to add it. However, as a default, listing the first N lines seems more intuitive when diagnosing a test failure.
