### PR TITLE
Cleanup OptionStore types

### DIFF
--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -22,6 +22,7 @@ from .interpreter import AstInterpreter
 if T.TYPE_CHECKING:
     from ..build import BuildTarget
     from ..interpreterbase import TYPE_var
+    from ..options import OptionDict
     from .visitor import AstVisitor
 
 
@@ -130,14 +131,14 @@ class IntrospectionInterpreter(AstInterpreter):
         if self.environment.first_invocation or (self.subproject != '' and self.subproject not in self.coredata.initialized_subprojects):
             if self.subproject == '':
                 self.coredata.optstore.initialize_from_top_level_project_call(
-                    T.cast('T.Dict[T.Union[OptionKey, str], str]', self.project_default_options),
+                    T.cast('OptionDict', self.project_default_options),
                     {},  # TODO: not handled by this Interpreter.
                     self.environment.options)
             else:
                 self.coredata.optstore.initialize_from_subproject_call(
                     self.subproject,
                     {},  # TODO: this isn't handled by the introspection interpreter...
-                    T.cast('T.Dict[T.Union[OptionKey, str], str]', self.project_default_options),
+                    T.cast('OptionDict', self.project_default_options),
                     {})  # TODO: this isn't handled by the introspection interpreter...
                 self.coredata.initialized_subprojects.add(self.subproject)
 

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -11,7 +11,6 @@ import os
 import typing as T
 
 from .. import compilers, environment, mesonlib, options
-from .. import coredata as cdata
 from ..build import Executable, Jar, SharedLibrary, SharedModule, StaticLibrary
 from ..compilers import detect_compiler_for
 from ..interpreterbase import InvalidArguments, SubProject
@@ -99,6 +98,16 @@ class IntrospectionInterpreter(AstInterpreter):
                 return [node.value]
             return None
 
+        def create_options_dict(options: T.List[str], subproject: str = '') -> T.Mapping[OptionKey, str]:
+            result: T.MutableMapping[OptionKey, str] = {}
+            for o in options:
+                try:
+                    (key, value) = o.split('=', 1)
+                except ValueError:
+                    raise mesonlib.MesonException(f'Option {o!r} must have a value separated by equals sign.')
+                result[OptionKey(key)] = value
+            return result
+
         proj_name = args[0]
         proj_vers = kwargs.get('version', 'undefined')
         if isinstance(proj_vers, ElementaryNode):
@@ -116,20 +125,19 @@ class IntrospectionInterpreter(AstInterpreter):
 
         def_opts = self.flatten_args(kwargs.get('default_options', []))
         _project_default_options = mesonlib.stringlistify(def_opts)
-        string_dict = cdata.create_options_dict(_project_default_options, self.subproject)
-        self.project_default_options = {OptionKey(s): v for s, v in string_dict.items()}
+        self.project_default_options = create_options_dict(_project_default_options, self.subproject)
         self.default_options.update(self.project_default_options)
         if self.environment.first_invocation or (self.subproject != '' and self.subproject not in self.coredata.initialized_subprojects):
             if self.subproject == '':
                 self.coredata.optstore.initialize_from_top_level_project_call(
-                    T.cast('T.Dict[T.Union[OptionKey, str], str]', string_dict),
+                    T.cast('T.Dict[T.Union[OptionKey, str], str]', self.project_default_options),
                     {},  # TODO: not handled by this Interpreter.
                     self.environment.options)
             else:
                 self.coredata.optstore.initialize_from_subproject_call(
                     self.subproject,
                     {},  # TODO: this isn't handled by the introspection interpreter...
-                    T.cast('T.Dict[T.Union[OptionKey, str], str]', string_dict),
+                    T.cast('T.Dict[T.Union[OptionKey, str], str]', self.project_default_options),
                     {})  # TODO: this isn't handled by the introspection interpreter...
                 self.coredata.initialized_subprojects.add(self.subproject)
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -656,28 +656,10 @@ class Target(HoldableObject, metaclass=abc.ABCMeta):
             # set, use the value of 'install' if it's enabled.
             self.build_by_default = True
 
