### PR TITLE
man page: Update basic instructions

### DIFF
--- a/man/meson.1
+++ b/man/meson.1
@@ -40,19 +40,6 @@ your build dir. After that you just run the build command. Meson will
 autodetect changes in your source tree and regenerate all files
 needed to build the project.
 
-The setup command is the default operation. If no actual command is
-specified, Meson will assume you meant to do a setup. That means
-that you can set up a build directory without the setup command
-like this:
-
-.B meson [
-.I options
-.B ] [
-.I build directory
-.B ] [
-.I source directory
-.B ]
-
 .SS "options:"
 .TP
 \fB\-\-version\fR
@@ -657,6 +644,13 @@ try to read configuration from .editorconfig
 .TP
 \fB-o OUTPUT, --output OUTPUT\fR
 output file (implies having exactly one input)
+
+.SH When no command is specified
+
+If you run Meson without a subcommand, it will assume you meant
+\fBmeson setup\fR. However, this syntax is deprecated, and Meson
+will print a warning message if it is used. You should always use
+\fBmeson setup\fR explicitly, instead of relying on the default.
 
 .SH EXIT STATUS
 


### PR DESCRIPTION
The man page's discussion of basic `meson` usage in the intro was extremely out of date, suggesting that running `meson` without a command was the same as `meson setup` (despite being deprecated syntax). This PR updates the text to:

- Move the mention of the (deprecated) default command mode down near the end of the page, instead of presenting it right up front.
- <s>Replace instructions to run 'ninja' with 'meson compile' as the build command.<s/>