### PR TITLE
mtest: set VALGRIND_OPTS to fail tests on errors

### DIFF
--- a/docs/markdown/snippets/valgrind_test.md
+++ b/docs/markdown/snippets/valgrind_test.md
@@ -1,0 +1,6 @@
+## Valgrind now fails tests if errors are found
+
+Valgrind does not reflect an error in its exit code by default, meaning
+a test may silently pass despite memory errors. Meson now exports
+`VALGRIND_OPTS` such that Valgrind will exit with status 1 to indicate
+an error if `VALGRIND_OPTS` is not set in the environment.

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -2064,15 +2064,16 @@ class TestHarness:
 
     @staticmethod
     def get_wrapper(options: argparse.Namespace) -> T.List[str]:
-        wrap: T.List[str] = []
         if options.gdb:
             wrap = [options.gdb_path, '--quiet']
             if options.repeat > 1:
                 wrap += ['-ex', 'run', '-ex', 'quit']
             # Signal the end of arguments to gdb
             wrap += ['--args']
-        if options.wrapper:
-            wrap += options.wrapper
+        elif options.wrapper:
+            wrap = options.wrapper
+        else:
+            wrap = []
         return wrap
 
     def get_pretty_suite(self, test: TestSerialisation) -> str:

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1485,6 +1485,15 @@ class SingleTestRunner:
         if ('MSAN_OPTIONS' not in env or not env['MSAN_OPTIONS']):
             env['MSAN_OPTIONS'] = 'halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1'
 
+        # Valgrind also doesn't reflect errors in its exit code by default.
+        if 'VALGRIND_OPTS' not in env or not env['VALGRIND_OPTS']:
+            try:
+                wrapper_name = TestHarness.get_wrapper(self.options)[0]
+                if 'valgrind' in wrapper_name:
+                    env['VALGRIND_OPTS'] = '--error-exitcode=1'
+            except IndexError:
+                pass
+
         if self.options.interactive or self.test.timeout is None or self.test.timeout <= 0:
             timeout = None
         elif self.options.timeout_multiplier is None:


### PR DESCRIPTION
We currently suggest that users run `meson test --wrapper valgrind`, but this doesn't do what one might expect: Valgrind doesn't error out on violations/issues it detects.

In the past, we had special handling for Valgrind in tests, see 1f76b76a84cb635f764ecbd2b77aaba1d375d72b but it was later dropped in 951262d7590343ffa9730666c427ad9d708a9fb6.

This is similar to what we do for {A,UB,M}SAN_OPTIONS to give sensible behaviour that users expect out-of-the-box.

Note that we're not adding --exit-on-first-error=yes here, as there may be several issues in an application, or a test may be rather slow, and so on. But --error-exitcode=1 to simply make Valgrind's exit status reflect whether an error was found is uncontroversial.

Bug: https://github.com/mesonbuild/meson/issues/4727
Bug: https://github.com/mesonbuild/meson/issues/1105
Bug: https://github.com/mesonbuild/meson/issues/1175
Bug: https://github.com/mesonbuild/meson/issues/13745