### PR TITLE
cmake: Fix target_link_libraries against project targets

### DIFF
--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -223,6 +223,7 @@ class ConverterTarget:
         self.install = target.install
         self.install_dir: T.Optional[Path] = None
         self.link_libraries = target.link_libraries
+        self.link_targets: T.List[str] = []
         self.link_flags = target.link_flags + target.link_lang_flags
         self.public_link_flags: T.List[str] = []
         self.depends_raw: T.List[str] = []
@@ -363,6 +364,8 @@ class ConverterTarget:
             self.public_link_flags += rtgt.public_link_flags
             self.public_compile_opts += rtgt.public_compile_opts
             self.link_libraries += rtgt.libraries
+            self.depends_raw += rtgt.target_dependencies
+            self.link_targets += rtgt.target_dependencies
 
         elif self.type.upper() not in ['EXECUTABLE', 'OBJECT_LIBRARY']:
             mlog.warning('CMake: Target', mlog.bold(self.cmake_name), 'not found in CMake trace. This can lead to build errors')
@@ -957,17 +960,27 @@ class CMakeInterpreter:
                 object_libs += [tgt]
             self.languages += [x for x in tgt.languages if x not in self.languages]
 
-        # Second pass: Detect object library dependencies
+        # Second pass: Populate link_with project internal targets
+        for tgt in self.targets:
+            for i in tgt.link_targets:
+                # Handle target-based link libraries
+                link_with = self.output_target_map.target(i)
+                if not link_with or isinstance(link_with, ConverterCustomTarget):
+                    # Generated file etc.
+                    continue
+                tgt.link_with.append(link_with)
+
+        # Third pass: Detect object library dependencies
         for tgt in self.targets:
             tgt.process_object_libs(object_libs, self._object_lib_workaround)
 
-        # Third pass: Reassign dependencies to avoid some loops
+        # Fourth pass: Reassign dependencies to avoid some loops
         for tgt in self.targets:
             tgt.process_inter_target_dependencies()
         for ctgt in self.custom_targets:
             ctgt.process_inter_target_dependencies()
 
-        # Fourth pass: Remove rassigned dependencies
+        # Fifth pass: Remove reassigned dependencies
         for tgt in self.targets:
             tgt.cleanup_dependencies()
 

--- a/mesonbuild/cmake/tracetargets.py
+++ b/mesonbuild/cmake/tracetargets.py
@@ -45,6 +45,7 @@ class ResolvedTarget:
         self.public_link_flags:   T.List[str] = []
         self.public_compile_opts: T.List[str] = []
         self.libraries:           T.List[str] = []
+        self.target_dependencies: T.List[str] = []
 
 def resolve_cmake_trace_targets(target_name: str,
                                 trace: 'CMakeTraceParser',
@@ -144,9 +145,13 @@ def resolve_cmake_trace_targets(target_name: str,
             targets += [x for x in tgt.properties['IMPORTED_LOCATION'] if x]
 
         if 'LINK_LIBRARIES' in tgt.properties:
-            targets += [x for x in tgt.properties['LINK_LIBRARIES'] if x]
+            link_libraries = [x for x in tgt.properties['LINK_LIBRARIES'] if x]
+            targets += link_libraries
+            res.target_dependencies += link_libraries
         if 'INTERFACE_LINK_LIBRARIES' in tgt.properties:
-            targets += [x for x in tgt.properties['INTERFACE_LINK_LIBRARIES'] if x]
+            link_libraries = [x for x in tgt.properties['INTERFACE_LINK_LIBRARIES'] if x]
+            targets += link_libraries
+            res.target_dependencies += link_libraries
 
         if f'IMPORTED_LINK_DEPENDENT_LIBRARIES_{cfg}' in tgt.properties:
             targets += [x for x in tgt.properties[f'IMPORTED_LINK_DEPENDENT_LIBRARIES_{cfg}'] if x]


### PR DESCRIPTION
These were supported for shared libraries, but for static libraries the link_with property was never populated with `LINK_LIBRARIES` or `INTERFACE_LINK_LIBRARIES`.

Fixes #13101