### PR TITLE
poc: executable_linker_args

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3613,6 +3613,9 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             # Add link args added using add_global_link_arguments()
             # These override per-project link arguments
             commands += self.build.get_global_link_args(linker, target.for_machine)
+            # Add link args added from the env: SHAREDLIBRARY_LINK_FLAGS, EXECUTABLE_LINK_FLAGS.
+            # These will override global/per-project for all targets of a same type.
+            commands += self.environment.coredata.get_external_target_group_link_args(target.get_target_group(), target.for_machine, linker.get_language())
             # Link args added from the env: LDFLAGS. We want these to override
             # all the defaults but not the per-target link args.
             commands += self.environment.coredata.get_external_link_args(target.for_machine, linker.get_language())

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1769,6 +1769,10 @@ class BuildTarget(Target):
     def get(self, lib_type: T.Literal['static', 'shared']) -> LibTypes:
         """Base case used by BothLibraries"""
         return self
+    
+    def get_target_group(self) -> str:
+        return self.__class__.__name__.lower()
+
 
 class FileInTargetPrivateDir:
     """Represents a file with the path '/path/to/build/target_private_dir/fname'.

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1424,6 +1424,7 @@ def get_global_options(lang: str,
     description = f'Extra arguments passed to the {lang}'
     argkey = OptionKey(f'{lang}_args', machine=for_machine)
     largkey = OptionKey(f'{lang}_link_args', machine=for_machine)
+    eargkey = OptionKey(f'{lang}_executable_link_args', machine=for_machine)
 
     comp_args_from_envvar = False
     comp_options = env.coredata.optstore.get_pending_value(argkey)
@@ -1437,8 +1438,15 @@ def get_global_options(lang: str,
         link_args_from_envvar = True
         link_options = env.env_opts.get(largkey, [])
 
+    exe_link_args_from_envvar = False
+    exe_link_options = env.coredata.optstore.get_pending_value(eargkey)
+    if exe_link_options is None:
+        exe_link_args_from_envvar = True
+        exe_link_options = env.env_opts.get(eargkey, [])
+
     assert isinstance(comp_options, (str, list)), 'for mypy'
     assert isinstance(link_options, (str, list)), 'for mypy'
+    assert isinstance(exe_link_options, (str, list)), 'for mypy'
 
     cargs = options.UserStringArrayOption(
         argkey.name,
@@ -1450,6 +1458,11 @@ def get_global_options(lang: str,
         description + ' linker',
         link_options, split_args=True, allow_dups=True)
 
+    eargs = options.UserStringArrayOption(
+        eargkey.name,
+        description + ' linker that apply to executable targets',
+        exe_link_options, split_args=True, allow_dups=True)
+
     if comp.INVOKES_LINKER and comp_args_from_envvar and link_args_from_envvar:
         # If the compiler acts as a linker driver, and we're using the
         # environment variable flags for both the compiler and linker
@@ -1458,6 +1471,5 @@ def get_global_options(lang: str,
         # autotools compatibility.
         largs.extend_value(comp_options)
 
-    opts: dict[OptionKey, options.AnyOptionType] = {argkey: cargs, largkey: largs}
-
+    opts: dict[OptionKey, options.AnyOptionType] = {argkey: cargs, largkey: largs, eargkey: eargs}
     return opts

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -506,6 +506,14 @@ class CoreData:
         linkkey = OptionKey(f'{lang}_link_args', machine=for_machine)
         return T.cast('T.List[str]', self.optstore.get_value_for(linkkey))
 
+    @lru_cache(maxsize=None)
+    def get_external_target_group_link_args(self, target_group: str, for_machine: MachineChoice, lang: str) -> T.List[str]:
+        # mypy cannot analyze type of OptionKey
+        if target_group != "executable": # TODO: add support for other target groups
+            return []
+        linkkey = OptionKey(f'{lang}_{target_group}_link_args', machine=for_machine)
+        return T.cast('T.List[str]', self.optstore.get_value_for(linkkey))
+
     def is_cross_build(self, when_building_for: MachineChoice = MachineChoice.HOST) -> bool:
         if when_building_for == MachineChoice.BUILD:
             return False

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -54,6 +54,7 @@ NON_LANG_ENV_OPTIONS = [
     ('PKG_CONFIG_PATH', 'pkg_config_path'),
     ('CMAKE_PREFIX_PATH', 'cmake_prefix_path'),
     ('LDFLAGS', 'ldflags'),
+    ('EXECUTABLE_LINK_FLAGS', 'executable_link_flags'),
     ('CPPFLAGS', 'cppflags'),
 ]
 
@@ -825,6 +826,10 @@ class Environment:
                     elif keyname == 'cppflags':
                         for lang in compilers.compilers.LANGUAGES_USING_CPPFLAGS:
                             key = OptionKey(f'{lang}_args', machine=for_machine)
+                            env_opts[key].extend(p_list)
+                    if keyname == 'executable_link_flags':
+                        for lang in compilers.compilers.LANGUAGES_USING_LDFLAGS:
+                            key = OptionKey(name=f'{lang}_executable_link_args', machine=for_machine)
                             env_opts[key].extend(p_list)
                     else:
                         key = OptionKey.from_string(keyname).evolve(machine=for_machine)


### PR DESCRIPTION
An example of setting flags for a target group.

This example enables a new env var `EXECUTABLE_LINK_FLAGS` that overrides global/project lang linker flags for all `executable()` targets.

