### PR TITLE
modules: Add a module for DSL introspection

### DIFF
--- a/mesonbuild/modules/types.py
+++ b/mesonbuild/modules/types.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2025 Intel Corporation
+
+from __future__ import annotations
+import typing as T
+
+from . import ExtensionModule, ModuleInfo
+from ..interpreterbase import typed_pos_args, noKwargs
+
+if T.TYPE_CHECKING:
+    from . import ModuleState
+    from ..interpreter import Interpreter
+    from ..interpreterbase import TYPE_kwargs
+
+
+class TypesModule(ExtensionModule):
+
+    """A module that holds helper functions for inspecting Meson DSL."""
+
+    INFO = ModuleInfo('types', '1.9', unstable=True)
+
+    def __init__(self, interpreter: Interpreter) -> None:
+        super().__init__(interpreter)
+        self.methods.update({
+            'is_array': self.is_array_method,
+            'is_number': self.is_number_method,
+            'is_string': self.is_string_method,
+        })
+
+    @typed_pos_args('types.is_array', object)
+    @noKwargs
+    def is_array_method(self, state: ModuleState, args: T.Tuple[object], kwargs: TYPE_kwargs) -> bool:
+        return isinstance(args[0], list)
+
+    @typed_pos_args('types.is_number', object)
+    @noKwargs
+    def is_number_method(self, state: ModuleState, args: T.Tuple[object], kwargs: TYPE_kwargs) -> bool:
+        return isinstance(args[0], int)
+
+    @typed_pos_args('types.is_string', object)
+    @noKwargs
+    def is_string_method(self, state: ModuleState, args: T.Tuple[object], kwargs: TYPE_kwargs) -> bool:
+        return isinstance(args[0], str)
+
+
+def initialize(interp: Interpreter) -> TypesModule:
+    return TypesModule(interp)

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -75,6 +75,7 @@ modules = [
     'mesonbuild/modules/rust.py',
     'mesonbuild/modules/simd.py',
     'mesonbuild/modules/sourceset.py',
+    'mesonbuild/modules/types.py',
     'mesonbuild/modules/wayland.py',
     'mesonbuild/modules/windows.py',
     'mesonbuild/mparser.py',


### PR DESCRIPTION
This module provides methods for looking at the types of variables. The main thought for this is values returned from user data, such as `meson.get_external_property()`, and allowing choices to be made based on type information.

This implementation is rather incomplete, and there is no documentation provided (yet?).

Largely at this point I want to solicit feedback from the community, as I am concerned that this may help some niche cases, but be as a whole be a determent.

Cases that have come up where it would be helpful:
 1. `meson.get_external_property()`, where the type cannot be known

My hope is that we can either build consensus to move forward with this OR to build consensus to add language to the documentation as to why we don't have this, and don't want to add it, similar to the section on functions and macros.