### PR TITLE
docs: Clarify instructions for copying files

### DIFF
--- a/docs/markdown/FAQ.md
+++ b/docs/markdown/FAQ.md
@@ -729,3 +729,8 @@ Even though [MSVC documentation](https://learn.microsoft.com/en-us/cpp/build/ref
 uses `/D` for preprocessor defines, its [command-line syntax](https://learn.microsoft.com/en-us/cpp/build/reference/compiler-command-line-syntax)
 accepts `-` instead of `/`.
 It's not necessary to treat preprocessor defines specially in Meson ([GH-6269](https://github.com/mesonbuild/meson/issues/6269#issuecomment-560003922)).
+
+## Why do all outputs go to the build directory that corresponds to the source directory in which they are declared?
+
+This simplifies debugging build problems, since you always know that files in
+build directory X must come from the corresponding source directory X.

--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -186,7 +186,7 @@ new = fs.replace_suffix(original, '')  # /opt/foo.dll
 
 ### parent
 
-Returns the parent directory (i.e. dirname).
+Returns the parent directory (i.e., dirname).
 
 ```meson
 new = fs.parent('foo/bar')  # foo
@@ -195,7 +195,7 @@ new = fs.parent('foo/bar/baz.dll')  # foo/bar
 
 ### name
 
-Returns the last component of the path (i.e. basename).
+Returns the last component of the path (i.e., basename).
 
 ```meson
 fs.name('foo/bar/baz.dll.a')  # baz.dll.a
@@ -256,14 +256,20 @@ returns:
 
 *Since 0.64.0*
 
-Copy a file from the source directory to the build directory at build time
+Copy a file from the source directory to the build directory at build time.
+
+The destination directory is the current build directory; an alternate path
+for the destination file cannot be provided.
+Therefore, this function should be called from a `meson.build` in the source
+directory that corresponds to the desired destination directory.
+The source file argument may contain a directory path component.
 
 Has the following positional arguments:
    - src `File | str`: the file to copy
 
 Has the following optional arguments:
    - dest `str`: the name of the output file. If unset will be the basename of
-     the src argument
+     the src argument (i.e., the last component of its path).
 
 Has the following keyword arguments:
    - install `bool`: Whether to install the copied file, defaults to false

--- a/docs/yaml/functions/configure_file.yaml
+++ b/docs/yaml/functions/configure_file.yaml
@@ -20,7 +20,12 @@ description: |
 
   *(since 0.47.0)* When the `copy:` keyword argument is set to `true`,
   this function will copy the file provided in `input:` to a file in the
-  build directory with the name `output:` in the current directory.
+  current build directory with the name provided in `output:`.
+  The copy happens at configuration.  If the input file is subsequently
+  modified, Meson will regenerate the build files.
+  To perform the copy at build time (with the usual dependency on the source
+  file) use `copyfile()` from the FS (filesystem) module.
+
 
 warnings:
   - the `install_mode` kwarg ignored integer values between 0.62 -- 1.1.0.


### PR DESCRIPTION
I hope this is helpful.

Note that I added the meaning of "basename" in this context because Meson uses `@BASENAME@` to mean the input filename with extension removed.