### PR TITLE
avoid false positive PermissionError in declare_dependency

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -703,20 +703,18 @@ class Interpreter(InterpreterBase, HoldableObject):
             version = self.project_version
         d_module_versions = kwargs['d_module_versions']
         d_import_dirs = self.extract_incdirs(kwargs, 'd_import_dirs')
-        srcdir = Path(self.environment.source_dir)
+        srcdir = self.environment.source_dir
+        subproject_dir = os.path.abspath(os.path.join(srcdir, self.subproject_dir))
+        project_root = os.path.abspath(os.path.join(srcdir, self.root_subdir))
         # convert variables which refer to an -uninstalled.pc style datadir
         for k, v in variables.items():
             if not v:
                 FeatureNew.single_use('empty variable value in declare_dependency', '1.4.0', self.subproject, location=node)
-            try:
-                p = Path(v)
-            except ValueError:
-                continue
-            else:
-                if not self.is_subproject() and srcdir / self.subproject_dir in p.parents:
-                    continue
-                if p.is_absolute() and p.is_dir() and srcdir / self.root_subdir in [p] + list(Path(os.path.abspath(p)).parents):
-                    variables[k] = P_OBJ.DependencyVariableString(v)
+            if os.path.isabs(v) \
+                    and (self.is_subproject() or not is_parent_path(subproject_dir, v)) \
+                    and is_parent_path(project_root, v) \
+                    and os.path.isdir(v):
+                variables[k] = P_OBJ.DependencyVariableString(v)
 
         dep = dependencies.InternalDependency(version, incs, compile_args,
                                               link_args, libs, libs_whole, sources, extra_files,

--- a/test cases/unit/125 declare_dep var/meson.build
+++ b/test cases/unit/125 declare_dep var/meson.build
@@ -1,0 +1,7 @@
+project('foo')
+
+declare_dependency(
+  variables: {
+    'dir': get_option('dir')
+  }
+)

--- a/test cases/unit/125 declare_dep var/meson_options.txt
+++ b/test cases/unit/125 declare_dep var/meson_options.txt
@@ -1,0 +1,1 @@
+option('dir', type: 'string')

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -1862,6 +1862,18 @@ class LinuxlikeTests(BasePlatformTests):
         testdir = os.path.join(self.unit_test_dir, '124 pkgsubproj')
         self.init(testdir)
 
+    def test_unreadable_dir_in_declare_dep(self):
+        testdir = os.path.join(self.unit_test_dir, '125 declare_dep var')
+        tmpdir = Path(tempfile.mkdtemp())
+        self.addCleanup(windows_proof_rmtree, tmpdir)
+        declaredepdir = tmpdir / 'test'
+        declaredepdir.mkdir()
+        try:
+            tmpdir.chmod(0o444)
+            self.init(testdir, extra_args=f'-Ddir={declaredepdir}')
+        finally:
+            tmpdir.chmod(0o755)
+
     def check_has_flag(self, compdb, src, argument):
         for i in compdb:
             if src in i['file']:


### PR DESCRIPTION
If a directory that is passed to declare_dependency is not accessible (a parent has the x permission cleared), this can result in an OSError:

    ERROR: Unhandled python OSError. This is probably not a Meson bug, but an issue with your build environment.

This can cause false positives, for example, if the directory is under /var and root-owned.  Do the is_dir() test last, once it's known that the directory is related to the source directory, to avoid the false positives.

Fixes: #13584