### PR TITLE
rust: let doctests pick objects from dependencies

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -29,7 +29,7 @@ from ..mesonlib import (
     File, MachineChoice, MesonException, MesonBugException, OrderedSet,
     ExecutableSerialisation, EnvironmentException,
     classify_unity_sources, get_compiler_for_source,
-    get_rsp_threshold,
+    get_rsp_threshold, unique_list
 )
 from ..options import OptionKey
 
@@ -471,11 +471,11 @@ class Backend:
     def flatten_object_list(self, target: build.BuildTarget, proj_dir_to_build_root: str = ''
                             ) -> T.Tuple[T.List[str], T.List[build.BuildTargetTypes]]:
         obj_list, deps = self._flatten_object_list(target, target.get_objects(), proj_dir_to_build_root)
-        return list(dict.fromkeys(obj_list)), deps
+        return unique_list(obj_list), deps
 
     def determine_ext_objs(self, objects: build.ExtractedObjects) -> T.List[str]:
         obj_list, _ = self._flatten_object_list(objects.target, [objects], '')
-        return list(dict.fromkeys(obj_list))
+        return unique_list(obj_list)
 
     def _flatten_object_list(self, target: build.BuildTarget,
                              objects: T.Sequence[T.Union[str, 'File', build.ExtractedObjects]],

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -29,7 +29,7 @@ from ..compilers import Compiler
 from ..linkers import ArLikeLinker, RSPFileSyntax
 from ..mesonlib import (
     File, LibType, MachineChoice, MesonBugException, MesonException, OrderedSet, PerMachine,
-    ProgressBar, quote_arg
+    ProgressBar, quote_arg, unique_list
 )
 from ..mesonlib import get_compiler_for_source, has_path_sep, is_parent_path
 from ..options import OptionKey
@@ -2208,6 +2208,8 @@ class NinjaBackend(backends.Backend):
             rustdoc = rustc.get_rustdoc(self.environment)
             args = rustdoc.get_exe_args()
             args += self.get_rust_compiler_args(target.doctests.target, rustdoc, target.rust_crate_type)
+            o, _ = self.flatten_object_list(target.doctests.target)
+            obj_list = unique_list(obj_list + o)
             # Rustc does not add files in the obj_list to Rust rlibs,
             # and is added by Meson to all of the dependencies, including here.
             _, _, deps_args = self.get_rust_compiler_deps_and_args(target.doctests.target, rustdoc, obj_list)

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -154,6 +154,7 @@ __all__ = [
     'substitute_values',
     'substring_is_in_list',
     'typeslistify',
+    'unique_list',
     'verbose_git',
     'version_compare',
     'version_compare_condition_with_min',
@@ -2079,6 +2080,10 @@ def substring_is_in_list(substr: str, strlist: T.List[str]) -> bool:
         if substr in s:
             return True
     return False
+
+
+def unique_list(x: T.Iterable[_T]) -> T.List[_T]:
+    return list(dict.fromkeys(x))
 
 
 class OrderedSet(T.MutableSet[_T]):

--- a/test cases/rust/27 objects/lib1-dylib.rs
+++ b/test cases/rust/27 objects/lib1-dylib.rs
@@ -15,7 +15,8 @@ pub extern "C" fn c_func()
 }
 
 /// ```
-/// use lib12::rust_func;
+/// #[cfg(not(nodep))] use lib12::rust_func;
+/// #[cfg(nodep)] use lib12_nodep::rust_func;
 /// rust_func();
 /// ```
 pub fn rust_func()

--- a/test cases/rust/27 objects/meson.build
+++ b/test cases/rust/27 objects/meson.build
@@ -33,3 +33,8 @@ lib12_rlib = static_library('lib12', 'lib1-dylib.rs',
 
 rust = import('rust')
 rust.doctest('rlib with dep', lib12_rlib)
+
+lib12_rlib_nodep = static_library('lib12_nodep', 'lib1-dylib.rs')
+rust.doctest('rlib with dep in tests', lib12_rlib_nodep,
+  rust_args: ['--cfg', 'nodep'],
+  dependencies: dep2)


### PR DESCRIPTION
If a dependency includes object files, they have to be added to the doctest. However, NinjaBackend was not running flatten_object_list on the doctest.