### PR TITLE
Log non-fatally if CMake doesn't find a package

### DIFF
--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -416,11 +416,11 @@ class CMakeDependency(ExternalDependency):
         if not self.is_found:
             not_found_message = self.traceparser.get_cmake_var('PACKAGE_NOT_FOUND_MESSAGE')
             if len(not_found_message) > 0:
-                mlog.warning(
+                mlog.notice(
                     'CMake reported that the package {} was not found with the following reason:\n'
-                    '{}'.format(name, not_found_message[0]))
+                    '{}'.format(name, not_found_message[0]), fatal=False)
             else:
-                mlog.warning(
+                mlog.debug(
                     'CMake reported that the package {} was not found, '
                     'even though Meson\'s preliminary check succeeded.'.format(name))
             raise self._gen_exception('PACKAGE_FOUND is false')


### PR DESCRIPTION
If CMake fails to find a package, we should log it in `meson-log.txt`, but shouldn't bother the user unless there are details to report.  In addition, we were calling `mlog.warning()` without `fatal=False`, so if `msetup` was called with `--fatal-meson-warnings` we'd fail the entire setup in this case, even for optional dependencies.  Log a notice with `fatal=False` if CMake reported an error, and a debug message otherwise.

Notably, the `even though Meson's preliminary check succeeded` case can occur when a dependency is missing but its `Find*.cmake` is shipped with CMake itself.

Fixes https://github.com/mesonbuild/meson/pull/14216.