### PR TITLE
modules/gnome: Allow to generate markdown and reStructuredText dbus doc

### DIFF
--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -280,6 +280,8 @@ one XML file.
 * `object_manager`: *(Added 0.40.0)* if true generates object manager code
 * `annotations`: *(Added 0.43.0)* list of lists of 3 strings for the annotation for `'ELEMENT', 'KEY', 'VALUE'`
 * `docbook`: *(Added 0.43.0)* prefix to generate `'PREFIX'-NAME.xml` docbooks
+* `rst`: *(Added 1.9.0)* prefix to generate `'PREFIX'-NAME.rst` reStructuredTexts
+* `markdown`: *(Added 1.9.0)* prefix to generate `'PREFIX'-NAME.md` markdowns
 * `build_by_default`: causes, when set to true, to have this target be
   built by default, that is, when invoking plain `meson compile`, the default
   value is true for all built target types
@@ -289,8 +291,9 @@ one XML file.
 
 Starting *0.46.0*, this function returns a list of at least two custom
 targets (in order): one for the source code and one for the header.
-The list will contain a third custom target for the generated docbook
-files if that keyword argument is passed.
+The list can then contain other custom targets for the generated documentation
+files depending if the keyword argument is passed (in order): the docbook
+target, the reStructuredText target and the markdown target.
 
 Earlier versions return a single custom target representing all the
 outputs. Generally, you should just add this list of targets to a top

--- a/test cases/frameworks/7 gnome/gdbus/meson.build
+++ b/test cases/frameworks/7 gnome/gdbus/meson.build
@@ -52,6 +52,23 @@ assert(gdbus_src.length() == 3, 'expected 3 targets')
 assert(gdbus_src[0].full_path().endswith('.c'), 'expected 1 c source file')
 assert(gdbus_src[1].full_path().endswith('.h'), 'expected 1 c header file')
 
+if not pretend_glib_old and glib.version().version_compare('>=2.75.2')
+  gdbus_src_docs = gnome.gdbus_codegen('generated-gdbus-docs',
+    sources : files('data/com.example.Sample.xml'),
+    interface_prefix : 'com.example.',
+    namespace : 'Sample',
+    docbook : 'generated-gdbus-docs-doc',
+    rst : 'generated-gdbus-docs-rst',
+    markdown : 'generated-gdbus-docs-md',
+  )
+  assert(gdbus_src_docs.length() == 5, 'expected 5 targets')
+  assert(gdbus_src_docs[0].full_path().endswith('.c'), 'expected 1 c source file')
+  assert(gdbus_src_docs[1].full_path().endswith('.h'), 'expected 1 c header file')
+  assert('generated-gdbus-docs-doc' in gdbus_src_docs[2].full_path(), 'expected 1 docbook file')
+  assert('generated-gdbus-docs-rst' in gdbus_src_docs[3].full_path(), 'expected 1 reStructuredText file')
+  assert('generated-gdbus-docs-md' in gdbus_src_docs[4].full_path(), 'expected 1 markdown file')
+endif
+
 if not pretend_glib_old and glib.version().version_compare('>=2.51.3')
   includes = []
 else

--- a/test cases/frameworks/7 gnome/meson.build
+++ b/test cases/frameworks/7 gnome/meson.build
@@ -1,4 +1,4 @@
-project('gobject-introspection', 'c', meson_version: '>= 1.2.0')
+project('gobject-introspection', 'c', meson_version: '>= 1.9.0')
 
 copyfile = find_program('copyfile.py')
 copyfile_gen = generator(copyfile,


### PR DESCRIPTION
gdbus-docgen supports reStructuredText output since 2.71.1 and markdown since 2.75.2, allow to simply generate it.