### PR TITLE
ninjabackend: pass objects to doctests

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2208,10 +2208,9 @@ class NinjaBackend(backends.Backend):
             rustdoc = rustc.get_rustdoc(self.environment)
             args = rustdoc.get_exe_args()
             args += self.get_rust_compiler_args(target.doctests.target, rustdoc, target.rust_crate_type)
-            # There can be no non-Rust objects: the doctests are gathered from Rust
-            # sources and the tests are linked with the target (which is where the
-            # obj_list was linked into)
-            _, _, deps_args = self.get_rust_compiler_deps_and_args(target.doctests.target, rustdoc, [])
+            # Rustc does not add files in the obj_list to Rust rlibs,
+            # and is added by Meson to all of the dependencies, including here.
+            _, _, deps_args = self.get_rust_compiler_deps_and_args(target.doctests.target, rustdoc, obj_list)
             args += deps_args
             target.doctests.cmd_args = args.to_native() + [main_rust_file] + target.doctests.cmd_args
 

--- a/test cases/rust/27 objects/lib1-dylib.rs
+++ b/test cases/rust/27 objects/lib1-dylib.rs
@@ -13,3 +13,12 @@ pub extern "C" fn c_func()
 {
     unsafe { from_lib1(); }
 }
+
+/// ```
+/// use lib12::rust_func;
+/// rust_func();
+/// ```
+pub fn rust_func()
+{
+    unsafe { from_lib1(); }
+}

--- a/test cases/rust/27 objects/meson.build
+++ b/test cases/rust/27 objects/meson.build
@@ -1,4 +1,5 @@
-project('staticlib group', 'c', 'rust', meson_version: '>=1.8.0')
+project('staticlib group', 'c', 'rust', meson_version: '>=1.8.0',
+        default_options: ['rust_std=2021'])
 
 lib1 = static_library('lib1', 'lib1.c')
 dep1 = declare_dependency(objects: lib1.extract_all_objects(recursive: false))
@@ -26,3 +27,9 @@ lib12 = shared_library('dylib2objs_as_dep', 'lib1-dylib.rs',
   dependencies: dep2,
   rust_abi: 'c')
 executable('dylib_as_dep', 'main.rs', link_with: lib12)
+
+lib12_rlib = static_library('lib12', 'lib1-dylib.rs',
+  dependencies: dep2)
+
+rust = import('rust')
+rust.doctest('rlib with dep', lib12_rlib)


### PR DESCRIPTION
Fix my misunderstanding of the code before commit aede231ef ("ninjabackend: pass objects to generate_rust_target from non-Rust sources", 2025-07-29).

Object files were added by get_rust_compiler_deps_and_args() to both the main target and the doctest command lines:

```
        objs, od = self.flatten_object_list(target)
        for o in objs:
            args.append(f'-Clink-arg={o}')
            deps.append(o)
```

therefore they now need to be passed as the final argument of get_rust_compiler_deps_and_args() for both command lines as well. Failure to do so causes problems building doctests when the main target has objects as well.

Add a regression test as well.

Fixes: #14897