### PR TITLE
Add -F compiler flag on detected MacOS frameworks

### DIFF
--- a/mesonbuild/cmake/tracetargets.py
+++ b/mesonbuild/cmake/tracetargets.py
@@ -87,6 +87,7 @@ def resolve_cmake_trace_targets(target_name: str,
                     curr_path = Path(*path_to_framework)
                     framework_path = curr_path.parent
                     framework_name = curr_path.stem
+                    res.public_compile_opts += [f"-F{framework_path}"]
                     res.libraries += [f'-F{framework_path}', '-framework', framework_name]
                 else:
                     res.libraries += [curr]


### PR DESCRIPTION
Added `f"-F{framework_path}"` to `res.public_compile_opts`

This will make sure the compiler knows about the framework and can find the packaged headers.

See: https://github.com/mesonbuild/meson/issues/14641