### PR TITLE
Work around the mising RECORD file with homebrew pip.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -94,6 +94,11 @@ jobs:
         # productive -- only victim blaming -- however it bites particularly badly because this is a container/VM
         # See commit 5c479d7a13a518c18ccb4dc3b6bdd7bfc2a9bdb5 for a more thorough analysis.
         find /opt/homebrew/Cellar/python* -name EXTERNALLY-MANAGED -print0 | xargs -0 rm -vf
+        # Homebrew's installation of pip 25.0.1 in Python 3.13.3 is broken; it
+        # doesn't include a RECORD file, so it can't be upgraded by pip. Create
+        # a dummy RECORD file.
+        PIP_RECORD=$(python3 -c "import pip, os; print(f'{os.path.dirname(pip.__file__)}-{pip.__version__}.dist-info/RECORD')")
+        touch $PIP_RECORD
     # use python3 from homebrew because it is a valid framework, unlike the actions one:
     # https://github.com/actions/setup-python/issues/58
     - run: brew install pkg-config ninja llvm qt@5 boost ldc hdf5 openmpi lapack scalapack sdl2 boost-python3 gtk-doc zstd ncurses objfw libomp


### PR DESCRIPTION
For the last week or so, all macOS CI builds have been failing because of an issue with a recent Homebrew update.

The packaged version of `pip` 25.0.1 installed by homebrew *doesn't* include a `RECORD` file in the distribution metadata. As a result, any attempt to upgrade `pip` fails, because pip can't uninstall itself.

As a workaround to get CI unstuck, this writes a dummy RECORD file so that pip can be upgraded. This does leave a stray `pip-25.0.1.dist-info` folder after the `pip` upgrade... but at least CI can run.

The Homebrew documented workaround is to specify `--force-reinstall`; this doesn't work - again, because the existing version of pip can't be uninstalled.

Deleting the existing pip version can't work either, because without pip, you can't install pip.
