### PR TITLE
Fixes issue 14089 (detection of Intel compiler)

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -497,10 +497,7 @@ class IntelClCCompiler(IntelVisualStudioLikeCompiler, VisualStudioLikeCCompilerM
     def get_options(self) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
         key = self.form_compileropt_key('std')
-        # To shut up mypy.
-        if isinstance(opts, dict):
-            raise RuntimeError('This is a transitory issue that should not happen. Please report with full backtrace.')
-        std_opt = opts.get_value_object(key)
+        std_opt = opts[key]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
         std_opt.set_versions(['c89', 'c99', 'c11'])
         return opts


### PR DESCRIPTION
For some reason, a change in https://github.com/mesonbuild/meson/commit/181c3499fde491650269c236ea639c92f10c6914 required `opts` to _not_ be a dict, while that seems to be exactly what it's supposed to be.

This fixes issue https://github.com/mesonbuild/meson/issues/14089