### PR TITLE
Fix not passing user option args to scan-build build

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3799,9 +3799,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         gcda_elem.add_item('description', 'Deleting gcda files')
         self.add_build(gcda_elem)
 
-    def get_user_option_args(self, shut_up_pylint: bool = True) -> T.List[str]:
-        if shut_up_pylint:
-            return []
+    def get_user_option_args(self) -> T.List[str]:
         cmds = []
         for k, v in self.environment.coredata.optstore.items():
             if self.environment.coredata.optstore.is_project_option(k):


### PR DESCRIPTION
The option refactor (https://github.com/mesonbuild/meson/pull/14251) requires using False as argument in order for get_user_option_args to work as intended.

Closes https://github.com/mesonbuild/meson/issues/14959.