### PR TITLE
rustdoc: skip --crate-type option

### DIFF
--- a/mesonbuild/scripts/rustdoc.py
+++ b/mesonbuild/scripts/rustdoc.py
@@ -65,7 +65,7 @@ class Rustdoc:
                     if arg == '--test':
                         is_test = True
                         break
-                    elif arg in {'--crate-name', '--emit', '--out-dir', '-l'}:
+                    elif arg in {'--crate-name', '--emit', '--out-dir', '-l', '--crate-type'}:
                         prev = arg
                     elif arg != '-g' and not arg.startswith('-l'):
                         cmdlist.append(arg)


### PR DESCRIPTION
--crate-type is accepted by recent versions of rustdoc, but it
is not used by it and not listed in the documentation[1].
Remove it for compatibility with old versions of Rust.

[1] https://doc.rust-lang.org/rustdoc/command-line-arguments.html