-        self.raw_overrides = self.parse_overrides(kwargs)
+        self.raw_overrides = kwargs.get('override_options', {})
 
     def get_override(self, name: str) -> T.Optional[str]:
         return self.raw_overrides.get(name, None)
-
-    @staticmethod
-    def parse_overrides(kwargs: T.Dict[str, T.Any]) -> T.Dict[str, str]:
-        opts = kwargs.get('override_options', [])
-
-        # In this case we have an already parsed and ready to go dictionary
-        # provided by typed_kwargs
-        if isinstance(opts, dict):
-            return T.cast('T.Dict[OptionKey, str]', opts)
-
-        result: T.Dict[str, str] = {}
-        overrides = stringlistify(opts)
-        for o in overrides:
-            if '=' not in o:
-                raise InvalidArguments('Overrides must be of form "key=value"')
-            k, v = o.split('=', 1)
-            result[k] = v
-        return result
 
     def is_linkable_target(self) -> bool:
         return False

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -701,18 +701,14 @@ def register_builtin_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument('-D', action='append', dest='projectoptions', default=[], metavar="option",
                         help='Set the value of an option, can be used several times to set multiple options.')
 
-def create_options_dict(options: T.List[str], subproject: str = '') -> T.Dict[str, str]:
-    result: T.OrderedDict[OptionKey, str] = OrderedDict()
-    for o in options:
+def parse_cmd_line_options(args: SharedCMDOptions) -> None:
+    args.cmd_line_options = {}
+    for o in args.projectoptions:
         try:
             (key, value) = o.split('=', 1)
         except ValueError:
             raise MesonException(f'Option {o!r} must have a value separated by equals sign.')
-        result[key] = value
-    return result
-
-def parse_cmd_line_options(args: SharedCMDOptions) -> None:
-    args.cmd_line_options = create_options_dict(args.projectoptions)
+        args.cmd_line_options[key] = value
 
     # Merge builtin options set with --option into the dict.
     for key in chain(

--- a/mesonbuild/interpreter/dependencyfallbacks.py
+++ b/mesonbuild/interpreter/dependencyfallbacks.py
@@ -126,7 +126,7 @@ class DependencyFallbacksHolder(MesonInterpreterObject):
         if static is not None:
             default_library = 'static' if static else 'shared'
             mlog.log(f'Building fallback subproject with default_library={default_library}')
-            extra_default_options['default_library'] = default_library
+            extra_default_options[OptionKey('default_library')] = default_library
 
         # Configure the subproject
         subp_name = self.subproject_name

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -270,7 +270,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                 subproject: str = '',
                 subdir: str = '',
                 subproject_dir: str = 'subprojects',
-                default_project_options: T.Optional[T.Dict[OptionKey, str]] = None,
+                invoker_method_default_options: T.Optional[T.Dict[OptionKey, str]] = None,
                 ast: T.Optional[mparser.CodeBlockNode] = None,
                 relaxations: T.Optional[T.Set[InterpreterRuleRelaxation]] = None,
                 user_defined_options: T.Optional[coredata.SharedCMDOptions] = None,
@@ -295,11 +295,11 @@ class Interpreter(InterpreterBase, HoldableObject):
         self.subproject_stack: T.List[str] = []
         self.configure_file_outputs: T.Dict[str, int] = {}
         # Passed from the outside, only used in subprojects.
-        if default_project_options:
-            assert isinstance(default_project_options, dict)
-            self.default_project_options = default_project_options
+        if invoker_method_default_options:
+            assert isinstance(invoker_method_default_options, dict)
+            self.invoker_method_default_options = invoker_method_default_options
         else:
-            self.default_project_options = {}
+            self.invoker_method_default_options = {}
         self.project_default_options: T.List[str] = []
         self.build_func_dict()
         self.build_holder_map()
@@ -1199,9 +1199,8 @@ class Interpreter(InterpreterBase, HoldableObject):
                                                                               self.user_defined_options.cmd_line_options,
                                                                               self.environment.options)
             else:
