### PR TITLE
Add modules support (with order resolution, etc.) and 'import std' support for Meson (initial draft, tested in Clang)

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1704,6 +1704,9 @@ class BuildTarget(Target):
                 stdlib_args.extend(all_compilers[dl].language_stdlib_only_link_flags(self.environment))
         return stdlib_args
 
+    def uses_cpp(self) -> bool:
+        return 'cpp' in self.compilers
+
     def uses_rust(self) -> bool:
         return 'rust' in self.compilers
 

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -287,6 +287,9 @@ class CLikeCompiler(Compiler):
                 mode = CompileCheckMode.COMPILE
         cargs, largs = self._get_basic_compiler_args(environment, mode)
         extra_flags = cargs + self.linker_to_compiler_args(largs)
+        if environment.coredata.optstore.get_value('cpp_import_std'):
+            # extra_flags.extend(self.get_import_std)
+            pass
 
         # Is a valid executable output for all toolchains and platforms
         binname += '.exe'

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -309,6 +309,54 @@ class Interpreter(InterpreterBase, HoldableObject):
         self.compilers: PerMachine[T.Dict[str, 'compilers.Compiler']] = PerMachine({}, {})
         self.parse_project()
         self._redetect_machines()
+        self._cpp_import_std_bmi_dep = None
+
+        if self.coredata.optstore.get_value('cpp_import_std') and self.subproject == "":
+            self._cpp_import_std_bmi_dep = self._create_cpp_import_std_dep(self.environment)
+
+    def _create_cpp_import_std_dep(self, env: environment.Environment):
+        compiler_to_use: T.Optional[compilers.cpp.CPPCompiler] = None
+        for comp_lang, compiler in self.compilers.host.items():
+            if comp_lang == 'cpp':
+                compiler_to_use = T.cast(compilers.cpp.CPPCompiler, compiler)
+        if not compiler_to_use:
+            raise MesonException('cpp_import_std option is set to true but no cpp compiler could be found.'
+                                 ' Enable cpp language in your project to use this feature.')
+        # Construct the compiler command-line
+        commands = compiler_to_use.compiler_args()
+        commands.extend(compiler_to_use.get_import_std_lib_source_args(self.environment))
+        all_lists_to_add = [compiler_to_use.get_always_args(), compiler_to_use.get_debug_args(env.coredata.optstore.get_value('buildtype') == 'debug'),
+                            compiler_to_use.get_assert_args(disable=env.coredata.optstore.get_value('b_ndebug') in ['if-release', 'true'],
+                                                            env=env)]
+        for args_list in all_lists_to_add:
+            for arg in args_list:
+                commands.append(arg)
+        commands.append("-o")
+        commands.append("@OUTPUT@")
+        commands.append("@INPUT@")
+        no_ccache = True
+        command_list = compiler_to_use.get_exelist(ccache=not no_ccache) + commands.to_native()
+        tgt = build.CustomTarget('',
+                                 '', '', self.environment, command_list,
+                                 sources=[compiler_to_use.get_import_std_lib_source_file()],
+                                 outputs=[f'std{compiler_to_use.get_cpp20_module_bmi_extension()}'])
+        self.add_target('_cpp_import_std_bmi', tgt)
+        bmi_dep = dependencies.InternalDependency(
+            version='0.0',
+            incdirs=[],
+            compile_args=compiler_to_use.get_import_std_compile_args(self.environment),
+            # compile_args=[],
+            link_args=[],
+            libraries=[],
+            whole_libraries=[],
+            sources=[tgt],
+            extra_files=[],
+            ext_deps=[],
+            variables=[],
+            d_module_versions=[],
+            d_import_dirs=[],
+            objects=[])
+        return bmi_dep
 
     def __getnewargs_ex__(self) -> T.Tuple[T.Tuple[object], T.Dict[str, object]]:
         raise MesonBugException('This class is unpicklable')
@@ -3411,6 +3459,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         if targetclass not in {build.Executable, build.SharedLibrary, build.SharedModule, build.StaticLibrary, build.Jar}:
             mlog.debug('Unknown target type:', str(targetclass))
             raise RuntimeError('Unreachable code')
+
         self.__process_language_args(kwargs)
         if targetclass is build.StaticLibrary:
             for lang in compilers.all_languages - {'java'}:
@@ -3492,6 +3541,10 @@ class Interpreter(InterpreterBase, HoldableObject):
 
         target = targetclass(name, self.subdir, self.subproject, for_machine, srcs, struct, objs,
                              self.environment, self.compilers[for_machine], kwargs)
