### PR TITLE
Add --skip-if-not-found to meson install

### DIFF
--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -51,6 +51,7 @@ if T.TYPE_CHECKING:
         destdir: str
         dry_run: bool
         skip_subprojects: str
+        skip_if_not_found: bool
         tags: str
         strip: bool
 
@@ -82,6 +83,8 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
                         help='Doesn\'t actually install, but print logs. (Since 0.57.0)')
     parser.add_argument('--skip-subprojects', nargs='?', const='*', default='',
                         help='Do not install files from given subprojects. (Since 0.58.0)')
+    parser.add_argument('--skip-if-not-found', action='store_true',
+                        help='Skip installing target if it was not built. (Since 1.9.0)')
     parser.add_argument('--tags', default=None,
                         help='Install only targets having one of the given tags. (Since 0.60.0)')
     parser.add_argument('--strip', action='store_true',
@@ -313,6 +316,7 @@ class Installer:
         # ['*'] means skip all,
         # ['sub1', ...] means skip only those.
         self.skip_subprojects = [i.strip() for i in options.skip_subprojects.split(',')]
+        self.skip_if_not_found = options.skip_if_not_found
         self.tags = [i.strip() for i in options.tags.split(',')] if options.tags else None
 
     def remove(self, *args: T.Any, **kwargs: T.Any) -> None:
@@ -747,7 +751,7 @@ class Installer:
                 continue
             if not os.path.exists(t.fname):
                 # For example, import libraries of shared modules are optional
-                if t.optional:
+                if t.optional or self.skip_if_not_found:
                     self.log(f'File {t.fname!r} not found, skipping')
                     continue
                 else:


### PR DESCRIPTION
Sometimes when a project is partially built we only want to install a subset of the possible targets. Example:
- main project:
  - `foo_app` -> depends on `libfoo`. tagged as 'foo_app'
  - `bar_app` -> depends on `libbar`. tagged as 'bar_app'
- subprojects
  - `libfoo`
  - `libbar`

When building `foo_app` (`meson compile foo_app`) `libfoo` is built because it is a dependency. When installing `foo_app` to test it (`meson install --no-rebuild --tags foo_app,runtime`) `meson` will try to install **all** targets that are tagged as `runtime`, regardless if they were built or not. This gives the error:
```
ERROR: File 'libbar.so' could not be found
```
because `libbar` is automatically tagged with 'runtime'. Since it is a subproject dependency, we can't add a specific `install_tag` so we need to rely on the automatic 'runtime' tag.

This is a toy example, but the repo I am working with has many executable targets with varying library dependencies, so compiling + installing only a subset is needed for a nice developer experience.