### PR TITLE
More robust handling of linker argument wrapping

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -454,6 +454,75 @@ class RunResult(HoldableObject):
     cached: bool = False
 
 
+class LinkerOptionStyle(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def wrap(self, group: T.List[str]) -> T.List[str]:
+        ...
+
+
+@dataclass
+class PrefixArgumentLinkerOptionStyle(LinkerOptionStyle):
+    """
+    Represents a linker option style where each linker argument is preceded by a separate argument representing
+    the compiler's pass-through option, like Clang: ['-Xlinker', 'arg1', '-Xlinker', 'arg2'] passes ['arg1', 'arg2'] to the
+    linker.
+    """
+
+    prefix_arg: str
+
+    def wrap(self, group: T.List[str]) -> T.List[str]:
+        return [compiler_arg for linker_arg in group for compiler_arg in [self.prefix_arg, linker_arg]]
+
+
+@dataclass
+class SimplePrefixLinkerOptionStyle(LinkerOptionStyle):
+    """
+    Represents a linker option style where each linker argument is prefixed with the compiler's pass-through
+    option as part of the same argument, like DMD: ['-L=arg1', '-L=arg2'] passes ['arg1', 'arg2'] to the linker.
+    """
+
+    prefix: str
+
+    def wrap(self, group: T.List[str]) -> T.List[str]:
+        return [self.prefix + linker_arg for linker_arg in group]
+
+
+class LinkerArgumentWrapException(MesonException):
+    pass
+
+
+@dataclass
+class ManyInOneLinkerOptionStyle(LinkerOptionStyle):
+    """
+    Represents a linker option style where multiple linker arguments are passed as a single argument to the
+    compiler combined with a prefix, like GCC: ['-Wl,arg1,arg2'] passes ['arg1', 'arg2'] to the linker.
+    """
+
+    prefix: str
+    separator: str
+
+    fallback: T.Optional[LinkerOptionStyle] = None
+
+    def wrap(self, group: T.List[str]) -> T.List[str]:
+        for el in group:
+            if self.separator not in el:
+                continue
+
+            if self.fallback is not None:
+                return self.fallback.wrap(group)
+
+            full = ''
+            if len(group) > 1:
+                full = f' (part of arguments list {group!r})'
+            stripped = f'{self.prefix}{el}'
+            raise LinkerArgumentWrapException(f'Cannot wrap linker argument {el!r}{full} for compiler interface: '
+                                              f'would result in {stripped!r}, which the compiler would interpret as '
+                                              f'multiple linker arguments since it treats {self.separator!r} as the '
+                                              'separator.')
+
+        return [self.prefix + self.separator.join(group)]
+
+
 @dataclass
 class CompileResult(HoldableObject):
 
@@ -476,7 +545,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
     # manually searched.
     internal_libs: T.List[str] = []
 
-    LINKER_PREFIX: T.Union[None, str, T.List[str]] = None
+    LINKER_PREFIX: T.Optional[LinkerOptionStyle] = None
 
     # If the compiler is used to fire a separate linking step, environment
     # variables like CFLAGS have to be passed to the linking step as well.

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -545,7 +545,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
     # manually searched.
     internal_libs: T.List[str] = []
 
-    LINKER_PREFIX: T.Optional[LinkerOptionStyle] = None
+    LINKER_OPTION_STYLE: T.Optional[LinkerOptionStyle] = None
 
     # If the compiler is used to fire a separate linking step, environment
     # variables like CFLAGS have to be passed to the linking step as well.

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -10,7 +10,7 @@ import typing as T
 
 from .. import options
 from ..mesonlib import is_windows, LibType, version_compare
-from .compilers import Compiler, CompileCheckMode, CrossNoRunException
+from .compilers import Compiler, CompileCheckMode, CrossNoRunException, SimplePrefixLinkerOptionStyle
 
 if T.TYPE_CHECKING:
     from ..build import BuildTarget
@@ -45,7 +45,7 @@ class Phase(enum.Enum):
 
 class CudaCompiler(Compiler):
 
-    LINKER_PREFIX = '-Xlinker='
+    LINKER_PREFIX = SimplePrefixLinkerOptionStyle('-Xlinker=')
     language = 'cuda'
 
     # NVCC flags taking no arguments.

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -45,7 +45,7 @@ class Phase(enum.Enum):
 
 class CudaCompiler(Compiler):
 
-    LINKER_PREFIX = SimplePrefixLinkerOptionStyle('-Xlinker=')
+    LINKER_OPTION_STYLE = SimplePrefixLinkerOptionStyle('-Xlinker=')
     language = 'cuda'
 
     # NVCC flags taking no arguments.

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -109,7 +109,7 @@ class DmdLikeCompilerMixin(CompilerMixinBase):
 
         def _get_target_arch_args(self) -> T.List[str]: ...
 
-    LINKER_PREFIX = SimplePrefixLinkerOptionStyle('-L=')
+    LINKER_OPTION_STYLE = SimplePrefixLinkerOptionStyle('-L=')
 
     def get_output_args(self, outputname: str) -> T.List[str]:
         return ['-of=' + outputname]
@@ -355,8 +355,8 @@ class DmdLikeCompilerMixin(CompilerMixinBase):
                         darwin_versions: T.Tuple[str, str]) -> T.List[str]:
         sargs = super().get_soname_args(prefix, shlib_name, suffix, soversion, darwin_versions)
 
-        if not all(arg.startswith(self.LINKER_PREFIX.prefix) for arg in sargs):
-            raise MesonBugException(f'Not all soname arguments for the D compiler start with {repr(self.LINKER_PREFIX.prefix)}: {sargs}')
+        if not all(arg.startswith(self.LINKER_OPTION_STYLE.prefix) for arg in sargs):
+            raise MesonBugException(f'Not all soname arguments for the D compiler start with {repr(self.LINKER_OPTION_STYLE.prefix)}: {sargs}')
 
         return sargs
 
@@ -569,8 +569,8 @@ class DCompiler(Compiler):
 
 class GnuDCompiler(GnuCompiler, DCompiler):
 
-    # we mostly want DCompiler, but that gives us the Compiler.LINKER_PREFIX instead
-    LINKER_PREFIX = GnuCompiler.LINKER_PREFIX
+    # we mostly want DCompiler, but that gives us the Compiler.LINKER_OPTION_STYLE instead
+    LINKER_OPTION_STYLE = GnuCompiler.LINKER_OPTION_STYLE
     id = 'gcc'
 
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice,

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -11,7 +11,7 @@ from .. import mesonlib
 from ..arglist import CompilerArgs
 from ..linkers import RSPFileSyntax
 from ..mesonlib import (
-    EnvironmentException, version_compare, is_windows
+    EnvironmentException, MesonBugException, version_compare, is_windows
 )
 from ..options import OptionKey
 
@@ -19,13 +19,14 @@ from .compilers import (
     clike_debug_args,
     Compiler,
     CompileCheckMode,
+    SimplePrefixLinkerOptionStyle,
 )
 from .mixins.gnu import GnuCompiler
 from .mixins.gnu import gnu_common_warning_args
 
 if T.TYPE_CHECKING:
     from . import compilers
-    from ..build import BuildTarget, DFeatures
+    from ..build import DFeatures
     from ..dependencies import Dependency
     from ..envconfig import MachineInfo
     from ..environment import Environment
