### PR TITLE
Cuda `-Dcuda_link_args=foo` single arg fix

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -673,6 +673,8 @@ def detect_cuda_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
         if key in env.options:
             # To fix LDFLAGS issue
             val = env.options[key]
+            if isinstance(val, str):
+                val = [val]
             assert isinstance(val, list)
             env.coredata.set_options({key: cls.to_host_flags_base(val, Phase.LINKER)})
         linker = CudaLinker(compiler, for_machine, CudaCompiler.LINKER_PREFIX, [], version=CudaLinker.parse_version())

--- a/test cases/cuda/1 simple/test.json
+++ b/test cases/cuda/1 simple/test.json
@@ -1,0 +1,7 @@
+{
+  "matrix": {
+    "options": {
+      "cuda_link_args": [{ "val": "-ldl" }]
+    }
+  }
+}


### PR DESCRIPTION
@eli-schwartz I think this would be a candidate for a 1.7.1 backport.