### PR TITLE
fix [subproject:project options]

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -702,11 +702,12 @@ class Environment:
         # Store a global state of Cargo dependencies
         self.cargo: T.Optional[cargo.Interpreter] = None
 
-    def mfilestr2key(self, machine_file_string: str, section_subproject: T.Optional[str], machine: MachineChoice) -> OptionKey:
+    def mfilestr2key(self, machine_file_string: str, section: T.Optional[str], section_subproject: T.Optional[str], machine: MachineChoice) -> OptionKey:
         key = OptionKey.from_string(machine_file_string)
         assert key.machine == MachineChoice.HOST
         if key.subproject:
-            raise MesonException('Do not set subproject options in [built-in options] section, use [subproject:built-in options] instead.')
+            suggestion = section if section == 'project options' else 'built-in options'
+            raise MesonException(f'Do not set subproject options in [{section}] section, use [subproject:{suggestion}] instead.')
         if section_subproject:
             key = key.evolve(subproject=section_subproject)
         if machine == MachineChoice.BUILD:
@@ -724,7 +725,7 @@ class Environment:
         if paths:
             mlog.deprecation('The [paths] section is deprecated, use the [built-in options] section instead.')
             for strk, v in paths.items():
-                k = self.mfilestr2key(strk, None, machine)
+                k = self.mfilestr2key(strk, 'paths', None, machine)
                 self.options[k] = v
 
         # Next look for compiler options in the "properties" section, this is
@@ -737,7 +738,7 @@ class Environment:
         for strk, v in properties.properties.copy().items():
             if strk in deprecated_properties:
                 mlog.deprecation(f'{strk} in the [properties] section of the machine file is deprecated, use the [built-in options] section.')
-                k = self.mfilestr2key(strk, None, machine)
+                k = self.mfilestr2key(strk, 'properties', None, machine)
                 self.options[k] = v
                 del properties.properties[strk]
 
@@ -748,7 +749,7 @@ class Environment:
                 section_subproject = ''
             if section == 'built-in options':
                 for strk, v in values.items():
-                    key = self.mfilestr2key(strk, section_subproject, machine)
+                    key = self.mfilestr2key(strk, section, section_subproject, machine)
                     # If we're in the cross file, and there is a `build.foo` warn about that. Later we'll remove it.
                     if machine is MachineChoice.HOST and key.machine is not machine:
                         mlog.deprecation('Setting build machine options in cross files, please use a native file instead, this will be removed in meson 2.0', once=True)
@@ -758,7 +759,7 @@ class Environment:
                 # to read these from the native file
                 for strk, v in values.items():
                     # Project options are always for the host machine
-                    key = self.mfilestr2key(strk, section_subproject, machine)
+                    key = self.mfilestr2key(strk, section, section_subproject, machine)
                     self.options[key] = v
 
     def _set_default_options_from_env(self) -> None:

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -759,8 +759,6 @@ class Environment:
                 for strk, v in values.items():
                     # Project options are always for the host machine
                     key = self.mfilestr2key(strk, section_subproject, machine)
-                    if key.subproject:
-                        raise MesonException('Do not set subproject options in [built-in options] section, use [subproject:built-in options] instead.')
                     self.options[key] = v
 
     def _set_default_options_from_env(self) -> None:

--- a/test cases/common/282 subproj options/crossfile.ini
+++ b/test cases/common/282 subproj options/crossfile.ini
@@ -1,0 +1,2 @@
+[sub:project options]
+bar = true

--- a/test cases/common/282 subproj options/meson.build
+++ b/test cases/common/282 subproj options/meson.build
@@ -1,0 +1,3 @@
+project('pkg_opt_test')
+
+subproject('sub')

--- a/test cases/common/282 subproj options/subprojects/sub/meson.build
+++ b/test cases/common/282 subproj options/subprojects/sub/meson.build
@@ -1,0 +1,2 @@
+project('subproject')
+assert(get_option('bar') == true)

--- a/test cases/common/282 subproj options/subprojects/sub/meson_options.txt
+++ b/test cases/common/282 subproj options/subprojects/sub/meson_options.txt
@@ -1,0 +1,1 @@
+option('bar', type: 'boolean', value: false)


### PR DESCRIPTION
If your machine file contains subproject specific project options, meson will fail with:

```
ERROR: Do not set subproject options in [built-in options] section, use [subproject:built-in options] instead.
```

This is a regression introduced by the options refactor (https://github.com/mesonbuild/meson/commit/d37d649b08b832d52fa684bc0506829fb40d5261)

Fixes: #14414