### PR TITLE
Fix interaction between b_sanitize as array and option refactor

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1059,7 +1059,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     @typed_pos_args('get_option', str)
     @noKwargs
     def func_get_option(self, node: mparser.BaseNode, args: T.Tuple[str],
-                        kwargs: kwtypes.FuncGetOption) -> T.Union[options.UserOption, 'TYPE_var']:
+                        kwargs: TYPE_kwargs) -> T.Union[options.UserOption, 'TYPE_var']:
         optname = args[0]
 
         if ':' in optname:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1095,13 +1095,10 @@ class Interpreter(InterpreterBase, HoldableObject):
             if not value:
                 return 'none'
             return ','.join(sorted(value))
-        elif isinstance(value_object, options.UserOption):
-            if isinstance(value_object.value, str):
-                return P_OBJ.OptionString(value, f'{{{optname}}}')
-            return value
-        ocopy = copy.copy(value_object)
-        ocopy.value = value
-        return ocopy
+
+        if isinstance(value_object.value, str):
+            return P_OBJ.OptionString(value, f'{{{optname}}}')
+        return value
 
     @typed_pos_args('configuration_data', optargs=[dict])
     @noKwargs


### PR DESCRIPTION
Returning the default value for `b_sanitize` now misses the special check for it's handling (as would a feature option, but we don't currently have any builtin options that are features). don't do that.

Fixes: #14501