### PR TITLE
permit empty `name_suffix`

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1236,10 +1236,6 @@ class BuildTarget(Target):
             else:
                 if not isinstance(name_suffix, str):
                     raise InvalidArguments('name_suffix must be a string.')
-                if name_suffix == '':
-                    raise InvalidArguments('name_suffix should not be an empty string. '
-                                           'If you want meson to use the default behaviour '
-                                           'for each platform pass `[]` (empty array)')
                 self.suffix = name_suffix
                 self.name_suffix_set = True
         if isinstance(self, StaticLibrary):
@@ -2549,7 +2545,7 @@ class SharedLibrary(BuildTarget):
             self.prefix = prefix
         if self.suffix is None:
             self.suffix = suffix
-        self.filename = self.filename_tpl.format(self)
+        self.filename = self.filename_tpl.format(self).removesuffix('.')
         if import_filename_tpl:
             self.import_filename = import_filename_tpl.format(self)
         # There may have been more outputs added by the time we get here, so

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -622,7 +622,7 @@ _BUILD_TARGET_KWS: T.List[KwargInfo] = [
     BT_SOURCES_KW,
     INCLUDE_DIRECTORIES.evolve(name='d_import_dirs'),
     _NAME_PREFIX_KW,
-    _NAME_PREFIX_KW.evolve(name='name_suffix', validator=_name_suffix_validator),
+    _NAME_PREFIX_KW.evolve(name='name_suffix', validator=_name_validator),
     RUST_CRATE_TYPE_KW,
     KwargInfo('d_debug', ContainerTypeInfo(list, (str, int)), default=[], listify=True),
     D_MODULE_VERSIONS_KW,


### PR DESCRIPTION
This is required for building Haiku add-ons and kernel modules as it have no prefix or suffix and file name is used for loading.