### PR TITLE
Add framework linking for iOS builds.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -94,6 +94,11 @@ jobs:
         # productive -- only victim blaming -- however it bites particularly badly because this is a container/VM
         # See commit 5c479d7a13a518c18ccb4dc3b6bdd7bfc2a9bdb5 for a more thorough analysis.
         find /opt/homebrew/Cellar/python* -name EXTERNALLY-MANAGED -print0 | xargs -0 rm -vf
+        # Homebrew's installation of pip 25.0.1 in Python 3.13.3 is broken; it
+        # doesn't include a RECORD file, so it can't be upgraded by pip. Create
+        # a dummy RECORD file.
+        PIP_RECORD=$(python3 -c "import pip, os; print(f'{os.path.dirname(pip.__file__)}-{pip.__version__}.dist-info/RECORD')")
+        touch $PIP_RECORD
     # use python3 from homebrew because it is a valid framework, unlike the actions one:
     # https://github.com/actions/setup-python/issues/58
     - run: brew install pkg-config ninja llvm qt@5 boost ldc hdf5 openmpi lapack scalapack sdl2 boost-python3 gtk-doc zstd ncurses objfw libomp

--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -350,8 +350,14 @@ class PythonSystemDependency(SystemDependency, _PythonDependencyBase):
         SystemDependency.__init__(self, name, environment, kwargs)
         _PythonDependencyBase.__init__(self, installation, kwargs.get('embed', False))
 
-        # match pkg-config behavior
-        if self.link_libpython:
+        # For most platforms, match pkg-config behavior. iOS is a special case;
+        # check for that first, so that check takes priority over
+        # `link_libpython` (which *shouldn't* be set, but just in case)
+        if self.platform.startswith('ios-'):
+            # iOS doesn't use link_libpython - it links with the *framework*.
+            self.link_args = ['-framework', 'Python', '-F', self.variables.get('prefix')]
+            self.is_found = True
+        elif self.link_libpython:
             # link args
             if mesonlib.is_windows():
                 self.find_libpy_windows(environment, limited_api=False)


### PR DESCRIPTION
When building for iOS, and Python is a dependency, linking against the Python *framework* is required. This is done [automatically for all the standard library modules](https://github.com/python/cpython/blob/v3.14.0a7/configure.ac#L3459-L3463).

This behavior differs from macOS. On macOS, binary modules are linked with `-undefined dynamic_lookup`; that option is marked as deprecated for the iOS compiler, so it can't be used.

It also differs from Unix platforms that link against libPython - the link must be against the framework, not the library, as iOS doesn't allow "normal" dynamic library linking. As a result, existing `link_libpython` can't be used.
