### PR TITLE
gnome: Add missing install tag for vapi .deps file

### DIFF
--- a/docs/markdown/Installing.md
+++ b/docs/markdown/Installing.md
@@ -170,6 +170,7 @@ time, please help extending the list of well known categories.
   * `pkgconfig.generate()`,
   * `gnome.generate_gir()` - `.gir` file,
   * `gnome.generate_vapi()` - `.vapi` file (*Since 0.64.0*),
+  * `gnome.generate_vapi()` - `.deps` file (*Since 1.9.1*),
   * Files installed into `libdir` and with `.a` or `.pc` extension,
   * File installed into `includedir`,
   * Generated header files installed with `gnome.compile_resources()`,

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -2209,7 +2209,7 @@ class GnomeModule(ExtensionModule):
         with open(fname, 'w', encoding='utf-8') as ofile:
             for package in packages:
                 ofile.write(package + '\n')
-        return build.Data([mesonlib.File(True, outdir, fname)], install_dir, install_dir, mesonlib.FileMode(), state.subproject)
+        return build.Data([mesonlib.File(True, outdir, fname)], install_dir, install_dir, mesonlib.FileMode(), state.subproject, install_tag='devel')
 
     def _get_vapi_link_with(self, target: CustomTarget) -> T.List[build.LibTypes]:
         link_with: T.List[build.LibTypes] = []


### PR DESCRIPTION
I don't really know anything about these vala vapi files but I suspect this is the correct install tag for this file.