### PR TITLE
vulkan: Find Vulkan libraries in non-standard locations

### DIFF
--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -187,12 +187,9 @@ class VulkanDependencySystem(SystemDependency):
     def __init__(self, name: str, environment: 'Environment', kwargs: T.Dict[str, T.Any], language: T.Optional[str] = None) -> None:
         super().__init__(name, environment, kwargs, language=language)
 
-        try:
-            self.vulkan_sdk = os.environ.get('VULKAN_SDK', os.environ['VK_SDK_PATH'])
-            if not os.path.isabs(self.vulkan_sdk):
-                raise DependencyException('VULKAN_SDK must be an absolute path.')
-        except KeyError:
-            self.vulkan_sdk = None
+        self.vulkan_sdk = os.environ.get('VULKAN_SDK', os.environ.get('VK_SDK_PATH'))
+        if self.vulkan_sdk and not os.path.isabs(self.vulkan_sdk):
+            raise DependencyException('VULKAN_SDK must be an absolute path.')
 
         if self.vulkan_sdk:
             # TODO: this config might not work on some platforms, fix bugs as reported

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -239,7 +239,7 @@ class VulkanDependencySystem(SystemDependency):
                                                                  low=0, high=None, guess=e,
                                                                  prefix='#include <vulkan/vulkan.h>',
                                                                  env=environment,
-                                                                 extra_args=None,
+                                                                 extra_args=self.compile_args,
                                                                  dependencies=None))
                               # list containing vulkan version components and their expected value
                               for c, e in [('MAJOR', 1), ('MINOR', 3), ('PATCH', None)]]

--- a/test cases/frameworks/18 vulkan/meson.build
+++ b/test cases/frameworks/18 vulkan/meson.build
@@ -1,6 +1,8 @@
 project('vulkan test', 'c')
 
-vulkan_dep = dependency('vulkan', required : false)
+method = get_option('method')
+
+vulkan_dep = dependency('vulkan', required : false, method : method)
 if not vulkan_dep.found()
   error('MESON_SKIP_TEST: vulkan not found.')
 endif

--- a/test cases/frameworks/18 vulkan/meson.options
+++ b/test cases/frameworks/18 vulkan/meson.options
@@ -1,0 +1,6 @@
+option(
+    'method',
+    type : 'combo',
+    choices : ['auto', 'pkg-config', 'system'],
+    value : 'auto',
+)

--- a/test cases/frameworks/18 vulkan/test.json
+++ b/test cases/frameworks/18 vulkan/test.json
@@ -1,3 +1,14 @@
 {
+  "env": {
+    "VULKAN_SDK": "/usr"
+  },
+  "matrix": {
+    "options": {
+      "method": [
+        { "val": "pkg-config" },
+        { "val": "system" }
+      ]
+    }
+  },
   "expect_skip_on_jobname": ["azure", "cygwin", "macos", "msys2"]
 }


### PR DESCRIPTION
I'm trying to make Vulkan work for GTK on macOS.

On macOS, the Vulkan SDK can be installed in a user's home folder. If not installed system-wide (e.i. in `/usr/local`), Meson is not able to do a proper version check for Vulkan.

## Current behavior

The (obsolete) environment variable `VK_SDK_PATH` has to be set, or the `VULKAN_SDK` will not be used at all.

Vulkan version check fails, even if both `VK_SDK_PATH` and `VULKAN_SDK` are set:

```
Dependency vulkan found: NO. Found -1.-1.-1 but need: '>= 1.3'
```

## New behavior

`VULKAN_SDK` can be set without `VK_SDK_PATH`

The include path (based on `VULKAN_SDK`) is now provided to the version-check command, so `vulkan.h` can be found, and a version check can be done.

