### PR TITLE
interpreter: handle ExternalProgram commands in run_command

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -830,7 +830,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             elif isinstance(a, mesonlib.File):
                 expanded_args.append(a.absolute_path(srcdir, builddir))
             elif isinstance(a, ExternalProgram):
-                expanded_args.append(a.get_path())
+                expanded_args += a.command
             elif isinstance(a, compilers.Compiler):
                 FeatureNew.single_use('Compiler object as a variadic argument to `run_command`', '0.61.0', self.subproject, location=self.current_node)
                 prog = ExternalProgram(a.exelist[0], silent=True)


### PR DESCRIPTION
run_command() can take a list of parameters that will describe the command being run, and an ExternalProgram object can be provided here.

When setting up the ExternalProgram from a cross-file as a list, for instance:

        [binaries]
        rustc = ['rustc', '--target=arm-linux-androideabi']

The ExternalProgram.get_path() method will be used to prepare the run_command arguments, but it would return '--target=arm-androideabi' instead of the proper argument.

This commit ensures every part of the command is actually used in this case.