### PR TITLE
docs: disambiguate exe_wrapper

### DIFF
--- a/docs/markdown/Cross-compilation.md
+++ b/docs/markdown/Cross-compilation.md
@@ -139,6 +139,22 @@ of a wrapper, these lines are all you need to write. Meson will
 automatically use the given wrapper when it needs to run host
 binaries. This happens e.g. when running the project's test suite.
 
+Note that `exe_wrapper` in the cross file is handled separately
+from the `exe_wrapper` argument in
+[`add_test_setup`](Reference-manual_functions.md#add_test_setup_exe_wrapper)
+and [`meson test --wrapper`](Unit-tests.md#other-test-options)
+command line argument. Meson must have `exe_wrapper` specified in the
+cross file or else it will skip tests that attempt to run cross
+compiled binaries. Only the cross file `exe_wrapper` value will be
+stored in the `MESON_EXE_WRAPPER` environment variable. If another
+wrapper is given in the test setup with `exe_wrapper` or as a
+`meson test --wrapper` command line argument, then meson will prepend
+the additional wrapper before the cross file wrapper like the
+following command:
+```
+[prepend_wrapper] <cross_file_wrapper> <exe_binary> <args...>
+```
+
 ### Properties
 
 In addition to the properties allowed in [all machine


### PR DESCRIPTION
As of this commit, meson has three different pathways to set an `exe_wrapper` for test binaries.

exe_wrapper set through `meson test --wrapper`
CLI arg or `add_test_setup()` meson function argument are treated equally. One wrapper may be set through either of these mutually exclusive routes at a time.
The exe_wrapper field set in the cross file is handled separately internally in mtest.py. This route is *not* mutually exclusive with the others, and this field has more consequence over meson test behavior that the other two routes do not affect.
When I encountered this behavior in a project, it was very unintuitive to me, so I'm documenting what I see now.

Perhaps a future version of meson should treat these fields equally and explicitly document how they are combined.
For now, I think its a better first step to document current behavior to generate discussion about how exactly the future version should behave. I took a few steps towards treating these fields equally on [this branch](https://github.com/30Wedge/meson/tree/am/cross-exe-wrapper) but I found that it is not trivial, so I'd want to discuss it before going forwards.