### PR TITLE
Restore 1.8.x behavior of yielding options

### DIFF
--- a/docs/markdown/Build-options.md
+++ b/docs/markdown/Build-options.md
@@ -244,6 +244,10 @@ project which also has an option called `some_option`, then calling
 `yield` is `false`, `get_option` returns the value of the subproject's
 option.
 
+*Since 1.8.0* `-Dsub:some_option=anothervalue`, when used with a
+yielding option, sets the value separately from the option
+it yields to.
+
 
 ## Built-in build options
 

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -849,7 +849,7 @@ class OptionStore:
     def __len__(self) -> int:
         return len(self.options)
 
-    def get_key_and_value_object_for(self, key: 'T.Union[OptionKey, str]') -> T.Tuple[OptionKey, AnyOptionType]:
+    def get_value_object_for(self, key: 'T.Union[OptionKey, str]') -> AnyOptionType:
         key = self.ensure_and_validate_key(key)
         potential = self.options.get(key, None)
         if self.is_project_option(key):
@@ -863,15 +863,12 @@ class OptionStore:
                     raise KeyError(f'Tried to access nonexistant project parent option {parent_key}.')
                 # This is a global option but it can still have per-project
                 # augment, so return the subproject key.
-                return key, self.options[parent_key]
-        return key, potential
-
-    def get_value_object_for(self, key: 'T.Union[OptionKey, str]') -> AnyOptionType:
-        return self.get_key_and_value_object_for(key)[1]
+                return self.options[parent_key]
+        return potential
 
     def get_value_object_and_value_for(self, key: OptionKey) -> T.Tuple[AnyOptionType, ElementaryOptionValues]:
         assert isinstance(key, OptionKey)
-        _, vobject = self.get_key_and_value_object_for(key)
+        vobject = self.get_value_object_for(key)
         computed_value = vobject.value
         if key in self.augments:
             assert key.subproject is not None
@@ -1021,7 +1018,7 @@ class OptionStore:
             new_value = self.sanitize_dir_option_value(prefix, key, new_value)
 
         try:
-            actual_key, opt = self.get_key_and_value_object_for(key)
+            opt = self.get_value_object_for(key)
         except KeyError:
             raise MesonException(f'Unknown option: "{error_key}".')
 

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -174,7 +174,7 @@ class OptionTests(unittest.TestCase):
 
         optstore.initialize_from_subproject_call(subp, {}, {}, cmd_line, {})
         self.assertEqual(optstore.get_value_for(name, ''), top_value)
-        self.assertEqual(optstore.get_value_for(name, subp), top_value)
+        self.assertEqual(optstore.get_value_for(name, subp), sub_value)
 
     def test_augments(self):
         optstore = OptionStore(False)


### PR DESCRIPTION
Meson 1.8.x makes it possible to adjust the value of a yielding option with a subproject-specific augment.  This was an undocumented change  which was (voluntarily) undone in commit eae4efa72 ("options: resolve yielding options at the time they are added", 2025-07-13).

Since it is useful, try to preserve it by reimplementing yielding options: store a link to the parent project option, and undo it if `set_option` overrides it.

Because UserOption lookup now never checks `yielding`, this avoids the issue from #14774 too.