### PR TITLE
cargo: set edition for build machine as well

### DIFF
--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -608,6 +608,7 @@ class Interpreter:
         """
         default_options: T.List[mparser.BaseNode] = []
         default_options.append(build.string(f'rust_std={pkg.manifest.package.edition}'))
+        default_options.append(build.string(f'build.rust_std={pkg.manifest.package.edition}'))
         if pkg.downloaded:
             default_options.append(build.string('warning_level=0'))
 


### PR DESCRIPTION
@xclaesse, this is a trivial fix for compilation of glib-macros-0.20.4:

```
error[E0405]: cannot find trait `TryFrom` in this scope
  --> ../subprojects/glib-macros-0.20.4/src/clone.rs:22:10
   |
22 | impl<'a> TryFrom<&'a Ident> for CaptureKind {
   |          ^^^^^^^ not found in this scope
   |
   = note: 'std::convert::TryFrom' is included in the prelude starting in Edition 2021
help: consider importing this trait
   |
3  + use std::convert::TryFrom;
   |
```