### PR TITLE
handle monorepo license files specified in project() via ../

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1354,9 +1354,9 @@ class Backend:
         d.data.append(InstallDataBase(ifilename, ofilename, out_name, None, '',
                                       tag='devel', data_type='depmf'))
         for m in self.build.dep_manifest.values():
-            for ifilename, name in m.license_files:
-                ofilename = os.path.join(odirname, name.relative_name())
-                out_name = os.path.join(out_dir, name.relative_name())
+            for ifilename, name in m.license_mapping():
+                ofilename = os.path.join(odirname, name)
+                out_name = os.path.join(out_dir, name)
                 d.data.append(InstallDataBase(ifilename, ofilename, out_name, None,
                                               m.subproject, tag='devel', data_type='depmf'))
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -223,11 +223,18 @@ class DepManifest:
     license_files: T.List[T.Tuple[str, File]]
     subproject: str
 
+    def license_mapping(self) -> T.List[T.Tuple[str, str]]:
+        ret = []
+        for ifilename, name in self.license_files:
+            fname = os.path.join(*(x for x in pathlib.PurePath(os.path.normpath(name.fname)).parts if x != '..'))
+            ret.append((ifilename, os.path.join(name.subdir, fname)))
+        return ret
+
     def to_json(self) -> T.Dict[str, T.Union[str, T.List[str]]]:
         return {
             'version': self.version,
             'license': self.license,
-            'license_files': [l[1].relative_name() for l in self.license_files],
+            'license_files': [l[1] for l in self.license_mapping()],
         }
 
 

--- a/test cases/common/42 subproject/meson.build
+++ b/test cases/common/42 subproject/meson.build
@@ -1,7 +1,8 @@
 project('subproj user', 'c',
   version : '2.3.4',
   license : 'mylicense',
-  license_files: 'mylicense.txt',
+  # also grab the meson license to test monorepo support
+  license_files: ['mylicense.txt', '../../../COPYING'],
 )
 
 assert(meson.project_name() == 'subproj user', 'Incorrect project name')

--- a/test cases/common/42 subproject/test.json
+++ b/test cases/common/42 subproject/test.json
@@ -4,6 +4,7 @@
     {"type": "pdb", "file": "usr/bin/user"},
     {"type": "file", "file": "usr/share/sublib/sublib.depmf"},
     {"type": "file", "file": "usr/share/sublib/mylicense.txt"},
+    {"type": "file", "file": "usr/share/sublib/COPYING"},
     {"type": "file", "file": "usr/share/sublib/subprojects/sublib/sublicense1.txt"},
     {"type": "file", "file": "usr/share/sublib/subprojects/sublib/sublicense2.txt"}
   ]


### PR DESCRIPTION
We should simply remap these to elide the ../ as it's pretty obviously the natural expectation of using ../ to fetch files from outside the project and then drop them *into* the project.

Monorepos will likely have a single license file (or set) under which the monorepo is licensed. But there will be many components, each of which may use a different build system, which are "standalone" for the most part. We already support this case as long as you build from the monorepo, but the resulting license file gets installed to

```
{licensedir}/../
```

which is silly and unhelpful.

Bug: https://github.com/apache/arrow/issues/36411