### PR TITLE
Fix network path output in ninja backend on Windows again

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -410,6 +410,12 @@ class NinjaBuildElement:
             line = f' {name} = '
             newelems = []
             for i in elems:
+                if mesonlib.is_windows():
+                    # Support network paths with double-backslash (UNC)
+                    # Officially //foo/bar is not an UNC and mostly doesn't work
+                    # in Windows
+                    if i.startswith('//'):
+                        i = i.replace('//', '\\\\', 1)
                 if not should_quote or i == '&&': # Hackety hack hack
                     newelems.append(ninja_quote(i))
                 else:


### PR DESCRIPTION
Fixes #14932

Once upon a time, this had already been fixed in 2020 (Issue #8130) and somehow got doomed by a mystical regression.

(The original fix was from Samuel Longchamps, Commit 12cfd10)

This fix is important, since otherwise invalid UNC paths for SAMBA shares get written out on Windows via Ninja.

'//foo/bar' is not a valid UNC since according to Microsoft, a UNC is required to begin with double-backslash '\\foo'.