### PR TITLE
Add swift_module_name target argument

### DIFF
--- a/docs/markdown/snippets/swift-module-name.md
+++ b/docs/markdown/snippets/swift-module-name.md
@@ -1,0 +1,9 @@
+## Explicitly setting Swift module name is now supported
+
+It is now possible to set the Swift module name for a target via the
+*swift_module_name* target kwarg, overriding the default inferred from the
+target name.
+
+```meson
+lib = library('foo', 'foo.swift', swift_module_name: 'Foo')
+```

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2214,10 +2214,7 @@ class NinjaBackend(backends.Backend):
 
     def swift_module_file_name(self, target):
         return os.path.join(self.get_target_private_dir(target),
-                            self.target_swift_modulename(target) + '.swiftmodule')
-
-    def target_swift_modulename(self, target):
-        return target.name
+                            target.swift_module_name + '.swiftmodule')
 
     def determine_swift_dep_modules(self, target):
         result = []
@@ -2244,7 +2241,7 @@ class NinjaBackend(backends.Backend):
         return srcs, others
 
     def generate_swift_target(self, target) -> None:
-        module_name = self.target_swift_modulename(target)
+        module_name = target.swift_module_name
         swiftc = target.compilers['swift']
         abssrc = []
         relsrc = []

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -75,6 +75,7 @@ lang_arg_kwargs |= {
 vala_kwargs = {'vala_header', 'vala_gir', 'vala_vapi'}
 rust_kwargs = {'rust_crate_type', 'rust_dependency_map'}
 cs_kwargs = {'resources', 'cs_args'}
+swift_kwargs = {'swift_module_name'}
 
 buildtarget_kwargs = {
     'build_by_default',
@@ -110,7 +111,8 @@ known_build_target_kwargs = (
     pch_kwargs |
     vala_kwargs |
     rust_kwargs |
-    cs_kwargs)
+    cs_kwargs |
+    swift_kwargs)
 
 known_exe_kwargs = known_build_target_kwargs | {'implib', 'export_dynamic', 'pie', 'vs_module_defs', 'android_exe_type'}
 known_shlib_kwargs = known_build_target_kwargs | {'version', 'soversion', 'vs_module_defs', 'darwin_versions', 'rust_abi'}
@@ -1259,6 +1261,10 @@ class BuildTarget(Target):
         if any(not isinstance(v, str) for v in rust_dependency_map.values()):
             raise InvalidArguments(f'Invalid rust_dependency_map "{rust_dependency_map}": must be a dictionary with string values.')
         self.rust_dependency_map = rust_dependency_map
+
+        self.swift_module_name = kwargs.get('swift_module_name')
+        if not self.swift_module_name:
+            self.swift_module_name = self.name
 
     def _extract_pic_pie(self, kwargs: T.Dict[str, T.Any], arg: str, option: str) -> bool:
         # Check if we have -fPIC, -fpic, -fPIE, or -fpie in cflags

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -363,6 +363,7 @@ class _BuildTarget(_BaseBuildTarget):
     d_module_versions: T.List[T.Union[str, int]]
     d_unittest: bool
     rust_dependency_map: T.Dict[str, str]
+    swift_module_name: str
     sources: SourcesVarargsType
     c_args: T.List[str]
     cpp_args: T.List[str]

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -633,6 +633,7 @@ _BUILD_TARGET_KWS: T.List[KwargInfo] = [
         default={},
         since='1.2.0',
     ),
+    KwargInfo('swift_module_name', str, default='', since='1.9.0'),
     KwargInfo('build_rpath', str, default='', since='0.42.0'),
     KwargInfo(
         'gnu_symbol_visibility',


### PR DESCRIPTION
Allows explicitly setting the Swift module name. By default, this is set to the target name, which we might want to change for various reasons, for example when it isn't a valid module name, or when building two targets with the same module name (e.g. a host and native variant).