### PR TITLE
compilers/rust: fix sanity_check for Windows targets

### DIFF
--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -109,7 +109,7 @@ class RustCompiler(Compiler):
 
     def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
         source_name = os.path.join(work_dir, 'sanity.rs')
-        output_name = os.path.join(work_dir, 'rusttest')
+        output_name = os.path.join(work_dir, 'rusttest.exe')
         cmdlist = self.exelist.copy()
 
         with open(source_name, 'w', encoding='utf-8') as ofile:


### PR DESCRIPTION
Windows toolchains append `.exe` to executables. When cross-compiling on Linux, attempting to run `./rusttest` will not execute the generated `rusttest.exe`.

Fix this by always appending `.exe`, which is a valid filename on all supported platforms. This is what the `CLikeCompiler` class does too.

While reviewing `rust.py`, there are opportunities for improvements and better unification with the rest of the Meson code. However, this commit focuses on fixing cross-compilation with minimal changes.

Fixes: #14374