### PR TITLE
compilers: support prelinking with Clang

### DIFF
--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -208,6 +208,11 @@ class ClangCompiler(GnuLikeCompiler):
         # error.
         return ['-Werror=attributes']
 
+    def get_prelink_args(self, prelink_name: str, obj_list: T.List[str]) -> T.Tuple[T.List[str], T.List[str]]:
+        if not mesonlib.version_compare(self.version, '>=14'):
+            raise mesonlib.MesonException('prelinking requires clang >=14')
+        return [prelink_name], ['-r', '-o', prelink_name] + obj_list
+
     def get_coverage_link_args(self) -> T.List[str]:
         return ['--coverage']
 

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -1759,16 +1759,13 @@ class LinuxlikeTests(BasePlatformTests):
             self.assertNotIn('-lfoo', content)
 
     def test_prelinking(self):
-        # Prelinking currently only works on recently new GNU toolchains.
-        # Skip everything else. When support for other toolchains is added,
-        # remove limitations as necessary.
-        if 'clang' in os.environ.get('CC', 'dummy') and not is_osx():
-            raise SkipTest('Prelinking not supported with Clang.')
         testdir = os.path.join(self.unit_test_dir, '86 prelinking')
         env = get_fake_env(testdir, self.builddir, self.prefix)
         cc = detect_c_compiler(env, MachineChoice.HOST)
         if cc.id == "gcc" and not version_compare(cc.version, '>=9'):
             raise SkipTest('Prelinking not supported with gcc 8 or older.')
+        if cc.id == 'clang' and not version_compare(cc.version, '>=14'):
+            raise SkipTest('Prelinking not supported with Clang 13 or older.')
         self.init(testdir)
         self.build()
         outlib = os.path.join(self.builddir, 'libprelinked.a')


### PR DESCRIPTION
Clang supports prelinking using the same `-r` flag as GCC. There has been prior art in [1] which suggests that the feature was broken back then, but this seems to no longer be the case.

[1] https://github.com/mesonbuild/meson/pull/8883