### PR TITLE
unittests: fix overly loose regex in tests for `--slice=` option

### DIFF
--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -5196,7 +5196,7 @@ class AllPlatformTests(BasePlatformTests):
                                  '10/10': [10],
                                  }.items():
             output = self._run(self.mtest_command + ['--slice=' + arg])
-            tests = sorted([ int(x[5:]) for x in re.findall(r'test-[0-9]*', output) ])
+            tests = sorted([ int(x) for x in re.findall(r'\n[ 0-9]+/[0-9]+ test-([0-9]*)', output) ])
             self.assertEqual(tests, expectation)
 
         for arg, expectation in {'': 'error: argument --slice: value does not conform to format \'SLICE/NUM_SLICES\'',


### PR DESCRIPTION
The unit tests for the `meson test --slice=` option check that the option is working by extracting all tests that have been run from the command output. This is done with a rather loose regular expression "test-[0-9]*", which can easily match other parts of the output, as well.

One user for example reported that the test broke because they were executing tests in a directory called "meson-test-1.8.0-build", and given that the "test-1" part of that directory matches the regular expression we have too many matches.

Fix the issue by tightening the regex so that is way less likely to match anything from the host's build environment.

Reported-by: Dominique Leuenberger <dleuenberger@suse.com>

Fixes https://github.com/mesonbuild/meson/issues/14523.