### PR TITLE
cmake: Fix toolchain including unsupported languages

### DIFF
--- a/mesonbuild/cmake/common.py
+++ b/mesonbuild/cmake/common.py
@@ -19,6 +19,7 @@ language_map = {
     'cuda': 'CUDA',
     'objc': 'OBJC',
     'objcpp': 'OBJCXX',
+    'nasm': 'ASM_NASM',
     'cs': 'CSharp',
     'java': 'Java',
     'fortran': 'Fortran',

--- a/mesonbuild/cmake/toolchain.py
+++ b/mesonbuild/cmake/toolchain.py
@@ -175,7 +175,12 @@ class CMakeToolchain:
 
         # Set the compiler variables
         for lang, comp_obj in self.compilers.items():
-            prefix = 'CMAKE_{}_'.format(language_map.get(lang, lang.upper()))
+            language = language_map.get(lang, None)
+
+            if not language:
+                continue # unsupported language
+
+            prefix = 'CMAKE_{}_'.format(language)
 
             exe_list = comp_obj.get_exelist()
             if not exe_list:
@@ -211,7 +216,7 @@ class CMakeToolchain:
         # Generate the CMakeLists.txt
         mlog.debug('CMake Toolchain: Calling CMake once to generate the compiler state')
         languages = list(self.compilers.keys())
-        lang_ids = [language_map.get(x, x.upper()) for x in languages]
+        lang_ids = [language_map.get(x) for x in languages if x in language_map]
         cmake_content = dedent(f'''
             cmake_minimum_required(VERSION 3.10)
             project(CompInfo {' '.join(lang_ids)})


### PR DESCRIPTION
The most egregious cases are Nasm (which needs to be transformed to `ASM_NASM`) and Rust (which is not yet supported by CMake).

Without this change, projects including multiple languages will generate a toolchain file e.g.

```cmake
set(CMAKE_SIZEOF_VOID_P "8")
set(CMAKE_C_COMPILER "C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/MSVC/14.44.35207/bin/HostX64/x64/cl.EXE")
set(CMAKE_CXX_COMPILER "C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/MSVC/14.44.35207/bin/HostX64/x64/cl.EXE")
set(CMAKE_RUST_COMPILER "C:/Users/Amalia/.cargo/bin/rustc.EXE" "-C" "linker=link")
set(CMAKE_NASM_COMPILER "C:/Users/Amalia/.cargo/bin/nasm.EXE")
```

which will then cause:

```
WARNING: CMake Toolchain: Failed to determine CMake compilers state
 -- return code: 1
 -- stdout: Put cmake in trace mode, but with variables expanded.
 -- stdout: Put cmake in trace mode and sets the trace output format.
 -- stdout: Not searching for unused variables given on the command line.
 -- stdout: Put cmake in trace mode and redirect trace output to a file instead of stderr.
 -- stdout: Trace will be written to cmake_trace.txt
 -- stdout: -- Configuring incomplete, errors occurred!
 -- stdout: 
 -- stderr: CMake Error: Could not find cmake module file: CMakeDetermineRUSTCompiler.cmake
 -- stderr: CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.
 -- stderr: Missing variable is:
 -- stderr: CMAKE_RUST_COMPILER_ENV_VAR
 -- stderr: CMake Error: Could not find cmake module file: E:/gstreamer/build/meson-private/__CMake_compiler_info__/CMakeFiles/3.27.9/CMakeRUSTCompiler.cmake
 -- stderr: CMake Error at CMakeLists.txt:3 (project):
 -- stderr:   The CMAKE_RUST_COMPILER:
 -- stderr: 
 -- stderr:     C:/Users/Amalia/.cargo/bin/rustc.EXE;-C;linker=link
 -- stderr: 
 -- stderr:   is not a full path to an existing compiler tool.
 -- stderr: 
 -- stderr:   Tell CMake where to find the compiler by setting the CMake cache entry
 -- stderr:   CMAKE_RUST_COMPILER to the full path to the compiler, or to the compiler
 -- stderr:   name if it is in the PATH.
 -- stderr: 
 -- stderr: 
 -- stderr: CMake Error: Could not find cmake module file: CMakeRUSTInformation.cmake
 -- stderr: 
```

See https://cmake.org/cmake/help/v4.0/command/project.html