### PR TITLE
Use https for mesonbuild.com

### DIFF
--- a/data/syntax-highlighting/vim/syntax/meson.vim
+++ b/data/syntax-highlighting/vim/syntax/meson.vim
@@ -27,7 +27,7 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
-" http://mesonbuild.com/Syntax.html
+" https://mesonbuild.com/Syntax.html
 syn keyword mesonConditional	elif else if endif
 syn keyword mesonRepeat		foreach endforeach
 syn keyword mesonOperator	and not or in
@@ -54,7 +54,7 @@ syn match   mesonEscape	"\\N{\a\+\%(\s\a\+\)*}" contained
 syn match   mesonEscape	"\\$"
 
 " Meson only supports integer numbers
-" http://mesonbuild.com/Syntax.html#numbers
+" https://mesonbuild.com/Syntax.html#numbers
 syn match   mesonNumber	"\<\d\+\>"
 syn match   mesonNumber	"\<0x\x\+\>"
 syn match   mesonNumber	"\<0o\o\+\>"

--- a/docs/refman/templates/meson.vim.mustache
+++ b/docs/refman/templates/meson.vim.mustache
@@ -27,7 +27,7 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
-" http://mesonbuild.com/Syntax.html
+" https://mesonbuild.com/Syntax.html
 syn keyword mesonConditional	elif else if endif
 syn keyword mesonRepeat		foreach endforeach
 syn keyword mesonOperator	and not or in
@@ -54,7 +54,7 @@ syn match   mesonEscape	"\\N{\a\+\%(\s\a\+\)*}" contained
 syn match   mesonEscape	"\\$"
 
 " Meson only supports integer numbers
-" http://mesonbuild.com/Syntax.html#numbers
+" https://mesonbuild.com/Syntax.html#numbers
 syn match   mesonNumber	"\<\d\+\>"
 syn match   mesonNumber	"\<0x\x\+\>"
 syn match   mesonNumber	"\<0o\o\+\>"

--- a/man/meson.1
+++ b/man/meson.1
@@ -679,6 +679,6 @@ could not rebuild the required targets.
 
 .SH SEE ALSO
 
-http://mesonbuild.com/
+https://mesonbuild.com/
 
 https://wrapdb.mesonbuild.com/


### PR DESCRIPTION
Since http://mesonbuild.com redirects to https://mesonbuild.com anyway, use https directly in documentation.