### PR TITLE
Allow Wrap to look for custom subproject_dir

### DIFF
--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -2061,6 +2061,17 @@ def detect_subprojects(spdir_name: str, current_dir: str = '',
             continue
         append_this = True
         if os.path.isdir(trial):
+            # get subproject's spdir name from it's meson.build
+            from ..ast import IntrospectionInterpreter
+            from ..interpreterbase import InvalidArguments
+            intr = IntrospectionInterpreter(trial, '', 'none')
+            try:
+                intr.load_root_meson_file()
+            except InvalidArguments:  # Root meson file cannot be found
+                pass
+
+            spdir_name = intr.extract_subproject_dir() or 'subprojects'
+
             detect_subprojects(spdir_name, trial, result)
         elif trial.endswith('.wrap') and os.path.isfile(trial):
             basename = os.path.splitext(basename)[0]

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -30,6 +30,7 @@ from functools import lru_cache
 
 from . import WrapMode
 from .. import coredata
+from  ..interpreterbase.exceptions import InvalidArguments
 from ..mesonlib import (
     DirectoryLock, DirectoryLockAction, quiet_git, GIT, ProgressBar, MesonException,
     windows_proof_rmtree, Popen_safe
@@ -163,6 +164,20 @@ def parse_patch_url(patch_url: str) -> T.Tuple[str, str]:
         return version, revision
     else:
         raise WrapException(f'Invalid wrapdb URL {patch_url}')
+
+def get_subproject_dir():
+    """
+    Gets the value set for subprojects_dir in meson.build.
+    Returns none if not called from project root
+    """
+    from ..ast import IntrospectionInterpreter
+    intr = IntrospectionInterpreter('.', '', 'none')
+    try:
+        intr.load_root_meson_file()
+    except InvalidArguments: # Root meson file cannot be found
+        return None
+
+    return intr.extract_subproject_dir() or 'subprojects'
 
 class WrapException(MesonException):
     pass

--- a/mesonbuild/wrap/wraptool.py
+++ b/mesonbuild/wrap/wraptool.py
@@ -10,7 +10,7 @@ import typing as T
 
 from glob import glob
 from .wrap import (open_wrapdburl, read_and_decompress, WrapException, get_releases,
-                   get_releases_data, parse_patch_url)
+                   get_releases_data, parse_patch_url, get_subproject_dir)
 from pathlib import Path
 
 from .. import mesonlib, msubprojects
@@ -91,11 +91,12 @@ def get_latest_version(name: str, allow_insecure: bool) -> T.Tuple[str, str]:
 
 def install(options: 'argparse.Namespace') -> None:
     name = options.name
-    if not os.path.isdir('subprojects'):
+    subproject_dir_name = get_subproject_dir()
+    if subproject_dir_name is None or not os.path.isdir(subproject_dir_name):
         raise SystemExit('Subprojects dir not found. Run this script in your source root directory.')
-    if os.path.isdir(os.path.join('subprojects', name)):
+    if os.path.isdir(os.path.join(subproject_dir_name, name)):
         raise SystemExit('Subproject directory for this project already exists.')
-    wrapfile = os.path.join('subprojects', name + '.wrap')
+    wrapfile = os.path.join(subproject_dir_name, name + '.wrap')
     if os.path.exists(wrapfile):
         raise SystemExit('Wrap file already exists.')
     (version, revision) = get_latest_version(name, options.allow_insecure)
@@ -143,11 +144,13 @@ def do_promotion(from_path: str, spdir_name: str) -> None:
         outputdir = os.path.join(spdir_name, sproj_name)
         if os.path.exists(outputdir):
             raise SystemExit(f'Output dir {outputdir} already exists. Will not overwrite.')
-        shutil.copytree(from_path, outputdir, ignore=shutil.ignore_patterns('subprojects'))
+        shutil.copytree(from_path, outputdir, ignore=shutil.ignore_patterns(get_subproject_dir()))
 
 def promote(options: 'argparse.Namespace') -> None:
     argument = options.project_path
-    spdir_name = 'subprojects'
+    spdir_name = get_subproject_dir()
+    if spdir_name is None:
+        raise SystemExit('Subproject dir not found. Run this script in your source root directory.')
     sprojs = mesonlib.detect_subprojects(spdir_name)
 
     # check if the argument is a full path to a subproject directory or wrap file
@@ -189,8 +192,12 @@ def status(options: 'argparse.Namespace') -> None:
 
 def update_db(options: 'argparse.Namespace') -> None:
     data = get_releases_data(options.allow_insecure)
-    Path('subprojects').mkdir(exist_ok=True)
-    with Path('subprojects/wrapdb.json').open('wb') as f:
+    subproject_dir_name = get_subproject_dir()
+    if subproject_dir_name is None:
+        raise SystemExit('Subproject dir not found. Run this script in your source root directory.')
+
+    Path(subproject_dir_name).mkdir(exist_ok=True)
+    with Path(subproject_dir_name).joinpath('wrapdb.json').open('wb') as f:
         f.write(data)
 
 def run(options: 'argparse.Namespace') -> int:


### PR DESCRIPTION
This change fixes #14888, where wrap would install dependencies to `subprojects` regardless of what value is set. I have tested the commands: install, update-db, promote. I think those are the only ones that presume the name of subproject_dir.