### PR TITLE
AstInterpreter: Fix crash when dead code references variables that are never assigned

### DIFF
--- a/mesonbuild/interpreterbase/__init__.py
+++ b/mesonbuild/interpreterbase/__init__.py
@@ -61,6 +61,7 @@ __all__ = [
     'HoldableTypes',
 
     'UnknownValue',
+    'UndefinedVariable',
 ]
 
 from .baseobjects import (
@@ -85,6 +86,7 @@ from .baseobjects import (
     HoldableTypes,
 
     UnknownValue,
+    UndefinedVariable,
 )
 
 from .decorators import (

--- a/mesonbuild/interpreterbase/baseobjects.py
+++ b/mesonbuild/interpreterbase/baseobjects.py
@@ -127,6 +127,10 @@ class UnknownValue(MesonInterpreterObject):
     limitations in our code or because the value differs from machine to
     machine.'''
 
+class UndefinedVariable(MesonInterpreterObject):
+    '''This class is only used for the rewriter/static introspection tool and
+    represents the `value` a meson-variable has if it was never written to.'''
+
 HoldableTypes = (HoldableObject, int, bool, str, list, dict)
 TYPE_HoldableTypes = T.Union[TYPE_var, HoldableObject]
 InterpreterObjectTypeVar = T.TypeVar('InterpreterObjectTypeVar', bound=TYPE_HoldableTypes)

--- a/test cases/rewrite/7 tricky dataflow/addSrc.json
+++ b/test cases/rewrite/7 tricky dataflow/addSrc.json
@@ -68,5 +68,10 @@
         "type": "target",
         "target": "tgt6",
         "operation": "info"
+    },
+    {
+        "type": "target",
+        "target": "tgt7",
+        "operation": "info"
     }
 ]

--- a/test cases/rewrite/7 tricky dataflow/info.json
+++ b/test cases/rewrite/7 tricky dataflow/info.json
@@ -28,5 +28,10 @@
         "type": "target",
         "target": "tgt6",
         "operation": "info"
+    },
+    {
+        "type": "target",
+        "target": "tgt7",
+        "operation": "info"
     }
 ]

--- a/test cases/rewrite/7 tricky dataflow/meson.build
+++ b/test cases/rewrite/7 tricky dataflow/meson.build
@@ -33,3 +33,9 @@ dont_add_here_6 = ['foo.c']
 gen = generator(find_program('cp'), output: '@BASENAME@_copy.c', arguments: ['@INPUT@', '@OUTPUT@'])
 generated = gen.process(dont_add_here_6)
 executable('tgt6', generated)
+
+if false
+    # Should produce a warning, but should not crash
+    var = not_defined_1
+    executable('tgt7', not_defined_2, var)
+endif

--- a/test cases/unit/120 rewrite/meson.build
+++ b/test cases/unit/120 rewrite/meson.build
@@ -190,5 +190,11 @@ if a \
   debug('help!')
 endif
 
+if false
+  # Should produce a warning, but should not crash
+  foo = not_defined
+  message(not_defined)
+endif
+
 
 # End of file comment with no linebreak

--- a/unittests/rewritetests.py
+++ b/unittests/rewritetests.py
@@ -439,6 +439,7 @@ class RewriterTests(BasePlatformTests):
                 'tgt4@exe': {'name': 'tgt4', 'sources': ['unknown'], 'extra_files': []},
                 'tgt5@exe': {'name': 'tgt5', 'sources': ['unknown', 'new.c'], 'extra_files': []},
                 'tgt6@exe': {'name': 'tgt6', 'sources': ['unknown', 'new.c'], 'extra_files': []},
+                'tgt7@exe': {'name': 'tgt7', 'sources': ['unknown', 'unknown'], 'extra_files': []},
             }
         }
         self.assertEqualIgnoreOrder(out, expected)


### PR DESCRIPTION
Without this PR, the rewriter and the static introspection tool crash if `meson.build` contains something like
```meson
if false
  foo = not_defined
endif
```
or
```meson
if false
  message(not_defined)
endif
```
While it could be argued, that you should not write stuff like this, it raises a `MesonBugException` without this PR, which we have to fix.

Fixes #14667