### PR TITLE
Add `qt6.find_tool`

### DIFF
--- a/docs/markdown/Qt6-module.md
+++ b/docs/markdown/Qt6-module.md
@@ -164,6 +164,22 @@ This method takes the following keyword arguments:
   are `moc`, `uic`, `rcc` and `lrelease`. By default `tools` is set to `['moc',
   'uic', 'rcc', 'lrelease']`
 
+## find_tool
+
+*New in 1.9.0*
+
+This method returns an [external program](Reference-manual_returned_external_program.md) of the given tool.
+It can be used with e.g. [run_command](Reference-manual_functions.md#run_command)
+or [custom_target](Reference-manual_functions.md#custom_target).
+
+This function requires one positional argument: the tool name.
+
+This function takes the following keyword arguments:
+- `required` bool | FeatureOption: by default, `required` is set to `false`. If `required` is set to
+  `true` or an enabled [`feature`](Build-options.md#features) and the tool is
+  missing Meson will abort.
+- `method` string: The method to use to detect Qt, see [[dependency]]
+
 ## qml_module
 
 *New in 1.7.0*

--- a/mesonbuild/modules/_qt.py
+++ b/mesonbuild/modules/_qt.py
@@ -178,6 +178,10 @@ if T.TYPE_CHECKING:
         install_dir: str
         install: bool
 
+    class FindToolKwArgs(kwargs.ExtractRequired):
+
+        method: str
+
 def _list_in_set_validator(choices: T.Set[str]) -> T.Callable[[T.List[str]], T.Optional[str]]:
     """Check that the choice given was one of the given set."""
     def inner(checklist: T.List[str]) -> T.Optional[str]:
@@ -219,6 +223,7 @@ class QtBaseModule(ExtensionModule):
             'compile_ui': self.compile_ui,
             'compile_moc': self.compile_moc,
             'qml_module': self.qml_module,
+            'find_tool': self.find_tool,
         })
 
     def compilers_detect(self, state: ModuleState, qt_dep: QtDependencyType) -> None:
@@ -1170,3 +1175,28 @@ class QtBaseModule(ExtensionModule):
             output.extend(self._compile_resources_impl(state, compile_resource_kwargs))
 
         return ModuleReturnValue(output, [output])
+
+
+    @FeatureNew('qt.find_tool', '1.9')
+    @typed_pos_args('qt.find_tool', str)
+    @typed_kwargs(
+        'qt.find_tool',
+        KwargInfo('required', (bool, options.UserFeatureOption), default=True),
+        KwargInfo('method', str, default='auto'),
+    )
+    def find_tool(self, state: ModuleState, args: T.Tuple, kwargs: FindToolKwArgs) -> T.Union[ExternalProgram, build.Executable]:
+        self._detect_tools(state, kwargs['method'])
+
+        tool_name: str = args[0]
+
+        if tool_name not in self.tools:
+            m = 'Unknwon Qt tool {!r}'
+            raise MesonException(m.format(tool_name))
+
+        tool = self.tools[tool_name]
+
+        if not tool.found() and kwargs['required']:
+            m = 'Qt tool {!r} not found'
+            raise MesonException(m.format(tool_name))
+
+        return self.tools[tool_name]

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -177,5 +177,6 @@ foreach qt : ['qt4', 'qt5', 'qt6']
     accept_versions = ['>=@0@'.format(qtdep.version()), '<@0@'.format(qtdep.version()[0].to_int() + 1)]
     dependency(qt, modules: qt_modules, version: accept_versions, method : get_option('method'))
 
+    qtmodule.find_tool('rcc')
   endif
 endforeach


### PR DESCRIPTION
This PR adds `qt6.find_tool`. This new functions allows getting a Qt tool as external program so it can be used in `run_command` or `custom_target`.