### PR TITLE
compilers: refactor sanity checking code

### DIFF
--- a/mesonbuild/compilers/asm.py
+++ b/mesonbuild/compilers/asm.py
@@ -10,6 +10,7 @@ from .mixins.metrowerks import MetrowerksCompiler, mwasmarm_instruction_set_args
 from .mixins.ti import TICompiler
 
 if T.TYPE_CHECKING:
+    from ..environment import Environment
     from ..linkers.linkers import DynamicLinker
     from ..mesonlib import MachineChoice
     from ..envconfig import MachineInfo
@@ -38,6 +39,12 @@ class ASMCompiler(Compiler):
         if self._SUPPORTED_ARCHES and info.cpu_family not in self._SUPPORTED_ARCHES:
             raise EnvironmentException(f'ASM Compiler {self.id} does not support building for {info.cpu_family} CPU family.')
         super().__init__(ccache, exelist, version, for_machine, info, linker, full_version, is_cross)
+
+    def _sanity_check_compile_args(self, env: Environment, sourcename: str, binname: str) -> T.List[str]:
+        return []
+
+    def _sanity_check_source_code(self) -> str:
+        return ''
 
 
 class NasmCompiler(ASMCompiler):

--- a/mesonbuild/compilers/asm.py
+++ b/mesonbuild/compilers/asm.py
@@ -26,7 +26,12 @@ nasm_optimization_args: T.Dict[str, T.List[str]] = {
 }
 
 
-class NasmCompiler(Compiler):
+class ASMCompiler(Compiler):
+
+    """Shared base class for all ASM Compilers (Assemblers)"""
+
+
+class NasmCompiler(ASMCompiler):
     language = 'nasm'
     id = 'nasm'
 
@@ -152,7 +157,7 @@ class YasmCompiler(NasmCompiler):
         return ['--depfile', outfile]
 
 # https://learn.microsoft.com/en-us/cpp/assembler/masm/ml-and-ml64-command-line-reference
-class MasmCompiler(Compiler):
+class MasmCompiler(ASMCompiler):
     language = 'masm'
     id = 'ml'
 
@@ -210,7 +215,7 @@ class MasmCompiler(Compiler):
 
 
 # https://learn.microsoft.com/en-us/cpp/assembler/arm/arm-assembler-command-line-reference
-class MasmARMCompiler(Compiler):
+class MasmARMCompiler(ASMCompiler):
     language = 'masm'
     id = 'armasm'
 
@@ -261,14 +266,14 @@ class MasmARMCompiler(Compiler):
 
 
 # https://downloads.ti.com/docs/esd/SPRUI04/
-class TILinearAsmCompiler(TICompiler, Compiler):
+class TILinearAsmCompiler(TICompiler, ASMCompiler):
     language = 'linearasm'
 
     def __init__(self, ccache: T.List[str], exelist: T.List[str], version: str,
                  for_machine: MachineChoice, info: MachineInfo,
                  linker: T.Optional[DynamicLinker] = None,
                  full_version: T.Optional[str] = None, is_cross: bool = False):
-        Compiler.__init__(self, ccache, exelist, version, for_machine, info, linker, full_version, is_cross)
+        ASMCompiler.__init__(self, ccache, exelist, version, for_machine, info, linker, full_version, is_cross)
         TICompiler.__init__(self)
 
     def needs_static_linker(self) -> bool:
@@ -288,14 +293,14 @@ class TILinearAsmCompiler(TICompiler, Compiler):
         return 'd'
 
 
-class MetrowerksAsmCompiler(MetrowerksCompiler, Compiler):
+class MetrowerksAsmCompiler(MetrowerksCompiler, ASMCompiler):
     language = 'nasm'
 
     def __init__(self, ccache: T.List[str], exelist: T.List[str], version: str,
                  for_machine: 'MachineChoice', info: 'MachineInfo',
                  linker: T.Optional['DynamicLinker'] = None,
                  full_version: T.Optional[str] = None, is_cross: bool = False):
