### PR TITLE
devenv: do not use os.execv on Windows

### DIFF
--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -4453,6 +4453,10 @@ class AllPlatformTests(BasePlatformTests):
         self.assertIn(f'TEST_C="{expected}"', o)
         self.assertIn('export TEST_C', o)
 
+        cmd = self.meson_command + ['devenv', '-C', self.builddir] + python_command + ['-c', 'import sys; sys.exit(42)']
+        result = subprocess.run(cmd, encoding='utf-8')
+        self.assertEqual(result.returncode, 42)
+
     def test_clang_format_check(self):
         if self.backend is not Backend.ninja:
             raise SkipTest(f'Skipping clang-format tests with {self.backend.name} backend')


### PR DESCRIPTION
On Windows, os.execv spawn the process in background and returns 0. Therefore, it prevents devenv to return proper exit code from the called process. (see https://github.com/python/cpython/issues/63323 for reference.)

The solution is to call subprocess.run instead, on Windows, at the price of keeping the meson python process alive while the devenv subprocess runs.