### PR TITLE
Fix backend options

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1201,6 +1201,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                 self.coredata.initialized_subprojects.add(self.subproject)
 
         if not self.is_subproject():
+            self.coredata.optstore.validate_cmd_line_options(self.user_defined_options.cmd_line_options)
             self.build.project_name = proj_name
         self.active_projectname = proj_name
 

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1370,15 +1370,27 @@ class OptionStore:
                 if proj_key in self.options:
                     self.set_option(proj_key, valstr, True)
                 else:
-                    # Fail on unknown options that we can know must
-                    # exist at this point in time. Subproject and compiler
-                    # options are resolved later.
-                    #
-                    # Some base options (sanitizers etc) might get added later.
-                    # Permitting them all is not strictly correct.
-                    if key.subproject is None and not self.is_compiler_option(key) and not self.is_base_option(key):
-                        raise MesonException(f'Unknown options: "{keystr}"')
                     self.pending_options[key] = valstr
+
+    def validate_cmd_line_options(self, cmd_line_options: OptionStringLikeDict) -> None:
+        unknown_options = []
+        for keystr, valstr in cmd_line_options.items():
+            if isinstance(keystr, str):
+                key = OptionKey.from_string(keystr)
+            else:
+                key = keystr
+            # Fail on unknown options that we can know must exist at this point in time.
+            # Subproject and compiler options are resolved later.
+            #
+            # Some base options (sanitizers etc) might get added later.
+            # Permitting them all is not strictly correct.
+            if key.subproject is None and not self.is_compiler_option(key) and not self.is_base_option(key) and \
+               key in self.pending_options:
+                unknown_options.append(f'"{key}"')
+
+        if unknown_options:
+            keys = ', '.join(unknown_options)
+            raise MesonException(f'Unknown options: {keys}')
 
     def hacky_mchackface_back_to_list(self, optdict: T.Dict[str, str]) -> T.List[str]:
         if isinstance(optdict, dict):

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1243,7 +1243,7 @@ class OptionStore:
 
     def first_handle_prefix(self,
                             project_default_options: T.Union[T.List[str], OptionStringLikeDict],
-                            cmd_line_options: T.Union[T.List[str], OptionStringLikeDict],
+                            cmd_line_options: OptionStringLikeDict,
                             machine_file_options: T.Mapping[OptionKey, ElementaryOptionValues]) \
             -> T.Tuple[T.Union[T.List[str], OptionStringLikeDict],
                        T.Union[T.List[str], OptionStringLikeDict],
@@ -1282,7 +1282,7 @@ class OptionStore:
 
     def initialize_from_top_level_project_call(self,
                                                project_default_options_in: T.Union[T.List[str], OptionStringLikeDict],
-                                               cmd_line_options_in: T.Union[T.List[str], OptionStringLikeDict],
+                                               cmd_line_options_in: OptionStringLikeDict,
                                                machine_file_options_in: T.Mapping[OptionKey, ElementaryOptionValues]) -> None:
         first_invocation = True
         (project_default_options, cmd_line_options, machine_file_options) = self.first_handle_prefix(project_default_options_in,

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -529,7 +529,8 @@ class AllPlatformTests(BasePlatformTests):
         if self.backend is not Backend.ninja:
             raise SkipTest(f'{self.backend.name!r} backend can\'t install files')
         testdir = os.path.join(self.common_test_dir, '8 install')
-        self.init(testdir)
+        # sneak in a test that covers backend options...
+        self.init(testdir, extra_args=['-Dbackend_max_links=4'])
         intro = self.introspect('--targets')
         if intro[0]['type'] == 'executable':
             intro = intro[::-1]


### PR DESCRIPTION
Not the most surgical way to fix it, but I prefer to have a bigger fix that is conceptually more correct. Setting the backend as early as possible makes the processing of toplevel project and subprojects more similar.

Fixes: #14524