### PR TITLE
Add option to change the library naming scheme

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2469,21 +2469,12 @@ class SharedLibrary(BuildTarget):
     def get_default_install_dir(self) -> T.Union[T.Tuple[str, str], T.Tuple[None, None]]:
         return self.environment.get_shared_lib_dir(), '{libdir_shared}'
 
-    def determine_filenames(self):
-        """
-        See https://github.com/mesonbuild/meson/pull/417 for details.
-
-        First we determine the filename template (self.filename_tpl), then we
-        set the output filename (self.filename).
-
-        The template is needed while creating aliases (self.get_aliases),
-        which are needed while generating .so shared libraries for Linux.
-
-        Besides this, there's also the import library name (self.import_filename),
-        which is only used on Windows since on that platform the linker uses a
-        separate library called the "import library" during linking instead of
-        the shared library (DLL).
-        """
+    def determine_naming_info(self) -> T.Tuple[str, str, str, str, bool]:
+        prefix = ''
+        suffix = ''
+        filename_tpl = self.basic_filename_tpl
+        import_filename_tpl = ''
+        create_debug_file = False
         prefix = ''
         suffix = ''
         create_debug_file = False
@@ -2494,7 +2485,7 @@ class SharedLibrary(BuildTarget):
         if 'cs' in self.compilers:
             prefix = ''
             suffix = 'dll'
-            self.filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
+            filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
             create_debug_file = True
         # C, C++, Swift, Vala
         # Only Windows uses a separate import library for linking
@@ -2523,9 +2514,9 @@ class SharedLibrary(BuildTarget):
                 import_filename_tpl = '{0.prefix}{0.name}.dll.a'
             # Shared library has the soversion if it is defined
             if self.soversion:
-                self.filename_tpl = '{0.prefix}{0.name}-{0.soversion}.{0.suffix}'
+                filename_tpl = '{0.prefix}{0.name}-{0.soversion}.{0.suffix}'
             else:
-                self.filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
+                filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
         elif self.environment.machines[self.for_machine].is_cygwin():
             suffix = 'dll'
             # Shared library is of the form cygfoo.dll
@@ -2535,40 +2526,59 @@ class SharedLibrary(BuildTarget):
             import_prefix = self.prefix if self.prefix is not None else 'lib'
             import_filename_tpl = import_prefix + '{0.name}.dll.a'
             if self.soversion:
-                self.filename_tpl = '{0.prefix}{0.name}-{0.soversion}.{0.suffix}'
+                filename_tpl = '{0.prefix}{0.name}-{0.soversion}.{0.suffix}'
             else:
-                self.filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
+                filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
         elif self.environment.machines[self.for_machine].is_darwin():
             prefix = 'lib'
             suffix = 'dylib'
             # On macOS, the filename can only contain the major version
             if self.soversion:
                 # libfoo.X.dylib
-                self.filename_tpl = '{0.prefix}{0.name}.{0.soversion}.{0.suffix}'
+                filename_tpl = '{0.prefix}{0.name}.{0.soversion}.{0.suffix}'
             else:
                 # libfoo.dylib
-                self.filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
+                filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
         elif self.environment.machines[self.for_machine].is_android():
             prefix = 'lib'
             suffix = 'so'
             # Android doesn't support shared_library versioning
-            self.filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
+            filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
         else:
             prefix = 'lib'
             suffix = 'so'
             if self.ltversion:
                 # libfoo.so.X[.Y[.Z]] (.Y and .Z are optional)
-                self.filename_tpl = '{0.prefix}{0.name}.{0.suffix}.{0.ltversion}'
+                filename_tpl = '{0.prefix}{0.name}.{0.suffix}.{0.ltversion}'
             elif self.soversion:
                 # libfoo.so.X
-                self.filename_tpl = '{0.prefix}{0.name}.{0.suffix}.{0.soversion}'
+                filename_tpl = '{0.prefix}{0.name}.{0.suffix}.{0.soversion}'
             else:
                 # No versioning, libfoo.so
-                self.filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
+                filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
+        return (prefix, suffix, filename_tpl, import_filename_tpl, create_debug_file)
+
+    def determine_filenames(self):
+        """
+        See https://github.com/mesonbuild/meson/pull/417 for details.
+
+        First we determine the filename template (self.filename_tpl), then we
+        set the output filename (self.filename).
+
+        The template is needed while creating aliases (self.get_aliases),
+        which are needed while generating .so shared libraries for Linux.
+
+        Besides this, there's also the import library name (self.import_filename),
+        which is only used on Windows since on that platform the linker uses a
+        separate library called the "import library" during linking instead of
+        the shared library (DLL).
+        """
+        prefix, suffix, filename_tpl, import_filename_tpl, create_debug_file = self.determine_naming_info()
         if self.prefix is None:
             self.prefix = prefix
         if self.suffix is None:
             self.suffix = suffix
