### PR TITLE
Fix two shared objects in archive for AIX.

### DIFF
--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -1533,7 +1533,7 @@ class AIXDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
     def get_command_to_archive_shlib(self) -> T.List[str]:
         # Archive shared library object and remove the shared library object,
         # since it already exists in the archive.
-        command = ['ar', '-q', '-v', '$out', '$in', '&&', 'rm', '-f', '$in']
+        command = ['ar', '-r', '-s', '-v', '$out', '$in', '&&', 'rm', '-f', '$in']
         return command
 
     def get_link_whole_for(self, args: T.List[str]) -> T.List[str]:


### PR DESCRIPTION
In AIX, when we use ar -q to archive then if there is a shared object already existing with the same name a duplicate one is created if one tries to archive again.

Meson archives shared library during build time and relinks again during install time. At this stage when shared object is again made and archived again, creating two shared objects in the archive.

When we use "ar -rs" then  we ensure it is only one.

Reference: https://www.ibm.com/docs/en/aix/7.1?topic=ar-command

This patch is a fix to the same.

Before patch output:
rwxr-xr-x     0/0       5018 Apr 14 05:57 2025 libmylib.so
rwxr-xr-x     0/0       5018 Apr 14 05:58 2025 libmylib.so

After patch output:
rwxr-xr-x     0/0       5018 Apr 14 07:23 2025 libmylib.so