### PR TITLE
find_program: Respect --force-fallback-for

### DIFF
--- a/docs/markdown/Subprojects.md
+++ b/docs/markdown/Subprojects.md
@@ -227,34 +227,35 @@ the following command-line options:
 * **--wrap-mode=nofallback**
 
     Meson will not use subproject fallbacks for any dependency
-    declarations in the build files, and will only look for them in the
-    system. Note that this does not apply to unconditional subproject()
-    calls, and those are meant to be used for sources that cannot be
-    provided by the system, such as copylibs.
+    declarations and program lookups in the build files, and will only
+    look for them in the system. Note that this does not apply to
+    unconditional subproject() calls, and those are meant to be used for
+    sources that cannot be provided by the system, such as copylibs.
 
     This option may be overridden by `--force-fallback-for` for specific
     dependencies.
 
 * **--wrap-mode=forcefallback**
 
-    Meson will not look at the system for any dependencies which have
-    subproject fallbacks available, and will *only* use subprojects for
-    them. This is useful when you want to test your fallback setup, or
-    want to specifically build against the library sources provided by
-    your subprojects.
+    Meson will not look at the system for any dependencies and programs
+    which have subproject fallbacks available, and will *only* use
+    subprojects for them. This is useful when you want to test your
+    fallback setup, or want to specifically build against the library
+    sources provided by your subprojects.
 
-* **--force-fallback-for=list,of,dependencies**
+* **--force-fallback-for=list,of,dependencies,or,subprojects**
 
-    Meson will not look at the system for any dependencies listed there,
-    provided a fallback was supplied when the dependency was declared.
+    Meson will not look at the system for any dependencies and
+    subprojects listed there, provided a fallback was supplied in the
+    wrapfile or when the dependency was declared.
 
     This option takes precedence over `--wrap-mode=nofallback`, and when
     used in combination with `--wrap-mode=nodownload` will only work
-    if the dependency has already been downloaded.
+    if the subproject has already been downloaded.
 
-    This is useful when your project has many fallback dependencies,
-    but you only want to build against the library sources for a few
-    of them.
+    This is useful when your project has many fallback dependencies or
+    programs, but you only want to build against the library sources for
+    a few of them.
 
     **Warning**: This could lead to mixing system and subproject version of the
     same library in the same process. Take this case as example:
@@ -277,6 +278,10 @@ the following command-line options:
     library. To avoid that situation, every dependency that itself depend on
     `glib-2.0` must also be forced to fallback, in this case with
     `--force-fallback-for=glib,gsteamer`.
+
+    Starting with version 1.12, meson will also fallback into evaluating a
+    subproject during find_program, if a wrap file indicates it provides the
+    requested program and the wrap name of the is listed in `--force-fallback-for`.
 
 * **--wrap-mode=nopromote**
 

--- a/docs/markdown/snippets/find_program-forcefallback.md
+++ b/docs/markdown/snippets/find_program-forcefallback.md
@@ -1,0 +1,5 @@
+## find_program() now respects --force-fallback-for
+
+If a subproject listed in --force-fallback-for provides a particular
+program (via program_names in its wrapfile), find_program will use the
+program from the subproject instead of looking it up from the system.

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1818,13 +1818,17 @@ class Interpreter(InterpreterBase, HoldableObject):
             # Override find_program('meson') to return what we were invoked with
             return ExternalProgram('meson', self.environment.get_build_command(), silent=True)
 
-        fallback: SubProject | None = None
         wrap_mode_s = self.coredata.optstore.get_value_for(OptionKey('wrap_mode'))
+        force_fallback_for = self.coredata.optstore.get_value_for(OptionKey('force_fallback_for'))
         assert isinstance(wrap_mode_s, str), 'for mypy'
+        assert isinstance(force_fallback_for, list), 'for mypy'
         wrap_mode = WrapMode.from_string(wrap_mode_s)
-        if wrap_mode != WrapMode.nofallback and self.environment.wrap_resolver:
-            fallback = self.environment.wrap_resolver.find_program_provider(args)
-        if fallback and wrap_mode == WrapMode.forcefallback:
+
+        fallback: SubProject | None = \
+            self.environment.wrap_resolver.find_program_provider(args) \
+            if self.environment.wrap_resolver is not None \
+            else None
+        if fallback and (wrap_mode == WrapMode.forcefallback or fallback in force_fallback_for):
             return self.find_program_fallback(fallback, args, for_machine, default_options, required, extra_info)
 
         progobj = self.program_from_file_for(for_machine, args)

--- a/test cases/unit/31 forcefallback/meson.build
+++ b/test cases/unit/31 forcefallback/meson.build
@@ -7,3 +7,6 @@ notfound_dep = dependency('cannotabletofind', fallback: ['definitelynotfound', '
 test_not_zlib = executable('test_not_zlib', ['test_not_zlib.c'], dependencies: [zlib_dep, notfound_dep])
 
 test('test_not_zlib', test_not_zlib)
+
+false_bin = find_program('false')
+test('test_not_false', false_bin)

--- a/test cases/unit/31 forcefallback/subprojects/notfalse.wrap
+++ b/test cases/unit/31 forcefallback/subprojects/notfalse.wrap
@@ -1,0 +1,5 @@
+[wrap-file]
+directory = notfalse
+
+[provide]
+program_names = false

--- a/test cases/unit/31 forcefallback/subprojects/notfalse/meson.build
+++ b/test cases/unit/31 forcefallback/subprojects/notfalse/meson.build
@@ -1,0 +1,4 @@
+project('notfalse', 'c')
+
+notfalse_bin = executable('notfalse', 'notfalse.c')
+meson.override_find_program('false', notfalse_bin)

--- a/test cases/unit/31 forcefallback/subprojects/notfalse/notfalse.c
+++ b/test cases/unit/31 forcefallback/subprojects/notfalse/notfalse.c
@@ -1,0 +1,3 @@
+int main(int argc, char** argv) {
+    return 0;
+}

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -708,13 +708,13 @@ class AllPlatformTests(BasePlatformTests):
 
     def test_force_fallback_for(self):
         testdir = os.path.join(self.unit_test_dir, '31 forcefallback')
-        self.init(testdir, extra_args=['--force-fallback-for=zlib,foo'])
+        self.init(testdir, extra_args=['--force-fallback-for=zlib,foo,notfalse'])
         self.build()
         self.run_tests()
 
     def test_force_fallback_for_nofallback(self):
         testdir = os.path.join(self.unit_test_dir, '31 forcefallback')
-        self.init(testdir, extra_args=['--force-fallback-for=zlib,foo', '--wrap-mode=nofallback'])
+        self.init(testdir, extra_args=['--force-fallback-for=zlib,foo,notfalse', '--wrap-mode=nofallback'])
         self.build()
         self.run_tests()
 


### PR DESCRIPTION
Previously, find_program only used the subproject fallback if it didn't find the tool the normal way or global forcefallback was activated. Now it should also fall back if the subproject that provides the fallback is part of force-fallback-for.