### PR TITLE
Add -F compiler flag for included MacOS frameworks

### DIFF
--- a/mesonbuild/cmake/tracetargets.py
+++ b/mesonbuild/cmake/tracetargets.py
@@ -87,6 +87,7 @@ def resolve_cmake_trace_targets(target_name: str,
                     curr_path = Path(*path_to_framework)
                     framework_path = curr_path.parent
                     framework_name = curr_path.stem
+                    res.public_compile_opts += [f"-F{framework_path}"]
                     res.libraries += [f'-F{framework_path}', '-framework', framework_name]
                 else:
                     res.libraries += [curr]


### PR DESCRIPTION
Currently, when using frameworks on MacOS systems, Meson will send the appropriate flags to the linker but fails to pass flags to the compiler, resulting in the headers not being found for the included frameworks.

This patch adds the required "-F{framework}" flag to the compiler options, so that the compiler can find the headers of included frameworks.

See: https://github.com/mesonbuild/meson/issues/14641