### PR TITLE
gnome.mkenums: Use rspfiles on Windows when possible

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1582,7 +1582,7 @@ class Backend:
 
     def eval_custom_target_command(
             self, target: build.CustomTarget, absolute_outputs: bool = False) -> \
-            T.Tuple[T.List[str], T.List[str], T.List[str]]:
+            T.Tuple[T.List[str], T.List[str], T.List[str | programs.ExternalProgram]]:
         # We want the outputs to be absolute only when using the VS backend
         # XXX: Maybe allow the vs backend to use relative paths too?
         source_root = self.build_to_src
@@ -1595,7 +1595,7 @@ class Backend:
         outputs = [os.path.join(outdir, i) for i in target.get_outputs()]
         inputs = self.get_custom_target_sources(target)
         # Evaluate the command list
-        cmd: T.List[str] = []
+        cmd: T.List[str | programs.ExternalProgram] = []
         for i in target.command:
             if isinstance(i, build.BuildTarget):
                 cmd += self.build_target_to_cmd_array(i)
@@ -1631,6 +1631,9 @@ class Backend:
                     if not target.absolute_paths:
                         pdir = self.get_target_private_dir(target)
                     i = i.replace('@PRIVATE_DIR@', pdir)
+            elif isinstance(i, programs.ExternalProgram):
+                # Let it pass and be extended elsewhere
+                pass
             else:
                 raise RuntimeError(f'Argument {i} is of unknown type {type(i)}')
             cmd.append(i)
@@ -1655,7 +1658,7 @@ class Backend:
         # fixed.
         #
         # https://github.com/mesonbuild/meson/pull/737
-        cmd = [i.replace('\\', '/') for i in cmd]
+        cmd = [i.replace('\\', '/') if isinstance(i, str) else i for i in cmd]
         return inputs, outputs, cmd
 
     def get_introspect_command(self) -> str:
@@ -2016,6 +2019,8 @@ class Backend:
                         compiler += [j]
                     elif isinstance(j, (build.BuildTarget, build.CustomTarget)):
                         compiler += j.get_outputs()
+                    elif isinstance(j, programs.ExternalProgram):
+                        compiler += j.get_command()
                     else:
                         raise RuntimeError(f'Type "{type(j).__name__}" is not supported in get_introspection_data. This is a bug')
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1223,6 +1223,7 @@ class NinjaBackend(backends.Backend):
                                                 capture=ofilenames[0] if target.capture else None,
                                                 feed=srcs[0] if target.feed else None,
                                                 env=target.env,
+                                                can_use_rsp_file=target.rspable,
                                                 verbose=target.console)
         if reason:
             cmd_type = f' (wrapped by meson {reason})'

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2576,7 +2576,7 @@ class CommandBase:
     subproject: str
 
     def flatten_command(self, cmd: T.Sequence[T.Union[str, File, programs.ExternalProgram, BuildTargetTypes]]) -> \
-            T.List[T.Union[str, File, BuildTarget, 'CustomTarget']]:
+            T.List[T.Union[str, File, BuildTarget, CustomTarget, programs.ExternalProgram]]:
         cmd = listify(cmd)
         final_cmd: T.List[T.Union[str, File, BuildTarget, 'CustomTarget']] = []
         for c in cmd:
@@ -2593,7 +2593,8 @@ class CommandBase:
                     # Can only add a dependency on an external program which we
                     # know the absolute path of
                     self.depend_files.append(File.from_absolute_file(path))
-                final_cmd += c.get_command()
+                # Do NOT flatten -- it is needed for later parsing
+                final_cmd.append(c)
             elif isinstance(c, (BuildTarget, CustomTarget)):
                 self.dependencies.append(c)
                 final_cmd.append(c)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2663,6 +2663,7 @@ class CustomTarget(Target, CustomTargetBase, CommandBase):
                  install_dir: T.Optional[T.List[T.Union[str, Literal[False]]]] = None,
                  install_mode: T.Optional[FileMode] = None,
                  install_tag: T.Optional[T.List[T.Optional[str]]] = None,
+                 rspable: bool = False,
                  absolute_paths: bool = False,
                  backend: T.Optional['Backend'] = None,
                  description: str = 'Generating {} with a custom command',
@@ -2694,6 +2695,9 @@ class CustomTarget(Target, CustomTargetBase, CommandBase):
 
         # Whether to use absolute paths for all files on the commandline
         self.absolute_paths = absolute_paths
