### PR TITLE
CI: Use YAML aliases (anchors) for path filters

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -10,19 +10,14 @@ on:
       - master
       # Stable branches such as 0.56 or 1.0
       - '[0-9]+.[0-9]+'
-    paths:
+    paths: &shared_paths
       - "mesonbuild/**"
       - "test cases/**"
       - "unittests/**"
       - ".github/workflows/cygwin.yml"
       - "run*tests.py"
   pull_request:
-    paths:
-      - "mesonbuild/**"
-      - "test cases/**"
-      - "unittests/**"
-      - ".github/workflows/cygwin.yml"
-      - "run*tests.py"
+    paths: *shared_paths
 
 permissions:
   contents: read

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -7,16 +7,14 @@ concurrency:
 on:
   push:
     branches:
-    paths:
+    paths: &shared_paths
       - 'ci/ciimage/**'
       - '.github/workflows/images.yml'
 
   pull_request:
     branches:
       - master
-    paths:
-      - 'ci/ciimage/**'
-      - '.github/workflows/images.yml'
+    paths: *shared_paths
 
   # Rebuild the images every week (Sunday)
   schedule:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,19 +6,14 @@ concurrency:
 
 on:
   push:
-    paths:
+    paths: &shared_paths
     - "**.py"
     - ".github/workflows/lint.yml"
     - ".pylintrc"
     - ".flake8"
     - ".mypy.ini"
   pull_request:
-    paths:
-    - "**.py"
-    - ".github/workflows/lint.yml"
-    - ".pylintrc"
-    - ".flake8"
-    - ".mypy.ini"
+    paths: *shared_paths
 
 permissions:
   contents: read

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,19 +10,14 @@ on:
       - master
       # Stable branches such as 0.56 or 1.0
       - '[0-9]+.[0-9]+'
-    paths:
+    paths: &shared_paths
       - "mesonbuild/**"
       - "test cases/**"
       - "unittests/**"
       - ".github/workflows/macos.yml"
       - "run*tests.py"
   pull_request:
-    paths:
-      - "mesonbuild/**"
-      - "test cases/**"
-      - "unittests/**"
-      - ".github/workflows/macos.yml"
-      - "run*tests.py"
+    paths: *shared_paths
 
 permissions:
   contents: read

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -10,19 +10,14 @@ on:
       - master
       # Stable branches such as 0.56 or 1.0
       - '[0-9]+.[0-9]+'
-    paths:
+    paths: &shared_paths
       - "mesonbuild/**"
       - "test cases/**"
       - "unittests/**"
       - ".github/workflows/msys2.yml"
       - "run*tests.py"
   pull_request:
-    paths:
-      - "mesonbuild/**"
-      - "test cases/**"
-      - "unittests/**"
-      - ".github/workflows/msys2.yml"
-      - "run*tests.py"
+    paths: *shared_paths
 
 permissions:
   contents: read

--- a/.github/workflows/os_comp.yml
+++ b/.github/workflows/os_comp.yml
@@ -10,7 +10,7 @@ on:
       - master
       # Stable branches such as 0.56 or 1.0
       - '[0-9]+.[0-9]+'
-    paths:
+    paths: &shared_paths
       - "mesonbuild/**"
       - "test cases/**"
       - "unittests/**"
@@ -18,13 +18,7 @@ on:
       - ".github/workflows/os_comp.yml"
       - "run*tests.py"
   pull_request:
-    paths:
-      - "mesonbuild/**"
-      - "test cases/**"
-      - "unittests/**"
-      - ".github/workflows/images.yml"
-      - ".github/workflows/os_comp.yml"
-      - "run*tests.py"
+    paths: *shared_paths
 
 permissions:
   contents: read

--- a/.github/workflows/unusedargs_missingreturn.yml
+++ b/.github/workflows/unusedargs_missingreturn.yml
@@ -15,7 +15,7 @@ concurrency:
 
 on:
   push:
-    paths:
+    paths: &shared_paths
     - ".github/workflows/unusedargs_missingreturn.yml"
     - "test cases/cmake/**"
     - "test cases/common/**"
@@ -26,15 +26,7 @@ on:
     - "test cases/windows/**"
 
   pull_request:
-    paths:
-    - ".github/workflows/unusedargs_missingreturn.yml"
-    - "test cases/cmake/**"
-    - "test cases/common/**"
-    - "test cases/fortran/**"
-    - "test cases/linuxlike/**"
-    - "test cases/objc/**"
-    - "test cases/objcpp/**"
-    - "test cases/windows/**"
+    paths: *shared_paths
 
 permissions:
   contents: read

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -9,13 +9,11 @@ on:
   push:
     branches:
       - master
-    paths:
+    paths: &shared_paths
       - .github/workflows/website.yml
       - docs/**
   pull_request:
-    paths:
-      - .github/workflows/website.yml
-      - docs/**
+    paths: *shared_paths
   workflow_dispatch:
   release:
     types:


### PR DESCRIPTION
GitHub Actions workflows now support YAML anchors. See https://github.com/actions/runner/issues/1182 for more info