### PR TITLE
options: fix "deprecated" with dictionary argument and non-string types

### DIFF
--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -327,7 +327,13 @@ class UserOption(T.Generic[_T], HoldableObject):
         # Final isn't technically allowed in a __post_init__ method
         self.default: Final[_T] = self.value  # type: ignore[misc]
 
-    def listify(self, value: T.Any) -> T.List[T.Any]:
+    def listify(self, value: ElementaryOptionValues) -> T.List[str]:
+        if isinstance(value, list):
+            return value
+        if isinstance(value, bool):
+            return ['true'] if value else ['false']
+        if isinstance(value, int):
+            return [str(value)]
         return [value]
 
     def printable_value(self) -> ElementaryOptionValues:
@@ -503,7 +509,7 @@ class UserArrayOption(UserOption[T.List[_T]]):
 @dataclasses.dataclass
 class UserStringArrayOption(UserArrayOption[str]):
 
-    def listify(self, value: T.Any) -> T.List[T.Any]:
+    def listify(self, value: ElementaryOptionValues) -> T.List[str]:
         try:
             return listify_array_value(value, self.split_args)
         except MesonException as e:
@@ -1005,7 +1011,7 @@ class OptionStore:
                 if v in opt.deprecated:
                     mlog.deprecation(f'Option {key.name!r} value {v!r} is deprecated')
         elif isinstance(opt.deprecated, dict):
-            def replace(v: T.Any) -> T.Any:
+            def replace(v: str) -> str:
                 assert isinstance(opt.deprecated, dict) # No, Mypy can not tell this from two lines above
                 newvalue = opt.deprecated.get(v)
                 if newvalue is not None:

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -1578,7 +1578,7 @@ def listify(item: T.Any, flatten: bool = True) -> T.List[T.Any]:
             result.append(i)
     return result
 
-def listify_array_value(value: T.Union[str, T.List[str]], shlex_split_args: bool = False) -> T.List[str]:
+def listify_array_value(value: object, shlex_split_args: bool = False) -> T.List[str]:
     if isinstance(value, str):
         if value.startswith('['):
             try:

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -202,3 +202,14 @@ class OptionTests(unittest.TestCase):
         optstore = OptionStore(False)
         value = optstore.get_default_for_b_option(OptionKey('b_vscrt'))
         self.assertEqual(value, 'from_buildtype')
+
+    def test_deprecated_nonstring_value(self):
+        # TODO: add a lot more deprecated option tests
+        optstore = OptionStore(False)
+        name = 'deprecated'
+        do = UserStringOption(name, 'An option with some deprecation', '0',
+                              deprecated={'true': '1'})
+        optstore.add_system_option(name, do)
+        optstore.set_option(OptionKey(name), True)
+        value = optstore.get_value(name)
+        self.assertEqual(value, '1')


### PR DESCRIPTION
Since opt.deprecated is a dictionary with string keys, the lookup must use str() around the user-provided value; with some care because booleans will be the meson-ic 'true' and 'false' instead of Python's 'True' and 'False'.

Fixes: #14560 