### PR TITLE
cargo: reintroduce feature options, as a means to provide input for the interpreter

### DIFF
--- a/docs/markdown/Wrap-dependency-system-manual.md
+++ b/docs/markdown/Wrap-dependency-system-manual.md
@@ -362,6 +362,26 @@ Some naming conventions need to be respected:
 - The `extra_deps` variable is pre-defined and can be used to add extra dependencies.
   This is typically used as `extra_deps += dependency('foo')`.
 
+Cargo features are exposed as Meson boolean options, with the `feature-` prefix.
+This can be used to request features with `dependency('foo', default_options: '...')`.
+
+Currently, Meson is able to manage the set of enabled features for all crates found by a
+single invocation of `dependency()`, but not globally. Let's assume
+the main project depends on `foo-1-rs` and `bar-1-rs`, and they both depend on
+`common-1-rs`. The main project will first look up `foo-1-rs` which itself will
+configure `common-rs` with a set of features. Later, when `bar-1-rs` does a lookup
+for `common-1-rs` it has already been configured and the set of features cannot be
+changed. If `bar-1-rs` wants extra features from `common-1-rs`, Meson will error out.
+It is currently the responsibility of the main project to resolve those
+issues by enabling extra features on each subproject:
+```meson
+project(...,
+  default_options: {
+    'common-1-rs:feature-something': true,
+  },
+)
+```
+
 Since *1.5.0* Cargo wraps can also be provided with `Cargo.lock` file at the root
 of (sub)project source tree. Meson will automatically load that file and convert
 it into a series of wraps definitions.

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -23,7 +23,8 @@ import typing as T
 from . import builder
 from . import version
 from ..mesonlib import MesonException, Popen_safe
-from .. import coredata, mlog
+from ..options import OptionKey
+from .. import coredata, mlog, options
 from ..wrap.wrap import PackageDefinition
 
 if T.TYPE_CHECKING:
@@ -450,6 +451,14 @@ def _dependency_varname(package_name: str) -> str:
     return f'{fixup_meson_varname(package_name)}_dep'
 
 
+_OPTION_NAME_PREFIX = 'feature-'
+
+
+def _option_name(feature: str) -> str:
+    # Add a prefix to avoid collision with Meson reserved options (e.g. "debug")
+    return _OPTION_NAME_PREFIX + feature
+
+
 def _extra_args_varname() -> str:
     return 'extra_args'
 
@@ -481,7 +490,7 @@ class Interpreter:
         # Map of cargo package (name + api) to its state
         self.packages: T.Dict[PackageKey, PackageState] = {}
 
-    def interpret(self, subdir: str) -> mparser.CodeBlockNode:
+    def interpret(self, subp_name: str, subdir: str, default_options: OptionDict) -> T.Tuple[mparser.CodeBlockNode, T.Dict[OptionKey, options.UserOption]]:
         manifest = self._load_manifest(subdir)
         pkg, cached = self._fetch_package(manifest.package.name, manifest.package.api)
         if not cached:
@@ -489,15 +498,53 @@ class Interpreter:
             # FIXME: We should have a Meson option similar to `cargo build --no-default-features`
             self._enable_feature(pkg, 'default')
 
+        # default_options -> features
+        for key in default_options.keys():
+            if key.name.startswith(_OPTION_NAME_PREFIX) and default_options[key] == True:
+                self._enable_feature(pkg, key.name[len(_OPTION_NAME_PREFIX):])
+
+        # features -> default_options
+        for f in pkg.features:
+            key = OptionKey(_option_name(f))
+            default_options[key] = True
+
         # Build an AST for this package
         filename = os.path.join(self.environment.source_dir, subdir, 'Cargo.toml')
         build = builder.Builder(filename)
         ast = self._create_project(pkg, build)
+
+        # features = []
+        # features_args = []
+        ast += [
+            build.assign(build.array([]), 'features'),
+            build.assign(build.array([]), 'features_args')]
+
+        project_options: T.Dict[OptionKey, options.UserOption] = {}
+        for f in itertools.chain(pkg.manifest.dependencies.keys(), pkg.manifest.features.keys()):
+            if f == 'default':
+                continue
+
+            # option('f1', type: 'boolean', value: true/false, description: 'Cargo feature f1')
+            key = OptionKey(_option_name(f), subproject=subp_name)
+            project_options[key] = options.UserBooleanOption(key.name, f'Cargo feature {f}', False)
+
+            # if get_option('feature-f1')
+            #   features_args += ['--cfg', 'feature="f1"']
+            #   features += ['--f1']
+            # endif
+            lines = [
+                build.plusassign(build.array([build.string('--cfg'), build.string(f'feature="{f}"')]),
+                                 'features_args'),
+                build.plusassign(build.array([build.string(f)]),
+                                 'features')]
+
+            ast.append(build.if_(build.function('get_option', [build.string(_option_name(f))]), build.block(lines)))
+
         ast += [
             build.assign(build.function('import', [build.string('rust')]), 'rust'),
             build.function('message', [
                 build.string('Enabled features:'),
-                build.array([build.string(f) for f in pkg.features]),
+                build.method('join', build.string(','), [build.identifier('features')])
             ]),
         ]
         ast += self._create_dependencies(pkg, build)
