### PR TITLE
docs: Make link validator regex more greedy

### DIFF
--- a/docs/validatelinks.py
+++ b/docs/validatelinks.py
@@ -8,7 +8,7 @@ import re
 import aiohttp
 import asyncio
 
-LINK = re.compile(r'\[(?P<name>[A-Za-z0-9 ]+)\]\((?P<url>.*?)\)')
+LINK = re.compile(r'\[(?P<name>[^\]]+)\]\((?P<url>.*?)\)')
 
 
 async def fetch(session, name, url, timeout):


### PR DESCRIPTION
Update the link regex to match any character except `]` in the link text, instead of only alphanumeric characters and spaces. This allows the script to detect dead links whose text includes punctuation, special characters, or spans multiple lines.

See for example https://regex101.com/r/33ODNH/1 (old) versus https://regex101.com/r/33ODNH/2 (new).