### PR TITLE
Document `b_sanitize` and `b_lundef` interaction.

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -250,6 +250,11 @@ separated by a comma. Furthermore:
 
  - Otherwise, the array elements are returned in undefined order.
 
+Be aware that `b_lundef` is `true` by default, which is incompatible with the
+address sanitizer when building shared libraries with clang, as documented
+[by clang](https://clang.llvm.org/docs/AddressSanitizer.html#usage)
+(`b_lundef` makes meson use `-Wl,--no-undefined`, which is an alias for `-Wl,-z,defs`).
+
 \* < 0 means disable, == 0 means automatic selection, > 0 sets a specific number to use
 
 LLVM supports `thin` lto, for more discussion see [LLVM's documentation](https://clang.llvm.org/docs/ThinLTO.html)

--- a/docs/markdown/howtox.md
+++ b/docs/markdown/howtox.md
@@ -205,6 +205,11 @@ has native support for these with the `b_sanitize` option.
 $ meson setup <other options> -Db_sanitize=address
 ```
 
+Clang users might also need to set `-Db_lundef=false`, since otherwise meson will pass
+`-Wl,--no-undefined`, which is an alias for `-Wl,-z,defs`, which is incompatible
+with the address sanitizer when building shared libraries with clang as
+documented [by clang](https://clang.llvm.org/docs/AddressSanitizer.html#usage).
+
 After this you just compile your code and run the test suite. Address
 sanitizer will abort executables which have bugs so they show up as
 test failures.


### PR DESCRIPTION
This works fine with gcc, but fails with clang:
```bash
$CC -fsanitize=address -o libfoo.so foo.c -shared -Wl,--no-undefined
$CC -fsanitize=address main.c libfoo.so
```
This failure is documented
[here](https://clang.llvm.org/docs/AddressSanitizer.html#usage):
```txt
Simply compile and link your program with -fsanitize=address flag. The
AddressSanitizer run-time library should be linked to the final
executable, so make sure to use clang (not ld) for the final link step.
When linking shared libraries, the AddressSanitizer run-time is not
linked, so -Wl,-z,defs may cause link errors
(don't use it with AddressSanitizer).
```
Note that `b_lundef=true`(the default) makes meson use `-Wl,--no-undefined` which is an alias for `-Wl,-z,defs`. Thus,
```
CC=clang meson setup bd -Db_sanitize=address
```
fails if meson.build looks e.g. like this:
```
project('example', ['c'])
foo = shared_library('foo', 'foo.c')
executable('main', 'main.c', link_with: foo)
```
Which is exactly the problem
[this forum user could not understand alone](https://www.reddit.com/r/meson/comments/1l5d0wc/clang_on_linux_with_fsanitize/).

I don't know how to properly fix this, so I documented it in this commit.