### PR TITLE
compiler: add 'b_time64' base option

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -232,6 +232,7 @@ available on all platforms or with all compilers:
 | b_pgo               | off                  | off, generate, use                                            | Use profile guided optimization                                                |
 | b_sanitize          | none                 | see below                                                     | Code sanitizer to use                                                          |
 | b_staticpic         | true                 | true, false                                                   | Build static libraries as position independent                                 |
+| b_time64            | false                | true, false                                                   | Enable 64-bit time handling for 32-bit platforms (via `_TIME_BITS=64`)         |
 | b_pie               | false                | true, false                                                   | Build position-independent executables (since 0.49.0)                          |
 | b_vscrt             | from_buildtype       | none, md, mdd, mt, mtd, from_buildtype, static_from_buildtype | VS runtime library to use (since 0.48.0) (static_from_buildtype since 0.56.0)  |
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -330,6 +330,11 @@ def get_base_compile_args(target: 'BuildTarget', compiler: 'Compiler', env: 'Env
             pass
     except KeyError:
         pass
+    try:
+        if env.coredata.get_option_for_target(target, 'b_time64'):
+            args += compiler.get_time64_args()
+    except (KeyError, AttributeError):
+        pass
     return args
 
 def get_base_link_args(target: 'BuildTarget',
@@ -1091,6 +1096,13 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         """Get arguments to enable or disable assertion.
 
         :param disable: Whether to disable assertions
+        :return: A list of string arguments for this compiler
+        """
+        return []
+
+    def get_time64_args(self) -> T.List[str]:
+        """Get arguments to enable 64-bit time handling for 32-bit platforms.
+
         :return: A list of string arguments for this compiler
         """
         return []

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -1344,6 +1344,9 @@ class CLikeCompiler(Compiler):
             return ['-DNDEBUG']
         return []
 
+    def get_time64_args(self) -> T.List[str]:
+        return ['-D_TIME_BITS=64']
+
     @functools.lru_cache(maxsize=None)
     def can_compile(self, src: 'mesonlib.FileOrString') -> bool:
         # Files we preprocess can be anything, e.g. .in

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -344,6 +344,11 @@ class RustModule(ExtensionModule):
         if are_asserts_disabled_for_subproject(state.subproject, state.environment):
             clang_args.append('-DNDEBUG')
 
+        time64 = state.get_option('b_time64', state.subproject)
+        assert isinstance(time64, bool), 'for mypy'
+        if time64:
+            clang_args.append('-D_TIME_BITS=64')
+
         for de in kwargs['dependencies']:
             for i in de.get_include_dirs():
                 clang_args.extend([f'-I{x}' for x in i.to_string_list(

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -789,6 +789,7 @@ COMPILER_BASE_OPTIONS: T.Mapping[OptionKey, AnyOptionType] = {
         UserComboOption(
             'b_ndebug', 'Disable asserts', 'false', choices=['true', 'false', 'if-release']),
         UserBooleanOption('b_staticpic', 'Build static libraries as position independent', True),
+        UserBooleanOption('b_time64', 'Set _TIME_BITS=64', False),
         UserBooleanOption('b_pie', 'Build executables as position independent', False),
         UserBooleanOption('b_bitcode', 'Generate and embed bitcode (only macOS/iOS/tvOS)', False),
         UserComboOption(


### PR DESCRIPTION
Introduce a new base option called `b_time64`. This is a boolean option, which defaults to `false` (in which case it has no effect). If set to true, this will set `_TIME_BITS=64` (or equivalent) for all compilations.

This enables a workaround for the Y2038 problem. With `_TIME_BITS=64`, libc will switch `time_t` and other relevant time types to 64-bits, if not already 64-bit (i.e., this usually only affects 32-bit platforms). libc will also transparently switch to 64-bit syscalls.

For more background information, there is an LWN article about it (from 10 years ago):

    https://lwn.net/Articles/664800/

Handling of this option is similar to _FILE_OFFSET_BITS=64, which meson sets by default. Unfortunately, `time_t` is much more often used in public APIs, and thus more likely to lead to ABI mismatches when mixing code compiled with and without the option.

NB: This is a draft, as I have not spent too much time figuring out whether this should be a boolean option, or a choice-option (so you can override the value with `32`), and whether this needs support for other languages. This is mostly to start a discussion around the feature.