### PR TITLE
docs: Reduce reading comprehension requirements for install functions

### DIFF
--- a/docs/yaml/functions/configure_file.yaml
+++ b/docs/yaml/functions/configure_file.yaml
@@ -16,6 +16,8 @@ description: |
   it takes any source or configured file as the `input:` and assumes
   that the `output:` is produced when the specified command is run.
 
+  You can install the outputted file with the `install_dir:` kwarg, see below.
+
   *(since 0.47.0)* When the `copy:` keyword argument is set to `true`,
   this function will copy the file provided in `input:` to a file in the
   build directory with the name `output:` in the current directory.

--- a/docs/yaml/functions/custom_target.yaml
+++ b/docs/yaml/functions/custom_target.yaml
@@ -12,6 +12,8 @@ description: |
   custom_target('foo', output: 'file.txt', ...)
   ```
 
+  You can install the outputted files with the `install_dir:` kwarg, see below.
+
   *Since 0.60.0* the name argument is optional and defaults to the basename of the first
   output (`file.txt` in the example above).
 

--- a/docs/yaml/functions/install_data.yaml
+++ b/docs/yaml/functions/install_data.yaml
@@ -2,6 +2,9 @@ name: install_data
 returns: void
 description: |
   Installs files from the source tree that are listed as positional arguments.
+  Please note that this can only install static files from the source tree.
+  Generated files are installed via the `install_dir:` kwarg on the respective
+  generators, such as `custom_target()` or `configure_file().
 
   See [Installing](Installing.md) for more examples.
 

--- a/docs/yaml/functions/install_headers.yaml
+++ b/docs/yaml/functions/install_headers.yaml
@@ -9,6 +9,10 @@ description: |
   argument. As an example if this has the value `myproj` then the
   headers would be installed to `/{prefix}/include/myproj`.
 
+  Please note that this can only install static files from the source tree.
+  Generated files are installed via the `install_dir:` kwarg on the respective
+  generators, such as `custom_target()` or `configure_file().
+
 example: |
   For example, this will install `common.h` and `kola.h` into
   `/{prefix}/include`:


### PR DESCRIPTION
As we are becoming more popular, the docs have to be clearer because we're being exposed to a wider base of users with highly variable English language ability. Some of those can be helped with translations, but for the rest, let's repeat ourselves.

Fixes https://github.com/mesonbuild/meson/issues/14843