### PR TITLE
Use raw dependency linker args for Rust

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2093,7 +2093,9 @@ class NinjaBackend(backends.Backend):
                 args.append(f'-Clink-arg={lib}')
 
         for e in external_deps:
-            for a in e.get_link_args():
+            # Use raw linker args to prevent issues if/when rustc does its own
+            # dependency resolution
+            for a in e.get_link_args(raw = True):
                 if a in rustc.native_static_libs:
                     # Exclude link args that rustc already add by default
                     pass


### PR DESCRIPTION
rustc may do its own dependency resolution when passing to the linker. If a dependency isn't in a lib path, it will fail to resolve it, even when the dependency is passed in as an absolute path.

This addresses https://github.com/mesonbuild/meson/issues/14622.