### PR TITLE
macros: fix feature to disable verbosity

### DIFF
--- a/data/macros.meson
+++ b/data/macros.meson
@@ -29,14 +29,14 @@
     %{shrink:%{__meson} compile \
         -C %{_vpath_builddir} \
         -j %{_smp_build_ncpus} \
-        %{?__meson_verbose:--verbose} \
+        %[ 0%{?__meson_verbose} ? "--verbose" : "" ] \
         %{nil}}
 
 %meson_install \
     %{shrink:DESTDIR=%{buildroot} %{__meson} install \
         -C %{_vpath_builddir} \
         --no-rebuild \
-        %{!?__meson_verbose:--quiet} \
+        %[ ! 0%{?__meson_verbose} ? "--quiet" : "" ] \
         %{nil}}
 
 %meson_test \


### PR DESCRIPTION
Instead of relying on __meson_verbose being defined or not, handle
its value; in context of larger build systems (like open build service)
this allows a project wide configuration to override %__meson_verbose to 0

Fixes #14992
