### PR TITLE
minstall: Don't treat symlinks to directories as directories in do_copydir()

### DIFF
--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -507,6 +507,9 @@ class Installer:
                 abs_src = os.path.join(root, d)
                 filepart = os.path.relpath(abs_src, start=src_dir)
                 abs_dst = os.path.join(dst_dir, filepart)
+                if os.path.islink(abs_src):
+                    files.append(d)
+                    continue
                 # Remove these so they aren't visited by os.walk at all.
                 if filepart in exclude_dirs:
                     dirs.remove(d)


### PR DESCRIPTION
As documented in https://docs.python.org/3/library/os.html#os.walk:

> dirnames is a list of the names of the subdirectories in dirpath
> (including symlinks to directories, and excluding '.' and '..')

So currently, we treat any symlink to a directory as a directory instead of as a symlink. In practice, this means symlinks to directories are installed as empty directories instead of as symlinks.

Let's make sure the symlinks are kept intact by checking for symlinks when we iterate over the directory names and treating any symlinks we find as files instead of as symlinks.