### PR TITLE
utils: make .wraplock optional to support read-only source directories

### DIFF
--- a/mesonbuild/utils/platform.py
+++ b/mesonbuild/utils/platform.py
@@ -20,10 +20,13 @@ class DirectoryLockAction(enum.Enum):
     FAIL = 2
 
 class DirectoryLockBase:
-    def __init__(self, directory: str, lockfile: str, action: DirectoryLockAction, err: str) -> None:
+    def __init__(self, directory: str, lockfile: str, action: DirectoryLockAction, err: str,
+                 optional: bool = False) -> None:
         self.action = action
         self.err = err
         self.lockpath = os.path.join(directory, lockfile)
+        self.optional = optional
+        self.lockfile: T.Optional[T.TextIO] = None
 
     def __enter__(self) -> None:
         mlog.debug('Calling the no-op version of DirectoryLock')

--- a/mesonbuild/utils/win32.py
+++ b/mesonbuild/utils/win32.py
@@ -17,7 +17,16 @@ __all__ = ['DirectoryLock', 'DirectoryLockAction']
 class DirectoryLock(DirectoryLockBase):
 
     def __enter__(self) -> None:
-        self.lockfile = open(self.lockpath, 'w+', encoding='utf-8')
+        try:
+            self.lockfile = open(self.lockpath, 'w+', encoding='utf-8')
+        except (FileNotFoundError, IsADirectoryError):
+            # For FileNotFoundError, there is nothing to lock.
+            # For IsADirectoryError, something is seriously wrong.
+            raise
+        except OSError:
+            if self.action == DirectoryLockAction.IGNORE or self.optional:
+                return
+
         try:
             mode = msvcrt.LK_LOCK
             if self.action != DirectoryLockAction.WAIT:

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -588,7 +588,7 @@ class Resolver:
         try:
             with DirectoryLock(self.subdir_root, '.wraplock',
                                DirectoryLockAction.WAIT,
-                               'Failed to lock subprojects directory'):
+                               'Failed to lock subprojects directory', optional=True):
                 return self._resolve(packagename, force_method)
         except FileNotFoundError:
             raise WrapNotFoundException('Attempted to resolve subproject without subprojects directory present.')


### PR DESCRIPTION
.wraplock is nice to have, but prevents Meson from operating on a read-only source directory.

If the source directory is read-only, there is no possible conflict so in that case it is acceptable to return without any actual locking.

Fixes: #14948