### PR TITLE
gnome.generate_gir: Use rspfiles on Windows when possible

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -959,8 +959,8 @@ class GnomeModule(ExtensionModule):
 
         return gir_filelist_filename
 
-    @staticmethod
     def _make_gir_target(
+            self,
             state: 'ModuleState',
             girfile: str,
             scan_command: T.Sequence[T.Union['FileOrString', Executable, ExternalProgram, OverrideProgram]],
@@ -990,6 +990,11 @@ class GnomeModule(ExtensionModule):
         run_env.set('CFLAGS', [quote_arg(x) for x in env_flags], ' ')
         run_env.merge(kwargs['env'])
 
+        gir_dep, _, _ = self._get_gir_dep(state)
+
+        # response file supported?
+        rspable = mesonlib.version_compare(gir_dep.get_version(), '>= 1.85.0')
+
         return GirTarget(
             girfile,
             state.subdir,
@@ -1004,6 +1009,7 @@ class GnomeModule(ExtensionModule):
             install_dir=[install_dir],
             install_tag=['devel'],
             env=run_env,
+            rspable=rspable,
         )
 
     @staticmethod


### PR DESCRIPTION
I ran into GStreamer's CI being overwhelmed by a 5k long command line to g-ir-scanner. This will help bypass the limitation.

See https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/532

See #6710

(Marking as draft until the upstream MR is merged.)