### PR TITLE
cpp: Fix cpp_std=vc++14

### DIFF
--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -880,8 +880,7 @@ class CPP11AsCPP14Mixin(CompilerMixinBase):
                          'attempting best effort; setting the standard to C++14',
                          once=True, fatal=False)
         original_args = super().get_option_std_args(target, env, subproject)
-        std_mapping = {'/std:c++11': '/std:c++14',
-                       '/std:c++14': '/std:vc++14'}
+        std_mapping = {'/std:c++11': '/std:c++14'}
         processed_args = [std_mapping.get(x, x) for x in original_args]
         return processed_args
 


### PR DESCRIPTION
Fixes a regression introduced in commit d37d649b08b8 "Make all Meson level options overridable per subproject." This change results in every file printing the warning "cl : Command line warning D9002 : ignoring unknown option '/std:vc++14'"

Now that "get_option_..." is called before overwriting the option (instead of after), we have to operate on compiler options, not meson options.

There is no such compiler option as /std:vc++14 (the meson option vc++xx is split into /std:c++xx for the C++ standard version, and a separate flag that enables Microsoft extensions). Remove the mapping from c++14 to vc++14.