### PR TITLE
Fix shebang detection for file objects

### DIFF
--- a/docs/markdown/snippets/fix-file-objects-shebang.md
+++ b/docs/markdown/snippets/fix-file-objects-shebang.md
@@ -1,0 +1,11 @@
+## File objects can now be used directly as commands with shebang detection
+
+`File` objects from `files()` and `configure_file()` can now be used directly as
+the first argument in `custom_target()` and `run_target()` commands without
+needing the `find_program()` workaround.
+
+```meson
+codegen = configure_file(input: 'codegen.py.in', output: 'codegen.py', copy: true)
+custom_target('generated-code', command: [codegen, '@INPUT@', '@OUTPUT@'], 
+              input: 'template.h.in', output: 'generated.h')
+```

--- a/test cases/common/285 file objects in commands/buildtool.py
+++ b/test cases/common/285 file objects in commands/buildtool.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+import sys
+print(' '.join(sys.argv[1:]) if len(sys.argv) > 1 else 'Build tool executed')

--- a/test cases/common/285 file objects in commands/codegen.py.in
+++ b/test cases/common/285 file objects in commands/codegen.py.in
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+print('/* Generated header file */')

--- a/test cases/common/285 file objects in commands/meson.build
+++ b/test cases/common/285 file objects in commands/meson.build
@@ -1,0 +1,28 @@
+project('file objects in commands')
+
+# Tests fix for GitHub issue #11255
+codegen = configure_file(
+  input: 'codegen.py.in',
+  output: 'codegen.py',
+  copy: true
+)
+
+buildtool = files('buildtool.py')
+
+custom_target('generate-code',
+  output: 'generated.h',
+  command: [codegen],
+  capture: true,
+  build_by_default: true
+)
+
+custom_target('process-data',
+  output: 'processed.txt',
+  command: [buildtool, 'Processing data'],
+  capture: true,
+  build_by_default: true
+)
+
+run_target('run-codegen',
+  command: [codegen]
+)

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1423,6 +1423,27 @@ class AllPlatformTests(BasePlatformTests):
             self.utime(os.path.join(testdir, f))
             self.assertBuildRelinkedOnlyTarget('prog')
 
+    def test_file_objects_as_commands(self):
+        '''
+        Test File objects can be used directly as commands with shebang detection.
+        Fixes GitHub issue #11255.
+        '''
+        testdir = os.path.join(self.common_test_dir, '285 file objects in commands')
+        self.init(testdir, default_args=False)
+        self.build()
+        
+        generated_header = os.path.join(self.builddir, 'generated.h')
+        processed_data = os.path.join(self.builddir, 'processed.txt')
+        
+        self.assertPathExists(generated_header)
+        self.assertPathExists(processed_data)
+        
+        with open(generated_header, 'r') as f:
+            self.assertIn('Generated header file', f.read())
+        
+        with open(processed_data, 'r') as f:
+            self.assertIn('Processing data', f.read())
+
     def test_source_generator_program_cause_rebuild(self):
         '''
         Test that changes to generator programs in the source tree cause


### PR DESCRIPTION
Fixes https://github.com/mesonbuild/meson/issues/11255.

`File` objects from `files()` and `configure_file()` can now be used directly as the first argument in `custom_target()` and `run_target()` commands without needing the `find_program()` workaround.

```meson
codegen = configure_file(input: 'codegen.py.in', output: 'codegen.py', copy: true)
custom_target('generated-code', command: [codegen, '@INPUT@', '@OUTPUT@'], 
              input: 'template.h.in', output: 'generated.h')
```
