### PR TITLE
compilers: initial support for clang-based Borland C++ compilers

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -9,6 +9,7 @@ These are return values of the `get_id` (Compiler family) and
 | -----     | ---------------                  | --------------- |
 | arm       | ARM compiler                     |                 |
 | armclang  | ARMCLANG compiler                |                 |
+| bccclang  | Embarcadero C++ compiler         | gcc             |
 | ccomp     | The CompCert formally-verified C compiler |        |
 | ccrx      | Renesas RX Family C/C++ compiler |                 |
 | clang     | The Clang compiler               | gcc             |
@@ -69,6 +70,7 @@ These are return values of the `get_linker_id` method in a compiler object.
 | link       | MSVC linker                                 |
 | lld-link   | The LLVM linker, with the MSVC interface    |
 | xilink     | Used with Intel-cl only, MSVC like          |
+| ilink      | Turbo Incremental Link, used with bccclang  |
 | optlink    | optlink (used with DMD)                     |
 | rlink      | The Renesas linker, used with CCrx only     |
 | xc16-ar    | The Microchip linker, used with XC16 only   |

--- a/docs/markdown/snippets/clang-based-borland-compilers.md
+++ b/docs/markdown/snippets/clang-based-borland-compilers.md
@@ -1,0 +1,19 @@
+## Support for Clang-based Borland C++ Toolchain
+
+Meson now recognizes the [Clang-based Borland C++ compiler family](https://docwiki.embarcadero.com/RADStudio/Athens/en/Clang-enhanced_C++_Compilers),
+targeting `i686-pc-windows-omf` and `x86_64-pc-windows-elf`, as `bccclang`.
+
+There are certain limitations when using this toolchain:
+
+- Creating static libraries with the same object names in different directories
+  does not work. This is an issue in `tlib`, and a possible workaround is to
+  use the `prelink` option when creating your library.
+- `ilink` always allows undefined symbols.
+- Building VCL applications or linking with Delphi code is untested.
+
+Note that the newer `bcc64x` compiler (named "Windows 64-bit (modern)" in RAD
+Studio) is COFF-based. It behaves more like upstream Clang in a MinGW
+environment, so it is identified as normal `clang`.
+
+Previously, `bcc64x`'s linker was incorrectly identified as `ld.bfd`. Now it
+resolves to `ld.lld` correctly.

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -155,6 +155,13 @@ class ArmLtdClangCCompiler(ClangCCompiler):
 
     id = 'armltdclang'
 
+class BorlandClangCCompiler(ClangCCompiler):
+
+    id = 'bccclang'
+
+    # Override CCompiler.get_always_args
+    def get_always_args(self) -> T.List[str]:
+        return ['-q']
 
 class AppleClangCCompiler(AppleCompilerMixin, AppleCStdsMixin, ClangCCompiler):
 

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -344,6 +344,13 @@ class ArmLtdClangCPPCompiler(ClangCPPCompiler):
 
     id = 'armltdclang'
 
+class BorlandClangCPPCompiler(ClangCPPCompiler):
+
+    id = 'bccclang'
+
+    # Override CCompiler.get_always_args
+    def get_always_args(self) -> T.List[str]:
+        return ['-q']
 
 class AppleClangCPPCompiler(AppleCompilerMixin, AppleCPPStdsMixin, ClangCPPCompiler):
     def is_libcpp_enable_assertions_deprecated(self) -> bool:

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -936,12 +936,18 @@ def _detect_objc_or_objcpp_compiler(env: 'Environment', lang: str, for_machine: 
             if 'windows' in out or env.machines[for_machine].is_windows():
                 # If we're in a MINGW context this actually will use a gnu style ld
                 try:
-                    linker = guess_win_linker(env, compiler, comp, version, for_machine)
+                    if 'embt.com' in out:
+                        linker = guess_win_linker(env, compiler, comp, version, for_machine, extra_args=['-q'])
+                    else:
+                        linker = guess_win_linker(env, compiler, comp, version, for_machine)
                 except MesonException:
                     pass
 
             if not linker:
-                linker = guess_nix_linker(env, compiler, comp, version, for_machine)
+                if 'embt.com' in out:
+                    linker = guess_nix_linker(env, compiler, comp, version, for_machine, extra_args=['-q'])
+                else:
+                    linker = guess_nix_linker(env, compiler, comp, version, for_machine)
             return comp(
                 ccache, compiler, version, for_machine,
                 is_cross, info, linker=linker, defines=defines)

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -11,7 +11,7 @@ import re
 
 from .base import ArLikeLinker, RSPFileSyntax
 from .. import mesonlib
-from ..mesonlib import EnvironmentException, MesonException
+from ..mesonlib import EnvironmentException, MesonException, get_meson_command
 from ..arglist import CompilerArgs
 
 if T.TYPE_CHECKING:
@@ -446,6 +446,32 @@ class DLinker(StaticLinker):
     def rsp_file_syntax(self) -> RSPFileSyntax:
         return self.__rsp_syntax
 
+class TlibLinker(StaticLinker):
+
+    def __init__(self, exelist: T.List[str], bcc64: bool):
+        exelist = get_meson_command() + ['--internal', 'tlib'] + exelist
+        super().__init__(exelist)
+        self.id = 'tlib'
+        self._use_elf = bcc64
+        self._bcc64 = bcc64
+
+    def get_std_link_args(self, env: 'Environment', is_thin: bool) -> T.List[str]:
+        return ['/u']
+
+    def get_output_args(self, target: str) -> T.List[str]:
+        return [target]
+
+    def can_linker_accept_rsp(self) -> bool:
+        return True
+
+    def rsp_file_syntax(self) -> RSPFileSyntax:
+        return RSPFileSyntax.GCC
+
+    def get_linker_always_args(self) -> T.List[str]:
+        args = ['/p2048' if self._bcc64 else '/p512', '/N', '/B']
+        if self._use_elf:
+            args += ['/A'] # write GNU AR format archive with ELF objs
+        return args
 
 class CcrxLinker(StaticLinker):
 
@@ -1147,6 +1173,49 @@ class CompCertDynamicLinker(DynamicLinker):
                          rpath_paths: T.Tuple[str, ...], build_rpath: str,
                          install_rpath: str) -> T.Tuple[T.List[str], T.Set[bytes]]:
         return ([], set())
+
+class TurboDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
+
+    """Representation of Turbo Incremental Linker."""
+
+    id = 'ilink'
+
+    _SUBSYSTEMS: T.Dict[str, str] = {
+        "windows": "-tW",
+        "console": "-tC",
+    }
+
+    def __init__(self, exelist: T.List[str], for_machine: mesonlib.MachineChoice,
+                 *, version: str = 'unknown version'):
+        super().__init__(exelist, for_machine, '', [],
+                         version=version)
+
+    def get_accepts_rsp(self) -> bool:
+        return True
+
+    def get_allow_undefined_args(self) -> T.List[str]:
+        return []
+
+    def get_std_shared_lib_args(self) -> T.List[str]:
+        return ['-tD']
+
+    def get_win_subsystem_args(self, value: str) -> T.List[str]:
+        versionsuffix = None
+        if ',' in value:
+            value, versionsuffix = value.split(',', 1)
+        newvalue = self._SUBSYSTEMS.get(value)
+        if newvalue is not None:
+            args = [newvalue]
+            if versionsuffix is not None:
+                args += [f'-V{versionsuffix}']
+        else:
+            raise mesonlib.MesonBugException(f'win_subsystem: {value!r} not handled in Turbo linker. This should not be possible.')
+
+        return args
+
+    def get_always_args(self) -> T.List[str]:
+        parent = super().get_always_args()
+        return ['-q'] + parent
 
 class TIDynamicLinker(DynamicLinker):
 

--- a/mesonbuild/scripts/tlib.py
+++ b/mesonbuild/scripts/tlib.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import argparse
+import subprocess
+import typing as T
+import os
+import tempfile
+
+def _fix_args(args: T.List[str]) -> T.List[str]:
+    cmd: T.List[str] = []
+    for arg in args:
+        if arg[0] == '@':
+            with open(arg[1:], 'r', encoding='utf-8') as f:
+                cmd += _fix_args([line.strip() for line in f.readlines()])
+            continue
+        if '/' in arg and arg[0] != '/':
+            arg = os.path.normpath(arg)
+        if arg.endswith('.res'):
+            # Ignore .res objects in static linker
+            continue
+
+        cmd.append(arg)
+
+    return cmd
+
+def run(args: T.List[str]) -> int:
+    parser = argparse.ArgumentParser()
+
+    args = parser.parse_known_args(args)[1]
+
+    tlib_exe = args[0]
+    tlib_cmd = _fix_args(args[1:])
+
+    with tempfile.NamedTemporaryFile('w', delete=False, encoding='utf-8') as rsp_file:
+        try:
+            rsp_file.writelines(arg + '\n' for arg in tlib_cmd)
+            rsp_file.close()
+
+            returncode = subprocess.call([tlib_exe, "/B", f'@{rsp_file.name}'])
+        finally:
+            os.unlink(rsp_file.name)
+
+    return returncode


### PR DESCRIPTION
Fixes #12925.
https://docwiki.embarcadero.com/RADStudio/Athens/en/Win32_Clang-enhanced_Compilers

Tested configurations:
- [x] bcc32x
- [x] bcc64
- [x] bcc64x (like upstream clang + ld.lld, already works before this PR but `ld.lld` wasn't recognized properly)