### PR TITLE
CI: Fix filemode tests with cygwin 3.6.0

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -41,6 +41,10 @@ jobs:
       MESON_CI_JOBNAME: cygwin-${{ matrix.NAME }}
 
     steps:
+      # remove inheritable permissions since they break assumptions testsuite
+      # makes about file modes
+      - run: icacls . /inheritance:r /T /C
+
       - uses: actions/cache/restore@v4
         id: restore-cache
         with:

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -125,18 +125,6 @@ class BasePlatformTests(TestCase):
         newdir = os.path.realpath(newdir)
         self.change_builddir(newdir)
 
-    def new_builddir_in_tempdir(self):
-        # Can't keep the builddir inside the source tree for the umask tests:
-        # https://github.com/mesonbuild/meson/pull/5546#issuecomment-509666523
-        # And we can't do this for all tests because it causes the path to be
-        # a short-path which breaks other tests:
-        # https://github.com/mesonbuild/meson/pull/9497
-        newdir = tempfile.mkdtemp()
-        # In case the directory is inside a symlinked directory, find the real
-        # path otherwise we might not find the srcdir from inside the builddir.
-        newdir = os.path.realpath(newdir)
-        self.change_builddir(newdir)
-
     def _open_meson_log(self) -> io.TextIOWrapper:
         log = os.path.join(self.logdir, 'meson-log.txt')
         return open(log, encoding='utf-8')

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -590,8 +590,6 @@ class LinuxlikeTests(BasePlatformTests):
         Test that files installed by these tests have the correct permissions.
         Can't be an ordinary test because our installed_files.txt is very basic.
         '''
-        if is_cygwin():
-            self.new_builddir_in_tempdir()
         # Test file modes
         testdir = os.path.join(self.common_test_dir, '12 data')
         self.init(testdir)
@@ -644,8 +642,6 @@ class LinuxlikeTests(BasePlatformTests):
         '''
         Test that files are installed with correct permissions using install_mode.
         '''
-        if is_cygwin():
-            self.new_builddir_in_tempdir()
         testdir = os.path.join(self.common_test_dir, '190 install_mode')
         self.init(testdir)
         self.build()
@@ -684,8 +680,6 @@ class LinuxlikeTests(BasePlatformTests):
         install umask of 022, regardless of the umask at time the worktree
         was checked out or the build was executed.
         '''
-        if is_cygwin():
-            self.new_builddir_in_tempdir()
         # Copy source tree to a temporary directory and change permissions
         # there to simulate a checkout with umask 002.
         orig_testdir = os.path.join(self.unit_test_dir, '26 install umask')


### PR DESCRIPTION
Put cygwin filemode tests back under the sourcedir
Remove inheritable permissions from the sourcedir

For :reasons:, the unit tests which check file mode were built in the tempdir.

Instead, remove inheritable permissions from the working directory (which the GitHub VM image has set for some reaons), since they can interfere with getting exactly the file mode you asked for.

Partially reverts 04ae1cfb7999e25f476f84572ff0ad853629346c