### PR TITLE
More option cleanups

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -640,7 +640,7 @@ class CoreData:
             # adding languages and setting backend.
             if self.optstore.is_compiler_option(k) or self.optstore.is_backend_option(k):
                 continue
-            if self.optstore.is_base_option(k) and k.evolve(subproject=None) in options.BASE_OPTIONS:
+            if self.optstore.is_base_option(k) and k.evolve(subproject=None) in options.COMPILER_BASE_OPTIONS:
                 # set_options will report unknown base options
                 continue
             options_[k] = v
@@ -686,7 +686,7 @@ class CoreData:
             else:
                 skey = key
             if skey not in self.optstore:
-                self.optstore.add_system_option(skey, copy.deepcopy(options.BASE_OPTIONS[key]))
+                self.optstore.add_system_option(skey, copy.deepcopy(options.COMPILER_BASE_OPTIONS[key]))
                 if skey in env.options:
                     self.optstore.set_option(skey, env.options[skey])
                 elif subproject and key in env.options:

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -489,13 +489,6 @@ class CoreData:
 
         return dirty
 
-    def is_per_machine_option(self, optname: OptionKey) -> bool:
-        if isinstance(optname, str):
-            optname = OptionKey.from_string(optname)
-        if optname.as_host() in options.BUILTIN_OPTIONS_PER_MACHINE:
-            return True
-        return self.optstore.is_compiler_option(optname)
-
     def get_external_args(self, for_machine: MachineChoice, lang: str) -> T.List[str]:
         # mypy cannot analyze type of OptionKey
         key = OptionKey(f'{lang}_args', machine=for_machine)

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -690,6 +690,13 @@ class Environment:
                          'See: https://mesonbuild.com/Builtin-options.html#build-type-options',
                          fatal=False)
 
+        # Filter out build machine options that are not valid per-project.
+        # We allow this in the file because it makes the machine files more
+        # useful (ie, the same file can be used for host == build configuration
+        # a host != build configuration)
+        self.options = {k: v for k, v in self.options.items()
+                        if k.machine is MachineChoice.HOST or self.coredata.optstore.is_per_machine_option(k)}
+
         exe_wrapper = self.lookup_binary_entry(MachineChoice.HOST, 'exe_wrapper')
         if exe_wrapper is not None:
             self.exe_wrapper = ExternalProgram.from_bin_list(self, MachineChoice.HOST, 'exe_wrapper')

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -663,7 +663,7 @@ class Environment:
             # Keep only per machine options from the native file. The cross
             # file takes precedence over all other options.
             for key, value in list(self.options.items()):
-                if self.coredata.is_per_machine_option(key):
+                if self.coredata.optstore.is_per_machine_option(key):
                     self.options[key.as_build()] = value
             self._load_machine_file_options(config, properties.host, MachineChoice.HOST)
 

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -307,7 +307,7 @@ def list_buildoptions(coredata: cdata.CoreData, subprojects: T.Optional[T.List[s
     def add_keys(opts: T.Union[cdata.MutableKeyedOptionDictType, options.OptionStore], section: str) -> None:
         for key, opt in sorted(opts.items()):
             optdict = {'name': str(key), 'value': opt.value, 'section': section,
-                       'machine': key.machine.get_lower_case_name() if coredata.is_per_machine_option(key) else 'any'}
+                       'machine': key.machine.get_lower_case_name() if coredata.optstore.is_per_machine_option(key) else 'any'}
             if isinstance(opt, options.UserStringOption):
                 typestr = 'string'
             elif isinstance(opt, options.UserBooleanOption):

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -11,7 +11,7 @@ import typing as T
 
 from . import build, coredata, environment, interpreter, mesonlib, mintro, mlog
 from .mesonlib import MesonException
-from .options import BASE_OPTIONS, OptionKey
+from .options import COMPILER_BASE_OPTIONS, OptionKey
 
 if T.TYPE_CHECKING:
     from typing_extensions import Protocol
@@ -204,7 +204,7 @@ class MesonApp:
             if coredata.optstore.is_compiler_option(opt):
                 continue
             if (coredata.optstore.is_base_option(opt) and
-                    opt.evolve(subproject=None, machine=mesonlib.MachineChoice.HOST) in BASE_OPTIONS):
+                    opt.evolve(subproject=None, machine=mesonlib.MachineChoice.HOST) in COMPILER_BASE_OPTIONS):
                 continue
             keystr = str(opt)
             if keystr in cmd_line_options:

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -192,11 +192,6 @@ class MesonApp:
         pending = coredata.optstore.pending_options
         errlist: T.List[str] = []
         for opt in pending:
-            # Due to backwards compatibility setting build options in non-cross
-            # builds is permitted and is a no-op. This should be made
-            # a hard error.
-            if not coredata.is_cross_build() and opt.is_for_build():
-                continue
             # It is not an error to set wrong option for unknown subprojects or
             # language because we don't have control on which one will be selected.
             if opt.subproject and opt.subproject not in all_subprojects:

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1132,6 +1132,11 @@ class OptionStore:
         """Convenience method to check if this is a project option."""
         return key in self.project_options
 
+    def is_per_machine_option(self, optname: OptionKey) -> bool:
+        if optname.evolve(subproject=None, machine=MachineChoice.HOST) in BUILTIN_OPTIONS_PER_MACHINE:
+            return True
+        return self.is_compiler_option(optname)
+
     def is_reserved_name(self, key: OptionKey) -> bool:
         if key.name in _BUILTIN_NAMES:
             return True

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -755,7 +755,7 @@ BUILTIN_DIR_NOPREFIX_OPTIONS: T.Dict[OptionKey, T.Dict[str, str]] = {
 
 MSCRT_VALS = ['none', 'md', 'mdd', 'mt', 'mtd']
 
-BASE_OPTIONS: T.Mapping[OptionKey, AnyOptionType] = {
+COMPILER_BASE_OPTIONS: T.Mapping[OptionKey, AnyOptionType] = {
     OptionKey(o.name): o for o in T.cast('T.List[AnyOptionType]', [
         UserBooleanOption('b_pch', 'Use precompiled headers', True),
         UserBooleanOption('b_lto', 'Use link time optimization', False),
@@ -1091,7 +1091,7 @@ class OptionStore:
     def get_default_for_b_option(self, key: OptionKey) -> ElementaryOptionValues:
         assert self.is_base_option(key)
         try:
-            return T.cast('ElementaryOptionValues', BASE_OPTIONS[key.evolve(subproject=None)].default)
+            return T.cast('ElementaryOptionValues', COMPILER_BASE_OPTIONS[key.evolve(subproject=None)].default)
         except KeyError:
             raise MesonBugException(f'Requested base option {key} which does not exist.')
 

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1283,6 +1283,10 @@ class OptionStore:
                 key = OptionKey.from_string(keystr)
             else:
                 key = keystr
+            # Due to backwards compatibility we ignore all cross options when building
+            # natively.
+            if not self.is_cross and key.is_for_build():
+                continue
             if key.subproject is not None:
                 #self.pending_project_options[key] = valstr
                 augstr = str(key)


### PR DESCRIPTION
Here is another set of cleanups to the option handling code, peeled off of a large set of patches looking into how we handle options. This series is mostly moving code around to more optimal places and better documenting the code to explain what things are for or why something is done.

This code motion does allow some cleanups now (namely by putting the compile base option definitions in the options module), and will allow for more cleanup later.