### PR TITLE
Add `qt6.generate_qrc`

### DIFF
--- a/docs/markdown/Qt6-module.md
+++ b/docs/markdown/Qt6-module.md
@@ -238,6 +238,19 @@ replaced with `_`. Type registration may be invoked explicitly using
 See [Qt documentation](https://doc.qt.io/qt-6/resources.html#explicit-loading-and-unloading-of-embedded-resources)
 for more information
 
+## generate_qrc
+
+*New in 1.9.0*
+
+Generates a `.qrc` file that contains teh given files.
+
+It takes no positional arguments, and the following keyword arguments:
+  - `sources` (File | string | custom_target | custom_target index | generator_output)[]:
+    A list of files that to be included in the `.qrc`.<br/>
+  - `output` string:
+    The name of the `.qrc` file.<br/>
+  - `prefix` (string | empty):
+    If provides it sets the `prefix` property in the `.qrc`.<br/>
 
 ## Dependencies
 

--- a/mesonbuild/scripts/generate_qrc.py
+++ b/mesonbuild/scripts/generate_qrc.py
@@ -1,0 +1,27 @@
+import os
+import argparse
+import typing as T
+import xml.etree.ElementTree as ET
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--output')
+parser.add_argument("--prefix")
+parser.add_argument('sources', default=[], nargs='*')
+
+def run(argv: T.List[str]) -> int:
+    options, args = parser.parse_known_args(argv)
+
+    rcc = ET.Element('RCC')
+    qresource = ET.SubElement(rcc, 'qresource')
+
+    if options.prefix:
+        qresource.set("prefix", options.prefix)
+
+    for source in options.sources:
+        ET.SubElement(qresource, 'file').text = source
+
+    tree = ET.ElementTree(rcc)
+    ET.indent(tree, space='  ', level=0)
+    tree.write(os.path.join(options.output))
+
+    return 0

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -177,5 +177,6 @@ foreach qt : ['qt4', 'qt5', 'qt6']
     accept_versions = ['>=@0@'.format(qtdep.version()), '<@0@'.format(qtdep.version()[0].to_int() + 1)]
     dependency(qt, modules: qt_modules, version: accept_versions, method : get_option('method'))
 
+    qtmodule.generate_qrc(sources: ['test.json'], output: 'test.qrc')
   endif
 endforeach


### PR DESCRIPTION
This allows generating [Qt Resource Collection Files](https://doc.qt.io/qt-6/resources.html#qt-resource-collection-file). It can be used in [compile_resources](https://mesonbuild.com/Qt6-module.html#compile_resources) to files gnerated by a target in a Qt program.

W.I.P. until #14602 is fixed.