### PR TITLE
build/process_compilers: Skip throwing error for headers

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -963,7 +963,7 @@ class BuildTarget(Target):
                             self.compilers[lang] = compiler
                         break
                 else:
-                    if is_known_suffix(s):
+                    if is_known_suffix(s) and not is_header(s):
                         path = pathlib.Path(str(s)).as_posix()
                         m = f'No {self.for_machine.get_lower_case_name()} machine compiler for {path!r}'
                         raise MesonException(m)

--- a/test cases/vala/32 valaless vapigen/clib.c
+++ b/test cases/vala/32 valaless vapigen/clib.c
@@ -1,0 +1,5 @@
+#include "clib.h"
+
+int clib_fun(void) {
+    return 42;
+}

--- a/test cases/vala/32 valaless vapigen/clib.h
+++ b/test cases/vala/32 valaless vapigen/clib.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int clib_fun(void);

--- a/test cases/vala/32 valaless vapigen/meson.build
+++ b/test cases/vala/32 valaless vapigen/meson.build
@@ -1,0 +1,34 @@
+project('valaless-vapigen', 'c')
+
+if host_machine.system() == 'cygwin'
+  error('MESON_SKIP_TEST Does not work with the Vala currently packaged in cygwin')
+endif
+
+gnome = import('gnome')
+
+clib_src = [
+  'clib.c',
+  'clib.h'
+]
+
+clib_lib = shared_library('clib', clib_src)
+
+clib_gir = gnome.generate_gir(clib_lib,
+  sources: clib_src,
+  namespace: 'Clib',
+  nsversion: '0',
+  header: 'clib.h',
+  symbol_prefix: 'clib'
+)
+
+clib_vapi = gnome.generate_vapi('clib', sources: clib_gir[0])
+
+clib_dep = declare_dependency(
+  include_directories: include_directories('.'),
+  link_with: clib_lib,
+  sources: clib_gir,
+  dependencies: clib_vapi
+)
+
+
+test('clib-test', executable('clib-test', 'test_clib.c', dependencies: clib_dep))

--- a/test cases/vala/32 valaless vapigen/test_clib.c
+++ b/test cases/vala/32 valaless vapigen/test_clib.c
@@ -1,0 +1,9 @@
+#include <stdlib.h>
+#include <clib.h>
+
+int main(void) {
+    if (clib_fun () == 42)
+        return EXIT_SUCCESS;
+    else
+        return EXIT_FAILURE;
+}


### PR DESCRIPTION
Dependencies should be able to provide headers in its sources, even tho the target which uses the dependency may not use the language that header is for.

A specific example is vala, where C and Vala dependencies share the same name, so in meson they ought to share the same dependency object in order to provide a Vala and/or C dependency depending on who is using it. Doing so right now however fails, if the project of the dependency user doesn't list vala in its used languages, even tho they might just be interested in the C part of the dependency.