-                invoker_method_default_options = self.default_project_options
                 self.coredata.optstore.initialize_from_subproject_call(self.subproject,
-                                                                       invoker_method_default_options,
+                                                                       self.invoker_method_default_options,
                                                                        self.project_default_options,
                                                                        self.user_defined_options.cmd_line_options)
                 self.coredata.initialized_subprojects.add(self.subproject)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -879,10 +879,6 @@ class Interpreter(InterpreterBase, HoldableObject):
             return self.disabled_subproject(subp_name, disabled_feature=feature)
 
         default_options = kwargs['default_options']
-        if isinstance(default_options, str):
-            default_options = [default_options]
-        if isinstance(default_options, list):
-            default_options = dict((x.split('=', 1) for x in default_options))
         if extra_default_options:
             default_options = {**extra_default_options, **default_options}
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -115,6 +115,7 @@ if T.TYPE_CHECKING:
     from . import kwargs as kwtypes
     from ..backend.backends import Backend
     from ..interpreterbase.baseobjects import InterpreterObject, TYPE_var, TYPE_kwargs
+    from ..options import OptionDict
     from ..programs import OverrideProgram
     from .type_checking import SourcesVarargsType
 
@@ -868,7 +869,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         return sub
 
     def do_subproject(self, subp_name: str, kwargs: kwtypes.DoSubproject, force_method: T.Optional[wrap.Method] = None,
-                      extra_default_options: T.Optional[T.Dict[str, options.ElementaryOptionValues]] = None) -> SubprojectHolder:
+                      extra_default_options: T.Optional[OptionDict] = None) -> SubprojectHolder:
         if subp_name == 'sub_static':
             pass
         disabled, required, feature = extract_required_kwarg(kwargs, self.subproject)

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -393,7 +393,7 @@ class KwargInfo(T.Generic[_T]):
                deprecated_message: T.Union[str, None, _NULL_T] = _NULL,
                deprecated_values: T.Union[T.Dict[T.Union[_T, ContainerTypeInfo, type], T.Union[str, T.Tuple[str, str]]], None, _NULL_T] = _NULL,
                validator: T.Union[T.Callable[[_T], T.Optional[str]], None, _NULL_T] = _NULL,
