### PR TITLE
Fix behavior with options whose prefix is a builtin option name

### DIFF
--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -247,7 +247,7 @@ def validate_original_args(args):
     #longs = [x for x in args if x.startswith('--')]
     for optionkey in itertools.chain(mesonbuild.options.BUILTIN_DIR_OPTIONS, mesonbuild.options.BUILTIN_CORE_OPTIONS):
         longarg = mesonbuild.options.argparse_name_to_arg(optionkey.name)
-        shortarg = f'-D{optionkey.name}'
+        shortarg = f'-D{optionkey.name}='
         if has_startswith(args, longarg) and has_startswith(args, shortarg):
             sys.exit(
                 f'Got argument {optionkey.name} as both {shortarg} and {longarg}. Pick one.')

--- a/test cases/unit/128 long opt vs D/meson.build
+++ b/test cases/unit/128 long opt vs D/meson.build
@@ -1,0 +1,1 @@
+project('empty test')

--- a/test cases/unit/128 long opt vs D/meson_options.txt
+++ b/test cases/unit/128 long opt vs D/meson_options.txt
@@ -1,0 +1,1 @@
+option('sysconfdir2', type: 'string', value: '')

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1361,6 +1361,36 @@ class AllPlatformTests(BasePlatformTests):
         self.utime(os.path.join(testdir, 'srcgen.py'))
         self.assertRebuiltTarget('basic')
 
+    def test_long_opt_vs_D(self):
+        '''
+        Test that conflicts between -D for builtin options and the corresponding
+        long option are detected without false positives or negatives.
+        '''
+        testdir = os.path.join(self.unit_test_dir, '128 long opt vs D')
+
+        for opt in ['-Dsysconfdir=/etc', '-Dsysconfdir2=/etc']:
+            exception_raised = False
+            try:
+                self.init(testdir, extra_args=[opt, '--sysconfdir=/etc'])
+            except subprocess.CalledProcessError:
+                exception_raised = True
+            if 'sysconfdir2' in opt:
+                self.assertFalse(exception_raised, f'{opt} --sysconfdir raised an exception')
+            else:
+                self.assertTrue(exception_raised, f'{opt} --sysconfdir did not raise an exception')
+
+            exception_raised = False
+            try:
+                self.init(testdir, extra_args=['--sysconfdir=/etc', opt])
+            except subprocess.CalledProcessError:
+                exception_raised = True
+            if 'sysconfdir2' in opt:
+                self.assertFalse(exception_raised, f'--sysconfdir {opt} raised an exception')
+            else:
+                self.assertTrue(exception_raised, f'--sysconfdir {opt} did not raise an exception')
+
+            self.wipe()
+
     def test_static_library_lto(self):
         '''
         Test that static libraries can be built with LTO and linked to


### PR DESCRIPTION
`validate_original_args` only checks whether an option is *prefixed* with the name of a built-in option that was also set.  It does not check whether the prefix is the full name of the option specified with -D.  Adding an "=" at the end fixes the test.
    
Fixes: #14487