### PR TITLE
Unitests: move environment setup from run_unitests.py to test fixtures

### DIFF
--- a/run_mypy.py
+++ b/run_mypy.py
@@ -90,6 +90,7 @@ additional = [
     'tools',
     'docs/genrefman.py',
     'docs/refman',
+    'unittests/baseclass.py',
     'unittests/helpers.py',
 ]
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -40,14 +40,6 @@ from unittests.subprojectscommandtests import SubprojectsCommandTests
 from unittests.windowstests import WindowsTests
 from unittests.platformagnostictests import PlatformAgnosticTests
 
-def unset_envs():
-    # For unit tests we must fully control all command lines
-    # so that there are no unexpected changes coming from the
-    # environment, for example when doing a package build.
-    varnames = ['CPPFLAGS', 'LDFLAGS'] + list(mesonbuild.compilers.compilers.CFLAGS_MAPPING.values())
-    for v in varnames:
-        if v in os.environ:
-            del os.environ[v]
 
 def convert_args(argv):
     # If we got passed a list of tests, pass it on
@@ -101,7 +93,6 @@ def setup_backend():
     sys.argv = filtered
 
 def main():
-    unset_envs()
     setup_backend()
     cases = ['InternalTests', 'DataTests', 'AllPlatformTests', 'FailureTests',
              'PythonTests', 'NativeFileTests', 'RewriterTests', 'CrossFileTests',

--- a/unittests/baseclass.py
+++ b/unittests/baseclass.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2025 Intel Corporation
+
+from __future__ import annotations
+
+from unittest import TestCase, mock
+import os
+
+class BaseMesonTest(TestCase):
+
+    """Base test class for all Meson tests that does basic environment setup."""
+
+    env_patch: mock._patch_dict
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+
+        cls.env_patch = mock.patch.dict(os.environ)
+        cls.env_patch.start()
+
+        os.environ['COLUMNS'] = '80'
+        os.environ['PYTHONIOENCODING'] = 'utf8'
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        super().tearDownClass()
+        cls.env_patch.stop()

--- a/unittests/baseclass.py
+++ b/unittests/baseclass.py
@@ -4,7 +4,10 @@
 from __future__ import annotations
 
 from unittest import TestCase, mock
+import itertools
 import os
+
+from mesonbuild.compilers.compilers import CFLAGS_MAPPING
 
 class BaseMesonTest(TestCase):
 
@@ -21,6 +24,12 @@ class BaseMesonTest(TestCase):
 
         os.environ['COLUMNS'] = '80'
         os.environ['PYTHONIOENCODING'] = 'utf8'
+
+        # Remove any CFlags, etc coming from an external environment so that we
+        # get what we expect
+        for flag in itertools.chain(['CPPFLAGS', 'LDFLAGS'], CFLAGS_MAPPING.values()):
+            if flag in os.environ:
+                del os.environ[flag]
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016-2021 The Meson development team
-# Copyright © 2024 Intel Corporation
+# Copyright © 2024-2025 Intel Corporation
 
 from __future__ import annotations
 from pathlib import PurePath
@@ -29,7 +29,7 @@ from mesonbuild.mesonlib import (
 )
 import mesonbuild.modules.pkgconfig
 
-
+from .baseclass import BaseMesonTest
 from run_tests import (
     Backend, get_backend_commands,
     get_builddir_target_args, get_meson_script, run_configure_inprocess,
@@ -42,7 +42,8 @@ from run_tests import (
 # e.g. for assertXXX helpers.
 __unittest = True
 
-class BasePlatformTests(TestCase):
+
+class BasePlatformTests(BaseMesonTest):
     prefix = '/usr'
     libdir = 'lib'
 
@@ -86,17 +87,6 @@ class BasePlatformTests(TestCase):
             # VS doesn't have a stable output when no changes are done
             # XCode backend is untested with unit tests, help welcome!
             cls.no_rebuild_stdout = [f'UNKNOWN BACKEND {cls.backend.name!r}']
-
-        cls.env_patch = mock.patch.dict(os.environ)
-        cls.env_patch.start()
-
-        os.environ['COLUMNS'] = '80'
-        os.environ['PYTHONIOENCODING'] = 'utf8'
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        super().tearDownClass()
-        cls.env_patch.stop()
 
     def setUp(self):
         super().setUp()

--- a/unittests/cargotests.py
+++ b/unittests/cargotests.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright © 2022-2023 Intel Corporation
+# Copyright © 2022-2025 Intel Corporation
 
 from __future__ import annotations
 import unittest
@@ -12,6 +12,8 @@ from mesonbuild.cargo import builder, cfg, load_wraps
 from mesonbuild.cargo.cfg import TokenType
 from mesonbuild.cargo.version import convert
 
+# These tests do not need the MesonBaseClass because they don't invoke any Meson
+# environment, they're just testing parsers and convertors
 
 class CargoVersionTest(unittest.TestCase):
 

--- a/unittests/datatests.py
+++ b/unittests/datatests.py
@@ -30,10 +30,11 @@ from run_tests import (
     FakeBuild, get_fake_env
 )
 
+from .baseclass import BaseMesonTest
 from .helpers import *
 
 @unittest.skipIf(is_tarball(), 'Skipping because this is a tarball release')
-class DataTests(unittest.TestCase):
+class DataTests(BaseMesonTest):
 
     def test_snippets(self):
         hashcounter = re.compile('^ *(#)+')

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -49,9 +49,10 @@ from run_tests import (
     FakeCompilerOptions, get_fake_env, get_fake_options
 )
 
+from .baseclass import BaseMesonTest
 from .helpers import *
 
-class InternalTests(unittest.TestCase):
+class InternalTests(BaseMesonTest):
 
     def test_version_number(self):
         self.assertEqual(search_version('foobar 1.2.3'), '1.2.3')

--- a/unittests/taptests.py
+++ b/unittests/taptests.py
@@ -6,6 +6,8 @@ import io
 
 from mesonbuild.mtest import TAPParser, TestResult
 
+# These do not need to use the BaseMesonTest because they only test TAP parsing
+# and output, but do not initialize Meson
 
 class TAPParserTests(unittest.TestCase):
     def assert_test(self, events, **kwargs):


### PR DESCRIPTION
We currently have the `run_unttests.py` removing certain environment variables (CFLAGS and friends) before starting tests, because some tests do not behave correctly when they are set. The right place to do this is an a test fixture, particularly in `setUpClass`.

To facilitate this, a new base class has been added that adds this setup through a mock, and several test classes that should have this setup have been extended to use it. Then the environment setup is moved into the fixture.

Apart from being more correct, this allows running tests without the runner to be more useful, namely if one wants to invoke `pytest` or `python -m unittest` directly.