### PR TITLE
Internal IR for compiler args

### DIFF
--- a/mesonbuild/arguments.py
+++ b/mesonbuild/arguments.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2025 Intel Corporation
+
+"""An abstract IR for compile arguments.
+
+This provides us with a way to pass arguments around in a non-compiler specific
+way internally, and lower them into a non-abstract format when writing them in
+the backend.
+"""
+
+from __future__ import annotations
+import dataclasses
+import typing as T
+
+if T.TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
+    # A Union of all Argument types
+    Argument: TypeAlias = T.Union[
+        'Opaque', 'Warning', 'Error', 'Define', 'Undefine', 'LinkerSearch', 'LinkLibrary'
+    ]
+
+
+@dataclasses.dataclass
+class Opaque:
+
+    """An opaque argument.
+
+    This is an argument of unknown type, and Meson will do nothing but proxy it
+    through, except to apply a prefix to the value if it thinks it's necessary.
+
+    :param value:
+    """
+
+    value: str
+
+
+@dataclasses.dataclass
+class Warning:
+
+    """A compiler warning.
+
+    :param target: The warning to enable or disable. This will be stored as
+        given (ie, we don't try to convert between compilers).
+    :param enable: If true then enable the warning, otherwise suppress it.
+    """
+
+    target: str
+    enable: bool
+
+
+@dataclasses.dataclass
+class Error:
+
+    """A compiler error.
+
+    :param target: The warning to enable or disable. This will be stored as
+        given (ie, we don't try to convert between compilers).
+    :param enable: If true then enable the warning, otherwise suppress it.
+    """
+
+    target: str
+
+
+@dataclasses.dataclass
+class Define:
+
+    """A pre-processor define.
+
+    :param target: The value to define.
+    :param value: An optional value to set the define to. If undefined them the
+        value will be defined with no value.
+    """
+
+    target: str
+    value: T.Optional[str]
+
+
+@dataclasses.dataclass
+class Undefine:
+
+    """A pre-processor undefine.
+
+    :param target: The value to define.
+    """
+
+    target: str
+
+
+@dataclasses.dataclass
+class LinkerSearch:
+
+    """A location for the linker to search for libraries.
+
+    :param path: The path to search.
+    """
+
+    path: str
+
+
+@dataclasses.dataclass
+class LinkLibrary:
+
+    """A library to link with.
+
+    :param name: The name of the library to link.
+    """
+
+    name: str
+
+
+# TODO: rpath
+# TODO: rust cfgs
+# TODO: other flags we might handle differently and want to convert like lto, sanitizers, etc

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -2108,7 +2108,7 @@ class Backend:
         commands += compiler.get_compile_only_args()
         # Add per-target compile args, f.ex, `c_args : ['-DFOO']`. We set these
         # near the end since these are supposed to override everything else.
-        commands += self.escape_extra_args(target.get_extra_args(compiler.get_language()))
+        commands += self.escape_extra_args(compiler.make_arguments_concrete(target.get_extra_args(compiler.get_language())))
         # Do not escape this one, it is interpreted by the build system
         # (Xcode considers these as variables to expand at build time)
         if extras is not None:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -39,6 +39,7 @@ if T.TYPE_CHECKING:
     from typing_extensions import Literal, TypedDict
 
     from . import environment
+    from .arguments import Argument
     from ._typing import ImmutableListProtocol
     from .backend.backends import Backend
     from .compilers import Compiler
@@ -719,7 +720,7 @@ class BuildTarget(Target):
         # as Vala which generates .vapi and .h besides the compiled output.
         self.outputs = [self.filename]
         self.pch: T.Dict[str, T.List[str]] = {}
-        self.extra_args: T.DefaultDict[str, T.List[str]] = kwargs.get('language_args', defaultdict(list))
+        self.extra_args: T.DefaultDict[str, T.List[Argument]] = kwargs.get('language_args', defaultdict(list))
         self.sources: T.List[File] = []
         # If the same source is defined multiple times, use it only once.
         self.seen_sources: T.Set[File] = set()

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -25,6 +25,7 @@ from ..arglist import CompilerArgs
 
 if T.TYPE_CHECKING:
     from .. import coredata
