### PR TITLE
options: Fix long/short option mixture detection

### DIFF
--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -240,14 +240,14 @@ def validate_original_args(args):
 
     def has_startswith(coll, target):
         for entry in coll:
-            if entry.startswith(target):
+            if entry.startswith(target + '=') or entry == target:
                 return True
         return False
     #ds = [x for x in args if x.startswith('-D')]
     #longs = [x for x in args if x.startswith('--')]
     for optionkey in itertools.chain(mesonbuild.options.BUILTIN_DIR_OPTIONS, mesonbuild.options.BUILTIN_CORE_OPTIONS):
         longarg = mesonbuild.options.argparse_name_to_arg(optionkey.name)
-        shortarg = f'-D{optionkey.name}='
+        shortarg = f'-D{optionkey.name}'
         if has_startswith(args, longarg) and has_startswith(args, shortarg):
             sys.exit(
                 f'Got argument {optionkey.name} as both {shortarg} and {longarg}. Pick one.')


### PR DESCRIPTION
Take the key/value separator `=` into account when comparing long and short option names to avoid invalid matches.

Proof of Concept, run in top directory of checked out meson project:

```
./meson.py -Dunity=on --unity_size=4
```

Before this pull request, the output is:

```
Got argument unity as both -Dunity= and --unity. Pick one.
```

After this pull request, the output is:

```
usage: meson [-h]
             {setup,configure,dist,install,introspect,init,test,wrap,subprojects,rewrite,compile,devenv,env2mfile,reprotest,format,fmt,help} ...
meson: error: unrecognized arguments: --unity_size=4
```