### PR TITLE
ci: stop installing python2 for the msys2 jobs, it's gone

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -79,7 +79,6 @@ jobs:
             mingw-w64-${{ matrix.MSYS2_ARCH }}-libxml2
             mingw-w64-${{ matrix.MSYS2_ARCH }}-ninja
             mingw-w64-${{ matrix.MSYS2_ARCH }}-pkg-config
-            mingw-w64-${{ matrix.MSYS2_ARCH }}-python2
             mingw-w64-${{ matrix.MSYS2_ARCH }}-python
             mingw-w64-${{ matrix.MSYS2_ARCH }}-python-lxml
             mingw-w64-${{ matrix.MSYS2_ARCH }}-python-setuptools


### PR DESCRIPTION
MSYS2 dropped Python 2 in https://github.com/msys2/MINGW-packages/pull/23713