### PR TITLE
Swift/C++ interoperability fixup

### DIFF
--- a/docs/markdown/snippets/swift-pass-c-compiler-options.md
+++ b/docs/markdown/snippets/swift-pass-c-compiler-options.md
@@ -1,8 +1,9 @@
 ## Swift compiler receives select C family compiler options
 
-Meson now passes select few C family (C/Obj-C) compiler options to the
-Swift compiler, notably *-std=*, in order to improve the compatibility
-of C code as interpreted by the C compiler and the Swift compiler.
+Meson now passes select few C family (C/C++/Obj-C/Obj-C++) compiler
+options to the Swift compiler, notably *-std=*, in order to improve
+the compatibility of C code as interpreted by the C compiler and the
+Swift compiler.
 
 NB: This does not include any of the options set in the target's
 c_flags.

--- a/docs/markdown/snippets/swift_cxx_interoperability.md
+++ b/docs/markdown/snippets/swift_cxx_interoperability.md
@@ -1,13 +1,23 @@
 ## Swift/C++ interoperability is now supported
 
 It is now possible to create Swift executables that can link to C++ or
-Objective-C++ libraries. Only specifying a bridging header for the Swift
-target is required.
+Objective-C++ libraries. To enable this feature, set the target kwarg
+_swift\_interoperability\_mode_ to 'cpp'.
+
+To import C++ code, specify a bridging header in the Swift target's
+sources, or use another way such as adding a directory containing a
+Clang module map to its include path.
+
+Note: Enabling C++ interoperability in a library target is a breaking
+change. Swift libraries that enable it need their consumers to enable
+it as well, as per [the Swift documentation][1].
 
 Swift 5.9 is required to use this feature. Xcode 15 is required if the
 Xcode backend is used.
 
 ```meson
 lib = static_library('mylib', 'mylib.cpp')
-exe = executable('prog', 'main.swift', 'mylib.h', link_with: lib)
+exe = executable('prog', 'main.swift', 'mylib.h', link_with: lib, swift_interoperability_mode: 'cpp')
 ```
+
+[1]: https://www.swift.org/documentation/cxx-interop/project-build-setup/#vending-packages-that-enable-c-interoperability

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -1831,7 +1831,7 @@ class XCodeBackend(backends.Backend):
             settings_dict.add_item('SECTORDER_FLAGS', '')
             if is_swift and bridging_header:
                 settings_dict.add_item('SWIFT_OBJC_BRIDGING_HEADER', bridging_header)
