### PR TITLE
ninjabackend: ensure that native static libraries use Unix-style naming

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3581,7 +3581,15 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             for d in target.get_dependencies():
                 if isinstance(d, build.StaticLibrary):
                     for dep in d.get_external_deps():
-                        commands.extend_preserving_lflags(linker.get_dependency_link_args(dep))
+                        link_args = linker.get_dependency_link_args(dep)
+                        # Ensure that native static libraries use Unix-style naming if necessary.
+                        # Depending on the target/linker, rustc --print native-static-libs may
+                        # output MSVC-style names. Converting these to Unix-style is safe, as the
+                        # list contains only native static libraries.
+                        if dep.name == '_rust_native_static_libs' and linker.get_argument_syntax() != 'msvc':
+                            from ..linkers.linkers import VisualStudioLikeLinker
+                            link_args = VisualStudioLikeLinker.native_args_to_unix(link_args)
+                        commands.extend_preserving_lflags(link_args)
 
         # Add link args specific to this BuildTarget type that must not be overridden by dependencies
         commands += self.get_target_type_link_args_post_dependencies(target, linker)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2139,7 +2139,8 @@ class StaticLibrary(BuildTarget):
                 rustc = self.compilers['rust']
                 d = dependencies.InternalDependency('undefined', [], [],
                                                     rustc.native_static_libs,
-                                                    [], [], [], [], [], {}, [], [], [])
+                                                    [], [], [], [], [], {}, [], [], [],
+                                                    '_rust_native_static_libs')
                 self.external_deps.append(d)
         # By default a static library is named libfoo.a even on Windows because
         # MSVC does not have a consistent convention for what static libraries

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -170,7 +170,7 @@ class RustCompiler(Compiler):
         # are always part of C/C++ linkers. Rustc probably should not print
         # them, pkg-config for example never specify them.
         # FIXME: https://github.com/rust-lang/rust/issues/55120
-        exclude = {'-lc', '-lgcc_s', '-lkernel32', '-ladvapi32'}
+        exclude = {'-lc', '-lgcc_s', '-lkernel32', '-ladvapi32', '/defaultlib:msvcrt'}
         self.native_static_libs = [i for i in match.group(1).split() if i not in exclude]
 
     def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:


### PR DESCRIPTION
Fixes: #14366