### PR TITLE
add exe_wrapper to the wasm cross file

### DIFF
--- a/cross/wasm.txt
+++ b/cross/wasm.txt
@@ -2,6 +2,7 @@
 c = 'emcc'
 cpp = 'em++'
 ar = 'emar'
+exe_wrapper = 'node'
 
 [built-in options]
 c_args = []


### PR DESCRIPTION
This makes it possible to run tests ("1 trivial" passes).