### PR TITLE
Cargo workspace support

### DIFF
--- a/docs/markdown/snippets/main-project-cargo-lock.md
+++ b/docs/markdown/snippets/main-project-cargo-lock.md
@@ -1,0 +1,10 @@
+## Common `Cargo.lock` for all Cargo subprojects
+
+Meson will now parse a `Cargo.lock` in the toplevel source directory,
+and use it to resolve the versions of Cargo subprojects in preference
+to per-subproject `Cargo.lock` files.
+
+If you wish to experiment with Cargo subprojects, it is recommended
+to use `cargo` to set up `Cargo.lock` and `Cargo.toml` files,
+encompassing all Rust targets, in the toplevel source directory.
+Cargo subprojects remain unstable and subject to change.

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -14,7 +14,6 @@ import dataclasses
 import os
 import collections
 import urllib.parse
-import itertools
 import typing as T
 
 from . import builder, version, cfg
@@ -153,10 +152,8 @@ class Interpreter:
             return
         dep = pkg.manifest.dependencies.get(depname)
         if not dep:
-            if depname in itertools.chain(pkg.manifest.dev_dependencies, pkg.manifest.build_dependencies):
-                # FIXME: Not supported yet
-                return
-            raise MesonException(f'Dependency {depname} not defined in {pkg.manifest.package.name} manifest')
+            # It could be build/dev/target dependency. Just ignore it.
+            return
         pkg.required_deps.add(depname)
         dep_pkg, _ = self._fetch_package(dep.package, dep.api)
         if dep.default_features:

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -448,21 +448,41 @@ class Interpreter:
         ]
 
 
+def _parse_git_url(url: str, branch: T.Optional[str] = None) -> T.Tuple[str, str, str]:
+    if url.startswith('git+'):
+        url = url[4:]
+    parts = urllib.parse.urlparse(url)
+    query = urllib.parse.parse_qs(parts.query)
+    query_branch = query['branch'][0] if 'branch' in query else ''
+    branch = branch or query_branch
+    revision = parts.fragment or branch
+    directory = os.path.basename(parts.path)
+    if directory.endswith('.git'):
+        directory = directory[:-4]
+    if branch:
+        directory += f'-{branch}'
+    url = urllib.parse.urlunparse(parts._replace(params='', query='', fragment=''))
+    return url, revision, directory
+
+
 def load_wraps(source_dir: str, subproject_dir: str) -> T.List[PackageDefinition]:
     """ Convert Cargo.lock into a list of wraps """
 
-    wraps: T.List[PackageDefinition] = []
+    # Map directory -> PackageDefinition, to avoid duplicates. Multiple packages
+    # can have the same source URL, in that case we have a single wrap that
+    # provides multiple dependency names.
+    wraps: T.Dict[str, PackageDefinition] = {}
     filename = os.path.join(source_dir, 'Cargo.lock')
     if os.path.exists(filename):
         try:
             toml = load_toml(filename)
         except TomlImplementationMissing as e:
             mlog.warning('Failed to load Cargo.lock:', str(e), fatal=False)
-            return wraps
+            return []
         raw_cargolock = T.cast('raw.CargoLock', toml)
         cargolock = CargoLock.from_raw(raw_cargolock)
         for package in cargolock.package:
-            subp_name = _dependency_name(package.name, version.api(package.version))
+            meson_depname = _dependency_name(package.name, version.api(package.version))
             if package.source is None:
                 # This is project's package, or one of its workspace members.
                 pass
