### PR TITLE
Fix assertion failure for cmake.include_directories

### DIFF
--- a/docs/markdown/CMake-module.md
+++ b/docs/markdown/CMake-module.md
@@ -138,8 +138,8 @@ and supports the following methods:
    `include_type` kwarg *(new in 0.56.0)* controls the include type of the
    returned dependency object similar to the same kwarg in the
    [[dependency]] function.
- - `include_directories(target)` returns a Meson [[@inc]]
-   object for the specified target. Using this method is not necessary
+ - `include_directories(target)` returns an array of Meson [[@inc]]
+   objects for the specified target. Using this method is not necessary
    if the dependency object is used.
  - `target(target)` returns the raw build target.
  - `target_type(target)` returns the type of the target as a string

--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -154,10 +154,11 @@ class CMakeSubproject(ModuleObject):
 
     @noKwargs
     @typed_pos_args('cmake.subproject.include_directories', str)
-    def include_directories(self, state: ModuleState, args: T.Tuple[str], kwargs: TYPE_kwargs) -> build.IncludeDirs:
+    def include_directories(self, state: ModuleState, args: T.Tuple[str], kwargs: TYPE_kwargs) -> T.List[build.IncludeDirs]:
         info = self._args_to_info(args[0])
         inc = self.get_variable(state, [info['inc']], kwargs)
-        assert isinstance(inc, build.IncludeDirs), 'for mypy'
+        assert isinstance(inc, list), 'for mypy'
+        assert isinstance(inc[0], build.IncludeDirs), 'for mypy'
         return inc
 
     @noKwargs

--- a/test cases/cmake/13 system includes/main2.cpp
+++ b/test cases/cmake/13 system includes/main2.cpp
@@ -1,0 +1,5 @@
+#include <triggerWarn.hpp>
+
+int main(void) {
+  return 0;
+}

--- a/test cases/cmake/13 system includes/meson.build
+++ b/test cases/cmake/13 system includes/meson.build
@@ -13,6 +13,10 @@ endif
 cm = import('cmake')
 sub_pro = cm.subproject('cmMod')
 sub_dep = sub_pro.dependency('cmModLib')
+sub_inc = sub_pro.include_directories('cmModLib')
 
 exe1 = executable('main1', ['main.cpp'], dependencies: [sub_dep])
 test('test1', exe1)
+
+exe2 = executable('main2', ['main2.cpp'], include_directories: sub_inc)
+test('test2', exe1)


### PR DESCRIPTION
The return value of the include_directories() function from the CMake module is created like this:

            dir_node = assign(dir_var, function('include_directories', tgt.includes))
            sys_node = assign(sys_var, function('include_directories', tgt.sys_includes, {'is_system': True}))
            inc_node = assign(inc_var, array([id_node(dir_var), id_node(sys_var)]))

So it is a list of IncludeDirectories objects, not just one.