### PR TITLE
Add eld as default linker for Qualcomm Hexagon compiler

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -58,6 +58,7 @@ These are return values of the `get_linker_id` method in a compiler object.
 | Value      | Linker family                               |
 | -----      | ---------------                             |
 | ld.bfd     | The GNU linker                              |
+| ld.eld     | Qualcomm's embedded linker                  |
 | ld.gold    | The GNU gold linker                         |
 | ld.lld     | The LLVM linker, with the GNU interface     |
 | ld.mold    | The fast MOLD linker                        |

--- a/docs/markdown/snippets/eld-support.md
+++ b/docs/markdown/snippets/eld-support.md
@@ -1,0 +1,6 @@
+## Added Qualcomm's embedded linker, eld
+
+Qualcomm recently open-sourced their embedded linker.
+https://github.com/qualcomm/eld
+
+Meson users can now use this linker.

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -155,7 +155,10 @@ class ClangCompiler(GnuLikeCompiler):
         # llvm based) is retargetable, while GCC is not.
         #
 
-        # qcld: Qualcomm Snapdragon linker, based on LLVM
+        # eld: Qualcomm's opensource embedded linker
+        if linker == 'eld':
+            return ['-fuse-ld=eld']
+        # qcld: Qualcomm's deprecated linker
         if linker == 'qcld':
             return ['-fuse-ld=qcld']
         if linker == 'mold':

--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -166,6 +166,9 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
 
         linker = lld_cls(
             compiler, for_machine, comp_class.LINKER_PREFIX, override, system=system, version=v)
+    elif 'Hexagon' in o and 'LLVM' in o:
+        linker = linkers.ELDDynamicLinker(
+            compiler, for_machine, comp_class.LINKER_PREFIX, override, version=v)
     elif 'Snapdragon' in e and 'LLVM' in e:
         linker = linkers.QualcommLLVMDynamicLinker(
             compiler, for_machine, comp_class.LINKER_PREFIX, override, version=v)

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -1235,6 +1235,12 @@ class QualcommLLVMDynamicLinker(LLVMDynamicLinker):
 
     id = 'ld.qcld'
 
+class ELDDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, DynamicLinker):
+
+    """Qualcomm's opensource embedded linker"""
+
+    id = 'ld.eld'
+
 
 class NAGDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
 

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -5217,7 +5217,7 @@ class AllPlatformTests(BasePlatformTests):
         env = get_fake_env()
         cc = detect_c_compiler(env, MachineChoice.HOST)
         has_rsp = cc.linker.id in {
-            'ld.bfd', 'ld.gold', 'ld.lld', 'ld.mold', 'ld.qcld', 'ld.wasm',
+            'ld.bfd', 'ld.eld', 'ld.gold', 'ld.lld', 'ld.mold', 'ld.qcld', 'ld.wasm',
             'link', 'lld-link', 'mwldarm', 'mwldeppc', 'optlink', 'xilink',
         }
         self.assertEqual(cc.linker.get_accepts_rsp(), has_rsp)


### PR DESCRIPTION
Qualcomm opensourced their linker recently [https://github.com/qualcomm/eld](https://github.com/qualcomm/eld)
This PR sets eld as the default linker for Qualcomm's Hexagon compiler.