### PR TITLE
rust: skip doctests when host machine cannot run binaries directly

### DIFF
--- a/cross/ubuntu-armhf.txt
+++ b/cross/ubuntu-armhf.txt
@@ -4,6 +4,7 @@
 c = ['/usr/bin/arm-linux-gnueabihf-gcc']
 cpp = ['/usr/bin/arm-linux-gnueabihf-g++']
 rust = ['rustc', '--target', 'arm-unknown-linux-gnueabihf', '-C', 'linker=/usr/bin/arm-linux-gnueabihf-gcc-7']
+rustdoc = ['rustdoc', '--target', 'arm-unknown-linux-gnueabihf', '-C', 'linker=/usr/bin/arm-linux-gnueabihf-gcc-7']
 ar = '/usr/arm-linux-gnueabihf/bin/ar'
 strip = '/usr/arm-linux-gnueabihf/bin/strip'
 pkg-config = '/usr/bin/arm-linux-gnueabihf-pkg-config'

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -242,6 +242,10 @@ class RustModule(ExtensionModule):
     def doctest(self, state: ModuleState, args: T.Tuple[str, T.Union[SharedLibrary, StaticLibrary]], kwargs: FuncDoctest) -> ModuleReturnValue:
         name, base_target = args
 
+        if state.environment.is_cross_build() and state.environment.need_exe_wrapper(base_target.for_machine):
+            mlog.notice('skipping Rust doctests due to cross compilation', once=True)
+            return ModuleReturnValue(None, [])
+
         # Link the base target's crate into the tests
         kwargs['link_with'].append(base_target)
         kwargs['depends'].append(base_target)


### PR DESCRIPTION
`rustdoc --test` relies on running host binaries, and has no way of wrapping them with Meson's exe_wrapper.  Just skip the doctests in that case.

Fixes: #14583