### PR TITLE
options: global cmdline options must override default_options in subprojects

### DIFF
--- a/.github/workflows/os_comp.yml
+++ b/.github/workflows/os_comp.yml
@@ -100,10 +100,12 @@ jobs:
           - CC: 'gcc'
             CXX: 'g++'
           - MESON_ARGS: '--unity=on -Ddefault_library=static'
+            MESON_TEST_DDEFAULT_LIBRARY: yes
             RUN_TESTS_ARGS: '--no-unittests'
             CC: 'gcc'
             CXX: 'g++'
           - MESON_ARGS: '-Ddefault_library=both'
+            MESON_TEST_DDEFAULT_LIBRARY: yes
             RUN_TESTS_ARGS: '--no-unittests'
             CC: 'gcc'
             CXX: 'g++'
@@ -130,6 +132,7 @@ jobs:
       env:
         MESON_RSP_THRESHOLD: ${{ matrix.cfg.MESON_RSP_THRESHOLD }}
         MESON_ARGS: ${{ matrix.cfg.MESON_ARGS }}
+        MESON_TEST_DDEFAULT_LIBRARY: ${{ matrix.cfg.MESON_TEST_DDEFAULT_LIBRARY }}
         RUN_TESTS_ARGS: ${{ matrix.cfg.RUN_TESTS_ARGS }}
         CC: ${{ matrix.cfg.CC }}
         CXX: ${{ matrix.cfg.CXX }}

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -416,8 +416,8 @@ class CoreData:
     def set_from_configure_command(self, options: SharedCMDOptions) -> bool:
         unset_opts = getattr(options, 'unset_opts', [])
         all_D = options.projectoptions[:]
-        for keystr, valstr in options.cmd_line_options.items():
-            all_D.append(f'{keystr}={valstr}')
+        for key, valstr in options.cmd_line_options.items():
+            all_D.append(f'{key!s}={valstr}')
         return self.optstore.set_from_configure_command(all_D, unset_opts)
 
     def set_option(self, key: OptionKey, value, first_invocation: bool = False) -> bool:
@@ -712,9 +712,10 @@ def parse_cmd_line_options(args: SharedCMDOptions) -> None:
     args.cmd_line_options = {}
     for o in args.projectoptions:
         try:
-            (key, value) = o.split('=', 1)
+            keystr, value = o.split('=', 1)
         except ValueError:
             raise MesonException(f'Option {o!r} must have a value separated by equals sign.')
+        key = OptionKey.from_string(keystr)
         args.cmd_line_options[key] = value
 
     # Merge builtin options set with --option into the dict.
@@ -730,7 +731,7 @@ def parse_cmd_line_options(args: SharedCMDOptions) -> None:
                 cmdline_name = options.argparse_name_to_arg(name)
                 raise MesonException(
                     f'Got argument {name} as both -D{name} and {cmdline_name}. Pick one.')
-            args.cmd_line_options[key.name] = value
+            args.cmd_line_options[key] = value
             delattr(args, name)
 
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -43,7 +43,7 @@ from mesonbuild import envconfig
 if T.TYPE_CHECKING:
     from .compilers import Compiler
     from .compilers.mixins.visualstudio import VisualStudioLikeCompiler
-    from .options import ElementaryOptionValues
+    from .options import OptionDict, ElementaryOptionValues
     from .wrap.wrap import Resolver
     from . import cargo
 
@@ -646,12 +646,12 @@ class Environment:
         #
         # Note that order matters because of 'buildtype', if it is after
         # 'optimization' and 'debug' keys, it override them.
-        self.options: T.MutableMapping[OptionKey, ElementaryOptionValues] = collections.OrderedDict()
+        self.options: OptionDict = collections.OrderedDict()
 
         # Environment variables with the name converted into an OptionKey type.
         # These have subtly different behavior compared to machine files, so do
         # not store them in self.options.  See _set_default_options_from_env.
-        self.env_opts: T.MutableMapping[OptionKey, ElementaryOptionValues] = {}
+        self.env_opts: OptionDict = {}
 
         self.machinestore = machinefile.MachineFileStore(self.coredata.config_files, self.coredata.cross_files, self.source_dir)
 

