### PR TITLE
fix(dependencies:python): Link to debug Python libraries (python{vernum}_d.lib) in MSVC debug builds #14429

### DIFF
--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -243,7 +243,7 @@ class _PythonDependencyBase(_Base):
                             libpath = Path('libs') / f'python{vernum}t.lib'
                         else:
                             libpath = Path('libs') / f'python{vernum}.lib'
-                    mlog.debug("Using python static library: {!r}".format(str(libpath))
+                    mlog.debug("Using python static library: {!r}".format(str(libpath)))
                     # For a debug build, pyconfig.h may force linking with
                     # pythonX_d.lib (see meson#10776). This cannot be avoided
                     # and won't work unless we also have a debug build of

--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -234,10 +234,16 @@ class _PythonDependencyBase(_Base):
                         else:
                             libpath = Path(f'python{vernum}.dll')
                 else:
-                    if self.is_freethreaded:
-                        libpath = Path('libs') / f'python{vernum}t.lib'
+                    library = self.variables.get('LIBRARY', '')
+                    base_name, ext = os.path.splitext(library)
+                    if ext.lower() == '.lib':
+                        libpath = Path('libs') / f'{base_name}.lib'
                     else:
-                        libpath = Path('libs') / f'python{vernum}.lib'
+                        if self.is_freethreaded:
+                            libpath = Path('libs') / f'python{vernum}t.lib'
+                        else:
+                            libpath = Path('libs') / f'python{vernum}.lib'
+                    mlog.debug("Using python static library: {!r}".format(str(libpath))
                     # For a debug build, pyconfig.h may force linking with
                     # pythonX_d.lib (see meson#10776). This cannot be avoided
                     # and won't work unless we also have a debug build of


### PR DESCRIPTION
Describe the bug
When building the numpy project that depends on Python using Meson on Windows with MSVC in debug mode, the final linking step incorrectly uses the release Python library (e.g. python313.lib) instead of the debug library (python313_d.lib). Even though the build logs indicate that python313_d.lib is used during compilation (as evidenced by the modifications in pyconfig.h with #pragma message directives), the resulting .pyd files are linked against the release DLL. This causes runtime issues when using a debug Python interpreter.

The modification has been tested in the following environment:

- Test Project: numpy (master)
- Build type: Native build (no cross-compilation)
- Operating System: Windows 10
- Python Version: Python 3.13 (debug interpreter, e.g. python313_d.exe)
- Meson Version: 1.7.0
- Ninja Version: 1.11.1.git.kitware.jobserver-1

Please see issue #14429 for a more specific discussion.