### PR TITLE
pkgconfig: warn when pkg-config file cannot be used

### DIFF
--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -335,7 +335,7 @@ class PkgConfigDependency(ExternalDependency):
             # Fetch the libraries and library paths needed for using this
             self._set_libs()
         except DependencyException as e:
-            mlog.debug(f"Pkg-config error with '{name}': {e}")
+            mlog.warning(f"Pkg-config error with '{name}': {e}")
             if self.required:
                 raise
             else:


### PR DESCRIPTION
At GitLab we have hit an issue several times where compiling Git fails due to a supposedly-missing `curl` dependency. The funny thing is that libcurl _is_ installed, and the `curl.pc` file exists and is correctly propagated via the `PKG_CONFIG_PATH`. But Meson still decides to not use it, but it doesn't really provide a useful hint as to why that is:

    Run-time dependency libcurl found: NO (tried pkgconfig and cmake)
    Not looking for a fallback subproject for the dependency libcurl because:
    Use of fallback dependencies is disabled.

    meson.build:1060:8: ERROR: Dependency 'libcurl' is required but not found.

When digging into the logs it becomes immediately apparent what the issue is:

    Determining dependency 'libcurl' with pkg-config executable '/opt/gitlab/embedded/bin/pkg-config'
    env[PKG_CONFIG_PATH]: /opt/gitlab/embedded/lib/pkgconfig
    Called `/opt/gitlab/embedded/bin/pkg-config --modversion libcurl` -> 0
    8.14.1-DEV
    env[PKG_CONFIG_PATH]: /opt/gitlab/embedded/lib/pkgconfig
    Called `/opt/gitlab/embedded/bin/pkg-config --cflags libcurl` -> 1

    pkg-config error with 'libcurl': Could not generate cargs for libcurl:
    Package libbrotlidec was not found in the pkg-config search path.
    Perhaps you should add the directory containing `libbrotlidec.pc'
    to the PKG_CONFIG_PATH environment variable
    Package 'libbrotlidec', required by 'libcurl', not found

The root cause here is that on Amazon Linux 2023 "libbrotli-devel" is not installed together with "libcurl-devel", and as libcurl's pkg-config file lists "libbrotlidec" as a Require'd dependency we fail to resolve this transitive dependency.

The issue really sits with AL2023, but Meson makes it way harder than it should be to figure out the root cause as it doesn't tell us why we failed to use the pkg-config file without digging into the logs.

Improve this by printing such errors as warings instead. This leads to the following output:

    WARNING: Pkg-config error with 'libcurl': Could not generate cflags for libcurl:
    Package foobar was not found in the pkg-config search path.
    Perhaps you should add the directory containing `foobar.pc'
    to the PKG_CONFIG_PATH environment variable
    Package 'foobar', required by 'libcurl', not found

    Did not find CMake 'cmake'
    Found CMake: NO
    Run-time dependency libcurl found: NO (tried pkgconfig and cmake)
    Not looking for a fallback subproject for the dependency libcurl because:
    Use of fallback dependencies is disabled.

    meson.build:1060:8: ERROR: Dependency 'libcurl' is required but not found.

With this warning in place it becomes immediately obvious that the corresponding pkg-config file isn't missing, but broken.