### PR TITLE
Cleanups after the option refactor

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -41,6 +41,7 @@ if T.TYPE_CHECKING:
     from ..interpreter import Interpreter, Test
     from ..linkers.linkers import StaticLinker
     from ..mesonlib import FileMode, FileOrString
+    from ..options import ElementaryOptionValues
 
     from typing_extensions import TypedDict, NotRequired
 
@@ -2105,7 +2106,7 @@ class Backend:
             return target.subproject != ''
         raise MesonException(f'Internal error: invalid option type for "unity": {val}')
 
-    def get_target_option(self, target: build.BuildTarget, name: T.Union[str, OptionKey]) -> T.Union[str, int, bool, T.List[str]]:
+    def get_target_option(self, target: build.BuildTarget, name: T.Union[str, OptionKey]) -> ElementaryOptionValues:
         if isinstance(name, str):
             key = OptionKey(name, subproject=target.subproject)
         elif isinstance(name, OptionKey):

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1419,7 +1419,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
                               env: Environment,
                               target: T.Optional[BuildTarget],
                               subproject: T.Optional[str] = None
-                              ) -> T.Union[str, int, bool, T.List[str]]:
+                              ) -> options.ElementaryOptionValues:
         if isinstance(key, str):
             key = self.form_compileropt_key(key)
         if target:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -26,7 +26,7 @@ from ..arglist import CompilerArgs
 if T.TYPE_CHECKING:
     from .. import coredata
     from ..build import BuildTarget, DFeatures
-    from ..coredata import MutableKeyedOptionDictType, KeyedOptionDictType
+    from ..coredata import MutableKeyedOptionDictType
     from ..envconfig import MachineInfo
     from ..environment import Environment
     from ..linkers import RSPFileSyntax
