### PR TITLE
Fix rewrite after the option refactor

### DIFF
--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -119,7 +119,19 @@ class IntrospectionInterpreter(AstInterpreter):
         string_dict = cdata.create_options_dict(_project_default_options, self.subproject)
         self.project_default_options = {OptionKey(s): v for s, v in string_dict.items()}
         self.default_options.update(self.project_default_options)
-        self.coredata.set_default_options(self.default_options, self.subproject, self.environment)
+        if self.environment.first_invocation or (self.subproject != '' and self.subproject not in self.coredata.initialized_subprojects):
+            if self.subproject == '':
+                self.coredata.optstore.initialize_from_top_level_project_call(
+                    T.cast('T.Dict[T.Union[OptionKey, str], str]', string_dict),
+                    {},  # TODO: not handled by this Interpreter.
+                    self.environment.options)
+            else:
+                self.coredata.optstore.initialize_from_subproject_call(
+                    self.subproject,
+                    {},  # TODO: this isn't handled by the introspection interpreter...
+                    T.cast('T.Dict[T.Union[OptionKey, str], str]', string_dict),
+                    {})  # TODO: this isn't handled by the introspection interpreter...
+                self.coredata.initialized_subprojects.add(self.subproject)
 
         if not self.is_subproject() and 'subproject_dir' in kwargs:
             spdirname = kwargs['subproject_dir']

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -37,7 +37,7 @@ from .compilers import (
 )
 
 if T.TYPE_CHECKING:
-    from ..coredata import MutableKeyedOptionDictType
+    from ..options import MutableKeyedOptionDictType
     from ..dependencies import Dependency
     from ..envconfig import MachineInfo
     from ..environment import Environment

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -26,7 +26,7 @@ from ..arglist import CompilerArgs
 if T.TYPE_CHECKING:
     from .. import coredata
     from ..build import BuildTarget, DFeatures
-    from ..coredata import MutableKeyedOptionDictType
+    from ..options import MutableKeyedOptionDictType
     from ..envconfig import MachineInfo
     from ..environment import Environment
     from ..linkers import RSPFileSyntax

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -34,7 +34,7 @@ from .mixins.metrowerks import MetrowerksCompiler
 from .mixins.metrowerks import mwccarm_instruction_set_args, mwcceppc_instruction_set_args
 
 if T.TYPE_CHECKING:
-    from ..coredata import MutableKeyedOptionDictType
+    from ..options import MutableKeyedOptionDictType
     from ..dependencies import Dependency
     from ..envconfig import MachineInfo
     from ..environment import Environment

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2012-2017 The Meson development team
-# Copyright © 2023-2024 Intel Corporation
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 
@@ -19,7 +19,7 @@ from .compilers import Compiler, CompileCheckMode
 
 if T.TYPE_CHECKING:
     from ..build import BuildTarget
-    from ..coredata import MutableKeyedOptionDictType
+    from ..options import MutableKeyedOptionDictType
     from ..dependencies import Dependency
     from ..environment import Environment  # noqa: F401
     from ..envconfig import MachineInfo

--- a/mesonbuild/compilers/cython.py
+++ b/mesonbuild/compilers/cython.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright © 2021-2024 Intel Corporation
+# Copyright © 2021-2025 Intel Corporation
 from __future__ import annotations
 
 """Abstraction for Cython language compilers."""
@@ -11,7 +11,7 @@ from ..mesonlib import EnvironmentException, version_compare
 from .compilers import Compiler
 
 if T.TYPE_CHECKING:
-    from ..coredata import MutableKeyedOptionDictType
+    from ..options import MutableKeyedOptionDictType
     from ..environment import Environment
     from ..build import BuildTarget
 

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -27,7 +27,7 @@ from mesonbuild.mesonlib import (
 )
 
 if T.TYPE_CHECKING:
-    from ..coredata import MutableKeyedOptionDictType
+    from ..options import MutableKeyedOptionDictType
     from ..dependencies import Dependency
     from ..envconfig import MachineInfo
     from ..environment import Environment

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -18,7 +18,7 @@ from ..compilers import CompileCheckMode
 from .gnu import GnuLikeCompiler
 
 if T.TYPE_CHECKING:
-    from ...coredata import MutableKeyedOptionDictType
+    from ...options import MutableKeyedOptionDictType
     from ...environment import Environment
     from ...dependencies import Dependency  # noqa: F401
     from ..compilers import Compiler

--- a/mesonbuild/compilers/mixins/emscripten.py
+++ b/mesonbuild/compilers/mixins/emscripten.py
@@ -15,7 +15,6 @@ from ...mesonlib import LibType
 from mesonbuild.compilers.compilers import CompileCheckMode
 
 if T.TYPE_CHECKING:
