### PR TITLE
Make configuration accept unknown-but-maybe-valid-in-the-future options

### DIFF
--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1059,8 +1059,13 @@ class OptionStore:
     def set_option_maybe_root(self, o: OptionKey, new_value: str) -> bool:
         if o in self.options:
             return self.set_option(o, new_value)
-        o = o.as_root()
-        return self.set_option(o, new_value)
+        if self.accept_as_pending_option(o):
+            old_value = self.pending_options.get(o, None)
+            self.pending_options[o] = new_value
+            return old_value is None or str(old_value) == new_value
+        else:
+            o = o.as_root()
+            return self.set_option(o, new_value)
 
     def set_from_configure_command(self, D_args: T.List[str], U_args: T.List[str]) -> bool:
         dirty = False

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1056,11 +1056,7 @@ class OptionStore:
 
         return changed
 
-    def set_option_from_string(self, keystr: T.Union[OptionKey, str], new_value: str) -> bool:
-        if isinstance(keystr, OptionKey):
-            o = keystr
-        else:
-            o = OptionKey.from_string(keystr)
+    def set_option_maybe_root(self, o: OptionKey, new_value: str) -> bool:
         if o in self.options:
             return self.set_option(o, new_value)
         o = o.as_root()
@@ -1072,9 +1068,9 @@ class OptionStore:
         (global_options, perproject_global_options, project_options) = self.classify_D_arguments(D_args)
         U_args = [] if U_args is None else U_args
         for key, valstr in global_options:
-            dirty |= self.set_option_from_string(key, valstr)
+            dirty |= self.set_option_maybe_root(key, valstr)
         for key, valstr in project_options:
-            dirty |= self.set_option_from_string(key, valstr)
+            dirty |= self.set_option_maybe_root(key, valstr)
         for key, valstr in perproject_global_options:
             if key in self.augments:
                 if self.augments[key] != valstr:

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1057,6 +1057,9 @@ class OptionStore:
         return changed
 
     def set_option_maybe_root(self, o: OptionKey, new_value: str) -> bool:
+        if not self.is_cross and o.is_for_build():
+            return False
+
         if o in self.options:
             return self.set_option(o, new_value)
         if self.accept_as_pending_option(o):

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -203,6 +203,17 @@ class OptionTests(unittest.TestCase):
         value = optstore.get_default_for_b_option(OptionKey('b_vscrt'))
         self.assertEqual(value, 'from_buildtype')
 
+    def test_b_nonexistent(self):
+        optstore = OptionStore(False)
+        assert optstore.accept_as_pending_option(OptionKey('b_ndebug'))
+        assert not optstore.accept_as_pending_option(OptionKey('b_whatever'))
+
+    def test_subproject_nonexistent(self):
+        optstore = OptionStore(False)
+        subprojects = {'found'}
+        assert not optstore.accept_as_pending_option(OptionKey('foo', subproject='found'), subprojects)
+        assert optstore.accept_as_pending_option(OptionKey('foo', subproject='whatisthis'), subprojects)
+
     def test_deprecated_nonstring_value(self):
         # TODO: add a lot more deprecated option tests
         optstore = OptionStore(False)

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -208,6 +208,10 @@ class OptionTests(unittest.TestCase):
         assert optstore.accept_as_pending_option(OptionKey('b_ndebug'))
         assert not optstore.accept_as_pending_option(OptionKey('b_whatever'))
 
+    def test_reconfigure_b_nonexistent(self):
+        optstore = OptionStore(False)
+        optstore.set_from_configure_command(['b_ndebug=true'], [])
+
     def test_subproject_nonexistent(self):
         optstore = OptionStore(False)
         subprojects = {'found'}


### PR DESCRIPTION
This fixes #14615, which is reported as a 1.8.1 regression but was actually reproducible even  before with `meson configure` (instead of `meson setup --reconfigure`).

It's not trivial fix, though in the end the code becomes almost simpler. The crux of the issue is the disagreement between `OptionStore.validate_cmd_line_options`, `MesonApp.check_unused_options` and `OptionStore.set_option_from_string`. Place the desired semantics (mostly those from `check_unused_options`) in a new function so that the three share the same logic.

Fixes: #14615