### PR TITLE
Update linker detection for ELD

### DIFF
--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -166,7 +166,7 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
 
         linker = lld_cls(
             compiler, for_machine, comp_class.LINKER_PREFIX, override, system=system, version=v)
-    elif 'Hexagon' in o and 'LLVM' in o:
+    elif o.startswith("eld"):
         linker = linkers.ELDDynamicLinker(
             compiler, for_machine, comp_class.LINKER_PREFIX, override, version=v)
     elif 'Snapdragon' in e and 'LLVM' in e:


### PR DESCRIPTION
ELD updated the output for `--version` flag https://github.com/qualcomm/eld/pull/156 this commit updates detection for new output.