### PR TITLE
vala: Also add --target-glib if glib is built as subproject

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1357,6 +1357,10 @@ class BuildTarget(Target):
         deps = listify(deps)
         for dep in deps:
             if dep in self.added_deps:
+                # Prefer to add dependencies to added_deps which have a name
+                if dep.is_named():
+                    self.added_deps.remove(dep)
+                    self.added_deps.add(dep)
                 continue
 
             if isinstance(dep, dependencies.InternalDependency):

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -143,6 +143,11 @@ class Dependency(HoldableObject):
     def is_built(self) -> bool:
         return False
 
+    def is_named(self) -> bool:
+        if self.name is None:
+            return False
+        return self.name != f'dep{self._id}'
+
     def summary_value(self) -> T.Union[str, mlog.AnsiDecorator, mlog.AnsiText]:
         if not self.found():
             return mlog.red('NO')

--- a/test cases/unit/129 vala internal glib/lib.vala
+++ b/test cases/unit/129 vala internal glib/lib.vala
@@ -1,0 +1,3 @@
+public int func() {
+    return 42;
+}

--- a/test cases/unit/129 vala internal glib/meson.build
+++ b/test cases/unit/129 vala internal glib/meson.build
@@ -1,0 +1,21 @@
+project('vala internal glib')
+
+if not add_languages('vala', required: false)
+  error('MESON_SKIP_TEST valac not installed')
+endif
+
+glib_ver = get_option('glib-version')
+if glib_ver == 'unset'
+  error('Required to set -Dglib-version')
+endif
+
+glib_dep = declare_dependency(version: glib_ver)
+meson.override_dependency('glib-2.0', glib_dep)
+
+named_glib_dep = dependency('glib-2.0')
+
+assert(named_glib_dep.type_name() == 'internal')
+assert(glib_dep == named_glib_dep)
+
+tgt = static_library('vala-tgt', 'lib.vala',
+  dependencies: named_glib_dep)

--- a/test cases/unit/129 vala internal glib/meson.options
+++ b/test cases/unit/129 vala internal glib/meson.options
@@ -1,0 +1,1 @@
+option('glib-version', type: 'string', value: 'unset')


### PR DESCRIPTION
Previously, meson would only check if glib was part of target.external_dependencies and add --target-glib appropriately. This however had the downside of meson not adding --target-glib if glib was included as a subproject, potentially breaking otherwise builds.

Instead of checking external_dependencies, check target.added_deps for an occurrence of 'glib-2.0' and then pick the appropriate codepath (either from the external dependency based on version_reqs or for the internal dependency based on the actual version, potentially downgraded to the latest release version)

Related-to: #14694