### PR TITLE
gnome: initialize CFLAGS environment variable to linker arguments

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1168,7 +1168,7 @@ class GnomeModule(ExtensionModule):
         scan_cflags += list(self._get_scanner_cflags(self._get_external_args_for_langs(state, [lc[0] for lc in langs_compilers])))
         scan_internal_ldflags = []
         scan_external_ldflags = []
-        scan_env_ldflags = []
+        scan_env_ldflags = state.environment.coredata.get_external_link_args(MachineChoice.HOST, 'c')
         for cli_flags, env_flags in (self._get_scanner_ldflags(internal_ldflags), self._get_scanner_ldflags(dep_internal_ldflags)):
             scan_internal_ldflags += cli_flags
             scan_env_ldflags += env_flags

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1171,10 +1171,10 @@ class GnomeModule(ExtensionModule):
         scan_env_ldflags = []
         for cli_flags, env_flags in (self._get_scanner_ldflags(internal_ldflags), self._get_scanner_ldflags(dep_internal_ldflags)):
             scan_internal_ldflags += cli_flags
-            scan_env_ldflags = env_flags
+            scan_env_ldflags += env_flags
         for cli_flags, env_flags in (self._get_scanner_ldflags(external_ldflags), self._get_scanner_ldflags(dep_external_ldflags)):
             scan_external_ldflags += cli_flags
-            scan_env_ldflags = env_flags
+            scan_env_ldflags += env_flags
         girtargets_inc_dirs = self._get_gir_targets_inc_dirs(girtargets)
         inc_dirs = kwargs['include_directories']
 


### PR DESCRIPTION
The CFLAGS environment variable is used for g-ir-scanner's linking pass. It is emptied since commit 237513dff ("modules/gnome, modules/Python: Allow injecting RPATH flags through LDFLAGS if needed", 2025-04-09); which could even be considered a bugfix if it didn't break Fedora quite badly.

I could not write a testcase, but the culprit seems to be the -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 that Fedora places in CFLAGS.  The file contains
    
```
*cc1_options:
+ %{!r:%{!fpie:%{!fPIE:%{!fpic:%{!fPIC:%{!fno-pic:-fPIE}}}}}}
```
    
and the lack of `-fPIE` option when the specs file is left out upsets the linker.  Fix by priming the contents of the CFLAGS variable with the `c_link_args` being used for the build.

Fixes: #14631 