### PR TITLE
Bugfix: Generated binaries should not depend on devel package paths

### DIFF
--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2013-2021 The Meson development team
+# Copyright 2013-2025 The Meson development team
 
 from __future__ import annotations
 
@@ -423,11 +423,11 @@ class PkgConfigDependency(ExternalDependency):
                 if not path_has_root(path):
                     # Resolve the path as a compiler in the build directory would
                     path = os.path.join(self.env.get_build_dir(), path)
-                prefix_libpaths.add(path)
+                prefix_libpaths.add(Path(path).resolve().as_posix())
         # Library paths are not always ordered in a meaningful way
         #
         # Instead of relying on pkg-config or pkgconf to provide -L flags in a
-        # specific order, we reorder library paths ourselves, according to th
+        # specific order, we reorder library paths ourselves, according to the
         # order specified in PKG_CONFIG_PATH. See:
         # https://github.com/mesonbuild/meson/issues/4271
         #

--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -15,6 +15,7 @@ from pathlib import PurePath
 from functools import lru_cache
 import re
 import os
+import posixpath
 import shlex
 import typing as T
 
@@ -423,7 +424,7 @@ class PkgConfigDependency(ExternalDependency):
                 if not path_has_root(path):
                     # Resolve the path as a compiler in the build directory would
                     path = os.path.join(self.env.get_build_dir(), path)
-                prefix_libpaths.add(Path(path).resolve().as_posix())
+                prefix_libpaths.add(posixpath.normpath(path))
         # Library paths are not always ordered in a meaningful way
         #
         # Instead of relying on pkg-config or pkgconf to provide -L flags in a

--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2013-2021 The Meson development team
+# Copyright 2013-2025 The Meson development team
 
 from __future__ import annotations
 
@@ -437,11 +437,11 @@ class PkgConfigDependency(ExternalDependency):
                 if not path_has_root(path):
                     # Resolve the path as a compiler in the build directory would
                     path = os.path.join(self.env.get_build_dir(), path)
-                prefix_libpaths.add(path)
+                prefix_libpaths.add(Path(path).resolve().as_posix())
         # Library paths are not always ordered in a meaningful way
         #
         # Instead of relying on pkg-config or pkgconf to provide -L flags in a
-        # specific order, we reorder library paths ourselves, according to th
+        # specific order, we reorder library paths ourselves, according to the
         # order specified in PKG_CONFIG_PATH. See:
         # https://github.com/mesonbuild/meson/issues/4271
         #

--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -14,6 +14,7 @@ from pathlib import Path, PurePath
 from functools import lru_cache
 import re
 import os
+import posixpath
 import shlex
 import typing as T
 
@@ -437,7 +438,7 @@ class PkgConfigDependency(ExternalDependency):
                 if not path_has_root(path):
                     # Resolve the path as a compiler in the build directory would
                     path = os.path.join(self.env.get_build_dir(), path)
-                prefix_libpaths.add(Path(path).resolve().as_posix())
+                prefix_libpaths.add(posixpath.normpath(path))
         # Library paths are not always ordered in a meaningful way
         #
         # Instead of relying on pkg-config or pkgconf to provide -L flags in a

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -2198,7 +2198,7 @@ class AllPlatformTests(BasePlatformTests):
         kwargs = {'required': True, 'silent': True, 'native': MachineChoice.HOST}
         foo_dep = PkgConfigDependency('libanswer', env, kwargs)
         # Ensure link_args are properly quoted
-        libdir = PurePath(prefix) / PurePath(libdir)
+        libdir = Path(prefix, libdir).resolve()
         link_args = ['-L' + libdir.as_posix(), '-lanswer']
         self.assertEqual(foo_dep.get_link_args(), link_args)
         # Ensure include args are properly quoted

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -2198,7 +2198,7 @@ class AllPlatformTests(BasePlatformTests):
         kwargs = {'required': True, 'silent': True, 'native': MachineChoice.HOST}
         foo_dep = PkgConfigDependency('libanswer', env, kwargs)
         # Ensure link_args are properly quoted
-        libdir = Path(prefix, libdir).resolve()
+        libdir = PurePath(prefix) / PurePath(libdir)
         link_args = ['-L' + libdir.as_posix(), '-lanswer']
         self.assertEqual(foo_dep.get_link_args(), link_args)
         # Ensure include args are properly quoted

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -2300,7 +2300,7 @@ class AllPlatformTests(BasePlatformTests):
         kwargs = {'required': True, 'silent': True, 'native': MachineChoice.HOST}
         foo_dep = PkgConfigDependency('libanswer', env, kwargs)
         # Ensure link_args are properly quoted
-        libdir = Path(prefix, libdir).resolve()
+        libdir = PurePath(prefix) / PurePath(libdir)
         link_args = ['-L' + libdir.as_posix(), '-lanswer']
         self.assertEqual(foo_dep.get_link_args(), link_args)
         # Ensure include args are properly quoted

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -2300,7 +2300,7 @@ class AllPlatformTests(BasePlatformTests):
         kwargs = {'required': True, 'silent': True, 'native': MachineChoice.HOST}
         foo_dep = PkgConfigDependency('libanswer', env, kwargs)
         # Ensure link_args are properly quoted
-        libdir = PurePath(prefix) / PurePath(libdir)
+        libdir = Path(prefix, libdir).resolve()
         link_args = ['-L' + libdir.as_posix(), '-lanswer']
         self.assertEqual(foo_dep.get_link_args(), link_args)
         # Ensure include args are properly quoted

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2016-2021 The Meson development team
+# Copyright 2016-2025 The Meson development team
 
 from configparser import ConfigParser
 from pathlib import Path