-               convertor: T.Union[T.Callable[[_T], TYPE_var], None, _NULL_T] = _NULL) -> 'KwargInfo':
+               convertor: T.Union[T.Callable[[_T], object], None, _NULL_T] = _NULL) -> 'KwargInfo':
         """Create a shallow copy of this KwargInfo, with modifications.
 
         This allows us to create a new copy of a KwargInfo with modifications.

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -342,7 +342,7 @@ class Conf:
         if self.coredata.optstore.augments:
             mlog.log('\nCurrently set option augments:')
             for k, v in self.coredata.optstore.augments.items():
-                mlog.log(f'{k:21}{v:10}')
+                mlog.log(f'{k!s:21}{v:10}')
         else:
             mlog.log('\nThere are no option augments.')
 

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1222,40 +1222,31 @@ class OptionStore:
                 perproject_global_options.append(strvaluetuple)
         return (global_options, perproject_global_options, project_options)
 
-    def optlist2optdict(self, optlist: T.List[str]) -> T.Dict[str, str]:
-        optdict = {}
+    def optlist2optdict(self, optlist: T.List[str]) -> OptionStringLikeDict:
+        optdict: OptionStringLikeDict = {}
         for p in optlist:
             k, v = p.split('=', 1)
             optdict[k] = v
         return optdict
 
-    def prefix_split_options(self, coll: T.Union[T.List[str], OptionStringLikeDict]) -> T.Tuple[str, T.Union[T.List[str], OptionStringLikeDict]]:
+    def prefix_split_options(self, coll: OptionStringLikeDict) -> T.Tuple[str, OptionStringLikeDict]:
         prefix = None
-        if isinstance(coll, list):
-            others: T.List[str] = []
-            for e in coll:
-                if e.startswith('prefix='):
-                    prefix = e.split('=', 1)[1]
-                else:
-                    others.append(e)
-            return (prefix, others)
-        else:
-            others_d: OptionStringLikeDict = {}
-            for k, v in coll.items():
-                if isinstance(k, OptionKey) and k.name == 'prefix':
-                    prefix = v
-                elif k == 'prefix':
-                    prefix = v
-                else:
-                    others_d[k] = v
-            return (prefix, others_d)
+        others_d: OptionStringLikeDict = {}
+        for k, v in coll.items():
+            if isinstance(k, OptionKey) and k.name == 'prefix':
+                prefix = v
+            elif k == 'prefix':
+                prefix = v
+            else:
+                others_d[k] = v
+        return (prefix, others_d)
 
     def first_handle_prefix(self,
-                            project_default_options: T.Union[T.List[str], OptionStringLikeDict],
+                            project_default_options: OptionStringLikeDict,
                             cmd_line_options: OptionStringLikeDict,
                             machine_file_options: T.Mapping[OptionKey, ElementaryOptionValues]) \
-            -> T.Tuple[T.Union[T.List[str], OptionStringLikeDict],
-                       T.Union[T.List[str], OptionStringLikeDict],
+            -> T.Tuple[OptionStringLikeDict,
+                       OptionStringLikeDict,
                        T.MutableMapping[OptionKey, ElementaryOptionValues]]:
         # Copy to avoid later mutation
         nopref_machine_file_options = T.cast(
@@ -1294,16 +1285,11 @@ class OptionStore:
                                                cmd_line_options_in: OptionStringLikeDict,
                                                machine_file_options_in: T.Mapping[OptionKey, ElementaryOptionValues]) -> None:
         first_invocation = True
+        if isinstance(project_default_options_in, list):
+            project_default_options_in = self.optlist2optdict(project_default_options_in)
         (project_default_options, cmd_line_options, machine_file_options) = self.first_handle_prefix(project_default_options_in,
                                                                                                      cmd_line_options_in,
                                                                                                      machine_file_options_in)
-        if isinstance(project_default_options, str):
-            project_default_options = [project_default_options]
-        if isinstance(project_default_options, list):
-            project_default_options = self.optlist2optdict(project_default_options) # type: ignore [assignment]
-        if project_default_options is None:
-            project_default_options = {}
-        assert isinstance(machine_file_options, dict)
         for key, valstr in machine_file_options.items():
             # Due to backwards compatibility we ignore all build-machine options
             # when building natively.
@@ -1320,7 +1306,6 @@ class OptionStore:
                     self.set_option(proj_key, valstr, first_invocation)
                 else:
                     self.pending_options[key] = valstr
-        assert isinstance(project_default_options, dict)
         for keystr, valstr in project_default_options.items():
             # Ths is complicated by the fact that a string can have two meanings:
             #
@@ -1356,7 +1341,6 @@ class OptionStore:
                     self.set_option(proj_key, valstr)
                 else:
                     self.pending_options[key] = valstr
-        assert isinstance(cmd_line_options, dict)
         for keystr, valstr in cmd_line_options.items():
             if isinstance(keystr, str):
                 key = OptionKey.from_string(keystr)

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -810,7 +810,7 @@ class OptionStore:
         from .compilers import all_languages
         self.all_languages = set(all_languages)
         self.project_options = set()
-        self.augments: T.Dict[str, str] = {}
+        self.augments: T.Dict[str, ElementaryOptionValues] = {}
         self.is_cross = is_cross
 
         # Pending options are options that need to be initialized later, either

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1220,13 +1220,6 @@ class OptionStore:
                 perproject_global_options.append(valuetuple)
         return (global_options, perproject_global_options, project_options)
 
-    def optlist2optdict(self, optlist: T.List[str]) -> OptionDict:
-        optdict: OptionDict = {}
-        for p in optlist:
-            k, v = p.split('=', 1)
-            optdict[k] = v
-        return optdict
-
     def prefix_split_options(self, coll: OptionDict) -> T.Tuple[T.Optional[str], OptionDict]:
         prefix = None
         others_d: OptionDict = {}
@@ -1279,12 +1272,10 @@ class OptionStore:
         self.options[OptionKey('prefix')].set_value(prefix)
 
     def initialize_from_top_level_project_call(self,
-                                               project_default_options_in: T.Union[T.List[str], OptionDict],
+                                               project_default_options_in: OptionDict,
                                                cmd_line_options_in: OptionDict,
                                                machine_file_options_in: T.Mapping[OptionKey, ElementaryOptionValues]) -> None:
         first_invocation = True
-        if isinstance(project_default_options_in, list):
-            project_default_options_in = self.optlist2optdict(project_default_options_in)
         (project_default_options, cmd_line_options, machine_file_options) = self.first_handle_prefix(project_default_options_in,
                                                                                                      cmd_line_options_in,
                                                                                                      machine_file_options_in)
@@ -1380,11 +1371,9 @@ class OptionStore:
     def initialize_from_subproject_call(self,
                                         subproject: str,
                                         spcall_default_options: OptionDict,
-                                        project_default_options: T.Union[T.List[str], OptionDict],
+                                        project_default_options: OptionDict,
                                         cmd_line_options: OptionDict) -> None:
         is_first_invocation = True
-        if isinstance(project_default_options, list):
-            project_default_options = self.optlist2optdict(project_default_options)
         for keystr, valstr in itertools.chain(project_default_options.items(), spcall_default_options.items()):
             if isinstance(keystr, str):
                 key = OptionKey.from_string(keystr)

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1382,22 +1382,19 @@ class OptionStore:
             keys = ', '.join(unknown_options)
             raise MesonException(f'Unknown options: {keys}')
 
-    def hacky_mchackface_back_to_list(self, optdict: T.Union[T.List[str], OptionDict]) -> T.List[str]:
-        if isinstance(optdict, dict):
-            return [f'{k}={v}' for k, v in optdict.items()]
-        return optdict
-
     def initialize_from_subproject_call(self,
                                         subproject: str,
-                                        spcall_default_options_in: OptionDict,
-                                        project_default_options_in: T.Union[T.List[str], OptionDict],
+                                        spcall_default_options: OptionDict,
+                                        project_default_options: T.Union[T.List[str], OptionDict],
                                         cmd_line_options: OptionDict) -> None:
         is_first_invocation = True
-        spcall_default_options = self.hacky_mchackface_back_to_list(spcall_default_options_in)
-        project_default_options = self.hacky_mchackface_back_to_list(project_default_options_in)
-        for o in itertools.chain(project_default_options, spcall_default_options):
-            keystr, valstr = o.split('=', 1)
-            key = OptionKey.from_string(keystr)
+        if isinstance(project_default_options, list):
+            project_default_options = self.optlist2optdict(project_default_options)
+        for keystr, valstr in itertools.chain(project_default_options.items(), spcall_default_options.items()):
+            if isinstance(keystr, str):
+                key = OptionKey.from_string(keystr)
+            else:
+                key = keystr
             if key.subproject is None:
                 key = key.evolve(subproject=subproject)
             elif key.subproject == subproject:

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1301,12 +1301,7 @@ class OptionStore:
         if project_default_options is None:
             project_default_options = {}
         assert isinstance(machine_file_options, dict)
-        for keystr, valstr in machine_file_options.items():
-            if isinstance(keystr, str):
-                # FIXME, standardise on Key or string.
-                key = OptionKey.from_string(keystr)
-            else:
-                key = keystr
+        for key, valstr in machine_file_options.items():
             # Due to backwards compatibility we ignore all build-machine options
             # when building natively.
             if not self.is_cross and key.is_for_build():

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -810,7 +810,7 @@ class OptionStore:
         from .compilers import all_languages
         self.all_languages = set(all_languages)
         self.project_options = set()
-        self.augments: T.Dict[str, ElementaryOptionValues] = {}
+        self.augments: T.Dict[OptionKey, ElementaryOptionValues] = {}
         self.is_cross = is_cross
 
         # Pending options are options that need to be initialized later, either
@@ -879,9 +879,8 @@ class OptionStore:
         vobject = self.get_value_object_for(key)
         computed_value = vobject.value
         if key.subproject is not None:
-            keystr = str(key)
-            if keystr in self.augments:
-                computed_value = vobject.validate_value(self.augments[keystr])
+            if key in self.augments:
+                computed_value = vobject.validate_value(self.augments[key])
         return (vobject, computed_value)
 
     def get_value_for(self, name: 'T.Union[OptionKey, str]', subproject: T.Optional[str] = None) -> ElementaryOptionValues:
@@ -1070,17 +1069,18 @@ class OptionStore:
             dirty |= self.set_option_from_string(key, valstr)
         for key, valstr in project_options:
             dirty |= self.set_option_from_string(key, valstr)
-        for keystr, valstr in perproject_global_options:
-            if keystr in self.augments:
-                if self.augments[keystr] != valstr:
-                    self.augments[keystr] = valstr
+        for key, valstr in perproject_global_options:
+            if key in self.augments:
+                if self.augments[key] != valstr:
+                    self.augments[key] = valstr
                     dirty = True
             else:
-                self.augments[keystr] = valstr
+                self.augments[key] = valstr
                 dirty = True
-        for delete in U_args:
-            if delete in self.augments:
-                del self.augments[delete]
+        for keystr in U_args:
+            key = OptionKey.from_string(keystr)
+            if key in self.augments:
+                del self.augments[key]
                 dirty = True
         return dirty
 
@@ -1203,7 +1203,7 @@ class OptionStore:
         return key in self.module_options
 
     def classify_D_arguments(self, D: T.List[str]) -> T.Tuple[T.List[T.Tuple[OptionKey, str]],
-                                                              T.List[T.Tuple[str, str]],
+                                                              T.List[T.Tuple[OptionKey, str]],
                                                               T.List[T.Tuple[OptionKey, str]]]:
         global_options = []
         project_options = []
@@ -1217,9 +1217,7 @@ class OptionStore:
             elif key.subproject is None:
                 global_options.append(valuetuple)
             else:
-                # FIXME, augments are currently stored as strings, not OptionKeys
-                strvaluetuple = (keystr, valstr)
-                perproject_global_options.append(strvaluetuple)
+                perproject_global_options.append(valuetuple)
         return (global_options, perproject_global_options, project_options)
 
     def optlist2optdict(self, optlist: T.List[str]) -> OptionDict:
@@ -1296,8 +1294,7 @@ class OptionStore:
             if not self.is_cross and key.is_for_build():
                 continue
             if key.subproject:
-                augstr = str(key)
-                self.augments[augstr] = valstr
+                self.augments[key] = valstr
             elif key in self.options:
                 self.set_option(key, valstr, first_invocation)
             else:
@@ -1327,8 +1324,7 @@ class OptionStore:
             if not self.is_cross and key.is_for_build():
                 continue
             if key.subproject:
-                augstr = str(key)
-                self.augments[augstr] = valstr
+                self.augments[key] = valstr
             elif key in self.options:
                 self.set_option(key, valstr, first_invocation)
             else:
@@ -1351,8 +1347,7 @@ class OptionStore:
             if not self.is_cross and key.is_for_build():
                 continue
             if key.subproject:
-                augstr = str(key)
-                self.augments[augstr] = valstr
+                self.augments[key] = valstr
             elif key in self.options:
                 self.set_option(key, valstr, True)
             else:
@@ -1406,8 +1401,7 @@ class OptionStore:
                 self.set_option(key, valstr, is_first_invocation)
             else:
                 self.pending_options.pop(key, None)
-                aug_str = str(key)
-                self.augments[aug_str] = valstr
+                self.augments[key] = valstr
         # Check for pending options
         for key, valstr in cmd_line_options.items(): # type: ignore [assignment]
             if not isinstance(key, OptionKey):
@@ -1418,7 +1412,7 @@ class OptionStore:
             if key in self.options:
                 self.set_option(key, valstr, is_first_invocation)
             else:
-                self.augments[str(key)] = valstr
+                self.augments[key] = valstr
 
     def update_project_options(self, project_options: MutableKeyedOptionDictType, subproject: SubProject) -> None:
         for key, value in project_options.items():

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -327,7 +327,13 @@ class UserOption(T.Generic[_T], HoldableObject):
         # Final isn't technically allowed in a __post_init__ method
         self.default: Final[_T] = self.value  # type: ignore[misc]
 
-    def listify(self, value: T.Any) -> T.List[T.Any]:
+    def listify(self, value: ElementaryOptionValues) -> T.List[str]:
+        if isinstance(value, list):
+            return value
+        if isinstance(value, bool):
+            return ['true'] if value else ['false']
+        if isinstance(value, int):
+            return [str(value)]
         return [value]
 
     def printable_value(self) -> ElementaryOptionValues:
@@ -503,7 +509,7 @@ class UserArrayOption(UserOption[T.List[_T]]):
 @dataclasses.dataclass
 class UserStringArrayOption(UserArrayOption[str]):
 
-    def listify(self, value: T.Any) -> T.List[T.Any]:
+    def listify(self, value: ElementaryOptionValues) -> T.List[str]:
         try:
             return listify_array_value(value, self.split_args)
         except MesonException as e:
@@ -1005,7 +1011,7 @@ class OptionStore:
                 if v in opt.deprecated:
                     mlog.deprecation(f'Option {key.name!r} value {v!r} is deprecated')
         elif isinstance(opt.deprecated, dict):
-            def replace(v: T.Any) -> T.Any:
+            def replace(v: str) -> str:
                 assert isinstance(opt.deprecated, dict) # No, Mypy can not tell this from two lines above
                 newvalue = opt.deprecated.get(v)
                 if newvalue is not None:

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -1578,7 +1578,7 @@ def listify(item: T.Any, flatten: bool = True) -> T.List[T.Any]:
             result.append(i)
     return result
 
-def listify_array_value(value: T.Union[str, T.List[str]], shlex_split_args: bool = False) -> T.List[str]:
+def listify_array_value(value: object, shlex_split_args: bool = False) -> T.List[str]:
     if isinstance(value, str):
         if value.startswith('['):
             try:

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -202,3 +202,14 @@ class OptionTests(unittest.TestCase):
         optstore = OptionStore(False)
         value = optstore.get_default_for_b_option(OptionKey('b_vscrt'))
         self.assertEqual(value, 'from_buildtype')
+
+    def test_deprecated_nonstring_value(self):
+        # TODO: add a lot more deprecated option tests
+        optstore = OptionStore(False)
+        name = 'deprecated'
+        do = UserStringOption(name, 'An option with some deprecation', '0',
+                              deprecated={'true': '1'})
+        optstore.add_system_option(name, do)
+        optstore.set_option(OptionKey(name), True)
+        value = optstore.get_value(name)
+        self.assertEqual(value, '1')


### PR DESCRIPTION
Fix cases in which `str` was used for values that could actually be any type valid for an option.

Stop going back and forth between lists and dictionaries. Also stop going back and forth between str and OptionKey.