### PR TITLE
Docs: standardize between list and array as array

### DIFF
--- a/docs/markdown/Release-notes-for-0.38.0.md
+++ b/docs/markdown/Release-notes-for-0.38.0.md
@@ -106,7 +106,7 @@ the check is now ~40% faster.
 ## Array indexing now supports fallback values
 
 The second argument to the array
-[[list.get]] function is now returned
+[[array.get]] function is now returned
 if the specified index could not be found
 
 ```meson

--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -566,7 +566,7 @@ executable('exe1', 'foo.c', 'bar.c', 'foobar.c')
 
 Because of an internal implementation detail, the following syntax
 is currently also supported, even though the first argument of
-[[executable]] is a single [[@str]] and not a [[@list]]:
+[[executable]] is a single [[@str]] and not a [[@array]]:
 
 ```meson
 # WARNING: This example is only valid because of an internal

--- a/docs/markdown/Yaml-RefMan.md
+++ b/docs/markdown/Yaml-RefMan.md
@@ -150,9 +150,9 @@ optargs:
     ...
 
 varargs:
-  name: Some name                # [required]
-  type: str | list[str | int]    # [required]
-  description: Some helpful text # [required]
+  name: Some name                 # [required]
+  type: str | array[str | int]    # [required]
+  description: Some helpful text  # [required]
   since: 0.42.0
   deprecated: 100.99.0
   min_varargs: 1

--- a/docs/markdown/i18n-module.md
+++ b/docs/markdown/i18n-module.md
@@ -90,7 +90,7 @@ for each executable.
 Positional arguments are the following:
 
 * name `str`: the name of the resulting pot file.
-* sources `list[str|File|build_tgt|custom_tgt]`:
+* sources `array[str|File|build_tgt|custom_tgt]`:
           source files or targets. May be a list of `string`, `File`, [[@build_tgt]],
           or [[@custom_tgt]] returned from other calls to this function.
 

--- a/docs/yaml/builtins/meson.yaml
+++ b/docs/yaml/builtins/meson.yaml
@@ -139,7 +139,7 @@ methods:
           to install only a subset of the files.
           By default the script has no install tag which means it is not being run when
           `meson install --tags` argument is specified.
-      
+
       dry_run:
         type: bool
         since: 1.1.0
@@ -447,12 +447,12 @@ methods:
     description: Returns the version string specified in [[project]] function call.
 
   - name: project_license
-    returns: list[str]
+    returns: array[str]
     since: 0.45.0
     description: Returns the array of licenses specified in [[project]] function call.
 
   - name: project_license_files
-    returns: list[file]
+    returns: array[file]
     since: 1.1.0
     description: Returns the array of license files specified in the [[project]] function call.
 
@@ -498,10 +498,10 @@ methods:
 
     posargs:
       env:
-        type: env | str | list[str] | dict[str] | dict[list[str]]
+        type: env | str | array[str] | dict[str] | dict[array[str]]
         description: |
           The [[@env]] object to add.
-          Since *0.62.0* list of strings is allowed in dictionary values. In that
+          Since *0.62.0* array of strings is allowed in dictionary values. In that
           case values are joined using the separator.
     kwargs:
       separator:

