### PR TITLE
compilers: pgi: fix preprocessing arguments

### DIFF
--- a/mesonbuild/compilers/mixins/pgi.py
+++ b/mesonbuild/compilers/mixins/pgi.py
@@ -54,6 +54,12 @@ class PGICompiler(Compiler):
     def openmp_flags(self, env: Environment) -> T.List[str]:
         return ['-mp']
 
+    def get_preprocess_only_args(self) -> T.List[str]:
+        return ['-E', '-P', '-o', '-']
+
+    def get_preprocess_to_file_args(self) -> T.List[str]:
+        return ['-E', '-P']
+
     def get_optimization_args(self, optimization_level: str) -> T.List[str]:
         return clike_optimization_args[optimization_level]
 


### PR DESCRIPTION
Based on reports from the users, PGI compilers need an explicit "-o -" on the command line to emit preprocessed output on stdout.  Override the methods in the PGICompiler mixin to add it when output goes to stdout but not when output goes elsewhere.

Fixes: #8400 

Fixes: #13216