### PR TITLE
options: restore special behavior of CFLAGS vs. c_args

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -50,6 +50,13 @@ if T.TYPE_CHECKING:
     CompilersDict = T.Dict[str, Compiler]
 
 
+NON_LANG_ENV_OPTIONS = [
+    ('PKG_CONFIG_PATH', 'pkg_config_path'),
+    ('CMAKE_PREFIX_PATH', 'cmake_prefix_path'),
+    ('LDFLAGS', 'ldflags'),
+    ('CPPFLAGS', 'cppflags'),
+]
+
 build_filename = 'meson.build'
 
 
@@ -777,12 +784,7 @@ class Environment:
     def _set_default_options_from_env(self) -> None:
         opts: T.List[T.Tuple[str, str]] = (
             [(v, f'{k}_args') for k, v in compilers.compilers.CFLAGS_MAPPING.items()] +
-            [
-                ('PKG_CONFIG_PATH', 'pkg_config_path'),
-                ('CMAKE_PREFIX_PATH', 'cmake_prefix_path'),
-                ('LDFLAGS', 'ldflags'),
-                ('CPPFLAGS', 'cppflags'),
-            ]
+            NON_LANG_ENV_OPTIONS
         )
 
         env_opts: T.DefaultDict[OptionKey, T.List[str]] = collections.defaultdict(list)

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -843,9 +843,9 @@ class Environment:
                             key = key.evolve(f'{lang}_env_args')
                         env_opts[key].extend(p_list)
 
-        # Only store options that are not already in self.options,
-        # otherwise we'd override the machine files
         for k, v in env_opts.items():
+            # Only store options that are not already in self.options,
+            # otherwise we'd override the machine files
             if k not in self.options:
                 self.options[k] = v
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -648,6 +648,11 @@ class Environment:
         # 'optimization' and 'debug' keys, it override them.
         self.options: T.MutableMapping[OptionKey, ElementaryOptionValues] = collections.OrderedDict()
 
+        # Environment variables with the name converted into an OptionKey type.
+        # These have subtly different behavior compared to machine files, so do
+        # not store them in self.options.  See _set_default_options_from_env.
+        self.env_opts: T.MutableMapping[OptionKey, ElementaryOptionValues] = {}
+
         self.machinestore = machinefile.MachineFileStore(self.coredata.config_files, self.coredata.cross_files, self.source_dir)
 
         ## Read in native file(s) to override build machine configuration
@@ -819,35 +824,35 @@ class Environment:
                             env_opts[key].extend(p_list)
                     elif keyname == 'cppflags':
                         for lang in compilers.compilers.LANGUAGES_USING_CPPFLAGS:
-                            key = OptionKey(f'{lang}_env_args', machine=for_machine)
+                            key = OptionKey(f'{lang}_args', machine=for_machine)
                             env_opts[key].extend(p_list)
                     else:
                         key = OptionKey.from_string(keyname).evolve(machine=for_machine)
                         if evar in compilers.compilers.CFLAGS_MAPPING.values():
-                            # If this is an environment variable, we have to
-                            # store it separately until the compiler is
-                            # instantiated, as we don't know whether the
-                            # compiler will want to use these arguments at link
-                            # time and compile time (instead of just at compile
-                            # time) until we're instantiating that `Compiler`
-                            # object. This is required so that passing
-                            # `-Dc_args=` on the command line and `$CFLAGS`
-                            # have subtly different behavior. `$CFLAGS` will be
-                            # added to the linker command line if the compiler
-                            # acts as a linker driver, `-Dc_args` will not.
-                            #
-                            # We still use the original key as the base here, as
-                            # we want to inherit the machine and the compiler
-                            # language
                             lang = key.name.split('_', 1)[0]
-                            key = key.evolve(f'{lang}_env_args')
+                            key = key.evolve(f'{lang}_args')
                         env_opts[key].extend(p_list)
 
-        for k, v in env_opts.items():
+        # If this is an environment variable, we have to
+        # store it separately until the compiler is
+        # instantiated, as we don't know whether the
+        # compiler will want to use these arguments at link
+        # time and compile time (instead of just at compile
+        # time) until we're instantiating that `Compiler`
+        # object. This is required so that passing
+        # `-Dc_args=` on the command line and `$CFLAGS`
+        # have subtly different behavior. `$CFLAGS` will be
+        # added to the linker command line if the compiler
+        # acts as a linker driver, `-Dc_args` will not.
+        for (_, keyname), for_machine in itertools.product(NON_LANG_ENV_OPTIONS, MachineChoice):
+            key = OptionKey.from_string(keyname).evolve(machine=for_machine)
             # Only store options that are not already in self.options,
             # otherwise we'd override the machine files
-            if k not in self.options:
-                self.options[k] = v
+            if key in env_opts and key not in self.options:
+                self.options[key] = env_opts[key]
+                del env_opts[key]
+
+        self.env_opts.update(env_opts)
 
     def _set_default_binaries_from_env(self) -> None:
         """Set default binaries from the environment.

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -829,6 +829,12 @@ class OptionStore:
             key = key.as_host()
         return key
 
+    def get_pending_value(self, key: T.Union[OptionKey, str], default: T.Optional[ElementaryOptionValues] = None) -> ElementaryOptionValues:
+        key = self.ensure_and_validate_key(key)
+        if key in self.options:
+            return self.options[key].value
+        return self.pending_options.get(key, default)
+
     def get_value(self, key: T.Union[OptionKey, str]) -> ElementaryOptionValues:
         return self.get_value_object(key).value
 

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -986,6 +986,22 @@ class LinuxlikeTests(BasePlatformTests):
             self.assertEqual(got_rpath, yonder_libdir, rpath_format)
 
     @skip_if_not_base_option('b_sanitize')
+    def test_env_cflags_ldflags(self):
+        if is_cygwin():
+            raise SkipTest('asan not available on Cygwin')
+        if is_openbsd():
+            raise SkipTest('-fsanitize=address is not supported on OpenBSD')
+
+        testdir = os.path.join(self.common_test_dir, '1 trivial')
+        env = {'CFLAGS': '-fsanitize=address', 'LDFLAGS': '-I.'}
+        self.init(testdir, override_envvars=env)
+        self.build()
+        compdb = self.get_compdb()
+        for i in compdb:
+            self.assertIn("-fsanitize=address", i["command"])
+        self.wipe()
+
+    @skip_if_not_base_option('b_sanitize')
     def test_pch_with_address_sanitizer(self):
         if is_cygwin():
             raise SkipTest('asan not available on Cygwin')


### PR DESCRIPTION
For compatibility with Autotools, CFLAGS is added to the linker command line if the compiler acts as a linker driver.  However, this behavior was lost in commit d37d649b0 ("Make all Meson level options overridable per subproject.", 2025-02-13).

The issue is that LDFLAGS is stored in env.options as (for example) c_link_args, and from that point on it is treated as a machine-file option.  This includes not being able to override it in compilers.get_global_options:

- initialize_from_top_level_project_call places it in pending_options

- add_lang_args passes the right value to add_compiler_option

- add_compiler_option calls add_system_option_internal

- add_system_option_internal fishes the value out of pending_options and ignores what get_global_options provided.

Instead, store the putative values of the compiler options coming from the environment in a separate dictionary, that is only accessed by get_global_options, so that it never appears in pending_options.

Fixes: #14533