### PR TITLE
Revert "clang-tidy: run tool only on source files participating in targets"

### DIFF
--- a/docs/markdown/snippets/clang-tidy-improvement.md
+++ b/docs/markdown/snippets/clang-tidy-improvement.md
@@ -1,5 +1,0 @@
-## `clang-tidy`'s auto-generated targets correctly select source files
-
-In previous versions, the target would run `clang-tidy` on _every_ C-like source files (.c, .h, .cpp, .hpp). It did not work correctly because some files, especially headers, are not intended to be consumed as is.
-
-It will now run only on source files participating in targets.

--- a/mesonbuild/scripts/clangtidy.py
+++ b/mesonbuild/scripts/clangtidy.py
@@ -11,7 +11,7 @@ import os
 import shutil
 import sys
 
-from .run_tool import run_with_buffered_output, run_clang_tool_on_sources
+from .run_tool import run_clang_tool, run_with_buffered_output
 from ..environment import detect_clangtidy, detect_clangapply
 import typing as T
 
@@ -56,7 +56,7 @@ def run(args: T.List[str]) -> int:
             fixesdir.unlink()
         fixesdir.mkdir(parents=True)
 
-    tidyret = run_clang_tool_on_sources('clang-tidy', srcdir, builddir, run_clang_tidy, tidyexe, builddir, fixesdir)
+    tidyret = run_clang_tool('clang-tidy', srcdir, builddir, run_clang_tidy, tidyexe, builddir, fixesdir)
     if fixesdir is not None:
         print('Applying fix-its...')
         applyret = subprocess.run(applyexe + ['-format', '-style=file', '-ignore-insert-conflict', fixesdir]).returncode

--- a/mesonbuild/scripts/run_tool.py
+++ b/mesonbuild/scripts/run_tool.py
@@ -128,26 +128,6 @@ def run_clang_tool(name: str, srcdir: Path, builddir: Path, fn: T.Callable[..., 
         yield fn(path, *args)
     return asyncio.run(_run_workers(all_clike_files(name, srcdir, builddir), wrapper))
 
-def run_clang_tool_on_sources(name: str, srcdir: Path, builddir: Path, fn: T.Callable[..., T.Coroutine[None, None, int]], *args: T.Any) -> int:
-    if sys.platform == 'win32':
-        asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
-
-    source_files = set()
-    with open('meson-info/intro-targets.json', encoding='utf-8') as fp:
-        targets = json.load(fp)
-
-        for target in targets:
-            for target_source in target.get('target_sources') or []:
-                for source in target_source.get('sources') or []:
-                    source_files.add(Path(source))
-
-    clike_files = set(all_clike_files(name, srcdir, builddir))
-    source_files = source_files.intersection(clike_files)
-
-    def wrapper(path: Path) -> T.Iterable[T.Coroutine[None, None, int]]:
-        yield fn(path, *args)
-    return asyncio.run(_run_workers(source_files, wrapper))
-
 def run_tool_on_targets(fn: T.Callable[[T.Dict[str, T.Any]],
                                        T.Iterable[T.Coroutine[None, None, int]]]) -> int:
     if sys.platform == 'win32':


### PR DESCRIPTION
This reverts https://github.com/mesonbuild/meson/pull/14736 and closes https://github.com/mesonbuild/meson/issues/14949.

I'm not sure how what to do to the release snippet, so I would need some guidance on that.
