### PR TITLE
Fix source paths in introspection data for custom targets

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1914,7 +1914,7 @@ class Backend:
                 if isinstance(j, mesonlib.File):
                     source_list += [j.absolute_path(self.source_dir, self.build_dir)]
                 elif isinstance(j, str):
-                    source_list += [os.path.join(self.source_dir, j)]
+                    source_list += [os.path.join(self.source_dir, target.subdir, j)]
                 elif isinstance(j, (build.CustomTarget, build.BuildTarget)):
                     source_list += [os.path.join(self.build_dir, j.get_subdir(), o) for o in j.get_outputs()]
             source_list = [os.path.normpath(s) for s in source_list]


### PR DESCRIPTION
Before this patch if a relative path was given as a source to a custom target it would exported to the introspection data as `os.path.join(meson_root, relative_path)` which was usually incorrect and was never correct for subprojects.