### PR TITLE
Add prefix and suffix to vcs_tag()

### DIFF
--- a/docs/yaml/functions/vcs_tag.yaml
+++ b/docs/yaml/functions/vcs_tag.yaml
@@ -86,3 +86,19 @@ kwargs:
       A string used by the `meson install --tags` command
       to install only a subset of the files. By default the file has no install
       tag which means it is not being installed when `--tags` argument is specified.
+
+  prefix:
+    type: str
+    default: "''"
+    since: 1.10.0
+    description: |
+      A string prepended before the output of the command.
+      Note that it is *not* applied in the fallback case.
+
+  suffix:
+    type: str
+    default: "''"
+    since: 1.10.0
+    description: |
+      A string appended after the output of the command.
+      Note that it is *not* applied in the fallback case.

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -83,9 +83,11 @@ from .type_checking import (
     LANGUAGE_KW,
     NATIVE_KW,
     PRESERVE_PATH_KW,
+    PREFIX_KW,
     REQUIRED_KW,
     SHARED_LIB_KWS,
     SHARED_MOD_KWS,
+    SUFFIX_KW,
     DEPENDENCY_SOURCES_KW,
     SOURCES_VARARGS,
     STATIC_LIB_KWS,
@@ -1953,11 +1955,15 @@ class Interpreter(InterpreterBase, HoldableObject):
         INSTALL_DIR_KW.evolve(since='1.7.0'),
         INSTALL_TAG_KW.evolve(since='1.7.0'),
         INSTALL_MODE_KW.evolve(since='1.7.0'),
+        PREFIX_KW.evolve(since='1.10.0'),
+        SUFFIX_KW.evolve(since='1.10.0'),
     )
     def func_vcs_tag(self, node: mparser.BaseNode, args: T.List['TYPE_var'], kwargs: 'kwtypes.VcsTag') -> build.CustomTarget:
         if kwargs['fallback'] is None:
             FeatureNew.single_use('Optional fallback in vcs_tag', '0.41.0', self.subproject, location=node)
         fallback = kwargs['fallback'] or self.project_version
+        prefix = kwargs.get('prefix', '')
+        suffix = kwargs.get('suffix', '')
         replace_string = kwargs['replace_string']
         regex_selector = '(.*)' # default regex selector for custom command: use complete output
         vcs_cmd = kwargs['command']
@@ -1988,6 +1994,8 @@ class Interpreter(InterpreterBase, HoldableObject):
              'vcstagger',
              '@INPUT0@',
              '@OUTPUT0@',
+             prefix,
+             suffix,
              fallback,
              source_dir,
              replace_string,

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -872,3 +872,15 @@ PKGCONFIG_DEFINE_KW: KwargInfo = KwargInfo(
 DEPENDENCY_KWS: T.List[KwargInfo] = [
     DEFAULT_OPTIONS.evolve(since='0.38.0'),
 ]
+
+PREFIX_KW: KwargInfo[str] = KwargInfo(
+    'prefix',
+    str,
+    default='',
+)
+
+SUFFIX_KW: KwargInfo[str] = KwargInfo(
+    'suffix',
+    str,
+    default='',
+)

--- a/mesonbuild/scripts/vcstagger.py
+++ b/mesonbuild/scripts/vcstagger.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 import sys, os, subprocess, re
 import typing as T
 
-def config_vcs_tag(infile: str, outfile: str, fallback: str, source_dir: str, replace_string: str, regex_selector: str, cmd: T.List[str]) -> None:
+def config_vcs_tag(infile: str, outfile: str, prefix: str, suffix: str, fallback: str, source_dir: str, replace_string: str, regex_selector: str, cmd: T.List[str]) -> None:
     try:
         output = subprocess.check_output(cmd, cwd=source_dir)
-        new_string = re.search(regex_selector, output.decode()).group(1).strip()
+        new_string = prefix + re.search(regex_selector, output.decode()).group(1).strip() + suffix
     except Exception:
         new_string = fallback
 
@@ -26,9 +26,9 @@ def config_vcs_tag(infile: str, outfile: str, fallback: str, source_dir: str, re
 
 
 def run(args: T.List[str]) -> int:
-    infile, outfile, fallback, source_dir, replace_string, regex_selector = args[0:6]
-    command = args[6:]
-    config_vcs_tag(infile, outfile, fallback, source_dir, replace_string, regex_selector, command)
+    infile, outfile, prefix, suffix, fallback, source_dir, replace_string, regex_selector = args[0:8]
+    command = args[8:]
+    config_vcs_tag(infile, outfile, prefix, suffix, fallback, source_dir, replace_string, regex_selector, command)
     return 0
 
 if __name__ == '__main__':

--- a/test cases/common/66 vcstag/meson.build
+++ b/test cases/common/66 vcstag/meson.build
@@ -17,6 +17,11 @@ fallback : '1.0.0')
 version_src_fallback = vcs_tag(input : 'vcstag.c.in',
 output : 'vcstag-fallback.c')
 
+version_src_prefix_suffix = vcs_tag(input : 'vcstag.c.in',
+output : 'vcstag-prefix-suffix.c',
+prefix : 'prefix string -> ',
+suffix : ' <- suffix string')
+
 git = find_program('git')
 
 version_src_git_program = vcs_tag(input : 'vcstag.c.in',
@@ -38,6 +43,7 @@ install_dir: get_option('includedir'))
 
 executable('tagprog-custom', 'tagprog.c', version_src_custom)
 executable('tagprog-fallback', 'tagprog.c', version_src_fallback)
+executable('tagprog-prefix-suffix', 'tagprog.c', version_src_prefix_suffix)
 executable('tagprog-notfound-fallback', 'tagprog.c', version_src_notfound_fallback)
 executable('tagprog-git-program', 'tagprog.c', version_src_git_program)
 executable('tagprog-executable', 'tagprog.c', version_src_executable)


### PR DESCRIPTION
In Mesa, we want to append either an empty string if building from a release tarball, or the git commit but surrounded by parentheses and with a `git-` prefix.

This PR makes this possible, as can be seen in https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/37337