### PR TITLE
Draft: Do not let default_options for subprojects override toplevel options set on the commandline

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -267,6 +267,9 @@ class CoreData:
         # This is used by mconf to reload the option file if it's changed.
         self.options_files: T.Dict[SubProject, T.Optional[T.Tuple[str, str]]] = {}
 
+        # TODO: add docs
+        self.main_project_options: T.Set[str] = set()
+
         # Set of subprojects that have already been initialized once, this is
         # required to be stored and reloaded with the coredata, as we don't
         # want to overwrite options for such subprojects.

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1194,14 +1194,16 @@ class Interpreter(InterpreterBase, HoldableObject):
         assert isinstance(self.project_default_options, (list, dict))
         if self.environment.first_invocation or (self.subproject != '' and self.subproject not in self.coredata.initialized_subprojects):
             if self.subproject == '':
-                self.coredata.optstore.initialize_from_top_level_project_call(self.project_default_options,
-                                                                              self.user_defined_options.cmd_line_options,
-                                                                              self.environment.options)
+                ret = self.coredata.optstore.initialize_from_top_level_project_call(self.project_default_options,
+                                                                                    self.user_defined_options.cmd_line_options,
+                                                                                    self.environment.options)
+                self.coredata.main_project_options = ret
             else:
                 self.coredata.optstore.initialize_from_subproject_call(self.subproject,
                                                                        self.invoker_method_default_options,
                                                                        self.project_default_options,
-                                                                       self.user_defined_options.cmd_line_options)
+                                                                       self.user_defined_options.cmd_line_options,
+                                                                       self.coredata.main_project_options)
                 self.coredata.initialized_subprojects.add(self.subproject)
 
         if not self.is_subproject():


### PR DESCRIPTION
I bet there are better ways to handle this? Anyway, here's a tentative fix :)

Fixes #14690