### PR TITLE
macros: use smp_mflags

### DIFF
--- a/data/macros.meson
+++ b/data/macros.meson
@@ -28,7 +28,7 @@
 %meson_build \
     %{shrink:%{__meson} compile \
         -C %{_vpath_builddir} \
-        -j %{_smp_build_ncpus} \
+        %{_smp_mflags} \
         %[ 0%{?__meson_verbose} ? "--verbose" : "" ] \
         %{nil}}
 
@@ -42,7 +42,7 @@
 %meson_test \
     %{shrink:%{__meson} test \
         -C %{_vpath_builddir} \
-        --num-processes %{_smp_build_ncpus} \
+        %{_smp_mflags} \
         --print-errorlogs \
         %{nil}}
 


### PR DESCRIPTION
use `%{_smp_mflags}`
to avoid embedding the number of CPU cores
in the .src.rpm header's expanded SPEC field.

See also https://github.com/rpm-software-management/rpm/issues/2343

This patch was done while working on reproducible builds for openSUSE.