### PR TITLE
modules/gnome: Allow to specify the doc-format argument

### DIFF
--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -93,6 +93,7 @@ There are several keyword arguments. Many of these map directly to the
 `g-ir-scanner` tool so see its documentation for more information.
 
 * `dependencies`: deps to use during introspection scanning
+* `doc_format`: (*Added 1.8.0*) format of the inline documentation
 * `extra_args`: command line arguments to pass to gir compiler
 * `env`: (*Added 1.2.0*) environment variables to set, such as
   `{'NAME1': 'value1', 'NAME2': 'value2'}` or `['NAME1=value1', 'NAME2=value2']`,

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -82,6 +82,7 @@ if T.TYPE_CHECKING:
 
         build_by_default: bool
         dependencies: T.List[Dependency]
+        doc_format: T.Optional[str]
         export_packages: T.List[str]
         extra_args: T.List[str]
         fatal_warnings: bool
@@ -1103,6 +1104,7 @@ class GnomeModule(ExtensionModule):
         _EXTRA_ARGS_KW,
         ENV_KW.evolve(since='1.2.0'),
         KwargInfo('dependencies', ContainerTypeInfo(list, Dependency), default=[], listify=True),
+        KwargInfo('doc_format', (str, NoneType), since='1.8.0'),
         KwargInfo('export_packages', ContainerTypeInfo(list, str), default=[], listify=True),
         KwargInfo('fatal_warnings', bool, default=False, since='0.55.0'),
         KwargInfo('header', ContainerTypeInfo(list, str), default=[], listify=True),
@@ -1207,6 +1209,9 @@ class GnomeModule(ExtensionModule):
         if self._gir_has_option('--sources-top-dirs'):
             scan_command += ['--sources-top-dirs', os.path.join(state.environment.get_source_dir(), state.root_subdir)]
             scan_command += ['--sources-top-dirs', os.path.join(state.environment.get_build_dir(), state.root_subdir)]
+
+        if kwargs['doc_format'] is not None and self._gir_has_option('--doc-format'):
+            scan_command += ['--doc-format', kwargs['doc_format']]
 
         if '--warn-error' in scan_command:
             FeatureDeprecated.single_use('gnome.generate_gir argument --warn-error', '0.55.0',

--- a/test cases/frameworks/7 gnome/gir/meson.build
+++ b/test cases/frameworks/7 gnome/gir/meson.build
@@ -47,6 +47,7 @@ gnome.generate_gir(
   includes : ['GObject-2.0', 'MesonDep1-1.0'],
   # dep1_dep pulls in dep2_dep for us
   dependencies : [[fake_dep, dep1_dep]],
+  doc_format: 'gtk-doc-markdown',
   install : true,
   build_by_default : true,
 )


### PR DESCRIPTION
Add the support for the doc-format argument if g-ir-scanner supports it.

Ignore the argument otherwise as this is a no-op in such cases.