@@ -108,7 +109,7 @@ class DmdLikeCompilerMixin(CompilerMixinBase):
 
         def _get_target_arch_args(self) -> T.List[str]: ...
 
-    LINKER_PREFIX = '-L='
+    LINKER_PREFIX = SimplePrefixLinkerOptionStyle('-L=')
 
     def get_output_args(self, outputname: str) -> T.List[str]:
         return ['-of=' + outputname]
@@ -173,32 +174,6 @@ class DmdLikeCompilerMixin(CompilerMixinBase):
 
     def gen_import_library_args(self, implibname: str) -> T.List[str]:
         return self.linker.import_library_args(implibname)
-
-    def build_rpath_args(self, build_dir: str, from_dir: str, target: BuildTarget,
-                         extra_paths: T.Optional[T.List[str]] = None
-                         ) -> T.Tuple[T.List[str], T.Set[bytes]]:
-        if self.info.is_windows():
-            return ([], set())
-
-        # GNU ld, solaris ld, and lld acting like GNU ld
-        if self.linker.id.startswith('ld'):
-            # The way that dmd and ldc pass rpath to gcc is different than we would
-            # do directly, each argument -rpath and the value to rpath, need to be
-            # split into two separate arguments both prefaced with the -L=.
-            args: T.List[str] = []
-            (rpath_args, rpath_dirs_to_remove) = super().build_rpath_args(
-                    build_dir, from_dir, target)
-            for r in rpath_args:
-                if ',' in r:
-                    a, b = r.split(',', maxsplit=1)
-                    args.append(a)
-                    args.append(self.LINKER_PREFIX + b)
-                else:
-                    args.append(r)
-            return (args, rpath_dirs_to_remove)
-
-        return super().build_rpath_args(
-            build_dir, from_dir, target)
 
     @classmethod
     def _translate_args_to_nongnu(cls, args: T.List[str], info: MachineInfo, link_id: str) -> T.List[str]:
@@ -380,24 +355,10 @@ class DmdLikeCompilerMixin(CompilerMixinBase):
                         darwin_versions: T.Tuple[str, str]) -> T.List[str]:
         sargs = super().get_soname_args(prefix, shlib_name, suffix, soversion, darwin_versions)
 
-        # LDC and DMD actually do use a linker, but they proxy all of that with
-        # their own arguments
-        soargs: T.List[str] = []
-        if self.linker.id.startswith('ld.'):
-            for arg in sargs:
-                a, b = arg.split(',', maxsplit=1)
-                soargs.append(a)
-                soargs.append(self.LINKER_PREFIX + b)
-            return soargs
-        elif self.linker.id.startswith('ld64'):
-            for arg in sargs:
-                if not arg.startswith(self.LINKER_PREFIX):
-                    soargs.append(self.LINKER_PREFIX + arg)
-                else:
-                    soargs.append(arg)
-            return soargs
-        else:
-            return sargs
+        if not all(arg.startswith(self.LINKER_PREFIX.prefix) for arg in sargs):
+            raise MesonBugException(f'Not all soname arguments for the D compiler start with {repr(self.LINKER_PREFIX.prefix)}: {sargs}')
+
+        return sargs
 
     def get_allow_undefined_link_args(self) -> T.List[str]:
         args = self.linker.get_allow_undefined_args()

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -385,7 +385,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
             # linker. It'll exit with an error code, but still print the
             # linker version.
             with tempfile.NamedTemporaryFile(suffix='.c') as f:
