### PR TITLE
setup: restore behavior of project options together with --reconfigure

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -412,6 +412,13 @@ class CoreData:
             return option_object.validate_value(override)
         return value
 
+    def set_from_configure_command(self, options: SharedCMDOptions) -> bool:
+        unset_opts = getattr(options, 'unset_opts', [])
+        all_D = options.projectoptions[:]
+        for keystr, valstr in options.cmd_line_options.items():
+            all_D.append(f'{keystr}={valstr}')
+        return self.optstore.set_from_configure_command(all_D, unset_opts)
+
     def set_option(self, key: OptionKey, value, first_invocation: bool = False) -> bool:
         dirty = False
         try:

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -370,11 +370,7 @@ def run_impl(options: CMDOptions, builddir: str) -> int:
 
         save = False
         if has_option_flags(options):
-            unset_opts = getattr(options, 'unset_opts', [])
-            all_D = options.projectoptions[:]
-            for keystr, valstr in options.cmd_line_options.items():
-                all_D.append(f'{keystr}={valstr}')
-            save |= c.coredata.optstore.set_from_configure_command(all_D, unset_opts)
+            save |= c.coredata.set_from_configure_command(options)
             coredata.update_cmd_line_file(builddir, options)
         if options.clearcache:
             c.clear_cache()

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -125,9 +125,6 @@ class Conf:
     def clear_cache(self) -> None:
         self.coredata.clear_cache()
 
-    def set_options(self, options: T.Dict[OptionKey, str]) -> bool:
-        return self.coredata.set_options(options)
-
     def save(self) -> None:
         # Do nothing when using introspection
         if self.default_values_only:

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -180,6 +180,9 @@ class MesonApp:
     # See class Backend's 'generate' for comments on capture args and returned dictionary.
     def generate(self, capture: bool = False, vslite_ctx: T.Optional[dict] = None) -> T.Optional[dict]:
         env = environment.Environment(self.source_dir, self.build_dir, self.options)
+        if not env.first_invocation:
+            assert self.options.reconfigure
+            env.coredata.set_from_configure_command(self.options)
         mlog.initialize(env.get_log_dir(), self.options.fatal_warnings)
         if self.options.profile:
             mlog.set_timestamp_start(time.monotonic())

--- a/test cases/common/40 options/meson.build
+++ b/test cases/common/40 options/meson.build
@@ -40,8 +40,7 @@ if get_option('integer_opt') != 3
 endif
 
 negint = get_option('neg_int_opt')
-
-if negint != -3 and negint != -10
+if negint not in [-2, -3, -10]
   error('Incorrect value @0@ in negative integer option.'.format(negint))
 endif
 

--- a/unittests/platformagnostictests.py
+++ b/unittests/platformagnostictests.py
@@ -453,6 +453,16 @@ class PlatformAgnosticTests(BasePlatformTests):
             self.setconf('-Dneg_int_opt=0')
         self.assertIn('Unknown options: ":neg_int_opt"', e.exception.stdout)
 
+    def test_reconfigure_option(self) -> None:
+        testdir = self.copy_srcdir(os.path.join(self.common_test_dir, '40 options'))
+        self.init(testdir)
+        self.assertEqual(self.getconf('neg_int_opt'), -3)
+        with self.assertRaises(subprocess.CalledProcessError) as e:
+            self.init(testdir, extra_args=['--reconfigure', '-Dneg_int_opt=0'])
+        self.assertEqual(self.getconf('neg_int_opt'), -3)
+        self.init(testdir, extra_args=['--reconfigure', '-Dneg_int_opt=-2'])
+        self.assertEqual(self.getconf('neg_int_opt'), -2)
+
     def test_configure_option_changed_constraints(self) -> None:
         """Changing the constraints of an option without reconfiguring should work."""
         testdir = self.copy_srcdir(os.path.join(self.common_test_dir, '40 options'))


### PR DESCRIPTION
Project options were basically ignored when --reconfigure was passed, because after coredata was loaded nothing was going to look at them. This is because these lines were removed from the initialization of Environment

```
        # Command line options override those from cross/native files
        self.options.update(cmd_options.cmd_line_options)
```

Fortunately a fix is easy by reusing the the code that runs for `meson configure`.

Fixes: #14575