### PR TITLE
Fix --buildtype=custom

### DIFF
--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1040,7 +1040,7 @@ class OptionStore:
             assert isinstance(new_value, str), 'for mypy'
             self.reset_prefixed_options(old_value, new_value)
 
-        if changed and key.name == 'buildtype':
+        if changed and key.name == 'buildtype' and new_value != 'custom':
             assert isinstance(new_value, str), 'for mypy'
             optimization, debug = self.DEFAULT_DEPENDENTS[new_value]
             dkey = key.evolve(name='debug')

--- a/unittests/platformagnostictests.py
+++ b/unittests/platformagnostictests.py
@@ -203,10 +203,10 @@ class PlatformAgnosticTests(BasePlatformTests):
         # Reconfigure of not empty builddir should work
         self.new_builddir()
         Path(self.builddir, 'dummy').touch()
-        self.init(testdir, extra_args=['--reconfigure'])
+        self.init(testdir, extra_args=['--reconfigure', '--buildtype=custom'])
 
         # Setup a valid builddir should update options but not reconfigure
-        self.assertEqual(self.getconf('buildtype'), 'debug')
+        self.assertEqual(self.getconf('buildtype'), 'custom')
         o = self.init(testdir, extra_args=['-Dbuildtype=release'])
         self.assertIn('Directory already configured', o)
         self.assertNotIn('The Meson build system', o)


### PR DESCRIPTION
Trivial patch to avoid a Python exception by doing nothing.

Fixes: #14603 