### PR TITLE
qt dependency: Don't insert backslashes into cflags on windows

### DIFF
--- a/mesonbuild/dependencies/qt.py
+++ b/mesonbuild/dependencies/qt.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import abc
 import re
 import os
+from pathlib import Path
 import typing as T
 
 from .base import DependencyException, DependencyMethods
@@ -50,7 +51,7 @@ def _qt_get_private_includes(mod_inc_dir: str, module: str, mod_version: str) ->
             if len(dirname.split('.')) == 3:
                 private_dir = dirname
                 break
-    return [private_dir, os.path.join(private_dir, 'Qt' + module)]
+    return [private_dir, Path(private_dir, f'Qt{module}').as_posix()]
 
 
 def get_qmake_host_bins(qvars: T.Dict[str, str]) -> str:
@@ -303,7 +304,7 @@ class QmakeQtDependency(_QtBase, ConfigToolDependency, metaclass=abc.ABCMeta):
         modules_lib_suffix = _get_modules_lib_suffix(self.version, self.env.machines[self.for_machine], is_debug)
 
         for module in self.requested_modules:
-            mincdir = os.path.join(incdir, 'Qt' + module)
+            mincdir = Path(incdir, f'Qt{module}').as_posix()
             self.compile_args.append('-I' + mincdir)
 
             if module == 'QuickTest':


### PR DESCRIPTION
The use of `os.path.join` is inserting `\` into the compile_args, which is wrong since qmake outputs `/` even on Windows, and in fact it causes pkgconfig files that depend on qmake dependencies to have `\` path separators, which get resolved as escape sequences.

Use `Path.as_posix()` to avoid this.