### PR TITLE
modules/pkgconfig: Resolve dependencies in case of an internal dependency

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -156,6 +156,14 @@ class DependenciesHelper:
                 pass
             elif isinstance(obj, dependencies.ExternalDependency) and obj.name == 'threads':
                 pass
+            elif isinstance(obj, dependencies.InternalDependency) and all(lib.get_id() in self.metadata for lib in obj.libraries):
+                # Ensure BothLibraries are resolved:
+                if self.pub_libs and isinstance(self.pub_libs[0], build.StaticLibrary):
+                    obj = obj.get_as_static(recursive=True)
+                else:
+                    obj = obj.get_as_shared(recursive=True)
+                for lib in obj.libraries:
+                    processed_reqs.append(self.metadata[lib.get_id()].filebase)
             else:
                 raise mesonlib.MesonException('requires argument not a string, '
                                               'library with pkgconfig-generated file '

--- a/test cases/common/283 pkgconfig subproject/meson.build
+++ b/test cases/common/283 pkgconfig subproject/meson.build
@@ -1,0 +1,13 @@
+project('simple', 'c', meson_version: '>=1.9.0')
+pkgg = import('pkgconfig')
+
+simple2_dep = dependency('simple2')
+
+simple_lib = library('simple',
+    'simple.c',
+    dependencies: [simple2_dep]
+)
+
+pkgg.generate(simple_lib,
+requires: simple2_dep,
+)

--- a/test cases/common/283 pkgconfig subproject/simple.c
+++ b/test cases/common/283 pkgconfig subproject/simple.c
@@ -1,0 +1,6 @@
+#include"simple.h"
+#include <simple2.h>
+
+int simple_function(void) {
+    return simple_simple_function();
+}

--- a/test cases/common/283 pkgconfig subproject/simple.h
+++ b/test cases/common/283 pkgconfig subproject/simple.h
@@ -1,0 +1,6 @@
+#ifndef SIMPLE_H_
+#define SIMPLE_H_
+
+int simple_function(void);
+
+#endif

--- a/test cases/common/283 pkgconfig subproject/subprojects/simple2/exports.def
+++ b/test cases/common/283 pkgconfig subproject/subprojects/simple2/exports.def
@@ -1,0 +1,2 @@
+EXPORTS
+    simple_simple_function  @1

--- a/test cases/common/283 pkgconfig subproject/subprojects/simple2/meson.build
+++ b/test cases/common/283 pkgconfig subproject/subprojects/simple2/meson.build
@@ -1,0 +1,9 @@
+project('simple2', 'c', meson_version: '>=1.9.0')
+pkgg = import('pkgconfig')
+
+lib2 = library('simple2', 'simple2.c', vs_module_defs: 'exports.def')
+lib_dep = declare_dependency(link_with: lib2, include_directories: include_directories('.'))
+
+pkgg.generate(lib2)
+
+meson.override_dependency('simple2', lib_dep)

--- a/test cases/common/283 pkgconfig subproject/subprojects/simple2/simple2.c
+++ b/test cases/common/283 pkgconfig subproject/subprojects/simple2/simple2.c
@@ -1,0 +1,5 @@
+#include"simple2.h"
+
+int simple_simple_function(void) {
+    return 42;
+}

--- a/test cases/common/283 pkgconfig subproject/subprojects/simple2/simple2.h
+++ b/test cases/common/283 pkgconfig subproject/subprojects/simple2/simple2.h
@@ -1,0 +1,6 @@
+#ifndef SIMPLE2_H_
+#define SIMPLE2_H_
+
+int simple_simple_function(void);
+
+#endif

--- a/test cases/common/283 pkgconfig subproject/test.json
+++ b/test cases/common/283 pkgconfig subproject/test.json
@@ -1,0 +1,15 @@
+{
+    "installed": [
+        { "type": "file", "file": "usr/lib/pkgconfig/simple.pc"},
+        { "type": "file", "file": "usr/lib/pkgconfig/simple2.pc"}
+    ],
+    "matrix": {
+        "options": {
+            "default_library": [
+                { "val": "shared" },
+                { "val": "static" },
+                { "val": "both" }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
When giving a dependency object as requires, allow to use the dependency from a subproject (that is an InternalDepdency).