### PR TITLE
improve and unify logging for sanity checks

### DIFF
--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -102,10 +102,7 @@ class CsCompiler(BasicLinkerIsCompilerMixin, Compiler):
             cmdlist = [self.runner, obj]
         else:
             cmdlist = [os.path.join(work_dir, obj)]
-        pe = subprocess.Popen(cmdlist, cwd=work_dir)
-        pe.wait()
-        if pe.returncode != 0:
-            raise EnvironmentException('Executables created by Mono compiler %s are not runnable.' % self.name_string())
+        self.run_sanity_check(environment, cmdlist, work_dir, use_exe_wrapper_for_cross=False)
 
     def needs_static_linker(self) -> bool:
         return False

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -456,15 +456,7 @@ class DCompiler(Compiler):
         if pc.returncode != 0:
             raise EnvironmentException('D compiler %s cannot compile programs.' % self.name_string())
 
-        if self.is_cross:
-            if not environment.has_exe_wrapper():
-                # Can't check if the binaries run so we have to assume they do
-                return
-            cmdlist = environment.exe_wrapper.get_command() + [output_name]
-        else:
-            cmdlist = [output_name]
-        if subprocess.call(cmdlist) != 0:
-            raise EnvironmentException('Executables created by D compiler %s are not runnable.' % self.name_string())
+        stdo, stde = self.run_sanity_check(environment, [output_name], work_dir)
 
     def needs_static_linker(self) -> bool:
         return True

--- a/mesonbuild/compilers/java.py
+++ b/mesonbuild/compilers/java.py
@@ -91,10 +91,7 @@ class JavaCompiler(BasicLinkerIsCompilerMixin, Compiler):
         runner = shutil.which(self.javarunner)
         if runner:
             cmdlist = [runner, '-cp', '.', obj]
-            pe = subprocess.Popen(cmdlist, cwd=work_dir)
-            pe.wait()
-            if pe.returncode != 0:
-                raise EnvironmentException(f'Executables created by Java compiler {self.name_string()} are not runnable.')
+            self.run_sanity_check(environment, cmdlist, work_dir, use_exe_wrapper_for_cross=False)
         else:
             m = "Java Virtual Machine wasn't found, but it's needed by Meson. " \
                 "Please install a JRE.\nIf you have specific needs where this " \

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -307,21 +307,7 @@ class CLikeCompiler(Compiler):
         mlog.debug('-----')
         if pc.returncode != 0:
             raise mesonlib.EnvironmentException(f'Compiler {self.name_string()} cannot compile programs.')
-        # Run sanity check
-        if self.is_cross:
-            if not environment.has_exe_wrapper():
-                # Can't check if the binaries run so we have to assume they do
-                return
-            cmdlist = environment.exe_wrapper.get_command() + [binary_name]
-        else:
-            cmdlist = [binary_name]
-        mlog.debug('Running test binary command: ', mesonlib.join_args(cmdlist))
-        try:
-            pe, _, _ = Popen_safe_logged(cmdlist, 'Sanity check', cwd=work_dir)
-        except Exception as e:
-            raise mesonlib.EnvironmentException(f'Could not invoke sanity test executable: {e!s}.')
-        if pe.returncode != 0:
-            raise mesonlib.EnvironmentException(f'Executables created by {self.language} compiler {self.name_string()} are not runnable.')
+        self.run_sanity_check(environment, [binary_name], work_dir)
 
     def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
         code = 'int main(void) { int class=0; return class; }\n'

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -317,8 +317,7 @@ class CLikeCompiler(Compiler):
             cmdlist = [binary_name]
         mlog.debug('Running test binary command: ', mesonlib.join_args(cmdlist))
         try:
-            # fortran code writes to stdout
-            pe = subprocess.run(cmdlist, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            pe, _, _ = Popen_safe_logged(cmdlist, 'Sanity check', cwd=work_dir)
         except Exception as e:
             raise mesonlib.EnvironmentException(f'Could not invoke sanity test executable: {e!s}.')
         if pe.returncode != 0:

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import functools
-import subprocess, os.path
+import os.path
 import textwrap
 import re
 import typing as T
@@ -141,17 +141,7 @@ class RustCompiler(Compiler):
         if pc.returncode != 0:
             raise EnvironmentException(f'Rust compiler {self.name_string()} cannot compile programs.')
         self._native_static_libs(work_dir, source_name)
-        if self.is_cross:
-            if not environment.has_exe_wrapper():
-                # Can't check if the binaries run so we have to assume they do
-                return
-            cmdlist = environment.exe_wrapper.get_command() + [output_name]
-        else:
-            cmdlist = [output_name]
-        pe = subprocess.Popen(cmdlist, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        pe.wait()
-        if pe.returncode != 0:
-            raise EnvironmentException(f'Executables created by Rust compiler {self.name_string()} are not runnable.')
+        self.run_sanity_check(environment, [output_name], work_dir)
 
     def _native_static_libs(self, work_dir: str, source_name: str) -> None:
         # Get libraries needed to link with a Rust staticlib

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -8,7 +8,7 @@ import subprocess, os.path
 import typing as T
 
 from .. import mlog, options
-from ..mesonlib import EnvironmentException, MesonException, version_compare
+from ..mesonlib import MesonException, version_compare
 from .compilers import Compiler, clike_debug_args
 
 
@@ -170,13 +170,7 @@ class SwiftCompiler(Compiler):
 ''')
         pc = subprocess.Popen(self.exelist + extra_flags + ['-emit-executable', '-o', output_name, src], cwd=work_dir)
         pc.wait()
-        if pc.returncode != 0:
-            raise EnvironmentException('Swift compiler %s cannot compile programs.' % self.name_string())
-        if self.is_cross:
-            # Can't check if the binaries run so we have to assume they do
-            return
-        if subprocess.call(output_name) != 0:
-            raise EnvironmentException('Executables created by Swift compiler %s are not runnable.' % self.name_string())
+        self.run_sanity_check(environment, [output_name], work_dir)
 
     def get_debug_args(self, is_debug: bool) -> T.List[str]:
         return clike_debug_args[is_debug]


### PR DESCRIPTION
The logic for compiler sanity checks is duplicated across all languages. Improve it across the board by introducing a new helper function that handles cross compilation, logging and exception reporting.