### PR TITLE
envconfig: fix unhandled exception when cross-file lacks required keys

### DIFF
--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -281,7 +281,7 @@ class MachineInfo(HoldableObject):
         assert all(isinstance(v, str) for v in raw.values()), 'for mypy'
         literal = T.cast('T.Dict[str, str]', raw)
         minimum_literal = {'cpu', 'cpu_family', 'endian', 'system'}
-        if set(literal) < minimum_literal:
+        if minimum_literal - set(literal):
             raise EnvironmentException(
                 f'Machine info is currently {literal}\n' +
                 'but is missing {}.'.format(minimum_literal - set(literal)))


### PR DESCRIPTION

## Problem
When users forget to specify the required `endian` parameter in a cross-compilation configuration file, Meson currently throws an unhandled `KeyError` exception. This creates confusion as the error message doesn't clearly indicate what's missing, and instead suggests that this is a Meson bug that should be reported.

## Solution
Modified the condition check in the `MachineInfo.from_literal` method from:
```python
if set(literal) < minimum_literal:
```
to:
```python
if minimum_literal - set(literal):
```

This ensures that when mandatory fields are missing, users receive a clear error message explicitly stating which fields are missing, rather than encountering an unhandled exception.

## Related Issue
Fixes #14385