### PR TITLE
Vala: Fix GResource source directories

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1776,7 +1776,7 @@ class NinjaBackend(backends.Backend):
                 gres_xml, = self.get_custom_target_sources(gensrc)
                 args += ['--gresources=' + gres_xml]
                 for source_dir in gensrc.source_dirs:
-                    gres_dirs += [os.path.join(self.get_target_dir(gensrc), source_dir)]
+                    gres_dirs += [source_dir]
                 # Ensure that resources are built before vala sources
                 # This is required since vala code using [GtkTemplate] effectively depends on .ui files
                 # GResourceHeaderTarget is not suitable due to lacking depfile

--- a/test cases/vala/31 generated ui file subdirectory/meson.build
+++ b/test cases/vala/31 generated ui file subdirectory/meson.build
@@ -1,0 +1,22 @@
+project('demo', 'c', 'vala')
+
+gnome = import('gnome', required: false)
+
+if not gnome.found()
+  error('MESON_SKIP_TEST: gnome module not supported')
+endif
+
+deps = [
+  dependency('glib-2.0', version : '>=2.50'),
+  dependency('gobject-2.0'),
+  dependency('gtk+-3.0'),
+]
+
+subdir('subdir')
+
+executable(
+  'demo',
+  'test.vala',
+  resources,
+  dependencies: deps,
+)

--- a/test cases/vala/31 generated ui file subdirectory/subdir/TestBox.ui.in
+++ b/test cases/vala/31 generated ui file subdirectory/subdir/TestBox.ui.in
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk" version="3.0"/>
+  <template class="TestBox" parent="GtkBox">
+  </template>
+</interface>

--- a/test cases/vala/31 generated ui file subdirectory/subdir/meson.build
+++ b/test cases/vala/31 generated ui file subdirectory/subdir/meson.build
@@ -1,0 +1,13 @@
+ui_tgt = custom_target(
+  input: 'TestBox.ui.in',
+  output:  'TestBox.ui',
+  command: [find_program('cat')],
+  feed: true,
+  capture: true,
+)
+
+resources = gnome.compile_resources('test-resources',
+  'test.gresource.xml',
+  c_name: 'test_res',
+  dependencies: ui_tgt,
+)

--- a/test cases/vala/31 generated ui file subdirectory/subdir/test.gresource.xml
+++ b/test cases/vala/31 generated ui file subdirectory/subdir/test.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/com/mesonbuild/test">
+    <file>TestBox.ui</file>
+  </gresource>
+</gresources>

--- a/test cases/vala/31 generated ui file subdirectory/test.vala
+++ b/test cases/vala/31 generated ui file subdirectory/test.vala
@@ -1,0 +1,7 @@
+[GtkTemplate (ui = "/com/mesonbuild/test/TestBox.ui")]
+class TestBox: Gtk.Box {
+}
+
+int main() {
+    return 0;
+}


### PR DESCRIPTION
The code that adds `--gresourcesdir=` arguments to valac based on the source directories of GResource dependencies was incorrect. It added the current target directory to the source path, but the GResource source directories are already relative to the build directory.

Fixes #14646.