### PR TITLE
docs: Note that debug=false does not define NDEBUG

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -150,6 +150,10 @@ the two-way mapping:
 
 All other combinations of `debug` and `optimization` set `buildtype` to `'custom'`.
 
+Note that `-Ddebug=false` does not cause the compiler preprocessor macro
+`NDEBUG` to be defined.
+The macro can be defined using the base option `b_ndebug`, described below.
+
 #### Details for `warning_level`
 
 Exact flags per warning level is compiler specific, but there is an approximate


### PR DESCRIPTION
Hi @eli-schwartz,

Perhaps adding this note to the docs would be helpful to avoid user's confusing debug/non-debug builds with the setting of the NDEBUG macro.   Feel free to merge or reject this PR as you think best (or suggest wording changes).

Regards,
Paul