### PR TITLE
ast/introspection: remove keyword arguments from build targets that a…

### DIFF
--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -109,8 +109,8 @@ class IntrospectionBuildTarget(MesonInterpreterObject):
     typename: str
     defined_in: str
     subdir: str
-    build_by_default: bool
-    installed: bool
+    build_by_default: T.Union[bool, UnknownValue]
+    installed: T.Union[bool, UnknownValue]
     outputs: T.List[str]
     source_nodes: T.List[BaseNode]
     extra_files: BaseNode

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -33,7 +33,7 @@ from .compilers import (
     is_header, is_object, is_source, clink_langs, sort_clink, all_languages,
     is_known_suffix, detect_static_linker, LANGUAGES_USING_LDFLAGS
 )
-from .interpreterbase import FeatureNew, FeatureDeprecated, UnknownValue
+from .interpreterbase import FeatureNew, FeatureDeprecated
 
 if T.TYPE_CHECKING:
     from typing_extensions import Literal, TypedDict
@@ -650,7 +650,7 @@ class Target(HoldableObject, metaclass=abc.ABCMeta):
     def process_kwargs_base(self, kwargs: T.Dict[str, T.Any]) -> None:
         if 'build_by_default' in kwargs:
             self.build_by_default = kwargs['build_by_default']
-            if not isinstance(self.build_by_default, (bool, UnknownValue)):
+            if not isinstance(self.build_by_default, bool):
                 raise InvalidArguments('build_by_default must be a boolean value.')
 
         if not self.build_by_default and kwargs.get('install', False):
@@ -1225,9 +1225,7 @@ class BuildTarget(Target):
         self.resources = resources
         if kwargs.get('name_prefix') is not None:
             name_prefix = kwargs['name_prefix']
-            if isinstance(name_prefix, UnknownValue):
-                pass
-            elif isinstance(name_prefix, list):
+            if isinstance(name_prefix, list):
                 if name_prefix:
                     raise InvalidArguments('name_prefix array must be empty to signify default.')
             else:
@@ -1237,9 +1235,7 @@ class BuildTarget(Target):
                 self.name_prefix_set = True
         if kwargs.get('name_suffix') is not None:
             name_suffix = kwargs['name_suffix']
-            if isinstance(name_suffix, UnknownValue):
-                pass
-            elif isinstance(name_suffix, list):
+            if isinstance(name_suffix, list):
                 if name_suffix:
                     raise InvalidArguments('name_suffix array must be empty to signify default.')
             else:

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -174,7 +174,7 @@ def get_target_dir(coredata: cdata.CoreData, subdir: str) -> str:
         return subdir
 
 def list_targets_from_source(intr: IntrospectionInterpreter) -> T.List[T.Dict[str, object]]:
-    tlist = []
+    tlist: T.List[T.Dict[str, object]] = []
     root_dir = Path(intr.source_root).resolve()
 
     for i in intr.targets:


### PR DESCRIPTION
…re UnknownValue

It is not the build layer's job to handle ast types, so instead filter out UnknownValues before passing them to the build layer, then fix up any special values we need in the ast layer. This reveals that some of what we were previously doing only works because the build layer is pretty much untyped, if it was typed it would have screamed loudly.