--- a/docs/yaml/elementary/array.yml
+++ b/docs/yaml/elementary/array.yml
@@ -1,5 +1,5 @@
-name: list
-long_name: List
+name: array
+long_name: Array
 description: An array of elements. See [arrays](Syntax.md#arrays).
 is_container: true
 
@@ -30,7 +30,7 @@ methods:
   posargs:
     index:
       type: int
-      description: Index of the list position to query. Negative values start at the end of the list
+      description: Index of the array position to query. Negative values start at the end of the array
 
   optargs:
     fallback:
@@ -39,9 +39,9 @@ methods:
 
 - name: length
   returns: int
-  description: Returns the current size of the array / list.
+  description: Returns the current size of the array.
 
 - name: flatten
-  returns: list[any]
+  returns: array[any]
   since: 1.9.0
   description: Returns a flattened copy of the array, with all nested arrays removed.

--- a/docs/yaml/elementary/dict.yml
+++ b/docs/yaml/elementary/dict.yml
@@ -44,5 +44,5 @@ methods:
       description: Fallback value that is returned if the key is not in the [[@dict]].
 
 - name: keys
-  returns: list[str]
+  returns: array[str]
   description: Returns an array of keys in the dictionary.

--- a/docs/yaml/elementary/str.yml
+++ b/docs/yaml/elementary/str.yml
@@ -203,7 +203,7 @@ methods:
 
 # str.split
 - name: split
-  returns: list[str]
+  returns: array[str]
   description: |
     Splits the string at the specified character
     (or whitespace if not set) and returns the parts in an
@@ -224,7 +224,7 @@ methods:
       description: Specifies the character / substring where to split the string.
 
 - name: splitlines
-  returns: list[str]
+  returns: array[str]
   since: 1.2.0
   description: |
     Splits the string into an array of lines.
@@ -270,7 +270,7 @@ methods:
         The strings to join with the current string.
 
         Before Meson *0.60.0* this function only accepts a single positional
-        argument of the type [[list[str]]].
+        argument of the type [[array[str]]].
 
 # str.underscorify
 - name: underscorify

--- a/docs/yaml/functions/_build_target_base.yaml
+++ b/docs/yaml/functions/_build_target_base.yaml
@@ -43,13 +43,13 @@ kwargs:
     description: precompiled header file to use for the given language
 
   <lang>_args:
-    type: list[str]
+    type: array[str]
     description: |
       compiler flags to use for the given language;
       eg: `cpp_args` for C++
 
   vala_args:
-    type: list[str | file]
+    type: array[str | file]
     description: |
       Compiler flags for Vala. Unlike other languages this may contain Files
 
@@ -74,7 +74,7 @@ kwargs:
       but which will be removed on install
 
   dependencies:
-    type: list[dep]
+    type: array[dep]
     description: |
       one or more dependency objects
       created with
@@ -98,7 +98,7 @@ kwargs:
       0.56.0, use `win_subsystem` instead.
 
   link_args:
-    type: list[str]
+    type: array[str]
     description: |
       Flags to use during linking. You can use UNIX-style
       flags here for all platforms.
@@ -125,7 +125,7 @@ kwargs:
       *(broken until 0.55.0)*
 
   link_whole:
-    type: list[lib | custom_tgt | custom_idx]
+    type: array[lib | custom_tgt | custom_idx]
     since: 0.40.0
     description: |
       Links all contents of the given static libraries whether they are used or
@@ -133,18 +133,18 @@ kwargs:
       '/WHOLEARCHIVE' MSVC linker option. This allows the linked target to
       re-export symbols from all objects in the static libraries.
 
-      *(since 0.41.0)* If passed a list that list will be flattened.
+      *(since 0.41.0)* If passed an array that array will be flattened.
 
       *(since 0.51.0)* This argument also accepts outputs produced by
       custom targets. The user must ensure that the output is a library in
       the correct format.
 
   link_with:
-    type: list[lib | custom_tgt | custom_idx]
+    type: array[lib | custom_tgt | custom_idx]
     description: |
       One or more shared or static libraries
-      (built by this project) that this target should be linked with. *(since 0.41.0)* If passed a
-      list this list will be flattened. *(since 0.51.0)* The arguments can also be custom targets.
+      (built by this project) that this target should be linked with. *(since 0.41.0)* If passed an
+      array that array will be flattened. *(since 0.51.0)* The arguments can also be custom targets.
       In this case Meson will assume that merely adding the output file in the linker command
       line is sufficient to make linking work. If this is not sufficient,
       then the build system writer must write all other steps manually.
@@ -156,7 +156,7 @@ kwargs:
     description: Controls whether Meson adds the current source and build directories to the include path
 
   include_directories:
-    type: list[inc | str]
+    type: array[inc | str]
     description: |
       one or more objects created with the [[include_directories]] function,
       or *(since 0.50.0)* strings, which will be transparently expanded to include directory objects
@@ -175,7 +175,7 @@ kwargs:
       something like this: `install_dir : get_option('libdir') / 'projectname-1.0'`.
 
   install_mode:
-    type: list[str | int]
+    type: array[str | int]
     since: 0.47.0
     description: |
       Specify the file mode in symbolic format
@@ -198,7 +198,7 @@ kwargs:
       (but *not* before that). On Windows, this argument has no effect.
 
   objects:
-    type: list[extracted_obj | file | str]
+    type: array[extracted_obj | file | str]
     description: |
       List of object files that should be linked in this target.
 
@@ -208,7 +208,7 @@ kwargs:
       object files had to be placed in `sources`.
 
   name_prefix:
-    type: str | list[void]
+    type: str | array[void]
     description: |
       The string that will be used as the prefix for the
       target output filename by overriding the default (only used for
@@ -219,7 +219,7 @@ kwargs:
       Set this to `[]`, or omit the keyword argument for the default behaviour.
 
   name_suffix:
-    type: str | list[void]
+    type: str | array[void]
     description: |
       The string that will be used as the extension for the
       target by overriding the default. By default on Windows this is
@@ -235,7 +235,7 @@ kwargs:
       Set this to `[]`, or omit the keyword argument for the default behaviour.
 
   override_options:
-    type: list[str] | dict[str | bool | int | list[str]]
+    type: array[str] | dict[str | bool | int | array[str]]
     since: 0.40.0
     description: |
       takes an array of strings in the same format as `project`'s `default_options`
@@ -256,7 +256,7 @@ kwargs:
       do not support GNU visibility arguments.
 
   d_import_dirs:
-    type: list[inc | str]
+    type: array[inc | str]
     since: 0.62.0
     description: |
       the directories to add to the string search path (i.e. `-J` switch for DMD).
@@ -268,11 +268,11 @@ kwargs:
     description: When set to true, the D modules are compiled in debug mode.
 
   d_module_versions:
-    type: list[str | int]
+    type: array[str | int]
     description: List of module version identifiers set when compiling D sources.
 
   d_debug:
-    type: list[str]
+    type: array[str]
     description: |
       The [D version identifiers](https://dlang.org/spec/version.html#version) to add
       during the compilation of D source files.

--- a/docs/yaml/functions/add_global_arguments.yaml
+++ b/docs/yaml/functions/add_global_arguments.yaml
@@ -15,11 +15,11 @@ varargs:
 
 kwargs:
   language:
-    type: list[str]
+    type: array[str]
     required: true
     description: |
       Specifies the language(s) that the arguments should be
-      applied to. If a list of languages is given, the arguments are added
+      applied to. If an array of languages is given, the arguments are added
       to each of the corresponding compiler command lines. Note that there
       is no way to remove an argument set in this way. If you have an
       argument that is only used in a subset of targets, you have to specify

--- a/docs/yaml/functions/add_test_setup.yaml
+++ b/docs/yaml/functions/add_test_setup.yaml
@@ -18,7 +18,7 @@ posargs:
 
 kwargs:
   env:
-    type: env | list[str] | dict[str]
+    type: env | array[str] | dict[str]
     description: |
       environment variables to set
       , such as `['NAME1=value1', 'NAME2=value2']`,
@@ -26,7 +26,7 @@ kwargs:
       environment juggling. *(Since 0.52.0)* A dictionary is also accepted.
 
   exe_wrapper:
-    type: list[str | external_program]
+    type: array[str | external_program]
     description: The command or script followed by the arguments to it
 
   gdb:
@@ -52,9 +52,9 @@ kwargs:
       without the `--setup` option.
 
   exclude_suites:
-    type: list[str]
+    type: array[str]
     since: 0.57.0
     description:
-      A list of test suites that should be excluded when using this setup.
+      An array of test suites that should be excluded when using this setup.
       Suites specified in the `--suite` option
       to `meson test` will always run, overriding `add_test_setup` if necessary.

--- a/docs/yaml/functions/benchmark.yaml
+++ b/docs/yaml/functions/benchmark.yaml
@@ -28,11 +28,11 @@ posargs:
 
 kwargs:
   args:
-    type: list[str | file | tgt | external_program]
+    type: array[str | file | tgt | external_program]
     description: Arguments to pass to the executable
 
   env:
-    type: env | list[str] | dict[str]
+    type: env | array[str] | dict[str]
     description: |
       environment variables to set, such as `['NAME1=value1',
       'NAME2=value2']`, or an [[@env]] object which allows more sophisticated
@@ -46,11 +46,11 @@ kwargs:
       executable returns a non-zero return value (i.e. reports an error)
 
   suite:
-    type: str | list[str]
+    type: str | array[str]
     description: |
-      `'label'` (or list of labels `['label1', 'label2']`)
+      `'label'` (or array of labels `['label1', 'label2']`)
       attached to this test. The suite name is qualified by a (sub)project
-      name resulting in `(sub)project_name:label`. In the case of a list
+      name resulting in `(sub)project_name:label`. In the case of an array
       of strings, the suite names will be `(sub)project_name:label1`,
       `(sub)project_name:label2`, etc.
 
@@ -70,7 +70,7 @@ kwargs:
       for the test
 
   depends:
-    type: list[build_tgt | custom_tgt]
+    type: array[build_tgt | custom_tgt]
     since: 0.46.0
     description: |
       specifies that this test depends on the specified

--- a/docs/yaml/functions/build_target.yaml
+++ b/docs/yaml/functions/build_target.yaml
@@ -26,9 +26,9 @@ description: |
   build_target(<arguments and keyword arguments>, target_type : 'executable')
   ```
 
-  The lists for the kwargs (such as `sources`, `objects`, and `dependencies`) are
-  always flattened, which means you can freely nest and add lists while
-  creating the final list.
+  The arrays for the kwargs (such as `sources`, `objects`, and `dependencies`) are
+  always flattened, which means you can freely nest and add arrays while
+  creating the final array.
 
   The returned object also has methods that are documented in [[@build_tgt]].
 

--- a/docs/yaml/functions/configure_file.yaml
+++ b/docs/yaml/functions/configure_file.yaml
@@ -12,7 +12,7 @@ description: |
   A dictionary can be passed instead of a
   [[@cfg_data]] object.
 
-  When a list of strings is passed to the `command:` keyword argument,
+  When an array of strings is passed to the `command:` keyword argument,
   it takes any source or configured file as the `input:` and assumes
   that the `output:` is produced when the specified command is run.
 
@@ -34,7 +34,7 @@ kwargs:
       file specified as `output`.
 
   command:
-    type: list[str | file]
+    type: array[str | file]
     description: |
       As explained above, if specified, Meson does not create
       the file itself but rather runs the specified command, which allows
@@ -103,7 +103,7 @@ kwargs:
       string, the file is not installed.
 
   install_mode:
-    type: list[str | int]
+    type: array[str | int]
     since: 0.47.0
     description: |
       Specify the file mode in symbolic format

--- a/docs/yaml/functions/custom_target.yaml
+++ b/docs/yaml/functions/custom_target.yaml
@@ -15,7 +15,7 @@ description: |
   *Since 0.60.0* the name argument is optional and defaults to the basename of the first
   output (`file.txt` in the example above).
 
-  The list of strings passed to the `command` keyword argument accept
+  The array of strings passed to the `command` keyword argument accept
   the following special string substitutions:
 
   - `@INPUT@`: the full path to the input passed to `input`. If more than
@@ -103,7 +103,7 @@ kwargs:
       There are some compilers that can't be told to write
       their output to a file but instead write it to standard output. When
       this argument is set to true, Meson captures `stdout` and writes it
-      to the target file. Note that your command argument list may not
+      to the target file. Note that your command argument array may not
       contain `@OUTPUT@` when capture mode is active.
 
   console:
@@ -118,7 +118,7 @@ kwargs:
       serializing all targets in this pool.
 
   command:
-    type: list[str | file | exe | external_program]
+    type: array[str | file | exe | external_program]
     description: |
       Command to run to create outputs from inputs. The command
       may be strings or the return value of functions that return file-like
@@ -132,7 +132,7 @@ kwargs:
       -arg2'` as the latter will *not* work.
 
   depend_files:
-    type: list[str | file]
+    type: array[str | file]
     description: |
       files ([[@str]],
       [[@file]], or the return value of [[configure_file]] that
@@ -140,7 +140,7 @@ kwargs:
       argument. Useful for adding regen dependencies.
 
   depends:
-    type: list[build_tgt | custom_tgt | custom_idx]
+    type: array[build_tgt | custom_tgt | custom_idx]
     description: |
       Specifies that this target depends on the specified
       target(s), even though it does not take any of them as a command
@@ -162,8 +162,8 @@ kwargs:
       are also accepted.
 
   input:
-    type: list[str | file]
-    description: List of source files. *(since 0.41.0)* the list is flattened.
+    type: array[str | file]
+    description: Array of source files. *(since 0.41.0)* the array is flattened.
 
   install:
     type: bool
@@ -171,7 +171,7 @@ kwargs:
       the install step (see `install_dir` for details).
 
   install_dir:
-    type: str | list[str | bool]
+    type: str | array[str | bool]
     description: |
       If only one install_dir is provided, all outputs are installed there.
       *Since 0.40.0* Allows you to specify the installation directory for each
@@ -195,17 +195,17 @@ kwargs:
       This would install `second.file` to `otherdir` and not install `first.file`.
 
   install_mode:
-    type: list[str | int]
+    type: array[str | int]
     since: 0.47.0
     description: |
       The file mode and optionally the owner/uid and group/gid.
       See the `install_mode` kwarg of [[install_data]] for more information.
 
   install_tag:
-    type: list[str]
+    type: array[str]
     since: 0.60.0
     description: |
-      A list of strings, one per output, used by the `meson install --tags` command
+      An array of strings, one per output, used by the `meson install --tags` command
       to install only a subset of the files.
 
       By default all outputs have no install tag which means they are not being
@@ -214,12 +214,12 @@ kwargs:
       outputs that have no tag or are not installed.
 
   output:
-    type: list[str]
-    description: List of output files.
+    type: array[str]
+    description: Array of output files.
 
   env:
     since: 0.57.0
-    type: env | list[str] | dict[str]
+    type: env | array[str] | dict[str]
     description: |
       environment variables to set, such as
       `{'NAME1': 'value1', 'NAME2': 'value2'}` or `['NAME1=value1', 'NAME2=value2']`,
@@ -234,4 +234,4 @@ kwargs:
       There are some compilers that can't be told to read
       their input from a file and instead read it from standard input. When this
       argument is set to `true`, Meson feeds the input file to `stdin`. Note that
-      your argument list may not contain `@INPUT@` when feed mode is active.
+      your argument array may not contain `@INPUT@` when feed mode is active.

--- a/docs/yaml/functions/debug.yaml
+++ b/docs/yaml/functions/debug.yaml
@@ -5,10 +5,10 @@ description: Write the argument string to the meson build log.
 
 posargs:
   message:
-    type: str | int | bool | list[str | int | bool] | dict[str | int | bool]
+    type: str | int | bool | array[str | int | bool] | dict[str | int | bool]
     description: The message to print
 
 varargs:
   name: msg
-  type: str | int | bool | list[str | int | bool] | dict[str | int | bool]
+  type: str | int | bool | array[str | int | bool] | dict[str | int | bool]
   description: Additional parameters will be separated by spaces

--- a/docs/yaml/functions/declare_dependency.yaml
+++ b/docs/yaml/functions/declare_dependency.yaml
@@ -12,41 +12,41 @@ description: |
 
 kwargs:
   compile_args:
-    type: list[str]
+    type: array[str]
     description: Compile arguments to use.
 
   dependencies:
-    type: list[dep]
+    type: array[dep]
     description: Other dependencies needed to use this dependency.
 
   include_directories:
-    type: list[inc | str]
+    type: array[inc | str]
     description: |
       the directories to add to header search path,
       must be [[@inc]] objects or *(since 0.50.0)* plain strings.
 
   link_args:
-    type: list[str]
+    type: array[str]
     description: Link arguments to use.
 
   link_with:
-    type: list[lib]
+    type: array[lib]
     description: Libraries to link against.
 
   link_whole:
-    type: list[lib]
+    type: array[lib]
     since: 0.46.0
     description: Libraries to link fully, same as [[executable]].
 
   sources:
-    type: list[str | file | custom_tgt | custom_idx | generated_list]
+    type: array[str | file | custom_tgt | custom_idx | generated_list]
     description: |
       sources to add to targets
       (or generated header files
       that should be built before sources including them are built)
 
   extra_files:
-    type: list[str | file]
+    type: array[str | file]
     since: 1.2.0
     description: |
       extra files to add to targets.
@@ -59,31 +59,31 @@ kwargs:
       such as `1.2.3`. Defaults to the project version.
 
   variables:
-    type: dict[str] | list[str]
+    type: dict[str] | array[str]
     since: 0.54.0
     description: |
       a dictionary of arbitrary strings,
       this is meant to be used
       in subprojects where special variables would be provided via cmake or
-      pkg-config. *since 0.56.0* it can also be a list of `'key=value'` strings.
+      pkg-config. *since 0.56.0* it can also be an array of `'key=value'` strings.
 
   d_module_versions:
-    type: str | int | list[str | int]
+    type: str | int | array[str | int]
     since: 0.62.0
     description: |
       The [D version identifiers](https://dlang.org/spec/version.html#version) to add
       during the compilation of D source files.
 
   d_import_dirs:
-    type: list[inc | str]
+    type: array[inc | str]
     since: 0.62.0
     description: |
       the directories to add to the string search path (i.e. `-J` switch for DMD).
       Must be [[@inc]] objects or plain strings.
 
   objects:
-    type: list[extracted_obj]
+    type: array[extracted_obj]
     since: 1.1.0
     description: |
-      a list of object files, to be linked directly into the targets that use the
+      an array of object files, to be linked directly into the targets that use the
       dependency.

--- a/docs/yaml/functions/dependency.yaml
+++ b/docs/yaml/functions/dependency.yaml
@@ -78,7 +78,7 @@ varargs:
 
 kwargs:
   default_options:
-    type: list[str] | dict[str | bool | int | list[str]]
+    type: array[str] | dict[str | bool | int | array[str]]
     since: 0.38.0
     description: |
       An array of default option values
@@ -103,7 +103,7 @@ kwargs:
       for more details.
 
   fallback:
-    type: list[str] | str
+    type: array[str] | str
     description: |
       Manually specifies a subproject fallback
       to use in case the dependency is not found in the system.
@@ -120,7 +120,7 @@ kwargs:
       in this case the subproject must use
       `meson.override_dependency('dependency_name', subproj_dep)`
       to specify the dependency object used in the superproject.
-      If the value is an empty list, it has the same effect as
+      If the value is an empty array it has the same effect as
       `allow_fallback: false`.
 
   language:
@@ -181,14 +181,14 @@ kwargs:
       value is `true` otherwise the default value is `false`.
 
   version:
-    type: list[str] | str
+    type: array[str] | str
     since: 0.37.0
     description: |
       Specifies the required version,
       a string containing a
       comparison operator followed by the version string, examples include
       `>1.0.0`, `<=2.3.5` or `3.1.4` for exact matching.
-      You can also specify multiple restrictions by passing a list to this
+      You can also specify multiple restrictions by passing an array to this
       keyword argument, such as: `['>=3.14.0', '<=4.1.0']`.
       These requirements are never met if the version is unknown.
 

--- a/docs/yaml/functions/environment.yaml
+++ b/docs/yaml/functions/environment.yaml
@@ -7,12 +7,12 @@ arg_flattening: false
 
 optargs:
   env:
-    type: str | list[str] | dict[str] | dict[list[str]]
+    type: str | array[str] | dict[str] | dict[array[str]]
     since: 0.52.0
     description: |
       If provided, each key/value pair is added into the [[@env]] object
       as if [[env.set]] method was called for each of them.
-      Since *0.62.0* list of strings is allowed in dictionary values. In that
+      Since *0.62.0* arrays of strings are allowed in dictionary values. In that
       case values are joined using the separator.
 
 kwargs:

--- a/docs/yaml/functions/executable.yaml
+++ b/docs/yaml/functions/executable.yaml
@@ -4,9 +4,9 @@ description: |
   Creates a new executable. The first argument specifies its name and
   the remaining positional arguments define the input files to use.
 
-  The lists for the kwargs (such as `sources`, `objects`, and `dependencies`) are
-  always flattened, which means you can freely nest and add lists while
-  creating the final list.
+  The arrays for the kwargs (such as `sources`, `objects`, and `dependencies`) are
+  always flattened, which means you can freely nest and add arrays while
+  creating the final array.
 
   The returned object also has methods that are documented in [[@exe]].
 

--- a/docs/yaml/functions/files.yaml
+++ b/docs/yaml/functions/files.yaml
@@ -1,5 +1,5 @@
 name: files
-returns: list[file]
+returns: array[file]
 description: |
   This command takes the strings given to it in arguments and returns
   corresponding File objects that you can use as sources for build

--- a/docs/yaml/functions/find_program.yaml
+++ b/docs/yaml/functions/find_program.yaml
@@ -24,7 +24,7 @@ description: |
   (because the command invocator will reject the command otherwise) and
   Unixes (if the script file does not have the executable bit set).
   Hence, you *must not* manually add the interpreter while using this
-  script as part of a list of commands. Since *0.50.0* if the "python3"
+  script as part of an array of commands. Since *0.50.0* if the "python3"
   program is requested and it is not found in the system, Meson will return
   its current interpreter.
 
@@ -98,7 +98,7 @@ kwargs:
       instead of a not-found object.
 
   version:
-    type: str | list[str]
+    type: str | array[str]
     since: 0.52.0
     description: |
       Specifies the required version, see
@@ -117,12 +117,12 @@ kwargs:
       If this is unspecified, `program_name --version` will be used.
 
   dirs:
-    type: list[str]
+    type: array[str]
     since: 0.53.0
-    description: extra list of absolute paths where to look for program names.
+    description: extra array of absolute paths where to look for program names.
 
   default_options:
-    type: list[str] | dict[str | bool | int | list[str]]
+    type: array[str] | dict[str | bool | int | array[str]]
     since: 1.3.0
     description: |
       An array of default option values

--- a/docs/yaml/functions/generator.yaml
+++ b/docs/yaml/functions/generator.yaml
@@ -45,12 +45,12 @@ posargs:
 
 kwargs:
   arguments:
-    type: list[str]
-    description: A list of template strings that will be the command line arguments passed to the executable.
+    type: array[str]
+    description: An array of template strings that will be the command line arguments passed to the executable.
 
   depends:
     # Not sure why this is not just `target`
-    type: list[build_tgt | custom_tgt | custom_idx]
+    type: array[build_tgt | custom_tgt | custom_idx]
     since: 0.51.0
     description: |
       An array of build targets that must be built before
@@ -68,9 +68,9 @@ kwargs:
       recompilation,
 
   output:
-    type: list[str]
+    type: array[str]
     description: |
-      Template string (or list of template strings) defining
+      Template string (or array of template strings) defining
       how an output file name is (or multiple output names are) generated
       from a single source file name.
 

--- a/docs/yaml/functions/get_option.yaml
+++ b/docs/yaml/functions/get_option.yaml
@@ -1,5 +1,5 @@
 name: get_option
-returns: str | int | bool | feature | list[str | int | bool]
+returns: str | int | bool | feature | array[str | int | bool]
 description: |
   Obtains the value of the [project build option](Build-options.md)
   specified in the positional argument.

--- a/docs/yaml/functions/install_data.yaml
+++ b/docs/yaml/functions/install_data.yaml
@@ -25,7 +25,7 @@ kwargs:
       If omitted, the directory defaults to `{datadir}/{projectname}` *(since 0.45.0)*.
 
   install_mode:
-    type: list[str | int]
+    type: array[str | int]
     since: 0.38.0
     description: |
       specify the file mode in symbolic format and
@@ -58,16 +58,16 @@ kwargs:
       This is equivalent to GNU Automake's `nobase` option.
 
   rename:
-    type: list[str]
+    type: array[str]
     since: 0.46.0
     description: |
-      If specified renames each source file into corresponding file from `rename` list.
+      If specified renames each source file into corresponding file from `rename` array.
       Nested paths are allowed and they are
-      joined with `install_dir`. Length of `rename` list must be equal to
+      joined with `install_dir`. Length of `rename` array must be equal to
       the number of sources.
 
   sources:
-    type: list[file | str]
+    type: array[file | str]
     description: Additional files to install.
 
   follow_symlinks:

--- a/docs/yaml/functions/install_emptydir.yaml
+++ b/docs/yaml/functions/install_emptydir.yaml
@@ -16,7 +16,7 @@ varargs:
 
 kwargs:
   install_mode:
-    type: list[str | int]
+    type: array[str | int]
     description: |
       Specify the file mode in symbolic format and optionally the owner/uid and
       group/gid for the created directory.

--- a/docs/yaml/functions/install_headers.yaml
+++ b/docs/yaml/functions/install_headers.yaml
@@ -57,7 +57,7 @@ kwargs:
       Incompatible with the `install_dir` kwarg.
 
   install_mode:
-    type: list[str | int]
+    type: array[str | int]
     since: 0.47.0
     description: |
       Specify the file mode in symbolic format

--- a/docs/yaml/functions/install_man.yaml
+++ b/docs/yaml/functions/install_man.yaml
@@ -20,7 +20,7 @@ warnings:
 
 kwargs:
   install_mode:
-    type: list[str | int]
+    type: array[str | int]
     since: 0.47.0
     description: |
       Specify the file mode in symbolic format

--- a/docs/yaml/functions/install_subdir.yaml
+++ b/docs/yaml/functions/install_subdir.yaml
@@ -66,7 +66,7 @@ posargs:
 
 kwargs:
   install_mode:
-    type: list[str | int]
+    type: array[str | int]
     since: 0.47.0
     description: |
       Specify the file mode in symbolic format
@@ -83,16 +83,16 @@ kwargs:
       tag which means they are not being installed when `--tags` argument is specified.
 
   exclude_files:
-    type: list[str]
+    type: array[str]
     description: |
-      A list of file names that should not be installed.
+      An array of file names that should not be installed.
       Names are interpreted as paths relative to the `subdir_name` location.
 
   exclude_directories:
-    type: list[str]
+    type: array[str]
     since: 0.47.0
     description: |
-      A list of directory names that should not be installed.
+      An array of directory names that should not be installed.
       Names are interpreted as paths relative to the `subdir_name` location.
 
   install_dir:

--- a/docs/yaml/functions/library.yaml
+++ b/docs/yaml/functions/library.yaml
@@ -40,13 +40,13 @@ kwargs:
         type being build.
 
   <lang>_static_args:
-    type: list[str]
+    type: array[str]
     since: 1.3.0
     description:
       Arguments that are only passed to a static library
 
   vala_static_args:
-    type: list[str | file]
+    type: array[str | file]
     since: 1.3.0
     description:
       Arguments that are only passed to a static library
@@ -54,13 +54,13 @@ kwargs:
       Like `vala_args`, [[files]] is allowed in addition to string
 
   <lang>_shared_args:
-    type: list[str]
+    type: array[str]
     since: 1.3.0
     description:
       Arguments that are only passed to a shared library
 
   vala_shared_args:
-    type: list[str | file]
+    type: array[str | file]
     since: 1.3.0
     description:
       Arguments that are only passed to a shared library

--- a/docs/yaml/functions/message.yaml
+++ b/docs/yaml/functions/message.yaml
@@ -6,11 +6,11 @@ arg_flattening: false
 
 posargs:
   text:
-    type: str | int | bool | list[str | int | bool] | dict[str | int | bool]
+    type: str | int | bool | array[str | int | bool] | dict[str | int | bool]
     description: The message to print.
 
 varargs:
   name: more_text
   since: 0.54.0
-  type: str | int | bool | list[str | int | bool] | dict[str | int | bool]
+  type: str | int | bool | array[str | int | bool] | dict[str | int | bool]
   description: Additional text that will be printed separated by spaces.

--- a/docs/yaml/functions/project.yaml
+++ b/docs/yaml/functions/project.yaml
@@ -13,9 +13,9 @@ description: |
   would probably want to use the name _libfoobar_ instead of _The Foobar
   Library_.
 
-  It may be followed by the list of programming languages that the project uses.
+  It may be followed by the array of programming languages that the project uses.
 
-  *(since 0.40.0)* The list of languages is optional.
+  *(since 0.40.0)* The array of languages is optional.
 
   These languages may be used both for `native: false` (the default)
   (host machine) targets and for `native: true` (build machine) targets.
@@ -38,7 +38,7 @@ varargs:
 
 kwargs:
   default_options:
-    type: list[str] | dict[str | bool | int | list[str]]
+    type: array[str] | dict[str | bool | int | array[str]]
     description: |
       Accepts strings in the form `key=value`
       which have the same format as options to `meson configure`.
@@ -76,7 +76,7 @@ kwargs:
       Usually something like `>=0.28.0`.
 
   license:
-    type: str | list[str]
+    type: str | array[str]
     description: |
       Takes a string or array of strings describing the license(s) the code is under.
 
@@ -98,7 +98,7 @@ kwargs:
       value in your Meson build files with `meson.project_license()`.
 
   license_files:
-    type: str | list[str]
+    type: str | array[str]
     since: 1.1.0
     description: |
       Takes a string or array of strings with the paths to the license file(s)

--- a/docs/yaml/functions/run_command.yaml
+++ b/docs/yaml/functions/run_command.yaml
@@ -40,7 +40,7 @@ kwargs:
       empty string.
 
   env:
-    type: env | list[str] | dict[str]
+    type: env | array[str] | dict[str]
     since: 0.50.0
     description: |
       environment variables to set,

--- a/docs/yaml/functions/run_target.yaml
+++ b/docs/yaml/functions/run_target.yaml
@@ -31,25 +31,25 @@ posargs:
 
 kwargs:
   command:
-    type: list[exe| external_program | custom_tgt | file | str]
+    type: array[exe| external_program | custom_tgt | file | str]
     description: |
-      A list containing the command to run and the arguments
-      to pass to it. Each list item may be a string or a target. For
+      An array containing the command to run and the arguments
+      to pass to it. Each array element may be a string or a target. For
       instance, passing the return value of [[executable]]
       as the first item will run that executable, or passing a string as
       the first item will find that command in `PATH` and run it.
 
   depends:
-    type: list[build_tgt | custom_tgt | custom_idx]
+    type: array[build_tgt | custom_tgt | custom_idx]
     description: |
-      A list of targets that this target depends on but which
+      An array of targets that this target depends on but which
       are not listed in the command array (because, for example, the
       script does file globbing internally, custom_idx was not possible
       as a type between 0.60 and 1.4.0).
 
   env:
     since: 0.57.0
-    type: env | list[str] | dict[str]
+    type: env | array[str] | dict[str]
     description: |
       environment variables to set, such as
       `{'NAME1': 'value1', 'NAME2': 'value2'}` or `['NAME1=value1', 'NAME2=value2']`,

--- a/docs/yaml/functions/shared_library.yaml
+++ b/docs/yaml/functions/shared_library.yaml
@@ -29,13 +29,13 @@ kwargs:
       `soversion` is not defined, it is set to `3`.
 
   darwin_versions:
-    type: str | int | list[str]
+    type: str | int | array[str]
     since: 0.48.0
     description: |
       Defines the `compatibility version` and `current version` for the dylib on macOS.
-      If a list is specified, it must be
+      If an array is specified, it must be
       either zero, one, or two elements. If only one element is specified
-      or if it's not a list, the specified value will be used for setting
+      or if it's not an array the specified value will be used for setting
       both compatibility version and current version. If unspecified, the
       `soversion` will be used as per the aforementioned rules.
 

--- a/docs/yaml/functions/structured_sources.yaml
+++ b/docs/yaml/functions/structured_sources.yaml
@@ -10,7 +10,7 @@ description: |
 
 posargs:
   root:
-    type: list[str | file | custom_tgt | custom_idx | generated_list]
+    type: array[str | file | custom_tgt | custom_idx | generated_list]
     description: Sources to put at the root of the generated structure
 
 optargs:

--- a/docs/yaml/functions/subdir.yaml
+++ b/docs/yaml/functions/subdir.yaml
@@ -21,6 +21,6 @@ posargs:
 
 kwargs:
   if_found:
-    type: list[dep]
+    type: array[dep]
     since: 0.44.0
     description: Only enter the subdir if all [[dep.found]] methods return `true`.

--- a/docs/yaml/functions/subproject.yaml
+++ b/docs/yaml/functions/subproject.yaml
@@ -42,7 +42,7 @@ posargs:
 
 kwargs:
   default_options:
-    type: list[str] | dict[str | bool | int | list[str]]
+    type: array[str] | dict[str | bool | int | array[str]]
     since: 0.37.0
     description: |
       An array of default option values

--- a/docs/yaml/functions/summary.yaml
+++ b/docs/yaml/functions/summary.yaml
@@ -16,7 +16,7 @@ description: |
   - an integer, boolean or string
   - *since 0.57.0* an external program or a dependency
   - *since 0.58.0* a feature option
-  - a list of those.
+  - an array of those.
 
   Instead of calling summary as `summary(key, value)`, it is also possible to
   directly pass a dictionary to the [[summary]] function, as seen in the example
@@ -38,7 +38,7 @@ example: |
   summary({'Some boolean': false,
           'Another boolean': true,
           'Some string': 'Hello World',
-          'A list': ['string', 1, true],
+          'An array': ['string', 1, true],
           }, section: 'Configuration')
   ```
 
@@ -56,7 +56,7 @@ example: |
       Some boolean   : False
       Another boolean: True
       Some string    : Hello World
-      A list         : string
+      An array        : string
                        1
                        True
   ```
@@ -65,7 +65,7 @@ arg_flattening: false
 
 posargs:
   key_or_dict:
-    type: str | dict[str | bool | int | dep | external_program | list[str | bool | int | dep | external_program]]
+    type: str | dict[str | bool | int | dep | external_program | array[str | bool | int | dep | external_program]]
     description: |
       The name of the new entry, or a dict containing multiple entries.  If a
       dict is passed it is equivalent to calling summary() once for each
@@ -74,7 +74,7 @@ posargs:
 
 optargs:
   value:
-    type: str | bool | int | dep | external_program | list[str | bool | int | dep | external_program]
+    type: str | bool | int | dep | external_program | array[str | bool | int | dep | external_program]
     description: |
       The value to print for the `key`.  Only valid if `key_or_dict` is a str.
 
@@ -92,5 +92,5 @@ kwargs:
     type: str
     since: 0.54.0
     description: |
-      The separator to use when printing list values in this summary.  If no
-      separator is given, each list item will be printed on its own line.
+      The separator to use when printing array values in this summary.  If no
+      separator is given, each array item will be printed on its own line.

--- a/docs/yaml/functions/vcs_tag.yaml
+++ b/docs/yaml/functions/vcs_tag.yaml
@@ -22,7 +22,7 @@ description: |
 
 kwargs:
   command:
-    type: list[exe | external_program | custom_tgt | file | str]
+    type: array[exe | external_program | custom_tgt | file | str]
     description: |
       The command to execute, see [[custom_target]] for details
       on how this command must be specified.
@@ -71,7 +71,7 @@ kwargs:
       The subdirectory to install the generated file to (e.g. `share/myproject`).
 
   install_mode:
-    type: list[str | int]
+    type: array[str | int]
     since: 1.7.0
     description: |
       Specify the file mode in symbolic format

--- a/docs/yaml/objects/cfg_data.yaml
+++ b/docs/yaml/objects/cfg_data.yaml
@@ -114,7 +114,7 @@ methods:
       description: The name of the variable to query
 
 - name: keys
-  returns: list[str]
+  returns: array[str]
   since: 0.57.0
   description: |
     Returns an array of keys of

--- a/docs/yaml/objects/compiler.yaml
+++ b/docs/yaml/objects/compiler.yaml
@@ -45,9 +45,9 @@ methods:
   description: You have found a bug if you can see this!
   kwargs:
     args:
-      type: list[str]
+      type: array[str]
       description: |
-        Used to pass a list of compiler arguments.
+        Used to pass an array of compiler arguments.
         Defining include paths for headers not in the default include path
         via `-Isome/path/to/header` is generally supported, however, usually not
         recommended.
@@ -61,7 +61,7 @@ methods:
   description: You have found a bug if you can see this!
   kwargs:
     include_directories:
-      type: inc | list[inc]
+      type: inc | array[inc]
       since: 0.38.0
       description: Extra directories for header searches.
 
@@ -70,7 +70,7 @@ methods:
   description: You have found a bug if you can see this!
   kwargs:
     dependencies:
-      type: dep | list[dep]
+      type: dep | array[dep]
       description: Additionally dependencies required for compiling and / or linking.
 
 - name: _prefix
@@ -78,7 +78,7 @@ methods:
   description: You have found a bug if you can see this!
   kwargs:
     prefix:
-      type: str | list[str]
+      type: str | array[str]
       description: |
         Used to add `#include`s and other things that are required
         for the symbol to be declared. Since 1.0.0 an array is accepted
@@ -184,7 +184,7 @@ methods:
   description: Returns the compiler's version number as a string.
 
 - name: cmd_array
-  returns: list[str]
+  returns: array[str]
   description: Returns an array containing the command(s) for the compiler.
 
 
@@ -441,10 +441,10 @@ methods:
         *(since 0.47.0)* The value of a `feature` option can also be passed here.
 
     has_headers:
-      type: list[str]
+      type: array[str]
       since: 0.50.0
       description: |
-        List of headers that must be found as well.
+        An array of headers that must be found as well.
         This check is equivalent to checking each header with a
         [[compiler.has_header]] call.
 
@@ -468,7 +468,7 @@ methods:
       description: If `true`, this method will return a [[@disabler]] on a failed check.
 
     dirs:
-      type: list[str]
+      type: array[str]
       description: |
         Additional directories to search in.
 
@@ -478,19 +478,19 @@ methods:
 # does not work, since all _common kwargs need to be prefixed `header_` here
 # kwargs_inherit: compiler._common
     header_args:
-      type: list[str]
+      type: array[str]
       since: 0.51.0
       description: |
         When the `has_headers` kwarg is also used, this argument is passed to
         [[compiler.has_header]] as `args`.
     header_include_directories:
-      type: inc | list[inc]
+      type: inc | array[inc]
       since: 0.51.0
       description: |
         When the `has_headers` kwarg is also used, this argument is passed to
         [[compiler.has_header]] as `include_directories`.
     header_dependencies:
-      type: dep | list[dep]
+      type: dep | array[dep]
       since: 0.51.0
       description: |
         When the `has_headers` kwarg is also used, this argument is passed to
@@ -539,7 +539,7 @@ methods:
     - compiler._required
 
 - name: get_supported_arguments
-  returns: list[str]
+  returns: array[str]
   since: 0.43.0
   varargs_inherit: compiler.has_multi_arguments
   description: |
@@ -558,11 +558,11 @@ methods:
           - `'require'`: Abort if at least one argument is not supported
 
 - name: first_supported_argument
-  returns: list[str]
+  returns: array[str]
   since: 0.43.0
   varargs_inherit: compiler.has_multi_arguments
   description: |
-    Given a list of strings, returns a single-element list containing the first
+    Given an array of strings, returns a single-element array containing the first
     argument that passes the [[compiler.has_argument]] test or an empty array if
     none pass.
 
@@ -601,7 +601,7 @@ methods:
     - compiler._required
 
 - name: get_supported_link_arguments
-  returns: list[str]
+  returns: array[str]
   since: 0.46.0
   varargs_inherit: compiler.has_multi_link_arguments
   description: |
@@ -621,11 +621,11 @@ methods:
   #         - `'require'`: Abort if at least one argument is not supported
 
 - name: first_supported_link_argument
-  returns: list[str]
+  returns: array[str]
   since: 0.46.0
   varargs_inherit: compiler.has_multi_link_arguments
   description: |
-    Given a list of strings, returns the first argument that passes the
+    Given an array of strings, returns the first argument that passes the
     [[compiler.has_link_argument]] test or an empty array if none pass.
 
 - name: has_function_attribute
@@ -645,7 +645,7 @@ methods:
     - compiler._required
 
 - name: get_supported_function_attributes
-  returns: list[str]
+  returns: array[str]
   since: 0.48.0
   description: |
     Returns an array containing any names that are supported GCC style attributes.
@@ -666,10 +666,10 @@ methods:
     operating systems.
 
 - name: preprocess
-  returns: list[custom_idx]
+  returns: array[custom_idx]
   since: 0.64.0
   description: |
-    Preprocess a list of source files but do not compile them. The preprocessor
+    Preprocess an array of source files but do not compile them. The preprocessor
     will receive the same arguments (include directories, defines, etc) as with
     normal compilation. That includes for example args added with
     `add_project_arguments()`, or on the command line with `-Dc_args=-DFOO`.
@@ -694,15 +694,15 @@ methods:
         the source filename and `@BASENAME@` is replaced by the source filename
         without its extension.
     compile_args:
-      type: list[str]
+      type: array[str]
       description: |
         Extra flags to pass to the preprocessor
     dependencies:
-      type: dep | list[dep]
+      type: dep | array[dep]
       description: Additionally dependencies required.
       since: 1.1.0
     depends:
-      type: list[build_tgt | custom_tgt]
+      type: array[build_tgt | custom_tgt]
       description: |
         Specifies that this target depends on the specified
         target(s). These targets should be built before starting

--- a/docs/yaml/objects/custom_tgt.yaml
+++ b/docs/yaml/objects/custom_tgt.yaml
@@ -25,9 +25,9 @@ methods:
       custom target's output argument.
 
   - name: to_list
-    returns: list[custom_idx]
+    returns: array[custom_idx]
     since: 0.54.0
     description: |
-        Returns a list of opaque objects that references this target,
+        Returns an array of opaque objects that references this target,
         and can be used as a source in other targets. This can be used to
         iterate outputs with `foreach` loop.

--- a/docs/yaml/objects/dep.yaml
+++ b/docs/yaml/objects/dep.yaml
@@ -34,11 +34,11 @@ methods:
 
     kwargs:
       define_variable:
-        type: list[str]
+        type: array[str]
         since: 0.44.0
         description: |
           You can also redefine a
-          variable by passing a list to this kwarg
+          variable by passing an array to this kwarg
           that can affect the retrieved variable: `['prefix', '/'])`.
 
           *(Since 1.3.0)* Multiple variables can be specified in pairs.
@@ -224,7 +224,7 @@ methods:
         description: The default value to return when the variable does not exist
 
       pkgconfig_define:
-        type: list[str]
+        type: array[str]
         description: See [[dep.get_pkgconfig_variable]]
 
   - name: as_static
@@ -250,4 +250,3 @@ methods:
       recursive:
         type: bool
         description: If true, this is recursively applied to dependencies
-  

--- a/docs/yaml/objects/generator.yaml
+++ b/docs/yaml/objects/generator.yaml
@@ -9,20 +9,20 @@ methods:
   - name: process
     returns: generated_list
     description: |
-      Takes a list of files, causes them to be processed and returns an object containing the result
+      Takes an array of files, causes them to be processed and returns an object containing the result
       which can then, for example, be passed into a build target definition.
 
     varargs:
       name: source
       min_varargs: 1
       type: str | file | custom_tgt | custom_idx | generated_list
-      description: List of sources to process.
+      description: sources to process.
 
     kwargs:
       extra_args:
-        type: list[str]
+        type: array[str]
         description: |
-          If present, will be used to replace an entry `@EXTRA_ARGS@` in the argument list.
+          If present, will be used to replace an entry `@EXTRA_ARGS@` in the argument array.
 
       preserve_path_from:
         type: str
@@ -36,7 +36,7 @@ methods:
           directory}/one.out`.
 
       env:
-        type: env | list[str] | dict[str]
+        type: env | array[str] | dict[str]
         since: 1.3.0
         description: |
           environment variables to set, such as


### PR DESCRIPTION
When arrays were added they were called arrays. Because the are implemented with Python lists, that language started leaking into talking about Meson types. This is confusing. I've attempted, as much as possible, to move to using one name, array. I picked array because 1) It's the original name used, and 2) what Meson has are more properly arrays as they have a fixed length, while a critical property of lists are the ability to link and unlink them.

There are a couple of places where the list language has leaked into the names of keyword arguments. I have not made any attempt to change those, I don't know if it's that useful or not.