### PR TITLE
options: Make sure the gnu99 deprecation is only printed once

### DIFF
--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -623,7 +623,7 @@ class UserStdOption(UserComboOption):
                     f'However, the deprecated {std} std currently falls back to {newstd}.\n' +
                     'This will be an error in meson 2.0.\n' +
                     'If the project supports both GNU and MSVC compilers, a value such as\n' +
-                    '"c_std=gnu11,c11" specifies that GNU is preferred but it can safely fallback to plain c11.')
+                    '"c_std=gnu11,c11" specifies that GNU is preferred but it can safely fallback to plain c11.', once=True)
                 return newstd
         raise MesonException(f'None of values {candidates} are supported by the {self.lang.upper()} compiler. ' +
                              f'Possible values for option "{self.name}" are {self.choices}')


### PR DESCRIPTION
Cuts down the spam radically when building with MSVC.