### PR TITLE
deprecate variable substitution with boolean values

### DIFF
--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -1266,6 +1266,9 @@ def do_replacement_meson(regex: T.Pattern[str], line: str,
                 if isinstance(var, str):
                     var_str = var
                 elif isinstance(var, int):
+                    if isinstance(var, bool):
+                        msg = f'Variable substitution with boolean value {varname!r} is deprecated.'
+                        mlog.deprecation(msg)
                     var_str = str(var)
                 else:
                     msg = f'Tried to replace variable {varname!r} value with ' \


### PR DESCRIPTION
in python boolean subclasses integer so `isinstance(True, int)` passes
this has the unintended side-effect of inserting `True` and `False` during preprocessing.

Raising an exception would break backwards compatibility and could harm projects that make use of this.

Message can very likely be improved.