### PR TITLE
compilers-fortran: Fix preprocessing when fortran uses concat operator

### DIFF
--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -446,6 +446,11 @@ class IntelLLVMFortranCompiler(IntelFortranCompiler):
 
     id = 'intel-llvm'
 
+    def get_preprocess_only_args(self) -> T.List[str]:
+        return ['-preprocess-only']
+
+    def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
+        return []
 
 class IntelClFortranCompiler(IntelVisualStudioLikeCompiler, FortranCompiler):
 

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -534,6 +534,8 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
         # We want to allow preprocessing files with any extension, such as
         # foo.c.in. In that case we need to tell GCC/CLANG to treat them as
         # assembly file.
+        if self.language == 'fortran':
+            return self.get_preprocess_only_args()
         lang = gnu_lang_map.get(self.language, 'assembler-with-cpp')
         return self.get_preprocess_only_args() + [f'-x{lang}']
 

--- a/test cases/fortran/23 preprocess/main.f90
+++ b/test cases/fortran/23 preprocess/main.f90
@@ -1,4 +1,14 @@
 #define MYDEF program
 MYDEF foo
-    write (*,*) 'Hello, world!'
+    character(20) :: str
+#ifdef CORRECT
+        str = 'Hello, ' // 'world!'
+#else
+        str = 'Preprocessing error!'
+#endif
+    if (str /= 'Hello, world!') then
+        print *, 'Preprocessing failed.'
+        error stop 1
+    end if
+    stop 0
 end MYDEF foo

--- a/test cases/fortran/23 preprocess/meson.build
+++ b/test cases/fortran/23 preprocess/meson.build
@@ -1,7 +1,12 @@
-project('preprocess', 'fortran')
+project('preprocess', 'fortran', meson_version: '>1.3.2')
 
 fc = meson.get_compiler('fortran')
 
-pp_files = fc.preprocess('main.f90', output: '@PLAINNAME@')
+pp_files = fc.preprocess(
+    'main.f90',
+    compile_args: ['-DCORRECT=true'],
+    output: '@PLAINNAME@')
 
-library('foo', pp_files)
+t = executable('foo', pp_files)
+
+test('check_result', t)


### PR DESCRIPTION
Fixes #14695 

This fixes preprocessing in fortran where code uses the concatenation operator. It also fixes preprocessing when compiling with ifx.

Note on the testing:
- ~The test is currently failing as I don't now how to check the output of the compiled program via the project tests.~
- Is it possible to add ifx as a compiler for this test to avoid a regression on this?

Any help or pointers for these notes would be appreciated!