### PR TITLE
Allow initializing languages per-machine

### DIFF
--- a/docs/markdown/Build-options.md
+++ b/docs/markdown/Build-options.md
@@ -262,7 +262,7 @@ visual studio. It should be the same name as an executable target
 name.
 
 ```meson
-project('my_project', 'c', default_options: ['backend_startup_project=my_exe'])
+project('my_project', host_machine_languages : 'c', default_options: ['backend_startup_project=my_exe'])
 executable('my_exe', ...)
 ```
 

--- a/docs/markdown/Creating-releases.md
+++ b/docs/markdown/Creating-releases.md
@@ -103,7 +103,7 @@ following example.
 
 `meson.build`:
 ```meson
-project('tig', 'c',
+project('tig', host_machine_languages : 'c',
   version : run_command('version.sh', 'get-vcs').stdout.strip())
 
 meson.add_dist_script('version.sh', 'set-dist', meson.project_version())

--- a/docs/markdown/Cython.md
+++ b/docs/markdown/Cython.md
@@ -20,7 +20,7 @@ Generally Cython is most useful when combined with the python module's
 extension_module method:
 
 ```meson
-project('my project', 'cython')
+project('my project', host_machine_languages : 'cython')
 
 py = import('python').find_installation()
 dep_py = py.dependency()
@@ -57,7 +57,7 @@ allows options only on a per-target granularity. This means that if you need to 
 cython files being transpiled to C and to C++ you need two targets:
 
 ```meson
-project('my project', 'cython')
+project('my project', host_machine_languages : 'cython')
 
 cython_cpp_lib = static_library(
     'helper_lib',

--- a/docs/markdown/D.md
+++ b/docs/markdown/D.md
@@ -9,7 +9,7 @@ Meson has support for compiling D programs. A minimal `meson.build`
 file for D looks like this:
 
 ```meson
-project('myapp', 'd')
+project('myapp', host_machine_languages : 'd')
 
 executable('myapp', 'app.d')
 ```
@@ -22,7 +22,7 @@ feature for conditional compilation, you can use it using the
 `d_module_versions` target property:
 
 ```meson
-project('myapp', 'd')
+project('myapp', host_machine_languages : 'd')
 executable('myapp', 'app.d', d_module_versions: ['Demo', 'FeatureA'])
 ```
 
@@ -31,7 +31,7 @@ conditions are compiled automatically in debug builds, and extra
 identifiers can be added with the `d_debug` argument:
 
 ```meson
-project('myapp', 'd')
+project('myapp', host_machine_languages : 'd')
 executable('myapp', 'app.d', d_debug: [3, 'DebugFeatureA'])
 ```
 
@@ -66,7 +66,7 @@ GNU D compiler does not have this feature.
 
 This is an example for using D unittests with Meson:
 ```meson
-project('myapp_tested', 'd')
+project('myapp_tested', host_machine_languages : 'd')
 
 myapp_src = ['app.d', 'alpha.d', 'beta.d']
 executable('myapp', myapp_src)
@@ -84,7 +84,7 @@ find the dependency once it is installed.
 
 This is an example on how to build a D shared library:
 ```meson
-project('mylib', 'd', version: '1.2.0')
+project('mylib', host_machine_languages : 'd', version: '1.2.0')
 
 project_soversion = 0
 glib_dep = dependency('glib-2.0')
@@ -121,7 +121,7 @@ confusing errors.
 This is an example of how to use the D library we just built and
 installed in an application:
 ```meson
-project('myapp', 'd')
+project('myapp', host_machine_languages : 'd')
 
 mylib_dep = dependency('mylib', version: '>= 1.2.0')
 myapp_src = ['app.d', 'alpha.d', 'beta.d']

--- a/docs/markdown/Design-rationale.md
+++ b/docs/markdown/Design-rationale.md
@@ -180,7 +180,7 @@ Let's start simple. Here is the code to compile a single executable
 binary.
 
 ```meson
-project('compile one', 'c')
+project('compile one', host_machine_languages : 'c')
 executable('program', 'prog.c')
 ```
 
