### PR TITLE
env2mfile: Use a cross vapigen on Debian if available

### DIFF
--- a/mesonbuild/scripts/env2mfile.py
+++ b/mesonbuild/scripts/env2mfile.py
@@ -234,6 +234,7 @@ def dpkg_architecture_to_machine_info(output: str, options: T.Any) -> MachineInf
         'g-ir-inspect',
         'g-ir-scanner',
         'pkg-config',
+        'vapigen',
     ]:
         try:
             infos.binaries[tool] = locate_path("%s-%s" % (host_arch, tool))

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1782,6 +1782,7 @@ class InternalTests(unittest.TestCase):
                 'g-ir-generate': [f'/usr/bin/{gnu_tuple}-g-ir-generate'],
                 'g-ir-inspect': [f'/usr/bin/{gnu_tuple}-g-ir-inspect'],
                 'g-ir-scanner': [f'/usr/bin/{gnu_tuple}-g-ir-scanner'],
+                'vapigen': [f'/usr/bin/{gnu_tuple}-vapigen'],
             }
 
         for title, dpkg_arch, gccsuffix, env, expected in [


### PR DESCRIPTION
As with many compilers and other tools relevant to cross-compiling, an executable prefixed with the host architecture's GNU architecture tuple might or might not exist, but if it does exist, we can be quite confident that it's the appropriate executable to use for that host architecture.

Vala's vapigen tool reads GIR XML files that can vary between architectures (for example `GLib-2.0.gir` and `GstAudio-1.0.gir` contain constants that take architecture-specific values), so on Debian it needs to search an architecture-specific location. Accordingly, the `valac (>= 0.56.18-3)` package provides a `${DEB_HOST_GNU_TYPE}-vapigen` script which wraps the vapigen binary and sets appropriate search paths.

Bug-Debian: https://bugs.debian.org/1116552