### PR TITLE
cmake: warn about unknown generator expressions

### DIFF
--- a/mesonbuild/cmake/generator.py
+++ b/mesonbuild/cmake/generator.py
@@ -170,6 +170,8 @@ def parse_generator_expressions(
         # Evaluate the function
         if func in supported:
             res = supported[func](args)
+        else:
+            mlog.warning(f"Unknown generator expression '$<{func}:{args}>'.", once=True, fatal=False)
 
         return res
 


### PR DESCRIPTION
If a given project uses a generator expression that meson does not support it will change the outcome and potentially result in wrong behavior, the user should be aware of that so they can deal with it.