@@ -195,7 +195,7 @@ the function call can become unwieldy. That is why the system supports
 keyword arguments. They look like this.
 
 ```meson
-project('compile several', 'c')
+project('compile several', host_machine_languages : 'c')
 sourcelist = ['main.c', 'file1.c', 'file2.c', 'file3.c']
 executable('program', sources : sourcelist)
 ```
@@ -203,7 +203,7 @@ executable('program', sources : sourcelist)
 External dependencies are simple to use.
 
 ```meson
-project('external lib', 'c')
+project('external lib', host_machine_languages : 'c')
 libdep = find_dep('extlibrary', required : true)
 sourcelist = ['main.c', 'file1.c', 'file2.c', 'file3.c']
 executable('program', sources : sourcelist, dep : libdep)
@@ -218,7 +218,7 @@ Here's a slightly more complicated definition. It should still be
 understandable.
 
 ```meson
-project('build library', 'c')
+project('build library', host_machine_languages : 'c')
 foolib = shared_library('foobar', sources : 'foobar.c',\
 install : true)
 exe = executable('testfoobar', 'tester.c', link : foolib)
@@ -236,7 +236,7 @@ Above we mentioned precompiled headers as a feature not supported by
 other build systems. Here's how you would use them.
 
 ```meson
-project('pch demo', 'cpp')
+project('pch demo', host_machine_languages : 'cpp')
 executable('myapp', 'myapp.cpp', pch : 'pch/myapp.hh')
 ```
 

--- a/docs/markdown/FAQ.md
+++ b/docs/markdown/FAQ.md
@@ -141,7 +141,7 @@ wanted to build a shared library in one dir and link tests against it
 in another dir, you would do something like this:
 
 ```meson
-project('simple', 'c')
+project('simple', host_machine_languages : 'c')
 subdir('src')   # library is built here
 subdir('tests') # test binaries would link against the library here
 ```