-                cmd = compiler + [cls.LINKER_PREFIX + "--version", f.name]
+                cmd = [*compiler, *cls.LINKER_PREFIX.wrap(['--version']), f.name]
                 _, o, _ = Popen_safe(cmd)
 
             linker = linkers.WASMDynamicLinker(

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -385,11 +385,11 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
             # linker. It'll exit with an error code, but still print the
             # linker version.
             with tempfile.NamedTemporaryFile(suffix='.c') as f:
-                cmd = [*compiler, *cls.LINKER_PREFIX.wrap(['--version']), f.name]
+                cmd = [*compiler, *cls.LINKER_OPTION_STYLE.wrap(['--version']), f.name]
                 _, o, _ = Popen_safe(cmd)
 
             linker = linkers.WASMDynamicLinker(
-                compiler, env, for_machine, cls.LINKER_PREFIX,
+                compiler, env, for_machine, cls.LINKER_OPTION_STYLE,
                 [], version=search_version(o))
             return cls(
                 ccache, compiler, version, for_machine, env,
@@ -541,14 +541,14 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
         if 'PGI Compilers' in out:
             cls = c.PGICCompiler if lang == 'c' else cpp.PGICPPCompiler
             env.add_lang_args(cls.language, cls, for_machine)
-            linker = linkers.PGIDynamicLinker(compiler, env, for_machine, cls.LINKER_PREFIX, [], version=version)
+            linker = linkers.PGIDynamicLinker(compiler, env, for_machine, cls.LINKER_OPTION_STYLE, [], version=version)
             return cls(
                 ccache, compiler, version, for_machine,
                 env, linker=linker)
         if 'NVIDIA Compilers and Tools' in out:
             cls = c.NvidiaHPC_CCompiler if lang == 'c' else cpp.NvidiaHPC_CPPCompiler
             env.add_lang_args(cls.language, cls, for_machine)
-            linker = linkers.NvidiaHPC_DynamicLinker(compiler, env, for_machine, cls.LINKER_PREFIX, [], version=version)
+            linker = linkers.NvidiaHPC_DynamicLinker(compiler, env, for_machine, cls.LINKER_OPTION_STYLE, [], version=version)
             return cls(
                 ccache, compiler, version, for_machine,
                 env, linker=linker)
@@ -593,7 +593,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
                 cls.gcc_version = _get_gnu_version_from_defines(defines)
 
                 env.add_lang_args(cls.language, cls, for_machine)
-                linker = linkers.Xc32DynamicLinker(compiler, env, for_machine, cls.LINKER_PREFIX, [], version=version)
+                linker = linkers.Xc32DynamicLinker(compiler, env, for_machine, cls.LINKER_OPTION_STYLE, [], version=version)
 
                 return cls(
                     ccache, compiler, version, for_machine,
@@ -718,7 +718,7 @@ def detect_cuda_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
             val = env.options[key]
             assert isinstance(val, list)
             env.coredata.optstore.set_option(key, cls.to_host_flags_base(val, Phase.LINKER))
-        linker = CudaLinker(compiler, env, for_machine, CudaCompiler.LINKER_PREFIX, [], version=CudaLinker.parse_version())
+        linker = CudaLinker(compiler, env, for_machine, CudaCompiler.LINKER_OPTION_STYLE, [], version=CudaLinker.parse_version())
         return cls(ccache, compiler, version, for_machine, cpp_compiler, env, linker=linker)
 
     _handle_exceptions(popen_exceptions, compilers)
@@ -843,7 +843,7 @@ def detect_fortran_compiler(env: 'Environment', for_machine: MachineChoice) -> C
                 cls = fortran.PGIFortranCompiler
                 env.add_lang_args(cls.language, cls, for_machine)
                 linker = linkers.PGIDynamicLinker(compiler, env, for_machine,
-                                                  cls.LINKER_PREFIX, [], version=version)
+                                                  cls.LINKER_OPTION_STYLE, [], version=version)
                 return cls(
                     compiler, version, for_machine, env,
                     full_version=full_version, linker=linker)
@@ -852,7 +852,7 @@ def detect_fortran_compiler(env: 'Environment', for_machine: MachineChoice) -> C
                 cls = fortran.NvidiaHPC_FortranCompiler
                 env.add_lang_args(cls.language, cls, for_machine)
                 linker = linkers.PGIDynamicLinker(compiler, env, for_machine,
-                                                  cls.LINKER_PREFIX, [], version=version)
+                                                  cls.LINKER_OPTION_STYLE, [], version=version)
                 return cls(
                     compiler, version, for_machine, env,
                     full_version=full_version, linker=linker)
@@ -903,7 +903,7 @@ def detect_fortran_compiler(env: 'Environment', for_machine: MachineChoice) -> C
                 cls = fortran.NAGFortranCompiler
                 env.add_lang_args(cls.language, cls, for_machine)
                 linker = linkers.NAGDynamicLinker(
-                    compiler, env, for_machine, cls.LINKER_PREFIX, [],
+                    compiler, env, for_machine, cls.LINKER_OPTION_STYLE, [],
                     version=version)
                 return cls(
                     compiler, version, for_machine, env,
@@ -1163,13 +1163,13 @@ def detect_rust_compiler(env: 'Environment', for_machine: MachineChoice) -> Rust
                         exelist=exelist, version=cc.linker.version,
                         direct=True, machine=cc.linker.machine)
                 else:
-                    linker = type(cc.linker)(exelist, env, for_machine, cc.LINKER_PREFIX,
+                    linker = type(cc.linker)(exelist, env, for_machine, cc.LINKER_OPTION_STYLE,
                                              always_args=[], system=cc.linker.system,
                                              version=cc.linker.version)
                     exelist += cc.linker.get_always_args()
             elif 'link' in override[0]:
                 linker = guess_win_linker(env,
-                                          override, cls, version, for_machine, use_linker_prefix=False)
+                                          override, cls, version, for_machine, wrap_linker_args=False)
                 # rustc takes linker arguments without a prefix, and
                 # inserts the correct prefix itself.
                 assert isinstance(linker, linkers.VisualStudioLikeLinkerMixin)
@@ -1254,7 +1254,7 @@ def detect_d_compiler(env: 'Environment', for_machine: MachineChoice) -> Compile
                     linker = guess_win_linker(env,
                                               exelist,
                                               cls, full_version, for_machine,
-                                              use_linker_prefix=True, invoked_directly=False,
+                                              wrap_linker_args=True, invoked_directly=False,
                                               extra_args=extra_args)
                 else:
                     # LDC writes an object file to the current working directory.

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -14,6 +14,7 @@ from .compilers import (
     clike_debug_args,
     Compiler,
     CompileCheckMode,
+    ManyInOneLinkerOptionStyle,
 )
 from .mixins.clike import CLikeCompiler
 from .mixins.gnu import GnuCompiler,  gnu_optimization_args
@@ -346,7 +347,7 @@ class ElbrusFortranCompiler(ElbrusCompiler, FortranCompiler):
 
 class G95FortranCompiler(FortranCompiler):
 
-    LINKER_PREFIX = '-Wl,'
+    LINKER_PREFIX = ManyInOneLinkerOptionStyle('-Wl,', ',')
     id = 'g95'
 
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice,
@@ -367,7 +368,7 @@ class G95FortranCompiler(FortranCompiler):
 
 class SunFortranCompiler(FortranCompiler):
 
-    LINKER_PREFIX = '-Wl,'
+    LINKER_PREFIX = ManyInOneLinkerOptionStyle('-Wl,', ',')
     id = 'sun'
 
     def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -347,7 +347,7 @@ class ElbrusFortranCompiler(ElbrusCompiler, FortranCompiler):
 
 class G95FortranCompiler(FortranCompiler):
 
-    LINKER_PREFIX = ManyInOneLinkerOptionStyle('-Wl,', ',')
+    LINKER_OPTION_STYLE = ManyInOneLinkerOptionStyle('-Wl,', ',')
     id = 'g95'
 
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice,
@@ -368,7 +368,7 @@ class G95FortranCompiler(FortranCompiler):
 
 class SunFortranCompiler(FortranCompiler):
 
-    LINKER_PREFIX = ManyInOneLinkerOptionStyle('-Wl,', ',')
+    LINKER_OPTION_STYLE = ManyInOneLinkerOptionStyle('-Wl,', ',')
     id = 'sun'
 
     def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -356,8 +356,8 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
     that the actual concrete subclass define their own implementation.
     """
 
-    LINKER_PREFIX = ManyInOneLinkerOptionStyle('-Wl,', ',',
-                                               fallback=PrefixArgumentLinkerOptionStyle('-Xlinker'))
+    LINKER_OPTION_STYLE = ManyInOneLinkerOptionStyle('-Wl,', ',',
+                                                     fallback=PrefixArgumentLinkerOptionStyle('-Xlinker'))
 
     def __init__(self) -> None:
         self.base_options = {

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -17,7 +17,7 @@ import typing as T
 from ... import mesonlib
 from ... import mlog
 from ...options import OptionKey, UserStdOption
-from mesonbuild.compilers.compilers import CompileCheckMode
+from mesonbuild.compilers.compilers import CompileCheckMode, ManyInOneLinkerOptionStyle
 
 if T.TYPE_CHECKING:
     from ..._typing import ImmutableListProtocol
@@ -356,7 +356,7 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
     that the actual concrete subclass define their own implementation.
     """
 
-    LINKER_PREFIX = '-Wl,'
+    LINKER_PREFIX = ManyInOneLinkerOptionStyle('-Wl,', ',')
 
     def __init__(self) -> None:
         self.base_options = {

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -17,7 +17,7 @@ import typing as T
 from ... import mesonlib
 from ... import mlog
 from ...options import OptionKey, UserStdOption
-from mesonbuild.compilers.compilers import CompileCheckMode, ManyInOneLinkerOptionStyle
+from mesonbuild.compilers.compilers import CompileCheckMode, ManyInOneLinkerOptionStyle, PrefixArgumentLinkerOptionStyle
 
 if T.TYPE_CHECKING:
     from ..._typing import ImmutableListProtocol
@@ -356,7 +356,8 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
     that the actual concrete subclass define their own implementation.
     """
 
-    LINKER_PREFIX = ManyInOneLinkerOptionStyle('-Wl,', ',')
+    LINKER_PREFIX = ManyInOneLinkerOptionStyle('-Wl,', ',',
+                                               fallback=PrefixArgumentLinkerOptionStyle('-Xlinker'))
 
     def __init__(self) -> None:
         self.base_options = {

--- a/mesonbuild/compilers/mixins/tasking.py
+++ b/mesonbuild/compilers/mixins/tasking.py
@@ -49,7 +49,7 @@ class TaskingCompiler(Compiler):
     Functionality that is common to all TASKING family compilers.
     '''
 
-    LINKER_PREFIX = SimplePrefixLinkerOptionStyle('-Wl')
+    LINKER_OPTION_STYLE = SimplePrefixLinkerOptionStyle('-Wl')
 
     def __init__(self) -> None:
         if not self.is_cross:

--- a/mesonbuild/compilers/mixins/tasking.py
+++ b/mesonbuild/compilers/mixins/tasking.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import os
 import typing as T
 
+from ...compilers.compilers import SimplePrefixLinkerOptionStyle
 from ...mesonlib import EnvironmentException
 from ...options import OptionKey
 
@@ -48,7 +49,7 @@ class TaskingCompiler(Compiler):
     Functionality that is common to all TASKING family compilers.
     '''
 
-    LINKER_PREFIX = '-Wl'
+    LINKER_PREFIX = SimplePrefixLinkerOptionStyle('-Wl')
 
     def __init__(self) -> None:
         if not self.is_cross:

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -114,7 +114,7 @@ class RustSystemDependency(InternalDependency):
 
 class RustCompiler(Compiler):
 
-    # rustc doesn't invoke the compiler itself, it doesn't need a LINKER_PREFIX
+    # rustc doesn't invoke the compiler itself, it doesn't need a LINKER_OPTION_STYLE
     language = 'rust'
     id = 'rustc'
 

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -32,7 +32,7 @@ swift_optimization_args: T.Dict[str, T.List[str]] = {
 
 class SwiftCompiler(Compiler):
 
-    LINKER_PREFIX = PrefixArgumentLinkerOptionStyle('-Xlinker')
+    LINKER_OPTION_STYLE = PrefixArgumentLinkerOptionStyle('-Xlinker')
     language = 'swift'
     id = 'llvm'
 

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -9,7 +9,7 @@ import typing as T
 
 from .. import mlog, options
 from ..mesonlib import first, MesonException, version_compare
-from .compilers import Compiler, clike_debug_args
+from .compilers import Compiler, clike_debug_args, PrefixArgumentLinkerOptionStyle
 
 if T.TYPE_CHECKING:
     from .. import build
@@ -32,7 +32,7 @@ swift_optimization_args: T.Dict[str, T.List[str]] = {
 
 class SwiftCompiler(Compiler):
 
-    LINKER_PREFIX = ['-Xlinker']
+    LINKER_PREFIX = PrefixArgumentLinkerOptionStyle('-Xlinker')
     language = 'swift'
     id = 'llvm'
 

--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -37,7 +37,7 @@ def __failed_to_detect_linker(compiler: T.List[str], args: T.List[str], stdout: 
 
 def guess_win_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Type['Compiler'],
                      comp_version: str, for_machine: MachineChoice, *,
-                     use_linker_prefix: bool = True, invoked_directly: bool = True,
+                     wrap_linker_args: bool = True, invoked_directly: bool = True,
                      extra_args: T.Optional[T.List[str]] = None) -> 'DynamicLinker':
     from . import linkers
     env.add_lang_args(comp_class.language, comp_class, for_machine)
@@ -48,10 +48,10 @@ def guess_win_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
         rsp_syntax = RSPFileSyntax.GCC
 
     # Explicitly pass logo here so that we can get the version of link.exe
-    if not use_linker_prefix or comp_class.LINKER_PREFIX is None:
+    if not wrap_linker_args or comp_class.LINKER_OPTION_STYLE is None:
         check_args = ['/logo', '--version']
     else:
-        check_args = comp_class.LINKER_PREFIX.wrap(['/logo', '--version'])
+        check_args = comp_class.LINKER_OPTION_STYLE.wrap(['/logo', '--version'])
 
     check_args += env.coredata.get_external_link_args(for_machine, comp_class.language)
 
@@ -74,16 +74,16 @@ def guess_win_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
     if 'LLD' in o.split('\n', maxsplit=1)[0]:
         if 'compatible with GNU linkers' in o:
             return linkers.LLVMDynamicLinker(
-                compiler, env, for_machine, comp_class.LINKER_PREFIX,
+                compiler, env, for_machine, comp_class.LINKER_OPTION_STYLE,
                 override, version=search_version(o))
         if not invoked_directly:
             return linkers.ClangClDynamicLinker(
-                env, for_machine, override, exelist=compiler, prefix=comp_class.LINKER_PREFIX,
+                env, for_machine, override, exelist=compiler, prefix=comp_class.LINKER_OPTION_STYLE,
                 version=search_version(o), direct=False, machine=None,
                 rsp_syntax=rsp_syntax)
         return linkers.ClangClDynamicLinker(
             env, for_machine, [],
-            prefix=comp_class.LINKER_PREFIX if use_linker_prefix else None,
+            prefix=comp_class.LINKER_OPTION_STYLE if wrap_linker_args else None,
             exelist=compiler, version=search_version(o), direct=invoked_directly,
             rsp_syntax=rsp_syntax)
     elif 'OPTLINK' in o:
@@ -99,7 +99,7 @@ def guess_win_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
 
         return linkers.MSVCDynamicLinker(
             env, for_machine, [], machine=target, exelist=compiler,
-            prefix=comp_class.LINKER_PREFIX if use_linker_prefix else None,
+            prefix=comp_class.LINKER_OPTION_STYLE if wrap_linker_args else None,
             version=search_version(out), direct=invoked_directly,
             rsp_syntax=rsp_syntax)
     elif 'GNU coreutils' in o:
@@ -130,7 +130,7 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
     system = env.machines[for_machine].system
     ldflags = env.coredata.get_external_link_args(for_machine, comp_class.language)
     extra_args += comp_class._unix_args_to_native(ldflags, env.machines[for_machine])
-    check_args = comp_class.LINKER_PREFIX.wrap(['--version']) + extra_args
+    check_args = comp_class.LINKER_OPTION_STYLE.wrap(['--version']) + extra_args
 
     override: T.List[str] = []
     value = env.lookup_binary_entry(for_machine, comp_class.language + '_ld')
@@ -147,7 +147,7 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
     v = search_version(o + e)
     linker: DynamicLinker
     if 'LLD' in o.split('\n', maxsplit=1)[0] or 'tiarmlnk' in e:
-        cmd = compiler + override + comp_class.LINKER_PREFIX.wrap(['-v']) + extra_args
+        cmd = compiler + override + comp_class.LINKER_OPTION_STYLE.wrap(['-v']) + extra_args
         _, newo, newerr = Popen_safe_logged(cmd, msg='Detecting LLD linker via')
 
         lld_cls: T.Type[DynamicLinker]
@@ -157,13 +157,13 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
             lld_cls = linkers.LLVMDynamicLinker
 
         linker = lld_cls(
-            compiler, env, for_machine, comp_class.LINKER_PREFIX, override, system=system, version=v)
+            compiler, env, for_machine, comp_class.LINKER_OPTION_STYLE, override, system=system, version=v)
     elif o.startswith("eld"):
         linker = linkers.ELDDynamicLinker(
-            compiler, env, for_machine, comp_class.LINKER_PREFIX, override, version=v)
+            compiler, env, for_machine, comp_class.LINKER_OPTION_STYLE, override, version=v)
     elif 'Snapdragon' in e and 'LLVM' in e:
         linker = linkers.QualcommLLVMDynamicLinker(
-            compiler, env, for_machine, comp_class.LINKER_PREFIX, override, version=v)
+            compiler, env, for_machine, comp_class.LINKER_OPTION_STYLE, override, version=v)
     elif e.startswith('lld-link: '):
         # The LLD MinGW frontend didn't respond to --version before version 9.0.0,
         # and produced an error message about failing to link (when no object
@@ -181,7 +181,7 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
             _, o, e = Popen_safe([linker_cmd, '--version'])
             v = search_version(o)
 
-        linker = linkers.LLVMDynamicLinker(compiler, env, for_machine, comp_class.LINKER_PREFIX, override, version=v)
+        linker = linkers.LLVMDynamicLinker(compiler, env, for_machine, comp_class.LINKER_OPTION_STYLE, override, version=v)
     elif 'GNU' in o or 'GNU' in e:
         gnu_cls: T.Type[GnuDynamicLinker]
         # this is always the only thing on stdout, except for swift
@@ -192,7 +192,7 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
             gnu_cls = linkers.MoldDynamicLinker
         else:
             gnu_cls = linkers.GnuBFDDynamicLinker
-        linker = gnu_cls(compiler, env, for_machine, comp_class.LINKER_PREFIX, override, version=v)
+        linker = gnu_cls(compiler, env, for_machine, comp_class.LINKER_OPTION_STYLE, override, version=v)
     elif 'Solaris' in e or 'Solaris' in o:
         for line in (o+e).split('\n'):
             if 'ld: Software Generation Utilities' in line:
@@ -201,22 +201,22 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
         else:
             v = 'unknown version'
         linker = linkers.SolarisDynamicLinker(
-            compiler, env, for_machine, comp_class.LINKER_PREFIX, override,
+            compiler, env, for_machine, comp_class.LINKER_OPTION_STYLE, override,
             version=v)
     elif 'ld: 0706-012 The -- flag is not recognized' in e:
-        _, _, e = Popen_safe(compiler + comp_class.LINKER_PREFIX.wrap(['-V']) + extra_args)
+        _, _, e = Popen_safe(compiler + comp_class.LINKER_OPTION_STYLE.wrap(['-V']) + extra_args)
         linker = linkers.AIXDynamicLinker(
-            compiler, env, for_machine, comp_class.LINKER_PREFIX, override,
+            compiler, env, for_machine, comp_class.LINKER_OPTION_STYLE, override,
             version=search_version(e))
     elif o.startswith('zig ld'):
         linker = linkers.ZigCCDynamicLinker(
-            compiler, env, for_machine, comp_class.LINKER_PREFIX, override, version=v)
+            compiler, env, for_machine, comp_class.LINKER_OPTION_STYLE, override, version=v)
     # detect xtools first, bug #10805
     elif 'xtools-' in o.split('\n', maxsplit=1)[0]:
         xtools = o.split(' ', maxsplit=1)[0]
         v = xtools.split('-', maxsplit=2)[1]
         linker = linkers.AppleDynamicLinker(
-            compiler, env, for_machine, comp_class.LINKER_PREFIX, override,
+            compiler, env, for_machine, comp_class.LINKER_OPTION_STYLE, override,
             system=system, version=v
         )
     # detect linker on MacOS - must be after other platforms because the
@@ -225,7 +225,7 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
     # First might be apple clang, second is for real gcc, the third is icc.
     # Note that "ld: unknown option: " sometimes instead is "ld: unknown options:".
     elif e.endswith('(use -v to see invocation)\n') or 'macosx_version' in e or 'ld: unknown option' in e:
-        cmd = compiler + comp_class.LINKER_PREFIX.wrap(['-v']) + extra_args
+        cmd = compiler + comp_class.LINKER_OPTION_STYLE.wrap(['-v']) + extra_args
         _, newo, newerr = Popen_safe_logged(cmd, msg='Detecting Apple linker via')
 
         for line in newerr.split('\n'):
@@ -235,16 +235,16 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
         else:
             __failed_to_detect_linker(compiler, check_args, o, e)
         linker = linkers.AppleDynamicLinker(
-            compiler, env, for_machine, comp_class.LINKER_PREFIX, override,
+            compiler, env, for_machine, comp_class.LINKER_OPTION_STYLE, override,
             system=system, version=v
         )
     elif 'ld.exe: unrecognized option' in e or 'ld: unrecognized option' in e:
         linker = linkers.OS2AoutDynamicLinker(
-            compiler, env, for_machine, comp_class.LINKER_PREFIX, override,
+            compiler, env, for_machine, comp_class.LINKER_OPTION_STYLE, override,
             version='none')
     elif 'emxomfld: invalid option' in e:
         linker = linkers.OS2OmfDynamicLinker(
-            compiler, env, for_machine, comp_class.LINKER_PREFIX, override,
+            compiler, env, for_machine, comp_class.LINKER_OPTION_STYLE, override,
             version='none')
     else:
         __failed_to_detect_linker(compiler, check_args, o, e)

--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -50,10 +50,8 @@ def guess_win_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
     # Explicitly pass logo here so that we can get the version of link.exe
     if not use_linker_prefix or comp_class.LINKER_PREFIX is None:
         check_args = ['/logo', '--version']
-    elif isinstance(comp_class.LINKER_PREFIX, str):
-        check_args = [comp_class.LINKER_PREFIX + '/logo', comp_class.LINKER_PREFIX + '--version']
-    else: # list
-        check_args = comp_class.LINKER_PREFIX + ['/logo'] + comp_class.LINKER_PREFIX + ['--version']
+    else:
+        check_args = comp_class.LINKER_PREFIX.wrap(['/logo', '--version'])
 
     check_args += env.coredata.get_external_link_args(for_machine, comp_class.language)
 
@@ -85,7 +83,7 @@ def guess_win_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
                 rsp_syntax=rsp_syntax)
         return linkers.ClangClDynamicLinker(
             env, for_machine, [],
-            prefix=comp_class.LINKER_PREFIX if use_linker_prefix else [],
+            prefix=comp_class.LINKER_PREFIX if use_linker_prefix else None,
             exelist=compiler, version=search_version(o), direct=invoked_directly,
             rsp_syntax=rsp_syntax)
     elif 'OPTLINK' in o:
@@ -101,7 +99,7 @@ def guess_win_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
 
         return linkers.MSVCDynamicLinker(
             env, for_machine, [], machine=target, exelist=compiler,
-            prefix=comp_class.LINKER_PREFIX if use_linker_prefix else [],
+            prefix=comp_class.LINKER_PREFIX if use_linker_prefix else None,
             version=search_version(out), direct=invoked_directly,
             rsp_syntax=rsp_syntax)
     elif 'GNU coreutils' in o:
@@ -132,11 +130,7 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
     system = env.machines[for_machine].system
     ldflags = env.coredata.get_external_link_args(for_machine, comp_class.language)
     extra_args += comp_class._unix_args_to_native(ldflags, env.machines[for_machine])
-
-    if isinstance(comp_class.LINKER_PREFIX, str):
-        check_args = [comp_class.LINKER_PREFIX + '--version'] + extra_args
-    else:
-        check_args = comp_class.LINKER_PREFIX + ['--version'] + extra_args
+    check_args = comp_class.LINKER_PREFIX.wrap(['--version']) + extra_args
 
     override: T.List[str] = []
     value = env.lookup_binary_entry(for_machine, comp_class.language + '_ld')
@@ -153,10 +147,7 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
     v = search_version(o + e)
     linker: DynamicLinker
     if 'LLD' in o.split('\n', maxsplit=1)[0] or 'tiarmlnk' in e:
-        if isinstance(comp_class.LINKER_PREFIX, str):
-            cmd = compiler + override + [comp_class.LINKER_PREFIX + '-v'] + extra_args
-        else:
-            cmd = compiler + override + comp_class.LINKER_PREFIX + ['-v'] + extra_args
+        cmd = compiler + override + comp_class.LINKER_PREFIX.wrap(['-v']) + extra_args
         _, newo, newerr = Popen_safe_logged(cmd, msg='Detecting LLD linker via')
 
         lld_cls: T.Type[DynamicLinker]
@@ -213,10 +204,7 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
             compiler, env, for_machine, comp_class.LINKER_PREFIX, override,
             version=v)
     elif 'ld: 0706-012 The -- flag is not recognized' in e:
-        if isinstance(comp_class.LINKER_PREFIX, str):
-            _, _, e = Popen_safe(compiler + [comp_class.LINKER_PREFIX + '-V'] + extra_args)
-        else:
-            _, _, e = Popen_safe(compiler + comp_class.LINKER_PREFIX + ['-V'] + extra_args)
+        _, _, e = Popen_safe(compiler + comp_class.LINKER_PREFIX.wrap(['-V']) + extra_args)
         linker = linkers.AIXDynamicLinker(
             compiler, env, for_machine, comp_class.LINKER_PREFIX, override,
             version=search_version(e))
@@ -237,10 +225,7 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
     # First might be apple clang, second is for real gcc, the third is icc.
     # Note that "ld: unknown option: " sometimes instead is "ld: unknown options:".
     elif e.endswith('(use -v to see invocation)\n') or 'macosx_version' in e or 'ld: unknown option' in e:
-        if isinstance(comp_class.LINKER_PREFIX, str):
-            cmd = compiler + [comp_class.LINKER_PREFIX + '-v'] + extra_args
-        else:
-            cmd = compiler + comp_class.LINKER_PREFIX + ['-v'] + extra_args
+        cmd = compiler + comp_class.LINKER_PREFIX.wrap(['-v']) + extra_args
         _, newo, newerr = Popen_safe_logged(cmd, msg='Detecting Apple linker via')
 
         for line in newerr.split('\n'):

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -1786,7 +1786,7 @@ class CudaLinker(PosixDynamicLinkerMixin, DynamicLinker):
         #   nvcc fatal : Don't know what to do with 'subprojects/foo/libbar.so.0.1.2'
         #
         from ..compilers.cuda import CudaCompiler
-        return CudaCompiler.LINKER_PREFIX.prefix
+        return CudaCompiler.LINKER_OPTION_STYLE.prefix
 
     def fatal_warnings(self) -> T.List[str]:
         return ['--warning-as-error']

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -19,6 +19,7 @@ if T.TYPE_CHECKING:
     from ..mesonlib import MachineChoice
     from ..build import BuildTarget
     from ..compilers import Compiler
+    from ..compilers.compilers import LinkerOptionStyle
 
 
 class StaticLinker:
@@ -132,19 +133,16 @@ class DynamicLinker(metaclass=abc.ABCMeta):
     def id(self) -> str:
         pass
 
-    def _apply_prefix(self, arg: T.Union[str, T.List[str]]) -> T.List[str]:
-        args = [arg] if isinstance(arg, str) else arg
+    def _apply_prefix(self, *args: T.Union[str, T.List[str]]) -> T.List[str]:
         if self.prefix_arg is None:
-            return args
-        elif isinstance(self.prefix_arg, str):
-            return [self.prefix_arg + arg for arg in args]
-        ret: T.List[str] = []
-        for arg in args:
-            ret += self.prefix_arg + [arg]
-        return ret
+            return mesonlib.listify(list(args))
+
+        return [arg
+                for group in args
+                for arg in self.prefix_arg.wrap(mesonlib.stringlistify(group))]
 
     def __init__(self, exelist: T.List[str], env: Environment,
-                 for_machine: mesonlib.MachineChoice, prefix_arg: T.Union[str, T.List[str]],
+                 for_machine: mesonlib.MachineChoice, prefix_arg: T.Optional[LinkerOptionStyle],
                  always_args: T.List[str], *, system: str = 'unknown system',
                  version: str = 'unknown version'):
         self.exelist = exelist
@@ -650,7 +648,7 @@ class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
 
     if T.TYPE_CHECKING:
         for_machine = MachineChoice.HOST
-        def _apply_prefix(self, arg: T.Union[str, T.List[str]]) -> T.List[str]: ...
+        def _apply_prefix(self, *args: T.Union[str, T.List[str]]) -> T.List[str]: ...
 
     _OPTIMIZATION_ARGS: T.Dict[str, T.List[str]] = {
         'plain': [],
@@ -739,7 +737,7 @@ class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
             # For PE/COFF the soname argument has no effect
             return []
         sostr = '' if soversion is None else '.' + soversion
-        return self._apply_prefix(f'-soname,{prefix}{shlib_name}.{suffix}{sostr}')
+        return self._apply_prefix(['-soname', f'{prefix}{shlib_name}.{suffix}{sostr}'])
 
     def build_rpath_args(self, build_dir: str, from_dir: str, target: BuildTarget,
                          extra_paths: T.Optional[T.List[str]] = None
@@ -775,7 +773,7 @@ class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
             # by default, but is not on dragonfly/openbsd for some reason. Without this
             # $ORIGIN in the runtime path will be undefined and any binaries
             # linked against local libraries will fail to resolve them.
-            args.extend(self._apply_prefix('-z,origin'))
+            args.extend(self._apply_prefix(['-z', 'origin']))
 
         # In order to avoid relinking for RPATH removal, the binary needs to contain just
         # enough space in the ELF header to hold the final installation RPATH.
@@ -788,7 +786,7 @@ class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
                 paths = padding
             else:
                 paths = paths + ':' + padding
-        args.extend(self._apply_prefix('-rpath,' + paths))
+        args.extend(self._apply_prefix(['-rpath', paths]))
 
         # TODO: should this actually be "for solaris/sunos"?
         # NOTE: Remove the zigcc check once zig support "-rpath-link"
@@ -818,7 +816,7 @@ class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
         #   -Wl,-rpath-link,/path/to/folder1:/path/to/folder2:...
         if self.id in {'ld.bfd', 'ld.gold'} and mesonlib.version_compare(self.version, '<2.28'):
             for p in rpath_paths:
-                args.extend(self._apply_prefix('-rpath-link,' + os.path.join(build_dir, p)))
+                args.extend(self._apply_prefix(['-rpath-link', os.path.join(build_dir, p)]))
 
         return (args, rpath_dirs_to_remove)
 
@@ -835,7 +833,7 @@ class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
         if newvalue is not None:
             if versionsuffix is not None:
                 newvalue += f':{versionsuffix}'
-            args = [f'--subsystem,{newvalue}']
+            args = ['--subsystem', newvalue]
         else:
             raise mesonlib.MesonBugException(f'win_subsystem: {value!r} not handled in MinGW linker. This should not be possible.')
 
@@ -856,7 +854,7 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
         if self.system == 'ios':
             return []
         else:
-            return self._apply_prefix('-undefined,dynamic_lookup')
+            return self._apply_prefix(['-undefined', 'dynamic_lookup'])
 
     def get_std_shared_module_args(self, target: 'BuildTarget') -> T.List[str]:
         if self.system == 'ios':
@@ -924,7 +922,7 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
         if darwin_versions:
             args.extend(['-compatibility_version', darwin_versions[0],
                          '-current_version', darwin_versions[1]])
-        return args
+        return self._apply_prefix(args)
 
     def build_rpath_args(self, build_dir: str, from_dir: str, target: BuildTarget,
                          extra_paths: T.Optional[T.List[str]] = None
@@ -945,12 +943,12 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
             all_paths.update(extra_paths)
         for rp in all_paths:
             rpath_dirs_to_remove.add(rp.encode('utf8'))
-            args.extend(self._apply_prefix('-rpath,' + rp))
+            args.extend(self._apply_prefix(['-rpath', rp]))
 
         return (args, rpath_dirs_to_remove)
 
     def get_thinlto_cache_args(self, path: str) -> T.List[str]:
-        return ["-Wl,-cache_path_lto," + path]
+        return self._apply_prefix(['-cache_path_lto', path])
 
     def get_lto_obj_cache_path(self, path: str) -> T.List[str]:
         # https://clang.llvm.org/docs/CommandGuide/clang.html#cmdoption-flto
@@ -991,7 +989,7 @@ class GnuGoldDynamicLinker(GnuDynamicLinker):
     id = 'ld.gold'
 
     def get_thinlto_cache_args(self, path: str) -> T.List[str]:
-        return ['-Wl,-plugin-opt,cache-dir=' + path]
+        return self._apply_prefix(['-plugin-opt', 'cache-dir=' + path])
 
 
 class GnuBFDDynamicLinker(GnuDynamicLinker):
@@ -1004,7 +1002,7 @@ class MoldDynamicLinker(GnuDynamicLinker):
     id = 'ld.mold'
 
     def get_thinlto_cache_args(self, path: str) -> T.List[str]:
-        return ['-Wl,--thinlto-cache-dir=' + path]
+        return self._apply_prefix(['--thinlto-cache-dir=' + path])
 
 
 class LLVMDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, DynamicLinker):
@@ -1018,7 +1016,7 @@ class LLVMDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, Dyna
     id = 'ld.lld'
 
     def __init__(self, exelist: T.List[str], env: Environment,
-                 for_machine: mesonlib.MachineChoice, prefix_arg: T.Union[str, T.List[str]],
+                 for_machine: mesonlib.MachineChoice, prefix_arg: T.Optional[LinkerOptionStyle],
                  always_args: T.List[str], *, system: str = 'unknown system',
                  version: str = 'unknown version'):
         super().__init__(exelist, env, for_machine, prefix_arg, always_args, system=system, version=version)
@@ -1055,7 +1053,7 @@ class LLVMDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, Dyna
         return []
 
     def get_thinlto_cache_args(self, path: str) -> T.List[str]:
-        return ['-Wl,--thinlto-cache-dir=' + path]
+        return self._apply_prefix(['--thinlto-cache-dir=' + path])
 
     def get_win_subsystem_args(self, value: str) -> T.List[str]:
         # lld does not support a numeric subsystem value
@@ -1065,7 +1063,7 @@ class LLVMDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, Dyna
         if value in self._SUBSYSTEMS:
             if version is not None:
                 value += f':{version}'
-            return self._apply_prefix([f'--subsystem,{value}'])
+            return self._apply_prefix(['--subsystem', value])
         else:
             raise mesonlib.MesonBugException(f'win_subsystem: {value} not handled in lld linker. This should not be possible.')
 
@@ -1111,7 +1109,7 @@ class CcrxDynamicLinker(DynamicLinker):
 
     def __init__(self, env: Environment, for_machine: mesonlib.MachineChoice,
                  *, version: str = 'unknown version'):
-        super().__init__(['rlink.exe'], env, for_machine, '', [],
+        super().__init__(['rlink.exe'], env, for_machine, None, [],
                          version=version)
 
     def get_accepts_rsp(self) -> bool:
@@ -1146,7 +1144,7 @@ class Xc16DynamicLinker(DynamicLinker):
 
     def __init__(self, env: Environment, for_machine: mesonlib.MachineChoice,
                  *, version: str = 'unknown version'):
-        super().__init__(['xc16-gcc'], env, for_machine, '', [],
+        super().__init__(['xc16-gcc'], env, for_machine, None, [],
                          version=version)
 
     def get_link_whole_for(self, args: T.List[str]) -> T.List[str]:
@@ -1210,7 +1208,7 @@ class CompCertDynamicLinker(DynamicLinker):
 
     def __init__(self, env: Environment, for_machine: mesonlib.MachineChoice,
                  *, version: str = 'unknown version'):
-        super().__init__(['ccomp'], env, for_machine, '', [],
+        super().__init__(['ccomp'], env, for_machine, None, [],
                          version=version)
 
     def get_link_whole_for(self, args: T.List[str]) -> T.List[str]:
@@ -1249,7 +1247,7 @@ class TIDynamicLinker(DynamicLinker):
 
     def __init__(self, exelist: T.List[str], env: Environment, for_machine: mesonlib.MachineChoice,
                  *, version: str = 'unknown version'):
-        super().__init__(exelist, env, for_machine, '', [],
+        super().__init__(exelist, env, for_machine, None, [],
                          version=version)
 
     def get_link_whole_for(self, args: T.List[str]) -> T.List[str]:
@@ -1295,7 +1293,7 @@ class ArmDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
 
     def __init__(self, env: Environment, for_machine: mesonlib.MachineChoice,
                  *, version: str = 'unknown version'):
-        super().__init__(['armlink'], env, for_machine, '', [],
+        super().__init__(['armlink'], env, for_machine, None, [],
                          version=version)
 
     def get_accepts_rsp(self) -> bool:
@@ -1429,7 +1427,7 @@ class VisualStudioLikeLinkerMixin(DynamicLinkerBase):
 
     if T.TYPE_CHECKING:
         for_machine = MachineChoice.HOST
-        def _apply_prefix(self, arg: T.Union[str, T.List[str]]) -> T.List[str]: ...
+        def _apply_prefix(self, *args: T.Union[str, T.List[str]]) -> T.List[str]: ...
 
     _OPTIMIZATION_ARGS: T.Dict[str, T.List[str]] = {
         'plain': [],
@@ -1444,7 +1442,7 @@ class VisualStudioLikeLinkerMixin(DynamicLinkerBase):
     }
 
     def __init__(self, exelist: T.List[str], env: Environment,
-                 for_machine: mesonlib.MachineChoice, prefix_arg: T.Union[str, T.List[str]],
+                 for_machine: mesonlib.MachineChoice, prefix_arg: T.Optional[LinkerOptionStyle],
                  always_args: T.List[str], *, version: str = 'unknown version',
                  direct: bool = True, machine: str = 'x86', rsp_syntax:
                  RSPFileSyntax = RSPFileSyntax.MSVC):
@@ -1516,7 +1514,7 @@ class MSVCDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
     def __init__(self, env: Environment, for_machine: mesonlib.MachineChoice,
                  always_args: T.List[str], *,
                  exelist: T.Optional[T.List[str]] = None,
-                 prefix: T.Union[str, T.List[str]] = '',
+                 prefix: T.Optional[LinkerOptionStyle] = None,
                  machine: str = 'x86', version: str = 'unknown version',
                  direct: bool = True, rsp_syntax: RSPFileSyntax = RSPFileSyntax.MSVC):
         super().__init__(exelist or ['link.exe'], env, for_machine,
@@ -1545,7 +1543,7 @@ class ClangClDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
     def __init__(self, env: Environment, for_machine: mesonlib.MachineChoice,
                  always_args: T.List[str], *,
                  exelist: T.Optional[T.List[str]] = None,
-                 prefix: T.Union[str, T.List[str]] = '',
+                 prefix: T.Optional[LinkerOptionStyle] = None,
                  machine: str = 'x86', version: str = 'unknown version',
                  direct: bool = True, rsp_syntax: RSPFileSyntax = RSPFileSyntax.MSVC):
         super().__init__(exelist or ['lld-link.exe'], env, for_machine,
@@ -1579,10 +1577,10 @@ class XilinkDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
     def __init__(self, env: Environment, for_machine: mesonlib.MachineChoice,
                  always_args: T.List[str], *,
                  exelist: T.Optional[T.List[str]] = None,
-                 prefix: T.Union[str, T.List[str]] = '',
+                 prefix: T.Optional[LinkerOptionStyle] = None,
                  machine: str = 'x86', version: str = 'unknown version',
                  direct: bool = True):
-        super().__init__(['xilink.exe'], env, for_machine, '', always_args, version=version)
+        super().__init__(['xilink.exe'], env, for_machine, None, always_args, version=version)
 
     def get_win_subsystem_args(self, value: str) -> T.List[str]:
         return self._apply_prefix([f'/SUBSYSTEM:{value.upper()}'])
@@ -1650,13 +1648,13 @@ class SolarisDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
                 paths = padding
             else:
                 paths = paths + ':' + padding
-        return (self._apply_prefix(f'-rpath,{paths}'), rpath_dirs_to_remove)
+        return (self._apply_prefix(['-rpath', paths]), rpath_dirs_to_remove)
 
     def get_soname_args(self, prefix: str, shlib_name: str, suffix: str,
                         soversion: str, darwin_versions: T.Tuple[str, str]
                         ) -> T.List[str]:
         sostr = '' if soversion is None else '.' + soversion
-        return self._apply_prefix(f'-soname,{prefix}{shlib_name}.{suffix}{sostr}')
+        return self._apply_prefix(['-soname', f'{prefix}{shlib_name}.{suffix}{sostr}'])
 
 
 class AIXDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
@@ -1736,7 +1734,7 @@ class OptlinkDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
                  *, version: str = 'unknown version'):
         # Use optlink instead of link so we don't interfere with other link.exe
         # implementations.
-        super().__init__(exelist, env, for_machine, '', [], version=version)
+        super().__init__(exelist, env, for_machine, None, [], version=version)
 
     def get_allow_undefined_args(self) -> T.List[str]:
         return []
@@ -1788,7 +1786,7 @@ class CudaLinker(PosixDynamicLinkerMixin, DynamicLinker):
         #   nvcc fatal : Don't know what to do with 'subprojects/foo/libbar.so.0.1.2'
         #
         from ..compilers.cuda import CudaCompiler
-        return CudaCompiler.LINKER_PREFIX
+        return CudaCompiler.LINKER_PREFIX.prefix
 
     def fatal_warnings(self) -> T.List[str]:
         return ['--warning-as-error']
@@ -1806,7 +1804,7 @@ class MetrowerksLinker(DynamicLinker):
 
     def __init__(self, exelist: T.List[str], env: Environment, for_machine: mesonlib.MachineChoice,
                  *, version: str = 'unknown version'):
-        super().__init__(exelist, env, for_machine, '', [],
+        super().__init__(exelist, env, for_machine, None, [],
                          version=version)
 
     def fatal_warnings(self) -> T.List[str]:
@@ -1858,7 +1856,7 @@ class TaskingLinker(DynamicLinker):
 
     def __init__(self, exelist: T.List[str], env: Environment, for_machine: mesonlib.MachineChoice,
                  *, version: str = 'unknown version'):
-        super().__init__(exelist, env, for_machine, '', [],
+        super().__init__(exelist, env, for_machine, None, [],
                          version=version)
 
     def get_accepts_rsp(self) -> bool:

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -28,6 +28,7 @@ import mesonbuild.modules.gnome
 import mesonbuild.scripts.env2mfile
 from mesonbuild import coredata
 from mesonbuild.compilers.c import ClangCCompiler, GnuCCompiler
+from mesonbuild.compilers.compilers import ManyInOneLinkerOptionStyle
 from mesonbuild.compilers.cpp import VisualStudioCPPCompiler
 from mesonbuild.compilers.d import DmdDCompiler
 from mesonbuild.compilers.detect import detect_c_compiler
@@ -273,7 +274,7 @@ class InternalTests(unittest.TestCase):
     def test_compiler_args_class_gnuld(self):
         ## Test --start/end-group
         env = get_fake_env()
-        linker = linkers.GnuBFDDynamicLinker([], env, MachineChoice.HOST, '-Wl,', [])
+        linker = linkers.GnuBFDDynamicLinker([], env, MachineChoice.HOST, ManyInOneLinkerOptionStyle('-Wl,', ','), [])
         gcc = GnuCCompiler([], [], 'fake', MachineChoice.HOST, env, linker=linker)
         ## Ensure that the fake compiler is never called by overriding the relevant function
         gcc.get_default_include_dirs = lambda: ['/usr/include', '/usr/share/include', '/usr/local/include']
@@ -303,7 +304,7 @@ class InternalTests(unittest.TestCase):
     def test_compiler_args_remove_system(self):
         ## Test --start/end-group
         env = get_fake_env()
-        linker = linkers.GnuBFDDynamicLinker([], env, MachineChoice.HOST, '-Wl,', [])
+        linker = linkers.GnuBFDDynamicLinker([], env, MachineChoice.HOST, ManyInOneLinkerOptionStyle('-Wl,', ','), [])
         gcc = GnuCCompiler([], [], 'fake', MachineChoice.HOST, env, linker=linker)
         ## Ensure that the fake compiler is never called by overriding the relevant function
         gcc.get_default_include_dirs = lambda: ['/usr/include', '/usr/share/include', '/usr/local/include']


### PR DESCRIPTION
Split out from #14261, needed to make Swift compilation use the generic C/... code path.

Not all compilers (swiftc in case of #14261) concatenate linker arguments with ','. This removes that assumption and instead always passes the arguments in a list where applicable, and reworks the linker argument wrapper syntaxes for the compilers to more accurately represent the three different option styles.

Some Apple ld options, notably -install_name, are also not exposed directly on the compiler options interface, hence add the linker prefix here.

I feel like the linker class should never deal with compiler's linker prefix, instead the compiler class through which everything goes anyway should add it, but that would be a more significant refactor and for now this should do.