@@ -472,25 +492,24 @@ def load_wraps(source_dir: str, subproject_dir: str) -> T.List[PackageDefinition
                     checksum = cargolock.metadata[f'checksum {package.name} {package.version} ({package.source})']
                 url = f'https://crates.io/api/v1/crates/{package.name}/{package.version}/download'
                 directory = f'{package.name}-{package.version}'
-                wraps.append(PackageDefinition.from_values(subp_name, subproject_dir, 'file', {
-                    'directory': directory,
-                    'source_url': url,
-                    'source_filename': f'{directory}.tar.gz',
-                    'source_hash': checksum,
-                    'method': 'cargo',
-                }))
+                if directory not in wraps:
+                    wraps[directory] = PackageDefinition.from_values(meson_depname, subproject_dir, 'file', {
+                        'directory': directory,
+                        'source_url': url,
+                        'source_filename': f'{directory}.tar.gz',
+                        'source_hash': checksum,
+                        'method': 'cargo',
+                    })
+                wraps[directory].add_provided_dep(meson_depname)
             elif package.source.startswith('git+'):
-                parts = urllib.parse.urlparse(package.source[4:])
-                query = urllib.parse.parse_qs(parts.query)
-                branch = query['branch'][0] if 'branch' in query else ''
-                revision = parts.fragment or branch
-                url = urllib.parse.urlunparse(parts._replace(params='', query='', fragment=''))
-                wraps.append(PackageDefinition.from_values(subp_name, subproject_dir, 'git', {
-                    'directory': package.name,
-                    'url': url,
-                    'revision': revision,
-                    'method': 'cargo',
-                }))
+                url, revision, directory = _parse_git_url(package.source)
+                if directory not in wraps:
+                    wraps[directory] = PackageDefinition.from_values(directory, subproject_dir, 'git', {
+                        'url': url,
+                        'revision': revision,
+                        'method': 'cargo',
+                    })
+                wraps[directory].add_provided_dep(meson_depname)
             else:
                 mlog.warning(f'Unsupported source URL in {filename}: {package.source}')
-    return wraps
+    return list(wraps.values())

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -150,7 +150,7 @@ class Interpreter:
             if not dep.optional:
                 self._add_dependency(pkg, depname)
 
-    def _dep_package(self, dep: Dependency) -> PackageState:
+    def _dep_package(self, pkg: PackageState, dep: Dependency) -> PackageState:
         if dep.git:
             _, _, directory = _parse_git_url(dep.git, dep.branch)
             dep_pkg, _ = self._fetch_package_from_subproject(dep.package, directory)
@@ -189,7 +189,7 @@ class Interpreter:
         if not dep:
             # It could be build/dev/target dependency. Just ignore it.
             return
-        dep_pkg = self._dep_package(dep)
+        dep_pkg = self._dep_package(pkg, dep)
         pkg.required_deps.add(depname)
         if dep.default_features:
             self._enable_feature(dep_pkg, 'default')
@@ -214,7 +214,7 @@ class Interpreter:
                     depname = depname[:-1]
                     if depname in pkg.required_deps:
                         dep = pkg.manifest.dependencies[depname]
-                        dep_pkg = self._dep_package(dep)
+                        dep_pkg = self._dep_package(pkg, dep)
                         self._enable_feature(dep_pkg, dep_f)
                     else:
                         # This feature will be enabled only if that dependency
@@ -224,7 +224,7 @@ class Interpreter:
                     self._add_dependency(pkg, depname)
                     dep = pkg.manifest.dependencies.get(depname)
                     if dep:
-                        dep_pkg = self._dep_package(dep)
+                        dep_pkg = self._dep_package(pkg, dep)
                         self._enable_feature(dep_pkg, dep_f)
             elif f.startswith('dep:'):
                 self._add_dependency(pkg, f[4:])
@@ -291,7 +291,7 @@ class Interpreter:
         ast: T.List[mparser.BaseNode] = []
         for depname in pkg.required_deps:
             dep = pkg.manifest.dependencies[depname]
-            dep_pkg = self._dep_package(dep)
+            dep_pkg = self._dep_package(pkg, dep)
             ast += self._create_dependency(dep_pkg, dep, build)
         ast.append(build.assign(build.array([]), 'system_deps_args'))
         for name, sys_dep in pkg.manifest.system_dependencies.items():
@@ -413,7 +413,7 @@ class Interpreter:
             dep = pkg.manifest.dependencies[name]
             dependencies.append(build.identifier(_dependency_varname(dep.package)))
             if name != dep.package:
-                dep_pkg = self._dep_package(dep)
+                dep_pkg = self._dep_package(pkg, dep)
                 dep_lib_name = dep_pkg.manifest.lib.name
                 dependency_map[build.string(fixup_meson_varname(dep_lib_name))] = build.string(name)
         for name, sys_dep in pkg.manifest.system_dependencies.items():

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -77,23 +77,23 @@ class Interpreter:
     def get_build_def_files(self) -> T.List[str]:
         return [os.path.join(subdir, 'Cargo.toml') for subdir in self.manifests]
 
-    def interpret(self, subdir: str) -> mparser.CodeBlockNode:
+    def interpret(self, subdir: str, project_root: T.Optional[str] = None) -> mparser.CodeBlockNode:
         manifest = self._load_manifest(subdir)
         filename = os.path.join(self.environment.source_dir, subdir, 'Cargo.toml')
         build = builder.Builder(filename)
-        return self.interpret_package(manifest, build, subdir)
+        return self.interpret_package(manifest, build, subdir, project_root)
 
-    def interpret_package(self, manifest: Manifest, build: builder.Builder, subdir: str) -> mparser.CodeBlockNode:
+    def interpret_package(self, manifest: Manifest, build: builder.Builder, subdir: str, project_root: T.Optional[str]) -> mparser.CodeBlockNode:
+        # Build an AST for this package
+        ast: T.List[mparser.BaseNode] = []
         pkg, cached = self._fetch_package(manifest.package.name, manifest.package.api)
         if not cached:
             # This is an entry point, always enable the 'default' feature.
             # FIXME: We should have a Meson option similar to `cargo build --no-default-features`
             self._enable_feature(pkg, 'default')
-
-        # Build an AST for this package
-        ast: T.List[mparser.BaseNode] = []
-        ast += self._create_project(pkg.manifest.package.name, pkg, build)
-        ast.append(build.assign(build.function('import', [build.string('rust')]), 'rust'))
+        if not project_root:
+            ast += self._create_project(pkg.manifest.package.name, pkg, build)
+            ast.append(build.assign(build.function('import', [build.string('rust')]), 'rust'))
         ast += self._create_package(pkg, build, subdir)
         return build.block(ast)
 

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -21,7 +21,7 @@ from .toml import load_toml, TomlImplementationMissing
 from .manifest import Manifest, CargoLock, fixup_meson_varname
 from ..mesonlib import MesonException, MachineChoice
 from .. import coredata, mlog
-from ..wrap.wrap import PackageDefinition
+from ..wrap.wrap import PackageDefinition, CargoState
 
 if T.TYPE_CHECKING:
     from . import raw
@@ -465,22 +465,22 @@ def _parse_git_url(url: str, branch: T.Optional[str] = None) -> T.Tuple[str, str
     return url, revision, directory
 
 
-def load_wraps(source_dir: str, subproject_dir: str) -> T.List[PackageDefinition]:
+def load_wraps(source_dir: str, subproject_dir: str) -> CargoState:
     """ Convert Cargo.lock into a list of wraps """
 
     # Map directory -> PackageDefinition, to avoid duplicates. Multiple packages
     # can have the same source URL, in that case we have a single wrap that
     # provides multiple dependency names.
-    wraps: T.Dict[str, PackageDefinition] = {}
     filename = os.path.join(source_dir, 'Cargo.lock')
     if os.path.exists(filename):
         try:
             toml = load_toml(filename)
         except TomlImplementationMissing as e:
             mlog.warning('Failed to load Cargo.lock:', str(e), fatal=False)
-            return []
+            return CargoState()
         raw_cargolock = T.cast('raw.CargoLock', toml)
         cargolock = CargoLock.from_raw(raw_cargolock)
+        wraps: T.Dict[str, PackageDefinition] = {}
         for package in cargolock.package:
             meson_depname = _dependency_name(package.name, version.api(package.version))
             if package.source is None:
@@ -512,4 +512,5 @@ def load_wraps(source_dir: str, subproject_dir: str) -> T.List[PackageDefinition
                 wraps[directory].add_provided_dep(meson_depname)
             else:
                 mlog.warning(f'Unsupported source URL in {filename}: {package.source}')
-    return list(wraps.values())
+        return CargoState(cargolock.package, wraps.values())
+    return CargoState()

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -18,7 +18,7 @@ import typing as T
 
 from . import builder, version, cfg
 from .toml import load_toml, TomlImplementationMissing
-from .manifest import Manifest, CargoLock, fixup_meson_varname
+from .manifest import Manifest, CargoLock, Workspace, fixup_meson_varname
 from ..mesonlib import MesonException, MachineChoice, version_compare_many
 from .. import coredata, mlog
 from ..wrap.wrap import PackageDefinition, CargoState
@@ -55,6 +55,9 @@ class PackageState:
     features: T.Set[str] = dataclasses.field(default_factory=set)
     required_deps: T.Set[str] = dataclasses.field(default_factory=set)
     optional_deps_features: T.Dict[str, T.Set[str]] = dataclasses.field(default_factory=lambda: collections.defaultdict(set))
+    # If this package is member of a workspace.
+    ws_subdir: T.Optional[str] = None
+    ws_member: T.Optional[str] = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -63,16 +66,30 @@ class PackageKey:
     api: str
 
 
+@dataclasses.dataclass
+class WorkspaceState:
+    workspace: Workspace
+    subdir: str
+    # member path -> PackageState, for all members of this workspace
+    packages: T.Dict[str, PackageState] = dataclasses.field(default_factory=dict)
+    # package name to member path, for all members of this workspace
+    packages_to_member: T.Dict[str, str] = dataclasses.field(default_factory=dict)
+    # member paths that are required to be built
+    required_members: T.List[str] = dataclasses.field(default_factory=list)
+
+
 class Interpreter:
     def __init__(self, env: Environment) -> None:
         self.environment = env
         self.host_rustc = T.cast('RustCompiler', self.environment.coredata.compilers[MachineChoice.HOST]['rust'])
         # Map Cargo.toml's subdir to loaded manifest.
-        self.manifests: T.Dict[str, Manifest] = {}
+        self.manifests: T.Dict[str, T.Union[Manifest, Workspace]] = {}
         # Map of cargo package (name + api) to its state
         self.packages: T.Dict[PackageKey, PackageState] = {}
         # Rustc's config
         self.cfgs = self._get_cfgs()
+        # Map subdir to workspace
+        self.workspaces: T.Dict[str, WorkspaceState] = {}
 
     def get_build_def_files(self) -> T.List[str]:
         return [os.path.join(subdir, 'Cargo.toml') for subdir in self.manifests]
@@ -81,17 +98,23 @@ class Interpreter:
         manifest = self._load_manifest(subdir)
         filename = os.path.join(self.environment.source_dir, subdir, 'Cargo.toml')
         build = builder.Builder(filename)
+        if isinstance(manifest, Workspace):
+            return self.interpret_workspace(manifest, build, subdir, project_root)
         return self.interpret_package(manifest, build, subdir, project_root)
 
     def interpret_package(self, manifest: Manifest, build: builder.Builder, subdir: str, project_root: T.Optional[str]) -> mparser.CodeBlockNode:
         # Build an AST for this package
         ast: T.List[mparser.BaseNode] = []
-        pkg, cached = self._fetch_package(manifest.package.name, manifest.package.api)
-        if not cached:
-            # This is an entry point, always enable the 'default' feature.
-            # FIXME: We should have a Meson option similar to `cargo build --no-default-features`
-            self._enable_feature(pkg, 'default')
-        if not project_root:
+        if project_root:
+            ws = self.workspaces[project_root]
+            member = ws.packages_to_member[manifest.package.name]
+            pkg = ws.packages[member]
+        else:
+            pkg, cached = self._fetch_package(manifest.package.name, manifest.package.api)
+            if not cached:
+                # This is an entry point, always enable the 'default' feature.
+                # FIXME: We should have a Meson option similar to `cargo build --no-default-features`
+                self._enable_feature(pkg, 'default')
             ast += self._create_project(pkg.manifest.package.name, pkg, build)
             ast.append(build.assign(build.function('import', [build.string('rust')]), 'rust'))
         ast += self._create_package(pkg, build, subdir)
@@ -113,6 +136,71 @@ class Interpreter:
 
         return ast
 
+    def interpret_workspace(self, workspace: Workspace, build: builder.Builder, subdir: str, project_root: T.Optional[str]) -> mparser.CodeBlockNode:
+        ws = self._get_workspace(workspace, subdir)
+        name = os.path.dirname(subdir)
+        subprojects_dir = os.path.join(subdir, 'subprojects')
+        self.environment.wrap_resolver.load_and_merge(subprojects_dir, T.cast('SubProject', name))
+        ast: T.List[mparser.BaseNode] = []
+        if not ws.required_members:
+            for member in ws.workspace.default_members:
+                self._require_workspace_member(ws, member)
+
+        # Call subdir() for each required member of the workspace. The order is
+        # important, if a member depends on another member, that member must be
+        # processed first.
+        processed_members: T.Dict[str, PackageState] = {}
+
+        def _process_member(member: str) -> None:
+            if member in processed_members:
+                return
+            pkg = ws.packages[member]
+            for depname in pkg.required_deps:
+                dep = pkg.manifest.dependencies[depname]
+                if dep.path:
+                    dep_member = os.path.normpath(os.path.join(pkg.ws_member, dep.path))
+                    _process_member(dep_member)
+            ast.append(build.function('subdir', [build.string(member)]))
+            processed_members[member] = pkg
+
+        ast.append(build.assign(build.function('import', [build.string('rust')]), 'rust'))
+        for member in ws.required_members:
+            _process_member(member)
+        if not project_root:
+            ast = self._create_project(name, None, build) + ast
+
+        return build.block(ast)
+
+    def _load_workspace_member(self, ws: WorkspaceState, m: str) -> None:
+        m = os.path.normpath(m)
+        # Load member's manifest
+        m_subdir = os.path.join(ws.subdir, m)
+        manifest_ = self._load_manifest(m_subdir, ws.workspace, m)
+        assert isinstance(manifest_, Manifest)
+        self._add_workspace_member(manifest_, ws, m)
+
+    def _add_workspace_member(self, manifest_: Manifest, ws: WorkspaceState, m: str) -> None:
+        pkg = PackageState(manifest_, ws_subdir=ws.subdir, ws_member=m)
+        ws.packages[m] = pkg
+        ws.packages_to_member[manifest_.package.name] = m
+
+    def _get_workspace(self, workspace: Workspace, subdir: str) -> WorkspaceState:
+        ws = self.workspaces.get(subdir)
+        if ws:
+            return ws
+        ws = WorkspaceState(workspace, subdir)
+        for m in workspace.members:
+            self._load_workspace_member(ws, m)
+        self.workspaces[subdir] = ws
+        return ws
+
+    def _require_workspace_member(self, ws: WorkspaceState, member: str) -> PackageState:
+        pkg = ws.packages[member]
+        if member not in ws.required_members:
+            self._prepare_package(pkg)
+            ws.required_members.append(member)
+        return pkg
+
     def _fetch_package(self, package_name: str, api: str) -> T.Tuple[PackageState, bool]:
         key = PackageKey(package_name, api)
         pkg = self.packages.get(key)
@@ -130,6 +218,11 @@ class Interpreter:
         downloaded = \
             subp_name in self.environment.wrap_resolver.wraps and \
             self.environment.wrap_resolver.wraps[subp_name].type is not None
+        if isinstance(manifest, Workspace):
+            ws = self._get_workspace(manifest, subdir)
+            member = ws.packages_to_member[package_name]
+            pkg = self._require_workspace_member(ws, member)
+            return pkg, False
         key = PackageKey(package_name, version.api(manifest.package.version))
 
         pkg = self.packages.get(key)
@@ -151,7 +244,14 @@ class Interpreter:
                 self._add_dependency(pkg, depname)
 
     def _dep_package(self, pkg: PackageState, dep: Dependency) -> PackageState:
-        if dep.git:
+        if dep.path:
+            if not pkg.ws_subdir:
+                raise MesonException("path dependencies only supported inside workspaces")
+            ws = self.workspaces[pkg.ws_subdir]
+            dep_member = os.path.normpath(os.path.join(pkg.ws_member, dep.path))
+            self._load_workspace_member(ws, dep_member)
+            dep_pkg = self._require_workspace_member(ws, dep_member)
+        elif dep.git:
             _, _, directory = _parse_git_url(dep.git, dep.branch)
             dep_pkg, _ = self._fetch_package_from_subproject(dep.package, directory)
         else:
@@ -168,18 +268,30 @@ class Interpreter:
             dep_pkg, _ = self._fetch_package(dep.package, dep.api)
         return dep_pkg
 
-    def _load_manifest(self, subdir: str) -> Manifest:
+    def _load_manifest(self, subdir: str, workspace: T.Optional[Workspace] = None, member_path: str = '') -> T.Union[Manifest, Workspace]:
         manifest_ = self.manifests.get(subdir)
         if not manifest_:
             path = os.path.join(self.environment.source_dir, subdir)
             filename = os.path.join(path, 'Cargo.toml')
             toml = load_toml(filename)
+            workspace_ = None
+            if 'workspace' in toml:
+                raw_workspace = T.cast('raw.VirtualManifest', toml)
+                workspace_ = Workspace.from_raw(raw_workspace)
+            manifest_ = None
             if 'package' in toml:
                 raw_manifest = T.cast('raw.Manifest', toml)
-                manifest_ = Manifest.from_raw(raw_manifest, path)
-                self.manifests[subdir] = manifest_
-            else:
-                raise MesonException(f'{subdir}/Cargo.toml does not have [package] section')
+                manifest_ = Manifest.from_raw(raw_manifest, path, workspace, member_path)
+            if not manifest_ and not workspace_:
+                raise MesonException(f'{subdir}/Cargo.toml does not have [package] or [workspace] section')
+
+            if workspace_:
+                if manifest_:
+                    raise NotImplementedError
+                self.manifests[subdir] = workspace_
+                return workspace_
+
+            self.manifests[subdir] = manifest_
         return manifest_
 
     def _add_dependency(self, pkg: PackageState, depname: str) -> None:

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -79,6 +79,11 @@ class Interpreter:
 
     def interpret(self, subdir: str) -> mparser.CodeBlockNode:
         manifest = self._load_manifest(subdir)
+        filename = os.path.join(self.environment.source_dir, subdir, 'Cargo.toml')
+        build = builder.Builder(filename)
+        return self.interpret_package(manifest, build, subdir)
+
+    def interpret_package(self, manifest: Manifest, build: builder.Builder, subdir: str) -> mparser.CodeBlockNode:
         pkg, cached = self._fetch_package(manifest.package.name, manifest.package.api)
         if not cached:
             # This is an entry point, always enable the 'default' feature.
@@ -86,11 +91,14 @@ class Interpreter:
             self._enable_feature(pkg, 'default')
 
         # Build an AST for this package
-        filename = os.path.join(self.environment.source_dir, subdir, 'Cargo.toml')
-        build = builder.Builder(filename)
-        ast = self._create_project(pkg, build)
-        ast += [
-            build.assign(build.function('import', [build.string('rust')]), 'rust'),
+        ast: T.List[mparser.BaseNode] = []
+        ast += self._create_project(pkg, build)
+        ast.append(build.assign(build.function('import', [build.string('rust')]), 'rust'))
+        ast += self._create_package(pkg, build, subdir)
+        return build.block(ast)
+
+    def _create_package(self, pkg: PackageState, build: builder.Builder, subdir: str) -> T.List[mparser.BaseNode]:
+        ast: T.List[mparser.BaseNode] = [
             build.function('message', [
                 build.string('Enabled features:'),
                 build.array([build.string(f) for f in pkg.features]),
@@ -103,7 +111,7 @@ class Interpreter:
             for crate_type in pkg.manifest.lib.crate_type:
                 ast.extend(self._create_lib(pkg, build, crate_type))
 
-        return build.block(ast)
+        return ast
 
     def _fetch_package(self, package_name: str, api: str) -> T.Tuple[PackageState, bool]:
         key = PackageKey(package_name, api)

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -129,15 +129,18 @@ class Interpreter:
             return pkg, True
         pkg = PackageState(manifest, downloaded)
         self.packages[key] = pkg
+        self._prepare_package(pkg)
+        return pkg, False
+
+    def _prepare_package(self, pkg: PackageState) -> None:
         # Merge target specific dependencies that are enabled
-        for condition, dependencies in manifest.target.items():
+        for condition, dependencies in pkg.manifest.target.items():
             if cfg.eval_cfg(condition, self.cfgs):
-                manifest.dependencies.update(dependencies)
+                pkg.manifest.dependencies.update(dependencies)
         # Fetch required dependencies recursively.
-        for depname, dep in manifest.dependencies.items():
+        for depname, dep in pkg.manifest.dependencies.items():
             if not dep.optional:
                 self._add_dependency(pkg, depname)
-        return pkg, False
 
     def _dep_package(self, dep: Dependency) -> PackageState:
         if dep.git:

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -160,14 +160,17 @@ class Interpreter:
                 if dep.path:
                     dep_member = os.path.normpath(os.path.join(pkg.ws_member, dep.path))
                     _process_member(dep_member)
-            ast.append(build.function('subdir', [build.string(member)]))
+            if member == '.':
+                ast.extend(self._create_package(pkg, build, subdir))
+            else:
+                ast.append(build.function('subdir', [build.string(member)]))
             processed_members[member] = pkg
 
         ast.append(build.assign(build.function('import', [build.string('rust')]), 'rust'))
         for member in ws.required_members:
             _process_member(member)
         if not project_root:
-            ast = self._create_project(name, None, build) + ast
+            ast = self._create_project(name, processed_members.get('.'), build) + ast
 
         return build.block(ast)
 
@@ -191,6 +194,8 @@ class Interpreter:
         ws = WorkspaceState(workspace, subdir)
         for m in workspace.members:
             self._load_workspace_member(ws, m)
+        if workspace.root_package:
+            self._add_workspace_member(workspace.root_package, ws, '.')
         self.workspaces[subdir] = ws
         return ws
 
@@ -286,8 +291,7 @@ class Interpreter:
                 raise MesonException(f'{subdir}/Cargo.toml does not have [package] or [workspace] section')
 
             if workspace_:
-                if manifest_:
-                    raise NotImplementedError
+                workspace_.root_package = manifest_
                 self.manifests[subdir] = workspace_
                 return workspace_
 

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -111,13 +111,22 @@ class Interpreter:
         if pkg:
             return pkg, True
         meson_depname = _dependency_name(package_name, api)
-        subdir, _ = self.environment.wrap_resolver.resolve(meson_depname)
+        return self._fetch_package_from_subproject(package_name, meson_depname)
+
+    def _fetch_package_from_subproject(self, package_name: str, meson_depname: str) -> T.Tuple[PackageState, bool]:
+        subp_name, _ = self.environment.wrap_resolver.find_dep_provider(meson_depname)
+        subdir, _ = self.environment.wrap_resolver.resolve(subp_name)
         subprojects_dir = os.path.join(subdir, 'subprojects')
-        self.environment.wrap_resolver.load_and_merge(subprojects_dir, T.cast('SubProject', meson_depname))
+        self.environment.wrap_resolver.load_and_merge(subprojects_dir, T.cast('SubProject', subp_name))
         manifest = self._load_manifest(subdir)
         downloaded = \
-            meson_depname in self.environment.wrap_resolver.wraps and \
-            self.environment.wrap_resolver.wraps[meson_depname].type is not None
+            subp_name in self.environment.wrap_resolver.wraps and \
+            self.environment.wrap_resolver.wraps[subp_name].type is not None
+        key = PackageKey(package_name, version.api(manifest.package.version))
+
+        pkg = self.packages.get(key)
+        if pkg:
+            return pkg, True
         pkg = PackageState(manifest, downloaded)
         self.packages[key] = pkg
         # Merge target specific dependencies that are enabled
@@ -131,7 +140,12 @@ class Interpreter:
         return pkg, False
 
     def _dep_package(self, dep: Dependency) -> PackageState:
-        return self.packages[PackageKey(dep.package, dep.api)]
+        if dep.git:
+            _, _, directory = _parse_git_url(dep.git, dep.branch)
+            dep_pkg, _ = self._fetch_package_from_subproject(dep.package, directory)
+        else:
+            dep_pkg, _ = self._fetch_package(dep.package, dep.api)
+        return dep_pkg
 
     def _load_manifest(self, subdir: str) -> Manifest:
         manifest_ = self.manifests.get(subdir)
@@ -154,8 +168,8 @@ class Interpreter:
         if not dep:
             # It could be build/dev/target dependency. Just ignore it.
             return
+        dep_pkg = self._dep_package(dep)
         pkg.required_deps.add(depname)
-        dep_pkg, _ = self._fetch_package(dep.package, dep.api)
         if dep.default_features:
             self._enable_feature(dep_pkg, 'default')
         for f in dep.features:
@@ -250,7 +264,8 @@ class Interpreter:
         ast: T.List[mparser.BaseNode] = []
         for depname in pkg.required_deps:
             dep = pkg.manifest.dependencies[depname]
-            ast += self._create_dependency(dep, build)
+            dep_pkg = self._dep_package(dep)
+            ast += self._create_dependency(dep_pkg, dep, build)
         ast.append(build.assign(build.array([]), 'system_deps_args'))
         for name, sys_dep in pkg.manifest.system_dependencies.items():
             if sys_dep.enabled(pkg.features):
@@ -284,10 +299,11 @@ class Interpreter:
             ),
         ]
 
-    def _create_dependency(self, dep: Dependency, build: builder.Builder) -> T.List[mparser.BaseNode]:
-        pkg = self._dep_package(dep)
+    def _create_dependency(self, pkg: PackageState, dep: Dependency, build: builder.Builder) -> T.List[mparser.BaseNode]:
+        version_ = dep.meson_version or [pkg.manifest.package.version]
+        api = dep.api or pkg.manifest.package.api
         kw = {
-            'version': build.array([build.string(s) for s in dep.meson_version]),
+            'version': build.array([build.string(s) for s in version_]),
         }
         # Lookup for this dependency with the features we want in default_options kwarg.
         #
@@ -305,7 +321,7 @@ class Interpreter:
             build.assign(
                 build.function(
                     'dependency',
-                    [build.string(_dependency_name(dep.package, dep.api))],
+                    [build.string(_dependency_name(dep.package, api))],
                     kw,
                 ),
                 _dependency_varname(dep.package),
@@ -335,7 +351,7 @@ class Interpreter:
                 build.if_(build.not_in(build.identifier('f'), build.identifier('actual_features')), build.block([
                     build.function('error', [
                         build.string('Dependency'),
-                        build.string(_dependency_name(dep.package, dep.api)),
+                        build.string(_dependency_name(dep.package, api)),
                         build.string('previously configured with features'),
                         build.identifier('actual_features'),
                         build.string('but need'),

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -19,7 +19,7 @@ import typing as T
 from . import builder, version, cfg
 from .toml import load_toml, TomlImplementationMissing
 from .manifest import Manifest, CargoLock, fixup_meson_varname
-from ..mesonlib import MesonException, MachineChoice
+from ..mesonlib import MesonException, MachineChoice, version_compare_many
 from .. import coredata, mlog
 from ..wrap.wrap import PackageDefinition, CargoState
 
@@ -144,6 +144,16 @@ class Interpreter:
             _, _, directory = _parse_git_url(dep.git, dep.branch)
             dep_pkg, _ = self._fetch_package_from_subproject(dep.package, directory)
         else:
+            # From all available versions from Cargo.lock, pick the most recent
+            # satisfying the constraints
+            cargo_lock_pkgs = self.environment.wrap_resolver.cargo_state.named(dep.package)
+            for cargo_pkg in cargo_lock_pkgs:
+                if version_compare_many(cargo_pkg.version, dep.meson_version):
+                    dep.update_version(f'={cargo_pkg.version}')
+                    break
+            else:
+                if not dep.meson_version:
+                    raise MesonException(f'Cannot determine version of cargo package {dep.package}')
             dep_pkg, _ = self._fetch_package(dep.package, dep.api)
         return dep_pkg
 

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -92,7 +92,7 @@ class Interpreter:
 
         # Build an AST for this package
         ast: T.List[mparser.BaseNode] = []
-        ast += self._create_project(pkg, build)
+        ast += self._create_project(pkg.manifest.package.name, pkg, build)
         ast.append(build.assign(build.function('import', [build.string('rust')]), 'rust'))
         ast += self._create_package(pkg, build, subdir)
         return build.block(ast)
@@ -248,32 +248,38 @@ class Interpreter:
             value = value[1:-1]
         return pair[0], value
 
-    def _create_project(self, pkg: PackageState, build: builder.Builder) -> T.List[mparser.BaseNode]:
+    def _create_project(self, name: str, pkg: T.Optional[PackageState], build: builder.Builder) -> T.List[mparser.BaseNode]:
         """Create the project() function call
 
         :param pkg: The package to generate from
         :param build: The AST builder
         :return: a list nodes
         """
+        args: T.List[mparser.BaseNode] = [
+            build.string(name),
+            build.string('rust'),
+        ]
+        kwargs: T.Dict[str, mparser.BaseNode] = {
+            # Always assume that the generated meson is using the latest features
+            # This will warn when when we generate deprecated code, which is helpful
+            # for the upkeep of the module
+            'meson_version': build.string(f'>= {coredata.stable_version}'),
+        }
+        if not pkg:
+            return [
+                build.function('project', args, kwargs),
+            ]
+
         default_options: T.List[mparser.BaseNode] = []
         default_options.append(build.string(f'rust_std={pkg.manifest.package.edition}'))
         default_options.append(build.string(f'build.rust_std={pkg.manifest.package.edition}'))
         if pkg.downloaded:
             default_options.append(build.string('warning_level=0'))
 
-        args: T.List[mparser.BaseNode] = []
-        args.extend([
-            build.string(pkg.manifest.package.name),
-            build.string('rust'),
-        ])
-        kwargs: T.Dict[str, mparser.BaseNode] = {
+        kwargs.update({
             'version': build.string(pkg.manifest.package.version),
-            # Always assume that the generated meson is using the latest features
-            # This will warn when when we generate deprecated code, which is helpful
-            # for the upkeep of the module
-            'meson_version': build.string(f'>= {coredata.stable_version}'),
             'default_options': build.array(default_options),
-        }
+        })
         if pkg.manifest.package.license:
             kwargs['license'] = build.string(pkg.manifest.package.license)
         elif pkg.manifest.package.license_file:

--- a/mesonbuild/cargo/manifest.py
+++ b/mesonbuild/cargo/manifest.py
@@ -253,7 +253,7 @@ class Dependency:
             elif v.startswith('='):
                 api.add(version.api(v[1:].strip()))
         if not api:
-            return '0'
+            return ''
         elif len(api) == 1:
             return api.pop()
         else:
@@ -278,6 +278,17 @@ class Dependency:
 
         raw_dep = _depv_to_dep(raw_depv)
         return cls.from_raw_dict(name, raw_dep, member_path, raw_ws_dep)
+
+    def update_version(self, v: str) -> None:
+        self.version = v
+        try:
+            delattr(self, 'api')
+        except AttributeError:
+            pass
+        try:
+            delattr(self, 'meson_version')
+        except AttributeError:
+            pass
 
 
 @dataclasses.dataclass
@@ -487,6 +498,14 @@ class CargoLockPackage:
     source: T.Optional[str] = None
     checksum: T.Optional[str] = None
     dependencies: T.List[str] = dataclasses.field(default_factory=list)
+
+    @lazy_property
+    def api(self) -> str:
+        return version.api(self.version)
+
+    @lazy_property
+    def subproject(self) -> str:
+        return f'{self.name}-{self.api}-rs'
 
     @classmethod
     def from_raw(cls, raw: raw.CargoLockPackage) -> CargoLockPackage:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -236,6 +236,7 @@ class InterpreterRuleRelaxation(Enum):
     '''
 
     ALLOW_BUILD_DIR_FILE_REFERENCES = 1
+    CARGO_SUBDIR = 2
 
 permitted_dependency_kwargs = {
     'allow_fallback',
@@ -967,6 +968,19 @@ class Interpreter(InterpreterBase, HoldableObject):
                 return self.disabled_subproject(subp_name, exception=e)
             raise e
 
+    def _save_ast(self, subdir: str, ast: mparser.CodeBlockNode) -> None:
+        # Debug print the generated meson file
+        from ..ast import AstIndentationGenerator, AstPrinter
+        printer = AstPrinter(update_ast_line_nos=True)
+        ast.accept(AstIndentationGenerator())
+        ast.accept(printer)
+        printer.post_process()
+        meson_filename = os.path.join(self.build.environment.get_build_dir(), subdir, 'meson.build')
+        with open(meson_filename, "w", encoding='utf-8') as f:
+            f.write(printer.result)
+        mlog.log('Generated Meson AST:', meson_filename)
+        mlog.cmd_ci_include(meson_filename)
+
     def _do_subproject_meson(self, subp_name: str, subdir: str,
                              default_options: OptionDict,
                              kwargs: kwtypes.DoSubproject,
@@ -975,18 +989,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                              relaxations: T.Optional[T.Set[InterpreterRuleRelaxation]] = None) -> SubprojectHolder:
         with mlog.nested(subp_name):
             if ast:
-                # Debug print the generated meson file
-                from ..ast import AstIndentationGenerator, AstPrinter
-                printer = AstPrinter(update_ast_line_nos=True)
-                ast.accept(AstIndentationGenerator())
-                ast.accept(printer)
-                printer.post_process()
-                meson_filename = os.path.join(self.build.environment.get_build_dir(), subdir, 'meson.build')
-                with open(meson_filename, "w", encoding='utf-8') as f:
-                    f.write(printer.result)
-                mlog.log('Generated Meson AST:', meson_filename)
-                mlog.cmd_ci_include(meson_filename)
-
+                self._save_ast(subdir, ast)
             new_build = self.build.copy()
             subi = Interpreter(new_build, self.backend, subp_name, subdir, self.subproject_dir,
                                default_options, ast=ast, relaxations=relaxations,
@@ -1069,7 +1072,8 @@ class Interpreter(InterpreterBase, HoldableObject):
             return self._do_subproject_meson(
                 subp_name, subdir, default_options, kwargs, ast,
                 # FIXME: Are there other files used by cargo interpreter?
-                [os.path.join(subdir, 'Cargo.toml')])
+                [os.path.join(subdir, 'Cargo.toml')],
+                relaxations={InterpreterRuleRelaxation.CARGO_SUBDIR})
 
     @typed_pos_args('get_option', str)
     @noKwargs
@@ -2470,7 +2474,12 @@ class Interpreter(InterpreterBase, HoldableObject):
 
         os.makedirs(os.path.join(self.environment.build_dir, subdir), exist_ok=True)
 
-        if not self._evaluate_subdir(self.environment.get_source_dir(), subdir):
+        if InterpreterRuleRelaxation.CARGO_SUBDIR in self.relaxations and \
+           os.path.exists(os.path.join(self.environment.get_source_dir(), subdir, 'Cargo.toml')):
+            codeblock = self.environment.cargo.interpret(subdir, self.root_subdir)
+            self._save_ast(subdir, codeblock)
+            self._evaluate_codeblock(codeblock, subdir)
+        elif not self._evaluate_subdir(self.environment.get_source_dir(), subdir):
             buildfilename = os.path.join(subdir, environment.build_filename)
             raise InterpreterException(f"Nonexistent build file '{buildfilename!s}'")
 

--- a/mesonbuild/interpreterbase/interpreterbase.py
+++ b/mesonbuild/interpreterbase/interpreterbase.py
@@ -733,6 +733,11 @@ class InterpreterBase:
         except mesonlib.MesonException as me:
             me.file = absname
             raise me
+        self._evaluate_codeblock(codeblock, subdir, visitors)
+        return True
+
+    def _evaluate_codeblock(self, codeblock: mparser.CodeBlockNode, subdir: str,
+                            visitors: T.Optional[T.Iterable[AstVisitor]] = None) -> None:
         try:
             prev_subdir = self.subdir
             self.subdir = subdir
@@ -744,4 +749,3 @@ class InterpreterBase:
             pass
         finally:
             self.subdir = prev_subdir
-        return True

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -318,6 +318,9 @@ class PackageDefinition:
             with open(self.get_hashfile(subproject_directory), 'w', encoding='utf-8') as file:
                 file.write(self.wrapfile_hash + '\n')
 
+    def add_provided_dep(self, name: str) -> None:
+        self.provided_deps[name] = None
+
 def get_directory(subdir_root: str, packagename: str) -> str:
     fname = os.path.join(subdir_root, packagename + '.wrap')
     if os.path.isfile(fname):

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from .. import mlog
+from collections import defaultdict
 import contextlib
 from dataclasses import dataclass
 import urllib.request
@@ -32,7 +33,7 @@ from . import WrapMode
 from .. import coredata
 from ..mesonlib import (
     DirectoryLock, DirectoryLockAction, quiet_git, GIT, ProgressBar, MesonException,
-    windows_proof_rmtree, Popen_safe
+    Version, version_compare, windows_proof_rmtree, Popen_safe
 )
 from ..interpreterbase import FeatureNew
 from ..interpreterbase import SubProject
@@ -42,7 +43,7 @@ if T.TYPE_CHECKING:
     import http.client
     from typing_extensions import Literal
 
-    from ..cargo.manifest import CargoLock
+    from ..cargo.manifest import CargoLock, CargoLockPackage
 
     Method = Literal['meson', 'cmake', 'cargo']
 
@@ -61,7 +62,6 @@ ALL_TYPES = ['file', 'git', 'hg', 'svn', 'redirect']
 
 if mesonlib.is_windows():
     from ..programs import ExternalProgram
-    from ..mesonlib import version_compare
     _exclude_paths: T.List[str] = []
     while True:
         _patch = ExternalProgram('patch', silent=True, exclude_paths=_exclude_paths)
@@ -344,10 +344,21 @@ class CargoState:
     """State for cargo package definitions to avoid recomputing cargo wraps."""
 
     wraps: T.Dict[str, PackageDefinition]
+    versions: T.Dict[str, T.List[CargoLockPackage]]
 
-    def __init__(self, wraps: T.Iterable[PackageDefinition] = None):
+    def __init__(self, packages: T.Iterable[CargoLockPackage] = None, wraps: T.Iterable[PackageDefinition] = None):
         wraps = wraps or []
         self.wraps = {wrap.name: wrap for wrap in wraps}
+
+        packages = packages or []
+        self.versions = defaultdict(list)
+        for pkg in packages:
+            self.versions[pkg.name].append(pkg)
+        for version_set in self.versions.values():
+            version_set.sort(reverse=True, key=lambda pkg: Version(pkg.version))
+
+    def named(self, name: str) -> T.Sequence[CargoLockPackage]:
+        return self.versions[name]
 
 
 @dataclass(eq=False)

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -42,6 +42,8 @@ if T.TYPE_CHECKING:
     import http.client
     from typing_extensions import Literal
 
+    from ..cargo.manifest import CargoLock
+
     Method = Literal['meson', 'cmake', 'cargo']
 
 try:
@@ -337,6 +339,17 @@ def verbose_git(cmd: T.List[str], workingdir: str, check: bool = False) -> bool:
     except mesonlib.GitException as e:
         raise WrapException(str(e))
 
+
+class CargoState:
+    """State for cargo package definitions to avoid recomputing cargo wraps."""
+
+    wraps: T.Dict[str, PackageDefinition]
+
+    def __init__(self, wraps: T.Iterable[PackageDefinition] = None):
+        wraps = wraps or []
+        self.wraps = {wrap.name: wrap for wrap in wraps}
+
+
 @dataclass(eq=False)
 class Resolver:
     source_dir: str
@@ -346,6 +359,7 @@ class Resolver:
     wrap_frontend: bool = False
     allow_insecure: bool = False
     silent: bool = False
+    cargo_state: T.Optional[CargoState] = None
 
     def __post_init__(self) -> None:
         self.subdir_root = os.path.join(self.source_dir, self.subdir)
@@ -371,12 +385,18 @@ class Resolver:
             mlog.warning(f'failed to process netrc file: {e}.', fatal=False)
 
     def load_wraps(self) -> None:
-        # Load Cargo.lock at the root of source tree
-        source_dir = os.path.dirname(self.subdir_root)
-        if os.path.exists(os.path.join(source_dir, 'Cargo.lock')):
+        # 1) If there's cargo state from parent resolver, use it
+        # 2) If there is a root Cargo.lock file, use it
+        # 3) Otherwise load Cargo.lock at the root of source tree
+        if self.cargo_state is None:
             from .. import cargo
-            for wrap in cargo.load_wraps(source_dir, self.subdir_root):
-                self.wraps[wrap.name] = wrap
+            if os.path.exists(os.path.join(self.source_dir, 'Cargo.lock')):
+                self.cargo_state = cargo.load_wraps(self.source_dir, '')
+            elif os.path.exists(os.path.join(self.subdir_root, 'Cargo.lock')):
+                self.cargo_state = cargo.load_wraps(self.subdir_root, self.subproject)
+            else:
+                self.cargo_state = CargoState()
+        self.wraps.update(self.cargo_state.wraps)
         # Load subprojects/*.wrap
         if os.path.isdir(self.subdir_root):
             root, dirs, files = next(os.walk(self.subdir_root))
@@ -460,7 +480,9 @@ class Resolver:
 
     def load_and_merge(self, subdir: str, subproject: SubProject) -> None:
         if self.wrap_mode != WrapMode.nopromote and subdir not in self.loaded_dirs:
-            other_resolver = Resolver(self.source_dir, subdir, subproject, self.wrap_mode, self.wrap_frontend, self.allow_insecure, self.silent)
+            other_resolver = Resolver(self.source_dir, subdir, subproject, self.wrap_mode,
+                                      self.wrap_frontend, self.allow_insecure, self.silent,
+                                      self.cargo_state)
             self._merge_wraps(other_resolver)
             self.loaded_dirs.add(subdir)
 

--- a/test cases/rust/29 cargo workspace/meson.build
+++ b/test cases/rust/29 cargo workspace/meson.build
@@ -1,0 +1,13 @@
+project('cargo workspace', 'c', 'rust')
+
+foo_rs = dependency('foo-1-rs')
+e = executable('test-foo-1-rs', 'test_foo_1.rs',
+  dependencies: [foo_rs],
+)
+test('test-foo-1-rs', e)
+
+foo_cdylib = dependency('foo-1-cdylib')
+e = executable('test-foo-1-cdylib', 'test_foo_1.c',
+  dependencies: [foo_cdylib],
+)
+test('test-foo-1-rs', e)

--- a/test cases/rust/29 cargo workspace/subprojects/foo.wrap
+++ b/test cases/rust/29 cargo workspace/subprojects/foo.wrap
@@ -1,0 +1,5 @@
+[wrap-file]
+method=cargo
+
+[provide]
+dependency_names=foo-1-rs

--- a/test cases/rust/29 cargo workspace/subprojects/foo/Cargo.toml
+++ b/test cases/rust/29 cargo workspace/subprojects/foo/Cargo.toml
@@ -1,0 +1,15 @@
+[workspace]
+resolver = "2"
+members = [
+    "src/foo",
+    "src/member1"
+]
+default-members = ["src/foo"]
+
+[workspace.package]
+edition = "2021"
+version = "1.0.0"
+
+[workspace.dependencies]
+member1 = { path="./src/member1" }
+member2 = { path="src/member2", features = ["f1"] }

--- a/test cases/rust/29 cargo workspace/subprojects/foo/src/foo/Cargo.toml
+++ b/test cases/rust/29 cargo workspace/subprojects/foo/src/foo/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "foo"
+edition.workspace = true
+version.workspace = true
+
+[lib]
+crate-type = ["lib", "cdylib"]
+
+[dependencies]
+m1 = { path="../member1", package="member1" }

--- a/test cases/rust/29 cargo workspace/subprojects/foo/src/foo/src/lib.rs
+++ b/test cases/rust/29 cargo workspace/subprojects/foo/src/foo/src/lib.rs
@@ -1,0 +1,6 @@
+extern crate m1;
+
+#[no_mangle]
+pub extern "C" fn foo() -> i32 {
+    m1::member1() + 1
+}

--- a/test cases/rust/29 cargo workspace/subprojects/foo/src/lib.rs
+++ b/test cases/rust/29 cargo workspace/subprojects/foo/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn foo() -> i32 {
+    member1::member1() + 1
+}

--- a/test cases/rust/29 cargo workspace/subprojects/foo/src/member1/Cargo.toml
+++ b/test cases/rust/29 cargo workspace/subprojects/foo/src/member1/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "member1"
+edition.workspace = true
+version.workspace = true
+
+[dependencies]
+member2 = { workspace = true, features=["f2"] }

--- a/test cases/rust/29 cargo workspace/subprojects/foo/src/member1/src/lib.rs
+++ b/test cases/rust/29 cargo workspace/subprojects/foo/src/member1/src/lib.rs
@@ -1,0 +1,5 @@
+extern crate member2;
+
+pub fn member1() -> i32 {
+    member2::member2() + 1
+}

--- a/test cases/rust/29 cargo workspace/subprojects/foo/src/member2/Cargo.toml
+++ b/test cases/rust/29 cargo workspace/subprojects/foo/src/member2/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "member2"
+edition.workspace = true
+version.workspace = true
+
+[features]
+default = []
+f1 = []
+f2 = []

--- a/test cases/rust/29 cargo workspace/subprojects/foo/src/member2/src/lib.rs
+++ b/test cases/rust/29 cargo workspace/subprojects/foo/src/member2/src/lib.rs
@@ -1,0 +1,5 @@
+#[cfg(feature = "f1")]
+#[cfg(feature = "f2")]
+pub fn member2() -> i32 {
+    1
+}

--- a/test cases/rust/29 cargo workspace/test_foo_1.c
+++ b/test cases/rust/29 cargo workspace/test_foo_1.c
@@ -1,0 +1,5 @@
+extern int foo(void);
+
+int main(void) {
+  return foo() == 3 ? 0 : 1;
+}

--- a/test cases/rust/29 cargo workspace/test_foo_1.rs
+++ b/test cases/rust/29 cargo workspace/test_foo_1.rs
@@ -1,0 +1,5 @@
+extern crate foo;
+
+pub fn main() {
+  assert!(foo::foo() == 3);
+}

--- a/unittests/cargotests.py
+++ b/unittests/cargotests.py
@@ -193,6 +193,10 @@ class CargoLockTest(unittest.TestCase):
                     name = "bar"
                     version = "0.1"
                     source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.19#23c5599424cc75ec66618891c915d9f490f6e4c2"
+                    [[package]]
+                    name = "member"
+                    version = "0.1"
+                    source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=0.19#23c5599424cc75ec66618891c915d9f490f6e4c2"
                     '''))
             wraps = load_wraps(tmpdir, 'subprojects')
             self.assertEqual(len(wraps), 2)
@@ -202,12 +206,13 @@ class CargoLockTest(unittest.TestCase):
             self.assertEqual(wraps[0].get('method'), 'cargo')
             self.assertEqual(wraps[0].get('source_url'), 'https://crates.io/api/v1/crates/foo/0.1/download')
             self.assertEqual(wraps[0].get('source_hash'), '8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb')
-            self.assertEqual(wraps[1].name, 'bar-0.1-rs')
-            self.assertEqual(wraps[1].directory, 'bar')
+            self.assertEqual(wraps[1].name, 'gtk-rs-core-0.19')
+            self.assertEqual(wraps[1].directory, 'gtk-rs-core-0.19')
             self.assertEqual(wraps[1].type, 'git')
             self.assertEqual(wraps[1].get('method'), 'cargo')
             self.assertEqual(wraps[1].get('url'), 'https://github.com/gtk-rs/gtk-rs-core')
             self.assertEqual(wraps[1].get('revision'), '23c5599424cc75ec66618891c915d9f490f6e4c2')
+            self.assertEqual(list(wraps[1].provided_deps), ['gtk-rs-core-0.19', 'bar-0.1-rs', 'member-0.1-rs'])
 
 class CargoTomlTest(unittest.TestCase):
     CARGO_TOML_1 = textwrap.dedent('''\


### PR DESCRIPTION
My own cleaned up and fixed version of #14681.

There is one important change compared to both current versions and that PR: Meson will now parse a `Cargo.lock` in the toplevel source directory, and use it to resolve the versions of Cargo subprojects in preference to per-subproject `Cargo.lock` files.

This makes sure that all subprojects use a consistent version of a crate.