### PR TITLE
Print environment variables in log for autoconf subprojects

### DIFF
--- a/mesonbuild/modules/external_project.py
+++ b/mesonbuild/modules/external_project.py
@@ -201,6 +201,9 @@ class ExternalProject(NewExtensionModule):
     def _run(self, step: str, command: T.List[str], workdir: Path) -> None:
         mlog.log(f'External project {self.name}:', mlog.bold(step))
         m = 'Running command ' + str(command) + ' in directory ' + str(workdir) + '\n'
+        m += 'With environment variables:\n'
+        for k, v in sorted(self.run_env.items()):
+            m += f'  {k}={v}\n'
         log_filename = Path(mlog.get_log_dir(), f'{self.name}-{step}.log')
         output = None
         if not self.verbose:

--- a/mesonbuild/scripts/externalproject.py
+++ b/mesonbuild/scripts/externalproject.py
@@ -66,7 +66,14 @@ class ExternalProject:
         return 0
 
     def _run(self, step: str, command: T.List[str], env: T.Optional[T.Dict[str, str]] = None) -> int:
+        run_env = os.environ.copy()
+        if env:
+            run_env.update(env)
+        
         m = 'Running command ' + str(command) + ' in directory ' + str(self.build_dir) + '\n'
+        m += 'With environment variables:\n'
+        for k, v in sorted(run_env.items()):
+            m += f'  {k}={v}\n'
         log_filename = Path(self.log_dir, f'{self.name}-{step}.log')
         output = None
         if not self.verbose:
@@ -75,9 +82,7 @@ class ExternalProject:
             output.flush()
         else:
             print(m)
-        run_env = os.environ.copy()
-        if env:
-            run_env.update(env)
+
         p, o, e = Popen_safe(command, stderr=subprocess.STDOUT, stdout=output,
                              cwd=self.build_dir,
                              env=run_env)


### PR DESCRIPTION
For an autoconf subproject, the configure, build and install log now also contains the environment variables at the point of invocation. This is helpful to debug the exact setting that these commands are run in (e.g. the DESTDIR variable is important for install, or some compiler flags for the configure/build).