-    from ... import coredata
     from ...environment import Environment
     from ...compilers.compilers import Compiler
     from ...dependencies import Dependency
@@ -57,7 +56,7 @@ class EmscriptenMixin(Compiler):
             args.append(f'-sPTHREAD_POOL_SIZE={count}')
         return args
 
-    def get_options(self) -> coredata.MutableKeyedOptionDictType:
+    def get_options(self) -> options.MutableKeyedOptionDictType:
         opts = super().get_options()
 
         key = OptionKey(f'{self.language}_thread_count', machine=self.for_machine)

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2019-2022 The meson development team
-# Copyright © 2023 Intel Corporation
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 
@@ -21,7 +21,7 @@ from mesonbuild.compilers.compilers import CompileCheckMode
 
 if T.TYPE_CHECKING:
     from ..._typing import ImmutableListProtocol
-    from ...coredata import MutableKeyedOptionDictType
+    from ...options import MutableKeyedOptionDictType
     from ...environment import Environment
     from ..compilers import Compiler
 else:

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -15,12 +15,12 @@ from .mixins.clike import CLikeCompiler
 from .mixins.gnu import GnuCompiler, GnuCStds, gnu_common_warning_args, gnu_objc_warning_args
 
 if T.TYPE_CHECKING:
-    from .. import coredata
     from ..envconfig import MachineInfo
     from ..environment import Environment
     from ..linkers.linkers import DynamicLinker
     from ..mesonlib import MachineChoice
     from ..build import BuildTarget
+    from ..options import MutableKeyedOptionDictType
 
 
 class ObjCCompiler(CLikeCompiler, Compiler):
@@ -36,7 +36,7 @@ class ObjCCompiler(CLikeCompiler, Compiler):
                           linker=linker)
         CLikeCompiler.__init__(self)
 
