### PR TITLE
tests: work around broken PyPy globbing by removing inert code

### DIFF
--- a/test cases/python/4 custom target depends extmodule/blaster.py
+++ b/test cases/python/4 custom target depends extmodule/blaster.py
@@ -7,8 +7,7 @@ import argparse
 from pathlib import Path
 
 filedir = Path(os.path.dirname(__file__)).resolve()
-if list(filedir.glob('ext/*tachyon*')):
-    sys.path.insert(0, (filedir / 'ext').as_posix())
+sys.path.insert(0, (filedir / 'ext').as_posix())
 
 if hasattr(os, 'add_dll_directory'):
     os.add_dll_directory(filedir / 'ext' / 'lib')


### PR DESCRIPTION
We check to see if a test extension exists, and if so add its path to sys.path... immediately before unconditionally importing it, obviously.

This raises the question: why bother checking? Can it ever fail? What if it does fail, do we simply not add path entries and then expect the rest of the test file to work??? The whole thing seems silly and useless.

In fact it can fail, if the python interpreter and/or standard library is broken. This is the case for the initial release of PyPy 3.11, in which `'*tachyon*'` fails to glob correctly (and `'tachyon*'` would work, funnily enough -- this is valid too for our use case although still just as pointless).

Delete the useless check. It's technically correct to delete it, and it *also* works around the PyPy breakage as a bonus.

Closes: https://github.com/mesonbuild/meson/issues/14307