### PR TITLE
Fix Rust static linking with +verbatim= on the wasm build

### DIFF
--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -200,7 +200,7 @@ class RustCompiler(Compiler):
         if version_compare(self.version, '< 1.67.0'):
             return False
         # GNU ld support '-l:PATH'
-        if 'ld.' in self.linker.id:
+        if 'ld.' in self.linker.id and self.linker.id != 'ld.wasm':
             return True
         # -l:+verbatim does not work (yet?) with MSVC link or Apple ld64
         # (https://github.com/rust-lang/rust/pull/138753).  For ld64, it


### PR DESCRIPTION
Depends on #15024

This PR fixes the static linking failure similar to #15020 but observed in the Emscripten build.

### Reproducer

The test 3 mentioned in #15020 also fails on Emscripten, which is solved by this PR.

Assuming the current directory is at the meson repository cloning #15024 (73363f80c493f244011f05c390c51d93c8ae6ad3) which contains a modified version of the test 3.

```console
$ cat <<'EOF' | docker build --progress=plain -t wasmrustbase -
FROM rustlang/rust:nightly
RUN apt-get update && apt-get install -y ninja-build
# Setup emsdk following https://doc.rust-lang.org/beta/rustc/platform-support/wasm32-unknown-emscripten.html
RUN git clone -b 4.0.15 https://github.com/emscripten-core/emsdk
RUN ./emsdk/emsdk install 4.0.15
RUN ./emsdk/emsdk activate 4.0.15
ENV PATH=/emsdk:/emsdk/node/22.16.0_64bit/bin:/emsdk/upstream/emscripten:$PATH
RUN rustup target add wasm32-unknown-emscripten
RUN cat <<EOT > /cross.meson
[binaries]
c = 'emcc'
cpp = 'em++'
ar = 'emar'
ranlib = 'emranlib'
pkgconfig = ['pkg-config', '--static']
rust = ['rustc', '--target', 'wasm32-unknown-emscripten']

[host_machine]
system = 'emscripten'
cpu_family = 'wasm32'
cpu = 'wasm32'
endian = 'little'
EOT
EOF
$ docker run --rm -it -v "$(pwd):/meson:ro" -w "/meson/test cases/rust/3 staticlib" wasmrustbase \
  /bin/bash -c "/meson/meson.py setup --cross-file /cross.meson /tmp/build/ && /meson/meson.py compile -C /tmp/build/"
```

### Expected behaviour

The build succeeds without errors.

### Actual behaviour

The following error was observed.

```
[6/7] Compiling Rust source '../../meson/test cases/rust/3 staticlib/prog2.rs'
FAILED: prog2.js 
rustc --target wasm32-unknown-emscripten -C linker=emcc --color=always -C debug-assertions=yes -C overflow-checks=no --crate-type bin -g --crate-name prog2 --emit dep-info=prog2.js.p/prog2.d --emit link=prog2.js -C metadata=prog2@exe --extern stuff2=libstuff2.rlib -Clink-arg=libvalue.a -L. '../../meson/test cases/rust/3 staticlib/prog2.rs'
error: linking with `emcc` failed: exit status: 1
  |
  = note:  "emcc" "-s" "EXPORTED_FUNCTIONS=[\"_main\"]" "<2 object files omitted>" "<sysroot>/lib/rustlib/wasm32-unknown-emscripten/lib/libpanic_unwind-*.rlib" "/tmp/build/libstuff2.rlib" "-l" "libvalue.a" "./libother.rlib" "<sysroot>/lib/rustlib/wasm32-unknown-emscripten/lib/{libstd-*,libcfg_if-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_std_workspace_alloc-*,libminiz_oxide-*,libadler2-*,libunwind-*,liblibc-*,librustc_std_workspace_core-*,liballoc-*,libcore-*,libcompiler_builtins-*}.rlib" "-B<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/bin/gcc-ld" "--target=wasm32-unknown-emscripten" "-sDISABLE_EXCEPTION_CATCHING=0" "-L" "." "-L" "<sysroot>/lib/rustlib/wasm32-unknown-emscripten/lib/self-contained" "-o" "prog2.js" "-O0" "-g" "libvalue.a" "-sABORTING_MALLOC=0" "-sWASM_BIGINT"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: wasm-ld: error: unable to find library -llibvalue.a
          emcc: error: '/emsdk/upstream/bin/wasm-ld -o prog2.wasm prog2.prog2.469b2b9d6e0fbc5f-cgu.0.rcgu.o prog2.cnxth23sfng0seuw92pmh651m.rcgu.o /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/libpanic_unwind-c0bad0543470cda4.rlib /tmp/build/libstuff2.rlib -llibvalue.a ./libother.rlib /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/libstd-3b262c67262ef72c.rlib /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/libcfg_if-3ce2ed7df91e5d76.rlib /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/librustc_demangle-8c0610e500ed71ad.rlib /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/libstd_detect-2f3e31fe2082be1a.rlib /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/libhashbrown-c3b63418ab2a4610.rlib /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/librustc_std_workspace_alloc-c577400955fb7353.rlib /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/libminiz_oxide-b80b61631b7485c0.rlib /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/libadler2-3df7462430c82929.rlib /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/libunwind-d09d5f7306655ccc.rlib /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/liblibc-d2f3b0b08679fbd1.rlib /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/librustc_std_workspace_core-3e1c7452eff69a15.rlib /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/liballoc-fdf4f934ee4765a0.rlib /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/libcore-d28efc6ee55530c8.rlib /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/libcompiler_builtins-463934c8cc0ef616.rlib -L. -L/usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-emscripten/lib/self-contained libvalue.a -L/emsdk/upstream/emscripten/cache/sysroot/lib/wasm32-emscripten -L/emsdk/upstream/emscripten/src/lib -lGL-getprocaddr -lal -lhtml5 -lstubs-debug -lnoexit -lc-debug -ldlmalloc-debug -lcompiler_rt -lc++-debug -lc++abi-debug -lsockets -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-cxx-exceptions -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr /tmp/tmpvmfzxxnblibemscripten_js_symbols.so --export=emscripten_stack_get_end --export=emscripten_stack_get_free --export=emscripten_stack_get_base --export=emscripten_stack_get_current --export=emscripten_stack_init --export=_emscripten_stack_alloc --export=__cxa_can_catch --export=__cxa_increment_exception_refcount --export=__cxa_decrement_exception_refcount --export=setThrew --export=__cxa_free_exception --export=__wasm_call_ctors --export=_emscripten_stack_restore --export=__get_exception_message --export=free --export-if-defined=__start_em_asm --export-if-defined=__stop_em_asm --export-if-defined=__start_em_lib_deps --export-if-defined=__stop_em_lib_deps --export-if-defined=__start_em_js --export-if-defined=__stop_em_js --export-if-defined=main --export-if-defined=__main_argc_argv --export-if-defined=fflush --export-table -z stack-size=65536 --no-growable-memory --initial-heap=16777216 --no-entry --stack-first --table-base=1' failed (returned 1)
```
