### PR TITLE
Split only at first equal sign more often

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1915,7 +1915,7 @@ class NinjaBackend(backends.Backend):
                                 from_subproject: bool, proc_macro_dylib_path: T.Optional[str],
                                 deps: T.List[RustDep]) -> None:
         raw_edition: T.Optional[str] = mesonlib.first(reversed(args), lambda x: x.startswith('--edition'))
-        edition: RUST_EDITIONS = '2015' if not raw_edition else raw_edition.split('=')[-1]
+        edition: RUST_EDITIONS = '2015' if not raw_edition else raw_edition.split('=', 1)[-1]
 
         cfg: T.List[str] = []
         arg_itr: T.Iterator[str] = iter(args)

--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -550,7 +550,7 @@ class PkgConfigDependency(ExternalDependency):
     def extract_field(self, la_file: str, fieldname: str) -> T.Optional[str]:
         with open(la_file, encoding='utf-8') as f:
             for line in f:
-                arr = line.strip().split('=')
+                arr = line.strip().split('=', 1)
                 if arr[0] == fieldname:
                     return arr[1][1:-1]
         return None

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -59,7 +59,7 @@ def setup_backend():
     be = 'ninja'
     for a in sys.argv:
         if a.startswith('--backend'):
-            be = a.split('=')[1]
+            be = a.split('=', 1)[1]
         else:
             filtered.append(a)
     # Since we invoke the tests via unittest or xtest test runner

--- a/test cases/common/49 custom target/my_compiler.py
+++ b/test cases/common/49 custom target/my_compiler.py
@@ -13,10 +13,10 @@ if __name__ == '__main__':
        not args[2].startswith('--output'):
         print(args[0], '--input=input_file --output=output_file')
         sys.exit(1)
-    with open(args[1].split('=')[1]) as f:
+    with open(args[1].split('=', 1)[1]) as f:
         ifile = f.read()
     if ifile != 'This is a text only input file.\n':
         print('Malformed input')
         sys.exit(1)
-    with open(args[2].split('=')[1], 'w') as ofile:
+    with open(args[2].split('=', 1)[1], 'w') as ofile:
         ofile.write('This is a binary output file.\n')


### PR DESCRIPTION
Most of the `split` calls for the '=' character have a maxsplit set to 1 with only a few exceptions. These should be no exceptions to avoid unintended behavior.

Example output with adjusted test case:

```
MY_COMPILER_ENV=value ./test\ cases/common/49\ custom\ target/my_compiler.py --input=input=file --output=output=file /bin/ls
```

```
Traceback (most recent call last):
  File "/home/user/projects/meson/./test cases/common/49 custom target/my_compiler.py", line 16, in <module>
    with open(args[1].split('=')[1]) as f:
         ~~~~^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'input'
```

According to my given arguments, `input=file` should have been opened, not `input`.