### PR TITLE
format: do not group '--' arg

### DIFF
--- a/mesonbuild/mformat.py
+++ b/mesonbuild/mformat.py
@@ -670,7 +670,7 @@ class ArgumentFormatter(FullAstVisitor):
             if self.config.group_arg_value:
                 for arg in node.arguments[:-1]:
                     group_args = False
-                    if isinstance(arg, mparser.StringNode) and arg.value.startswith('--'):
+                    if isinstance(arg, mparser.StringNode) and arg.value.startswith('--') and arg.value != '--':
                         next_arg = node.arguments[arg_index + 1]
                         if isinstance(next_arg, mparser.StringNode) and not next_arg.value.startswith('--'):
                             group_args = True


### PR DESCRIPTION
The group_arg_value option allow to put --key and its value on the same line on multiline arguments. However, when the options is `--`, it is an argument separator, and should not be grouped with the following argument.