### PR TITLE
fix yielding options in the toplevel project

### DIFF
--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -937,7 +937,7 @@ class OptionStore:
                 # Subproject is set to yield, but top level
                 # project does not have an option of the same
                 pass
-            valobj.yielding = bool(valobj.parent)
+        valobj.yielding = bool(valobj.parent)
 
         self.options[key] = valobj
         self.project_options.add(key)

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -121,6 +121,14 @@ class OptionTests(unittest.TestCase):
         self.assertEqual(optstore.get_value_for(name, 'sub'), sub_value)
         self.assertEqual(num_options(optstore), 2)
 
+    def test_toplevel_project_yielding(self):
+        optstore = OptionStore(False)
+        name = 'someoption'
+        top_value = 'top'
+        vo = UserStringOption(name, 'A top level option', top_value, True)
+        optstore.add_project_option(OptionKey(name, ''), vo)
+        self.assertEqual(optstore.get_value_for(name, ''), top_value)
+
     def test_project_yielding(self):
         optstore = OptionStore(False)
         name = 'someoption'


### PR DESCRIPTION
Ensure that valobj.yielding is cleared for options in the toplevel project. Add a testcase.

This happened due to a misindentation of a statement. `set_from_configure_command` is correct in that it always assigns to `opt.yielding`, `add_project_option` must do the same.