### PR TITLE
Small option fixes for cross compilation

### DIFF
--- a/docs/yaml/functions/get_option.yaml
+++ b/docs/yaml/functions/get_option.yaml
@@ -20,6 +20,11 @@ description: |
   See [`feature` options](Build-options.md#features)
   documentation for more details.
 
+  For options that are [specified
+  per-machine](Builtin-options.md#specifying-options-per-machine)
+  `get_option()` retrieves the value of the option for the
+  build machine if the argument starts with `build.`.
+
 posargs:
   option_name:
     type: str

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -736,6 +736,8 @@ class Environment:
         if section_subproject:
             key = key.evolve(subproject=section_subproject)
         if machine == MachineChoice.BUILD:
+            if key.machine == MachineChoice.BUILD:
+                mlog.deprecation('Setting build machine options in the native file does not need the "build." prefix', once=True)
             return key.evolve(machine=machine)
         return key
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1085,7 +1085,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         value_object: T.Optional[options.AnyOptionType]
 
         try:
-            optkey = options.OptionKey(optname, self.subproject)
+            optkey = options.OptionKey.from_string(optname).evolve(subproject=self.subproject)
             value_object, value = self.coredata.optstore.get_value_object_and_value_for(optkey)
         except KeyError:
             if self.coredata.optstore.is_base_option(optkey):

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -147,7 +147,7 @@ class Conf:
         Each column will have a specific width, and will be line wrapped.
         """
         total_width = shutil.get_terminal_size(fallback=(160, 0))[0]
-        _col = max(total_width // 5, 20)
+        _col = max(total_width // 5, 24)
         last_column = total_width - (3 * _col) - 3
         four_column = (_col, _col, _col, last_column if last_column > 1 else _col)
 
@@ -207,11 +207,12 @@ class Conf:
         self.choices_col.append(choices)
         self.descr_col.append(descr)
 
-    def add_option(self, name: str, descr: str, value: T.Any, choices: T.Any) -> None:
+    def add_option(self, key: OptionKey, descr: str, value: T.Any, choices: T.Any) -> None:
         self._add_section()
         value = stringify(value)
         choices = stringify(choices)
-        self._add_line(mlog.green(name), mlog.yellow(value), mlog.blue(choices), descr)
+        self._add_line(mlog.green(str(key.evolve(subproject=None))), mlog.yellow(value),
+                       mlog.blue(choices), descr)
 
     def add_title(self, title: str) -> None:
         self._add_section()
@@ -248,7 +249,7 @@ class Conf:
             #    printable_value = '<inherited from main project>'
             #if isinstance(o, options.UserFeatureOption) and o.is_auto():
             #    printable_value = auto.printable_value()
-            self.add_option(k.name, o.description, printable_value, o.printable_choices())
+            self.add_option(k, o.description, printable_value, o.printable_choices())
 
     def print_conf(self, pager: bool) -> None:
         if pager:

--- a/test cases/unit/69 cross/crossfile.in
+++ b/test cases/unit/69 cross/crossfile.in
@@ -3,3 +3,6 @@ system = '@system@'
 cpu_family = '@cpu_family@'
 cpu = '@cpu@'
 endian = '@endian@'
+
+[built-in options]
+c_args = ['-funroll-loops']

--- a/test cases/unit/69 cross/meson.build
+++ b/test cases/unit/69 cross/meson.build
@@ -1,16 +1,25 @@
 project('crosstest')
 
+add_languages('c', native: true)
 if get_option('generate')
     conf_data = configuration_data()
     conf_data.set('system', build_machine.system())
     conf_data.set('cpu', build_machine.cpu())
     conf_data.set('cpu_family', build_machine.cpu_family())
     conf_data.set('endian', build_machine.endian())
+    conf_data.set('c_args', '-pedantic')
 
     configure_file(input: 'crossfile.in',
                 output: 'crossfile',
                 configuration: conf_data)
-    message('Written cross file')
+    configure_file(input: 'nativefile.in',
+                output: 'nativefile',
+                configuration: conf_data)
+    message('Written native and cross file')
+
+    add_languages('c', native: false)
+    assert(get_option('build.c_args') == get_option('c_args'))
 else
     assert(meson.is_cross_build(), 'not setup as cross build')
+    assert(get_option('build.c_args') == ['-pedantic'])
 endif

--- a/test cases/unit/69 cross/nativefile.in
+++ b/test cases/unit/69 cross/nativefile.in
@@ -1,0 +1,2 @@
+[built-in options]
+c_args = ['@c_args@']

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -3316,10 +3316,15 @@ class AllPlatformTests(BasePlatformTests):
     def test_identity_cross(self):
         testdir = os.path.join(self.unit_test_dir, '69 cross')
         # Do a build to generate a cross file where the host is this target
-        self.init(testdir, extra_args=['-Dgenerate=true'])
+        # build.c_args is ignored here.
+        self.init(testdir, extra_args=['-Dgenerate=true', '-Dc_args=-funroll-loops',
+                                       '-Dbuild.c_args=-pedantic'])
+        self.meson_native_files = [os.path.join(self.builddir, "nativefile")]
+        self.assertTrue(os.path.exists(self.meson_native_files[0]))
         self.meson_cross_files = [os.path.join(self.builddir, "crossfile")]
         self.assertTrue(os.path.exists(self.meson_cross_files[0]))
-        # Now verify that this is detected as cross
+        # Now verify that this is detected as cross and build options are
+        # processed correctly
         self.new_builddir()
         self.init(testdir)
 


### PR DESCRIPTION
- allow retrieving build options with `get_option('build.c_args')`
- include `build.` prefix in `meson configure` output
- allow setting build options in machine files with a `build.` prefix (it's deprecated but should not assert)

Fixes: #14788
Fixes: #14789