+        self.filename_tpl = filename_tpl
         self.filename = self.filename_tpl.format(self)
         if import_filename_tpl:
             self.import_filename = import_filename_tpl.format(self)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2316,6 +2316,18 @@ class StaticLibrary(BuildTarget):
                                                     [], [], [], [], [], {}, [], [], [],
                                                     '_rust_native_static_libs')
                 self.external_deps.append(d)
+
+        default_prefix, default_suffix = self.determine_default_prefix_and_suffix()
+        if not self.name_prefix_set:
+            self.prefix = default_prefix
+        if not self.name_suffix_set:
+            self.suffix = default_suffix
+        self.filename = self.prefix + self.name + '.' + self.suffix
+        self.outputs[0] = self.filename
+
+    def determine_default_prefix_and_suffix(self) -> T.Tuple[str, str]:
+        prefix = ''
+        suffix = ''
         # By default a static library is named libfoo.a even on Windows because
         # MSVC does not have a consistent convention for what static libraries
         # are called. The MSVC CRT uses libfoo.lib syntax but nothing else uses
@@ -2327,16 +2339,16 @@ class StaticLibrary(BuildTarget):
         # See our FAQ for more detailed rationale:
         # https://mesonbuild.com/FAQ.html#why-does-building-my-project-with-msvc-output-static-libraries-called-libfooa
         if not hasattr(self, 'prefix'):
-            self.prefix = 'lib'
+            prefix = 'lib'
         if not hasattr(self, 'suffix'):
             if self.uses_rust():
                 if self.rust_crate_type == 'rlib':
                     # default Rust static library suffix
-                    self.suffix = 'rlib'
+                    suffix = 'rlib'
                 elif self.rust_crate_type == 'staticlib':
-                    self.suffix = 'a'
+                    suffix = 'a'
             else:
-                self.suffix = 'a'
+                suffix = 'a'
                 if 'c' in self.compilers and self.compilers['c'].get_id() == 'tasking' and not self.prelink:
                     key = OptionKey('b_lto', self.subproject, self.for_machine)
                     try:
@@ -2345,9 +2357,8 @@ class StaticLibrary(BuildTarget):
                         v = self.environment.coredata.optstore.get_value_for(key)
                     assert isinstance(v, bool), 'for mypy'
                     if v:
-                        self.suffix = 'ma'
-        self.filename = self.prefix + self.name + '.' + self.suffix
-        self.outputs[0] = self.filename
+                        suffix = 'ma'
+        return (prefix, suffix)
 
     def get_link_deps_mapping(self, prefix: str) -> T.Mapping[str, str]:
         return {}

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -68,6 +68,12 @@ DEFAULT_STATIC_LIBRARY_NAMES = {
     'darwin': ('lib', 'a'),
 }
 
+DEFAULT_SHARED_LIBRARY_NAMES = {
+    'unix': ('lib', 'so', ''),
+    'windows': ('', 'dll', 'dll.lib'),
+    'darwin': ('lib', 'dylib', ''),
+}
+
 pch_kwargs = {'c_pch', 'cpp_pch'}
 
 lang_arg_kwargs = {f'{lang}_args' for lang in all_languages}
@@ -2479,13 +2485,17 @@ class SharedLibrary(BuildTarget):
         return self.environment.get_shared_lib_dir(), '{libdir_shared}'
 
     def determine_naming_info(self) -> T.Tuple[str, str, str, str, bool]:
-        prefix = ''
-        suffix = ''
+        scheme = self.environment.coredata.get_option_for_target(self, 'namingscheme')
+        if scheme != 'default':
+            prefix, suffix, import_suffix_dotless = DEFAULT_SHARED_LIBRARY_NAMES[scheme]
+            import_suffix = '.' + import_suffix_dotless
+        else:
+            prefix = None
+            suffix = None
+            import_suffix = None
         filename_tpl = self.basic_filename_tpl
         import_filename_tpl = ''
         create_debug_file = False
-        prefix = ''
-        suffix = ''
         create_debug_file = False
         self.filename_tpl = self.basic_filename_tpl
         import_filename_tpl = None
@@ -2500,27 +2510,29 @@ class SharedLibrary(BuildTarget):
         # Only Windows uses a separate import library for linking
         # For all other targets/platforms import_filename stays None
         elif self.environment.machines[self.for_machine].is_windows():
-            suffix = 'dll'
+            suffix = suffix if suffix is not None else 'dll'
             if self.uses_rust():
                 # Shared library is of the form foo.dll
-                prefix = ''
+                prefix = prefix if prefix is not None else ''
                 # Import library is called foo.dll.lib
                 import_filename_tpl = '{0.prefix}{0.name}.dll.lib'
                 # .pdb file is only created when debug symbols are enabled
                 create_debug_file = self.environment.coredata.optstore.get_value_for(OptionKey("debug"))
             elif self.get_using_msvc():
                 # Shared library is of the form foo.dll
-                prefix = ''
+                prefix = prefix if prefix is not None else ''
                 # Import library is called foo.lib