--- a/mesonbuild/interpreter/dependencyfallbacks.py
+++ b/mesonbuild/interpreter/dependencyfallbacks.py
@@ -122,17 +122,17 @@ class DependencyFallbacksHolder(MesonInterpreterObject):
         # dependency('foo', static: true) should implicitly add
         # default_options: ['default_library=static']
         static = kwargs.get('static')
-        extra_default_options = {}
+        forced_options = {}
         if static is not None:
             default_library = 'static' if static else 'shared'
             mlog.log(f'Building fallback subproject with default_library={default_library}')
-            extra_default_options[OptionKey('default_library')] = default_library
+            forced_options[OptionKey('default_library')] = default_library
 
         # Configure the subproject
         subp_name = self.subproject_name
         varname = self.subproject_varname
         func_kwargs.setdefault('version', [])
-        self.interpreter.do_subproject(subp_name, func_kwargs, extra_default_options=extra_default_options)
+        self.interpreter.do_subproject(subp_name, func_kwargs, forced_options=forced_options)
         return self._get_subproject_dep(subp_name, varname, kwargs)
 
     def _get_subproject(self, subp_name: str) -> T.Optional[SubprojectHolder]:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1207,7 +1207,8 @@ class Interpreter(InterpreterBase, HoldableObject):
                 self.coredata.optstore.initialize_from_subproject_call(self.subproject,
                                                                        self.invoker_method_default_options,
                                                                        self.project_default_options,
-                                                                       self.user_defined_options.cmd_line_options)
+                                                                       self.user_defined_options.cmd_line_options,
+                                                                       self.environment.options)
                 self.coredata.initialized_subprojects.add(self.subproject)
 
         if not self.is_subproject():

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -115,7 +115,7 @@ if T.TYPE_CHECKING:
     from . import kwargs as kwtypes
     from ..backend.backends import Backend
     from ..interpreterbase.baseobjects import InterpreterObject, TYPE_var, TYPE_kwargs
-    from ..options import OptionDict
+    from ..options import ElementaryOptionValues, OptionDict
     from ..programs import OverrideProgram
     from .type_checking import SourcesVarargsType
 
@@ -301,7 +301,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             self.invoker_method_default_options = invoker_method_default_options
         else:
             self.invoker_method_default_options = {}
-        self.project_default_options: T.List[str] = []
+        self.project_default_options: T.Mapping[OptionKey, ElementaryOptionValues] = {}
         self.build_func_dict()
         self.build_holder_map()
         self.user_defined_options = user_defined_options
@@ -1189,9 +1189,6 @@ class Interpreter(InterpreterBase, HoldableObject):
         self._load_option_file()
 
         self.project_default_options = kwargs['default_options']
