### PR TITLE
CI: always install llvm for MSYS2

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -85,6 +85,7 @@ jobs:
             mingw-w64-${{ matrix.MSYS2_ARCH }}-python-pip
             mingw-w64-${{ matrix.MSYS2_ARCH }}-python-fastjsonschema
             mingw-w64-${{ matrix.MSYS2_ARCH }}-objfw
+            mingw-w64-${{ matrix.MSYS2_ARCH }}-llvm
             mingw-w64-${{ matrix.MSYS2_ARCH }}-${{ matrix.TOOLCHAIN }}
 
       - name: Install dependencies

--- a/test cases/frameworks/15 llvm/test.json
+++ b/test cases/frameworks/15 llvm/test.json
@@ -2,9 +2,9 @@
   "matrix": {
     "options": {
       "method": [
-        { "val": "config-tool", "expect_skip_on_jobname": ["msys2-gcc"] },
-        { "val": "cmake", "expect_skip_on_jobname": ["msys2-gcc"] },
-        { "val": "combination", "expect_skip_on_jobname": ["msys2-gcc"] }
+        { "val": "config-tool" },
+        { "val": "cmake" },
+        { "val": "combination" }
       ],
       "link-static": [
         { "val": true, "expect_skip_on_jobname": ["arch", "opensuse", "linux-gentoo-gcc"] },


### PR DESCRIPTION
Due to some recent package splits llvm is no longer installed when clang is installed and the meson test suite was depending on the transitive dependency.

Instead explicitly install llvm in all cases.