### PR TITLE
mformat: force multiline arguments with comma

### DIFF
--- a/mesonbuild/mformat.py
+++ b/mesonbuild/mformat.py
@@ -242,6 +242,10 @@ class MultilineArgumentDetector(FullAstVisitor):
         if node.is_multiline:
             self.is_multiline = True
 
+        nargs = len(node)
+        if nargs and nargs == len(node.commas):
+            self.is_multiline = True
+
         if self.is_multiline:
             return
 

--- a/test cases/format/1 default/indentation.meson
+++ b/test cases/format/1 default/indentation.meson
@@ -92,3 +92,11 @@ if meson.project_version().version_compare('>1.2')
         # comment
     endif
 endif
+
+# Test for trailing comma:
+m = [1, 2, 3]
+n = [
+    1,
+    2,
+    3,
+]


### PR DESCRIPTION
Force multiline arguments when there is a trailing comma. This is the behavior of muon.

Fixes #14721.