-        if isinstance(self.project_default_options, str):
-            self.project_default_options = [self.project_default_options]
-        assert isinstance(self.project_default_options, (list, dict))
         if self.environment.first_invocation or (self.subproject != '' and self.subproject not in self.coredata.initialized_subprojects):
             if self.subproject == '':
                 self.coredata.optstore.initialize_from_top_level_project_call(self.project_default_options,

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -271,7 +271,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                 subproject: str = '',
                 subdir: str = '',
                 subproject_dir: str = 'subprojects',
-                invoker_method_default_options: T.Optional[T.Dict[OptionKey, str]] = None,
+                invoker_method_default_options: T.Optional[T.Dict[OptionKey, ElementaryOptionValues]] = None,
                 ast: T.Optional[mparser.CodeBlockNode] = None,
                 relaxations: T.Optional[T.Set[InterpreterRuleRelaxation]] = None,
                 user_defined_options: T.Optional[coredata.SharedCMDOptions] = None,
@@ -934,7 +934,8 @@ class Interpreter(InterpreterBase, HoldableObject):
             m += ['method', mlog.bold(method)]
         mlog.log(*m, '\n', nested=False)
 
-        methods_map: T.Dict[wrap.Method, T.Callable[[str, str, T.Dict[OptionKey, str, kwtypes.DoSubproject]], SubprojectHolder]] = {
+        methods_map: T.Dict[wrap.Method, T.Callable[[str, str, T.Dict[OptionKey, ElementaryOptionValues], kwtypes.DoSubproject],
+                                                    SubprojectHolder]] = {
             'meson': self._do_subproject_meson,
             'cmake': self._do_subproject_cmake,
             'cargo': self._do_subproject_cargo,
@@ -956,7 +957,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             raise e
 
     def _do_subproject_meson(self, subp_name: str, subdir: str,
-                             default_options: T.Dict[str, options.ElementaryOptionValues],
+                             default_options: T.Dict[OptionKey, ElementaryOptionValues],
                              kwargs: kwtypes.DoSubproject,
                              ast: T.Optional[mparser.CodeBlockNode] = None,
                              build_def_files: T.Optional[T.List[str]] = None,
@@ -1016,7 +1017,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         return self.subprojects[subp_name]
 
     def _do_subproject_cmake(self, subp_name: str, subdir: str,
-                             default_options: T.Dict[str, options.ElementaryOptionValues],
+                             default_options: T.Dict[OptionKey, ElementaryOptionValues],
                              kwargs: kwtypes.DoSubproject) -> SubprojectHolder:
         from ..cmake import CMakeInterpreter
         with mlog.nested(subp_name):
@@ -1043,7 +1044,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         return result
 
     def _do_subproject_cargo(self, subp_name: str, subdir: str,
-                             default_options: T.Dict[str, options.ElementaryOptionValues],
+                             default_options: T.Dict[OptionKey, ElementaryOptionValues],
                              kwargs: kwtypes.DoSubproject) -> SubprojectHolder:
         from .. import cargo
         FeatureNew.single_use('Cargo subproject', '1.3.0', self.subproject, location=self.current_node)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -115,7 +115,7 @@ if T.TYPE_CHECKING:
     from . import kwargs as kwtypes
     from ..backend.backends import Backend
     from ..interpreterbase.baseobjects import InterpreterObject, TYPE_var, TYPE_kwargs
-    from ..options import ElementaryOptionValues, OptionDict
+    from ..options import OptionDict
     from ..programs import OverrideProgram
     from .type_checking import SourcesVarargsType
 
@@ -271,7 +271,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                 subproject: str = '',
                 subdir: str = '',
                 subproject_dir: str = 'subprojects',
-                invoker_method_default_options: T.Optional[T.Dict[OptionKey, ElementaryOptionValues]] = None,
+                invoker_method_default_options: T.Optional[OptionDict] = None,
                 ast: T.Optional[mparser.CodeBlockNode] = None,
                 relaxations: T.Optional[T.Set[InterpreterRuleRelaxation]] = None,
                 user_defined_options: T.Optional[coredata.SharedCMDOptions] = None,
@@ -301,7 +301,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             self.invoker_method_default_options = invoker_method_default_options
         else:
             self.invoker_method_default_options = {}
-        self.project_default_options: T.Mapping[OptionKey, ElementaryOptionValues] = {}
+        self.project_default_options: OptionDict = {}
         self.build_func_dict()
         self.build_holder_map()
         self.user_defined_options = user_defined_options
@@ -934,7 +934,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             m += ['method', mlog.bold(method)]
         mlog.log(*m, '\n', nested=False)
 
-        methods_map: T.Dict[wrap.Method, T.Callable[[str, str, T.Dict[OptionKey, ElementaryOptionValues], kwtypes.DoSubproject],
+        methods_map: T.Dict[wrap.Method, T.Callable[[str, str, OptionDict, kwtypes.DoSubproject],
                                                     SubprojectHolder]] = {
             'meson': self._do_subproject_meson,
             'cmake': self._do_subproject_cmake,
@@ -957,7 +957,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             raise e
 
     def _do_subproject_meson(self, subp_name: str, subdir: str,
-                             default_options: T.Dict[OptionKey, ElementaryOptionValues],
+                             default_options: OptionDict,
                              kwargs: kwtypes.DoSubproject,
                              ast: T.Optional[mparser.CodeBlockNode] = None,
                              build_def_files: T.Optional[T.List[str]] = None,
@@ -1017,7 +1017,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         return self.subprojects[subp_name]
 
     def _do_subproject_cmake(self, subp_name: str, subdir: str,
-                             default_options: T.Dict[OptionKey, ElementaryOptionValues],
+                             default_options: OptionDict,
                              kwargs: kwtypes.DoSubproject) -> SubprojectHolder:
         from ..cmake import CMakeInterpreter
         with mlog.nested(subp_name):
@@ -1044,7 +1044,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         return result
 
     def _do_subproject_cargo(self, subp_name: str, subdir: str,
-                             default_options: T.Dict[OptionKey, ElementaryOptionValues],
+                             default_options: OptionDict,
                              kwargs: kwtypes.DoSubproject) -> SubprojectHolder:
         from .. import cargo
         FeatureNew.single_use('Cargo subproject', '1.3.0', self.subproject, location=self.current_node)
@@ -1626,7 +1626,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     # the host machine.
     def find_program_impl(self, args: T.List[mesonlib.FileOrString],
                           for_machine: MachineChoice = MachineChoice.HOST,
-                          default_options: T.Optional[T.Dict[OptionKey, options.ElementaryOptionValues]] = None,
+                          default_options: T.Optional[OptionDict] = None,
                           required: bool = True, silent: bool = True,
                           wanted: T.Union[str, T.List[str]] = '',
                           search_dirs: T.Optional[T.List[str]] = None,
@@ -1657,7 +1657,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         return progobj
 
     def program_lookup(self, args: T.List[mesonlib.FileOrString], for_machine: MachineChoice,
-                       default_options: T.Optional[T.Dict[OptionKey, options.ElementaryOptionValues]],
+                       default_options: T.Optional[OptionDict],
                        required: bool,
                        search_dirs: T.Optional[T.List[str]],
                        wanted: T.Union[str, T.List[str]],
@@ -1725,7 +1725,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         return True
 
     def find_program_fallback(self, fallback: str, args: T.List[mesonlib.FileOrString],
-                              default_options: T.Dict[OptionKey, options.ElementaryOptionValues],
+                              default_options: OptionDict,
                               required: bool, extra_info: T.List[mlog.TV_Loggable]
                               ) -> T.Optional[T.Union[ExternalProgram, build.Executable, OverrideProgram]]:
         mlog.log('Fallback to subproject', mlog.bold(fallback), 'which provides program',

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1362,7 +1362,7 @@ class OptionStore:
                 else:
                     self.pending_options[key] = valstr
 
-    def accept_as_pending_option(self, key: OptionKey, known_subprojects: T.Optional[T.Union[T.Set[str], T.KeysView[str]]] = None,
+    def accept_as_pending_option(self, key: OptionKey, known_subprojects: T.Optional[T.Container[str]] = None,
                                  first_invocation: bool = False) -> bool:
         # Fail on unknown options that we can know must exist at this point in time.
         # Subproject and compiler options are resolved later.

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1362,7 +1362,8 @@ class OptionStore:
                 else:
                     self.pending_options[key] = valstr
 
-    def accept_as_pending_option(self, key: OptionKey, known_subprojects: T.Optional[T.Union[T.Set[str], T.KeysView[str]]] = None) -> bool:
+    def accept_as_pending_option(self, key: OptionKey, known_subprojects: T.Optional[T.Union[T.Set[str], T.KeysView[str]]] = None,
+                                 first_invocation: bool = False) -> bool:
         # Fail on unknown options that we can know must exist at this point in time.
         # Subproject and compiler options are resolved later.
         #
@@ -1372,6 +1373,8 @@ class OptionStore:
             if known_subprojects is None or key.subproject not in known_subprojects:
                 return True
         if self.is_compiler_option(key):
+            return True
+        if first_invocation and self.is_backend_option(key):
             return True
         return (self.is_base_option(key) and
                 key.evolve(subproject=None, machine=MachineChoice.HOST) in COMPILER_BASE_OPTIONS)

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -809,7 +809,6 @@ class OptionStore:
         self.module_options: T.Set[OptionKey] = set()
         from .compilers import all_languages
         self.all_languages = set(all_languages)
-        self.project_options = set()
         self.augments: T.Dict[OptionKey, ElementaryOptionValues] = {}
         self.is_cross = is_cross
 

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1380,7 +1380,6 @@ class OptionStore:
                                         spcall_default_options: OptionDict,
                                         project_default_options: OptionDict,
                                         cmd_line_options: OptionDict) -> None:
-        is_first_invocation = True
         for keystr, valstr in itertools.chain(project_default_options.items(), spcall_default_options.items()):
             if isinstance(keystr, str):
                 key = OptionKey.from_string(keystr)
@@ -1394,7 +1393,7 @@ class OptionStore:
             # If the key points to a project option, set the value from that.
             # Otherwise set an augment.
             if key in self.project_options:
-                self.set_option(key, valstr, is_first_invocation)
+                self.set_option(key, valstr, True)
             else:
                 self.pending_options.pop(key, None)
                 self.augments[key] = valstr
@@ -1406,7 +1405,7 @@ class OptionStore:
                 continue
             self.pending_options.pop(key, None)
             if key in self.options:
-                self.set_option(key, valstr, is_first_invocation)
+                self.set_option(key, valstr, True)
             else:
                 self.augments[key] = valstr
 

--- a/test cases/common/223 persubproject options/meson.build
+++ b/test cases/common/223 persubproject options/meson.build
@@ -1,5 +1,5 @@
 project('persubproject options', 'c', 'cpp',
-  default_options : ['werror=true',
+  default_options : ['werror=true', 'default_library=both',
                      'warning_level=3',
                      'cpp_std=c++11'])
 

--- a/test cases/common/223 persubproject options/test.json
+++ b/test cases/common/223 persubproject options/test.json
@@ -1,7 +1,0 @@
-{
-    "matrix": {
-        "options": {
-            "default_library": [ { "val": "both" } ]
-        }
-    }
-}

--- a/test cases/common/223 persubproject options/test.json
+++ b/test cases/common/223 persubproject options/test.json
@@ -1,0 +1,3 @@
+{
+  "skip_on_env": ["MESON_TEST_DDEFAULT_LIBRARY"]
+}

--- a/test cases/common/247 deprecated option/test.json
+++ b/test cases/common/247 deprecated option/test.json
@@ -26,77 +26,77 @@
   },
   "stdout": [
     {
-      "line": ".*DEPRECATION: Option 'o1' is deprecated",
+      "line": ".*DEPRECATION: Option \"o1\" is deprecated",
       "match": "re",
       "count": 1
     },
     {
-      "line": ".*DEPRECATION: Option 'o2' value 'a' is deprecated",
+      "line": ".*DEPRECATION: Option \"o2\" value 'a' is deprecated",
       "match": "re",
       "count": 1
     },
     {
-      "line": ".*DEPRECATION: Option 'o3' value 'a' is replaced by 'c'",
+      "line": ".*DEPRECATION: Option \"o3\" value 'a' is replaced by 'c'",
       "match": "re",
       "count": 1
     },
     {
-      "line": ".*DEPRECATION: Option 'o4' value 'true' is replaced by 'enabled'",
+      "line": ".*DEPRECATION: Option \"o4\" value 'true' is replaced by 'enabled'",
       "match": "re",
       "count": 1
     },
     {
-      "line": ".*DEPRECATION: Option 'o5' value 'auto' is replaced by 'false'",
+      "line": ".*DEPRECATION: Option \"o5\" value 'auto' is replaced by 'false'",
       "match": "re",
       "count": 1
     },
     {
-      "line": ".*DEPRECATION: Option 'p1' is deprecated",
+      "line": ".*DEPRECATION: Option \"p1\" is deprecated",
       "match": "re",
       "count": 1
     },
     {
-      "line": ".*DEPRECATION: Option 'p2' value 'a' is deprecated",
+      "line": ".*DEPRECATION: Option \"p2\" value 'a' is deprecated",
       "match": "re",
       "count": 1
     },
     {
-      "line": ".*DEPRECATION: Option 'p3' value 'a' is replaced by 'c'",
+      "line": ".*DEPRECATION: Option \"p3\" value 'a' is replaced by 'c'",
       "match": "re",
       "count": 1
     },
     {
-      "line": ".*DEPRECATION: Option 'p4' value 'true' is replaced by 'enabled'",
+      "line": ".*DEPRECATION: Option \"p4\" value 'true' is replaced by 'enabled'",
       "match": "re",
       "count": 1
     },
     {
-      "line": ".*DEPRECATION: Option 'p5' value 'auto' is replaced by 'false'",
+      "line": ".*DEPRECATION: Option \"p5\" value 'auto' is replaced by 'false'",
       "match": "re",
       "count": 1
     },
     {
-      "line": ".*DEPRECATION: Option 'c1' is deprecated",
+      "line": ".*DEPRECATION: Option \"c1\" is deprecated",
       "match": "re",
       "count": 1
     },
     {
-      "line": ".*DEPRECATION: Option 'c2' value 'a' is deprecated",
+      "line": ".*DEPRECATION: Option \"c2\" value 'a' is deprecated",
       "match": "re",
       "count": 1
     },
     {
-      "line": ".*DEPRECATION: Option 'c3' value 'a' is replaced by 'c'",
+      "line": ".*DEPRECATION: Option \"c3\" value 'a' is replaced by 'c'",
       "match": "re",
       "count": 1
     },
     {
-      "line": ".*DEPRECATION: Option 'c4' value 'true' is replaced by 'enabled'",
+      "line": ".*DEPRECATION: Option \"c4\" value 'true' is replaced by 'enabled'",
       "match": "re",
       "count": 1
     },
     {
-      "line": ".*DEPRECATION: Option 'c5' value 'auto' is replaced by 'false'",
+      "line": ".*DEPRECATION: Option \"c5\" value 'auto' is replaced by 'false'",
       "match": "re",
       "count": 1
     }

--- a/unittests/machinefiletests.py
+++ b/unittests/machinefiletests.py
@@ -563,12 +563,18 @@ class NativeFileTests(BasePlatformTests):
                 check = cm.exception.stdout
             self.assertIn(check, 'Parent should override default_library')
 
-    def test_builtin_options_machinefile_global_loses_over_subproject(self):
-        # The buildfile says subproject(... default_library: static), ensure that it overrides the machinefile
-        # FIXME: Should it??
+    def test_builtin_options_machinefile_global_overrides_subproject(self):
+        # The buildfile says subproject(... default_library: static), ensure that's overridden
         testcase = os.path.join(self.common_test_dir, '223 persubproject options')
         config = self.helper_create_native_file({'built-in options': {'default_library': 'both'}})
-        self.init(testcase, extra_args=['--native-file', config])
+
+        with self.assertRaises((RuntimeError, subprocess.CalledProcessError)) as cm:
+            self.init(testcase, extra_args=['--native-file', config])
+            if isinstance(cm, RuntimeError):
+                check = str(cm.exception)
+            else:
+                check = cm.exception.stdout
+            self.assertIn(check, 'Parent should override default_library')
 
     def test_builtin_options_compiler_properties(self):
         # the properties section can have lang_args, and those need to be

--- a/unittests/machinefiletests.py
+++ b/unittests/machinefiletests.py
@@ -550,8 +550,8 @@ class NativeFileTests(BasePlatformTests):
         # into augments.
         self.assertEqual(found, 2, 'Did not find all two sections')
 
-    def test_builtin_options_subprojects_overrides_buildfiles(self):
-        # If the buildfile says subproject(... default_library: shared), ensure that's overwritten
+    def test_builtin_options_machinefile_overrides_subproject(self):
+        # The buildfile says subproject(... default_library: static), the machinefile overrides it
         testcase = os.path.join(self.common_test_dir, '223 persubproject options')
         config = self.helper_create_native_file({'sub2:built-in options': {'default_library': 'shared'}})
 
@@ -563,8 +563,9 @@ class NativeFileTests(BasePlatformTests):
                 check = cm.exception.stdout
             self.assertIn(check, 'Parent should override default_library')
 
-    def test_builtin_options_subprojects_dont_inherits_parent_override(self):
-        # If the buildfile says subproject(... default_library: shared), ensure that's overwritten
+    def test_builtin_options_machinefile_global_loses_over_subproject(self):
+        # The buildfile says subproject(... default_library: static), ensure that it overrides the machinefile
+        # FIXME: Should it??
         testcase = os.path.join(self.common_test_dir, '223 persubproject options')
         config = self.helper_create_native_file({'built-in options': {'default_library': 'both'}})
         self.init(testcase, extra_args=['--native-file', config])

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -240,6 +240,68 @@ class OptionTests(unittest.TestCase):
         self.assertFalse(optstore.accept_as_pending_option(OptionKey('foo', subproject='found'), subprojects))
         self.assertTrue(optstore.accept_as_pending_option(OptionKey('foo', subproject='whatisthis'), subprojects))
 
+    def test_subproject_cmdline_override_global(self):
+        name = 'optimization'
+        subp = 'subp'
+        new_value = '0'
+
+        optstore = OptionStore(False)
+        prefix = UserStringOption('prefix', 'This is needed by OptionStore', '/usr')
+        optstore.add_system_option('prefix', prefix)
+        o = UserComboOption(name, 'Optimization level', '0', choices=['plain', '0', 'g', '1', '2', '3', 's'])
+        optstore.add_system_option(name, o)
+
+        toplevel_proj_default = {OptionKey(name): 's'}
+        subp_proj_default = {OptionKey(name): '3'}
+        cmd_line = {OptionKey(name): new_value}
+
+        optstore.initialize_from_top_level_project_call(toplevel_proj_default, cmd_line, {})
+        optstore.initialize_from_subproject_call(subp, {}, subp_proj_default, cmd_line, {})
+        self.assertEqual(optstore.get_value_for(name, subp), new_value)
+        self.assertEqual(optstore.get_value_for(name), new_value)
+
+    def test_subproject_cmdline_override_global_and_augment(self):
+        name = 'optimization'
+        subp = 'subp'
+        global_value = 's'
+        new_value = '0'
+
+        optstore = OptionStore(False)
+        prefix = UserStringOption('prefix', 'This is needed by OptionStore', '/usr')
+        optstore.add_system_option('prefix', prefix)
+        o = UserComboOption(name, 'Optimization level', '0', choices=['plain', '0', 'g', '1', '2', '3', 's'])
+        optstore.add_system_option(name, o)
+
+        toplevel_proj_default = {OptionKey(name): '1'}
+        subp_proj_default = {OptionKey(name): '3'}
+        cmd_line = {OptionKey(name): global_value, OptionKey(name, subproject=subp): new_value}
+
+        optstore.initialize_from_top_level_project_call(toplevel_proj_default, cmd_line, {})
+        optstore.initialize_from_subproject_call(subp, {}, subp_proj_default, cmd_line, {})
+        self.assertEqual(optstore.get_value_for(name, subp), new_value)
+        self.assertEqual(optstore.get_value_for(name), global_value)
+
+    def test_subproject_cmdline_override_toplevel(self):
+        name = 'default_library'
+        subp = 'subp'
+        toplevel_value = 'both'
+        subp_value = 'static'
+
+        optstore = OptionStore(False)
+        prefix = UserStringOption('prefix', 'This is needed by OptionStore', '/usr')
+        optstore.add_system_option('prefix', prefix)
+        o = UserComboOption(name, 'Kind of library', 'both', choices=['shared', 'static', 'both'])
+        optstore.add_system_option(name, o)
+
+        toplevel_proj_default = {OptionKey(name): 'shared'}
+        subp_proj_default = {OptionKey(name): subp_value}
+        cmd_line = {OptionKey(name, subproject=''): toplevel_value}
+
+        optstore.initialize_from_top_level_project_call(toplevel_proj_default, cmd_line, {})
+        optstore.initialize_from_subproject_call(subp, {}, subp_proj_default, cmd_line, {})
+        self.assertEqual(optstore.get_value_for(name, subp), subp_value)
+        self.assertEqual(optstore.get_value_for(name), toplevel_value)
+
     def test_deprecated_nonstring_value(self):
         # TODO: add a lot more deprecated option tests
         optstore = OptionStore(False)

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -224,6 +224,12 @@ class OptionTests(unittest.TestCase):
         self.assertTrue(optstore.accept_as_pending_option(OptionKey('b_ndebug')))
         self.assertFalse(optstore.accept_as_pending_option(OptionKey('b_whatever')))
 
+    def test_backend_option_pending(self):
+        optstore = OptionStore(False)
+        # backend options are known after the first invocation
+        self.assertTrue(optstore.accept_as_pending_option(OptionKey('backend_whatever'), set(), True))
+        self.assertFalse(optstore.accept_as_pending_option(OptionKey('backend_whatever'), set(), False))
+
     def test_reconfigure_b_nonexistent(self):
         optstore = OptionStore(False)
         optstore.set_from_configure_command(['b_ndebug=true'], [])

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -55,9 +55,9 @@ class OptionTests(unittest.TestCase):
         """Test that subproject system options get their default value from the global
            option (e.g. "sub:b_lto" can be initialized from "b_lto")."""
         optstore = OptionStore(False)
-        name = 'someoption'
-        default_value = 'somevalue'
-        new_value = 'new_value'
+        name = 'b_lto'
+        default_value = 'false'
+        new_value = 'true'
         k = OptionKey(name)
         subk = k.evolve(subproject='sub')
         optstore.initialize_from_top_level_project_call({}, {}, {OptionKey(name): new_value})

--- a/unittests/platformagnostictests.py
+++ b/unittests/platformagnostictests.py
@@ -175,7 +175,7 @@ class PlatformAgnosticTests(BasePlatformTests):
         with self.subTest('Changing the backend'):
             with self.assertRaises(subprocess.CalledProcessError) as cm:
                 self.setconf('-Dbackend=none')
-            self.assertIn("ERROR: Tried to modify read only option 'backend'", cm.exception.stdout)
+            self.assertIn('ERROR: Tried to modify read only option "backend"', cm.exception.stdout)
 
         # Check that the new value was not written in the store.
         with self.subTest('option is stored correctly'):
@@ -451,7 +451,7 @@ class PlatformAgnosticTests(BasePlatformTests):
                 f.write(line)
         with self.assertRaises(subprocess.CalledProcessError) as e:
             self.setconf('-Dneg_int_opt=0')
-        self.assertIn('Unknown options: ":neg_int_opt"', e.exception.stdout)
+        self.assertIn('Unknown option: "neg_int_opt"', e.exception.stdout)
 
     def test_reconfigure_option(self) -> None:
         testdir = self.copy_srcdir(os.path.join(self.common_test_dir, '40 options'))
@@ -501,7 +501,7 @@ class PlatformAgnosticTests(BasePlatformTests):
         os.unlink(os.path.join(testdir, 'meson_options.txt'))
         with self.assertRaises(subprocess.CalledProcessError) as e:
             self.setconf('-Dneg_int_opt=0')
-        self.assertIn('Unknown options: ":neg_int_opt"', e.exception.stdout)
+        self.assertIn('Unknown option: "neg_int_opt"', e.exception.stdout)
 
     def test_configure_options_file_added(self) -> None:
         """A new project option file should be detected."""

--- a/unittests/platformagnostictests.py
+++ b/unittests/platformagnostictests.py
@@ -421,12 +421,12 @@ class PlatformAgnosticTests(BasePlatformTests):
 
         with self.subTest('unknown user option'):
             out = self.init(testdir, extra_args=['-Dnot_an_option=1'], allow_fail=True)
-            self.assertIn('ERROR: Unknown options: "not_an_option"', out)
+            self.assertIn('ERROR: Unknown option: "not_an_option"', out)
 
         with self.subTest('unknown builtin option'):
             self.new_builddir()
             out = self.init(testdir, extra_args=['-Db_not_an_option=1'], allow_fail=True)
-            self.assertIn('ERROR: Unknown options: "b_not_an_option"', out)
+            self.assertIn('ERROR: Unknown option: "b_not_an_option"', out)
 
 
     def test_configure_new_option(self) -> None:


### PR DESCRIPTION
Global (non-per-subproject) have their own place in the hierarchy of sources for subproject options.

Fixes: #14690.