-        Compiler.__init__(self, ccache, exelist, version, for_machine, info, linker, full_version, is_cross)
+        ASMCompiler.__init__(self, ccache, exelist, version, for_machine, info, linker, full_version, is_cross)
         MetrowerksCompiler.__init__(self)
 
         self.warn_args: T.Dict[str, T.List[str]] = {

--- a/mesonbuild/compilers/asm.py
+++ b/mesonbuild/compilers/asm.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import os
 import typing as T
 
-from ..mesonlib import EnvironmentException, get_meson_command
+from .. import mlog
+from ..mesonlib import EnvironmentException, Popen_safe, join_args, get_meson_command
 from ..options import OptionKey
 from .compilers import Compiler
 from .mixins.metrowerks import MetrowerksCompiler, mwasmarm_instruction_set_args, mwasmeppc_instruction_set_args
@@ -25,6 +26,10 @@ nasm_optimization_args: T.Dict[str, T.List[str]] = {
 }
 
 
+class _CheckUnimplementedException(Exception):
+    pass
+
+
 class ASMCompiler(Compiler):
 
     """Shared base class for all ASM Compilers (Assemblers)"""
@@ -41,10 +46,57 @@ class ASMCompiler(Compiler):
         self._compiler = compiler
 
     def _sanity_check_compile_args(self, env: Environment, sourcename: str, binname: str) -> T.List[str]:
+        # TODO: fallback back to this is always wrong, it means that the
+        # concrete implementation is missing the sanity check implementation
         return []
 
+    def _sanity_check_filenames(self) -> T.Tuple[str, str]:
+        src, bin = super()._sanity_check_filenames()
+        bin = '{}.obj'.format(os.path.splitext(bin)[0])
+        return src, bin
+
     def _sanity_check_source_code(self) -> str:
-        return ''
+        raise _CheckUnimplementedException()
+
+    def _run_sanity_check(self, env: Environment, cmdlist: T.List[str], work_dir: str) -> None:
+        # This is a bit of a hack
+        return
+
+    def sanity_check(self, work_dir: str, env: Environment) -> None:
+        try:
+            super().sanity_check(work_dir, env)
+        except _CheckUnimplementedException:
+            if self.info.kernel:
+                name = self.info.kernel
+                if self.info.subsystem:
+                    name = f'{name} {self.info.subsystem}'
+            else:
+                name = self.info.system
+            mlog.warning(
+                f'Missing {self.id} sanity check code for {name}.',
+                'You can help by providing such an implementation',
+                fatal=False, once=True)
+            return
+
+        # This is the object from the compilation
+        src = self._sanity_check_filenames()[1]
+        bin = self._compiler._sanity_check_filenames()[1]
+
+        cmdlist = self._compiler._sanity_check_compile_args(env, src, bin)
+
+        pc, stdo, stde = Popen_safe(cmdlist, cwd=work_dir)
+        mlog.debug('Sanity check linker command line:', join_args(cmdlist))
+        mlog.debug('Sanity check linker stdout:')
+        mlog.debug(stdo)
+        mlog.debug('-----\nSanity check linker stderr:')
+        mlog.debug(stde)
+        mlog.debug('-----')
+        if pc.returncode != 0:
+            raise EnvironmentError(
+                f'Compiler {self._compiler.name_string()} could not link an object from the {self.name_string()} assembler')
+
+        # This is also a hack
+        return super()._run_sanity_check(env, [os.path.join(work_dir, bin)], work_dir)
 
 
 class NasmCompiler(ASMCompiler):

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -76,9 +76,8 @@ class CCompiler(CLikeCompiler, Compiler):
     def get_no_stdinc_args(self) -> T.List[str]:
         return ['-nostdinc']
 
-    def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
-        code = 'int main(void) { int class=0; return class; }\n'
-        return self._sanity_check_impl(work_dir, environment, 'sanitycheckc.c', code)
+    def _sanity_check_source_code(self) -> str:
+        return 'int main(void) { int class=0; return class; }\n'
 
     def has_header_symbol(self, hname: str, symbol: str, prefix: str,
                           env: 'Environment', *,

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -86,9 +86,8 @@ class CPPCompiler(CLikeCompiler, Compiler):
     def get_no_stdlib_link_args(self) -> T.List[str]:
         return ['-nostdlib++']
 
-    def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
-        code = 'class breakCCompiler;int main(void) { return 0; }\n'
-        return self._sanity_check_impl(work_dir, environment, 'sanitycheckcpp.cc', code)
+    def _sanity_check_source_code(self) -> str:
+        return 'class breakCCompiler;int main(void) { return 0; }\n'
 
     def get_compiler_check_args(self, mode: CompileCheckMode) -> T.List[str]:
         # -fpermissive allows non-conforming code to compile which is necessary

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -3,11 +3,10 @@
 
 from __future__ import annotations
 
-import os.path, subprocess
+import os.path
 import textwrap
 import typing as T
 
-from ..mesonlib import EnvironmentException
 from ..linkers import RSPFileSyntax
 
 from .compilers import Compiler
@@ -83,26 +82,21 @@ class CsCompiler(BasicLinkerIsCompilerMixin, Compiler):
     def get_pch_name(self, header_name: str) -> str:
         return ''
 
-    def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
-        src = 'sanity.cs'
-        obj = 'sanity.exe'
-        source_name = os.path.join(work_dir, src)
-        with open(source_name, 'w', encoding='utf-8') as ofile:
-            ofile.write(textwrap.dedent('''
-                public class Sanity {
-                    static public void Main () {
-                    }
+    def _sanity_check_source_code(self) -> str:
+        return textwrap.dedent('''
+            public class Sanity {
+                static public void Main () {
                 }
-                '''))
-        pc = subprocess.Popen(self.exelist + self.get_always_args() + [src], cwd=work_dir)
-        pc.wait()
-        if pc.returncode != 0:
-            raise EnvironmentException('C# compiler %s cannot compile programs.' % self.name_string())
+            }
+            ''')
+
+    def _sanity_check_compile_args(self, env: Environment, sourcename: str, binname: str) -> T.List[str]:
+        return self.exelist + self.get_always_args() + [sourcename] + self.get_output_args(binname)
+
+    def _sanity_check_run_with_exe_wrapper(self, env: Environment, command: T.List[str]) -> T.List[str]:
         if self.runner:
-            cmdlist = [self.runner, obj]
-        else:
-            cmdlist = [os.path.join(work_dir, obj)]
-        self.run_sanity_check(environment, cmdlist, work_dir, use_exe_wrapper_for_cross=False)
+            return [self.runner] + command
+        return command
 
     def needs_static_linker(self) -> bool:
         return False

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -5,15 +5,14 @@
 from __future__ import annotations
 
 import enum
-import os.path
 import string
 import typing as T
 
 from .. import options
 from .. import mlog
+from .. import mesonlib
 from ..mesonlib import (
-    EnvironmentException, Popen_safe,
-    is_windows, LibType, version_compare
+    EnvironmentException, is_windows, LibType, version_compare
 )
 from .compilers import Compiler, CompileCheckMode
 
@@ -187,6 +186,7 @@ class CudaCompiler(Compiler):
                  host_compiler: Compiler, info: 'MachineInfo',
                  linker: T.Optional['DynamicLinker'] = None,
                  full_version: T.Optional[str] = None):
+        self.detected_cc = ''
         super().__init__(ccache, exelist, version, for_machine, info, linker=linker, full_version=full_version, is_cross=is_cross)
         self.host_compiler = host_compiler
         self.base_options = host_compiler.base_options
@@ -499,55 +499,36 @@ class CudaCompiler(Compiler):
     def thread_link_flags(self, environment: 'Environment') -> T.List[str]:
         return self._to_host_flags(self.host_compiler.thread_link_flags(environment), Phase.LINKER)
 
-    def sanity_check(self, work_dir: str, env: 'Environment') -> None:
-        mlog.debug('Sanity testing ' + self.get_display_language() + ' compiler:', ' '.join(self.exelist))
-        mlog.debug('Is cross compiler: %s.' % str(self.is_cross))
+    def _sanity_check_source_code(self) -> str:
+        return r'''
+            #include <cuda_runtime.h>
+            #include <stdio.h>
 
-        sname = 'sanitycheckcuda.cu'
-        code = r'''
-        #include <cuda_runtime.h>
-        #include <stdio.h>
+            __global__ void kernel (void) {}
 
-        __global__ void kernel (void) {}
-
-        int main(void){
-            struct cudaDeviceProp prop;
-            int count, i;
-            cudaError_t ret = cudaGetDeviceCount(&count);
-            if(ret != cudaSuccess){
-                fprintf(stderr, "%d\n", (int)ret);
-            }else{
-                for(i=0;i<count;i++){
-                    if(cudaGetDeviceProperties(&prop, i) == cudaSuccess){
-                        fprintf(stdout, "%d.%d\n", prop.major, prop.minor);
+            int main(void){
+                struct cudaDeviceProp prop;
+                int count, i;
+                cudaError_t ret = cudaGetDeviceCount(&count);
+                if(ret != cudaSuccess){
+                    fprintf(stderr, "%d\n", (int)ret);
+                }else{
+                    for(i=0;i<count;i++){
+                        if(cudaGetDeviceProperties(&prop, i) == cudaSuccess){
+                            fprintf(stdout, "%d.%d\n", prop.major, prop.minor);
+                        }
                     }
                 }
+                fflush(stderr);
+                fflush(stdout);
+                return 0;
             }
-            fflush(stderr);
-            fflush(stdout);
-            return 0;
-        }
-        '''
-        binname = sname.rsplit('.', 1)[0]
-        binname += '_cross' if self.is_cross else ''
-        source_name = os.path.join(work_dir, sname)
-        binary_name = os.path.join(work_dir, binname + '.exe')
-        with open(source_name, 'w', encoding='utf-8') as ofile:
-            ofile.write(code)
+            '''
 
-        # The Sanity Test for CUDA language will serve as both a sanity test
-        # and a native-build GPU architecture detection test, useful later.
-        #
-        # For this second purpose, NVCC has very handy flags, --run and
-        # --run-args, that allow one to run an application with the
-        # environment set up properly. Of course, this only works for native
-        # builds; For cross builds we must still use the exe_wrapper (if any).
-        self.detected_cc = ''
-        flags = []
-
+    def _sanity_check_compile_args(self, env: Environment, sourcename: str, binname: str) -> T.List[str]:
         # Disable warnings, compile with statically-linked runtime for minimum
         # reliance on the system.
-        flags += ['-w', '-cudart', 'static', source_name]
+        flags = ['-w', '-cudart', 'static', sourcename]
 
         # Use the -ccbin option, if available, even during sanity checking.
         # Otherwise, on systems where CUDA does not support the default compiler,
@@ -562,33 +543,30 @@ class CudaCompiler(Compiler):
             # a ton of compiler flags to differentiate between
             # arm and x86_64. So just compile.
             flags += self.get_compile_only_args()
-        flags += self.get_output_args(binary_name)
+        flags += self.get_output_args(binname)
 
-        # Compile sanity check
-        cmdlist = self.exelist + flags
-        mlog.debug('Sanity check compiler command line: ', ' '.join(cmdlist))
-        pc, stdo, stde = Popen_safe(cmdlist, cwd=work_dir)
-        mlog.debug('Sanity check compile stdout: ')
-        mlog.debug(stdo)
-        mlog.debug('-----\nSanity check compile stderr:')
-        mlog.debug(stde)
-        mlog.debug('-----')
-        if pc.returncode != 0:
-            raise EnvironmentException(f'Compiler {self.name_string()} cannot compile programs.')
+        return self.exelist + flags
 
-        # Run sanity check (if possible)
-        if self.is_cross:
+    def _run_sanity_check(self, env: Environment, cmdlist: T.List[str], work_dir: str) -> None:
+        # Can't check binaries, so we have to assume they work
+        if self.is_cross and not env.has_exe_wrapper():
+            mlog.debug('Cannot run cross check')
             return
 
-        cmdlist = self.exelist + ['--run', f'"{binary_name}"']
+        cmdlist = self._sanity_check_run_with_exe_wrapper(env, cmdlist)
+        mlog.debug('Sanity check built target output for', self.for_machine, self.language, 'compiler')
+        mlog.debug(' -- Running test binary command: ', mesonlib.join_args(cmdlist))
         try:
-            stdo, stde = self.run_sanity_check(env, cmdlist, work_dir)
-        except EnvironmentException:
+            pe, stdo, stde = mesonlib.Popen_safe_logged(cmdlist, 'Sanity check', cwd=work_dir)
+            mlog.debug(' -- stdout:\n', stdo)
+            mlog.debug(' -- stderr:\n', stde)
+            mlog.debug(' -- returncode:', pe.returncode)
+        except Exception as e:
+            raise EnvironmentException(f'Could not invoke sanity check executable: {e!s}.')
+
+        if pe.returncode != 0:
             raise EnvironmentException(f'Executables created by {self.language} compiler {self.name_string()} are not runnable.')
 
-        # Interpret the result of the sanity test.
-        # As mentioned above, it is not only a sanity test but also a GPU
-        # architecture detection test.
         if stde == '':
             self.detected_cc = stdo
 

--- a/mesonbuild/compilers/cython.py
+++ b/mesonbuild/compilers/cython.py
@@ -1,13 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright © 2021-2025 Intel Corporation
-from __future__ import annotations
 
 """Abstraction for Cython language compilers."""
 
+from __future__ import annotations
+import os
 import typing as T
 
 from .. import options
-from ..mesonlib import EnvironmentException, version_compare
+from ..mesonlib import version_compare
 from .compilers import Compiler
 
 if T.TYPE_CHECKING:
@@ -49,15 +50,21 @@ class CythonCompiler(Compiler):
     def get_depfile_suffix(self) -> str:
         return 'dep'
 
-    def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
-        code = 'print("hello world")'
-        with self.cached_compile(code, environment.coredata) as p:
-            if p.returncode != 0:
-                raise EnvironmentException(f'Cython compiler {self.id!r} cannot compile programs')
-
     def get_pic_args(self) -> T.List[str]:
         # We can lie here, it's fine
         return []
+
+    def _sanity_check_source_code(self) -> str:
+        return 'print("Hello world")'
+
+    def _sanity_check_compile_args(self, env: Environment, sourcename: str, binname: str) -> T.List[str]:
+        return self.exelist + self.get_always_args() + self.get_output_args(binname) + [sourcename]
+
+    def _run_sanity_check(self, env: Environment, cmdlist: T.List[str], work_dir: str) -> None:
+        # Cython will do a Cython -> C -> Exe, so the output file will actually have
+        # the name of the C compiler.
+        # TODO: find a way to not make this so hacky
+        return super()._run_sanity_check(env, [os.path.join(work_dir, 'sanity_check_for_c.exe')], work_dir)
 
     def compute_parameters_with_absolute_paths(self, parameter_list: T.List[str],
                                                build_dir: str) -> T.List[str]:

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import os.path
 import re
-import subprocess
 import typing as T
 
 from .. import mesonlib
@@ -438,24 +437,11 @@ class DCompiler(Compiler):
                          full_version=full_version, is_cross=is_cross)
         self.arch = arch
 
-    def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
-        source_name = os.path.join(work_dir, 'sanity.d')
-        output_name = os.path.join(work_dir, 'dtest')
-        with open(source_name, 'w', encoding='utf-8') as ofile:
-            ofile.write('''void main() { }''')
+    def _sanity_check_source_code(self) -> str:
+        return 'void main() { }'
 
-        compile_cmdlist = self.exelist + self.get_output_args(output_name) + self._get_target_arch_args() + [source_name]
-
-        # If cross-compiling, we can't run the sanity check, only compile it.
-        if self.is_cross and not environment.has_exe_wrapper():
-            compile_cmdlist += self.get_compile_only_args()
-
-        pc = subprocess.Popen(compile_cmdlist, cwd=work_dir)
-        pc.wait()
-        if pc.returncode != 0:
-            raise EnvironmentException('D compiler %s cannot compile programs.' % self.name_string())
-
-        stdo, stde = self.run_sanity_check(environment, [output_name], work_dir)
+    def _sanity_check_compile_args(self, env: Environment, sourcename: str, binname: str) -> T.List[str]:
+        return self.exelist + self.get_output_args(binname) + self._get_target_arch_args() + [sourcename]
 
     def needs_static_linker(self) -> bool:
         return True

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -22,6 +22,7 @@ import os
 import typing as T
 
 if T.TYPE_CHECKING:
+    from .asm import ASMCompiler
     from .compilers import Compiler
     from .c import CCompiler
     from .cpp import CPPCompiler
@@ -1335,20 +1336,20 @@ def detect_nasm_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
         if 'NASM' in output:
             comp_class = NasmCompiler
             env.add_lang_args(comp_class.language, comp_class, for_machine)
-            return comp_class([], comp, version, for_machine, info, cc.linker, is_cross=is_cross)
+            return comp_class([], comp, version, for_machine, info, cc, is_cross=is_cross)
         elif 'yasm' in output:
             comp_class = YasmCompiler
             env.add_lang_args(comp_class.language, comp_class, for_machine)
-            return comp_class([], comp, version, for_machine, info, cc.linker, is_cross=is_cross)
+            return comp_class([], comp, version, for_machine, info, cc, is_cross=is_cross)
         elif 'Metrowerks' in output or 'Freescale' in output:
             if 'ARM' in output:
                 comp_class_mwasmarm = MetrowerksAsmCompilerARM
                 env.add_lang_args(comp_class_mwasmarm.language, comp_class_mwasmarm, for_machine)
-                return comp_class_mwasmarm([], comp, version, for_machine, info, cc.linker, is_cross=is_cross)
+                return comp_class_mwasmarm([], comp, version, for_machine, info, cc, is_cross=is_cross)
             else:
                 comp_class_mwasmeppc = MetrowerksAsmCompilerEmbeddedPowerPC
                 env.add_lang_args(comp_class_mwasmeppc.language, comp_class_mwasmeppc, for_machine)
-                return comp_class_mwasmeppc([], comp, version, for_machine, info, cc.linker, is_cross=is_cross)
+                return comp_class_mwasmeppc([], comp, version, for_machine, info, cc, is_cross=is_cross)
 
     _handle_exceptions(popen_exceptions, compilers)
     raise EnvironmentException('Unreachable code (exception to make mypy happy)')
@@ -1364,7 +1365,7 @@ def detect_masm_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
         info = env.machines[for_machine]
 
     from .asm import MasmCompiler, MasmARMCompiler
-    comp_class: T.Type[Compiler]
+    comp_class: T.Type[ASMCompiler]
     if info.cpu_family == 'x86':
         comp = ['ml']
         comp_class = MasmCompiler
@@ -1389,7 +1390,7 @@ def detect_masm_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
         output = Popen_safe(comp + [arg])[2]
         version = search_version(output)
         env.add_lang_args(comp_class.language, comp_class, for_machine)
-        return comp_class([], comp, version, for_machine, info, cc.linker, is_cross=is_cross)
+        return comp_class([], comp, version, for_machine, info, cc, is_cross=is_cross)
     except OSError as e:
         popen_exceptions[' '.join(comp + [arg])] = e
     _handle_exceptions(popen_exceptions, [comp])

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import textwrap
 import typing as T
 import functools
 import os
@@ -61,10 +62,12 @@ class FortranCompiler(CLikeCompiler, Compiler):
         largs = env.coredata.get_external_link_args(self.for_machine, self.language)
         return cargs, largs
 
-    def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
-        source_name = 'sanitycheckf.f'
-        code = '      PROGRAM MAIN\n      PRINT *, "Fortran compilation is working."\n      END\n'
-        return self._sanity_check_impl(work_dir, environment, source_name, code)
+    def _sanity_check_source_code(self) -> str:
+        return textwrap.dedent('''
+            PROGRAM MAIN
+                PRINT *, "Fortran compilation is working."
+            END
+            ''')
 
     def get_optimization_args(self, optimization_level: str) -> T.List[str]:
         return gnu_optimization_args[optimization_level]

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -268,50 +268,15 @@ class CLikeCompiler(Compiler):
     def gen_import_library_args(self, implibname: str) -> T.List[str]:
         return self.linker.import_library_args(implibname)
 
-    def _sanity_check_impl(self, work_dir: str, environment: 'Environment',
-                           sname: str, code: str) -> None:
-        mlog.debug('Sanity testing ' + self.get_display_language() + ' compiler:', mesonlib.join_args(self.exelist))
-        mlog.debug(f'Is cross compiler: {self.is_cross!s}.')
-
-        source_name = os.path.join(work_dir, sname)
-        binname = sname.rsplit('.', 1)[0]
-        mode = CompileCheckMode.LINK
-        if self.is_cross:
-            binname += '_cross'
-            if not environment.has_exe_wrapper():
-                # Linking cross built C/C++ apps is painful. You can't really
-                # tell if you should use -nostdlib or not and for example
-                # on OSX the compiler binary is the same but you need
-                # a ton of compiler flags to differentiate between
-                # arm and x86_64. So just compile.
-                mode = CompileCheckMode.COMPILE
-        cargs, largs = self._get_basic_compiler_args(environment, mode)
+    def _sanity_check_compile_args(self, env: Environment, sourcename: str, binname: str) -> T.List[str]:
+        # Cross-compiling is hard. For example, you might need -nostdlib, or to pass --target, etc.
+        mode = CompileCheckMode.COMPILE if self.is_cross and not env.has_exe_wrapper() else CompileCheckMode.LINK
+        cargs, largs = self._get_basic_compiler_args(env, mode)
         extra_flags = cargs + self.linker_to_compiler_args(largs)
-
-        # Is a valid executable output for all toolchains and platforms
-        binname += '.exe'
-        # Write binary check source
-        binary_name = os.path.join(work_dir, binname)
-        with open(source_name, 'w', encoding='utf-8') as ofile:
-            ofile.write(code)
-        # Compile sanity check
-        # NOTE: extra_flags must be added at the end. On MSVC, it might contain a '/link' argument
-        # after which all further arguments will be passed directly to the linker
-        cmdlist = self.exelist + [sname] + self.get_output_args(binname) + extra_flags
-        pc, stdo, stde = mesonlib.Popen_safe(cmdlist, cwd=work_dir)
-        mlog.debug('Sanity check compiler command line:', mesonlib.join_args(cmdlist))
-        mlog.debug('Sanity check compile stdout:')
-        mlog.debug(stdo)
-        mlog.debug('-----\nSanity check compile stderr:')
-        mlog.debug(stde)
-        mlog.debug('-----')
-        if pc.returncode != 0:
-            raise mesonlib.EnvironmentException(f'Compiler {self.name_string()} cannot compile programs.')
-        self.run_sanity_check(environment, [binary_name], work_dir)
-
-    def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
-        code = 'int main(void) { int class=0; return class; }\n'
-        return self._sanity_check_impl(work_dir, environment, 'sanitycheckc.c', code)
+        # It is important that extra_flags is last as it may contain `/link`
+        # directives, MSVC-compatible compilers will pass all arguments after
+        # that to the linker
+        return self.exelist + [sourcename] + self.get_output_args(binname) + extra_flags
 
     def check_header(self, hname: str, prefix: str, env: 'Environment', *,
                      extra_args: T.Union[None, T.List[str], T.Callable[['CompileCheckMode'], T.List[str]]] = None,

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -48,9 +48,8 @@ class ObjCCompiler(CLikeCompiler, Compiler):
     def get_display_language() -> str:
         return 'Objective-C'
 
-    def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
-        code = '#import<stddef.h>\nint main(void) { return 0; }\n'
-        return self._sanity_check_impl(work_dir, environment, 'sanitycheckobjc.m', code)
+    def _sanity_check_source_code(self) -> str:
+        return '#import<stddef.h>\nint main(void) { return 0; }\n'
 
     def form_compileropt_key(self, basename: str) -> OptionKey:
         if basename == 'std':

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -50,9 +50,8 @@ class ObjCPPCompiler(CLikeCompiler, Compiler):
     def get_display_language() -> str:
         return 'Objective-C++'
 
-    def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
-        code = '#import<stdio.h>\nclass MyClass;int main(void) { return 0; }\n'
-        return self._sanity_check_impl(work_dir, environment, 'sanitycheckobjcpp.mm', code)
+    def _sanity_check_source_code(self) -> str:
+        return '#import<stdio.h>\nclass MyClass;int main(void) { return 0; }\n'
 
     def get_options(self) -> MutableKeyedOptionDictType:
         opts = super().get_options()

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -107,44 +107,43 @@ class RustCompiler(Compiler):
     def needs_static_linker(self) -> bool:
         return False
 
-    def sanity_check(self, work_dir: str, environment: Environment) -> None:
-        source_name = os.path.join(work_dir, 'sanity.rs')
-        output_name = os.path.join(work_dir, 'rusttest.exe')
+    def _sanity_check_compile_args(self, env: Environment, sourcename: str, binname: str) -> T.List[str]:
         cmdlist = self.exelist.copy()
+        assert self.linker is not None, 'for mypy'
+        if self.info.kernel == 'none' and 'ld.' in self.linker.id:
+            cmdlist.extend(['-C', 'link-arg=-nostartfiles'])
+        cmdlist.extend(self.get_output_args(binname))
+        cmdlist.append(sourcename)
+        return cmdlist
 
-        with open(source_name, 'w', encoding='utf-8') as ofile:
-            # If machine kernel is not `none`, try to compile a dummy program.
-            # If 'none', this is likely a `no-std`(i.e. bare metal) project.
-            if self.info.kernel != 'none':
-                ofile.write(textwrap.dedent(
-                    '''fn main() {
-                    }
-                    '''))
-            else:
-                # If rustc linker is gcc, add `-nostartfiles`
-                if 'ld.' in self.linker.id:
-                    cmdlist.extend(['-C', 'link-arg=-nostartfiles'])
-                ofile.write(textwrap.dedent(
-                    '''#![no_std]
-                    #![no_main]
-                    #[no_mangle]
-                    pub fn _start() {
-                    }
-                    #[panic_handler]
-                    fn panic(_info: &core::panic::PanicInfo) -> ! {
-                        loop {}
-                    }
-                    '''))
+    def _sanity_check_source_code(self) -> str:
+        if self.info.kernel != 'none':
+            return textwrap.dedent(
+                '''fn main() {
+                }
+                ''')
+        return textwrap.dedent(
+            '''#![no_std]
+            #![no_main]
+            #[no_mangle]
+            pub fn _start() {
+            }
+            #[panic_handler]
+            fn panic(_info: &core::panic::PanicInfo) -> ! {
+                loop {}
+            }
+            ''')
 
-        cmdlist.extend(['-o', output_name, source_name])
-        pc, stdo, stde = Popen_safe_logged(cmdlist, cwd=work_dir)
-        if pc.returncode != 0:
-            raise EnvironmentException(f'Rust compiler {self.name_string()} cannot compile programs.')
+    def sanity_check(self, work_dir: str, environment: Environment) -> None:
+        super().sanity_check(work_dir, environment)
+        source_name = self._sanity_check_filenames()[0]
         self._native_static_libs(work_dir, source_name)
-        self.run_sanity_check(environment, [output_name], work_dir)
 
     def _native_static_libs(self, work_dir: str, source_name: str) -> None:
         # Get libraries needed to link with a Rust staticlib
+        if self.native_static_libs:
+            return
+
         cmdlist = self.exelist + ['--crate-type', 'staticlib', '--print', 'native-static-libs', source_name]
         p, stdo, stde = Popen_safe_logged(cmdlist, cwd=work_dir)
         if p.returncode != 0:

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -177,22 +177,21 @@ class SwiftCompiler(Compiler):
 
         return parameter_list
 
-    def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
-        src = 'swifttest.swift'
-        source_name = os.path.join(work_dir, src)
-        output_name = os.path.join(work_dir, 'swifttest')
-        extra_flags: T.List[str] = []
-        extra_flags += environment.coredata.get_external_args(self.for_machine, self.language)
+    def _sanity_check_compile_args(self, env: Environment, sourcename: str, binname: str) -> T.List[str]:
+        cmdlist = self.exelist.copy()
+        # TODO: I can't test this, but it doesn't seem right
         if self.is_cross:
-            extra_flags += self.get_compile_only_args()
+            cmdlist.extend(self.get_compile_only_args())
         else:
-            extra_flags += environment.coredata.get_external_link_args(self.for_machine, self.language)
-        with open(source_name, 'w', encoding='utf-8') as ofile:
-            ofile.write('''print("Swift compilation is working.")
-''')
-        pc = subprocess.Popen(self.exelist + extra_flags + ['-emit-executable', '-o', output_name, src], cwd=work_dir)
-        pc.wait()
-        self.run_sanity_check(environment, [output_name], work_dir)
+            cmdlist.extend(env.coredata.get_external_link_args(self.for_machine, self.language))
+        cmdlist.extend(self.get_std_exe_link_args())
+        cmdlist.extend(self.get_output_args(binname))
+        cmdlist.append(sourcename)
+
+        return cmdlist
+
+    def _sanity_check_source_code(self) -> str:
+        return 'print("Swift compilation is working.")'
 
     def get_debug_args(self, is_debug: bool) -> T.List[str]:
         return clike_debug_args[is_debug]

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -55,8 +55,11 @@ class MissingCompiler(_MissingCompilerBase):
         def get_output_args(self, outputname: str) -> T.List[str]:
             return []
 
-        def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
-            return None
+        def _sanity_check_compile_args(self, env: Environment, sourcename: str, binname: str) -> T.List[str]:
+            return []
+
+        def _sanity_check_source_code(self) -> str:
+            return ''
 
     def __getattr__(self, item: str) -> T.Any:
         if item.startswith('__'):


### PR DESCRIPTION
The goal is to reduce code duplication, and allow each language to implement as little as possible to get good checking. The main motivation is that half of the checks are fragile, as they add the work directory to the paths of the generated files they want to use. This works when run inside mesonmain because we always have an absolute build directory, but when put into run_project_tests.py it doesn't work because that gives a relative build directory.

This work was based on #14758, in which I realized that the implementation of sanity_check for Cuda was less than ideal. This is still not fully ideal, as there's a lot of duplication with `compiles`, but the amount of work required to make `compiles` generic enough for this is large, and I really want to get back to other things, so an improvement is an improvement. This also allows me to get to the point that the above mentioned PR works correctly for all languages, and that is enough.

This PR seems like it should have a pretty big reduction in LOC, but doesn't. There's a few reasons for that: better doc strings is one, but the biggest is that for many languages the implementation was so basic and limited that the hooks took as many or more lines than the original implementation did. They are benefiting less in cleanup and more in enhanced functionality.