### PR TITLE
rust: fix detection of main file

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1983,7 +1983,7 @@ class NinjaBackend(backends.Backend):
             return orderdeps, main_rust_file
 
         for i in target.get_sources():
-            if main_rust_file is None:
+            if main_rust_file is None and i.endswith('.rs'):
                 main_rust_file = i.rel_to_builddir(self.build_to_src)
         for g in target.get_generated_sources():
             for i in g.get_outputs():
@@ -1991,7 +1991,7 @@ class NinjaBackend(backends.Backend):
                     fname = os.path.join(self.get_target_private_dir(target), i)
                 else:
                     fname = os.path.join(g.get_subdir(), i)
-                if main_rust_file is None:
+                if main_rust_file is None and fname.endswith('.rs'):
                     main_rust_file = fname
                 orderdeps.append(fname)
 

--- a/test cases/rust/13 external c dependencies/foo.h
+++ b/test cases/rust/13 external c dependencies/foo.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int foo;

--- a/test cases/rust/13 external c dependencies/meson.build
+++ b/test cases/rust/13 external c dependencies/meson.build
@@ -21,3 +21,10 @@ e = executable(
 )
 
 test('cdepstest', e)
+
+e2 = executable(
+  'prog2', 'prog.rs',
+  dependencies : declare_dependency(link_with: l, sources: files('foo.h')),
+)
+
+test('cdepstest', e2)


### PR DESCRIPTION
If any dependency has "sources" in it, the file from the dependency might end up in the rustc command line.