### PR TITLE
clike: Unset _FORTIFY_SOURCE together with -O0

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -171,7 +171,7 @@ class CLikeCompiler(Compiler):
         return ['-c']
 
     def get_no_optimization_args(self) -> T.List[str]:
-        return ['-O0']
+        return ['-O0', '-U_FORTIFY_SOURCE']
 
     def get_output_args(self, outputname: str) -> T.List[str]:
         return ['-o', outputname]

--- a/test cases/common/281 -D_FORTIFY_SOURCE=2 and -O0/meson.build
+++ b/test cases/common/281 -D_FORTIFY_SOURCE=2 and -O0/meson.build
@@ -1,0 +1,7 @@
+project('check header', 'c', 'cpp')
+
+fallback = ''
+
+foreach comp : [meson.get_compiler('c'), meson.get_compiler('cpp')]
+  assert(comp.check_header('stdio.h', prefix : fallback), 'Stdio missing.')
+endforeach

--- a/test cases/common/281 -D_FORTIFY_SOURCE=2 and -O0/test.json
+++ b/test cases/common/281 -D_FORTIFY_SOURCE=2 and -O0/test.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "CFLAGS": "-O2 -D_FORTIFY_SOURCE=2 -Werror"
+  }
+}


### PR DESCRIPTION
If -O2, -D_FORTIFY_SOURCE=2 and -Werror are present in, e.g., the environment's CFLAGS, then configuration tests that run the compiler will fail unexpectedly due to the use of -O0 (from get_no_optimization_args()), which is not compatible with -D_FORTIFY_SOURCE=2. To overcome this potential problem, provide -U_FORTIFY_SOURCE along with -O0.

Fixes: #14417