### PR TITLE
select the correct meson_command for pyinstaller builds, even on not-Windows

### DIFF
--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -305,7 +305,7 @@ def run(original_args: T.List[str], mainfile: str) -> int:
 
 def main() -> int:
     # Always resolve the command path so Ninja can find it for regen, tests, etc.
-    if 'meson.exe' in sys.executable:
+    if getattr(sys, 'frozen', False):
         assert os.path.isabs(sys.executable)
         launcher = sys.executable
     else:


### PR DESCRIPTION
We have previously updated the python_command handling to correctly detect PyInstaller builds without assuming that it is only Windows, back in commit c39ee881a1959ae37aded8e0c24cec23b2bd6a90. But the fix was incomplete. This affects e.g. running --internal scripts such as symbolextractor.

The issue in this case is slightly more subtle. While sys.executable won't be a valid python so it intuitively falls over quite badly when trying to run it as one, getting the original command is broken in a more interesting way. PyInstaller sets `sys.argv[0]` to the basename of the executable, which then got absolutized to a nonexistent file in the current working directory.


Fixes: https://github.com/mesonbuild/meson/issues/14412