### PR TITLE
Print external project logfile on CI systems

### DIFF
--- a/mesonbuild/modules/external_project.py
+++ b/mesonbuild/modules/external_project.py
@@ -201,10 +201,10 @@ class ExternalProject(NewExtensionModule):
     def _run(self, step: str, command: T.List[str], workdir: Path) -> None:
         mlog.log(f'External project {self.name}:', mlog.bold(step))
         m = 'Running command ' + str(command) + ' in directory ' + str(workdir) + '\n'
-        log_filename = Path(mlog.get_log_dir(), f'{self.name}-{step}.log')
+        logfile = Path(mlog.get_log_dir(), f'{self.name}-{step}.log')
         output = None
         if not self.verbose:
-            output = open(log_filename, 'w', encoding='utf-8')
+            output = open(logfile, 'w', encoding='utf-8')
             output.write(m + '\n')
             output.flush()
         else:
@@ -215,7 +215,10 @@ class ExternalProject(NewExtensionModule):
         if p.returncode != 0:
             m = f'{step} step returned error code {p.returncode}.'
             if not self.verbose:
-                m += '\nSee logs: ' + str(log_filename)
+                m += '\nSee logs: ' + str(logfile)
+            contents = mlog.ci_fold_file(logfile, f'CI platform detected, click here for {os.path.basename(logfile)} contents.')
+            if contents:
+                print(contents)
             raise MesonException(m)
 
     def _create_targets(self, extra_depends: T.List[T.Union['BuildTarget', 'CustomTarget']]) -> T.List['TYPE_var']:

--- a/mesonbuild/scripts/externalproject.py
+++ b/mesonbuild/scripts/externalproject.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import typing as T
 
 from ..mesonlib import Popen_safe, split_args, determine_worker_count
+from .. import mlog
 
 class ExternalProject:
     def __init__(self, options: argparse.Namespace):
@@ -67,10 +68,10 @@ class ExternalProject:
 
     def _run(self, step: str, command: T.List[str], env: T.Optional[T.Dict[str, str]] = None) -> int:
         m = 'Running command ' + str(command) + ' in directory ' + str(self.build_dir) + '\n'
-        log_filename = Path(self.log_dir, f'{self.name}-{step}.log')
+        logfile = Path(self.log_dir, f'{self.name}-{step}.log')
         output = None
         if not self.verbose:
-            output = open(log_filename, 'w', encoding='utf-8')
+            output = open(logfile, 'w', encoding='utf-8')
             output.write(m + '\n')
             output.flush()
         else:
@@ -84,8 +85,11 @@ class ExternalProject:
         if p.returncode != 0:
             m = f'{step} step returned error code {p.returncode}.'
             if not self.verbose:
-                m += '\nSee logs: ' + str(log_filename)
+                m += '\nSee logs: ' + str(logfile)
             print(m)
+            contents = mlog.ci_fold_file(logfile, f'CI platform detected, click here for {os.path.basename(logfile)} contents.')
+            if contents:
+                print(contents)
         return p.returncode
 
 def run(args: T.List[str]) -> int:


### PR DESCRIPTION
If an error occurs during an autoconf subproject call on CI, then only "See logs: < path to log> " is printed - which makes it a bit hard to analyze the problem. With this PR, the full content of the log file is printed instead.