### PR TITLE
Draft: ExternalDependency: add get_runtime_paths method

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1189,6 +1189,11 @@ class Backend:
         """
         results = set()
         for dep in target.external_deps:
+            if callable(getattr(dep, 'get_runtime_paths', None)):
+                bindirs = dep.get_runtime_paths()
+                if bindirs:
+                    results.update(bindirs)
+                    continue
 
             if dep.type_name == 'pkgconfig':
                 # If by chance pkg-config knows the bin dir...

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -478,6 +478,8 @@ class ExternalDependency(Dependency, HasNativeKwarg):
                         raise DependencyException(m.format(self.name, not_found, self.version))
                     return
 
+    def get_runtime_paths(self) -> T.Optional[T.List[str]]:
+        return None
 
 class NotFoundDependency(Dependency):
     def __init__(self, name: str, environment: 'Environment') -> None:

--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -388,6 +388,12 @@ class PythonSystemDependency(SystemDependency, _PythonDependencyBase):
     def log_tried() -> str:
         return 'sysconfig'
 
+    def get_runtime_paths(self) -> T.Optional[T.List[str]]:
+        bindir = self.variables.get('BINDIR')
+        if bindir:
+            return [bindir]
+        return None
+
 def python_factory(env: 'Environment', for_machine: 'MachineChoice',
                    kwargs: T.Dict[str, T.Any],
                    installation: T.Optional['BasicPythonExternalProgram'] = None) -> T.List['DependencyGenerator']:


### PR DESCRIPTION
Still very draft, but works!

Fixes https://github.com/mesonbuild/meson/issues/14712