### PR TITLE
Revert "test 64-bit types for atomic"

### DIFF
--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -56,24 +56,22 @@ packages['netcdf'] = netcdf_factory
 class AtomicBuiltinDependency(BuiltinDependency):
     def __init__(self, name: str, env: Environment, kwargs: T.Dict[str, T.Any]):
         super().__init__(name, env, kwargs)
-        self.feature_since = ('1.7.0', "consider checking for `atomic_fetch_add` of a 64-bit type with and without `find_library('atomic')`")
+        self.feature_since = ('1.7.0', "consider checking for `atomic_flag_clear` with and without `find_library('atomic')`")
 
-        code = '''#include <stdatomic.h>\n\nint main() {\n    atomic_int_least64_t a;\n    return atomic_fetch_add(&b, 1);\n}''' # [ignore encoding] this is C, not python, Mr. Lint
-
-        self.is_found = bool(self.clib_compiler.links(code, env)[0])
+        if self.clib_compiler.has_function('atomic_flag_clear', '#include <stdatomic.h>', env)[0]:
+            self.is_found = True
 
 
 class AtomicSystemDependency(SystemDependency):
     def __init__(self, name: str, env: Environment, kwargs: T.Dict[str, T.Any]):
         super().__init__(name, env, kwargs)
-        self.feature_since = ('1.7.0', "consider checking for `atomic_fetch_add` of a 64-bit type with and without `find_library('atomic')`")
+        self.feature_since = ('1.7.0', "consider checking for `atomic_flag_clear` with and without `find_library('atomic')`")
 
         h = self.clib_compiler.has_header('stdatomic.h', '', env)
-        if not h[0]:
-            return
-
         self.link_args = self.clib_compiler.find_library('atomic', env, [], self.libtype)
-        self.is_found = bool(self.link_args)
+
+        if h[0] and self.link_args:
+            self.is_found = True
 
 
 class DlBuiltinDependency(BuiltinDependency):


### PR DESCRIPTION
This reverts commit 60d0410c0ae22fd8f37a798736973a53128b2966.

The rationale for making this change was bogus and misunderstands the purpose of the dependency.

> The check is currently broken as atomic_flag_clear is a macro, not a
> function. Change it to test linkage instead.

... does not make any sense since the standard requires it to be a function. We already test linkage.

> Also test if atomics work with 64-bit types. On certain platforms like
> MIPS, external libatomic is needed.

... misses the fact that we already check for external libatomic ***first***, for precisely this reason. That was in the original design of this dependency.

Checking for more interesting forms of atomic usage is quite pointless. You can't write code that "requires" -latomic, as the toolchain may arbitrarily implement *anything* internally or else as a helper library, and we can't force it to do the latter.

Instead, we:

- check if the ISO header exists, and -latomic is a valid library. If so, assume it's needed. Maybe it is, maybe it isn't, -latomic can always be pruned by `-Wl,--as-needed` so we refuse to clutch pearls over it

- if -latomic doesn't exist, smoketest that the toolchain has "some kind of atomic support". That is, the ISO header exists and one randomly chosen function successfully links. This is not intended to be comprehensive, it is a fallback.

Notice that unlike most dependencies with a "builtin" method, we do NOT prefer the builtin! This is, again, because the ***primary purpose*** of `dependency('atomic')` is to handle the fact that you should always use -latomic if it exists.

Okay, so why revert the change? Maybe it doesn't matter? Well... that's a problem, since it was never actually tested. The code fails with:

```
$ gcc -latomic -o /tmp/foo /tmp/foo.c
In file included from /tmp/foo.c:1:
/tmp/foo.c: In function ‘main’:
/tmp/foo.c:5:30: error: ‘b’ undeclared (first use in this function)
    5 |     return atomic_fetch_add(&b, 1);
      |                              ^
/tmp/foo.c:5:30: note: each undeclared identifier is reported only once for each function it appears in
```

As it was never tested, we shall not assume it fixes a real world problem. But it sure does break the fallback.