### PR TITLE
Add -parse-as-library to Swift library targets

### DIFF
--- a/docs/markdown/snippets/swift-parse-as-library.md
+++ b/docs/markdown/snippets/swift-parse-as-library.md
@@ -1,0 +1,8 @@
+## Top-level statement handling in Swift libraries
+
+The Swift compiler normally treats modules with a single source
+file (and files named main.swift) to run top-level code at program
+start. This emits a main symbol which is usually undesirable in a
+library target. Meson now automatically passes the *-parse-as-library*
+flag to the Swift compiler in case of single-file library targets to
+disable this behavior unless the source file is called main.swift.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2270,6 +2270,13 @@ class NinjaBackend(backends.Backend):
             compile_args += swiftc.get_cxx_interoperability_args(target.compilers)
         compile_args += self.build.get_project_args(swiftc, target.subproject, target.for_machine)
         compile_args += self.build.get_global_args(swiftc, target.for_machine)
+        if isinstance(target, (build.StaticLibrary, build.SharedLibrary)):
+            # swiftc treats modules with a single source file, and the main.swift file in multi-source file modules
+            # as top-level code. This is undesirable in library targets since it emits a main function. Add the
+            # -parse-as-library option as necessary to prevent emitting the main function while keeping files explicitly
+            # named main.swift treated as the entrypoint of the module in case this is desired.
+            if len(abssrc) == 1 and os.path.basename(abssrc[0]) != 'main.swift':
+                compile_args += swiftc.get_library_args()
         for i in reversed(target.get_include_dirs()):
             basedir = i.get_curdir()
             for d in i.get_incdirs():

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -159,6 +159,9 @@ class SwiftCompiler(Compiler):
         else:
             return ['-cxx-interoperability-mode=off']
 
+    def get_library_args(self) -> T.List[str]:
+        return ['-parse-as-library']
+
     def compute_parameters_with_absolute_paths(self, parameter_list: T.List[str],
                                                build_dir: str) -> T.List[str]:
         for idx, i in enumerate(parameter_list):

--- a/test cases/swift/14 single-file library/main.swift
+++ b/test cases/swift/14 single-file library/main.swift
@@ -1,0 +1,3 @@
+import SingleFile
+
+callMe()

--- a/test cases/swift/14 single-file library/meson.build
+++ b/test cases/swift/14 single-file library/meson.build
@@ -1,0 +1,4 @@
+project('single-file library', 'swift')
+
+lib = static_library('SingleFile', 'singlefile.swift')
+executable('program', 'main.swift', link_with: [lib])

--- a/test cases/swift/14 single-file library/singlefile.swift
+++ b/test cases/swift/14 single-file library/singlefile.swift
@@ -1,0 +1,1 @@
+public func callMe() {}

--- a/test cases/swift/15 main in single-file library/main.swift
+++ b/test cases/swift/15 main in single-file library/main.swift
@@ -1,0 +1,3 @@
+import CProgram
+
+precondition(callMe() == 4)

--- a/test cases/swift/15 main in single-file library/meson.build
+++ b/test cases/swift/15 main in single-file library/meson.build
@@ -1,0 +1,4 @@
+project('main in single-file library', 'swift', 'c')
+
+lib = static_library('Library', 'main.swift', include_directories: ['.'])
+executable('program', 'program.c', link_with: [lib])

--- a/test cases/swift/15 main in single-file library/module.modulemap
+++ b/test cases/swift/15 main in single-file library/module.modulemap
@@ -1,0 +1,3 @@
+module CProgram [extern_c] {
+  header "program.h"
+}

--- a/test cases/swift/15 main in single-file library/program.c
+++ b/test cases/swift/15 main in single-file library/program.c
@@ -1,0 +1,5 @@
+#include "program.h"
+
+int callMe() {
+    return 4;
+}

--- a/test cases/swift/15 main in single-file library/program.h
+++ b/test cases/swift/15 main in single-file library/program.h
@@ -1,0 +1,1 @@
+int callMe(void);

--- a/test cases/swift/16 main in multi-file library/main.swift
+++ b/test cases/swift/16 main in multi-file library/main.swift
@@ -1,0 +1,4 @@
+import CProgram
+
+precondition(callMe() == 4)
+precondition(callMe2() == 6)

--- a/test cases/swift/16 main in multi-file library/meson.build
+++ b/test cases/swift/16 main in multi-file library/meson.build
@@ -1,0 +1,4 @@
+project('main in multi-file library', 'swift', 'c')
+
+lib = static_library('Library', 'main.swift', 'more.swift', include_directories: ['.'])
+executable('program', 'program.c', link_with: [lib])

--- a/test cases/swift/16 main in multi-file library/module.modulemap
+++ b/test cases/swift/16 main in multi-file library/module.modulemap
@@ -1,0 +1,3 @@
+module CProgram [extern_c] {
+  header "program.h"
+}

--- a/test cases/swift/16 main in multi-file library/more.swift
+++ b/test cases/swift/16 main in multi-file library/more.swift
@@ -1,0 +1,3 @@
+func callMe2() -> Int {
+    6
+}

--- a/test cases/swift/16 main in multi-file library/program.c
+++ b/test cases/swift/16 main in multi-file library/program.c
@@ -1,0 +1,5 @@
+#include "program.h"
+
+int callMe() {
+    return 4;
+}

--- a/test cases/swift/16 main in multi-file library/program.h
+++ b/test cases/swift/16 main in multi-file library/program.h
@@ -1,0 +1,1 @@
+int callMe(void);

--- a/test cases/swift/8 extra args/lib.swift
+++ b/test cases/swift/8 extra args/lib.swift
@@ -1,0 +1,3 @@
+public func callMe() {
+    print("test")
+}

--- a/test cases/swift/8 extra args/main.swift
+++ b/test cases/swift/8 extra args/main.swift
@@ -1,1 +1,0 @@
-print("test")

--- a/test cases/swift/8 extra args/meson.build
+++ b/test cases/swift/8 extra args/meson.build
@@ -2,8 +2,8 @@ project('extra args', 'swift')
 
 trace_fname = 'trace.json'
 
-lib = static_library('main',
-  'main.swift',
+lib = static_library('lib',
+  'lib.swift',
   swift_args: [
     '-emit-loaded-module-trace',
     '-emit-loaded-module-trace-path', '../' + trace_fname


### PR DESCRIPTION
swiftc adds a main function consisting of top-level statements to objects generated by a swiftc invocation with a single input file, leading to duplicate symbols when linking the final executable (in case of a static library). This argument prevents this from happening, apply it to library targets automatically when the single file is not called main.swift (in order to preserve the behavior if wanted).