### PR TITLE
CI: install cygwin to D:/cygwin for better installation performance

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -49,7 +49,7 @@ jobs:
         id: restore-cache
         with:
           # should use 'pip3 cache dir' to discover this path
-          path: C:\cygwin\home\runneradmin\.cache\pip
+          path: \cygwin\home\runneradmin\.cache\pip
           key: cygwin-pip-${{ github.run_number }}
           restore-keys: cygwin-pip-
 
@@ -60,6 +60,7 @@ jobs:
       - uses: cygwin/cygwin-install-action@v5
         with:
           platform: ${{ matrix.ARCH }}
+          install-dir: \cygwin
           packages: |
             cmake
             gcc-fortran
@@ -88,12 +89,12 @@ jobs:
         run: |
           export PATH=/usr/bin:/usr/local/bin:$(cygpath ${SYSTEMROOT})/system32
           python3 -m pip --disable-pip-version-check install gcovr fastjsonschema pefile pytest pytest-subtests pytest-xdist
-        shell: C:\cygwin\bin\bash.exe --noprofile --norc -o igncr -eo pipefail '{0}'
+        shell: \cygwin\bin\bash.exe --noprofile --norc -o igncr -eo pipefail '{0}'
 
       - uses: actions/cache/save@v4
         with:
           # should use 'pip3 cache dir' to discover this path
-          path: C:\cygwin\home\runneradmin\.cache\pip
+          path: \cygwin\home\runneradmin\.cache\pip
           key: cygwin-pip-${{ github.run_number }}
 
       - name: Run tests
@@ -104,7 +105,7 @@ jobs:
           # Cygwin's static boost installation is broken (some static library
           # variants such as boost_thread are not present)
           SKIP_STATIC_BOOST: 1
-        shell: C:\cygwin\bin\bash.exe --noprofile --norc -o igncr -eo pipefail '{0}'
+        shell: \cygwin\bin\bash.exe --noprofile --norc -o igncr -eo pipefail '{0}'
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The D drive (which is where the GH workspace is by default) is faster compared to the C drive, and extracting packages there is a few minutes faster.

Since the installation location is used in several places, try to specify it in one place as a matrix variable. Since variables can't be used in "shell:" create a cygwin wrapper script and add it to PATH. This also removes the duplicated shell command lines while at it.