### PR TITLE
Cargo cross compilation support

### DIFF
--- a/docs/markdown/snippets/subproject_and_override_program_native.md
+++ b/docs/markdown/snippets/subproject_and_override_program_native.md
@@ -11,3 +11,6 @@ two versions of the same program, which have different outputs based on the
 machine they are for. For backwards compatibility reasons the default is for the
 host machine. Inside a native subproject the host and build machine will both be
 the build machine.
+
+Cargo workspaces use this feature automatically when building procedural macro
+crates and their dependencies.

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -26,7 +26,7 @@ from .toml import load_toml
 from .manifest import Manifest, CargoLock, CargoLockPackage, Workspace, fixup_meson_varname
 from ..mesonlib import (
     is_parent_path, lazy_property, MesonException, MachineChoice,
-    unique_list, SubProject,
+    PerMachine, unique_list, SubProject,
 )
 from .. import coredata, mlog
 from ..wrap.wrap import PackageDefinition
@@ -91,8 +91,10 @@ class PackageState:
     # If this package is member of a workspace.
     ws_subdir: T.Optional[str] = None
     ws_member: T.Optional[str] = None
-    # Package configuration state
-    cfg: T.Optional[PackageConfiguration] = None
+    # Per-machine configuration state
+    cfg: PerMachine[T.Optional[PackageConfiguration]] = dataclasses.field(
+        default_factory=lambda: PerMachine(None, None)
+    )
     # Subproject name as known to the wrap resolver (may differ from the
     # meson dep name for git sources, where the wrap is named after the
     # git directory rather than the crate name + api version).
@@ -185,8 +187,7 @@ class PackageState:
             machine = MachineChoice.HOST
 
         rustc = T.cast('RustCompiler', environment.coredata.compilers[machine]['rust'])
-
-        cfg = self.cfg
+        cfg = self.cfg[MachineChoice.HOST]
 
         args: T.List[str] = []
         args.extend(self.get_lint_args(rustc))
@@ -403,7 +404,7 @@ class Interpreter:
             if member in processed_members:
                 return
             pkg = ws.packages[member]
