### PR TITLE
dist: Ensure modification time matches git commit time

### DIFF
--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -175,6 +175,14 @@ class GitDist(Dist):
         ret = subprocess.call(['git', '-C', self.src_root, 'diff-index', '--quiet', 'HEAD'])
         return ret == 1
 
+    def get_timestamp(self, src: T.Union[str, os.PathLike]):
+        tstamp_cmd = ['git', '-C', src, 'show', '--summary', '--format=%ct', 'HEAD']
+        run_cmd = subprocess.run(tstamp_cmd, capture_output=True, check=True)
+
+        ts = int(run_cmd.stdout.splitlines()[0])
+        return ts
+
+
     def copy_git(self, src: T.Union[str, os.PathLike], distdir: str, revision: str = 'HEAD',
                  prefix: T.Optional[str] = None, subdir: T.Optional[str] = None) -> None:
         cmd = ['git', 'archive', '--format', 'tar', revision]
@@ -229,6 +237,7 @@ class GitDist(Dist):
 
     def create_dist(self, archives: T.List[str]) -> T.List[str]:
         self.process_git_project(self.src_root, self.distdir)
+        ts = self.get_timestamp(self.src_root)
         for path in self.subprojects.values():
             sub_src_root = os.path.join(self.src_root, path)
             sub_distdir = os.path.join(self.distdir, path)
@@ -239,6 +248,7 @@ class GitDist(Dist):
             else:
                 shutil.copytree(sub_src_root, sub_distdir)
         self.run_dist_scripts()
+        os.utime(self.distdir, (ts, ts))
         output_names = []
         for a in archives:
             compressed_name = self.distdir + archive_extension[a]


### PR DESCRIPTION
This helps making the tarballs for git projects reproducible:

  $ sha256sum _build{,2}/meson-dist/cellbroadcastd-0.0.2.tar.xz
  15ecdeae9c4cb7b94ada6c5bf6fa08db0d28a9c819550215af0be3bf219fa066  _build/meson-dist/cellbroadcastd-0.0.2.tar.xz
  15ecdeae9c4cb7b94ada6c5bf6fa08db0d28a9c819550215af0be3bf219fa066  _build2/meson-dist/cellbroadcastd-0.0.2.tar.xz

Before we had mismatching checksums due to timestamp differences, see the following diffoscope(1) output:

```
  $ diffoscope _build{,2}/meson-dist/cellbroadcastd-0.0.2.tar.xz
  --- _build/meson-dist/cellbroadcastd-0.0.2.tar.xz
  +++ _build2/meson-dist/cellbroadcastd-0.0.2.tar.xz
  ├── cellbroadcastd-0.0.2.tar
  │ ├── file list
  │ │ @@ -1,8 +1,8 @@
  │ │ -drwxrwxr-x   0 fortysixandtwo  (1000) fortysixandtwo  (1000)        0 2025-07-09 21:45:38.758605 cellbroadcastd-0.0.2/
  │ │ +drwxrwxr-x   0 fortysixandtwo  (1000) fortysixandtwo  (1000)        0 2025-07-09 21:45:25.298480 cellbroadcastd-0.0.2/
  │ │  -rw-rw-r--   0 fortysixandtwo  (1000) fortysixandtwo  (1000)      641 2025-07-09 12:07:06.000000 cellbroadcastd-0.0.2/.dir-locals.el
  │ │  -rw-rw-r--   0 fortysixandtwo  (1000) fortysixandtwo  (1000)      480 2025-07-09 12:07:06.000000 cellbroadcastd-0.0.2/.editorconfig
```


This was not yet tested extensively with (git-backed) meson subprojects, but should already improve on the status quo.