@@ -509,7 +556,7 @@ class Interpreter:
             for crate_type in pkg.manifest.lib.crate_type:
                 ast.extend(self._create_lib(pkg, build, crate_type))
 
-        return build.block(ast)
+        return build.block(ast), project_options
 
     def _fetch_package(self, package_name: str, api: str) -> T.Tuple[PackageState, bool]:
         key = PackageKey(package_name, api)
@@ -670,8 +717,14 @@ class Interpreter:
 
     def _create_dependency(self, dep: Dependency, build: builder.Builder) -> T.List[mparser.BaseNode]:
         pkg = self._dep_package(dep)
+
+        # { 'feature-f1': true }
+        options = build.dict({build.string(f'feature-{f}'): build.bool(True)
+                              for f in pkg.features})
+
         kw = {
             'version': build.array([build.string(s) for s in dep.version]),
+            'default_options': options,
         }
         # Lookup for this dependency with the features we want in default_options kwarg.
         #
@@ -714,7 +767,7 @@ class Interpreter:
             #     error()
             #   endif
             # endforeach
-            build.assign(build.array([build.string(f) for f in pkg.features]), 'needed_features'),
+            build.assign(build.array([build.string(f) for f in pkg.features if f != 'default']), 'needed_features'),
             build.foreach(['f'], build.identifier('needed_features'), build.block([
                 build.if_(build.not_in(build.identifier('f'), build.identifier('actual_features')), build.block([
                     build.function('error', [
@@ -794,16 +847,10 @@ class Interpreter:
                 kwargs['rust_abi'] = build.string('c')
             lib = build.function(target_type, posargs, kwargs)
 
-        features_args: T.List[mparser.BaseNode] = []
-        for f in pkg.features:
-            features_args += [build.string('--cfg'), build.string(f'feature="{f}"')]
-
-        # features_args = ['--cfg', 'feature="f1"', ...]
         # lib = xxx_library()
         # dep = declare_dependency()
         # meson.override_dependency()
         return [
-            build.assign(build.array(features_args), 'features_args'),
             build.assign(lib, 'lib'),
             build.assign(
                 build.function(
@@ -811,7 +858,7 @@ class Interpreter:
                     kw={
                         'link_with': build.identifier('lib'),
                         'variables': build.dict({
-                            build.string('features'): build.string(','.join(pkg.features)),
+                            build.string('features'): build.method('join', build.string(','), [build.identifier('features')]),
                         })
                     },
                 ),

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1052,7 +1052,8 @@ class Interpreter(InterpreterBase, HoldableObject):
         if self.environment.cargo is None:
             self.environment.cargo = cargo.Interpreter(self.environment)
         with mlog.nested(subp_name):
-            ast = self.environment.cargo.interpret(subdir)
+            ast, options = self.environment.cargo.interpret(subp_name, subdir, default_options)
+            self.coredata.optstore.update_project_options(options, subp_name)
             return self._do_subproject_meson(
                 subp_name, subdir, default_options, kwargs, ast,
                 # FIXME: Are there other files used by cargo interpreter?


### PR DESCRIPTION
Without feature options there is no way for the superproject to reconcile differences between different invocations of `dependency()`. Until something along the lines of #14639 is completed, this makes it almost impossible to rely on Meson's Cargo interpreter when you have more than one `dependency()` using Cargo subprojects.

Reintroduce feature options as they were before afd89440a ("cargo: Fix feature resolution", Meson 1.7.0). However, the Cargo interpreter also "complete" the default_options provided by `_do_subproject_cargo()` with all the features that were enabled via Cargo.toml. This is also useful for the `meson/meson.build` files, which now have access to the set of enabled features.

Note however that the generated `meson.build` file is *not* independent of enabled features, because it still hardcodes the list of dependencies.