### PR TITLE
compilers: clike: Deduplicate compile and link args from actually used arg list

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -387,7 +387,7 @@ class CLikeCompiler(Compiler):
             sys_ld_args = env.coredata.get_external_link_args(self.for_machine, self.language)
             # CFLAGS and CXXFLAGS go to both linking and compiling, but we want them
             # to only appear on the command line once. Remove dupes.
-            largs += [x for x in sys_ld_args if x not in sys_args]
+            largs += [x for x in sys_ld_args if x not in cleaned_sys_args]
 
         cargs += self.get_compiler_args_for_mode(mode)
         return cargs, largs


### PR DESCRIPTION
Current behaviour is to loop over `sys_args` list which contains both included and ignored compiler arguments.

For instance, `CFLAGS` (or `c_args` as Meson option) contains `-I${includedir} -L${libdir}` and `LDFLAGS` (`c_link_args`) contains `-L${libdir}`. Given `CFLAGS` value is wrong as linker options belong to `LDFLAGS` and `-L` entry should not be included in compiler argument list. But since we have it in `sys_args` list this entry will not be included as linker flag too! This is definitely not our goal: wrong entry should just be ignored but instead it affects overall state.

Here is small example with some debug prints from Meson:

```
C_ARGS: ['-I/opt/x64-compile/include', '-L/opt/x64-compile/lib']
LINKER_ARGS: ['-L/opt/x64-compile/lib']
RESULT_CARGS: ['-I/opt/x64-compile/include', '-D_FILE_OFFSET_BITS=64']
RESULT_LDARGS: []

```
(this is captured during compiler.find_library() call)

And this is what we see looping over `cleaned_sys_args`:
```
C_ARGS: ['-I/opt/x64-compile/include', '-L/opt/x64-compile/lib'] 
LINKER_ARGS: ['-L/opt/x64-compile/lib']
RESULT_CARGS: ['-I/opt/x64-compile/include', '-D_FILE_OFFSET_BITS=64'] 
RESULT_LDARGS: ['-L/opt/x64-compile/lib']
```