### PR TITLE
cargo: Add global features options

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -460,3 +460,10 @@ all.
 *Since 1.3.0* The `python.allow_limited_api` option affects whether the
 `limited_api` keyword argument of the `extension_module` method is respected.
 If set to `false`, the effect of the `limited_api` argument is disabled.
+
+### Rust module
+
+| Option                    | Default value | Possible values      | Description |
+| ------                    | ------------- | -----------------    | ----------- |
+| cargo_features            | []            | comma-separated list | List of Cargo features to enable (e.g. "foo,mystuff/bar") (Since 1.9.0) |
+| cargo_no_default_features | false         | true, false          | Whether to disable default features (Since 1.9.0) |

--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -168,3 +168,20 @@ Only a subset of [[shared_library]] keyword arguments are allowed:
 - link_depends
 - link_with
 - override_options
+
+### add_cargo_features()
+
+```meson
+rustmod.add_cargo_features('f1', ...)
+```
+
+*Since 1.9.0*
+
+Enable features on cargo subprojects, in addition to features enabled by the
+user with `-Drust.cargo_features=f1,...` option.
+
+The `'package-name/feature'` syntax can be used to enable a feature only on a
+specific crate.
+
+This method cannot be called after the first cargo subproject has been
+invoked, usually via a `dependency()` fallback.

--- a/docs/markdown/Wrap-dependency-system-manual.md
+++ b/docs/markdown/Wrap-dependency-system-manual.md
@@ -361,6 +361,8 @@ Some naming conventions need to be respected:
   This is typically used as `extra_args += ['--cfg', 'foo']`.
 - The `extra_deps` variable is pre-defined and can be used to add extra dependencies.
   This is typically used as `extra_deps += dependency('foo')`.
+- The `features` variable is pre-defined and contains the list of features enabled
+  on this crate.
 
 Since *1.5.0* Cargo wraps can also be provided with `Cargo.lock` file at the root
 of (sub)project source tree. Meson will automatically load that file and convert

--- a/docs/markdown/snippets/rust-feature-options.md
+++ b/docs/markdown/snippets/rust-feature-options.md
@@ -1,0 +1,6 @@
+## cargo: Add global features options
+- Add rust.add_cargo_features() method to add features from meson.build.
+  It is similar to add_global_arguments(), we can add global cargo
+  features until it is first used.
+- Add rust.cargo_features and rust.cargo_no_default_features CLI options
+  to allow the user to add extra features.

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -500,9 +500,10 @@ class Interpreter:
         ast = self._create_project(pkg, build)
         ast += [
             build.assign(build.function('import', [build.string('rust')]), 'rust'),
+            build.assign(build.array([build.string(f) for f in pkg.features]), 'features'),
             build.function('message', [
                 build.string('Enabled features:'),
-                build.array([build.string(f) for f in pkg.features]),
+                build.identifier('features'),
             ]),
         ]
         ast += self._create_dependencies(pkg, build)

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -744,6 +744,10 @@ BUILTIN_CORE_OPTIONS: T.Mapping[OptionKey, AnyOptionType] = {
         UserStringOption('python.platlibdir', 'Directory for site-specific, platform-specific files.', ''),
         UserStringOption('python.purelibdir', 'Directory for site-specific, non-platform-specific files.', ''),
         UserBooleanOption('python.allow_limited_api', 'Whether to allow use of the Python Limited API', True),
+
+        # Rust module
+        UserStringArrayOption('rust.cargo_features', 'List of Cargo features to enable (e.g. "foo,mystuff/bar")', []),
+        UserBooleanOption('rust.cargo_no_default_features', 'Whether to disable default features', False),
     ])
 }
 
@@ -897,6 +901,30 @@ class OptionStore:
             key = name
         vobject, resolved_value = self.get_value_object_and_value_for(key)
         return resolved_value
