### PR TITLE
modules/pkgconfig: add support License variable

### DIFF
--- a/docs/markdown/Pkgconfig-module.md
+++ b/docs/markdown/Pkgconfig-module.md
@@ -72,6 +72,7 @@ keyword arguments.
 - `dataonly` field. (*since 0.54.0*) this is used for architecture-independent
    pkg-config files in projects which also have architecture-dependent outputs.
 - `conflicts` (*since 0.36.0, incorrectly issued a warning prior to 0.54.0*) list of strings to be put in the `Conflicts` field.
+- `license` a string specifying the package license in the SPDX license tag.
 
 Since 0.46 a `StaticLibrary` or `SharedLibrary` object can optionally
 be passed as first positional argument. If one is provided a default

--- a/test cases/common/44 pkgconfig-gen/meson.build
+++ b/test cases/common/44 pkgconfig-gen/meson.build
@@ -36,6 +36,7 @@ pkgg.generate(
   requires : 'glib-2.0', # Not really, but only here to test that this works.
   requires_private : ['gio-2.0', 'gobject-2.0'],
   libraries_private : [lib, '-lz'],
+  license : 'Apache-2.0',
 )
 
 env = environment()

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -176,6 +176,12 @@ class LinuxlikeTests(BasePlatformTests):
                 self.assertTrue(ct_dep.found())
                 self.assertIn('-lct', ct_dep.get_link_args(raw=True))
 
+        # Test for License variable
+        privatedir1 = self.privatedir
+        with open(os.path.join(privatedir1, 'simple.pc'), encoding='utf-8') as f:
+            content = f.read()
+            self.assertIn('License: Apache-2.0', content)
+
     def test_pkgconfig_gen_deps(self):
         '''
         Test that generated pkg-config files correctly handle dependencies


### PR DESCRIPTION
The pkg-config file has License variable that that sets the software license. 
This adds the function to handle License variables and test.

Ref: https://github.com/pkgconf/pkgconf/blob/master/man/pc.5#L116