-    def get_options(self) -> coredata.MutableKeyedOptionDictType:
+    def get_options(self) -> MutableKeyedOptionDictType:
         opts = super().get_options()
         key = self.form_compileropt_key('std')
         opts.update({

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -15,12 +15,12 @@ from .mixins.clang import ClangCompiler, ClangCPPStds
 from .mixins.clike import CLikeCompiler
 
 if T.TYPE_CHECKING:
-    from .. import coredata
     from ..envconfig import MachineInfo
     from ..environment import Environment
     from ..linkers.linkers import DynamicLinker
     from ..mesonlib import MachineChoice
     from ..build import BuildTarget
+    from ..options import MutableKeyedOptionDictType
 
 
 class ObjCPPCompiler(CLikeCompiler, Compiler):
@@ -54,7 +54,7 @@ class ObjCPPCompiler(CLikeCompiler, Compiler):
         code = '#import<stdio.h>\nclass MyClass;int main(void) { return 0; }\n'
         return self._sanity_check_impl(work_dir, environment, 'sanitycheckobjcpp.mm', code)
 
-    def get_options(self) -> coredata.MutableKeyedOptionDictType:
+    def get_options(self) -> MutableKeyedOptionDictType:
         opts = super().get_options()
         key = self.form_compileropt_key('std')
         opts.update({

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2012-2022 The Meson development team
-# Copyright © 2023-2024 Intel Corporation
+# Copyright © 2023-2025 Intel Corporation
 
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ from ..options import OptionKey
 from .compilers import Compiler, CompileCheckMode, clike_debug_args
 
 if T.TYPE_CHECKING:
-    from ..coredata import MutableKeyedOptionDictType
+    from ..options import MutableKeyedOptionDictType
     from ..envconfig import MachineInfo
     from ..environment import Environment  # noqa: F401
     from ..linkers.linkers import DynamicLinker

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -14,7 +14,7 @@ from .compilers import Compiler, clike_debug_args
 
 if T.TYPE_CHECKING:
     from .. import build
-    from ..coredata import MutableKeyedOptionDictType
+    from ..options import MutableKeyedOptionDictType
     from ..dependencies import Dependency
     from ..envconfig import MachineInfo
     from ..environment import Environment

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -43,7 +43,7 @@ if T.TYPE_CHECKING:
     from .mesonlib import FileOrString
     from .cmake.traceparser import CMakeCacheEntry
     from .interpreterbase import SubProject
-    from .options import ElementaryOptionValues
+    from .options import ElementaryOptionValues, MutableKeyedOptionDictType
     from .build import BuildTarget
 
     class SharedCMDOptions(Protocol):
@@ -62,7 +62,6 @@ if T.TYPE_CHECKING:
         native_file: T.List[str]
 
     OptionDictType = T.Dict[str, options.AnyOptionType]
-    MutableKeyedOptionDictType = T.Dict['OptionKey', options.AnyOptionType]
     CompilerCheckCacheKey = T.Tuple[T.Tuple[str, ...], str, FileOrString, T.Tuple[str, ...], CompileCheckMode]
     # code, args
     RunCheckCacheKey = T.Tuple[str, T.Tuple[str, ...]]

--- a/mesonbuild/interpreterbase/interpreterbase.py
+++ b/mesonbuild/interpreterbase/interpreterbase.py
@@ -704,7 +704,7 @@ class InterpreterBase:
                 self.coredata.options_files[self.subproject] = (option_file, hashlib.sha1(f.read()).hexdigest())
             oi = optinterpreter.OptionInterpreter(self.environment.coredata.optstore, self.subproject)
             oi.process(option_file)
-            self.coredata.update_project_options(oi.options, self.subproject)
+            self.coredata.optstore.update_project_options(oi.options, self.subproject)
             self.build_def_files.add(option_file)
         else:
             self.coredata.options_files[self.subproject] = None

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -190,9 +190,10 @@ class Conf:
                 items = [l[i] if l[i] else ' ' * four_column[i] for i in range(4)]
                 mlog.log(*items)
 
-    def split_options_per_subproject(self, options: T.Union[coredata.MutableKeyedOptionDictType, options.OptionStore]) -> T.Dict[str, 'coredata.MutableKeyedOptionDictType']:
-        result: T.Dict[str, 'coredata.MutableKeyedOptionDictType'] = {}
-        for k, o in options.items():
+    def split_options_per_subproject(self, opts: T.Union[options.MutableKeyedOptionDictType, options.OptionStore]
+                                     ) -> T.Dict[str, options.MutableKeyedOptionDictType]:
+        result: T.Dict[str, options.MutableKeyedOptionDictType] = {}
+        for k, o in opts.items():
             if k.subproject:
                 self.all_subprojects.add(k.subproject)
             result.setdefault(k.subproject, {})[k] = o
@@ -228,7 +229,7 @@ class Conf:
         self._add_line(mlog.normal_yellow(section + ':'), '', '', '')
         self.print_margin = 2
 
-    def print_options(self, title: str, opts: T.Union[coredata.MutableKeyedOptionDictType, options.OptionStore]) -> None:
+    def print_options(self, title: str, opts: T.Union[options.MutableKeyedOptionDictType, options.OptionStore]) -> None:
         if not opts:
             return
         if title:
@@ -264,10 +265,10 @@ class Conf:
         test_option_names = {OptionKey('errorlogs'),
                              OptionKey('stdsplit')}
 
-        dir_options: 'coredata.MutableKeyedOptionDictType' = {}
-        test_options: 'coredata.MutableKeyedOptionDictType' = {}
-        core_options: 'coredata.MutableKeyedOptionDictType' = {}
-        module_options: T.Dict[str, 'coredata.MutableKeyedOptionDictType'] = collections.defaultdict(dict)
+        dir_options: options.MutableKeyedOptionDictType = {}
+        test_options: options.MutableKeyedOptionDictType = {}
+        core_options: options.MutableKeyedOptionDictType = {}
+        module_options: T.Dict[str, options.MutableKeyedOptionDictType] = collections.defaultdict(dict)
         for k, v in self.coredata.optstore.options.items():
             if k in dir_option_names:
                 dir_options[k] = v

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -96,7 +96,7 @@ class Conf:
                         if ophash != conf_options[1]:
                             oi = OptionInterpreter(self.coredata.optstore, sub)
                             oi.process(opfile)
-                            self.coredata.update_project_options(oi.options, sub)
+                            self.coredata.optstore.update_project_options(oi.options, sub)
                             self.coredata.options_files[sub] = (opfile, ophash)
                 else:
                     opfile = os.path.join(self.source_dir, 'meson.options')
@@ -105,12 +105,12 @@ class Conf:
                     if os.path.exists(opfile):
                         oi = OptionInterpreter(self.coredata.optstore, sub)
                         oi.process(opfile)
-                        self.coredata.update_project_options(oi.options, sub)
+                        self.coredata.optstore.update_project_options(oi.options, sub)
                         with open(opfile, 'rb') as f:
                             ophash = hashlib.sha1(f.read()).hexdigest()
                         self.coredata.options_files[sub] = (opfile, ophash)
                     else:
-                        self.coredata.update_project_options({}, sub)
+                        self.coredata.optstore.update_project_options({}, sub)
         elif os.path.isfile(os.path.join(self.build_dir, environment.build_filename)):
             # Make sure that log entries in other parts of meson don't interfere with the JSON output
             with mlog.no_logging():

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -290,9 +290,9 @@ def list_buildoptions(coredata: cdata.CoreData, subprojects: T.Optional[T.List[s
     test_option_names = {OptionKey('errorlogs'),
                          OptionKey('stdsplit')}
 
-    dir_options: 'cdata.MutableKeyedOptionDictType' = {}
-    test_options: 'cdata.MutableKeyedOptionDictType' = {}
-    core_options: 'cdata.MutableKeyedOptionDictType' = {}
+    dir_options: options.MutableKeyedOptionDictType = {}
+    test_options: options.MutableKeyedOptionDictType = {}
+    core_options: options.MutableKeyedOptionDictType = {}
     for k, v in coredata.optstore.items():
         if k in dir_option_names:
             dir_options[k] = v
@@ -304,7 +304,7 @@ def list_buildoptions(coredata: cdata.CoreData, subprojects: T.Optional[T.List[s
                 for s in subprojects:
                     core_options[k.evolve(subproject=s)] = v
 
-    def add_keys(opts: T.Union[cdata.MutableKeyedOptionDictType, options.OptionStore], section: str) -> None:
+    def add_keys(opts: T.Union[options.MutableKeyedOptionDictType, options.OptionStore], section: str) -> None:
         for key, opt in sorted(opts.items()):
             optdict = {'name': str(key), 'value': opt.value, 'section': section,
                        'machine': key.machine.get_lower_case_name() if coredata.optstore.is_per_machine_option(key) else 'any'}

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -15,7 +15,6 @@ from .interpreterbase import FeatureNew, FeatureDeprecated, typed_pos_args, type
 from .interpreter.type_checking import NoneType, in_set_validator
 
 if T.TYPE_CHECKING:
-    from . import coredata
     from .interpreterbase import TYPE_var, TYPE_kwargs
     from .interpreterbase import SubProject
     from typing_extensions import TypedDict, Literal
@@ -67,7 +66,7 @@ optname_regex = re.compile('[^a-zA-Z0-9_-]')
 
 class OptionInterpreter:
     def __init__(self, optionstore: 'OptionStore', subproject: 'SubProject') -> None:
-        self.options: 'coredata.MutableKeyedOptionDictType' = {}
+        self.options: options.MutableKeyedOptionDictType = {}
         self.subproject = subproject
         self.option_types: T.Dict[str, T.Callable[..., options.AnyOptionType]] = {
             'string': self.string_parser,

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from collections import OrderedDict
 from itertools import chain
 import argparse
+import copy
 import dataclasses
 import itertools
 import os
@@ -1236,21 +1237,28 @@ class OptionStore:
     def first_handle_prefix(self,
                             project_default_options: T.Union[T.List[str], OptionStringLikeDict],
                             cmd_line_options: T.Union[T.List[str], OptionStringLikeDict],
-                            machine_file_options: T.Union[T.List[str], OptionStringLikeDict]) \
+                            machine_file_options: T.Mapping[OptionKey, ElementaryOptionValues]) \
             -> T.Tuple[T.Union[T.List[str], OptionStringLikeDict],
                        T.Union[T.List[str], OptionStringLikeDict],
-                       T.Union[T.List[str], OptionStringLikeDict]]:
+                       T.MutableMapping[OptionKey, ElementaryOptionValues]]:
+        # Copy to avoid later mutation
+        nopref_machine_file_options = T.cast(
+            'T.MutableMapping[OptionKey, ElementaryOptionValues]', copy.copy(machine_file_options))
+
         prefix = None
         (possible_prefix, nopref_project_default_options) = self.prefix_split_options(project_default_options)
         prefix = prefix if possible_prefix is None else possible_prefix
-        (possible_prefix, nopref_native_file_options) = self.prefix_split_options(machine_file_options)
-        prefix = prefix if possible_prefix is None else possible_prefix
+
+        possible_prefixv = nopref_machine_file_options.pop(OptionKey('prefix'), None)
+        assert possible_prefixv is None or isinstance(possible_prefixv, str), 'mypy: prefix from machine file was not a string?'
+        prefix = prefix if possible_prefixv is None else possible_prefixv
+
         (possible_prefix, nopref_cmd_line_options) = self.prefix_split_options(cmd_line_options)
         prefix = prefix if possible_prefix is None else possible_prefix
 
         if prefix is not None:
             self.hard_reset_from_prefix(prefix)
-        return (nopref_project_default_options, nopref_cmd_line_options, nopref_native_file_options)
+        return (nopref_project_default_options, nopref_cmd_line_options, nopref_machine_file_options)
 
     def hard_reset_from_prefix(self, prefix: str) -> None:
         prefix = self.sanitize_prefix(prefix)
@@ -1268,7 +1276,7 @@ class OptionStore:
     def initialize_from_top_level_project_call(self,
                                                project_default_options_in: T.Union[T.List[str], OptionStringLikeDict],
                                                cmd_line_options_in: T.Union[T.List[str], OptionStringLikeDict],
-                                               machine_file_options_in: T.Union[T.List[str], OptionStringLikeDict]) -> None:
+                                               machine_file_options_in: T.Mapping[OptionKey, ElementaryOptionValues]) -> None:
         first_invocation = True
         (project_default_options, cmd_line_options, machine_file_options) = self.first_handle_prefix(project_default_options_in,
                                                                                                      cmd_line_options_in,

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1323,8 +1323,10 @@ class OptionStore:
             #
             # The key parsing function can not handle the difference between the two
             # and defaults to A.
-            assert isinstance(keystr, str)
-            key = OptionKey.from_string(keystr)
+            if isinstance(keystr, str):
+                key = OptionKey.from_string(keystr)
+            else:
+                key = keystr
             # Due to backwards compatibility we ignore all cross options when building
             # natively.
             if not self.is_cross and key.is_for_build():

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -41,6 +41,7 @@ if T.TYPE_CHECKING:
         'UserIntegerOption', 'UserStdOption', 'UserStringArrayOption',
         'UserStringOption', 'UserUmaskOption']
     ElementaryOptionValues: TypeAlias = T.Union[str, int, bool, T.List[str]]
+    MutableKeyedOptionDictType: TypeAlias = T.Dict['OptionKey', AnyOptionType]
 
     _OptionKeyTuple: TypeAlias = T.Tuple[T.Optional[str], MachineChoice, str]
 

--- a/test cases/rewrite/7 prefix/meson.build
+++ b/test cases/rewrite/7 prefix/meson.build
@@ -1,0 +1,5 @@
+project('lalala', 'cpp',
+    default_options : [
+        'prefix=/export/doocs',
+    ],
+)

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -32,7 +32,7 @@ class OptionTests(unittest.TestCase):
         vo = UserStringOption(k.name, 'An option of some sort', default_value)
         optstore.add_system_option(k.name, vo)
         self.assertEqual(optstore.get_value_for(k), default_value)
-        optstore.initialize_from_top_level_project_call([f'someoption={new_value}'], {}, {})
+        optstore.initialize_from_top_level_project_call({OptionKey('someoption'): new_value}, {}, {})
         self.assertEqual(optstore.get_value_for(k), new_value)
 
     def test_parsing(self):

--- a/unittests/rewritetests.py
+++ b/unittests/rewritetests.py
@@ -408,7 +408,6 @@ class RewriterTests(BasePlatformTests):
         for orig_line, new_line in zip_longest(original_contents.splitlines(), new_contents.splitlines()):
             self.assertEqual(orig_line, new_line)
 
-    @unittest.expectedFailure
     def test_rewrite_prefix(self) -> None:
         self.prime('7 prefix')
         out = self.rewrite_raw(self.builddir, ['kwargs', 'info', 'project', '/'])

--- a/unittests/rewritetests.py
+++ b/unittests/rewritetests.py
@@ -407,3 +407,18 @@ class RewriterTests(BasePlatformTests):
         # Do it line per line because it is easier to debug like that
         for orig_line, new_line in zip_longest(original_contents.splitlines(), new_contents.splitlines()):
             self.assertEqual(orig_line, new_line)
+
+    @unittest.expectedFailure
+    def test_rewrite_prefix(self) -> None:
+        self.prime('7 prefix')
+        out = self.rewrite_raw(self.builddir, ['kwargs', 'info', 'project', '/'])
+        expected = {
+            'kwargs': {
+                'project#/': {
+                    "default_options": [
+                        'prefix=/export/doocs'
+                    ]
+                }
+            }
+        }
+        self.assertDictEqual(out, expected)


### PR DESCRIPTION
~based on: https://github.com/mesonbuild/meson/pull/14353 for practical reasons~

This removes the last use of `coredata.set_default_options`, which is only used in the rewriter path after the optionrefactor merge, and is completely broken by that merge. Instead we use the same path that the other interpreters use, so we can completely delete this code.

Closes: #14382