### PR TITLE
dependencies/python: Fix Framework Python when pkg-config is installed

### DIFF
--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -333,7 +333,9 @@ class PythonPkgConfigDependency(PkgConfigDependency, _PythonDependencyBase):
             # Add rpath, will be de-duplicated if necessary
             if framework_prefix.startswith('/Applications/Xcode.app/'):
                 self.link_args += ['-Wl,-rpath,' + framework_prefix]
-                self.raw_link_args += ['-Wl,-rpath,' + framework_prefix]
+                if self.raw_link_args is not None:
+                    # When None, self.link_args is used
+                    self.raw_link_args += ['-Wl,-rpath,' + framework_prefix]
 
 class PythonFrameworkDependency(ExtraFrameworkDependency, _PythonDependencyBase):
 

--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -330,7 +330,7 @@ class PythonPkgConfigDependency(PkgConfigDependency, _PythonDependencyBase):
         # But not Apple, because it's a framework
         if self.env.machines.host.is_darwin() and 'PYTHONFRAMEWORKPREFIX' in self.variables:
             framework_prefix = self.variables['PYTHONFRAMEWORKPREFIX']
-            # Add rpath, will be de-duplicated if necessary
+            # Add rpath, will be de-duplicated if necessary
             if framework_prefix.startswith('/Applications/Xcode.app/'):
                 self.link_args += ['-Wl,-rpath,' + framework_prefix]
                 self.raw_link_args += ['-Wl,-rpath,' + framework_prefix]


### PR DESCRIPTION
In this case, self.raw_link_args is None.

Fixes #14534.