### PR TITLE
Fix IntrospectionInterpreter._add_languages to allow simplifying compiler options

### DIFF
--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -205,7 +205,7 @@ class IntrospectionInterpreter(AstInterpreter):
                     else:
                         continue
                 if comp:
-                    self.coredata.process_compiler_options(lang, comp, self.environment, self.subproject)
+                    self.coredata.process_compiler_options(lang, comp, self.subproject)
 
     def func_dependency(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> None:
         args = self.flatten_args(args)

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -6,7 +6,6 @@
 # or an interpreter-based tool
 
 from __future__ import annotations
-import copy
 import os
 import typing as T
 
@@ -205,13 +204,8 @@ class IntrospectionInterpreter(AstInterpreter):
                         raise
                     else:
                         continue
-                if self.subproject:
-                    options = {}
-                    for k in comp.get_options():
-                        v = copy.copy(self.coredata.optstore.get_value_object(k))
-                        k = k.evolve(subproject=self.subproject)
-                        options[k] = v
-                    self.coredata.add_compiler_options(options, lang, for_machine, self.environment, self.subproject)
+                if comp:
+                    self.coredata.process_compiler_options(lang, comp, self.environment, self.subproject)
 
     def func_dependency(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> None:
         args = self.flatten_args(args)

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -107,7 +107,7 @@ def detect_compiler_for(env: 'Environment', lang: str, for_machine: MachineChoic
     if comp is None:
         return comp
     assert comp.for_machine == for_machine
-    env.coredata.process_compiler_options(lang, comp, env, subproject)
+    env.coredata.process_compiler_options(lang, comp, subproject)
     if not skip_sanity_check:
         comp.sanity_check(env.get_scratch_dir(), env)
     env.coredata.compilers[comp.for_machine][lang] = comp

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -575,14 +575,14 @@ class CoreData:
     def add_compiler_options(self, c_options: MutableKeyedOptionDictType, lang: str, for_machine: MachineChoice,
                              env: Environment, subproject: str) -> None:
         for k, o in c_options.items():
-            comp_key = OptionKey(f'{k.name}', None, for_machine)
+            assert k.subproject is None and k.machine is for_machine
             if lang == 'objc' and k.name == 'c_std':
                 # For objective C, always fall back to c_std.
-                self.optstore.add_compiler_option('c', comp_key, o)
+                self.optstore.add_compiler_option('c', k, o)
             elif lang == 'objcpp' and k.name == 'cpp_std':
-                self.optstore.add_compiler_option('cpp', comp_key, o)
+                self.optstore.add_compiler_option('cpp', k, o)
             else:
-                self.optstore.add_compiler_option(lang, comp_key, o)
+                self.optstore.add_compiler_option(lang, k, o)
 
     def add_lang_args(self, lang: str, comp: T.Type['Compiler'],
                       for_machine: MachineChoice, env: 'Environment') -> None:

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -572,8 +572,7 @@ class CoreData:
 
         return dirty
 
-    def add_compiler_options(self, c_options: MutableKeyedOptionDictType, lang: str, for_machine: MachineChoice,
-                             env: Environment, subproject: str) -> None:
+    def add_compiler_options(self, c_options: MutableKeyedOptionDictType, lang: str, for_machine: MachineChoice) -> None:
         for k, o in c_options.items():
             assert k.subproject is None and k.machine is for_machine
             if lang == 'objc' and k.name == 'c_std':
@@ -594,8 +593,8 @@ class CoreData:
         for gopt_key, gopt_valobj in compilers.get_global_options(lang, comp, for_machine, env).items():
             self.optstore.add_compiler_option(lang, gopt_key, gopt_valobj)
 
-    def process_compiler_options(self, lang: str, comp: Compiler, env: Environment, subproject: str) -> None:
-        self.add_compiler_options(comp.get_options(), lang, comp.for_machine, env, subproject)
+    def process_compiler_options(self, lang: str, comp: Compiler, subproject: str) -> None:
+        self.add_compiler_options(comp.get_options(), lang, comp.for_machine)
 
         for key in comp.base_options:
             if subproject:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1531,7 +1531,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                     self.backend.allow_thin_archives[for_machine] = False
             else:
                 # update new values from commandline, if it applies
-                self.coredata.process_compiler_options(lang, comp, self.environment, self.subproject)
+                self.coredata.process_compiler_options(lang, comp, self.subproject)
 
             if for_machine == MachineChoice.HOST or self.environment.is_cross_build():
                 logger_fun = mlog.log

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -997,7 +997,7 @@ def have_working_compiler(lang: str, use_tmp: bool) -> bool:
             return False
         if not compiler:
             return False
-        env.coredata.process_compiler_options(lang, compiler, env, '')
+        env.coredata.process_compiler_options(lang, compiler, '')
         try:
             compiler.sanity_check(env.get_scratch_dir(), env)
         except mesonlib.MesonException:


### PR DESCRIPTION
Extracted from #14498 