### PR TITLE
[RFC] Tests: set DYLD_LIBRARY_PATH on Darwin

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1283,7 +1283,7 @@ class Backend:
                     raise MesonException('Bad object in test command.')
 
             t_env = copy.deepcopy(t.env)
-            if not machine.is_windows() and not machine.is_cygwin() and not machine.is_darwin():
+            if not machine.is_windows() and not machine.is_cygwin():
                 ld_lib_path_libs: T.Set[build.SharedLibrary] = set()
                 for d in depends:
                     if isinstance(d, build.BuildTarget):
@@ -1295,7 +1295,10 @@ class Backend:
                 ld_lib_path: T.Set[str] = set(os.path.join(env_build_dir, l.get_subdir()) for l in ld_lib_path_libs)
 
                 if ld_lib_path:
-                    t_env.prepend('LD_LIBRARY_PATH', list(ld_lib_path), ':')
+                    if machine.is_darwin():
+                        t_env.prepend('DYLD_LIBRARY_PATH', list(ld_lib_path), ':')
+                    else:
+                        t_env.prepend('LD_LIBRARY_PATH', list(ld_lib_path), ':')
 
             ts = TestSerialisation(t.get_name(), t.project_name, t.suite, cmd, is_cross,
                                    exe_wrapper, self.environment.need_exe_wrapper(),


### PR DESCRIPTION
From what I can tell, `DYLD_LIBRARY_PATH` has precedence over rpath, just like `LD_LIBRARY_PATH` has on other Unices.

Enhance https://github.com/mesonbuild/meson/pull/11119 to work on Darwin.