### PR TITLE
tests/d: Limit integer debug and version statements

### DIFF
--- a/test cases/d/9 features/app.d
+++ b/test cases/d/9 features/app.d
@@ -1,4 +1,4 @@
-
+import std.conv;
 import std.stdio;
 import std.array : split;
 import std.string : strip;
@@ -14,6 +14,22 @@ auto getMenu ()
 auto getPeople ()
 {
     return import ("people.txt").strip.split ("\n");
+}
+
+// Put these in templates to prevent the compiler from failing to parse them
+// since frontend version 2.111
+template VersionInt (int v) {
+    mixin(`version(` ~ v.to!string ~ `)
+        enum VersionInt = true;
+    else
+        enum VersionInt = false;`);
+}
+template DebugInt (int v) {
+    import std.conv;
+    mixin(`debug(` ~ v.to!string ~ `)
+        enum DebugInt = true;
+    else
+        enum DebugInt = false;`);
 }
 
 void main (string[] args)
@@ -43,13 +59,13 @@ void main (string[] args)
     }
 
     version (With_VersionInteger)
-        version(3) exit(0);
+        static if (VersionInt!3) exit(0);
 
     version (With_Debug)
         debug exit(0);
 
     version (With_DebugInteger)
-        debug(3) exit(0);
+        static if (DebugInt!(3)) exit(0);
 
     version (With_DebugIdentifier)
         debug(DebugIdentifier) exit(0);
@@ -57,9 +73,9 @@ void main (string[] args)
     version (With_DebugAll) {
         int dbg = 0;
         debug dbg++;
-        debug(2) dbg++;
-        debug(3) dbg++;
-        debug(4) dbg++;
+        static if (DebugInt!2) dbg++;
+        static if (DebugInt!3) dbg++;
+        static if (DebugInt!4) dbg++;
         debug(DebugIdentifier) dbg++;
 
         if (dbg == 5)

--- a/test cases/d/9 features/meson.build
+++ b/test cases/d/9 features/meson.build
@@ -2,13 +2,16 @@ project('D Features', 'd', meson_version: '>=1.6', default_options : ['debug=fal
 
 dc = meson.get_compiler('d')
 
-# GDC 13 hard errors if options are given number values.
-# https://github.com/mesonbuild/meson/pull/11996
-
-if dc.get_id() == 'gcc' and dc.version().version_compare('>=13')
-    number_options_supported = false
+# See: https://dlang.org/changelog/2.111.0.html#dmd.deprecation-version-debug-number
+# GDC fails even before that: https://github.com/mesonbuild/meson/pull/11996
+if dc.get_id() == 'gcc'
+  number_options_supported = dc.version().version_compare('<13')
+elif dc.get_id() == 'dmd'
+  number_options_supported = dc.version().version_compare('<2.111')
+elif dc.get_id() == 'llvm'
+  number_options_supported = dc.version().version_compare('<1.41')
 else
-    number_options_supported = true
+  error(f'Unknown D compiler id')
 endif
 
 # ONLY FOR BACKWARDS COMPATIBILITY.


### PR DESCRIPTION
Since dmd frontend version 2.111 integer debug and version statements error during parsing:
https://dlang.org/changelog/2.111.0.html#dmd.deprecation-version-debug-number

This should fix the failing opensuse image build.