+        if target.uses_cpp():
+            if self.coredata.optstore.get_value('cpp_import_std') and self.subproject == '':
+                target.add_deps([self._cpp_import_std_bmi_dep])
+
         if objs and target.uses_rust():
             FeatureNew.single_use('objects in Rust targets', '1.8.0', self.subproject)
 

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -581,6 +581,12 @@ def choices_are_different(a: _U, b: _U) -> bool:
     return False
 
 
+class UseImportStd(UserBooleanOption):
+    def __init__(self, lang):
+        self.lang = lang.lower()
+        opt_name =f'{self.lang}_import_std'
+        super().__init__(opt_name, 'Whether to use import std; module in your targets', False)
+
 class UserStdOption(UserComboOption):
     '''
     UserOption specific to c_std and cpp_std options. User can set a list of

--- a/mesonbuild/scripts/depscan.py
+++ b/mesonbuild/scripts/depscan.py
@@ -11,6 +11,7 @@ import pathlib
 import pickle
 import re
 import typing as T
+import subprocess as sp
 
 if T.TYPE_CHECKING:
     from typing_extensions import Literal, TypedDict, NotRequired
@@ -201,8 +202,37 @@ class DependencyScanner:
 
         return 0
 
+
+class CppDependenciesScanner:
+    pass
+
+class ClangDependencyScanner(CppDependenciesScanner):
+    def __init__(self, compilation_db_file, json_output_file, dd_output_file=None):
+        self.compilation_db_file = compilation_db_file
+        self.output_file = output_file
+        self.dd_output_file = dd_output_file
+
+    def scan(self):
+        try:
+            r = sp.run(["/usr/local/Cellar/llvm/20.1.1/bin/clang-scan-deps",
+                        "-format=p1689",
+                        "-compilation-database", self.compilation_db_file],
+                       capture_output=True,
+                       check=True)
+            print(r.stdout)
+            #json.loads(r.stdout)
+            return 0
+        except sp.SubprocessError:
+            return 1
+        except sp.TimeoutExpired:
+            return 2
+
+
 def run(args: T.List[str]) -> int:
-    assert len(args) == 2, 'got wrong number of arguments!'
-    outfile, pickle_file = args
-    scanner = DependencyScanner(pickle_file, outfile)
-    return scanner.scan()
+    assert len(args) > 2, 'At least <compilation_db> and <json_output-file> arguments'
+    comp_db, json_output, dd_output = args
+    ClangDependencyScanner(compilation_db_file, output_file)
+    # assert len(args) == 2, 'got wrong number of arguments!'
+    # outfile, pickle_file = args
+    # scanner = DependencyScanner(pickle_file, outfile)
+    # return scanner.scan()

--- a/mesonbuild/scripts/depscanaccumulate.py
+++ b/mesonbuild/scripts/depscanaccumulate.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+from collections import defaultdict
+from dataclasses import dataclass
+import json
+import os
+import subprocess as sp
+import sys
+import typing as T
+
+ModuleName: T.TypeAlias = str
+ObjectFile: T.TypeAlias = str
+
+
+@dataclass(frozen=True)
+class ModuleProviderInfo:
+    logical_name: ModuleName
+    source_path: str
+    is_interface: bool = False
+
+
+class CppDependenciesScanner:
+    pass
+
+class DynDepRule:
+    def __init__(self, out: str, imp_outs: T.Optional[T.List[str]], imp_ins: T.List[str]):
+        self.output = [f'build {out}']
+        if imp_outs:
+            imp_out_str = " ".join(imp_outs)
+            self.output.append(f" | {imp_out_str}")
+        self.output.append(": dyndep")
+        if imp_ins:
+            imp_ins_str = " ".join(imp_ins)
+            self.output.append(" | " + imp_ins_str)
+        self.output_str = "".join(self.output) + "\n"
+
+    def __str__(self):
+        return self.output_str
+
+
+class ClangDependencyScanner(CppDependenciesScanner):
+    def __init__(self, compilation_db_file, json_output_file, dd_output_file=None):
+        self.compilation_db_file = compilation_db_file
+        self.json_output_file = json_output_file
+        self.dd_output_file = dd_output_file
+
+    def scan(self) -> T.Tuple[T.Mapping[ObjectFile, ModuleName],
+                              T.Mapping[ObjectFile, ModuleProviderInfo]]:
+        try:
+            r = sp.run(["/usr/local/Cellar/llvm/20.1.1/bin/clang-scan-deps",
+                        "-format=p1689",
+                        "-compilation-database", self.compilation_db_file],
+                       capture_output=True)
+            if r.returncode != 0:
+                print(r.stderr)
+                raise sp.SubprocessError("Failed to run command")
+            process_output = r.stdout
+            with open(self.json_output_file, 'wb') as f:
+                f.write(process_output)
+            dependencies_info = json.loads(r.stdout)
+            all_deps_per_objfile = self.generate_dependencies(dependencies_info["rules"])
+            self.generate_dd_file(all_deps_per_objfile)
+        except sp.SubprocessError:
+            return 1
+        except sp.TimeoutExpired:
+            return 2
+
+    def generate_dd_file(self, deps_per_object_file):
+        with open('deps.dd', "w") as f:
+            f.write('ninja_dyndep_version = 1\n')
+            for obj, reqprov in deps_per_object_file.items():
+                requires, provides = reqprov
+                dd = DynDepRule(obj, [p.logical_name + ".pcm" for p in provides],
+                                [r + '.pcm' for r in requires])
+                f.write(str(dd))
+
+    def generate_dependencies(self, rules: T.List):
+        all_entries: T.Mapping[ObjectFile, T.Tuple[T.Set(ModuleName), T.Set(ModuleProviderInfo)]] = defaultdict(lambda: (set(), set()))
+        for r in rules:
+            obj_processed = r["primary-output"]
+            # Add empty entries so that dyndep rule is generated for every file with a potential dyndep rule
+            # or ninja will complain
+            all_entries[obj_processed] = (set(), set())
+            for req in r.get("requires", []):
+                all_entries[obj_processed][0].add(req["logical-name"])
+            for prov in r.get("provides", []):
+                all_entries[obj_processed][1].add(ModuleProviderInfo(
+                    logical_name=prov["logical-name"],
+                    source_path=prov["source-path"],
+                    is_interface=prov.get('is-interface', False)))
+        return all_entries
+
+def run(args: T.List[str]) -> int:
+    assert len(args) >= 2, 'At least <compilation_db> and <json_output-file> arguments'
+    comp_db_path, json_output_path, dd_output = args
+    scanner = ClangDependencyScanner(comp_db_path, json_output_path)
+    return scanner.scan()
+
+if __name__ == '__main__':
+    run(sys.argv[1:])

--- a/mesonbuild/scripts/depscanaccumulate.py
+++ b/mesonbuild/scripts/depscanaccumulate.py
@@ -21,15 +21,18 @@ class ModuleProviderInfo:
 class CppDependenciesScanner:
     pass
 
+def normalize_filename(fname):
+    return fname.replace(':', '-')
+
 class DynDepRule:
     def __init__(self, out: str, imp_outs: T.Optional[T.List[str]], imp_ins: T.List[str]):
         self.output = [f'build {out}']
         if imp_outs:
-            imp_out_str = " ".join(imp_outs)
+            imp_out_str = " ".join([normalize_filename(o) for o in imp_outs])
             self.output.append(f" | {imp_out_str}")
         self.output.append(": dyndep")
         if imp_ins:
-            imp_ins_str = " ".join(imp_ins)
+            imp_ins_str = " ".join([normalize_filename(inf) for inf in imp_ins])
             self.output.append(" | " + imp_ins_str)
         self.output_str = "".join(self.output) + "\n"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,28 @@
+[project]
+name = "python-forms-app"
+version = "0.1.0"
+description = ""
+authors = [
+    {name = "German Diago Gomez",email = "germandiago@gmail.com"}
+]
+readme = "README.md"
+requires-python = ">=3.9"
+
+[tool.poetry]
+packages = [{include = "meson", from = "mesonbuild"}]
+package-mode = false
+
+[tool.poetry.group.dev.dependencies]
+mypy = "^1.17.0"
+python-lsp-server = "^1.13.0"
+pyright = "^1.1.403"
+flake8 = "^7.3.0"
+pytest = "^8.4.1"
+requests = "^2.32.4"
+types-sqlalchemy = "^1.4.53.38"
+types-jinja2 = "^2.11.9"
+types-flask = "^1.1.6"
+
 [build-system]
-requires = ["setuptools>=42", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/test cases/cpp/1 import std/import_std.cpp
+++ b/test cases/cpp/1 import std/import_std.cpp
@@ -1,0 +1,12 @@
+import std;
+
+constexpr char const * const PROJECT_NAME  = "import std";
+
+int main(int argc, char **argv) {
+    if (argc != 1) {
+        std::cout << argv[0] << " takes no arguments.\n";
+        return 1;
+    }
+    std::cout << "This is project " << PROJECT_NAME << ".\n";
+    return 0;
+}

--- a/test cases/cpp/1 import std/meson.build
+++ b/test cases/cpp/1 import std/meson.build
@@ -1,0 +1,14 @@
+project(
+  'import std',
+  'cpp',
+  version : '0.1',
+  meson_version : '>= 1.3.0',
+  default_options : ['warning_level=3', 'cpp_std=c++23',
+                     'cpp_import_std=true'],
+)
+
+
+exe = executable(
+  'import std',
+  'import_std.cpp'
+)

--- a/test cases/cpp/1 import std/meson/native/clang19_modules.ini
+++ b/test cases/cpp/1 import std/meson/native/clang19_modules.ini
@@ -1,0 +1,10 @@
+[binaries]
+c   = '/usr/local/Cellar/llvm/20.1.1/bin/clang'
+cpp = '/usr/local/Cellar/llvm/20.1.1/bin/clang++'
+objc = '/usr/local/Cellar/llvm/20.1.1/bin/clang'
+objcpp = '/usr/local/Cellar/llvm/20.1.1/bin/clang++'
+
+[built-in options]
+cpp_link_args='-L/usr/local/opt/llvm/lib/c++ -L/usr/local/opt/llvm/lib/unwind -lunwind -L/usr/local/opt/llvm/lib'
+cpp_args = '-I/usr/local/opt/llvm/include'
+c_args = '-I/usr/local/opt/llvm/include'


### PR DESCRIPTION
EDIT: updated top comment. I will keep it up to date with changes added. Please read again since there are changes since yesterday. LAST UPDATE: september, the 8th, 2025

-----------------------------------

### Changes: 8th september 2025

Test project is here: [Nesecidad-0.0.2.zip](https://github.com/user-attachments/files/22200566/Nesecidad-0.0.2.zip)

     - more intuitive file conventions for modules.
     - project attachment updated: now it uses module interface unit, 
       module partition units and a single module implementation unit.
     

Add module partitions and implementation modules.

This commit adds support for implementation partitions
and modifies file conventions for a modularized target.

The conventions are:

  - your primary interface unit for your module should always
    be called 'module.cppm'. It should export module 'target-name'.

  - your interface partitions can have any name supported by a module.
    For example: MyThings.cppm. The interface partition
    should declare 'export module target-name:MyThings'.

  - Your *importable* interface implementation units should end with
    'Impl.cppm'. For example 'MyThingsImpl.cppm'. This should
    'module target-name:MyThings' (without export).

  - Your *non-importable* implementation can have any name *with an
    extension .cpp*, not a .cppm, since implementation units are
    not importable. It is highly recommended, though, that if you
    have a single implementation file, it is called moduleImpl.cpp.

  You can see the project attached in Github draft PR:
  https://github.com/mesonbuild/meson/pull/14989 as an example that uses
  interface partitions, primary interface units, an implementation
  module (but not an implementation module partition, though it should
  work), multiple targets and import std.

  It can run a couple of tests when fully compiled and it resolves
  dependency order via scanner with Clang.

----- 

### Changes 7th september:

Test project is here: [Nesecidad-0.0.1.tar.gz](https://github.com/user-attachments/files/22196953/Nesecidad-0.0.1.tar.gz)

DRAFT: Add modules support via clang-scan-deps.

Tested on Clang 19 on MacOS.

BEWARE, WARNING: This is a drafty implementation
whose only goal was to see module resolution working
in a project. This is not representative of the
quality of the code I would be willing to submit,
but just a fast test.

That said: support for modules has been added consisting of:

  - a global (not per target) scan step via clang-scan-deps.
  - the scan + accumulate step are done at once via
    clang-scan-deps.
  - dependency order resolution for module imports should
    work.
  - the strategy to activate scanning right now is global,
    even subprojects are scanned, based on compile_commands.json
    generated. You need clang 17 and above though only
    Clang 19 has been tested.

Only primary interface units have been tested so far (no partitions, etc), 
but the dependency order resolution is already there. Probably some 
problems could arise in name conventions when adding these but the 
order resolution should work already.


The script depscanaccumulate.py *currently has the path to
clang-scan-deps hardcoded* and will not work unless you fix it
to point to your clang-scan-deps until I do some cleanups.

Please find attached a small project to work with
that I converted in the Github issue:
https://github.com/mesonbuild/meson/pull/14989.

The project is a NES emulator that *does almost nothing* since it was
an abandoned side-project, but for the sake of converting to modules
it has been invaluable.

There are many strategies to do the scanning:

    - per file.
    - per target.
    - globally (as it is currently done with this prototype)

Also, we could make a differentiation to split the files that
are modules from the normal source files, but I would not
recommend it. I think doing per-target scans all-or-nothing
per target should be enough.

Currently, the .pcm files are put at the top-level of the
build directory. This should go in some global per-project
cache to the best of my understanding.

There is a small trick now, which is not optimal, but it does
the job: the cpp_COMPILER rule is added -fmodule-output={the-pcm-file}.pcm
-fprebuilt-module-path={the-build-dir} in its ARGS and since not all files are
modules, this is surrounded by --start-no-unused-arguments and
--end-no-unused-arguments. This avoids the need to generate more
fancy or dynamic stuff, which I do not know even if it is possible
at all at the moment.

This method of compiling generates a .o file and a .pcm as a
side-effect. There is another way, potentially more parallel,
to build separately (via --precompile flag) a .pcm and a .o,
but again, this will do as a first step I guess...

I would expect that for big projects, unless clang-scan-deps is
really fast, there might be other strategies that are better for
incremental builds but something like this should do for now.

I would even expect that Meson could choose in a smart way
what strategy to adopt? (maybe)

Your targets are what you are already familiar with, this is
a transparent feature except for:

   1. the name of your build target should have the name of the module, something like 'my.module'
   2. you need to have a module interface file called 'my.module.cppm'.

Control to opt-out from module scanning, when the strategy is not
global scanning, should probably be added, but since I used
compile_commands.json + global scanning I did not get bothered, which
whould have deviated me from my goal.

   I updated and activated the rule for should_use_dyndeps() in the
   ninja backend that already existed in the code and generated
   the depscanaccumulate rule.
   Check the build.ninja file to see what it is generated.

   - I generate every target with a dependency on std
     (using cpp_import_std feature, which is active).

   - A single deps.dd file is generated every time a file is touched.

   - any file you touch should trigger a deps.dd scan.

 We could make a differentiation to split the files that
 are modules from the normal source files to do less agressive scanning,
 but I would not recommend it. I think doing per-target scans
 all-or-nothing per target should be enough since these tools should do
 bulk updates and not be invoked once per file anyway.

 Currently, the .pcm files are put at the top-level of the
 build directory. This should go in some global per-project
 cache to the best of my understanding.

 There is a small trick now, which is not optimal, but it does
 the job: the cpp_COMPILE rule is added -fmodule-output={the-pcm-file}.pcm
 -fprebuilt-module-path={the-build-dir} and since not all files are
 modules, this is surrounded by --start-no-unused-arguments and
 --end-no-unused-arguments. If the file is just a normal translation unit,
 a .pcm will not be generated even if it was specified.

 This avoids the need to generate more fancy or dynamic stuff, which I do
 not know even if it is possible at all at the moment.

Please find attached a small project to work with
that I converted. The project is a NES emulator that
*does almost nothing* since it was an abandoned side-project,
but for the sake of converting to modules has been invaluable.

-------------------------------------------------------------------------
Also add 'import std' support for Meson Clang/GCC.

This commit adds the ability for Meson targets for:

 - clang (tested in clang 19 homebrew MacOS)
 - gcc (tested in a Docker container with Linx GCC15)

The feature can be used by setting a new option 'cpp_import_std'
globally, which can be true or false.

By default the option is conservatively set to false.

If enabled, during the configuration phase, Meson checks that the
compiler supports building the std library as a module via compiler
version checks.

At build time, it adds a custom target to build the std bmi. This bmi is
wrapped in a dependency and included in build targets that are
executables, shared libraries and libraries if the target uses c++
language and it is not in a subproject. See build_target function.

A best effort has been done to align debug/release flags with the built
version of the std library, though this needs review.

Note that in order to use the feature, the minimum version is C++23,
since import std is a C++23 feature.

An example of how to use it can be found in test '1 import std'.

Smoke-tested in:

   - Clang 19 homebrew, in my Mac.
   - Gcc 15 in Docker container.
   - Tested with a multi-file project that uses subprojects
     by replacing all std library with 'import std'.

ROADMAP:

  - Add override to build targets to avoid using 'import std'?


