### PR TITLE
Fix Boost regex no longer being a library.

### DIFF
--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -984,13 +984,6 @@ boost_libraries = {
         single=[],
         multi=[],
     ),
-    'boost_regex': BoostLibrary(
-        name='boost_regex',
-        shared=[],
-        static=[],
-        single=[],
-        multi=[],
-    ),
     'boost_serialization': BoostLibrary(
         name='boost_serialization',
         shared=[],


### PR DESCRIPTION
This will most likely fail on all older platforms where Boost regex is still a library, but let's first see if this fixes the current MacOS failure.