@@ -781,6 +781,8 @@ class InternalTests(unittest.TestCase):
                 instance_method.return_value = FakeInstance(env, MachineChoice.HOST, silent=True)
                 kwargs = {'required': True, 'silent': True, 'native': MachineChoice.HOST}
                 foo_dep = PkgConfigDependency('foo', env, kwargs)
+                p1 = p1.resolve()
+                p2 = p2.resolve()
                 self.assertEqual(foo_dep.get_link_args(),
                                  [(p1 / 'libfoo.a').as_posix(), (p2 / 'libbar.a').as_posix()])
                 bar_dep = PkgConfigDependency('bar', env, kwargs)

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -781,8 +781,6 @@ class InternalTests(unittest.TestCase):
                 instance_method.return_value = FakeInstance(env, MachineChoice.HOST, silent=True)
                 kwargs = {'required': True, 'silent': True, 'native': MachineChoice.HOST}
                 foo_dep = PkgConfigDependency('foo', env, kwargs)
-                p1 = p1.resolve()
-                p2 = p2.resolve()
                 self.assertEqual(foo_dep.get_link_args(),
                                  [(p1 / 'libfoo.a').as_posix(), (p2 / 'libbar.a').as_posix()])
                 bar_dep = PkgConfigDependency('bar', env, kwargs)

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2016-2021 The Meson development team
+# Copyright 2016-2025 The Meson development team
 
 from configparser import ConfigParser
 from pathlib import Path
@@ -1103,6 +1103,8 @@ Thread model: posix'''), '21.9.0')
                 instance_method.return_value = FakeInstance(env, MachineChoice.HOST, silent=True)
                 kwargs = {'required': True, 'silent': True, 'native': MachineChoice.HOST}
                 foo_dep = PkgConfigDependency('foo', env, kwargs)
+                p1 = p1.resolve()
+                p2 = p2.resolve()
                 self.assertEqual(foo_dep.get_link_args(),
                                  [(p1 / 'libfoo.a').as_posix(), (p2 / 'libbar.a').as_posix()])
                 bar_dep = PkgConfigDependency('bar', env, kwargs)

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1103,8 +1103,6 @@ Thread model: posix'''), '21.9.0')
                 instance_method.return_value = FakeInstance(env, MachineChoice.HOST, silent=True)
                 kwargs = {'required': True, 'silent': True, 'native': MachineChoice.HOST}
                 foo_dep = PkgConfigDependency('foo', env, kwargs)
-                p1 = p1.resolve()
-                p2 = p2.resolve()
                 self.assertEqual(foo_dep.get_link_args(),
                                  [(p1 / 'libfoo.a').as_posix(), (p2 / 'libbar.a').as_posix()])
                 bar_dep = PkgConfigDependency('bar', env, kwargs)

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2016-2022 The Meson development team
+# Copyright 2016-2025 The Meson development team
 
 import stat
 import subprocess
@@ -1167,7 +1167,7 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertTrue(relative_path_dep.found())
 
         # Ensure link_args are properly quoted
-        libpath = Path(self.builddir) / '../relativepath/lib'
+        libpath = Path(self.builddir).parent / 'relativepath/lib'
         link_args = ['-L' + libpath.as_posix(), '-lrelativepath']
         self.assertEqual(relative_path_dep.get_link_args(), link_args)
 

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2016-2022 The Meson development team
+# Copyright 2016-2025 The Meson development team
 
 import stat
 import subprocess
@@ -1218,7 +1218,7 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertTrue(relative_path_dep.found())
 
         # Ensure link_args are properly quoted
-        libpath = Path(self.builddir) / '../relativepath/lib'
+        libpath = Path(self.builddir).parent / 'relativepath/lib'
         link_args = ['-L' + libpath.as_posix(), '-lrelativepath']
         self.assertEqual(relative_path_dep.get_link_args(), link_args)
 


### PR DESCRIPTION
Prefix library paths specified by -L are converted to canonical paths to improve the library runpath stored in the binary output. For example, if `pkg-config --libs add` returns the following:

    -L/usr/local/lib/pkgconfig/../../lib -ladd

we convert the path so that it is as if it had returned:

    -L/usr/local/lib -ladd

### Motivation

Consider a third-party math library that is distributed as two packages for installation: `libadd` and `libadd-devel`.
The first installs the following files (under `/opt` or `/usr/local` as the system administrator chooses):

    lib/libadd.so.0 -> libadd.so.0.1.0
    lib/libadd.so.0.1.0

The second, which is the development package, installs the following files:

    include/add/add.h
    lib/libadd.so -> libadd.so.0
    lib/pkgconfig/add.pc

The file `add.pc` is as follows:
```
prefix=${pcfiledir}/../..
includedir=${prefix}/include
libdir=${prefix}/lib

Name: add
Description: addition: add
Version: 0.1.0
Libs: -L${libdir} -ladd
Cflags: -I${includedir}
```

On a build machine, the sysadmin has installed both packages.   But the application that uses this math library will be deployed on hundreds of machines (virtual machines in the cloud, nodes on a supercomputer, docker containers, etc.).   The system administrator only installs `libadd` on those machines, not `libadd-devel`, nor `meson`, `ninja`, etc.

The problem is that, without this patch, a `meson.build` file containing
```
add_dep = dependency('add', method: 'pkg-config')
executable('myapp', 'myapp.c', dependencies: add_dep)
```
will create an application binary with the following library runpath:
```
$ ldd myapp
    ...
    libadd.so.0 => /usr/local/lib/pkgconfig/../../lib/libadd.so.0
    ...
```
and this won't run on the deployment nodes since the directory `/usr/local/lib/pkgconfig` does not exist there.

With this patch:
```
$ ldd myapp
    ...
    libadd.so.0 => /usr/local/lib/libadd.so.0
    ...
```
and all is well.