@@ -223,14 +223,14 @@ executable('foobar', ...
 You probably had a project that looked something like this:
 
 ```meson
-project('foobar', 'cpp')
+project('foobar', host_machine_languages : 'cpp')
 ```
 
 This defaults to `c++11` on GCC compilers. Suppose you want to use
 `c++14` instead, so you change the definition to this:
 
 ```meson
-project('foobar', 'cpp', default_options : ['cpp_std=c++14'])
+project('foobar', host_machine_languages : 'cpp', default_options : ['cpp_std=c++14'])
 ```
 
 But when you recompile, it still uses `c++11`. The reason for this is

--- a/docs/markdown/GuiTutorial.md
+++ b/docs/markdown/GuiTutorial.md
@@ -57,7 +57,7 @@ The build definition goes to a file called `meson.build` and looks
 like this:
 
 ```meson
-project('sdldemo', 'c')
+project('sdldemo', host_machine_languages : 'c')
 
 executable('sdlprog', 'sdlprog.c')
 ```
@@ -160,7 +160,7 @@ As a final step we need to update our build definition file to use the
 newly obtained dependency.
 
 ```meson
-project('sdldemo', 'c',
+project('sdldemo', host_machine_languages : 'c',
         default_options: 'default_library=static')
 
 sdl2_dep = dependency('sdl2')
@@ -173,7 +173,7 @@ executable('sdlprog', 'sdlprog.c',
 **NOTE:** If you're on Windows you need to include the sdl2main dependency as well; To do so you can modify the above build script like so:
 
 ```meson
-project('sdldemo', 'c',
+project('sdldemo', host_machine_languages : 'c',
         default_options: 'default_library=static')
 
 sdl2_dep = dependency('sdl2')

--- a/docs/markdown/IndepthTutorial.md
+++ b/docs/markdown/IndepthTutorial.md
@@ -15,8 +15,11 @@ tests of our project.
 To start things up, here is the top level `meson.build` file.
 
 ```meson
-project('c++ foolib', 'cpp',
+project(
+  'c++ foolib',
+  host_machine_languages : 'cpp',
   version : '1.0.0',
+  meson_version : '>= 1.8.0',
   license : 'MIT')
 add_global_arguments('-DSOME_TOKEN=value', language : 'cpp')
 glib_dep = dependency('glib-2.0')

--- a/docs/markdown/Installing.md
+++ b/docs/markdown/Installing.md
@@ -21,7 +21,7 @@ By default Meson will not install anything. Build targets can be
 installed by tagging them as installable in the definition.
 
 ```meson
-project('install', 'c')
+project('install', host_machine_languages : 'c')
 shared_library('mylib', 'libfile.c', install : true)
 ```
 

--- a/docs/markdown/Java.md
+++ b/docs/markdown/Java.md
@@ -9,7 +9,7 @@ Meson has experimental support for compiling Java programs. The basic
 syntax consists of only one function and would be used like this:
 
 ```meson
-project('javaprog', 'java')
+project('javaprog', host_machine_languages : 'java')
 
 myjar = jar('mything', 'com/example/Prog.java',
             main_class : 'com.example.Prog')

--- a/docs/markdown/Meson-sample.md
+++ b/docs/markdown/Meson-sample.md
@@ -7,7 +7,7 @@ short-description: Simple project step by step explanation
 A Meson file that builds an executable looks like this.
 
 ```meson
-project('simple', 'c')
+project('simple', host_machine_languages : 'c')
 executable('myexe', 'source.c')
 ```
 
@@ -25,7 +25,7 @@ Variables are fully supported. The above code snippet could also have
 been declared like this.
 
 ```meson
-project('simple', 'c')
+project('simple', host_machine_languages : 'c')
 src = 'source.c'
 executable('myexe', src)
 ```
@@ -34,7 +34,7 @@ Most executables consist of more than one source file. The easiest way
 to deal with this is to put them in an array.
 
 ```meson
-project('simple', 'c')
+project('simple', host_machine_languages : 'c')
 src = ['source1.c', 'source2.c', 'source3.c']
 executable('myexe', src)
 ```
@@ -44,7 +44,7 @@ arguments to functions can only be passed using them. The above
 snippet could be rewritten like this.
 
 ```meson
-project('simple', 'c')
+project('simple', host_machine_languages : 'c')
 src = ['source1.c', 'source2.c', 'source3.c']
 executable('myexe', sources : src)
 ```
@@ -57,7 +57,7 @@ which represents the given build target. It can be passed on to other
 functions, like this.
 
 ```meson
-project('simple', 'c')
+project('simple', host_machine_languages : 'c')
 src = ['source1.c', 'source2.c', 'source3.c']
 exe = executable('myexe', src)
 test('simple test', exe)

--- a/docs/markdown/Porting-from-autotools.md
+++ b/docs/markdown/Porting-from-autotools.md
@@ -47,7 +47,7 @@ AC_PROG_CC
 ```
 `meson.build`:
 ```meson
-project('appstream-glib', 'c', version : '0.3.6')
+project('appstream-glib', host_machine_languages : 'c', version : '0.3.6')
 ```
 Note that this must be the first line of your `meson.build` file.
 

--- a/docs/markdown/Shipping-prebuilt-binaries-as-wraps.md
+++ b/docs/markdown/Shipping-prebuilt-binaries-as-wraps.md
@@ -14,7 +14,7 @@ library at the top level and headers in a subdirectory called
 `include`. The Meson build definition would look like the following.
 
 ```meson
-project('bob', 'c')
+project('bob', host_machine_languages : 'c')
 
 # Do some sanity checking so that meson can fail early instead of at final link time
 if not (host_machine.system() == 'windows' and host_machine.cpu_family() == 'x86_64')
@@ -32,7 +32,7 @@ meson.override_dependency('bob', bob_dep)
 Now you can use this subproject as if it was a Meson project:
 
 ```meson
-project('using dep', 'c')
+project('using dep', host_machine_languages : 'c')
 bob_dep = dependency('bob')
 executable('prog', 'prog.c', dependencies : bob_dep)
 ```

--- a/docs/markdown/Subprojects.md
+++ b/docs/markdown/Subprojects.md
@@ -33,7 +33,7 @@ As an example, suppose we have a simple project that provides a shared
 library. Its `meson.build` would look like this.
 
 ```meson
-project('libsimple', 'c')
+project('libsimple', host_machine_languages : 'c')
 
 inc = include_directories('include')
 libsimple = shared_library('simple',
@@ -108,7 +108,7 @@ Then copy `libsimple` into `subprojects` directory.
 Your project's `meson.build` should look like this.
 
 ```meson
-project('my_project', 'cpp')
+project('my_project', host_machine_languages : 'cpp')
 
 libsimple_proj = subproject('libsimple')
 libsimple_dep = libsimple_proj.get_variable('libsimple_dep')
@@ -135,7 +135,7 @@ Here's how you would use system libraries and fall back to embedding sources
 if the dependency is not available.
 
 ```meson
-project('my_project', 'cpp')
+project('my_project', host_machine_languages : 'cpp')
 
 libsimple_dep = dependency('libsimple', required : false)
 
@@ -166,7 +166,7 @@ method described above.
 Using this shortcut the build definition would look like this.
 
 ```meson
-project('my_project', 'cpp')
+project('my_project', host_machine_languages : 'cpp')
 
 libsimple_dep = dependency('libsimple', fallback : ['libsimple', 'libsimple_dep'])
 

--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -342,7 +342,7 @@ my_sources += files('bar.c')
 # than they're defined in
 
 # Example to set an API version for use in library(), install_header(), etc
-project('project', 'c', version: '0.2.3')
+project('project', host_machine_languages : 'c', version: '0.2.3')
 version_array = meson.project_version().split('.')
 # version_array now has the value ['0', '2', '3']
 api_version = '.'.join([version_array[0], version_array[1]])

--- a/docs/markdown/Tutorial.md
+++ b/docs/markdown/Tutorial.md
@@ -46,7 +46,7 @@ Then we create a Meson build description and put it in a file called
 `meson.build` in the same directory. Its contents are the following.
 
 ```meson
-project('tutorial', 'c')
+project('tutorial', host_machine_languages : 'c')
 executable('demo', 'main.c')
 ```
 
@@ -160,7 +160,7 @@ Then we edit the Meson file, instructing it to find and use the GTK+
 libraries.
 
 ```meson
-project('tutorial', 'c')
+project('tutorial', host_machine_languages : 'c')
 gtkdep = dependency('gtk+-3.0')
 executable('demo', 'main.c', dependencies : gtkdep)
 ```

--- a/docs/markdown/Vala.md
+++ b/docs/markdown/Vala.md
@@ -9,7 +9,7 @@ Meson supports compiling applications and libraries written in
 [Genie](https://wiki.gnome.org/Projects/Genie) . A skeleton `meson.build` file:
 
 ```meson
-project('vala app', 'vala', 'c')
+project('vala app', host_machine_languages : 'vala')
 
 dependencies = [
     dependency('glib-2.0'),
@@ -60,7 +60,7 @@ Everything works seamlessly in the background and only a single extra line is
 needed:
 
 ```meson
-project('vala app', 'vala', 'c')
+project('vala app', host_machine_languages : 'vala')
 
 dependencies = [
     dependency('glib-2.0'),
@@ -98,7 +98,7 @@ This requires `--target-glib 2.38`, or a newer version, to be passed
 to Vala. With Meson this is simply done with:
 
 ```meson
-project('vala app', 'vala', 'c')
+project('vala app', host_machine_languages : 'vala')
 
 dependencies = [
     dependency('glib-2.0', version: '>=2.38'),
@@ -116,7 +116,7 @@ files to be built into the binary as GResources. For completeness,
 the next example shows this:
 
 ```meson
-project('vala app', 'vala', 'c')
+project('vala app', host_machine_languages : 'vala')
 
 dependencies = [
     dependency('glib-2.0', version: '>=2.38'),
@@ -152,7 +152,7 @@ directory to the VAPI search path. In Meson this is done with the
 `add_project_arguments()` function:
 
 ```meson
-project('vala app', 'vala', 'c')
+project('vala app', host_machine_languages : 'vala')
 
 vapi_dir = meson.current_source_dir() / 'vapi'
 
@@ -198,7 +198,7 @@ with Vala and installed in Vala's standard search path. Meson just
 needs to be told to only find the library for the Vala compiler:
 
 ```meson
-project('vala app', 'vala', 'c')
+project('vala app', host_machine_languages : 'vala')
 
 dependencies = [
     dependency('glib-2.0'),
@@ -218,7 +218,7 @@ the maths library separately. In this example Meson is told to find
 the library only for the C compiler:
 
 ```meson
-project('vala app', 'vala', 'c')
+project('vala app', host_machine_languages : 'vala')
 
 dependencies = [
     dependency('glib-2.0'),
@@ -240,7 +240,7 @@ pkg-config file and the VAPI is in the `vapi` directory of your
 project source files:
 
 ```meson
-project('vala app', 'vala', 'c')
+project('vala app', host_machine_languages : 'vala')
 
 vapi_dir = meson.current_source_dir() / 'vapi'
 

--- a/docs/markdown/Wayland-module.md
+++ b/docs/markdown/Wayland-module.md
@@ -12,7 +12,7 @@ might be removed from Meson altogether.
 ## Quick Usage
 
 ```meson
-project('hello-wayland', 'c')
+project('hello-wayland', host_machine_languages : 'c')
 
 wl_dep = dependency('wayland-client')
 wl_mod = import('unstable-wayland')

--- a/docs/markdown/howtox.md
+++ b/docs/markdown/howtox.md
@@ -73,7 +73,7 @@ There is a table of all environment variables supported
 ## Set default C/C++ language version
 
 ```meson
-project('myproj', 'c', 'cpp',
+project('myproj', host_machine_languages : ['c', 'cpp'],
         default_options : ['c_std=c11', 'cpp_std=c++11'])
 ```
 

--- a/docs/markdown/snippets/per-machine-project-languages.md
+++ b/docs/markdown/snippets/per-machine-project-languages.md
@@ -1,0 +1,17 @@
+## project() can now accept languages per-machine
+
+```meson
+project(
+  'foo',
+  'c',  # for both machines
+  host_machine_languages : ['objc'],  # only for the host
+  build_machine_languages : ['cpp'],  # only for the builder
+)
+```
+
+Which would be equivalent to:
+```meson
+project('foo', 'c')
+add_languages('objc', required : true, native : false)
+add_languages('cpp', required : true, native : true)
+```

--- a/docs/yaml/functions/project.yaml
+++ b/docs/yaml/functions/project.yaml
@@ -34,7 +34,15 @@ posargs:
 varargs:
   name: language
   type: str
-  description: The languages that Meson should initialize.
+  description: |
+    Languages that are required for Meson to initialize for both the host and
+    build machines.
+
+    NOTE: If a project can depend on Meson >= 1.8.0 it should strongly consider
+    using the `host_machine_languages` and `build_machine_languages` keyword
+    arguments instead, as most projects likely do not need all of (or any) build
+    machine compilers, and only host machine compilers. This can make building
+    the project easier as only one toolchain is then required.
 
 kwargs:
   default_options:
@@ -120,3 +128,24 @@ kwargs:
       use the default value. It should be noted that this keyword
       argument is ignored inside subprojects. There can be only one
       subproject dir and it is set in the top level Meson file.
+
+  host_machine_languages:
+    type: str | list[str]
+    since: 1.8.0
+    description: |
+      Programming languages that Meson needs to initialize for the host machine.
+
+      When cross compiling, a project may not need to build and binaries to run
+      on the build machine, and as such likely doesn't want to initialize a
+      toolchain for that platform. This is particularly true on Windows, because
+      MSVC is very difficult to configure this way.
+
+  build_machine_languages:
+    type: str | list[str]
+    since: 1.8.0
+    description: |
+      Programming languages that Meson needs to initialize for the build
+      machine.
+
+      If a project needs to build binaries to run at build time, such as
+      code generators.

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1162,6 +1162,12 @@ class Interpreter(InterpreterBase, HoldableObject):
     @typed_kwargs(
         'project',
         DEFAULT_OPTIONS,
+        KwargInfo('build_machine_languages', ContainerTypeInfo(list, str),
+                  listify=True, default=[], since='1.8.0',
+                  since_message='Use add_languages(..., native : true) after the project() call'),
+        KwargInfo('host_machine_languages', ContainerTypeInfo(list, str),
+                  listify=True, default=[], since='1.8.0',
+                  since_message='Use add_languages(..., native : false) after the project() call'),
         KwargInfo('meson_version', (str, NoneType)),
         KwargInfo(
             'version',
@@ -1314,7 +1320,9 @@ class Interpreter(InterpreterBase, HoldableObject):
             mesonlib.setup_vsenv(force_vsenv)
 
         self.add_languages(proj_langs, True, MachineChoice.HOST)
+        self.add_languages(kwargs['host_machine_languages'], True, MachineChoice.HOST)
         self.add_languages(proj_langs, False, MachineChoice.BUILD)
+        self.add_languages(kwargs['build_machine_languages'], True, MachineChoice.BUILD)
 
         self.set_backend()
         if not self.is_subproject():

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -213,6 +213,8 @@ class Project(TypedDict):
     license: T.List[str]
     license_files: T.List[str]
     subproject_dir: str
+    build_machine_languages: T.List[str]
+    host_machine_languages: T.List[str]
 
 
 class _FoundProto(Protocol):

--- a/test cases/native/10 build and host languages/lib.c
+++ b/test cases/native/10 build and host languages/lib.c
@@ -1,0 +1,8 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright © 2025 Intel Corporation
+ */
+
+#include "lib.h"
+
+const char * lib_func(void) { return "host"; }

--- a/test cases/native/10 build and host languages/lib.h
+++ b/test cases/native/10 build and host languages/lib.h
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright © 2025 Intel Corporation
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+const char * lib_func(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/test cases/native/10 build and host languages/main.cpp
+++ b/test cases/native/10 build and host languages/main.cpp
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright © 2025 Intel Corporation
+ */
+
+#ifdef HOST_BUILD
+#include "lib.h"
+#endif
+
+#include <iostream>
+#include <cstring>
+
+namespace {
+
+const char * machine() {
+#ifdef HOST_BUILD
+    return lib_func();
+#else
+    return "build";
+#endif
+}
+
+}
+
+int main() {
+    const char * m = machine();
+    std::cout << "build for " << m << " machine" << std::endl;
+    return std::strcmp(m, FOR_MACHINE) == 0 ? 0 : 1;
+}

--- a/test cases/native/10 build and host languages/meson.build
+++ b/test cases/native/10 build and host languages/meson.build
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2025 Intel Corporation
+
+project(
+  'host and build languages',
+  host_machine_languages : ['cpp', 'c'],
+  build_machine_languages : ['cpp'],
+  license : 'Apache-2.0',
+  meson_version : '>= 1.8.0',
+)
+
+host_main = executable(
+  'main_for_host',
+  'lib.c', 'main.cpp',
+  cpp_args : ['-DHOST_BUILD', '-DFOR_MACHINE="host"'],
+  native : false,
+)
+
+test('host', host_main)
+
+build_main = executable(
+  'main_for_build',
+  'main.cpp',
+  cpp_args : ['-DFOR_MACHINE="build"'],
+  native : true,
+)
+
+test('build', build_main)


### PR DESCRIPTION
When cross compiling, it's often not useful or interesting to have the same toolchain for the host and build machine. Often, a project only needs a host toolchain, and needs no build toolchain at all. In some situations (like MSVC) having to set up a build machine toolchain is painful and annoying when not needed. Alternatively, sometimes a specific language is only needed for the build machine and isn't useful for the host machine.

Currently, the only way to handle this is the non-obvious solution of not setting languages at all in the `project()` call, and then adding them with `add_languages()`, like so:
```meson
project('foo')

add_languages('c', native : false)
add_languages('cpp', native : true)
```

This isn't obvious, and since many developers don't cross compile often, they don't think about cross compiling, so they don't do that, they just set the languages and everything works exactly as they expect.

Having an explicit, project call oriented way to set up the languages, makes it easier for a developer to do the right thing the first time, since they are asked to consider whether they need a toolchain for both the host and and build machines, or just for one or the other. The above could be written as:
```meson
project(
  'foo',
  host_machine_languages : ['c'],
  build_machine_languages : ['cpp'],
  meson_version : '>= 1.8.0',
)
```

This is abundantly clear when reading the `meson.build` file what is necessary, and the developer had to consider what was needed. It would also open a path to using a linter to identify unused languages, or languages unused on a given machine, with a path to easily fixing that.