### PR TITLE
linkers: darwin: do not use -bundle for shared_modules

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -262,8 +262,7 @@ with `b_asneeded`, so that option will be silently disabled.
 
 [[shared_module]]s will not have
 bitcode embedded because `-Wl,-bitcode_bundle` is incompatible with
-both `-bundle` and `-Wl,-undefined,dynamic_lookup` which are necessary
-for shared modules to work.
+`-Wl,-undefined,dynamic_lookup` which is necessary for shared modules to work.
 
 ## Compiler options
 

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -796,7 +796,7 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
         return self._apply_prefix('-undefined,dynamic_lookup')
 
     def get_std_shared_module_args(self, target: 'BuildTarget') -> T.List[str]:
-        return ['-bundle'] + self._apply_prefix('-undefined,dynamic_lookup')
+        return ['-dynamiclib'] + self._apply_prefix('-undefined,dynamic_lookup')
 
     def get_pie_args(self) -> T.List[str]:
         return []


### PR DESCRIPTION
Both dynamic libraries and bundles these days can be dynamically loaded using the dl APIs (e.g. dlopen, dlclose). It is not possible to include bundles on a linker command line as if they were shared libraries, but that's pretty much the only difference.

However, bundles fail the Apple verification for iOS:

2025-02-10 13:54:09.095 ERROR: Validation failed (409) The binary is invalid.
  The executable 'Runner.app/Frameworks/numpy._core._operand_flag_tests.framework/numpy._core._operand_flag_tests'
  has type 'BUNDLE' that is not valid. Only 'EXECUTE' is permitted.
2025-02-10 13:54:09.096 ERROR: Validation failed (409) Missing load commands.
  The executable at 'Runner.app/Frameworks/numpy._core._operand_flag_tests.framework'
  does not have the necessary load commands. Try rebuilding the app with the latest
  Xcode version. If you are using third party development tools, contact the provider.

So switch to -dynamiclib for shared modules as well.

Fixes: #14240