### PR TITLE
docs: document missing languages in `project()`

### DIFF
--- a/docs/yaml/functions/project.yaml
+++ b/docs/yaml/functions/project.yaml
@@ -24,7 +24,7 @@ description: |
 
   Supported values for languages are `c`, `cpp` (for `C++`), `cuda`,
   `cython`, `d`, `objc`, `objcpp`, `fortran`, `java`, `cs` (for `C#`),
-  `vala` and `rust`.
+  `swift`, `nasm`, `masm`, `linearasm`, `vala` and `rust`.
 
 posargs:
   project_name:


### PR DESCRIPTION
The main reason I made this PR was to document Meson's support for `nasm` added in [0.64.0](https://mesonbuild.com/Release-notes-for-0-64-0.html#new-languages-nasm-and-masm). I tried to add all other missing supported languages, but I might have missed some.