### PR TITLE
Fix yielding when top project does not define the option.

### DIFF
--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -810,7 +810,13 @@ class OptionStore:
             assert key.subproject is not None
             if potential is not None and potential.yielding:
                 parent_key = key.evolve(subproject='')
-                parent_option = self.options[parent_key]
+                try:
+                    parent_option = self.options[parent_key]
+                except KeyError:
+                    # Subproject is set to yield, but top level
+                    # project does not have an option of the same
+                    # name. Return the subproject option.
+                    return potential
                 # If parent object has different type, do not yield.
                 # This should probably be an error.
                 if type(parent_option) is type(potential):

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -100,6 +100,22 @@ class OptionTests(unittest.TestCase):
         self.assertEqual(optstore.get_value_for(name, 'sub'), top_value)
         self.assertEqual(optstore.num_options(), 2)
 
+    def test_project_yielding_not_defined_in_top_project(self):
+        optstore = OptionStore(False)
+        top_name = 'a_name'
+        top_value = 'top'
+        sub_name = 'different_name'
+        sub_value = 'sub'
+        vo = UserStringOption(top_name, 'A top level option', top_value)
+        optstore.add_project_option(OptionKey(top_name, ''), vo)
+        self.assertEqual(optstore.get_value_for(top_name, ''), top_value)
+        self.assertEqual(optstore.num_options(), 1)
+        vo2 = UserStringOption(sub_name, 'A subproject option', sub_value, True)
+        optstore.add_project_option(OptionKey(sub_name, 'sub'), vo2)
+        self.assertEqual(optstore.get_value_for(top_name, ''), top_value)
+        self.assertEqual(optstore.get_value_for(sub_name, 'sub'), sub_value)
+        self.assertEqual(optstore.num_options(), 2)
+
     def test_augments(self):
         optstore = OptionStore(False)
         name = 'cpp_std'


### PR DESCRIPTION
Closes #14281.