### PR TITLE
backends: allow LD_LIBRARY_PATH to be overwritten in test environments

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1295,7 +1295,7 @@ class Backend:
                 env_build_dir = self.environment.get_build_dir()
                 ld_lib_path: T.Set[str] = set(os.path.join(env_build_dir, l.get_subdir()) for l in ld_lib_path_libs)
 
-                if ld_lib_path:
+                if ld_lib_path and not t_env.has_name('LD_LIBRARY_PATH') and not t_env.is_unset('LD_LIBRARY_PATH'):
                     t_env.prepend('LD_LIBRARY_PATH', list(ld_lib_path), ':')
 
             ts = TestSerialisation(t.get_name(), t.project_name, t.suite, cmd, is_cross,

--- a/mesonbuild/utils/core.py
+++ b/mesonbuild/utils/core.py
@@ -87,6 +87,9 @@ class EnvironmentVariables(HoldableObject):
     def has_name(self, name: str) -> bool:
         return name in self.varnames
 
+    def is_unset(self, name: str) -> bool:
+        return name in self.unset_vars
+
     def get_names(self) -> T.Set[str]:
         return self.varnames
 


### PR DESCRIPTION
This patch makes meson not touch LD_LIBRARY_PATH in test environments if it was set or unset. This is useful for writing test cases that validate behaviour of or otherwise depend on LD_LIBRARY_PATH, e.g. for [mlibc](https://github.com/managarm/mlibc)'s RTLD.

I'm not sure if anything out there relies on LD_LIBRARY_PATH being prepended by meson AND manually sets LD_LIBRARY_PATH, this could affect such use cases.

This was shortly discussed on IRC.