### PR TITLE
vala: Only pass the soname to the --shared-library argument

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1777,7 +1777,7 @@ class NinjaBackend(backends.Backend):
                 valac_outputs.append(girname)
                 shared_target = target.get('shared')
                 if isinstance(shared_target, build.SharedLibrary):
-                    args += ['--shared-library', self.get_target_filename_for_linking(shared_target)]
+                    args += ['--shared-library', shared_target.get_filename()]
                 # Install GIR to default location if requested by user
                 if len(target.install_dir) > 3 and target.install_dir[3] is True:
                     target.install_dir[3] = os.path.join(self.environment.get_datadir(), 'gir-1.0')


### PR DESCRIPTION
This argument requires only the filename, not the path and the actual library we want to use is the one defined with the soname.

Closes: https://github.com/mesonbuild/meson/issues/14803