### PR TITLE
Allow explicit selection of Java compiler

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -393,6 +393,7 @@ machine](#Environment-variables-per-machine) section for details.
 | C#            | CSC      | CSC       | The linker is the compiler                  |
 | Cython        | CYTHON   |           |                                             |
 | nasm          | NASM     |           | Uses the C linker                           |
+| java          | JAVAC    |           |                                             |
 | archiver      |          | AR        |                                             |
 
 *The old environment variables are still supported, but are deprecated

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -101,6 +101,7 @@ ENV_VAR_COMPILER_MAP: T.Mapping[str, str] = {
     'rust': 'RUSTC',
     'vala': 'VALAC',
     'nasm': 'NASM',
+    'java': 'JAVAC',
 
     # Linkers
     'c_ld': 'CC_LD',


### PR DESCRIPTION
Makes Java more consistent with other compilers and allows explicit
selection of Java compiler version and/or provider when building with
Meson.
