### PR TITLE
linkers: fix Apple ld -install_name with custom suffix

### DIFF
--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -857,7 +857,7 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
         install_name = ['@rpath/', prefix, shlib_name]
         if soversion is not None:
             install_name.append('.' + soversion)
-        install_name.append('.dylib')
+        install_name.append('.' + suffix)
         args = ['-install_name', ''.join(install_name)]
         if darwin_versions:
             args.extend(['-compatibility_version', darwin_versions[0],


### PR DESCRIPTION
Use the custom suffix instead of .dylib in `get_soname_args`, so that executables that are linked to a custom-suffix library can be ran from the build tree.

Fixes: #14470