### PR TITLE
msetup: remove bad warning about unused options

### DIFF
--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016-2018 The Meson development team
-# Copyright © 2023-2024 Intel Corporation
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 
@@ -189,9 +189,9 @@ class MesonApp:
             return self._generate(env, capture, vslite_ctx)
 
     def check_unused_options(self, coredata: 'coredata.CoreData', cmd_line_options: T.Any, all_subprojects: T.Any) -> None:
+        from mesonbuild.compilers import BASE_OPTIONS
         pending = coredata.optstore.pending_project_options
         errlist: T.List[str] = []
-        permitlist: T.List[str] = []
         for opt in pending:
             # Due to backwards compatibility setting build options in non-cross
             # builds is permitted and is a no-op. This should be made
@@ -203,11 +203,9 @@ class MesonApp:
             if opt.subproject and opt.subproject not in all_subprojects:
                 continue
             if coredata.optstore.is_compiler_option(opt):
-                permitlist.append(opt.name)
                 continue
-            # Ditto for base options.
-            if coredata.optstore.is_base_option(opt):
-                permitlist.append(opt.name)
+            if (coredata.optstore.is_base_option(opt) and
+                    opt.evolve(subproject=None, machine=mesonlib.MachineChoice.HOST) in BASE_OPTIONS):
                 continue
             keystr = str(opt)
             if keystr in cmd_line_options:
@@ -215,15 +213,6 @@ class MesonApp:
         if errlist:
             errstr = ', '.join(errlist)
             raise MesonException(f'Unknown options: {errstr}')
-        if permitlist:
-            # This is needed due to backwards compatibility.
-            # It was permitted to define some command line options that
-            # were not used. This can be seen as a bug, since
-            # if you define -Db_lto but the compiler class does not
-            # support it, this option gets silently swallowed.
-            # So at least print a message about it.
-            optstr = ','.join(permitlist)
-            mlog.warning(f'The following command line option(s) were not used: {optstr}', fatal=False)
 
         coredata.optstore.clear_pending()
 

--- a/unittests/platformagnostictests.py
+++ b/unittests/platformagnostictests.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2021 The Meson development team
-# Copyright © 2024 Intel Corporation
+# Copyright © 2024-2025 Intel Corporation
 
 from __future__ import annotations
 import json
@@ -415,11 +415,14 @@ class PlatformAgnosticTests(BasePlatformTests):
     def test_setup_with_unknown_option(self):
         testdir = os.path.join(self.common_test_dir, '1 trivial')
 
-        out = self.init(testdir, extra_args=['--wipe', '-Dnot_an_option=1'], allow_fail=True)
-        self.assertIn('ERROR: Unknown options: "not_an_option"', out)
+        with self.subTest('unknown user option'):
+            out = self.init(testdir, extra_args=['-Dnot_an_option=1'], allow_fail=True)
+            self.assertIn('ERROR: Unknown options: "not_an_option"', out)
 
-        out = self.init(testdir, extra_args=['--wipe', '-Db_not_an_option=1'])
-        self.assertIn('WARNING: The following command line option(s) were not used: b_not_an_option', out)
+        with self.subTest('unknown builtin option'):
+            self.new_builddir()
+            out = self.init(testdir, extra_args=['-Db_not_an_option=1'], allow_fail=True)
+            self.assertIn('ERROR: Unknown options: "b_not_an_option"', out)
 
 
     def test_configure_new_option(self) -> None:


### PR DESCRIPTION
This is just a bad warning, while it *could* give the user useful information, it often doesn't since it can get values to warn about from:

  - environment variables
  - the command line
  - machine files
  - `project(default_options : ...)`
  - `subproject(default_options : ...)`
  - `dependency(default_options : ...)`

The problem of course is that user may have no control over these values. 3 of them are hardcoded into the meson.build files, so the user can't do anything about them. And there are legitimate reasons to have unused values in those, like setting defaults for a language only used on specific platforms.

Environment variables may be set by the distro (NixOS sets them for any enabled language, so just having a D compiler causes `DFLAGS` to be set, for example). They likely don't want to special case "only set the environment variables if the project is going to use them".

For machine files it limits the utility of the files, since the user needs to be sure that they don't include any options that wont be used.

Finally, the command line could be altered by wrapper scripts, or simply programmed to insert options that *may* be used but aren't required. like setting `objc_args` regardless of whether ObjectivC bindings are generated.

However, we should resume erroring on unknown `b_` option like Meson did prior to the option refactor.