### PR TITLE
vs2010backend: fix EmbedManifest state when /Manifest:Embed is used

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1513,8 +1513,9 @@ class Vs2010Backend(backends.Backend):
             additional_links.append(self.relpath(lib, self.get_target_dir(target)))
 
         if len(extra_link_args) > 0:
-            extra_link_args.append('%(AdditionalOptions)')
-            ET.SubElement(link, "AdditionalOptions").text = ' '.join(extra_link_args)
+            args = [self.escape_additional_option(arg) for arg in extra_link_args]
+            args.append('%(AdditionalOptions)')
+            ET.SubElement(link, "AdditionalOptions").text = ' '.join(args)
         if len(additional_libpaths) > 0:
             additional_libpaths.insert(0, '%(AdditionalLibraryDirectories)')
             ET.SubElement(link, 'AdditionalLibraryDirectories').text = ';'.join(additional_libpaths)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -703,9 +703,8 @@ class Vs2010Backend(backends.Backend):
             # Fix weird mt.exe error:
             # mt.exe is trying to compile a non-existent .generated.manifest file and link it
             # with the target. This does not happen without masm props.
-            ET.SubElement(direlem, 'EmbedManifest').text = 'true' if masm_type else 'false'
-            if not gen_manifest:
-                ET.SubElement(direlem, 'GenerateManifest').text = 'false'
+            ET.SubElement(direlem, 'EmbedManifest').text = 'true' if masm_type or gen_manifest == 'embed' else 'false'
+            ET.SubElement(direlem, 'GenerateManifest').text = 'true' if gen_manifest else 'false'
 
         return (root, type_config)
 
@@ -2133,6 +2132,7 @@ class Vs2010Backend(backends.Backend):
         pass
 
     # Returns if a target generates a manifest or not.
+    # Returns 'embed' if the generated manifest is embedded.
     def get_gen_manifest(self, target: T.Optional[build.BuildTarget]):
         if not isinstance(target, build.BuildTarget):
             return True
@@ -2150,6 +2150,8 @@ class Vs2010Backend(backends.Backend):
             arg = arg.upper()
             if arg == '/MANIFEST:NO':
                 return False
+            if arg.startswith('/MANIFEST:EMBED'):
+                return 'embed'
             if arg == '/MANIFEST' or arg.startswith('/MANIFEST:'):
                 break
         return True

--- a/test cases/windows/25 embed manifest/DPIAware.manifest
+++ b/test cases/windows/25 embed manifest/DPIAware.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <asmv3:application>
+    <asmv3:windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</assembly>

--- a/test cases/windows/25 embed manifest/meson.build
+++ b/test cases/windows/25 embed manifest/meson.build
@@ -1,0 +1,11 @@
+project('can-manifests-be-embedded', 'c')
+
+cc = meson.get_compiler('c')
+
+if cc.get_linker_id() not in ['link', 'lld-link', 'xilink'] # cc.get_linker_argument_syntax() != 'link'
+  error('MESON_SKIP_TEST: test is only relevant for the Microsoft linker')
+endif
+
+# Ensure that the manifest can be embedded
+executable('prog', 'prog.c',
+  link_args: ['/MANIFEST:EMBED', '/MANIFESTINPUT:' + meson.project_source_root() / 'DPIAware.manifest'])

--- a/test cases/windows/25 embed manifest/prog.c
+++ b/test cases/windows/25 embed manifest/prog.c
@@ -1,0 +1,3 @@
+int main(int argc, char *argv[]) {
+    return 0;
+}


### PR DESCRIPTION
With introduction of dfd8cfbd8d9c VS compile is broken for cases where /MANIFEST:EMBED linker flag is actually used. The fix keeps the default creation of <EmbedManifest> but adopts the same strategy as e3db7af0ea41, that is to scan the link flags for the embed case to decide state is emit 'true' or 'false' for EmbedManifest.