### PR TITLE
tests: support DC being more than plain dmd or ldc2

### DIFF
--- a/test cases/d/14 dub with deps/meson.build
+++ b/test cases/d/14 dub with deps/meson.build
@@ -12,12 +12,9 @@ endif
 
 if meson.get_compiler('d').get_id() == 'gcc'
     error('MESON_SKIP_TEST: can\'t build dependencies with GDC')
-elif meson.get_compiler('d').get_id() == 'llvm'
-    dc = 'ldc2'
-elif meson.get_compiler('d').get_id() == 'dmd'
-    dc = 'dmd'
 endif
 
+dc = meson.get_compiler('d').cmd_array()[0]
 arch = host_machine.cpu_family()
 
 if host_machine.system() == 'windows'


### PR DESCRIPTION
Dub is very thorough about what it encodes in a build id even collecting the compiler path. Therefore, if dub is not provided the exact same compiler path that meson got during setup, the dependency would not be found and the test would fail.