### PR TITLE
haiku: fix `executable.export_dynamic` and `dynamic_module` behavior

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -364,6 +364,9 @@ class Backend:
         elif isinstance(target, build.Executable):
             if target.import_filename:
                 return Path(self.get_target_dir(target), target.get_import_filename()).as_posix()
+            # It is always possible to link with executable on Haiku.
+            elif self.environment.machines[target.for_machine].is_haiku():
+                return Path(self.get_target_dir(target), target.get_filename()).as_posix()
             else:
                 return None
         raise AssertionError(f'BUG: Tried to link to {target!r} which is not linkable')

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -399,7 +399,7 @@ def get_base_link_args(target: 'BuildTarget',
     if not bitcode:
         from ..build import SharedModule
         args.extend(linker.headerpad_args())
-        if (not isinstance(target, SharedModule) and
+        if ((not isinstance(target, SharedModule) or env.machines[target.for_machine].is_haiku()) and
                 option_enabled(linker.base_options, target, env, 'b_lundef')):
             args.extend(linker.no_undefined_link_args())
         else:

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -674,6 +674,8 @@ class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
 
     def export_dynamic_args(self, env: 'Environment') -> T.List[str]:
         m = env.machines[self.for_machine]
+        if m.is_haiku():
+            return self._apply_prefix('-soname=_APP_')
         if m.is_windows() or m.is_cygwin():
             return self._apply_prefix('--export-all-symbols')
         return self._apply_prefix('-export-dynamic')


### PR DESCRIPTION
Unlike Linux, in Haiku `executable` target should behave as `shared_library` target when linked with `dynamic_module` target.
Haiku executables always provides dynamic symbol table and can be linked with like ordinary shared library. In order to not depend on executable file name, by convention `_APP_` (sic.) SONAME should be specified for executable with that `dynamic_module` are linked.

Expected behavior specification:

`executable(export_dynamic: true)`:
- `-Wl,-soname=_APP_`

`dynamic_module()`:
- No `--allow-shlib-undefined` flag.
- Path to executable is passed to linker arguments. No import library is used.