### PR TITLE
options: Validate option values before adding to augments

### DIFF
--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -910,7 +910,7 @@ class OptionStore:
             proj_key = key.evolve(subproject=None)
             self.add_system_option_internal(proj_key, valobj)
             if pval is not None:
-                self.augments[key] = pval
+                self.augments[key] = valobj.validate_value(pval)
         else:
             self.options[key] = valobj
             if pval is not None:


### PR DESCRIPTION
Boolean options need to be translated from string "true" to True and so on, otherwise we will get an assertion later when trying to set the value:

```
Traceback (most recent call last):
  File "meson.git/mesonbuild/mesonmain.py", line 193, in run
    return options.run_func(options)
           ~~~~~~~~~~~~~~~~^^^^^^^^^
  File "meson.git/mesonbuild/msetup.py", line 395, in run
    app.generate()
    ~~~~~~~~~~~~^^
  File "meson.git/mesonbuild/msetup.py", line 194, in generate
    return self._generate(env, capture, vslite_ctx)
           ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "meson.git/mesonbuild/msetup.py", line 282, in _generate
    captured_compile_args = intr.backend.generate(capture, vslite_ctx)
  File "meson.git/mesonbuild/backend/ninjabackend.py", line 647, in generate
    self.generate_target(t)
    ~~~~~~~~~~~~~~~~~~~~^^^
  File "meson.git/mesonbuild/backend/ninjabackend.py", line 1099, in generate_target
    elem = self.generate_link(target, outname, final_obj_list, linker, pch_objects, stdlib_args=stdlib_args)
  File "meson.git/mesonbuild/backend/ninjabackend.py", line 3632, in generate_link
    base_link_args = compilers.get_base_link_args(target,
                                                  linker,
                                                  self.environment)
  File "meson.git/mesonbuild/compilers/compilers.py", line 405, in get_base_link_args
    option_enabled(linker.base_options, target, env, 'b_lundef')):
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "meson.git/mesonbuild/compilers/compilers.py", line 234, in option_enabled
    assert isinstance(ret, bool), 'must return bool'  # could also be str
           ~~~~~~~~~~^^^^^^^^^^^
AssertionError: must return bool
```

This assertion is being hit because the vo-aacenc wrap sets `b_lundef=true` in `default_options:` in `project()`, which ends up in `self.augments` when the project is being invoked as a subproject.

This regressed in 2bafe7dc403b92c7b1f7bbad62dd8533e90f8523.

First noticed at: https://github.com/mesonbuild/wrapdb/actions/runs/18123699172/job/51573947286?pr=2425