### PR TITLE
rewriter: fix UnknownValues in build targets

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1223,7 +1223,9 @@ class BuildTarget(Target):
         self.resources = resources
         if kwargs.get('name_prefix') is not None:
             name_prefix = kwargs['name_prefix']
-            if isinstance(name_prefix, list):
+            if isinstance(name_prefix, UnknownValue):
+                pass
+            elif isinstance(name_prefix, list):
                 if name_prefix:
                     raise InvalidArguments('name_prefix array must be empty to signify default.')
             else:
@@ -1233,7 +1235,9 @@ class BuildTarget(Target):
                 self.name_prefix_set = True
         if kwargs.get('name_suffix') is not None:
             name_suffix = kwargs['name_suffix']
-            if isinstance(name_suffix, list):
+            if isinstance(name_suffix, UnknownValue):
+                pass
+            elif isinstance(name_suffix, list):
                 if name_suffix:
                     raise InvalidArguments('name_suffix array must be empty to signify default.')
             else:

--- a/test cases/unit/58 introspect buildoptions/meson.build
+++ b/test cases/unit/58 introspect buildoptions/meson.build
@@ -14,5 +14,13 @@ if r.returncode() != 0
   error('FAILED')
 endif
 
+name_prefix = 'lib'
+if get_option('buildtype') == 'release'
+  # ensure that these variables become an UnkownValue
+  name_prefix = []
+endif
+
+static_library('hello', 'hello.c', name_prefix: name_prefix)
+
 add_languages(r.stdout().strip(), required: true)
 add_languages('afgggergearvearghergervergreaergaergasv', required: false)


### PR DESCRIPTION
Fixes another problem with running "meson configure" on Mesa. While "meson configure" never worked on Mesa prior to 1.9.0, this particular issue is a regression.

Cc: @Volker-Weissmann 
Cc: @dlundqvist
Related: #14840