### PR TITLE
vala: Pass --shared-library to valac when generating a .gir file

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1765,6 +1765,9 @@ class NinjaBackend(backends.Backend):
                 girname = os.path.join(self.get_target_dir(target), target.vala_gir)
                 args += ['--gir', os.path.join('..', target.vala_gir)]
                 valac_outputs.append(girname)
+                shared_target = target.get('shared')
+                if isinstance(shared_target, build.SharedLibrary):
+                    args += ['--shared-library', self.get_target_filename_for_linking(shared_target)]
                 # Install GIR to default location if requested by user
                 if len(target.install_dir) > 3 and target.install_dir[3] is True:
                     target.install_dir[3] = os.path.join(self.environment.get_datadir(), 'gir-1.0')


### PR DESCRIPTION
This is required to make sure that the generated .gir file actually contains all the information to be used dynamically.

Valac supports this argument since 0.29.3 released in 2015.

Fixes: #14562 