+
+        # Whether to enable using response files for the underlying tool
+        self.rspable = rspable
 
     def get_default_install_dir(self) -> T.Union[T.Tuple[str, str], T.Tuple[None, None]]:
         return None, None

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1991,6 +1991,7 @@ class GnomeModule(ExtensionModule):
             extra_depends=depends,
             # https://github.com/mesonbuild/meson/issues/973
             absolute_paths=True,
+            rspable=mesonlib.is_windows() or mesonlib.is_cygwin(),
             description='Generating GObject enum file {}',
         )
 

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -38,6 +38,7 @@ if T.TYPE_CHECKING:
     from ..environment import Environment
     from ..compilers.compilers import Compiler
     from ..interpreterbase.baseobjects import SubProject
+    from .. import programs
 
     class _EnvPickleLoadable(Protocol):
 
@@ -1738,7 +1739,7 @@ def Popen_safe_logged(args: T.List[str], msg: str = 'Called', **kwargs: T.Any) -
     return p, o, e
 
 
-def iter_regexin_iter(regexiter: T.Iterable[str], initer: T.Iterable[str]) -> T.Optional[str]:
+def iter_regexin_iter(regexiter: T.Iterable[str], initer: T.Iterable[str | programs.ExternalProgram]) -> T.Optional[str]:
     '''
     Takes each regular expression in @regexiter and tries to search for it in
     every item in @initer. If there is a match, returns that match.
@@ -1754,7 +1755,7 @@ def iter_regexin_iter(regexiter: T.Iterable[str], initer: T.Iterable[str]) -> T.
     return None
 
 
-def _substitute_values_check_errors(command: T.List[str], values: T.Dict[str, T.Union[str, T.List[str]]]) -> None:
+def _substitute_values_check_errors(command: T.List[str | programs.ExternalProgram], values: T.Dict[str, T.Union[str, T.List[str]]]) -> None:
     # Error checking
     inregex: T.List[str] = ['@INPUT([0-9]+)?@', '@PLAINNAME@', '@BASENAME@']
     outregex: T.List[str] = ['@OUTPUT([0-9]+)?@', '@OUTDIR@']
@@ -1794,7 +1795,7 @@ def _substitute_values_check_errors(command: T.List[str], values: T.Dict[str, T.
                 raise MesonException(m.format(match2.group(), len(values['@OUTPUT@'])))
 
 
-def substitute_values(command: T.List[str], values: T.Dict[str, T.Union[str, T.List[str]]]) -> T.List[str]:
+def substitute_values(command: T.List[str | programs.ExternalProgram], values: T.Dict[str, T.Union[str, T.List[str]]]) -> T.List[str | programs.ExternalProgram]:
     '''
     Substitute the template strings in the @values dict into the list of
     strings @command and return a new list. For a full list of the templates,
@@ -1821,7 +1822,7 @@ def substitute_values(command: T.List[str], values: T.Dict[str, T.Union[str, T.L
     _substitute_values_check_errors(command, values)
 
     # Substitution
-    outcmd: T.List[str] = []
+    outcmd: T.List[str | programs.ExternalProgram] = []
     rx_keys = [re.escape(key) for key in values if key not in ('@INPUT@', '@OUTPUT@')]
     value_rx = re.compile('|'.join(rx_keys)) if rx_keys else None
     for vv in command:


### PR DESCRIPTION
This MR aims to update the work made in https://github.com/mesonbuild/meson/pull/4966 to allow (known) custom targets, like Gnome's `glib-mkenums`, to use response files.

I'm setting it as draft because this doesn't completely work on Windows; this is because I cannot find a suitable point in the target lifecycle to convert arguments to response files:

- Doing so in the Gnome module breaks placeholder variables conversion
- Doing so at the Ninja backend level breaks generation altogether (making the `CUSTOM_COMMAND` rule rspable means I have to supply a placeholder to `rsp_content` -- see below)
- Doing so at the generic backend level (either in `as_meson_exe_cmdline` or `get_executable_serialisation`) seems like the wisest choice, however on Windows scripts must go through an interpreter. In the case of `glib-mkenums` it's Python, but it's not possible to ensure I'm converting *just* the call to `glib-mkenums`, as the command + arguments have already been completely flattened

All feedback, and ideas to fix the last hurdle, is appreciated.

(EDIT -- I think there's still an outstanding bug, in that the space escaping doesn't work in some circumstances, yielding a broken interpreter call `C:\Program ` instead of the full Python path. I need to sort out the response file handling before being able to determine where it happens and why.)

Fixes #6710