### PR TITLE
linkers: Fix dsymutil being unable to symbolicate binaries with LTO

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1570,6 +1570,15 @@ class Backend:
         cmd = [i.replace('\\', '/') if isinstance(i, str) else i for i in cmd]
         return inputs, outputs, cmd
 
+    def transform_link_args(self, target: build.BuildTarget, args: list[str]) -> list[str]:
+        resolved_args = []
+        for i in args:
+            if '@PRIVATE_DIR@' in i:
+                pdir = self.get_target_private_dir(target)
+                i = i.replace('@PRIVATE_DIR@', pdir)
+            resolved_args.append(i)
+        return resolved_args
+
     def get_introspect_command(self) -> str:
         return ' '.join(shlex.quote(x) for x in self.environment.get_build_command() + ['introspect'])
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3623,11 +3623,12 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         # options passed on the command-line, in default_options, etc.
         # These have the lowest priority.
         if isinstance(target, build.StaticLibrary):
-            commands += linker.get_base_link_args(target, linker, self.environment)
+            base_link_args = linker.get_base_link_args(target, linker, self.environment)
         else:
-            commands += compilers.get_base_link_args(target,
-                                                     linker,
-                                                     self.environment)
+            base_link_args = compilers.get_base_link_args(target,
+                                                          linker,
+                                                          self.environment)
+        commands += self.transform_link_args(target, base_link_args)
         # Add -nostdlib if needed; can't be overridden
         commands += self.get_no_stdlib_link_args(target, linker)
         # Add things like /NOLOGO; usually can't be overridden

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -354,6 +354,8 @@ def get_base_link_args(target: 'BuildTarget',
                 threads=num_threads,
                 mode=lto_mode,
                 thinlto_cache_dir=thinlto_cache_dir))
+            obj_cache_path = os.path.join('@PRIVATE_DIR@', "lto.o")
+            args.extend(linker.get_lto_obj_cache_path(obj_cache_path))
     except (KeyError, AttributeError):
         pass
     try:
@@ -1035,6 +1037,9 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
     def get_lto_link_args(self, *, threads: int = 0, mode: str = 'default',
                           thinlto_cache_dir: T.Optional[str] = None) -> T.List[str]:
         return self.linker.get_lto_args()
+
+    def get_lto_obj_cache_path(self, path: str) -> T.List[str]:
+        return self.linker.get_lto_obj_cache_path(path)
 
     def sanitizer_compile_args(self, value: T.List[str]) -> T.List[str]:
         return []

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -231,6 +231,9 @@ class DynamicLinker(metaclass=abc.ABCMeta):
     def get_thinlto_cache_args(self, path: str) -> T.List[str]:
         return []
 
+    def get_lto_obj_cache_path(self, path: str) -> T.List[str]:
+        return []
+
     def sanitizer_args(self, value: T.List[str]) -> T.List[str]:
         return []
 
@@ -897,6 +900,10 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
 
     def get_thinlto_cache_args(self, path: str) -> T.List[str]:
         return ["-Wl,-cache_path_lto," + path]
+
+    def get_lto_obj_cache_path(self, path: str) -> T.List[str]:
+        # https://clang.llvm.org/docs/CommandGuide/clang.html#cmdoption-flto
+        return ["-Wl,-object_path_lto," + path]
 
     def export_dynamic_args(self, env: 'Environment') -> T.List[str]:
         if mesonlib.version_compare(self.version, '>=224.1'):


### PR DESCRIPTION
According to https://clang.llvm.org/docs/CommandGuide/clang.html#cmdoption-flto, the `-object_path_lto` flag is needed to preserve the intermediate object files.

This will come handy if someone needs to run `dsymutil` on LTO'd binaries generated by Meson.

cc @nirbheek 