-                import_filename_tpl = '{0.prefix}{0.name}.lib'
+                import_suffix = import_suffix if import_suffix is not None else '.lib'
+                import_filename_tpl = '{0.prefix}{0.name}' + import_suffix
                 # .pdb file is only created when debug symbols are enabled
                 create_debug_file = self.environment.coredata.optstore.get_value_for(OptionKey("debug"))
             # Assume GCC-compatible naming
             else:
                 # Shared library is of the form libfoo.dll
-                prefix = 'lib'
+                prefix = prefix if prefix is not None else 'lib'
                 # Import library is called libfoo.dll.a
-                import_filename_tpl = '{0.prefix}{0.name}.dll.a'
+                import_suffix = import_suffix if import_suffix is not None else '.dll.a'
+                import_filename_tpl = '{0.prefix}{0.name}' + import_suffix
             # Shared library has the soversion if it is defined
             if self.soversion:
                 filename_tpl = '{0.prefix}{0.name}-{0.soversion}.{0.suffix}'
@@ -2532,15 +2544,16 @@ class SharedLibrary(BuildTarget):
             # (ld --dll-search-prefix=cyg is the default)
             prefix = 'cyg'
             # Import library is called libfoo.dll.a
+            import_suffix = import_suffix if import_suffix is not None else '.dll.a'
             import_prefix = self.prefix if self.prefix is not None else 'lib'
-            import_filename_tpl = import_prefix + '{0.name}.dll.a'
+            import_filename_tpl = import_prefix + '{0.name}{:0.import_suffix}'
             if self.soversion:
                 filename_tpl = '{0.prefix}{0.name}-{0.soversion}.{0.suffix}'
             else:
                 filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
         elif self.environment.machines[self.for_machine].is_darwin():
-            prefix = 'lib'
-            suffix = 'dylib'
+            prefix = prefix if prefix is not None else 'lib'
+            suffix = prefix if prefix is not None else 'dylib'
             # On macOS, the filename can only contain the major version
             if self.soversion:
                 # libfoo.X.dylib
@@ -2549,13 +2562,13 @@ class SharedLibrary(BuildTarget):
                 # libfoo.dylib
                 filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
         elif self.environment.machines[self.for_machine].is_android():
-            prefix = 'lib'
-            suffix = 'so'
+            prefix = prefix if prefix is not None else 'lib'
+            suffix = prefix if prefix is not None else 'so'
             # Android doesn't support shared_library versioning
             filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
         else:
-            prefix = 'lib'
-            suffix = 'so'
+            prefix = prefix if prefix is not None else 'lib'
+            suffix = suffix if suffix is not None else 'so'
             if self.ltversion:
                 # libfoo.so.X[.Y[.Z]] (.Y and .Z are optional)
                 filename_tpl = '{0.prefix}{0.name}.{0.suffix}.{0.ltversion}'

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -62,6 +62,12 @@ if T.TYPE_CHECKING:
         import_dirs: T.List[IncludeDirs]
         versions: T.List[T.Union[str, int]]
 
+DEFAULT_STATIC_LIBRARY_NAMES = {
+    'unix': ('lib', 'a'),
+    'windows': ('', 'lib'),
+    'darwin': ('lib', 'a'),
+}
+
 pch_kwargs = {'c_pch', 'cpp_pch'}
 
 lang_arg_kwargs = {f'{lang}_args' for lang in all_languages}
@@ -2326,6 +2332,9 @@ class StaticLibrary(BuildTarget):
         self.outputs[0] = self.filename
 
     def determine_default_prefix_and_suffix(self) -> T.Tuple[str, str]:
+        scheme = self.environment.coredata.get_option_for_target(self, 'namingscheme')
+        if scheme != 'default':
+            return DEFAULT_STATIC_LIBRARY_NAMES[scheme]
         prefix = ''
         suffix = ''
         # By default a static library is named libfoo.a even on Windows because

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -722,6 +722,7 @@ BUILTIN_CORE_OPTIONS: T.Mapping[OptionKey, AnyOptionType] = {
         UserBooleanOption('errorlogs', "Whether to print the logs from failing tests", True),
         UserUmaskOption('install_umask', 'Default umask to apply on permissions of installed files', OctalInt(0o022)),
         UserComboOption('layout', 'Build directory layout', 'mirror', choices=['mirror', 'flat']),
+        UserComboOption('namingscheme', 'How targets are named', 'default', choices=['default', 'unix', 'windows', 'darwin']),
         UserComboOption('optimization', 'Optimization level', '0', choices=['plain', '0', 'g', '1', '2', '3', 's']),
         UserBooleanOption('prefer_static', 'Whether to try static linking before shared linking', False),
         UserBooleanOption('stdsplit', 'Split stdout and stderr in test logs', True),


### PR DESCRIPTION
With this you can choose the library naming scheme regardless of the platform used.

A thing to decide before merging is whether we should keep the current scheme (`.a` on Windows) or switch to the platform default (`.dll` for libs and `.dll.lib` for import libs).