### PR TITLE
pkgconfig: Fix class cached to be keyed on extra_paths

### DIFF
--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -555,8 +555,8 @@ def clear_internal_caches() -> None:
     from mesonbuild.mesonlib import PerMachine
     mesonbuild.interpreterbase.FeatureNew.feature_registry = {}
     CMakeDependency.class_cmakeinfo = PerMachine(None, None)
-    PkgConfigInterface.class_impl = PerMachine(False, False)
-    PkgConfigInterface.class_cli_impl = PerMachine(False, False)
+    PkgConfigInterface.class_impl = PerMachine({}, {})
+    PkgConfigInterface.class_cli_impl = PerMachine({}, {})
     PkgConfigInterface.pkg_bin_per_machine = PerMachine(None, None)
 
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -289,7 +289,7 @@ def run_mtest_inprocess(commandlist: T.List[str]) -> T.Tuple[int, str]:
 def clear_meson_configure_class_caches() -> None:
     CCompiler.find_library_cache.clear()
     CCompiler.find_framework_cache.clear()
-    PkgConfigInterface.class_impl.assign(False, False)
+    PkgConfigInterface.class_impl.assign({}, {})
     mesonlib.project_meson_versions.clear()
 
 def run_configure_inprocess(commandlist: T.List[str], env: T.Optional[T.Dict[str, str]] = None, catch_exception: bool = False) -> T.Tuple[int, str, str]:


### PR DESCRIPTION
Add `extra_paths` to cache keys for `PkgConfigInterface` and `PkgConfigCLI` instances, to avoid incorrectly reusing an instance with a different `extra_paths` value, see:
https://github.com/mesonbuild/meson/pull/14657#discussion_r2320623799