### PR TITLE
rust: Fix dependency on proc macro crates

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3750,7 +3750,10 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
 
     def get_dependency_filename(self, t):
         if isinstance(t, build.SharedLibrary):
-            return self.get_target_shsym_filename(t)
+            if t.uses_rust() and t.rust_crate_type == 'proc-macro':
+                return self.get_target_filename(t)
+            else:
+                return self.get_target_shsym_filename(t)
         elif isinstance(t, mesonlib.File):
             if t.is_built:
                 return t.relative_name()


### PR DESCRIPTION
When building a proc-macro crate the build target is actually a shared library target.  The resulting library (the .so file directly) is used in the targets that depend on it.  But being a shared object there are symbols extracted from it and the symbols file is the actual file recorded as the dependency.  When another crate uses a macro from the first crate, being dependent on the symbols file it means that if the macro _implementation_ changes, but symbols stay the same, the symbol extractor does not rewrite the symbols file and nothing else gets rebuilt.

That would be fine when it comes to classic shared library, but due to the fact that the shared library is used by the compiler (just like a gcc plugin or another compiler plugin) the result does not change only based on the symbols, but also based on the implementation.  Therefore if the target in the dependency is a proc-macro crate, instead of depending on the symbols file, depend on the shared object filename.

With this change, when a macro implementation changes in a proc-macro crate, all crates using that macro will be rebuilt.