### PR TITLE
msetup: not-found subprojects do not have known options

### DIFF
--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -16,6 +16,7 @@ from .options import OptionKey
 if T.TYPE_CHECKING:
     from typing_extensions import Protocol
     from .coredata import SharedCMDOptions
+    from .interpreter import SubprojectHolder
 
     class CMDOptions(SharedCMDOptions, Protocol):
 
@@ -192,9 +193,9 @@ class MesonApp:
                                     'Some other Meson process is already using this build directory. Exiting.'):
             return self._generate(env, capture, vslite_ctx)
 
-    def check_unused_options(self, coredata: 'coredata.CoreData', cmd_line_options: T.Dict[OptionKey, str], all_subprojects: T.Mapping[str, object]) -> None:
+    def check_unused_options(self, coredata: 'coredata.CoreData', cmd_line_options: T.Dict[OptionKey, str], all_subprojects: T.Mapping[str, SubprojectHolder]) -> None:
         errlist: T.List[str] = []
-        known_subprojects = all_subprojects.keys()
+        known_subprojects = [name for name, obj in all_subprojects.items() if obj.found()]
         for opt in cmd_line_options:
             # Accept options that exist or could appear in subsequent reconfigurations,
             # including options for subprojects that were not used


### PR DESCRIPTION
If a subproject was not used, its options are not known and therefore should not be used.

Fixes: #14969

(I would like to add a testcase, but I'm really busy for the next couple of weeks)