### PR TITLE
mdist.py: Import gzip only when needed

### DIFF
--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import abc
 import argparse
-import gzip
 import os
 import sys
 import shlex
@@ -294,6 +293,7 @@ class HgDist(Dist):
                 shutil.copyfileobj(tf, bf)
             output_names.append(bz2name)
         if 'gztar' in archives:
+            import gzip
             with gzip.open(gzname, 'wb') as zf, open(tarname, 'rb') as tf:
                 shutil.copyfileobj(tf, zf)
             output_names.append(gzname)


### PR DESCRIPTION
This is already done for bz2 and lzma, but even gzip is not always available in a minimal Python installation. For example, this happens when building Python from source without having zlib available.

Basically, this is the same solution as https://github.com/mesonbuild/meson/pull/6077 but for gzip.