@@ -272,7 +272,7 @@ def option_enabled(boptions: T.Set[OptionKey],
         return False
 
 
-def get_option_value(options: 'KeyedOptionDictType', opt: OptionKey, fallback: '_T') -> '_T':
+def get_option_value(options: options.OptionStore, opt: OptionKey, fallback: '_T') -> '_T':
     """Get the value of an option, or the fallback value."""
     try:
         v: '_T' = options.get_value(opt) # type: ignore [assignment]

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -272,37 +272,11 @@ def option_enabled(boptions: T.Set[OptionKey],
         return False
 
 
-def get_option_value(options: options.OptionStore, opt: OptionKey, fallback: '_T') -> '_T':
-    """Get the value of an option, or the fallback value."""
-    try:
-        v: '_T' = options.get_value(opt) # type: ignore [assignment]
-    except (KeyError, AttributeError):
-        return fallback
-
-    assert isinstance(v, type(fallback)), f'Should have {type(fallback)!r} but was {type(v)!r}'
-    # Mypy doesn't understand that the above assert ensures that v is type _T
-    return v
-
 def get_option_value_for_target(env: 'Environment', target: 'BuildTarget', opt: OptionKey, fallback: '_T') -> '_T':
     """Get the value of an option, or the fallback value."""
     try:
         v = env.coredata.get_option_for_target(target, opt)
     except (KeyError, AttributeError):
-        return fallback
-
-    assert isinstance(v, type(fallback)), f'Should have {type(fallback)!r} but was {type(v)!r}'
-    # Mypy doesn't understand that the above assert ensures that v is type _T
-    return v
-
-
-def get_target_option_value(target: 'BuildTarget',
-                            env: 'Environment',
-                            opt: T.Union[OptionKey, str],
-                            fallback: '_T') -> '_T':
-    """Get the value of an option, or the fallback value."""
-    try:
-        v = env.coredata.get_option_for_target(target, opt)
-    except KeyError:
         return fallback
 
     assert isinstance(v, type(fallback)), f'Should have {type(fallback)!r} but was {type(v)!r}'

--- a/mesonbuild/compilers/mixins/islinker.py
+++ b/mesonbuild/compilers/mixins/islinker.py
@@ -16,10 +16,10 @@ import typing as T
 from ...mesonlib import EnvironmentException, MesonException, is_windows
 
 if T.TYPE_CHECKING:
-    from ...coredata import KeyedOptionDictType
     from ...environment import Environment
     from ...compilers.compilers import Compiler
     from ...build import BuildTarget
+    from ...options import OptionStore
 else:
     # This is a bit clever, for mypy we pretend that these mixins descend from
     # Compiler, so we get all of the methods and attributes defined for us, but
@@ -71,7 +71,7 @@ class BasicLinkerIsCompilerMixin(Compiler):
     def get_std_shared_lib_link_args(self) -> T.List[str]:
         return []
 
-    def get_std_shared_module_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+    def get_std_shared_module_args(self, options: OptionStore) -> T.List[str]:
         return self.get_std_shared_lib_link_args()
 
     def get_link_whole_for(self, args: T.List[str]) -> T.List[str]:

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -395,9 +395,6 @@ class CoreData:
     def get_option(self, key: OptionKey) -> ElementaryOptionValues:
         return self.optstore.get_value_for(key.name, key.subproject)
 
-    def get_option_object_for_target(self, target: 'BuildTarget', key: T.Union[str, OptionKey]) -> options.AnyOptionType:
-        return self.get_option_for_subproject(key, target.subproject)
-
     def get_option_for_target(self, target: 'BuildTarget', key: T.Union[str, OptionKey]) -> ElementaryOptionValues:
         if isinstance(key, str):
             assert ':' not in key
@@ -422,13 +419,6 @@ class CoreData:
             # This should be an error, fix before merging.
             key = key.evolve(subproject=subproject)
         return self.optstore.get_value_for(key)
-
-    def get_option_object_for_subproject(self, key: T.Union[str, OptionKey], subproject) -> options.AnyOptionType:
-        #keyname = key.name
-        if key.subproject != subproject:
-            # This should be an error, fix before merging.
-            key = key.evolve(subproject=subproject)
-        return self.optstore.get_value_object_for(key)
 
     def set_option(self, key: OptionKey, value, first_invocation: bool = False) -> bool:
         dirty = False

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2014-2016 The Meson development team
-# Copyright © 2023-2024 Intel Corporation
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 
@@ -190,7 +190,7 @@ class Conf:
                 items = [l[i] if l[i] else ' ' * four_column[i] for i in range(4)]
                 mlog.log(*items)
 
-    def split_options_per_subproject(self, options: T.Union[coredata.MutableKeyedOptionDictType, coredata.KeyedOptionDictType]) -> T.Dict[str, 'coredata.MutableKeyedOptionDictType']:
+    def split_options_per_subproject(self, options: T.Union[coredata.MutableKeyedOptionDictType, options.OptionStore]) -> T.Dict[str, 'coredata.MutableKeyedOptionDictType']:
         result: T.Dict[str, 'coredata.MutableKeyedOptionDictType'] = {}
         for k, o in options.items():
             if k.subproject:
@@ -228,7 +228,7 @@ class Conf:
         self._add_line(mlog.normal_yellow(section + ':'), '', '', '')
         self.print_margin = 2
 
-    def print_options(self, title: str, opts: T.Union[coredata.MutableKeyedOptionDictType, coredata.KeyedOptionDictType]) -> None:
+    def print_options(self, title: str, opts: T.Union[coredata.MutableKeyedOptionDictType, options.OptionStore]) -> None:
         if not opts:
             return
         if title:

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -304,7 +304,7 @@ def list_buildoptions(coredata: cdata.CoreData, subprojects: T.Optional[T.List[s
                 for s in subprojects:
                     core_options[k.evolve(subproject=s)] = v
 
-    def add_keys(opts: T.Union[cdata.MutableKeyedOptionDictType, cdata.KeyedOptionDictType], section: str) -> None:
+    def add_keys(opts: T.Union[cdata.MutableKeyedOptionDictType, options.OptionStore], section: str) -> None:
         for key, opt in sorted(opts.items()):
             optdict = {'name': str(key), 'value': opt.value, 'section': section,
                        'machine': key.machine.get_lower_case_name() if coredata.is_per_machine_option(key) else 'any'}

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -20,6 +20,7 @@ if T.TYPE_CHECKING:
     from ..interpreterbase import TYPE_var, TYPE_kwargs
     from ..programs import OverrideProgram
     from ..dependencies import Dependency
+    from ..options import ElementaryOptionValues
 
 class ModuleState:
     """Object passed to all module methods.
@@ -132,7 +133,7 @@ class ModuleState:
         self._interpreter.func_test(self.current_node, real_args, kwargs)
 
     def get_option(self, name: str, subproject: str = '',
-                   machine: MachineChoice = MachineChoice.HOST) -> T.Union[T.List[str], str, int, bool]:
+                   machine: MachineChoice = MachineChoice.HOST) -> ElementaryOptionValues:
         return self.environment.coredata.get_option(OptionKey(name, subproject, machine))
 
     def is_user_defined_option(self, name: str, subproject: str = '',

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -288,7 +288,7 @@ class UserOption(T.Generic[_T], HoldableObject):
     def listify(self, value: T.Any) -> T.List[T.Any]:
         return [value]
 
-    def printable_value(self) -> T.Union[str, int, bool, T.List[T.Union[str, int, bool]]]:
+    def printable_value(self) -> ElementaryOptionValues:
         assert isinstance(self.value, (str, int, bool, list))
         return self.value
 

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -50,8 +50,6 @@ if T.TYPE_CHECKING:
         default: str
         choices: T.List
 
-    OptionValueType: TypeAlias = T.Union[str, int, bool, T.List[str]]
-
 DEFAULT_YIELDING = False
 
 # Can't bind this near the class method it seems, sadly.
@@ -797,7 +795,7 @@ class OptionStore:
             key = key.evolve(machine=MachineChoice.HOST)
         return key
 
-    def get_value(self, key: T.Union[OptionKey, str]) -> 'OptionValueType':
+    def get_value(self, key: T.Union[OptionKey, str]) -> ElementaryOptionValues:
         return self.get_value_object(key).value
 
     def __len__(self) -> int:
@@ -833,7 +831,7 @@ class OptionStore:
                 return self.options[parent_key]
             return potential
 
-    def get_value_object_and_value_for(self, key: OptionKey) -> 'T.Tuple[AnyOptionType, OptionValueType]':
+    def get_value_object_and_value_for(self, key: OptionKey) -> T.Tuple[AnyOptionType, ElementaryOptionValues]:
         assert isinstance(key, OptionKey)
         vobject = self.get_value_object_for(key)
         computed_value = vobject.value
@@ -843,7 +841,7 @@ class OptionStore:
                 computed_value = vobject.validate_value(self.augments[keystr])
         return (vobject, computed_value)
 
-    def get_value_for(self, name: 'T.Union[OptionKey, str]', subproject: T.Optional[str] = None) -> 'OptionValueType':
+    def get_value_for(self, name: 'T.Union[OptionKey, str]', subproject: T.Optional[str] = None) -> ElementaryOptionValues:
         if isinstance(name, str):
             key = OptionKey(name, subproject)
         else:
@@ -1102,7 +1100,7 @@ class OptionStore:
         key = self.ensure_and_validate_key(key)
         return self.options[key]
 
-    def get_option_from_meson_file(self, key: OptionKey) -> 'T.Tuple[AnyOptionType, OptionValueType]':
+    def get_option_from_meson_file(self, key: OptionKey) -> T.Tuple[AnyOptionType, ElementaryOptionValues]:
         assert isinstance(key, OptionKey)
         (value_object, value) = self.get_value_object_and_value_for(key)
         return (value_object, value)

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -850,11 +850,6 @@ class OptionStore:
         vobject, resolved_value = self.get_value_object_and_value_for(key)
         return resolved_value
 
-    def num_options(self) -> int:
-        basic = len(self.options)
-        build = len(self.build_options) if self.build_options else 0
-        return basic + build
-
     def add_system_option(self, key: T.Union[OptionKey, str], valobj: AnyOptionType) -> None:
         key = self.ensure_and_validate_key(key)
         if '.' in key.name:

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -6,6 +6,12 @@ from mesonbuild.options import *
 import unittest
 
 
+def num_options(store: OptionStore) -> int:
+    basic = len(store.options)
+    build = len(store.build_options) if store.build_options else 0
+    return basic + build
+
+
 class OptionTests(unittest.TestCase):
 
     def test_basic(self):
@@ -64,11 +70,11 @@ class OptionTests(unittest.TestCase):
         vo = UserStringOption(name, 'An option set twice', original_value)
         optstore.add_system_option(name, vo)
         self.assertEqual(optstore.get_value_for(name), original_value)
-        self.assertEqual(optstore.num_options(), 1)
+        self.assertEqual(num_options(optstore), 1)
         vo2 = UserStringOption(name, 'An option set twice', reset_value)
         optstore.add_system_option(name, vo2)
         self.assertEqual(optstore.get_value_for(name), original_value)
-        self.assertEqual(optstore.num_options(), 1)
+        self.assertEqual(num_options(optstore), 1)
 
     def test_project_nonyielding(self):
         optstore = OptionStore(False)
@@ -78,12 +84,12 @@ class OptionTests(unittest.TestCase):
         vo = UserStringOption(name, 'A top level option', top_value, False)
         optstore.add_project_option(OptionKey(name, ''), vo)
         self.assertEqual(optstore.get_value_for(name, ''), top_value, False)
-        self.assertEqual(optstore.num_options(), 1)
+        self.assertEqual(num_options(optstore), 1)
         vo2 = UserStringOption(name, 'A subproject option', sub_value)
         optstore.add_project_option(OptionKey(name, 'sub'), vo2)
         self.assertEqual(optstore.get_value_for(name, ''), top_value)
         self.assertEqual(optstore.get_value_for(name, 'sub'), sub_value)
-        self.assertEqual(optstore.num_options(), 2)
+        self.assertEqual(num_options(optstore), 2)
 
     def test_project_yielding(self):
         optstore = OptionStore(False)
@@ -93,12 +99,12 @@ class OptionTests(unittest.TestCase):
         vo = UserStringOption(name, 'A top level option', top_value)
         optstore.add_project_option(OptionKey(name, ''), vo)
         self.assertEqual(optstore.get_value_for(name, ''), top_value)
-        self.assertEqual(optstore.num_options(), 1)
+        self.assertEqual(num_options(optstore), 1)
         vo2 = UserStringOption(name, 'A subproject option', sub_value, True)
         optstore.add_project_option(OptionKey(name, 'sub'), vo2)
         self.assertEqual(optstore.get_value_for(name, ''), top_value)
         self.assertEqual(optstore.get_value_for(name, 'sub'), top_value)
-        self.assertEqual(optstore.num_options(), 2)
+        self.assertEqual(num_options(optstore), 2)
 
     def test_project_yielding_not_defined_in_top_project(self):
         optstore = OptionStore(False)
@@ -109,12 +115,12 @@ class OptionTests(unittest.TestCase):
         vo = UserStringOption(top_name, 'A top level option', top_value)
         optstore.add_project_option(OptionKey(top_name, ''), vo)
         self.assertEqual(optstore.get_value_for(top_name, ''), top_value)
-        self.assertEqual(optstore.num_options(), 1)
+        self.assertEqual(num_options(optstore), 1)
         vo2 = UserStringOption(sub_name, 'A subproject option', sub_value, True)
         optstore.add_project_option(OptionKey(sub_name, 'sub'), vo2)
         self.assertEqual(optstore.get_value_for(top_name, ''), top_value)
         self.assertEqual(optstore.get_value_for(sub_name, 'sub'), sub_value)
-        self.assertEqual(optstore.num_options(), 2)
+        self.assertEqual(num_options(optstore), 2)
 
     def test_augments(self):
         optstore = OptionStore(False)


### PR DESCRIPTION
This is all pretty straight forward stuff I pulled out of other work I was doing. there's a few typing cleanups, some dead code removal and one case of moving a method that's only used in unittests to a helper function in the unittest module.