### PR TITLE
Hack around hotdoc build failures

### DIFF
--- a/ci/ciimage/fedora/install.sh
+++ b/ci/ciimage/fedora/install.sh
@@ -17,6 +17,8 @@ pkgs=(
   qt6-qtdeclarative-devel qt6-qtbase-devel qt6-qttools-devel qt6-linguist qt6-qtbase-private-devel
   libwmf-devel valgrind cmake openmpi-devel nasm gnustep-base-devel gettext-devel ncurses-devel
   libxml2-devel libxslt-devel libyaml-devel glib2-devel json-glib-devel libgcrypt-devel wayland-devel wayland-protocols-devel
+  # HACK: remove npm once we switch back to hotdoc sdist
+  nodejs-npm
 )
 
 # Sys update
@@ -24,7 +26,12 @@ dnf -y upgrade
 
 # Install deps
 dnf -y install "${pkgs[@]}"
-install_python_packages hotdoc
+# HACK: build hotdoc from git repo since current sdist is broken on modern compilers
+# change back to 'hotdoc' once it's fixed
+install_python_packages git+https://github.com/hotdoc/hotdoc
+
+# HACK: uninstall npm after building hotdoc, remove when we remove npm
+dnf -y remove nodejs-npm
 
 # Cleanup
 dnf -y clean all

--- a/ci/ciimage/opensuse/install.sh
+++ b/ci/ciimage/opensuse/install.sh
@@ -19,6 +19,8 @@ pkgs=(
   boost-devel libboost_date_time-devel libboost_filesystem-devel libboost_locale-devel libboost_system-devel
   libboost_test-devel libboost_log-devel libboost_regex-devel
   libboost_python3-devel libboost_regex-devel
+  # HACK: remove npm once we switch back to hotdoc sdist
+  npm
 )
 
 # Sys update
@@ -27,7 +29,12 @@ zypper --non-interactive update
 
 # Install deps
 zypper install -y "${pkgs[@]}"
-install_python_packages hotdoc
+# HACK: build hotdoc from git repo since current sdist is broken on modern compilers
+# change back to 'hotdoc' once it's fixed
+install_python_packages git+https://github.com/hotdoc/hotdoc
+
+# HACK: uninstall npm after building hotdoc, remove when we remove npm
+zypper remove -y -u npm
 
 echo 'export PKG_CONFIG_PATH="/usr/lib64/mpi/gcc/openmpi3/lib64/pkgconfig:$PKG_CONFIG_PATH"' >> /ci/env_vars.sh
 


### PR DESCRIPTION
Build hotdoc from the git repository to work around the build failures resulting from C99 incompatibilities.  The issues are already fixed, but the fix has not made it into a release yet.