### PR TITLE
tests: don't skip frameworks/17 mpi for auto/pkgconfig

### DIFF
--- a/ci/ciimage/ubuntu-rolling/install.sh
+++ b/ci/ciimage/ubuntu-rolling/install.sh
@@ -69,7 +69,7 @@ rustup target add arm-unknown-linux-gnueabihf
 # Use the GitHub API to get the latest release information
 LATEST_RELEASE=$(wget -qO- "https://api.github.com/repos/ziglang/zig/releases/latest")
 ZIGVER=$(echo "$LATEST_RELEASE" | jq -r '.tag_name')
-ZIG_BASE="zig-linux-x86_64-$ZIGVER"
+ZIG_BASE="zig-x86_64-linux-$ZIGVER"
 wget "https://ziglang.org/download/$ZIGVER/$ZIG_BASE.tar.xz"
 tar xf "$ZIG_BASE.tar.xz"
 rm -rf "$ZIG_BASE.tar.xz"

--- a/test cases/frameworks/17 mpi/test.json
+++ b/test cases/frameworks/17 mpi/test.json
@@ -2,10 +2,8 @@
   "matrix": {
     "options": {
       "method": [
-        { "val": "auto",
-          "expect_skip_on_jobname": ["ubuntu"] },
-        { "val": "pkg-config",
-          "expect_skip_on_jobname": ["ubuntu"] },
+        { "val": "auto" },
+        { "val": "pkg-config" },
         { "val": "config-tool",
           "expect_skip_on_jobname": ["fedora"] },
         {


### PR DESCRIPTION
This is fixed in Ubuntu rolling now and Bionic wasn't affected to
begin with.

Bug: https://bugs.debian.org/1078026