-            cfg = pkg.cfg
+            cfg = pkg.cfg[MachineChoice.HOST]
             if not cfg:
                 raise MesonException(f'Package {pkg.manifest.package.name!r} is not enabled for this build '
                                      'configuration. Maybe you forgot to enable a Cargo feature, or to check '
@@ -544,10 +545,10 @@ class Interpreter:
     def _prepare_package(self, pkg: PackageState) -> None:
         key = PackageKey(pkg.manifest.package.name, pkg.manifest.package.api)
         assert key in self.packages
-        if pkg.cfg:
+        if pkg.cfg[MachineChoice.HOST]:
             return
 
-        pkg.cfg = PackageConfiguration()
+        pkg.cfg[MachineChoice.HOST] = PackageConfiguration()
         # Merge target specific dependencies that are enabled
         cfgs = self._get_cfgs(MachineChoice.HOST)
         for condition, dependencies in pkg.manifest.target.items():
@@ -572,7 +573,7 @@ class Interpreter:
             if not dep.optional:
                 self._add_dependency(pkg, depname)
 
-    def _dep_package(self, pkg: PackageState, dep: Dependency) -> PackageState:
+    def _dep_package(self, pkg: PackageState, dep: Dependency, cfg: PackageConfiguration) -> PackageState:
         if dep.path:
             ws = self.workspaces[pkg.ws_subdir]
             dep_member = os.path.normpath(os.path.join(pkg.ws_member, dep.path))
@@ -594,8 +595,8 @@ class Interpreter:
             dep.update_version(f'={dep_pkg.manifest.package.version}')
 
         dep_key = PackageKey(dep.package, dep.api)
-        pkg.cfg.dep_packages.setdefault(dep_key, dep_pkg)
-        assert pkg.cfg.dep_packages[dep_key] == dep_pkg
+        cfg.dep_packages.setdefault(dep_key, dep_pkg)
+        assert cfg.dep_packages[dep_key] == dep_pkg
         return dep_pkg
 
     def _load_manifest(self, subdir: str, workspace: T.Optional[Workspace] = None, member_path: str = '') -> T.Tuple[T.Union[Manifest, Workspace], bool]:
@@ -620,7 +621,7 @@ class Interpreter:
         return manifest_, False
 
     def _add_dependency(self, pkg: PackageState, depname: str) -> None:
-        cfg = pkg.cfg
+        cfg = pkg.cfg[MachineChoice.HOST]
         if depname in cfg.required_deps:
             return
         dep = pkg.manifest.dependencies.get(depname)
@@ -628,7 +629,7 @@ class Interpreter:
             # It could be build/dev/target dependency. Just ignore it.
             return
         cfg.required_deps.add(depname)
-        dep_pkg = self._dep_package(pkg, dep)
+        dep_pkg = self._dep_package(pkg, dep, cfg)
         self._prepare_package(dep_pkg)
         if dep.default_features:
             self._enable_feature(dep_pkg, 'default')
@@ -638,7 +639,7 @@ class Interpreter:
             self._enable_feature(dep_pkg, f)
 
     def _enable_feature(self, pkg: PackageState, feature: str) -> None:
-        cfg = pkg.cfg
+        cfg = pkg.cfg[MachineChoice.HOST]
         if feature in cfg.features:
             return
         cfg.features.add(feature)
@@ -653,7 +654,7 @@ class Interpreter:
                     self._add_dependency(pkg, depname)
                 if depname in cfg.required_deps:
                     dep = pkg.manifest.dependencies[depname]
-                    dep_pkg = self._dep_package(pkg, dep)
+                    dep_pkg = self._dep_package(pkg, dep, cfg)
                     self._enable_feature(dep_pkg, dep_f)
                 else:
                     # This feature will be enabled only if that dependency

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -187,7 +187,7 @@ class PackageState:
             machine = MachineChoice.HOST
 
         rustc = T.cast('RustCompiler', environment.coredata.compilers[machine]['rust'])
-        cfg = self.cfg[MachineChoice.HOST]
+        cfg = self.cfg[machine]
 
         args: T.List[str] = []
         args.extend(self.get_lint_args(rustc))
@@ -300,6 +300,10 @@ class Interpreter:
             self.build_def_files.append(filename)
 
     @property
+    def is_cross(self) -> bool:
+        return self.environment.is_cross_build()
+
+    @property
     def features(self) -> T.List[str]:
         """Get the features list. Once read, it cannot be modified."""
         if self._features is None:
@@ -329,9 +333,10 @@ class Interpreter:
     def _prepare_entry_point(self, ws: WorkspaceState) -> None:
         pkgs = [self._require_workspace_member(ws, m) for m in ws.workspace.default_members]
         for pkg in pkgs:
-            self._prepare_package(pkg)
-            for feature in self.features:
-                self._enable_feature(pkg, feature)
+            for machine in pkg.manifest.machines_from(MachineChoice.HOST, bin=True, is_cross=self.is_cross):
+                self._prepare_package(pkg, machine)
+                for feature in self.features:
+                    self._enable_feature(pkg, feature, machine)
 
     def load_package(self, ws: WorkspaceState, package_name: T.Optional[str]) -> PackageState:
         if package_name is None:
@@ -369,9 +374,15 @@ class Interpreter:
         return build.block(ast)
 
     def _create_package(self, pkg: PackageState, build: builder.Builder, subdir: str) -> T.List[mparser.BaseNode]:
+        # proc_macro automatically adds native: true; passing "native: true"
+        # to cargo_ws.package() is only needed to query the features and
+        # pass them to meson/meson.build.
+        native = pkg.manifest.lib.crate_type == ['proc-macro']
         ast: T.List[mparser.BaseNode] = [
             build.assign(build.method('package', build.identifier('cargo_ws'),
-                                      [build.string(pkg.manifest.package.name)]), 'pkg_obj'),
+                                      [build.string(pkg.manifest.package.name)],
+                                      {'native': build.bool(native)}),
+                         'pkg_obj'),
             build.assign(build.method('features', build.identifier('pkg_obj')), 'features'),
             build.function('message', [
                 build.string('Enabled features:'),
@@ -404,16 +415,22 @@ class Interpreter:
             if member in processed_members:
                 return
             pkg = ws.packages[member]
-            cfg = pkg.cfg[MachineChoice.HOST]
-            if not cfg:
+            # Process dependencies for all configured machines
+            found = False
+            for machine in MachineChoice:
+                cfg = pkg.cfg[machine]
+                if not cfg:
+                    continue
+                for depname in cfg.required_deps:
+                    dep = pkg.manifest.dependencies[depname]
+                    if dep.path:
+                        dep_member = os.path.normpath(os.path.join(pkg.ws_member, dep.path))
+                        _process_member(dep_member)
+                found = True
+            if not found:
                 raise MesonException(f'Package {pkg.manifest.package.name!r} is not enabled for this build '
                                      'configuration. Maybe you forgot to enable a Cargo feature, or to check '
                                      'a Meson option?')
-            for depname in cfg.required_deps:
-                dep = pkg.manifest.dependencies[depname]
-                if dep.path:
-                    dep_member = os.path.normpath(os.path.join(pkg.ws_member, dep.path))
-                    _process_member(dep_member)
             if member == '.':
                 ast.extend(self._create_package(pkg, build, subdir))
             elif is_parent_path(self.subprojects_dir, member):
@@ -542,17 +559,17 @@ class Interpreter:
         pkg.subproject_name = subp_name
         return pkg
 
-    def _prepare_package(self, pkg: PackageState) -> None:
+    def _prepare_package(self, pkg: PackageState, machine: MachineChoice) -> None:
         key = PackageKey(pkg.manifest.package.name, pkg.manifest.package.api)
         assert key in self.packages
-        if pkg.cfg[MachineChoice.HOST]:
-            return
+        if pkg.cfg[machine] is not None:
+            return  # Already prepared for this machine
 
-        pkg.cfg[MachineChoice.HOST] = PackageConfiguration()
-        # Merge target specific dependencies that are enabled
-        cfgs = self._get_cfgs(MachineChoice.HOST)
+        pkg.cfg[machine] = PackageConfiguration()
+        # Merge target-specific dependencies that are enabled for this machine
+        target_cfgs = self._get_cfgs(machine)
         for condition, dependencies in pkg.manifest.target.items():
-            if eval_cfg(condition, cfgs):
+            if eval_cfg(condition, target_cfgs):
                 pkg.manifest.dependencies.update(dependencies)
 
         # If you specify the optional dependency with the dep: prefix anywhere in the [features]
@@ -568,10 +585,10 @@ class Interpreter:
                 pkg.manifest.features[name].append(f'dep:{name}')
                 deps.add(name)
 
-        # Fetch required dependencies recursively.
+        # Fetch required dependencies recursively for this machine
         for depname, dep in pkg.manifest.dependencies.items():
             if not dep.optional:
-                self._add_dependency(pkg, depname)
+                self._add_dependency(pkg, depname, machine)
 
     def _dep_package(self, pkg: PackageState, dep: Dependency, cfg: PackageConfiguration) -> PackageState:
         if dep.path:
@@ -620,8 +637,8 @@ class Interpreter:
         self.manifests[subdir] = manifest_
         return manifest_, False
 
-    def _add_dependency(self, pkg: PackageState, depname: str) -> None:
-        cfg = pkg.cfg[MachineChoice.HOST]
+    def _add_dependency(self, pkg: PackageState, depname: str, machine: MachineChoice) -> None:
+        cfg = pkg.cfg[machine]
         if depname in cfg.required_deps:
             return
         dep = pkg.manifest.dependencies.get(depname)
@@ -630,16 +647,18 @@ class Interpreter:
             return
         cfg.required_deps.add(depname)
         dep_pkg = self._dep_package(pkg, dep, cfg)
-        self._prepare_package(dep_pkg)
-        if dep.default_features:
-            self._enable_feature(dep_pkg, 'default')
-        for f in dep.features:
-            self._enable_feature(dep_pkg, f)
-        for f in cfg.optional_deps_features[depname]:
-            self._enable_feature(dep_pkg, f)
+        # Use machines_from() to determine which machines the dependency needs
+        for dep_machine in dep_pkg.manifest.machines_from(machine, self.is_cross):
+            self._prepare_package(dep_pkg, dep_machine)
+            if dep.default_features:
+                self._enable_feature(dep_pkg, 'default', dep_machine)
+            for f in dep.features:
+                self._enable_feature(dep_pkg, f, dep_machine)
+            for f in cfg.optional_deps_features[depname]:
+                self._enable_feature(dep_pkg, f, dep_machine)
 
-    def _enable_feature(self, pkg: PackageState, feature: str) -> None:
-        cfg = pkg.cfg[MachineChoice.HOST]
+    def _enable_feature(self, pkg: PackageState, feature: str, machine: MachineChoice) -> None:
+        cfg = pkg.cfg[machine]
         if feature in cfg.features:
             return
         cfg.features.add(feature)
@@ -651,19 +670,21 @@ class Interpreter:
                 if depname[-1] == '?':
                     depname = depname[:-1]
                 else:
-                    self._add_dependency(pkg, depname)
+                    self._add_dependency(pkg, depname, machine)
                 if depname in cfg.required_deps:
                     dep = pkg.manifest.dependencies[depname]
                     dep_pkg = self._dep_package(pkg, dep, cfg)
-                    self._enable_feature(dep_pkg, dep_f)
+                    # Use machines_from() to determine which machines the dependency needs
+                    for dep_machine in dep_pkg.manifest.machines_from(machine, self.is_cross):
+                        self._enable_feature(dep_pkg, dep_f, dep_machine)
                 else:
                     # This feature will be enabled only if that dependency
                     # is later added.
                     cfg.optional_deps_features[depname].add(dep_f)
             elif f.startswith('dep:'):
-                self._add_dependency(pkg, f[4:])
+                self._add_dependency(pkg, f[4:], machine)
             else:
-                self._enable_feature(pkg, f)
+                self._enable_feature(pkg, f, machine)
 
     def has_check_cfg(self, machine: MachineChoice) -> bool:
         if not self.environment.is_cross_build():

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -58,6 +58,7 @@ def _extra_deps_varname() -> str:
 @dataclasses.dataclass
 class PackageConfiguration:
     """Configuration for a package during dependency resolution."""
+    for_machine: MachineChoice
     features: T.Set[str] = dataclasses.field(default_factory=set)
     required_deps: T.Set[str] = dataclasses.field(default_factory=set)
     optional_deps_features: T.Dict[str, T.Set[str]] = dataclasses.field(default_factory=lambda: collections.defaultdict(set))
@@ -78,7 +79,7 @@ class PackageConfiguration:
             dep = manifest.dependencies[name]
             dep_key = PackageKey(dep.package, dep.api)
             dep_pkg = self.dep_packages[dep_key]
-            dep_lib_name = dep_pkg.library_name()
+            dep_lib_name = dep_pkg.library_name(self.for_machine)
             dep_crate_name = name if name != dep.package else dep_pkg.manifest.lib.name
             dependency_map[dep_lib_name] = dep_crate_name
         return dependency_map
@@ -106,14 +107,15 @@ class PackageState:
             return None
         return os.path.normpath(os.path.join(self.ws_subdir, self.ws_member))
 
-    def library_name(self, lib_type: RUST_ABI = 'rust') -> str:
+    def library_name(self, machine: MachineChoice = MachineChoice.HOST, lib_type: RUST_ABI = 'rust') -> str:
         # Add the API version to the library name to avoid conflicts when multiple
         # versions of the same crate are used. The Ninja backend removed everything
         # after the + to form the crate name.
         name = fixup_meson_varname(self.manifest.package.name)
+        suffix = '+build' if machine == MachineChoice.BUILD else ''
         if lib_type == 'c':
             return name
-        return f'{name}+{self.manifest.package.api.replace(".", "_")}'
+        return f'{name}+{self.manifest.package.api.replace(".", "_")}{suffix}'
 
     def has_both_machines(self) -> bool:
         return bool(self.cfg.host and self.cfg.build)
@@ -568,7 +570,7 @@ class Interpreter:
         if pkg.cfg[machine] is not None:
             return  # Already prepared for this machine
 
-        pkg.cfg[machine] = PackageConfiguration()
+        pkg.cfg[machine] = PackageConfiguration(for_machine=machine)
         # Merge target-specific dependencies that are enabled for this machine
         target_cfgs = self._get_cfgs(machine)
         for condition, dependencies in pkg.manifest.target.items():
@@ -778,8 +780,9 @@ class Interpreter:
 
     def _create_lib(self, pkg: PackageState, build: builder.Builder, subdir: str,
                     lib_type: RUST_ABI) -> T.List[mparser.BaseNode]:
+        machine = MachineChoice.BUILD if lib_type == 'proc-macro' else MachineChoice.HOST
         posargs: T.List[mparser.BaseNode] = [
-            build.string(pkg.library_name(lib_type)),
+            build.string(pkg.library_name(machine, lib_type)),
         ]
 
         kwargs: T.Dict[str, mparser.BaseNode] = {

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -115,6 +115,9 @@ class PackageState:
             return name
         return f'{name}+{self.manifest.package.api.replace(".", "_")}'
 
+    def has_both_machines(self) -> bool:
+        return bool(self.cfg.host and self.cfg.build)
+
     def get_env_dict(self, environment: Environment, subdir: str) -> T.Dict[str, str]:
         """Get environment variables for this package."""
         # Common variables for build.rs and crates

--- a/mesonbuild/cargo/manifest.py
+++ b/mesonbuild/cargo/manifest.py
@@ -15,7 +15,7 @@ from pathlib import PurePath
 
 
 from . import version
-from ..mesonlib import MesonException, lazy_property
+from ..mesonlib import MesonException, lazy_property, MachineChoice
 from .. import mlog
 
 if T.TYPE_CHECKING:
@@ -538,6 +538,33 @@ class Manifest:
 
     def __post_init__(self) -> None:
         self.features.setdefault('default', [])
+
+    def machines_from(self, parent_machine: MachineChoice, is_cross: bool,
+                      bin: bool = False) -> T.Iterable[MachineChoice]:
+        """Return the machines this manifest should be built for based on the machine
+           for the package that depended on this one."""
+        assert is_cross or parent_machine == MachineChoice.HOST
+        if self.lib is None:
+            if bin and self.bin:
+                yield parent_machine
+            return
+
+        if not is_cross:
+            yield parent_machine
+            return
+
+        need_build = False
+        need_host = False
+        for crate_type in self.lib.crate_type:
+            if crate_type == 'proc-macro' or parent_machine == MachineChoice.BUILD:
+                need_build = True
+            else:
+                need_host = True
+
+        if need_build:
+            yield MachineChoice.BUILD
+        if need_host:
+            yield MachineChoice.HOST
 
     @lazy_property
     def system_dependencies(self) -> T.Dict[str, SystemDependency]:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1133,6 +1133,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         mlog.warning('Cargo subproject is an experimental feature and has no backwards compatibility guarantees.',
                      once=True, location=self.current_node)
         self.add_languages(['rust'], True, MachineChoice.HOST)
+        self.add_languages(['rust'], True, MachineChoice.BUILD)
         with mlog.nested(subp_name):
             try:
                 cargo_int = self.cargo or cargo.Interpreter(self.environment, subdir, self.subproject_dir)

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -234,7 +234,7 @@ class RustCrate(ModuleObject):
 
     @property
     def cfg(self) -> PackageConfiguration:
-        return self.package.cfg[MachineChoice.HOST]
+        return self.package.cfg[self.for_machine]
 
     @noPosargs
     @noKwargs
@@ -290,8 +290,9 @@ class RustPackage(RustCrate):
 
     def __init__(self, state: ModuleState, rust_ws: RustWorkspace, package: cargo.PackageState, for_machine: MachineChoice) -> None:
         super().__init__(state, rust_ws, package, for_machine)
-        if not package.cfg[MachineChoice.HOST]:
-            raise MesonException(f"package {self.package.manifest.package.name}-{self.package.manifest.package.version} not configured")
+        if not package.cfg[self.for_machine]:
+            raise MesonException(f"package {self.package.manifest.package.name}-{self.package.manifest.package.version} not configured for {self.for_machine}")
+
         self.methods.update({
             'dependencies': self.dependencies_method,
             'library': self.library_method,
@@ -304,8 +305,10 @@ class RustPackage(RustCrate):
     def _dependencies_method(self, state: ModuleState, kwargs: RustPackageDependencies,
                              for_machine: MachineChoice) -> T.List[Dependency]:
         dependencies: T.List[Dependency] = []
+        cfg = self.package.cfg[for_machine]
+
         if kwargs['dependencies']:
-            for dep_key, dep_pkg in self.cfg.dep_packages.items():
+            for dep_key, dep_pkg in cfg.dep_packages.items():
                 if dep_pkg.manifest.lib:
                     if dep_pkg.ws_subdir != self.rust_ws.subdir or \
                         is_parent_path(os.path.join(self.rust_ws.subdir, state.subproject_dir),
@@ -321,7 +324,7 @@ class RustPackage(RustCrate):
 
         if kwargs['system_dependencies']:
             for name, sys_dep in self.package.manifest.system_dependencies.items():
-                if sys_dep.enabled(self.cfg.features):
+                if sys_dep.enabled(cfg.features):
                     # System dependencies use the original dependency name from Cargo.toml
                     dependency = state.dependency(sys_dep.name, native=(for_machine == MachineChoice.BUILD),
                                                   required=not sys_dep.optional,
@@ -351,6 +354,9 @@ class RustPackage(RustCrate):
 
     def merge_kw_args(self, state: ModuleState, kwargs: T.Union[RustPackageExecutable, RustPackageLibrary]) -> None:
         kwargs.setdefault('native', self.for_machine)
+        cfg = self.package.cfg[kwargs['native']]
+        if not cfg:
+            raise MesonException(f"package {self.package.manifest.package.name}-{self.package.manifest.package.version} not configured for {self.for_machine}")
 
         deps = kwargs['dependencies']
         kwargs['dependencies'] = self._dependencies_method(state, {
@@ -361,7 +367,7 @@ class RustPackage(RustCrate):
         kwargs['dependencies'].extend(deps)
 
         depmap = kwargs['rust_dependency_map']
-        kwargs['rust_dependency_map'] = self.cfg.get_dependency_map(self.package.manifest)
+        kwargs['rust_dependency_map'] = cfg.get_dependency_map(self.package.manifest)
         kwargs['rust_dependency_map'].update(depmap)
 
         rust_args = kwargs['rust_args']
@@ -415,7 +421,8 @@ class RustPackage(RustCrate):
     def _proc_macro_method(self, state: 'ModuleState', args: T.Tuple[
             T.Optional[T.Union[str, StructuredSources]],
             T.Optional[StructuredSources]], kwargs: RustPackageLibrary) -> SharedLibrary:
-        kwargs['native'] = MachineChoice.BUILD
+        if state.environment.is_cross_build():
+            kwargs['native'] = MachineChoice.BUILD
         kwargs['rust_abi'] = None
         kwargs['rust_crate_type'] = 'proc-macro'
         kwargs['rust_args'] = kwargs['rust_args'] + ['--extern', 'proc_macro']

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -33,7 +33,7 @@ if T.TYPE_CHECKING:
     from . import ModuleState
     from .. import cargo
     from ..build import ExecutableKeywordArguments, GeneratedTypes, IncludeDirs, LinkableTargetTypes, CommandTypes
-    from ..cargo.interpreter import RUST_ABI
+    from ..cargo.interpreter import RUST_ABI, PackageConfiguration
     from ..compilers.compilers import Language
     from ..compilers.rust import RustCompiler
     from ..dependencies import ExternalLibrary
@@ -162,7 +162,7 @@ class RustWorkspace(ModuleObject):
         """Returns list of package names in workspace."""
         package_names = [pkg.manifest.package.name
                          for pkg in self.ws.packages.values()
-                         if pkg.cfg]
+                         if pkg.cfg.host or pkg.cfg.build]
         return sorted(package_names)
 
     @typed_pos_args('workspace.package', optargs=[str])
@@ -232,6 +232,10 @@ class RustCrate(ModuleObject):
             'rust_dependency_map': self.rust_dependency_map_method, # type: ignore[dict-item]
         })
 
+    @property
+    def cfg(self) -> PackageConfiguration:
+        return self.package.cfg[MachineChoice.HOST]
+
     @noPosargs
     @noKwargs
     def name_method(self, state: ModuleState, args: T.List, kwargs: TYPE_kwargs) -> str:
@@ -260,7 +264,7 @@ class RustCrate(ModuleObject):
     @noKwargs
     def features_method(self, state: ModuleState, args: T.List, kwargs: TYPE_kwargs) -> T.List[str]:
         """Returns chosen features for specific package."""
-        return sorted(list(self.package.cfg.features))
+        return sorted(list(self.cfg.features))
 
     @noPosargs
     @noKwargs
@@ -278,7 +282,7 @@ class RustCrate(ModuleObject):
     @noKwargs
     def rust_dependency_map_method(self, state: ModuleState, args: T.List, kwargs: TYPE_kwargs) -> T.Dict[str, str]:
         """Returns rust dependency mapping for this package."""
-        return self.package.cfg.get_dependency_map(self.package.manifest)
+        return self.cfg.get_dependency_map(self.package.manifest)
 
 
 class RustPackage(RustCrate):
@@ -286,7 +290,7 @@ class RustPackage(RustCrate):
 
     def __init__(self, state: ModuleState, rust_ws: RustWorkspace, package: cargo.PackageState, for_machine: MachineChoice) -> None:
         super().__init__(state, rust_ws, package, for_machine)
-        if not package.cfg:
+        if not package.cfg[MachineChoice.HOST]:
             raise MesonException(f"package {self.package.manifest.package.name}-{self.package.manifest.package.version} not configured")
         self.methods.update({
             'dependencies': self.dependencies_method,
@@ -300,10 +304,8 @@ class RustPackage(RustCrate):
     def _dependencies_method(self, state: ModuleState, kwargs: RustPackageDependencies,
                              for_machine: MachineChoice) -> T.List[Dependency]:
         dependencies: T.List[Dependency] = []
-        cfg = self.package.cfg
-
         if kwargs['dependencies']:
-            for dep_key, dep_pkg in cfg.dep_packages.items():
+            for dep_key, dep_pkg in self.cfg.dep_packages.items():
                 if dep_pkg.manifest.lib:
                     if dep_pkg.ws_subdir != self.rust_ws.subdir or \
                         is_parent_path(os.path.join(self.rust_ws.subdir, state.subproject_dir),
@@ -319,7 +321,7 @@ class RustPackage(RustCrate):
 
         if kwargs['system_dependencies']:
             for name, sys_dep in self.package.manifest.system_dependencies.items():
-                if sys_dep.enabled(cfg.features):
+                if sys_dep.enabled(self.cfg.features):
                     # System dependencies use the original dependency name from Cargo.toml
                     dependency = state.dependency(sys_dep.name, native=(for_machine == MachineChoice.BUILD),
                                                   required=not sys_dep.optional,
@@ -359,8 +361,7 @@ class RustPackage(RustCrate):
         kwargs['dependencies'].extend(deps)
 
         depmap = kwargs['rust_dependency_map']
-        kwargs['rust_dependency_map'] = \
-            self.package.cfg.get_dependency_map(self.package.manifest)
+        kwargs['rust_dependency_map'] = self.cfg.get_dependency_map(self.package.manifest)
         kwargs['rust_dependency_map'].update(depmap)
 
         rust_args = kwargs['rust_args']

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -387,6 +387,8 @@ class RustPackage(RustCrate):
         if not self.package.manifest.lib:
             raise MesonException("no [lib] section in Cargo package")
 
+        self.merge_kw_args(state, kwargs)
+
         sources: T.Union[StructuredSources, str]
         tgt_name, sources = tgt_args
         if not tgt_name:
@@ -395,14 +397,12 @@ class RustPackage(RustCrate):
                 rust_abi = 'rust' if kwargs['rust_crate_type'] in {'lib', 'rlib', 'dylib', 'proc-macro'} else 'c'
             else:
                 rust_abi = kwargs['rust_abi']
-            tgt_name = self.package.library_name(rust_abi)
+            tgt_name = self.package.library_name(kwargs['native'], rust_abi)
         if not sources:
             sources = os.path.relpath(os.path.join(self.package.path, self.package.manifest.lib.path),
                                       state.subdir)
 
         lib_args: T.Tuple[str, SourcesVarargsType] = (tgt_name, [sources])
-        self.merge_kw_args(state, kwargs)
-
         if shared_mod:
             return state._interpreter.build_target(state.current_node, lib_args,
                                                    T.cast('_kwargs.SharedModule', kwargs),

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -181,6 +181,7 @@ class RustWorkspace(ModuleObject):
         # for both the host and the build machine.  In that case, always build the
         # subproject for the build machine to ensure that it is not run twice.
         if pkg.manifest.lib.crate_type == ['proc-macro']:
+            assert not pkg.has_both_machines()
             for_machine = state.machine_map.build
 
         kw: _kwargs.DoSubproject = {
@@ -439,6 +440,7 @@ class RustPackage(RustCrate):
         assert rust_abi in self.package.supported_abis()
 
         if state.environment.is_cross_build() and self.package.manifest.lib.crate_type == ['proc-macro']:
+            assert not self.package.has_both_machines()
             state.override_dependency(depname, dep, for_machine=MachineChoice.HOST)
             state.override_dependency(depname, dep, static=False, for_machine=MachineChoice.HOST)
             state.override_dependency(depname, dep, for_machine=MachineChoice.BUILD)

--- a/test cases/rust/34 rust.workspace workspace/meson.build
+++ b/test cases/rust/34 rust.workspace workspace/meson.build
@@ -37,7 +37,7 @@ endtestcase
 testcase expect_error('workspace member "nonexistent" not found')
   cargo_ws.package('nonexistent')
 endtestcase
-testcase expect_error('package another-0.1.0 not configured')
+testcase expect_error('package another-0.1.0 not configured for host machine')
   cargo_ws.package('another')
 endtestcase
 


### PR DESCRIPTION
A fourth part of my Cargo interpreter fixes, adding cross compilation support for procedural macro crates and everything that they depend on.

~~A very early draft, I'll make sure it works on a few more projects before making it non-draft.~~

~~Note that machine selection has the same issue as feature selection: if a subproject has a dependency on crate A for the host and another subproject has a dependency on crate B for the build machine, picking them one after another with `subproject` will miss the `override_dependency` for the build machine and cross compilation will remain broken.~~

~~Fixing this requires either a two-phase approach where all subprojects are added before feature resolution (and `meson.build` generation) proceeds; or triggering subproject compilation from a `Cargo.toml` in the toplevel projects instead of having Cargo interpretation just for subprojects (#14639).~~

Fixes: #11744