### PR TITLE
Docs: Set note/warning title color to black text

### DIFF
--- a/docs/theme/extra/css/notes.css
+++ b/docs/theme/extra/css/notes.css
@@ -14,7 +14,7 @@
     min-width: min-content;
     font-weight: bold;
     font-size: 120%;
-    color: #fff;
+    color: #000;
 }
 .note-topbar .glyphicon {
     top: 2px;


### PR DESCRIPTION
A followup to #13505, as I'd inadvertently made the headings of the Note/Warning boxes use white text, instead of black as intended. The white text really doesn't work with the blue Note background color.

cc: @jpakkane 

(Sorry about that!)