+
+    def get_str_for(self, name: 'T.Union[OptionKey, str]', subproject: T.Optional[str] = None) -> str:
+        value = self.get_value_for(name, subproject)
+        if not isinstance(value, str):
+            raise MesonException(f'Option "{name}" is not a string, it is {value!r}.')
+        return value
+
+    def get_int_for(self, name: 'T.Union[OptionKey, str]', subproject: T.Optional[str] = None) -> int:
+        value = self.get_value_for(name, subproject)
+        if not isinstance(value, int):
+            raise MesonException(f'Option "{name}" is not an integer, it is {value!r}.')
+        return value
+
+    def get_bool_for(self, name: 'T.Union[OptionKey, str]', subproject: T.Optional[str] = None) -> bool:
+        value = self.get_value_for(name, subproject)
+        if not isinstance(value, bool):
+            raise MesonException(f'Option "{name}" is not a boolean, it is {value!r}.')
+        return value
+
+    def get_string_list_for(self, name: 'T.Union[OptionKey, str]', subproject: T.Optional[str] = None) -> T.List[str]:
+        value = self.get_value_for(name, subproject)
+        if not isinstance(value, list):
+            raise MesonException(f'Option "{name}" is not a list, it is {value!r}.')
+        return value
 
     def add_system_option(self, key: T.Union[OptionKey, str], valobj: AnyOptionType) -> None:
         key = self.ensure_and_validate_key(key)

--- a/test cases/rust/28 cargo features option/meson.build
+++ b/test cases/rust/28 cargo features option/meson.build
@@ -1,0 +1,12 @@
+project('cargo features options')
+
+rust = import('rust')
+rust.add_cargo_features('f1')
+
+# We should only have f1 and f2, see test.json.
+d = dependency('foo-1-rs')
+features = d.get_variable('features').split(',')
+assert(features.length() == 2)
+assert('f1' in features)
+assert('f2' in features)
+

--- a/test cases/rust/28 cargo features option/subprojects/foo-1-rs.wrap
+++ b/test cases/rust/28 cargo features option/subprojects/foo-1-rs.wrap
@@ -1,0 +1,2 @@
+[wrap-file]
+method = cargo

--- a/test cases/rust/28 cargo features option/subprojects/foo-1-rs/Cargo.toml
+++ b/test cases/rust/28 cargo features option/subprojects/foo-1-rs/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "foo"
+version = "1"

--- a/test cases/rust/28 cargo features option/subprojects/foo-1-rs/src/lib.rs
+++ b/test cases/rust/28 cargo features option/subprojects/foo-1-rs/src/lib.rs
@@ -1,0 +1,1 @@
+pub const VALUE: i32 = 0;

--- a/test cases/rust/28 cargo features option/test.json
+++ b/test cases/rust/28 cargo features option/test.json
@@ -1,0 +1,12 @@
+{
+  "matrix": {
+    "options": {
+      "rust.cargo_features": [
+        { "val": "f2" }
+      ],
+      "rust.cargo_no_default_features": [
+        { "val": true }
+      ]
+    }
+  }
+}

--- a/unittests/datatests.py
+++ b/unittests/datatests.py
@@ -118,7 +118,7 @@ class DataTests(unittest.TestCase):
         mod_subcontents = []
         content = self._get_section_content("Module options", sections, md)
         subsections = tee(re.finditer(r"^### (.+)$", content, re.MULTILINE))
-        for idx, mod in enumerate(['Pkgconfig', 'Python']):
+        for idx, mod in enumerate(['Pkgconfig', 'Python', 'Rust']):
             mod_subcontents.append(self._get_section_content(f'{mod} module', subsections[idx], content))
         for subcontent in u_subcontents + mod_subcontents:
             # Find the option names


### PR DESCRIPTION
- Add rust.add_cargo_features() method to add features from meson.build.
  It is similar to add_global_arguments(), we can add global cargo
  features until it is first used.
- Add rust.cargo_features and rust.cargo_no_default_features CLI options
  to allow the user to add extra features.
