### PR TITLE
Add suffix function to the fs module

### DIFF
--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -206,11 +206,24 @@ fs.name('foo/bar/baz.dll.a')  # baz.dll.a
 *since 0.54.0*
 
 Returns the last component of the path, dropping the last part of the
-suffix
+suffix.
 
 ```meson
 fs.stem('foo/bar/baz.dll')  # baz
 fs.stem('foo/bar/baz.dll.a')  # baz.dll
+```
+
+### suffix
+
+*since 1.9.0*
+
+Returns the last dot-separated portion of the final component of the path
+including the dot, if any.
+
+```meson
+fs.suffix('foo/bar/baz.dll')  # .dll
+fs.suffix('foo/bar/baz.dll.a')  # .a
+fs.suffix('foo/bar')  # (empty)
 ```
 
 ### read

--- a/docs/markdown/snippets/fs_suffix.md
+++ b/docs/markdown/snippets/fs_suffix.md
@@ -1,0 +1,4 @@
+## Added suffix function to the FS module
+
+The basename and stem were already available. For completeness, expose also the
+suffix.

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -44,7 +44,7 @@ class FSModule(ExtensionModule):
 
     INFO = ModuleInfo('fs', '0.53.0')
 
-    def __init__(self, interpreter: 'Interpreter') -> None:
+    def __init__(self, interpreter: Interpreter) -> None:
         super().__init__(interpreter)
         self.methods.update({
             'as_posix': self.as_posix,
@@ -64,6 +64,7 @@ class FSModule(ExtensionModule):
             'replace_suffix': self.replace_suffix,
             'size': self.size,
             'stem': self.stem,
+            'suffix': self.suffix,
         })
 
     def _absolute_dir(self, state: ModuleState, arg: FileOrString) -> str:
@@ -224,6 +225,13 @@ class FSModule(ExtensionModule):
     def stem(self, state: ModuleState, args: T.Tuple[T.Union[FileOrString, BuildTargetTypes]], kwargs: T.Dict[str, T.Any]) -> str:
         path = self._obj_to_pathstr('fs.name', args[0], state)
         return os.path.splitext(os.path.basename(path))[0]
+
+    @noKwargs
+    @typed_pos_args('fs.suffix', (str, File, CustomTarget, CustomTargetIndex, BuildTarget))
+    @FeatureNew('fs.suffix', '1.9.0')
+    def suffix(self, state: ModuleState, args: T.Tuple[T.Union[FileOrString, BuildTargetTypes]], kwargs: T.Dict[str, T.Any]) -> str:
+        path = self._obj_to_pathstr('fs.suffix', args[0], state)
+        return os.path.splitext(path)[1]
 
     @FeatureNew('fs.read', '0.57.0')
     @typed_pos_args('fs.read', (str, File))

--- a/test cases/common/220 fs module/meson.build
+++ b/test cases/common/220 fs module/meson.build
@@ -52,6 +52,7 @@ unixabs = '/foo'
 if is_windows
   assert(fs.is_absolute(winabs), 'is_absolute windows not detected')
   assert(not fs.is_absolute(unixabs), 'is_absolute unix false positive')
+  assert(fs.is_absolute('//foo'), 'is_absolute failed on incomplete UNC path')
 else
   assert(fs.is_absolute(unixabs), 'is_absolute unix not detected')
   assert(not fs.is_absolute(winabs), 'is_absolute windows false positive')

--- a/test cases/common/220 fs module/meson.build
+++ b/test cases/common/220 fs module/meson.build
@@ -150,8 +150,10 @@ assert(fs.name(f[1]) == 'meson.build', 'failed to get basename')
 assert(fs.name('foo/bar/baz.dll.a') == 'baz.dll.a', 'failed to get basename with compound suffix')
 if host_machine.system() in ['cygwin', 'windows']
   assert(fs.name(btgt) == 'btgt.exe', 'failed to get basename of build target')
+  assert(fs.suffix(btgt) == '.exe', 'failed to get build target suffix')
 else
   assert(fs.name(btgt) == 'btgt', 'failed to get basename of build target')
+  assert(fs.suffix(btgt) == '', 'failed to get build target suffix')
 endif
 assert(fs.name(ctgt) == 'ctgt.txt', 'failed to get basename of custom target')
 assert(fs.name(ctgt[0]) == 'ctgt.txt', 'failed to get basename of custom target index')
@@ -160,6 +162,12 @@ assert(fs.stem('foo/bar/baz.dll.a') == 'baz.dll', 'failed to get stem with compo
 assert(fs.stem(btgt) == 'btgt', 'failed to get stem of build target')
 assert(fs.stem(ctgt) == 'ctgt', 'failed to get stem of custom target')
 assert(fs.stem(ctgt[0]) == 'ctgt', 'failed to get stem of custom target index')
+assert(fs.suffix('foo/bar/baz') == '', 'failed to get missing suffix')
+assert(fs.suffix('foo/bar/baz.') == '.', 'failed to get empty suffix')
+assert(fs.suffix('foo/bar/baz.dll') == '.dll', 'failed to get plain suffix')
+assert(fs.suffix('foo/bar/baz.dll.a') == '.a', 'failed to get final suffix')
+assert(fs.suffix(ctgt) == '.txt', 'failed to get suffix of custom target')
+assert(fs.suffix(ctgt[0]) == '.txt', 'failed to get suffix of custom target index')
 
 # relative_to
 if build_machine.system() == 'windows'

--- a/test cases/common/220 fs module/meson.build
+++ b/test cases/common/220 fs module/meson.build
@@ -84,7 +84,7 @@ assert(new == 'foo',  'replace_suffix did not only delete last suffix')
 
 # `/` on windows is interpreted like `.drive` which in general may not be `c:/`
 # the files need not exist for fs.replace_suffix()
-original = is_windows ? 'j:/foo/bar.txt' : '/foo/bar.txt'
+original = is_windows ? 'j:\\foo\\bar.txt' : '/foo/bar.txt'
 new_check = is_windows ? 'j:\\foo\\bar.ini' : '/foo/bar.ini'
 
 new = fs.replace_suffix(original, '.ini')
@@ -139,11 +139,7 @@ endif
 
 # parts of path
 assert(fs.parent('foo/bar') == 'foo', 'failed to get dirname')
-if not is_windows
-assert(fs.parent(f[1]) == 'subdir/..', 'failed to get dirname')
-else
-assert(fs.parent(f[1]) == 'subdir\..', 'failed to get dirname')
-endif
+assert(fs.parent(f[1]) == 'subdir/..', 'failed to get dirname for file')
 assert(fs.parent(btgt) == '.', 'failed to get dirname for build target')
 assert(fs.parent(ctgt) == '.', 'failed to get dirname for custom target')
 assert(fs.parent(ctgt[0]) == '.', 'failed to get dirname for custom target index')


### PR DESCRIPTION
When iterating over a list of files, it can be convenient to check suffixes. You could already do `fs.name(file).endswith('.txt')`, but `fs.suffix(file) == '.txt'` is just that tiny bit nicer. We also get the invariant `fs.name(file) == fs.stem(file) + fs.suffix(file)`.