### PR TITLE
cuda: Also search `extras/CUPTI` for `cupti`

### DIFF
--- a/mesonbuild/dependencies/cuda.py
+++ b/mesonbuild/dependencies/cuda.py
@@ -66,6 +66,12 @@ class CudaDependency(SystemDependency):
             self.incdir = os.path.join(self.cuda_path, self.target_path, 'include')
             self.compile_args += [f'-I{self.incdir}']
 
+        # CUPTI may be installed in a separate subdirectory
+        if 'cupti' in self.requested_modules:
+            cupti_incdir = os.path.join(self.cuda_path, 'extras', 'CUPTI', 'include')
+            if os.path.exists(cupti_incdir):
+                self.compile_args += [f'-I{cupti_incdir}']
+
         arch_libdir = self._detect_arch_libdir()
         self.libdir = os.path.join(self.cuda_path, self.target_path, arch_libdir)
         mlog.debug('CUDA library directory is', mlog.bold(self.libdir))
@@ -253,7 +259,16 @@ class CudaDependency(SystemDependency):
             # - libnvidia-ml.so in /usr/lib/ that is provided by the nvidia drivers
             #
             # Users should never link to the latter, since its ABI may change.
-            args = self.clib_compiler.find_library(module, self.env, [self.libdir, os.path.join(self.libdir, 'stubs')], self.libtype, ignore_system_dirs=True)
+            search_dirs = [self.libdir, os.path.join(self.libdir, 'stubs')]
+
+            # CUPTI may be installed in a separate subdirectory
+            if module == 'cupti':
+                for lib in ('lib64', 'lib'):
+                    cupti_libdir = os.path.join(self.cuda_path, 'extras', 'CUPTI', lib)
+                    if os.path.exists(cupti_libdir):
+                        search_dirs.append(cupti_libdir)
+
+            args = self.clib_compiler.find_library(module, self.env, search_dirs, self.libtype, ignore_system_dirs=True)
 
             if args is None:
                 self._report_dependency_error(f'Couldn\'t find requested CUDA module \'{module}\'')


### PR DESCRIPTION
Fixes https://github.com/mesonbuild/meson/issues/13241

CUPTI is sometimes installed in a separate subdirectory `extras/CUPTI`,
this is true for runfile installations on Linux. If the directory exists
and `cupti` is one of the requested, include this directory in include paths and
search it for `libcupti.so`.

The `lib64/` and `lib/` directories are searched in the same order as
seen in FindCUDAToolkit.cmake:
https://gitlab.kitware.com/cmake/cmake/-/blob/6b6e276c309a21337f3aa978d5fb782c460c4736/Modules/FindCUDAToolkit.cmake#L1352-1357