### PR TITLE
c: add more exceptions to -Wno-*

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -1272,12 +1272,21 @@ class CLikeCompiler(Compiler):
             # check the equivalent enable flag too "-Wforgotten-towel".
             if arg.startswith('-Wno-'):
                 # Make an exception for -Wno-attributes=x as -Wattributes=x is invalid
-                # for GCC at least.  Also, the opposite of -Wno-vla-larger-than is
-                # -Wvla-larger-than=N
+                # for GCC at least.  Also, the positive form of some flags require a
+                # value to be specified, i.e. we need to pass -Wfoo=N rather than just
+                # -Wfoo.
                 if arg.startswith('-Wno-attributes='):
                     pass
-                elif arg == '-Wno-vla-larger-than':
-                    new_args.append('-Wvla-larger-than=1000')
+                elif arg in {
+                    '-Wno-alloc-size-larger-than',
+                    '-Wno-alloca-larger-than',
+                    '-Wno-frame-larger-than',
+                    '-Wno-stack-usage',
+                    '-Wno-vla-larger-than',
+                }:
+                    # Pass an arbitrary value to the enabling flag; since the test program
+                    # is trivial, it is unlikely to provoke any of these warnings.
+                    new_args.append('-W' + arg[5:] + '=1000')
                 else:
                     new_args.append('-W' + arg[5:])
             if arg.startswith('-Wl,'):

--- a/test cases/common/104 has arg/meson.build
+++ b/test cases/common/104 has arg/meson.build
@@ -56,9 +56,22 @@ if cpp.get_id() == 'gcc' and cpp.version().version_compare('>=12.1.0')
   # Handle special -Wno-attributes=foo where -Wattributes=foo is invalid
   # i.e. our usual -Wno-foo -Wfoo hack doesn't work for -Wattributes=foo.
   assert(cpp.has_argument('-Wno-attributes=meson::i_do_not_exist'))
-  # Likewise, the positive counterpart to -Wno-vla-larger-than is
-  # -Wvla-larger-than=N
-  assert(cpp.has_argument('-Wno-vla-larger-than'))
+endif
+
+if cpp.get_id() == 'gcc'
+  # Handle negative flags whose positive counterparts require a value to be
+  # specified.
+  if cpp.version().version_compare('>=4.4.0')
+    assert(cpp.has_argument('-Wno-frame-larger-than'))
+  endif
+  if cpp.version().version_compare('>=4.7.0')
+    assert(cpp.has_argument('-Wno-stack-usage'))
+  endif
+  if cpp.version().version_compare('>=7.1.0')
+    assert(cpp.has_argument('-Wno-alloc-size-larger-than'))
+    assert(cpp.has_argument('-Wno-alloca-larger-than'))
+    assert(cpp.has_argument('-Wno-vla-larger-than'))
+  endif
 endif
 
 if cc.get_id() == 'clang' and cc.version().version_compare('<=4.0.0')


### PR DESCRIPTION
Commit eca1ac18dc1978b15b500c9f1710c05cb1ccc0ec (#14252) added support for properly detecting the -Wno-vla-larger-than flag: a value must be specified for its positive form (-Wvla-larger-than=N), or GCC will exit with the error "missing argument to ‘-Walloc-size-larger-than=’".

There is a handful of other -Wno-* flags whose positive form act in the same manner, but are not covered here:

  * -Wno-alloc-size-larger-than (GCC >=7.1.0)
  * -Wno-alloca-larger-than (GCC >=7.1.0)
  * -Wno-frame-larger-than (GCC >=4.4.0)
  * -Wno-stack-usage (GCC >=4.7.0)

Add logic to treat these in the same way.