### PR TITLE
add cpp-filesystem and cpp-experimental-filesystem dependency

### DIFF
--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -226,6 +226,8 @@ packages.defaults.update({
     'libcrypto': 'misc',
     'libssl': 'misc',
     'objfw': 'misc',
+    'cpp-filesystem': 'misc',
+    'cpp-experimental-filesystem': 'misc',
 
     # From platform:
     'appleframeworks': 'platform',


### PR DESCRIPTION
close #14249 

I tested with gcc 5-10 and clang 7-10 here: https://github.com/na-trium-144/meson-fs-dep-test/actions/runs/17265187744

```meson
filesystem_dep = dependency('cpp-filesystem')
```
1. Checks if `<filesystem>` header is available.
2. Checks if test code compiles and runs without crash with `<filesystem>`.
    - For instance when both gcc 8 and 9 are installed, gcc 9 does not need stdc++fs, while gcc 8 without stdc++fs causes segfault. So we need to actually run the test.
    - We cannot rely on compiler versions, because clang can use libstdc++.
3. If it fails, it tries to find `libstdc++fs` (for gcc 8) or `libc++fs` (for clang 7-8) and run test again with those libraries.
4. If it is cross compilation and cannot run host binaries, it just search `libstdc++fs` or `libc++fs` and use if it's found.

```meson
filesystem_dep = dependency('cpp-experimental-filesystem')
```
does the same with `<experimental/filesystem>`, using `libstdc++fs` (for gcc 6-7) and `libc++experimental` (for clang 5-6).

Example with fallback to experimental/filesystem:
```meson
filesystem_dep = dependency('cpp-filesystem', 'cpp-experimental-filesystem')
filesystem_is_experimental = filesystem_dep.name() == 'cpp-experimental-filesystem'

executable('main', 'main.cc',
  dependencies: [filesystem_dep],
  cpp_args: filesystem_is_experimental ? ['-DEXPERIMENTAL_FS'] : []
)
```
```cpp
#include <iostream>
#ifdef EXPERIMENTAL_FS
#include <experimental/filesystem>
namespace std_fs = std::experimental::filesystem;
#else
#include <filesystem>
namespace std_fs = std::filesystem;
#endif

int main(){
    std::cout << std_fs::exists("foo") << std::endl;
}
```
