### PR TITLE
cmake/interpreter: Don't add __CMake_build to includes

### DIFF
--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -421,9 +421,8 @@ class ConverterTarget:
         def non_optional(inputs: T.Iterable[T.Optional[Path]]) -> T.List[Path]:
             return [p for p in inputs if p is not None]
 
-        build_dir_rel = self.build_dir.relative_to(Path(self.env.get_build_dir()) / subdir)
         self.generated_raw = non_optional(rel_path(x, False, True) for x in self.generated_raw)
-        self.includes = non_optional(itertools.chain((rel_path(x, True, False) for x in OrderedSet(self.includes)), [build_dir_rel]))
+        self.includes = non_optional(itertools.chain((rel_path(x, True, False) for x in OrderedSet(self.includes))))
         self.sys_includes = non_optional(rel_path(x, True, False) for x in OrderedSet(self.sys_includes))
         self.sources = non_optional(rel_path(x, False, False) for x in self.sources)
 

--- a/test cases/cmake/28 include directories/main.c
+++ b/test cases/cmake/28 include directories/main.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+#include <cmTest.h>
+
+int main(void)
+{
+    cmTestFunc();
+    return 0;
+}
+

--- a/test cases/cmake/28 include directories/meson.build
+++ b/test cases/cmake/28 include directories/meson.build
@@ -1,0 +1,17 @@
+project('include directories test', 'c')
+
+cm = import('cmake')
+
+sub_pro = cm.subproject('cmTest')
+sub_dep = sub_pro.dependency('cmTest')
+
+missing_inc_dir_arg = '-Werror=missing-include-dirs'
+has_missing_inc_dir = meson.get_compiler('c').has_argument(missing_inc_dir_arg)
+if not has_missing_inc_dir
+  error('MESON_SKIP_TEST: Compiler does not support ' + missing_inc_dir_arg)
+else
+  add_project_arguments(missing_inc_dir_arg, language: 'c')
+endif
+
+exe1 = executable('exe1', ['main.c'], dependencies: [sub_dep])
+test('test1', exe1)

--- a/test cases/cmake/28 include directories/subprojects/cmTest/CMakeLists.txt
+++ b/test cases/cmake/28 include directories/subprojects/cmTest/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
+
+project(cmTest C)
+
+add_library(cmTest src/cmTest.c)
+target_include_directories(cmTest PUBLIC include)

--- a/test cases/cmake/28 include directories/subprojects/cmTest/include/cmTest.h
+++ b/test cases/cmake/28 include directories/subprojects/cmTest/include/cmTest.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void cmTestFunc(void);

--- a/test cases/cmake/28 include directories/subprojects/cmTest/src/cmTest.c
+++ b/test cases/cmake/28 include directories/subprojects/cmTest/src/cmTest.c
@@ -1,0 +1,7 @@
+#include "include/cmTest.h"
+#include <stdio.h>
+
+void cmTestFunc(void)
+{
+    printf ("Hello\n");
+}


### PR DESCRIPTION
Don't add `<project_source_dir>/<subproject>/__CMake_build` directory to include directories.

Fixes #12351