+    from ..arguments import Argument
     from ..build import BuildTarget, DFeatures
     from ..options import MutableKeyedOptionDictType
     from ..envconfig import MachineInfo
@@ -1417,6 +1418,22 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         if 'none' not in value:
             value = ['none'] + value
         std.choices = value
+
+    @abc.abstractmethod
+    def make_arguments_abstract(self, args: T.List[str]) -> T.List[Argument]:
+        """Convert concrete (string) arguments into abstract ones.
+
+        :param args: The list of string arguments to convert
+        :return: A list of Arguments.
+        """
+
+    @abc.abstractmethod
+    def make_arguments_concrete(self, args: T.List[Argument]) -> T.List[str]:
+        """Convert abstract Arguments into a list of strings for this compiler.
+
+        :param args: The Arguments to convert.
+        :return: A string list of arguments.
+        """
 
 
 def get_global_options(lang: str,

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -14,6 +14,7 @@ import re
 import subprocess
 import typing as T
 
+from ... import arguments
 from ... import mesonlib
 from ... import mlog
 from ...options import OptionKey, UserStdOption
@@ -536,6 +537,61 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
         # assembly file.
         lang = gnu_lang_map.get(self.language, 'assembler-with-cpp')
         return self.get_preprocess_only_args() + [f'-x{lang}']
+
+    def make_arguments_abstract(self, args: T.List[str]) -> T.List[arguments.Argument]:
+        ret: T.List[arguments.Argument] = []
+
+        for arg in args:
+            if arg.startswith('-D'):
+                v: T.Optional[str]
+                arg = arg.removeprefix('-D')
+                if '=' in arg:
+                    k, v = arg.split('=')
+                else:
+                    k, v = arg, None
+                ret.append(arguments.Define(k, v))
+            elif arg.startswith('-U'):
+                ret.append(arguments.Undefine(arg.removeprefix('-U')))
+            elif arg.startswith('-Wno-'):
+                ret.append(arguments.Warning(arg.removeprefix('-Wno-'), False))
+            elif arg.startswith('-l'):
+                ret.append(arguments.LinkerSearch(arg.removeprefix('-l')))
+            elif arg.startswith('-Werror='):
+                ret.append(arguments.Error(arg.removeprefix('-Werror=')))
+            elif arg.startswith('-Wno-'):
+                ret.append(arguments.Warning(arg.removeprefix('-Wno-'), False))
+            elif arg.startswith('-W'):
+                ret.append(arguments.Warning(arg.removeprefix('-W'), True))
+            else:
+                ret.append(arguments.Opaque(arg))
+
+        return ret
+
+    def make_arguments_concrete(self, args: T.List[arguments.Argument]) -> T.List[str]:
+        ret: T.List[str] = []
+
+        for arg in args:
+            match arg:
+                case arguments.Define(name, value):
+                    ret.append(f'-D{name}')
+                case arguments.Define(name, value):
+                    ret.append(f'-D{name}={value}')
+                case arguments.Undefine(name):
+                    ret.append(f'-U{name}')
+                case arguments.Error(name):
+                    ret.append(f'-Werror={name}')
+                case arguments.Warning(name, True):
+                    ret.append(f'-W{name}')
+                case arguments.Warning(name, False):
+                    ret.append(f'-Wno-{name}')
+                case arguments.LinkerSearch(name):
+                    ret.append(f'-L{name}')
+                case arguments.LinkLibrary(name):
+                    ret.append(f'-l{name}')
+                case arguments.Opaque(value):
+                    ret.append(value)
+
+        return ret
 
 
 class GnuCompiler(GnuLikeCompiler):

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -113,6 +113,7 @@ if T.TYPE_CHECKING:
     from typing_extensions import Literal
 
     from . import kwargs as kwtypes
+    from ..arguments import Argument
     from ..backend.backends import Backend
     from ..interpreterbase.baseobjects import InterpreterObject, TYPE_var, TYPE_kwargs
     from ..options import OptionDict
@@ -3341,11 +3342,13 @@ class Interpreter(InterpreterBase, HoldableObject):
         them for the IR.
         """
         d = kwargs.setdefault('depend_files', [])
-        new_args: T.DefaultDict[str, T.List[str]] = collections.defaultdict(list)
+        new_args: T.DefaultDict[str, T.List[Argument]] = collections.defaultdict(list)
 
         for l in compilers.all_languages:
             deps, args = self.__convert_file_args(kwargs[f'{l}_args'])
-            new_args[l] = args
+            # TODO: use correct machine
+            if args:
+                new_args[l] = self.compilers.host[l].make_arguments_abstract(args)
             d.extend(deps)
         kwargs['language_args'] = new_args
 
@@ -3412,12 +3415,12 @@ class Interpreter(InterpreterBase, HoldableObject):
         if targetclass is build.StaticLibrary:
             for lang in compilers.all_languages - {'java'}:
                 deps, args = self.__convert_file_args(kwargs.get(f'{lang}_static_args', []))
-                kwargs['language_args'][lang].extend(args)
+                kwargs['language_args'][lang].extend(self.compilers[for_machine][lang].make_arguments_abstract(args))
                 kwargs['depend_files'].extend(deps)
         elif targetclass is build.SharedLibrary:
             for lang in compilers.all_languages - {'java'}:
                 deps, args = self.__convert_file_args(kwargs.get(f'{lang}_shared_args', []))
-                kwargs['language_args'][lang].extend(args)
+                kwargs['language_args'][lang].extend(self.compilers[for_machine][lang].make_arguments_abstract(args))
                 kwargs['depend_files'].extend(deps)
         if targetclass is not build.Jar:
             self.check_for_jar_sources(sources, targetclass)

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -191,7 +191,8 @@ class RustModule(ExtensionModule):
                 del new_target_kwargs[kw]
 
         lang_args = base_target.extra_args.copy()
-        lang_args['rust'] = base_target.extra_args['rust'] + kwargs['rust_args'] + ['--test']
+        lang_args['rust'] = \
+            base_target.extra_args['rust'] + base_target.compilers['rust'].make_arguments_abstract(kwargs['rust_args'] + ['--test'])
         new_target_kwargs['language_args'] = lang_args
 
         sources = T.cast('T.List[SourceOutputs]', base_target.sources.copy())


### PR DESCRIPTION
This is set to draft because it's *very* much a Work in Progress.

The way we handle compiler arguments in Meson is to manipulate raw strings. This works fine when the majority of your compilers are the same, or at least attempt to be compatible. Unfortunately, Meson has to deal with many different toolchains, which often have incompatible argument syntax.

This manifests in a number of different ways:
 - It makes de-duplicating or removing arguments difficult. Consider the high complexity of the CompileArgs class
 - It makes checking for a kind of argument difficult. Ie, we have a check for `-Wl,-rlink` or `-rlink` inside of `build.py`, but that could miss `-rlink` for many compilers.
 - It means when converting a compiler argument from one language to another, like when proxying linker arguments, we need to determine the format the argument is already in and then attempt to convert.
- It makes it more difficult to set fields in the XCode and VisualStudio backends, which generally do not expect features to be set by compiler arguments, but by setting specific values. It is very easy to see this in the VS backend code, which has long `if` blocks converting string command line arguments to XML fields

In order to address this I propose moving to an abstract IR for these arguments. This abstract IR would simplify de-duplicating and cleaning arguments, as well as converting their forms. Each Compiler provides a mechanism to convert arguments from their format into the abstract IR, and a method to convert the abstract IR back into concrete arguments in their expected format. We then manipulate the abstract IR more easily. Consider something like this:

```python
[Define('X'), Opaque('-ffoobar'), Warning('foo'), Warning('foo'), 'Warning('foo', enable=false), Define('X')]
```

In this format it's pretty easy to look and see that we have two copies of `-DX` and two copies of `-Wfoo` along with `-Wno-foo`, cancelling both of those out.

Below is a very trivial implementation of this idea, with just enough implemented for GCC or Clang to compile the `1 trivial` test (run directly). This also is making use of python features we currently cant rely on, I'll rewrite those later.