### PR TITLE
Support sftp in wrap file

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -744,7 +744,7 @@ class Resolver:
                 resp = urllib.request.urlopen(req, timeout=REQ_TIMEOUT)
             except OSError as e:
                 mlog.log(str(e))
-                raise WrapException(f'could not get {urlstring} is the internet available?')
+                raise WrapException(f'could not get {urlstring}; is the internet available?')
         with contextlib.closing(resp) as resp, tmpfile as tmpfile:
             try:
                 dlsize = int(resp.info()['Content-Length'])

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -775,14 +775,17 @@ class Resolver:
             hashvalue = h.hexdigest()
         return hashvalue, tmpfile.name
 
+    def hash_file(self, path: str) -> str:
+        h = hashlib.sha256()
+        with open(path, 'rb') as f:
+            h.update(f.read())
+        return h.hexdigest()
+
     def check_hash(self, what: str, path: str, hash_required: bool = True) -> None:
         if what + '_hash' not in self.wrap.values and not hash_required:
             return
         expected = self.wrap.get(what + '_hash').lower()
-        h = hashlib.sha256()
-        with open(path, 'rb') as f:
-            h.update(f.read())
-        dhash = h.hexdigest()
+        dhash = self.hash_file(path)
         if dhash != expected:
             raise WrapException(f'Incorrect hash for {what}:\n {expected} expected\n {dhash} actual.')
 


### PR DESCRIPTION
Add and test basic support for sftp in wrap-file. The functionality depends on the "sftp" cli tool being installed, and fails with a helpful message if it is not. 

This solution requires any credentials to be supplied in the url, or some other
means of authentication (such as an identity file configured for the
user) to be used.

Mainly for testing purposes, "source_identityfile" can be used to point
out an identity file. Also mainly for testing purposes, "source_hostkey"
can be used to specify a trusted public key for the host.

The test sets up a temporary local ssh server using generated keys (committing them yields complaints from GitGuardian). 