### PR TITLE
ci: Fix cross-cuda action

### DIFF
--- a/.github/workflows/nonnative.yml
+++ b/.github/workflows/nonnative.yml
@@ -58,5 +58,6 @@ jobs:
     env:
       MESON_CI_JOBNAME: cuda-cross-${{ github.job }}
     steps:
+    - uses: actions/checkout@v4
     - name: Run tests
       run: bash -c 'source /ci/env_vars.sh; cd $GITHUB_WORKSPACE; ./run_tests.py $CI_ARGS --cross cuda-cross.json --cross-only'


### PR DESCRIPTION
I have added cuda-cross tests in https://github.com/mesonbuild/meson/pull/14612
This test seem to be broken at the moment this PR is meant to fix that.