### PR TITLE
symbolextractor: fix crash with current dumpbin.exe

### DIFF
--- a/mesonbuild/scripts/symbolextractor.py
+++ b/mesonbuild/scripts/symbolextractor.py
@@ -231,7 +231,11 @@ def _get_implib_exports(impfilename: str) -> T.Tuple[T.List[str], str]:
     if output:
         lines = output.split('\n')
         start = lines.index('File Type: LIBRARY')
-        end = lines.index('  Summary')
+        end = len(lines)
+        try:
+            end = lines.index('  Summary')
+        except ValueError:
+            pass
         return lines[start:end], None
     all_stderr += e
     # Next, try llvm-nm.exe provided by LLVM, then nm.exe provided by MinGW


### PR DESCRIPTION
The version of dumpbin.exe shipped with Visual Studio 2022 version 17.14.9, dumpbin version 14.44.35213.0, has a bug that causes it to omit the "Summary" section when the output is redirected (but not when the output is a console).

This results in a crash when trying to compile a shared_library:

```
Traceback (most recent call last):
  File "meson.py", line 27, in <module>
  File "mesonbuild\mesonmain.py", line 313, in main
  File "mesonbuild\mesonmain.py", line 300, in run
  File "mesonbuild\mesonmain.py", line 222, in run_script_command
  File "mesonbuild\scripts\symbolextractor.py", line 322, in run
  File "mesonbuild\scripts\symbolextractor.py", line 288, in gen_symbols
  File "mesonbuild\scripts\symbolextractor.py", line 259, in windows_syms
  File "mesonbuild\scripts\symbolextractor.py", line 234, in _get_implib_exports
ValueError: '  Summary' is not in list
[PYI-25552:ERROR] Failed to execute script 'meson' due to unhandled exception!
ninja: build stopped: subcommand failed.
```

Avoid the problem by treating the Summary section as optional.