### PR TITLE
cuda: use target-specific paths under CUDA Toolkit on Linux

### DIFF
--- a/mesonbuild/dependencies/cuda.py
+++ b/mesonbuild/dependencies/cuda.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 from .. import mesonlib
 from .. import mlog
-from ..environment import detect_cpu_family
 from .base import DependencyException, SystemDependency
 from .detect import packages
 
@@ -27,8 +26,11 @@ class CudaDependency(SystemDependency):
     supported_languages = ['cpp', 'c', 'cuda'] # see also _default_language
 
     def __init__(self, environment: 'Environment', kwargs: T.Dict[str, T.Any]) -> None:
-        compilers = environment.coredata.compilers[self.get_for_machine_from_kwargs(kwargs)]
+        for_machine = self.get_for_machine_from_kwargs(kwargs)
+        compilers = environment.coredata.compilers[for_machine]
+        machine = environment.machines[for_machine]
         language = self._detect_language(compilers)
+
         if language not in self.supported_languages:
             raise DependencyException(f'Language \'{language}\' is not supported by the CUDA Toolkit. Supported languages are {self.supported_languages}.')
 
@@ -50,14 +52,21 @@ class CudaDependency(SystemDependency):
         if not os.path.isabs(self.cuda_path):
             raise DependencyException(f'CUDA Toolkit path must be absolute, got \'{self.cuda_path}\'.')
 
+        # Cuda target directory relative to cuda path.
+        if  machine.is_linux():
+            # E.g. targets/x86_64-linux
+            self.target_path = os.path.join('targets', f"{machine.cpu_family}-{machine.system}")
+        else:
+            self.target_path = "."
+
         # nvcc already knows where to find the CUDA Toolkit, but if we're compiling
         # a mixed C/C++/CUDA project, we still need to make the include dir searchable
         if self.language != 'cuda' or len(compilers) > 1:
-            self.incdir = os.path.join(self.cuda_path, 'include')
+            self.incdir = os.path.join(self.cuda_path, self.target_path, 'include')
             self.compile_args += [f'-I{self.incdir}']
 
         arch_libdir = self._detect_arch_libdir()
-        self.libdir = os.path.join(self.cuda_path, arch_libdir)
+        self.libdir = os.path.join(self.cuda_path, self.target_path, arch_libdir)
         mlog.debug('CUDA library directory is', mlog.bold(self.libdir))
 
         self.is_found = self._find_requested_libraries()
@@ -211,8 +220,8 @@ class CudaDependency(SystemDependency):
         return '.'.join(version.split('.')[:2])
 
     def _detect_arch_libdir(self) -> str:
-        arch = detect_cpu_family(self.env.coredata.compilers.host)
         machine = self.env.machines[self.for_machine]
+        arch = machine.cpu_family
         msg = '{} architecture is not supported in {} version of the CUDA Toolkit.'
         if machine.is_windows():
             libdirs = {'x86': 'Win32', 'x86_64': 'x64'}
@@ -220,10 +229,7 @@ class CudaDependency(SystemDependency):
                 raise DependencyException(msg.format(arch, 'Windows'))
             return os.path.join('lib', libdirs[arch])
         elif machine.is_linux():
-            libdirs = {'x86_64': 'lib64', 'ppc64': 'lib', 'aarch64': 'lib64', 'loongarch64': 'lib64'}
-            if arch not in libdirs:
-                raise DependencyException(msg.format(arch, 'Linux'))
-            return libdirs[arch]
+            return "lib"
         elif machine.is_darwin():
             libdirs = {'x86_64': 'lib64'}
             if arch not in libdirs:


### PR DESCRIPTION
fix #14595 

This PR updates the cuda dependency to use target-specific include and library paths, such as `/usr/local/cuda/targets/aarch64-linux/lib` and `/usr/local/cuda/targets/aarch64-linux/include`, instead of defaulting to the host's `/usr/local/cuda/lib64`.

When cross-compiling, Meson currently:

- Detects the CUDA library directory using the build machine's architecture, not the target's.
- Hardcodes `lib64` for aarch64, even though NVIDIA's toolchain uses `lib` under the target-specific path.
- Ignores the `targets/<arch>-<os>` layout entirely, making it impossible to use  
  `CUDA_PATH=/usr/local/cuda/targets/aarch64-linux` as a workaround.

This causes incorrect link paths and build failures when targeting non-x86_64 platforms.

**Fix:**

- Use `for_machine` to determine the target architecture, not the host.
- On Linux, always use lib under the target path, matching NVIDIA's layout.
- Introduce self.target_path to resolve targets/<arch>-<os> subdirectories for both include and lib paths.
- Preserve existing behavior on Windows and macOS.

This fix only applies to Linux.

Tested with jetpack cuda 12.6 & jetpack cuda 10.2