-                if self.objversion >= 60 and 'cpp' in langs:
+                if self.objversion >= 60 and target.uses_swift_cpp_interop():
                     settings_dict.add_item('SWIFT_OBJC_INTEROP_MODE', 'objcxx')
             settings_dict.add_item('BUILD_DIR', symroot)
             settings_dict.add_item('OBJROOT', f'{symroot}/build')

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -75,7 +75,7 @@ lang_arg_kwargs |= {
 vala_kwargs = {'vala_header', 'vala_gir', 'vala_vapi'}
 rust_kwargs = {'rust_crate_type', 'rust_dependency_map'}
 cs_kwargs = {'resources', 'cs_args'}
-swift_kwargs = {'swift_module_name'}
+swift_kwargs = {'swift_interoperability_mode', 'swift_module_name'}
 
 buildtarget_kwargs = {
     'build_by_default',
@@ -1275,6 +1275,8 @@ class BuildTarget(Target):
             raise InvalidArguments(f'Invalid rust_dependency_map "{rust_dependency_map}": must be a dictionary with string values.')
         self.rust_dependency_map = rust_dependency_map
 
+        self.swift_interoperability_mode = kwargs.get('swift_interoperability_mode')
+
         self.swift_module_name = kwargs.get('swift_module_name')
         if self.swift_module_name == '':
             self.swift_module_name = self.name
@@ -1701,6 +1703,9 @@ class BuildTarget(Target):
 
     def uses_fortran(self) -> bool:
         return 'fortran' in self.compilers
+
+    def uses_swift_cpp_interop(self) -> bool:
+        return self.swift_interoperability_mode == 'cpp' and 'swift' in self.compilers
 
     def get_using_msvc(self) -> bool:
         '''

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1121,9 +1121,6 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
     def get_compile_only_args(self) -> T.List[str]:
         return []
 
-    def get_cxx_interoperability_args(self, lang: T.Dict[str, Compiler]) -> T.List[str]:
-        raise EnvironmentException('This compiler does not support CXX interoperability')
-
     def get_preprocess_only_args(self) -> T.List[str]:
         raise EnvironmentException('This compiler does not have a preprocessor')
 

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -153,11 +153,14 @@ class SwiftCompiler(Compiler):
 
         return ['-working-directory', path]
 
-    def get_cxx_interoperability_args(self, lang: T.Dict[str, Compiler]) -> T.List[str]:
-        if 'cpp' in lang or 'objcpp' in lang:
-            return ['-cxx-interoperability-mode=default']
-        else:
-            return ['-cxx-interoperability-mode=off']
+    def get_cxx_interoperability_args(self, target: T.Optional[build.BuildTarget] = None) -> T.List[str]:
+        if target is not None and not target.uses_swift_cpp_interop():
+            return []
+
+        if version_compare(self.version, '<5.9'):
+            raise MesonException(f'Compiler {self} does not support C++ interoperability')
+
+        return ['-cxx-interoperability-mode=default']
 
     def get_library_args(self) -> T.List[str]:
         return ['-parse-as-library']

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -140,7 +140,11 @@ class SwiftCompiler(Compiler):
             args += ['-swift-version', std]
 
         # Pass C compiler -std=... arg to swiftc
-        c_lang = first(['objc', 'c'], lambda x: x in target.compilers)
+        c_langs = ['objc', 'c']
+        if target.uses_swift_cpp_interop():
+            c_langs = ['objcpp', 'cpp', *c_langs]
+
+        c_lang = first(c_langs, lambda x: x in target.compilers)
         if c_lang is not None:
             cc = target.compilers[c_lang]
             args.extend(arg for c_arg in cc.get_option_std_args(target, env, subproject) for arg in ['-Xcc', c_arg])

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -363,6 +363,7 @@ class _BuildTarget(_BaseBuildTarget):
     d_module_versions: T.List[T.Union[str, int]]
     d_unittest: bool
     rust_dependency_map: T.Dict[str, str]
+    swift_interoperability_mode: Literal['c', 'cpp']
     swift_module_name: str
     sources: SourcesVarargsType
     c_args: T.List[str]

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -633,6 +633,7 @@ _BUILD_TARGET_KWS: T.List[KwargInfo] = [
         default={},
         since='1.2.0',
     ),
+    KwargInfo('swift_interoperability_mode', str, default='c', validator=in_set_validator({'c', 'cpp'}), since='1.9.0'),
     KwargInfo('swift_module_name', str, default='', since='1.9.0'),
     KwargInfo('build_rpath', str, default='', since='0.42.0'),
     KwargInfo(

--- a/test cases/swift/11 mixed cpp/meson.build
+++ b/test cases/swift/11 mixed cpp/meson.build
@@ -8,5 +8,5 @@ if not swiftc.version().version_compare('>= 5.9')
 endif
 
 lib = static_library('mylib', 'mylib.cpp')
-exe = executable('prog', 'main.swift', 'mylib.h', link_with: lib)
+exe = executable('prog', 'main.swift', 'mylib.h', link_with: lib, swift_interoperability_mode: 'cpp')
 test('cpp interface', exe)

--- a/test cases/swift/13 mixed objcpp/meson.build
+++ b/test cases/swift/13 mixed objcpp/meson.build
@@ -8,5 +8,5 @@ if not swiftc.version().version_compare('>= 5.9')
 endif
 
 lib = static_library('mylib', 'mylib.mm')
-exe = executable('prog', 'main.swift', 'mylib.h', link_with: lib)
+exe = executable('prog', 'main.swift', 'mylib.h', link_with: lib, swift_interoperability_mode: 'cpp')
 test('objcpp interface', exe)


### PR DESCRIPTION
Small fixup to #13317, includes the missing C++ part to #14296, and a per-target selection of Swift interop mode. The kwarg and value names are copied from their respective SwiftPM target options.

These changes are pulled out of #14261.

Reason for the kwarg is

> Enabling C++ interoperability for a Swift Package Manager target will need other targets that depend on such target to enable C++ interoperability as well.
> 
> Enabling C++ interoperability is a breaking change for an existing package, and so it must be done only in a new major semver version. Please bump up the package’s major version when you enable C++ interoperability!

(from https://www.swift.org/documentation/cxx-interop/project-build-setup/)