### PR TITLE
windows: Add support for Zig's builtin rc compiler

### DIFF
--- a/docs/markdown/snippets/zig-rc.md
+++ b/docs/markdown/snippets/zig-rc.md
@@ -1,0 +1,7 @@
+## Added support for Zig's builtin Windows Resource Compiler
+
+Using `zig rc` as `windres` no longer triggers the error `Could not determine
+type of Windows resource compiler`.
+
+Note: Zig 0.14.1 and later have modified their CLI for Meson compatibility, so
+this change is only relevant when using `zig rc` versions earlier than 0.14.1.

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -86,6 +86,7 @@ class WindowsModule(ExtensionModule):
             raise MesonException('Could not find Windows resource compiler')
 
         for (arg, match, rc_type) in [
+                # Zig >=0.14.1 is also matched by the regex below.
                 ('/?', '^.*Microsoft.*Resource Compiler.*$', ResourceCompilerType.rc),
                 ('/?', 'LLVM Resource Converter.*$', ResourceCompilerType.rc),
                 ('--version', '^.*GNU windres.*$', ResourceCompilerType.windres),
@@ -98,7 +99,15 @@ class WindowsModule(ExtensionModule):
                 self._rescomp = (rescomp, rc_type)
                 break
         else:
-            raise MesonException('Could not determine type of Windows resource compiler')
+            # Zig <0.14.1 prints its info to stderr, so we'll handle it separately.
+            _, _, e = mesonlib.Popen_safe(rescomp.get_command() + ['/?'])
+            # The string below should be indicative of a resinator rc compiler
+            # (which includes zig rc).
+            if re.search('^Supported Win32 RC Options:$', e, re.MULTILINE):
+                mlog.log('Windows resource compiler: Zig <0.14.1/restinator Resource Compiler')
+                self._rescomp = (rescomp, ResourceCompilerType.rc)
+            else:
+                raise MesonException('Could not determine type of Windows resource compiler')
 
         return self._rescomp
 


### PR DESCRIPTION
## Problems with Zig >=0.14.1
- The logs report `zig rc` >=0.14.1 as

   ```
   Windows resource compiler: Drop-in compatible with the Microsoft Resource Compiler.
   ```

   This description should be sufficient, but it's unfortunate that even the new fixed version of Zig fails to identify itself as Zig.
- Zig >=0.14.0 added support for the following flags:

  ```
    /:output-format <value>   If not specified, the output format is inferred.
      res                     (default if output format cannot be inferred)
      coff                    COFF object file (extension: .obj or .o)
      rcpp                    Preprocessed .rc file, implies /p
  ```

  This makes `zig rc`'s output more flexible. If I'm not mistaken, `zig rc /:output-format coff` would qualify it as `ResourceCompilerType.windres` instead of the currently used `ResourceCompilerType.rc`. But to my (limited) knowledge, GNU windres can also output several formats.

  Detecting the output mode specified by the user in the cross file or elsewhere is probably not worth the effort, but I wanted to document this fact somewhere.

## Choice of identifier string
The choice of identifier string is tricky. I went with the suggestion at https://github.com/mesonbuild/meson/issues/14372#issuecomment-2727223026. I can change it to something else if requested.

I have compiled the outputs of `--version`, `--help` and `/?` of all known Windows Resource Compilers: https://gist.github.com/meator/d427310ec1128066ee72400522bbe0b4 This list can help with picking good identifier strings.

## Testing
I was able to successfully configure a builddir with Zig versions 0.13.0, 0.14.0 and 0.14.1. I tested this on my WIP android-tools fork. I wasn't able to fully compile the project for unrelated reasons[^1], so that could perhaps use some more testing. The PR's changes are fairly simple, it shouldn't break anything.

I haven't added any unit tests because I don't think that would be appropriate here. The test would have to depend on Zig.

closes #14372

[^1]: android-tools depends on pthreads. Zig added support for these in 0.14.0 as documented in https://ziglang.org/download/0.14.0/release-notes.html#MinGW-w64. It also indirectly requires `windows.globalization.h`, which to my knowledge isn't bundled in Zig yet.
