### PR TITLE
Allow .version() to be called for overridden executables

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -275,7 +275,7 @@ class Build:
         self.stdlibs = PerMachine({}, {})
         self.test_setups: T.Dict[str, TestSetup] = {}
         self.test_setup_default_name = None
-        self.find_overrides: T.Dict[str, T.Union['Executable', programs.ExternalProgram, programs.OverrideProgram]] = {}
+        self.find_overrides: T.Dict[str, T.Union['OverrideExecutable', programs.ExternalProgram, programs.OverrideProgram]] = {}
         self.searched_programs: T.Set[str] = set() # The list of all programs that have been searched for.
 
         # If we are doing a cross build we need two caches, if we're doing a
@@ -3128,6 +3128,18 @@ class ConfigurationData(HoldableObject):
 
     def keys(self) -> T.Iterator[str]:
         return self.values.keys()
+
+class OverrideExecutable(Executable):
+    def __init__(self, executable: Executable, version: str):
+        self._executable = executable
+        self._version = version
+
+    def __getattr__(self, name: str) -> T.Any:
+        _executable = object.__getattribute__(self, '_executable')
+        return getattr(_executable, name)
+
+    def get_version(self, interpreter: T.Optional[Interpreter] = None) -> str:
+        return self._version
 
 # A bit poorly named, but this represents plain data files to copy
 # during install.

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -426,6 +426,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             build.Generator: OBJ.GeneratorHolder,
             build.GeneratedList: OBJ.GeneratedListHolder,
             build.ExtractedObjects: OBJ.GeneratedObjectsHolder,
+            build.OverrideExecutable: OBJ.OverrideExecutableHolder,
             build.RunTarget: OBJ.RunTargetHolder,
             build.AliasTarget: OBJ.AliasTargetHolder,
             build.Headers: OBJ.HeadersHolder,
@@ -1589,7 +1590,7 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     def program_from_overrides(self, command_names: T.List[mesonlib.FileOrString],
                                extra_info: T.List['mlog.TV_Loggable']
-                               ) -> T.Optional[T.Union[ExternalProgram, OverrideProgram, build.Executable]]:
+                               ) -> T.Optional[T.Union[ExternalProgram, OverrideProgram, build.OverrideExecutable]]:
         for name in command_names:
             if not isinstance(name, str):
                 continue
@@ -1604,7 +1605,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             if isinstance(name, str):
                 self.build.searched_programs.add(name)
 
-    def add_find_program_override(self, name: str, exe: T.Union[build.Executable, ExternalProgram, 'OverrideProgram']) -> None:
+    def add_find_program_override(self, name: str, exe: T.Union[build.OverrideExecutable, ExternalProgram, 'OverrideProgram']) -> None:
         if name in self.build.searched_programs:
             raise InterpreterException(f'Tried to override finding of executable "{name}" which has already been found.')
         if name in self.build.find_overrides:
@@ -1629,7 +1630,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                           search_dirs: T.Optional[T.List[str]] = None,
                           version_arg: T.Optional[str] = '',
                           version_func: T.Optional[ProgramVersionFunc] = None
-                          ) -> T.Union['ExternalProgram', 'build.Executable', 'OverrideProgram']:
+                          ) -> T.Union['ExternalProgram', 'build.OverrideExecutable', 'OverrideProgram']:
         args = mesonlib.listify(args)
 
         extra_info: T.List[mlog.TV_Loggable] = []

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -1142,3 +1142,14 @@ class StructuredSourcesHolder(ObjectHolder[build.StructuredSources]):
 
     def __init__(self, sources: build.StructuredSources, interp: 'Interpreter'):
         super().__init__(sources, interp)
+
+class OverrideExecutableHolder(BuildTargetHolder[build.OverrideExecutable]):
+    def __init__(self, exe: build.OverrideExecutable, interpreter: 'Interpreter') -> None:
+        super().__init__(exe, interpreter)
+        self.methods.update({'version': self.version_method})
+
+    @noPosargs
+    @noKwargs
+    @FeatureNew('OverrideExecutable.version', '1.9.0')
+    def version_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> str:
+        return self.held_object.get_version(self.interpreter)

--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -335,6 +335,8 @@ class MesonMain(MesonInterpreterObject):
             if not os.path.exists(abspath):
                 raise InterpreterException(f'Tried to override {name} with a file that does not exist.')
             exe = OverrideProgram(name, self.interpreter.project_version, command=[abspath])
+        elif isinstance(exe, build.Executable):
+            exe = build.OverrideExecutable(exe, self.interpreter.project_version)
         self.interpreter.add_find_program_override(name, exe)
 
     @typed_kwargs(

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -75,14 +75,14 @@ class ModuleState:
                      required: bool = True,
                      version_func: T.Optional[ProgramVersionFunc] = None,
                      wanted: T.Union[str, T.List[str]] = '', silent: bool = False,
-                     for_machine: MachineChoice = MachineChoice.HOST) -> T.Union[ExternalProgram, build.Executable, OverrideProgram]:
+                     for_machine: MachineChoice = MachineChoice.HOST) -> T.Union[ExternalProgram, build.OverrideExecutable, OverrideProgram]:
         if not isinstance(prog, list):
             prog = [prog]
         return self._interpreter.find_program_impl(prog, required=required, version_func=version_func,
                                                    wanted=wanted, silent=silent, for_machine=for_machine)
 
     def find_tool(self, name: str, depname: str, varname: str, required: bool = True,
-                  wanted: T.Optional[str] = None) -> T.Union['build.Executable', ExternalProgram, 'OverrideProgram']:
+                  wanted: T.Optional[str] = None) -> T.Union[build.OverrideExecutable, ExternalProgram, 'OverrideProgram']:
         # Look in overrides in case it's built as subproject
         progobj = self._interpreter.program_from_overrides([name], [])
         if progobj is not None:

--- a/test cases/native/9 override with exe/subprojects/sub/meson.build
+++ b/test cases/native/9 override with exe/subprojects/sub/meson.build
@@ -1,3 +1,11 @@
-project('sub', 'c', version : '1.0')
+project('sub', 'c', version : '1.0', meson_version: '>= 1.9.0')
 foobar = executable('foobar', 'foobar.c',  native : true)
 meson.override_find_program('foobar', foobar)
+
+found_foobar = find_program('foobar')
+if found_foobar.version() != meson.project_version()
+  error('Overriden Executable had incorrect version: got @0@, expected @1@'.format(found_foobar.version(), meson.project_version()))
+endif
+
+test('foobar executable', foobar, args : [ meson.current_build_dir() / 'test-output.c' ])
+test('overriden foobar executable', found_foobar, args : [ meson.current_build_dir() / 'test-output.c' ])


### PR DESCRIPTION
Right now, the set of available methods depends on the type of object returned by find_program. Specifically it fails if you attempt to call version on it, if it was an Executable put there with `meson.override_find_program`.

This also makes it possible that .get_version() can be called on the output of _find_tool by the modules (which is kind of required for #14422 [not really, as the returned value should never be an executable; but the mypy can't know that]).

For now this only uses the version of the subproject that called override_find_program but an additional `version` kwarg for `meson.override_find_program` could be added if required (at least from the Executable side, not sure about ExternalProgram)