### PR TITLE
compilers: Enable out-of-the-box MSVC compatibility with ccache

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -865,6 +865,8 @@ class Vs2010Backend(backends.Backend):
         # FIXME add args as needed.
         if entry[1:].startswith('fsanitize'):
             return True
+        if entry[1:] in frozenset(['Zi', 'Z7', 'ZI']):
+            return True
         return entry[1:].startswith('M')
 
     def add_additional_options(self, lang, parent_node, file_args):
@@ -1348,11 +1350,11 @@ class Vs2010Backend(backends.Backend):
         if '/fsanitize=address' in build_args:
             ET.SubElement(type_config, 'EnableASAN').text = 'true'
         # Debug format
-        if '/ZI' in build_args:
+        if '/ZI' in build_args or '-ZI' in build_args:
             ET.SubElement(clconf, 'DebugInformationFormat').text = 'EditAndContinue'
-        elif '/Zi' in build_args:
+        elif '/Zi' in build_args or '-Zi' in build_args:
             ET.SubElement(clconf, 'DebugInformationFormat').text = 'ProgramDatabase'
-        elif '/Z7' in build_args:
+        elif '/Z7' in build_args or '-Z7' in build_args:
             ET.SubElement(clconf, 'DebugInformationFormat').text = 'OldStyle'
         else:
             ET.SubElement(clconf, 'DebugInformationFormat').text = 'None'

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -851,6 +851,10 @@ class CMakeInterpreter:
         trace_args = self.trace.trace_args()
         cmcmp_args = [f'-DCMAKE_POLICY_WARNING_{x}=OFF' for x in DISABLE_POLICY_WARNINGS]
 
+        if mesonlib.version_compare(cmake_exe.version(), '>= 3.25'):
+            # Enable MSVC debug information variable
+            cmcmp_args += ['-DCMAKE_POLICY_CMP0141=NEW']
+
         self.fileapi.setup_request()
 
         # Run CMake

--- a/mesonbuild/cmake/toolchain.py
+++ b/mesonbuild/cmake/toolchain.py
@@ -174,6 +174,16 @@ class CMakeToolchain:
             return p
 
         # Set the compiler variables
+        comp_obj = self.compilers.get('c', self.compilers.get('cpp', None))
+        if comp_obj and comp_obj.get_id() == 'msvc':
+            debug_args = comp_obj.get_debug_args(True)
+            if '/Z7' in debug_args:
+                defaults['CMAKE_MSVC_DEBUG_INFORMATION_FORMAT'] = ['Embedded']
+            elif '/Zi' in debug_args:
+                defaults['CMAKE_MSVC_DEBUG_INFORMATION_FORMAT'] = ['ProgramDatabase']
+            elif '/ZI' in debug_args:
+                defaults['CMAKE_MSVC_DEBUG_INFORMATION_FORMAT'] = ['EditAndContinue']
+
         for lang, comp_obj in self.compilers.items():
             language = language_map.get(lang, None)
 

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -66,11 +66,6 @@ msvc_optimization_args: T.Dict[str, T.List[str]] = {
     's': ['/O1', '/Gw'],
 }
 
-msvc_debug_args: T.Dict[bool, T.List[str]] = {
-    False: [],
-    True: ['/Zi']
-}
-
 
 class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
 
@@ -180,7 +175,10 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
         return ['/Fo' + outputname]
 
     def get_debug_args(self, is_debug: bool) -> T.List[str]:
-        return msvc_debug_args[is_debug]
+        if is_debug:
+            return ['/Z7']
+        else:
+            return []
 
     def get_optimization_args(self, optimization_level: str) -> T.List[str]:
         args = msvc_optimization_args[optimization_level]

--- a/unittests/failuretests.py
+++ b/unittests/failuretests.py
@@ -41,10 +41,10 @@ def no_pkgconfig():
             return [None]
         return old_search(self, name, search_dirs, exclude_paths)
 
-    def new_which(cmd, *kwargs):
+    def new_which(cmd, **kwargs):
         if cmd == 'pkg-config':
             return None
-        return old_which(cmd, *kwargs)
+        return old_which(cmd, **kwargs)
 
     shutil.which = new_which
     ExternalProgram._search = new_search


### PR DESCRIPTION
Hi all,

This PR is to enable compatibility between ccache and MSVC. ccache has been for a long time compatible with MSVC (since 4.6) but when using debug mode, the /Z7 flag must be passed instead of /Zi. See https://ccache.dev/releasenotes.html#_ccache_4_6.

Some questions arise:

- should we check that ccache >= 4.6 before accepting the entry?
- is there a corresponding sccache version we should check for?

I verified Meson made 100% cachable builds with the GStreamer monorepo:

```ini
[options]
libnice:tests = disabled
libnice:examples = disabled
libnice:gupnp = disabled
openh264:tests = disabled
pygobject:tests = false
python = disabled
libav = disabled
ugly = enabled
bad = enabled
devtools = enabled
ges = enabled
rtsp_server = enabled
sharp = disabled
rs = disabled
gpl = enabled
introspection = disabled
prefix = E:/gstreamer/install
force_fallback_for = soundtouch
default_library = shared
b_vscrt = md
libxml:python = false

[properties]

```

