### PR TITLE
coredata: fix handling of prefix

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -572,12 +572,11 @@ class CoreData:
         # Set prefix first because it's needed to sanitize other options
         pfk = OptionKey('prefix')
         if pfk in opts_to_set:
-            prefix = self.sanitize_prefix(opts_to_set[pfk])
+            prefix = self.optstore.sanitize_prefix(opts_to_set[pfk])
             for key in options.BUILTIN_DIR_NOPREFIX_OPTIONS:
                 if key not in opts_to_set:
                     val = options.BUILTIN_OPTIONS[key].prefixed_default(key, prefix)
-                    tmpkey = options.convert_oldkey(key)
-                    dirty |= self.optstore.set_option(tmpkey, val)
+                    dirty |= self.optstore.set_option(key, val)
 
         unknown_options: T.List[OptionKey] = []
         for k, v in opts_to_set.items():

--- a/test cases/linuxlike/3 linker script/meson.build
+++ b/test cases/linuxlike/3 linker script/meson.build
@@ -1,4 +1,4 @@
-project('linker script', 'c')
+project('linker script', 'c', default_options : {'prefix': '/tmp'})
 
 # Solaris 11.4 ld supports --version-script only when you also specify
 # -z gnu-version-script-compat


### PR DESCRIPTION
Which was improperly updated by the option store refactor.

Fixes: #14329