### PR TITLE
Draft: GNOME: A utility for GApplication D-Bus Services

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -10,6 +10,7 @@ import copy
 import itertools
 import functools
 import os
+import re
 import subprocess
 import textwrap
 import typing as T
@@ -198,6 +199,11 @@ if T.TYPE_CHECKING:
         vtail: T.Optional[str]
         depends: T.List[T.Union[BuildTarget, CustomTarget, CustomTargetIndex]]
 
+    class InstallGApplication(TypedDict):
+
+        application_id: str
+        systemd_service: T.Optional[str]
+
     ToolType = T.Union[Executable, ExternalProgram, OverrideProgram]
 
 
@@ -242,6 +248,13 @@ def annotations_validator(annotations: T.List[T.Union[str, T.List[str]]]) -> T.O
                 return f'element {c+1} {badlist}'
     return None
 
+def application_id_validator(app_id:str)->T.Optional[str]:
+    if len(app_id) > 256:
+        return f'‘{app_id}’ is too long'
+    elif re.match(r"^[A-Za-z][A-Za-z0-9_\-]*(\.[A-Za-z][A-Za-z0-9_\-]*)+$", app_id) is None:
+        return f'‘{app_id}’ is not a valid ID'
+    return None
+
 # gresource compilation is broken due to the way
 # the resource compiler and Ninja clash about it
 #
@@ -265,6 +278,7 @@ class GnomeModule(ExtensionModule):
         self.install_update_mime_database = False
         self.devenv: T.Optional[mesonlib.EnvironmentVariables] = None
         self.native_glib_version: T.Optional[str] = None
+        self.dbus_dep: T.Optional[Dependency] = None
         self.methods.update({
             'post_install': self.post_install,
             'compile_resources': self.compile_resources,
@@ -278,6 +292,7 @@ class GnomeModule(ExtensionModule):
             'mkenums_simple': self.mkenums_simple,
             'genmarshal': self.genmarshal,
             'generate_vapi': self.generate_vapi,
+            'install_gapplication': self.install_gapplication,
         })
 
     def _get_native_glib_version(self, state: 'ModuleState') -> str:
@@ -2289,6 +2304,41 @@ class GnomeModule(ExtensionModule):
         rv = InternalDependency(None, incs, [], [], link_with, [], sources, [], [], {}, [], [], [])
         created_values.append(rv)
         return ModuleReturnValue(rv, created_values)
+
+    def _write_dbus_service(self, state: 'ModuleState', app_id: str, bin_path: str, systemd_service: T.Optional[str] = None) -> mesonlib.File:
+        scratch_dir = state.environment.get_scratch_dir()
+        service_name = f"{app_id}.service"
+        with open(os.path.join(scratch_dir, service_name), 'w', encoding='utf-8') as ofile:
+            ofile.write("[D-BUS Service]\n")
+            ofile.write(f"Name={app_id}\n")
+            ofile.write(f"Exec={bin_path} --gapplication-service\n")
+            if systemd_service:
+                ofile.write(f"SystemdService={systemd_service}\n")
+        return mesonlib.File(True, scratch_dir, service_name)
+
+    def _get_dbus_service_dir(self, state: 'ModuleState') -> str:
+        if not self.dbus_dep:
+            self.dbus_dep = state.dependency('dbus-1')
+        prefix = state.environment.get_prefix()
+        datadir = state.environment.get_datadir()
+        dbus_datadir = self.dbus_dep.get_variable(pkgconfig="datadir", default_value=os.path.join(prefix, datadir, "dbus-1"))
+        return self.dbus_dep.get_variable(pkgconfig="session_bus_services_dir", default_value=os.path.join(dbus_datadir, "services"))
+
+    @typed_pos_args('gnome.install_gapplication', Executable)
+    @typed_kwargs(
+        'gnome.install_gapplication',
+        KwargInfo('application_id', str, validator=application_id_validator, required=True),
+        KwargInfo('systemd_service', (str, NoneType)),
+    )
+    def install_gapplication(self, state: 'ModuleState', args: T.Tuple[Executable], kwargs: 'InstallGApplication') -> ModuleReturnValue:
+        executable,  = args
+        app_id = kwargs['application_id']
+        prefix = state.environment.get_prefix()
+        bin_dir, _, _ = executable.get_install_dir()
+        service_mfile = self._write_dbus_service(state, app_id, os.path.join(prefix, bin_dir[0], executable.name), kwargs.get('systemd_service'))
+        service_dir = self._get_dbus_service_dir(state)
+        res = build.Data([service_mfile], service_dir, service_dir, None, state.subproject,install_tag=executable.install_tag)
+        return ModuleReturnValue(res, [res])
 
 def initialize(interp: 'Interpreter') -> GnomeModule:
     mod = GnomeModule(interp)


### PR DESCRIPTION
This is a sorta feature request but with a rough implementation attached, I'm quite certain there are things I've overlooked (not being too familiar with meson internals) and of course there are no tests at present.

It's a simple enough idea: A method in the GNOME module that ‘just does the right thing’ to install a D-Bus service associating an executable with the app-id it provides (so as to be [`DBusActivatable`](https://specifications.freedesktop.org/desktop-entry-spec/latest/dbus.html)).

The task is simple enough, `.service` are very short and sweet, but require `configure_file`'ing to handle binary paths and potentially changeable app-ids (most commonly for devel builds) — at which point we are generating most of the file content. It's annoying busy-work every app has to repeat, a situation not too dissimilar to what `gnome.post_install` replaced.

Open questions:
- Is this a useful idea at all?
- How do we want to handle the service path?
  - Many apps currently assume `prefix / datadir / 'dbus-1' / 'services'`, which has the advantage of being simple and ‘just works’ with flatpak.
  - But it seems potentially more ‘correct’ to fetch `session_bus_services_dir` from `dbus-1`?
  - Maybe this wants to be handled at some ‘higher level’ in meson?
    - DBus is not GNOME specific after all, other things want to know where to shove services.
    - Are we ‘really’ looking for an `xdg` module that this could be built atop, the only really ‘GNOME’ thing is the `--gapplication-service` argument.
- What should it be called?
  - `install_gapplication` doesn't seem great.
- Should it be limited to `exe`s?
  - Rust apps in GNOME are currently all built as `custom_tgt`
  - Python apps are presumably `file` or `str`?
- Presumably others I've forgotten/not-noticed. 