### PR TITLE
clang-tidy: run tool only on source files participating in targets

### DIFF
--- a/docs/markdown/snippets/clang-tidy-improvement.md
+++ b/docs/markdown/snippets/clang-tidy-improvement.md
@@ -1,0 +1,5 @@
+## `clang-tidy`'s auto-generated targets correctly select source files
+
+In previous versions, the target would run `clang-tidy` on _every_ C-like source files (.c, .h, .cpp, .hpp). It did not work correctly because some files, especially headers, are not intended to be consumed as is.
+
+It will now run only on source files participating in targets.

--- a/mesonbuild/scripts/clangtidy.py
+++ b/mesonbuild/scripts/clangtidy.py
@@ -11,7 +11,7 @@ import os
 import shutil
 import sys
 
-from .run_tool import run_clang_tool, run_with_buffered_output
+from .run_tool import run_with_buffered_output, run_clang_tool_on_sources
 from ..environment import detect_clangtidy, detect_clangapply
 import typing as T
 
@@ -56,7 +56,7 @@ def run(args: T.List[str]) -> int:
             fixesdir.unlink()
         fixesdir.mkdir(parents=True)
 
-    tidyret = run_clang_tool('clang-tidy', srcdir, builddir, run_clang_tidy, tidyexe, builddir, fixesdir)
+    tidyret = run_clang_tool_on_sources('clang-tidy', srcdir, builddir, run_clang_tidy, tidyexe, builddir, fixesdir)
     if fixesdir is not None:
         print('Applying fix-its...')
         applyret = subprocess.run(applyexe + ['-format', '-style=file', '-ignore-insert-conflict', fixesdir]).returncode


### PR DESCRIPTION
clang-tidy can't be ran as is on every source file and header

closes #7662 