### PR TITLE
Add -parse-as-library to Swift library targets

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2220,6 +2220,8 @@ class NinjaBackend(backends.Backend):
         compile_args = self.generate_basic_compiler_args(target, swiftc)
         compile_args += swiftc.get_compile_only_args()
         compile_args += swiftc.get_module_args(module_name)
+        if isinstance(target, (build.StaticLibrary, build.SharedLibrary)):
+            compile_args += swiftc.get_library_args()
         for i in reversed(target.get_include_dirs()):
             basedir = i.get_curdir()
             for d in i.get_incdirs():

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -121,6 +121,9 @@ class SwiftCompiler(Compiler):
 
         return ['-working-directory', path]
 
+    def get_library_args(self) -> T.List[str]:
+        return ['-parse-as-library']
+
     def compute_parameters_with_absolute_paths(self, parameter_list: T.List[str],
                                                build_dir: str) -> T.List[str]:
         for idx, i in enumerate(parameter_list):

--- a/test cases/swift/12 single-file library/main.swift
+++ b/test cases/swift/12 single-file library/main.swift
@@ -1,0 +1,3 @@
+import SingleFile
+
+callMe()

--- a/test cases/swift/12 single-file library/meson.build
+++ b/test cases/swift/12 single-file library/meson.build
@@ -1,0 +1,4 @@
+project('single-file library', 'swift')
+
+lib = static_library('SingleFile', 'singlefile.swift')
+executable('program', 'main.swift', link_with: [lib])

--- a/test cases/swift/12 single-file library/singlefile.swift
+++ b/test cases/swift/12 single-file library/singlefile.swift
@@ -1,0 +1,1 @@
+public func callMe() {}

--- a/test cases/swift/8 extra args/main.swift
+++ b/test cases/swift/8 extra args/main.swift
@@ -1,1 +1,3 @@
-print("test")
+public func callMe() {
+    print("test")
+}


### PR DESCRIPTION
swiftc adds a main function consisting of top-level statements to objects generated by a swiftc invocation with a single input file, leading to duplicate symbols when linking the final executable (in case of a static library). This argument prevents this from happening, apply it to library targets automatically.