### PR TITLE
 ninja: don't exclude rustc native-static-link args 

### DIFF
--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -137,7 +137,7 @@ were never turned on by Meson.
 
 ```ini
 [properties]
-bindgen_clang_arguments = ['-target', 'x86_64-linux-gnu']
+bindgen_clang_arguments = ['--target', 'x86_64-linux-gnu']
 ```
 
 ### proc_macro()

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2102,10 +2102,7 @@ class NinjaBackend(backends.Backend):
 
         for e in external_deps:
             for a in e.get_link_args():
-                if a in rustc.native_static_libs:
-                    # Exclude link args that rustc already add by default
-                    continue
-                elif a.startswith('-L'):
+                if a.startswith('-L'):
                     args.append(a)
                     continue
                 elif a.endswith(('.dll', '.so', '.dylib', '.a', '.lib')):


### PR DESCRIPTION
`rustc --crate-type staticlib --print native-static-libs` doesn't print
the default libraries being linked with rustc by default, at least not
with rustc 1.89.0 (29483883e 2025-08-04).

Stripping those by default, such as ws2_32 on win32, prevents from
linking programs using sockets (ex qemu).


@bonzini @xclaesse 