### PR TITLE
qt module: look for qt tools only on build machine

### DIFF
--- a/mesonbuild/modules/_qt.py
+++ b/mesonbuild/modules/_qt.py
@@ -270,6 +270,9 @@ class QtBaseModule(ExtensionModule):
         self._tools_detected = True
         mlog.log(f'Detecting Qt{self.qt_version} tools')
         kwargs = {'required': required, 'modules': 'Core', 'method': method}
+        # Tools are for compile-time steps, so force native check for
+        # compatibility with cross-compile scenarios
+        kwargs["native"] = True
         # Just pick one to make mypy happy
         qt = T.cast('QtPkgConfigDependency', find_external_dependency(f'qt{self.qt_version}', state.environment, kwargs))
         if qt.found():


### PR DESCRIPTION
Qt tools may be needed at build time, let's make their detection based on the build machine rather than the host machine as currently done.

This incidentally fixes cross-compilation search for moc, rcc, uic and lrelease Qt tools because they are installed in libexec dir and that path is somehow not properly looked for otherwise.

Before:

```
Detecting Qt6 tools
Run-time dependency qt6 (modules: Core) found: YES 6.8.1 (pkg-config) Program /usr/bin/moc found: NO
Program /usr/lib/qt6/libexec/moc found: NO
Program moc6 found: NO
Program moc-qt6 found: NO
Program moc found: NO
```

After:

```
Detecting Qt6 tools
Found pkg-config: YES (/home/qschulz/work/upstream/buildroot/output/host/bin/pkg-config) 2.3.0
Build-time dependency qt6 (modules: Core) found: YES 6.8.1 (pkg-config)
Program /home/qschulz/work/upstream/buildroot/output/host/bin/moc found: NO
Program /home/qschulz/work/upstream/buildroot/output/host/libexec/moc found: YES 6.8.1 6.8.1 (/home/qschulz/work/upstream/buildroot/output/host/libexec/moc)
```

Cc @rossburton who suggested the fix in #13018. I am not entirely sure this is enough to fix #13018 hence why I omitted it in the commit log. Cc @cordlandwehr for awareness.

Cc @pinchartl and @kbingham maintainers of https://libcamera.org/ for which this patch is needed.

This was written for building the qcam (qt6-based) test application of libcamera in Buildroot 2025.02 where the build machine sysroot (provided by Buildroot) differs from the build distribution. I have not tested this patch in any other context.