### PR TITLE
ci: gentoo: enable sys-devel/gcc[jit] to get binpkg

### DIFF
--- a/ci/ciimage/gentoo/install.sh
+++ b/ci/ciimage/gentoo/install.sh
@@ -108,7 +108,7 @@ cat <<-EOF > /etc/portage/package.use/ci
 
 	# Some of these settings are needed just to get the binpkg but
 	# aren't negative to have anyway
-	sys-devel/gcc ada d
+	sys-devel/gcc ada d jit
 	>=sys-devel/gcc-13 ada objc objc++
 	sys-devel/gcc pgo lto
 


### PR DESCRIPTION
See https://github.com/mesonbuild/meson/issues/14756#issuecomment-3020599903.

When I changed Gentoo's binhost.git in a117703e74dfabc6972911504453c2492c11dead, I'd forgot that we match those settings in Meson's CI builder, so we've not been able to take advantage of the binpkg since then.