### PR TITLE
vcstagger: only strip the ending newlines, not all whitespaces before and after

### DIFF
--- a/mesonbuild/scripts/vcstagger.py
+++ b/mesonbuild/scripts/vcstagger.py
@@ -9,7 +9,7 @@ import typing as T
 def config_vcs_tag(infile: str, outfile: str, fallback: str, source_dir: str, replace_string: str, regex_selector: str, cmd: T.List[str]) -> None:
     try:
         output = subprocess.check_output(cmd, cwd=source_dir)
-        new_string = re.search(regex_selector, output.decode()).group(1).strip()
+        new_string = re.search(regex_selector, output.decode()).group(1).rstrip('\r\n')
     except Exception:
         new_string = fallback
 


### PR DESCRIPTION
Otherwise, it's impossible to use eg. `--format=' (%h)'`