### PR TITLE
get_llvm_tool_names: add llvm 20

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -206,6 +206,8 @@ def get_llvm_tool_names(tool: str) -> T.List[str]:
     # unless it becomes a stable release.
     suffixes = [
         '', # base (no suffix)
+        '-20.1', '20.1',
+        '-20',  '20',
         '-19.1', '19.1',
         '-19',  '19',
         '-18.1', '18.1',


### PR DESCRIPTION
this fixes the "frameworks: 15 llvm" tests with llvm 20.1