### PR TITLE
build: fix introspection interpreter issue when project selects Rust

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -900,7 +900,7 @@ class BuildTarget(Target):
             # No source files or parent targets, target consists of only object
             # files of unknown origin. Just add the first clink compiler
             # that we have and hope that it can link these objects
-            for lang in link_langs:
+            for lang in reversed(link_langs):
                 if lang in self.all_compilers:
                     self.compilers[lang] = self.all_compilers[lang]
                     break

--- a/test cases/rust/20 rust and cpp/meson.build
+++ b/test cases/rust/20 rust and cpp/meson.build
@@ -8,7 +8,7 @@ project(
   meson_version : '>= 1.2.0',
 )
 
-cpplib = static_library('cpp', 'lib.cpp')
+cpplib = static_library('cpp-lib', 'lib.cpp')
 exe = executable('main', 'main.rs', link_with : cpplib)
 
 test('main', exe)

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -3343,6 +3343,11 @@ class AllPlatformTests(BasePlatformTests):
         testdir = os.path.join(self.unit_test_dir, '58 introspect buildoptions')
         self._run(self.mconf_command + [testdir])
 
+    @skip_if_not_language('rust')
+    def test_meson_configure_srcdir(self):
+        testdir = os.path.join(self.rust_test_dir, '20 rust and cpp')
+        self._run(self.mconf_command + [testdir])
+
     def test_introspect_buildoptions_cross_only(self):
         testdir = os.path.join(self.unit_test_dir, '82 cross only introspect')
         testfile = os.path.join(testdir, 'meson.build')


### PR DESCRIPTION
The introspection interpreter sometimes produces targets with no source files; BuildTarget will then pick a random compiler, according to the order in clink_langs.

According to the comment in sort_clink, clink_langs are supposed to list languages from *lowest* to highest priority.  However, process_compilers_late() process clink_langs in straight order and returns the first language; which is the one with lowest priority.

This became visible with the addition of Rust to clink_langs, because Rust has limitation on the names of library targets, but the bug existed before.

Fixes: e49f2f7283e1d9f18e2f5f54647c07287cd70339