### PR TITLE
backends: do not look at compilers prior to generate()

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -500,11 +500,6 @@ class NinjaBackend(backends.Backend):
         # - https://github.com/mesonbuild/meson/pull/9453
         # - https://github.com/mesonbuild/meson/issues/9479#issuecomment-953485040
         self.allow_thin_archives = PerMachine[bool](True, True)
-        if self.environment:
-            for for_machine in MachineChoice:
-                if 'cuda' in self.environment.coredata.compilers[for_machine]:
-                    mlog.debug('cuda enabled globally, disabling thin archives for {}, since nvcc/nvlink cannot handle thin archives natively'.format(for_machine))
-                    self.allow_thin_archives[for_machine] = False
 
     def create_phony_target(self, dummy_outfile: str, rulename: str, phony_infilename: str) -> NinjaBuildElement:
         '''
@@ -595,6 +590,12 @@ class NinjaBackend(backends.Backend):
             # We don't yet have a use case where we'd expect to make use of this,
             # so no harm in catching and reporting something unexpected.
             raise MesonBugException('We do not expect the ninja backend to be given a valid \'vslite_ctx\'')
+        if self.environment:
+            for for_machine in MachineChoice:
+                if 'cuda' in self.environment.coredata.compilers[for_machine]:
+                    mlog.debug('cuda enabled globally, disabling thin archives for {}, since nvcc/nvlink cannot handle thin archives natively'.format(for_machine))
+                    self.allow_thin_archives[for_machine] = False
+
         ninja = environment.detect_ninja_command_and_version(log=True)
         if self.environment.coredata.optstore.get_value_for(OptionKey('vsenv')):
             builddir = Path(self.environment.get_build_dir())

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -147,6 +147,9 @@ class Vs2010Backend(backends.Backend):
         self.handled_target_deps = {}
         self.gen_lite = gen_lite  # Synonymous with generating the simpler makefile-style multi-config projects that invoke 'meson compile' builds, avoiding native MSBuild complications
 
+    def detect_toolset(self) -> None:
+        pass
+
     def get_target_private_dir(self, target):
         return os.path.join(self.get_target_dir(target), target.get_id())
 
@@ -227,6 +230,7 @@ class Vs2010Backend(backends.Backend):
         # Check for (currently) unexpected capture arg use cases -
         if capture:
             raise MesonBugException('We do not expect any vs backend to generate with \'capture = True\'')
+        self.detect_toolset()
         host_machine = self.environment.machines.host.cpu_family
         if host_machine in {'64', 'x86_64'}:
             # amd64 or x86_64

--- a/mesonbuild/backend/vs2012backend.py
+++ b/mesonbuild/backend/vs2012backend.py
@@ -21,6 +21,8 @@ class Vs2012Backend(Vs2010Backend):
         self.vs_version = '2012'
         self.sln_file_version = '12.00'
         self.sln_version_comment = '2012'
+
+    def detect_toolset(self) -> None:
         if self.environment is not None:
             # TODO: we assume host == build
             comps = self.environment.coredata.compilers.host

--- a/mesonbuild/backend/vs2013backend.py
+++ b/mesonbuild/backend/vs2013backend.py
@@ -20,6 +20,8 @@ class Vs2013Backend(Vs2010Backend):
         self.vs_version = '2013'
         self.sln_file_version = '12.00'
         self.sln_version_comment = '2013'
+
+    def detect_toolset(self) -> None:
         if self.environment is not None:
             # TODO: we assume host == build
             comps = self.environment.coredata.compilers.host

--- a/mesonbuild/backend/vs2015backend.py
+++ b/mesonbuild/backend/vs2015backend.py
@@ -21,6 +21,8 @@ class Vs2015Backend(Vs2010Backend):
         self.vs_version = '2015'
         self.sln_file_version = '12.00'
         self.sln_version_comment = '14'
+
+    def detect_toolset(self) -> None:
         if self.environment is not None:
             # TODO: we assume host == build
             comps = self.environment.coredata.compilers.host

--- a/mesonbuild/backend/vs2017backend.py
+++ b/mesonbuild/backend/vs2017backend.py
@@ -24,6 +24,8 @@ class Vs2017Backend(Vs2010Backend):
         self.vs_version = '2017'
         self.sln_file_version = '12.00'
         self.sln_version_comment = '15'
+
+    def detect_toolset(self) -> None:
         # We assume that host == build
         if self.environment is not None:
             comps = self.environment.coredata.compilers.host

--- a/mesonbuild/backend/vs2019backend.py
+++ b/mesonbuild/backend/vs2019backend.py
@@ -22,6 +22,8 @@ class Vs2019Backend(Vs2010Backend):
         super().__init__(build, interpreter)
         self.sln_file_version = '12.00'
         self.sln_version_comment = 'Version 16'
+
+    def detect_toolset(self) -> None:
         if self.environment is not None:
             comps = self.environment.coredata.compilers.host
             if comps and all(c.id == 'clang-cl' for c in comps.values()):

--- a/mesonbuild/backend/vs2022backend.py
+++ b/mesonbuild/backend/vs2022backend.py
@@ -22,6 +22,8 @@ class Vs2022Backend(Vs2010Backend):
         super().__init__(build, interpreter, gen_lite=gen_lite)
         self.sln_file_version = '12.00'
         self.sln_version_comment = 'Version 17'
+
+    def detect_toolset(self) -> None:
         if self.environment is not None:
             comps = self.environment.coredata.compilers.host
             if comps and all(c.id == 'clang-cl' for c in comps.values()):


### PR DESCRIPTION
This should fix #14668, a regression in 1.8.1.