### PR TITLE
Rust: Update bindgen handling for changes in bindgen 0.71

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -1047,7 +1047,11 @@ def detect_rust_compiler(env: 'Environment', for_machine: MachineChoice) -> Rust
             popen_exceptions[join_args(compiler + arg)] = e
             continue
 
-        version = search_version(out)
+        # Full version contains the "-nightly" or "-beta" suffixes, but version
+        # should just be X.Y.Z
+        full_version = search_version(out)
+        version = full_version.split('-', 1)[0]
+
         cls: T.Type[RustCompiler] = rust.RustCompiler
 
         # Clippy is a wrapper around rustc, but it doesn't have rustc in its
@@ -1063,7 +1067,8 @@ def detect_rust_compiler(env: 'Environment', for_machine: MachineChoice) -> Rust
             except OSError as e:
                 popen_exceptions[join_args(compiler + arg)] = e
                 continue
-            version = search_version(out)
+            full_version = search_version(out)
+            version = full_version.split('-', 1)[0]
 
             cls = rust.ClippyRustCompiler
             mlog.deprecation(
@@ -1143,7 +1148,7 @@ def detect_rust_compiler(env: 'Environment', for_machine: MachineChoice) -> Rust
             env.coredata.add_lang_args(cls.language, cls, for_machine, env)
             return cls(
                 compiler, version, for_machine, is_cross, info,
-                linker=linker)
+                linker=linker, full_version=full_version)
 
     _handle_exceptions(popen_exceptions, compilers)
     raise EnvironmentException('Unreachable code (exception to make mypy happy)')

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -100,6 +100,8 @@ class RustCompiler(Compiler):
         if 'link' in self.linker.id:
             self.base_options.add(OptionKey('b_vscrt'))
         self.native_static_libs: T.List[str] = []
+        self.is_beta = '-beta' in full_version
+        self.is_nightly = '-nightly' in full_version
 
     def needs_static_linker(self) -> bool:
         return False

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright © 2020-2024 Intel Corporation
+# Copyright © 2020-2025 Intel Corporation
 
 from __future__ import annotations
 import itertools
@@ -259,9 +259,11 @@ class RustModule(ExtensionModule):
                 _, _, err = mesonlib.Popen_safe(
                     T.cast('T.List[str]', self._bindgen_bin.get_command()) +
                     ['--rust-target', self._bindgen_rust_target])
-                # Sometimes this is "invalid Rust target" and sometimes "invalid
-                # rust target"
-                if 'Got an invalid' in err:
+                # < 0.71: Sometimes this is "invalid Rust target" and
+                # sometimes "invalid # rust target"
+                # >= 0.71: error: invalid value '...' for '--rust-target <RUST_TARGET>': "..." is not a valid Rust target, accepted values are of the form ...
+                # It's also much harder to hit this in 0.71 than in previous versions
+                if 'Got an invalid' in err or 'is not a valid Rust target' in err:
                     self._bindgen_rust_target = None
 
         name: str

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -24,6 +24,7 @@ from ..programs import ExternalProgram
 if T.TYPE_CHECKING:
     from . import ModuleState
     from ..build import IncludeDirs, LibTypes
+    from ..compilers.rust import RustCompiler
     from ..dependencies import Dependency, ExternalLibrary
     from ..interpreter import Interpreter
     from ..interpreter import kwargs as _kwargs
@@ -58,12 +59,14 @@ class RustModule(ExtensionModule):
     """A module that holds helper functions for rust."""
 
     INFO = ModuleInfo('rust', '0.57.0', stabilized='1.0.0')
+    _bindgen_rust_target: T.Optional[str]
 
     def __init__(self, interpreter: Interpreter) -> None:
         super().__init__(interpreter)
         self._bindgen_bin: T.Optional[T.Union[ExternalProgram, Executable, OverrideProgram]] = None
         if 'rust' in interpreter.compilers.host:
-            self._bindgen_rust_target: T.Optional[str] = interpreter.compilers.host['rust'].version
+            rustc = T.cast('RustCompiler', interpreter.compilers.host['rust'])
+            self._bindgen_rust_target = 'nightly' if rustc.is_nightly else rustc.version
         else:
             self._bindgen_rust_target = None
         self._bindgen_set_std = False


### PR DESCRIPTION
This makes the following adjustments:
- update the error message check for an invalid --rust-version
- pass --rust-edition if the rust edition is not "none"
- pass --rust-verison=nightly if we have a nightly compiler

This also fixes a related bug where we don't strip suffixes from the rustc version from the short version. We fix this by setting the `full_version` with the suffix (something full_version is meant for), and just the `X.Y.Z` is in the `version`. We also store the nightly and beta information so we can make use of that elsewhere, like in the rust module.

Fixes: #14299
