### PR TITLE
Remove dead code related to options

### DIFF
--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -128,10 +128,8 @@ class IntrospectionInterpreter(AstInterpreter):
                     if os.path.isdir(os.path.join(subprojects_dir, i)):
                         self.do_subproject(SubProject(i))
 
-        self.coredata.init_backend_options(self.backend)
-        options = {k: v for k, v in self.environment.options.items() if self.environment.coredata.optstore.is_backend_option(k)}
+        self.environment.init_backend_options(self.backend)
 
-        self.coredata.set_options(options)
         self._add_languages(proj_langs, True, MachineChoice.HOST)
         self._add_languages(proj_langs, True, MachineChoice.BUILD)
 

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -100,16 +100,6 @@ class IntrospectionInterpreter(AstInterpreter):
                 return [node.value]
             return None
 
-        def create_options_dict(options: T.List[str], subproject: str = '') -> T.Mapping[OptionKey, str]:
-            result: T.MutableMapping[OptionKey, str] = {}
-            for o in options:
-                try:
-                    (key, value) = o.split('=', 1)
-                except ValueError:
-                    raise mesonlib.MesonException(f'Option {o!r} must have a value separated by equals sign.')
-                result[OptionKey(key)] = value
-            return result
-
         proj_name = args[0]
         proj_vers = kwargs.get('version', 'undefined')
         if isinstance(proj_vers, ElementaryNode):

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3872,7 +3872,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         if extra_arg:
             target_name += f'-{extra_arg}'
             extra_args.append(f'--{extra_arg}')
-        colorout = self.environment.coredata.optstore.get_value('b_colorout') \
+        colorout = self.environment.coredata.optstore.get_value_for('b_colorout') \
             if OptionKey('b_colorout') in self.environment.coredata.optstore else 'always'
         assert isinstance(colorout, str), 'for mypy'
         extra_args.extend(['--color', colorout])

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -538,7 +538,7 @@ class Vs2010Backend(backends.Backend):
         replace_if_different(sln_filename, sln_filename_tmp)
 
     def generate_projects(self, vslite_ctx: dict = None) -> T.List[Project]:
-        startup_project = self.environment.coredata.optstore.get_value('backend_startup_project')
+        startup_project = self.environment.coredata.optstore.get_value_for('backend_startup_project')
         projlist: T.List[Project] = []
         startup_idx = 0
         for (i, (name, target)) in enumerate(self.build.targets.items()):

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -674,11 +674,13 @@ def detect_cuda_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
         cls = CudaCompiler
         env.add_lang_args(cls.language, cls, for_machine)
         key = OptionKey('cuda_link_args', machine=for_machine)
+        if for_machine is MachineChoice.BUILD and not is_cross:
+            key = key.as_host()
         if key in env.options:
             # To fix LDFLAGS issue
             val = env.options[key]
             assert isinstance(val, list)
-            env.coredata.set_options({key: cls.to_host_flags_base(val, Phase.LINKER)})
+            env.coredata.optstore.set_option(key, cls.to_host_flags_base(val, Phase.LINKER))
         linker = CudaLinker(compiler, for_machine, CudaCompiler.LINKER_PREFIX, [], version=CudaLinker.parse_version())
         return cls(ccache, compiler, version, for_machine, is_cross, host_compiler=cpp_compiler, info=info, linker=linker)
     raise EnvironmentException(f'Could not find suitable CUDA compiler: "{"; ".join([" ".join(c) for c in compilers])}"')

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -361,8 +361,8 @@ class CLikeCompiler(Compiler):
             # linking with static libraries since MSVC won't select a CRT for
             # us in that case and will error out asking us to pick one.
             try:
-                crt_val = env.coredata.optstore.get_value('b_vscrt')
-                buildtype = env.coredata.optstore.get_value('buildtype')
+                crt_val = env.coredata.optstore.get_value_for('b_vscrt')
+                buildtype = env.coredata.optstore.get_value_for('buildtype')
                 assert isinstance(crt_val, str), 'for mypy'
                 assert isinstance(buildtype, str), 'for mypy'
                 cargs += self.get_crt_compile_args(crt_val, buildtype)

--- a/mesonbuild/compilers/mixins/emscripten.py
+++ b/mesonbuild/compilers/mixins/emscripten.py
@@ -50,7 +50,7 @@ class EmscriptenMixin(Compiler):
 
     def thread_link_flags(self, env: 'Environment') -> T.List[str]:
         args = ['-pthread']
-        count = env.coredata.optstore.get_value(OptionKey(f'{self.language}_thread_count', machine=self.for_machine))
+        count = env.coredata.optstore.get_value_for(OptionKey(f'{self.language}_thread_count', machine=self.for_machine))
         assert isinstance(count, int)
         if count:
             args.append(f'-sPTHREAD_POOL_SIZE={count}')

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -490,7 +490,7 @@ class CoreData:
     def get_external_args(self, for_machine: MachineChoice, lang: str) -> T.List[str]:
         # mypy cannot analyze type of OptionKey
         key = OptionKey(f'{lang}_args', machine=for_machine)
-        return T.cast('T.List[str]', self.optstore.get_value(key))
+        return T.cast('T.List[str]', self.optstore.get_value_for(key))
 
     @lru_cache(maxsize=None)
     def get_external_link_args(self, for_machine: MachineChoice, lang: str) -> T.List[str]:
@@ -604,7 +604,7 @@ class CoreData:
 
     def emit_base_options_warnings(self) -> None:
         bcodekey = OptionKey('b_bitcode')
-        if bcodekey in self.optstore and self.optstore.get_value(bcodekey):
+        if bcodekey in self.optstore and self.optstore.get_value_for(bcodekey):
             msg = textwrap.dedent('''Base option 'b_bitcode' is enabled, which is incompatible with many linker options.
                                      Incompatible options such as \'b_asneeded\' have been disabled.'
                                      Please see https://mesonbuild.com/Builtin-options.html#Notes_about_Apple_Bitcode_support for more details.''')

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -420,9 +420,6 @@ class CoreData:
             raise MesonException(f'Tried to set unknown builtin option {str(key)}')
         dirty |= changed
 
-        if key.name == 'buildtype':
-            dirty |= self._set_others_from_buildtype(value)
-
         return dirty
 
     def clear_cache(self) -> None:
@@ -459,33 +456,6 @@ class CoreData:
         if actual_debug != debug:
             result.append(('debug', actual_debug, debug))
         return result
-
-    def _set_others_from_buildtype(self, value: str) -> bool:
-        dirty = False
-
-        if value == 'plain':
-            opt = 'plain'
-            debug = False
-        elif value == 'debug':
-            opt = '0'
-            debug = True
-        elif value == 'debugoptimized':
-            opt = '2'
-            debug = True
-        elif value == 'release':
-            opt = '3'
-            debug = False
-        elif value == 'minsize':
-            opt = 's'
-            debug = True
-        else:
-            assert value == 'custom'
-            return False
-
-        dirty |= self.optstore.set_option(OptionKey('optimization'), opt)
-        dirty |= self.optstore.set_option(OptionKey('debug'), debug)
-
-        return dirty
 
     def get_external_args(self, for_machine: MachineChoice, lang: str) -> T.List[str]:
         # mypy cannot analyze type of OptionKey

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -412,16 +412,6 @@ class CoreData:
     def set_from_configure_command(self, options: SharedCMDOptions) -> bool:
         return self.optstore.set_from_configure_command(options.cmd_line_options)
 
-    def set_option(self, key: OptionKey, value, first_invocation: bool = False) -> bool:
-        dirty = False
-        try:
-            changed = self.optstore.set_option(key, value, first_invocation)
-        except KeyError:
-            raise MesonException(f'Tried to set unknown builtin option {str(key)}')
-        dirty |= changed
-
-        return dirty
-
     def clear_cache(self) -> None:
         self.deps.host.clear()
         self.deps.build.clear()

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -503,26 +503,6 @@ class CoreData:
             return False
         return len(self.cross_files) > 0
 
-    def copy_build_options_from_regular_ones(self, shut_up_pylint: bool = True) -> bool:
-        # FIXME, needs cross compilation support.
-        if shut_up_pylint:
-            return False
-        dirty = False
-        assert not self.is_cross_build()
-        for k in options.BUILTIN_OPTIONS_PER_MACHINE:
-            o = self.optstore.get_value_object_for(k.name)
-            dirty |= self.optstore.set_option(k, o.value, True)
-        for bk, bv in self.optstore.items():
-            if bk.machine is MachineChoice.BUILD:
-                hk = bk.as_host()
-                try:
-                    hv = self.optstore.get_value_object(hk)
-                    dirty |= bv.set_value(hv.value)
-                except KeyError:
-                    continue
-
-        return dirty
-
     def set_options(self, opts_to_set: T.Dict[OptionKey, T.Any], subproject: str = '', first_invocation: bool = False) -> bool:
         dirty = False
         if not self.is_cross_build():
@@ -559,9 +539,6 @@ class CoreData:
                 unknown_options_str = ', '.join(sorted(str(s) for s in unknown_options))
                 sub = f'In subproject {subproject}: ' if subproject else ''
                 raise MesonException(f'{sub}Unknown options: "{unknown_options_str}"')
-
-        if not self.is_cross_build():
-            dirty |= self.copy_build_options_from_regular_ones()
 
         return dirty
 

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -604,9 +604,9 @@ class BoostDependency(SystemDependency):
         # MSVC is very picky with the library tags
         vscrt = ''
         try:
-            crt_val = self.env.coredata.optstore.get_value('b_vscrt')
+            crt_val = self.env.coredata.optstore.get_value_for('b_vscrt')
             assert isinstance(crt_val, str)
-            buildtype = self.env.coredata.optstore.get_value('buildtype')
+            buildtype = self.env.coredata.optstore.get_value_for('buildtype')
             assert isinstance(buildtype, str)
             vscrt = self.clib_compiler.get_crt_compile_args(crt_val, buildtype)[0]
         except (KeyError, IndexError, AttributeError):

--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -432,7 +432,7 @@ class PkgConfigDependency(ExternalDependency):
         #
         # Only prefix_libpaths are reordered here because there should not be
         # too many system_libpaths to cause library version issues.
-        pkg_config_path: T.List[str] = self.env.coredata.optstore.get_value(OptionKey('pkg_config_path', machine=self.for_machine)) # type: ignore[assignment]
+        pkg_config_path: T.List[str] = self.env.coredata.optstore.get_value_for(OptionKey('pkg_config_path', machine=self.for_machine)) # type: ignore[assignment]
         pkg_config_path = self._convert_mingw_paths(pkg_config_path)
         prefix_libpaths = OrderedSet(sort_libpaths(list(prefix_libpaths), pkg_config_path))
         system_libpaths: OrderedSet[str] = OrderedSet()

--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -397,7 +397,7 @@ class _PythonDependencyBase(_Base):
                     is_debug_build = debug or buildtype == 'debug'
                     vscrt_debug = False
                     if OptionKey('b_vscrt') in self.env.coredata.optstore:
-                        vscrt = self.env.coredata.optstore.get_value('b_vscrt')
+                        vscrt = self.env.coredata.optstore.get_value_for('b_vscrt')
                         if vscrt in {'mdd', 'mtd', 'from_buildtype', 'static_from_buildtype'}:
                             vscrt_debug = True
                     if is_debug_build and vscrt_debug and not self.variables.get('Py_DEBUG'):

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -833,9 +833,6 @@ class Environment:
                             env_opts[key].extend(p_list)
                     else:
                         key = OptionKey.from_string(keyname).evolve(machine=for_machine)
-                        if evar in compilers.compilers.CFLAGS_MAPPING.values():
-                            lang = key.name.split('_', 1)[0]
-                            key = key.evolve(f'{lang}_args')
                         env_opts[key].extend(p_list)
 
         # If this is an environment variable, we have to

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -906,6 +906,17 @@ class Environment:
         self.coredata = coredata.CoreData(options, self.scratch_dir, meson_command)
         self.first_invocation = True
 
+    def init_backend_options(self, backend_name: str) -> None:
+        # Only init backend options on first invocation otherwise it would
+        # override values previously set from command line.
+        if not self.first_invocation:
+            return
+
+        self.coredata.init_backend_options(backend_name)
+        for k, v in self.options.items():
+            if self.coredata.optstore.is_backend_option(k):
+                self.coredata.optstore.set_option(k, v)
+
     def is_cross_build(self, when_building_for: MachineChoice = MachineChoice.HOST) -> bool:
         return self.coredata.is_cross_build(when_building_for)
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3081,9 +3081,9 @@ class Interpreter(InterpreterBase, HoldableObject):
             return
         if OptionKey('b_sanitize') not in self.coredata.optstore:
             return
-        if (self.coredata.optstore.get_value('b_lundef') and
-                self.coredata.optstore.get_value('b_sanitize')):
-            value = self.coredata.optstore.get_value('b_sanitize')
+        if (self.coredata.optstore.get_value_for('b_lundef') and
+                self.coredata.optstore.get_value_for('b_sanitize')):
+            value = self.coredata.optstore.get_value_for('b_sanitize')
             mlog.warning(textwrap.dedent(f'''\
                     Trying to use {value} sanitizer on Clang with b_lundef.
                     This will probably not work.

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1155,13 +1155,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                 raise MesonBugException(f'Backend changed from {backend_name} to {self.backend.name}')
             self.coredata.optstore.set_option(OptionKey('backend'), self.backend.name, first_invocation=True)
 
-        # Only init backend options on first invocation otherwise it would
-        # override values previously set from command line.
-        if self.environment.first_invocation:
-            self.coredata.init_backend_options(backend_name)
-
-        options = {k: v for k, v in self.environment.options.items() if self.environment.coredata.optstore.is_backend_option(k)}
-        self.coredata.set_options(options)
+        self.environment.init_backend_options(backend_name)
 
     @typed_pos_args('project', str, varargs=str)
     @typed_kwargs(

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1483,8 +1483,6 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     def add_languages(self, args: T.List[str], required: bool, for_machine: MachineChoice) -> bool:
         success = self.add_languages_for(args, required, for_machine)
-        if not self.coredata.is_cross_build():
-            self.coredata.copy_build_options_from_regular_ones()
         self._redetect_machines()
         return success
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1153,7 +1153,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                 mlog.log('Auto detected Visual Studio backend:', mlog.bold(self.backend.name))
             if not self.environment.first_invocation:
                 raise MesonBugException(f'Backend changed from {backend_name} to {self.backend.name}')
-            self.coredata.set_option(OptionKey('backend'), self.backend.name, first_invocation=True)
+            self.coredata.optstore.set_option(OptionKey('backend'), self.backend.name, first_invocation=True)
 
         # Only init backend options on first invocation otherwise it would
         # override values previously set from command line.

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -922,7 +922,7 @@ class GnomeModule(ExtensionModule):
             if state.project_args.get(lang):
                 cflags += state.project_args[lang]
             if OptionKey('b_sanitize') in compiler.base_options:
-                sanitize = state.environment.coredata.optstore.get_value('b_sanitize')
+                sanitize = state.environment.coredata.optstore.get_value_for('b_sanitize')
                 assert isinstance(sanitize, list)
                 cflags += compiler.sanitizer_compile_args(sanitize)
                 # These must be first in ldflags

--- a/mesonbuild/modules/hotdoc.py
+++ b/mesonbuild/modules/hotdoc.py
@@ -146,31 +146,6 @@ class HotdocTargetBuilder:
             self.check_extra_arg_type(arg, value)
             self.set_arg_value(option, value)
 
-    def get_value(self, types, argname, default=None, value_processor=None,
-                  mandatory=False, force_list=False):
-        if not isinstance(types, list):
-            types = [types]
-        try:
-            uvalue = value = self.kwargs.pop(argname)
-            if value_processor:
-                value = value_processor(value)
-
-            for t in types:
-                if isinstance(value, t):
-                    if force_list and not isinstance(value, list):
-                        return [value], uvalue
-                    return value, uvalue
-            raise MesonException(f"{argname} field value {value} is not valid,"
-                                 f" valid types are {types}")
-        except KeyError:
-            if mandatory:
-                raise MesonException(f"{argname} mandatory field not found")
-
-            if default is not None:
-                return default, default
-
-        return None, None
-
     def add_extension_paths(self, paths: T.Union[T.List[str], T.Set[str]]) -> None:
         for path in paths:
             if path in self._extra_extension_paths:

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -206,7 +206,7 @@ class PythonInstallation(_ExternalProgramHolder['PythonExternalProgram']):
 
                 new_link_args = mesonlib.extract_as_list(kwargs, 'link_args')
 
-                is_debug = self.interpreter.environment.coredata.optstore.get_value('debug')
+                is_debug = self.interpreter.environment.coredata.optstore.get_value_for('debug')
                 if is_debug:
                     new_link_args.append(python_windows_debug_link_exception)
                 else:

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -443,7 +443,7 @@ class RustModule(ExtensionModule):
         if self._bindgen_rust_target and '--rust-target' not in cmd:
             cmd.extend(['--rust-target', self._bindgen_rust_target])
         if self._bindgen_set_std and '--rust-edition' not in cmd:
-            rust_std = state.environment.coredata.optstore.get_value('rust_std')
+            rust_std = state.environment.coredata.optstore.get_value_for('rust_std')
             assert isinstance(rust_std, str), 'for mypy'
             if rust_std != 'none':
                 cmd.extend(['--rust-edition', rust_std])

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1146,11 +1146,6 @@ class OptionStore:
                     new_value = prefix_mapping[new_prefix]
             valobj.set_value(new_value)
 
-    # FIXME, this should be removed.or renamed to "change_type_of_existing_object" or something like that
-    def set_value_object(self, key: T.Union[OptionKey, str], new_object: AnyOptionType) -> None:
-        key = self.ensure_and_validate_key(key)
-        self.options[key] = new_object
-
     def get_value_object(self, key: T.Union[OptionKey, str]) -> AnyOptionType:
         key = self.ensure_and_validate_key(key)
         return self.options[key]
@@ -1407,6 +1402,7 @@ class OptionStore:
 
     def update_project_options(self, project_options: MutableKeyedOptionDictType, subproject: SubProject) -> None:
         for key, value in project_options.items():
+            assert key.machine is MachineChoice.HOST
             if key not in self.options:
                 self.add_project_option(key, value)
                 continue
@@ -1420,7 +1416,7 @@ class OptionStore:
                 # If the choices have changed, use the new value, but attempt
                 # to keep the old options. If they are not valid keep the new
                 # defaults but warn.
-                self.set_value_object(key, value)
+                self.options[key] = value
                 try:
                     value.set_value(oldval.value)
                 except MesonException:

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -845,9 +845,6 @@ class OptionStore:
             return self.options[key].value
         return self.pending_options.get(key, default)
 
-    def get_value(self, key: T.Union[OptionKey, str]) -> ElementaryOptionValues:
-        return self.get_value_for(key)
-
     def __len__(self) -> int:
         return len(self.options)
 

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1318,14 +1318,7 @@ class OptionStore:
 
         # ignore subprojects for now for machine file and command line
         # options; they are applied later
-        for key, valstr in machine_file_options.items():
-            # Due to backwards compatibility we ignore all build-machine options
-            # when building natively.
-            if not self.is_cross and key.is_for_build():
-                continue
-            if not key.subproject:
-                self.set_user_option(key, valstr, True)
-        for key, valstr in cmd_line_options.items():
+        for key, valstr in itertools.chain(machine_file_options.items(), cmd_line_options.items()):
             # Due to backwards compatibility we ignore all build-machine options
             # when building natively.
             if not self.is_cross and key.is_for_build():

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1150,10 +1150,6 @@ class OptionStore:
         key = self.ensure_and_validate_key(key)
         return self.options[key]
 
-    def get_default_for_b_option(self, key: OptionKey) -> ElementaryOptionValues:
-        assert self.is_base_option(key)
-        return COMPILER_BASE_OPTIONS[key.evolve(subproject=None, machine=MachineChoice.HOST)].default
-
     def remove(self, key: OptionKey) -> None:
         del self.options[key]
         try:

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1185,12 +1185,6 @@ class OptionStore:
     def items(self) -> T.ItemsView['OptionKey', 'AnyOptionType']:
         return self.options.items()
 
-    def setdefault(self, k: OptionKey, o: AnyOptionType) -> AnyOptionType:
-        return self.options.setdefault(k, o)
-
-    def get(self, o: OptionKey, default: T.Optional[AnyOptionType] = None, **kwargs: T.Any) -> T.Optional[AnyOptionType]:
-        return self.options.get(o, default, **kwargs)
-
     def is_project_option(self, key: OptionKey) -> bool:
         """Convenience method to check if this is a project option."""
         return key in self.project_options

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -715,8 +715,7 @@ BUILTIN_CORE_OPTIONS: T.Mapping[OptionKey, AnyOptionType] = {
         ),
         UserComboOption('buildtype', 'Build type to use', 'debug', choices=buildtypelist),
         UserBooleanOption('debug', 'Enable debug symbols and other information', True),
-        UserComboOption('default_library', 'Default library type', 'shared', choices=['shared', 'static', 'both'],
-                        yielding=False),
+        UserComboOption('default_library', 'Default library type', 'shared', choices=['shared', 'static', 'both']),
         UserComboOption('default_both_libraries', 'Default library type for both_libraries', 'shared',
                         choices=['shared', 'static', 'auto']),
         UserBooleanOption('errorlogs', "Whether to print the logs from failing tests", True),
@@ -729,9 +728,8 @@ BUILTIN_CORE_OPTIONS: T.Mapping[OptionKey, AnyOptionType] = {
         UserBooleanOption('strip', 'Strip targets on install', False),
         UserComboOption('unity', 'Unity build', 'off', choices=['on', 'off', 'subprojects']),
         UserIntegerOption('unity_size', 'Unity block size', 4, min_value=2),
-        UserComboOption('warning_level', 'Compiler warning level to use', '1', choices=['0', '1', '2', '3', 'everything'],
-                        yielding=False),
-        UserBooleanOption('werror', 'Treat warnings as errors', False, yielding=False),
+        UserComboOption('warning_level', 'Compiler warning level to use', '1', choices=['0', '1', '2', '3', 'everything']),
+        UserBooleanOption('werror', 'Treat warnings as errors', False),
         UserComboOption('wrap_mode', 'Wrap mode', 'default', choices=['default', 'nofallback', 'nodownload', 'forcefallback', 'nopromote']),
         UserStringArrayOption('force_fallback_for', 'Force fallback for those subprojects', []),
         UserBooleanOption('vsenv', 'Activate Visual Studio environment', False, readonly=True),
@@ -955,14 +953,9 @@ class OptionStore:
     def add_builtin_option(self, key: OptionKey, opt: AnyOptionType) -> None:
         # Create a copy of the object, as we're going to mutate it
         opt = copy.copy(opt)
-        if key.subproject:
-            if opt.yielding:
-                # This option is global and not per-subproject
-                return
-        else:
-            new_value = argparse_prefixed_default(
-                opt, key, default_prefix())
-            opt.set_value(new_value)
+        assert key.subproject is None
+        new_value = argparse_prefixed_default(opt, key, default_prefix())
+        opt.set_value(new_value)
 
         modulename = key.get_module_prefix()
         if modulename:

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1152,10 +1152,7 @@ class OptionStore:
 
     def get_default_for_b_option(self, key: OptionKey) -> ElementaryOptionValues:
         assert self.is_base_option(key)
-        try:
-            return COMPILER_BASE_OPTIONS[key.evolve(subproject=None)].default
-        except KeyError:
-            raise MesonBugException(f'Requested base option {key} which does not exist.')
+        return COMPILER_BASE_OPTIONS[key.evolve(subproject=None, machine=MachineChoice.HOST)].default
 
     def remove(self, key: OptionKey) -> None:
         del self.options[key]
@@ -1210,7 +1207,8 @@ class OptionStore:
 
     def is_base_option(self, key: OptionKey) -> bool:
         """Convenience method to check if this is a base option."""
-        return key.name.startswith('b_')
+        # The "startswith" check is just an optimization
+        return key.name.startswith('b_') and key.evolve(subproject=None, machine=MachineChoice.HOST) in COMPILER_BASE_OPTIONS
 
     def is_backend_option(self, key: OptionKey) -> bool:
         """Convenience method to check if this is a backend option."""
@@ -1322,8 +1320,7 @@ class OptionStore:
             return True
         if first_invocation and self.is_backend_option(key):
             return True
-        return (self.is_base_option(key) and
-                key.evolve(subproject=None, machine=MachineChoice.HOST) in COMPILER_BASE_OPTIONS)
+        return self.is_base_option(key)
 
     def validate_cmd_line_options(self, cmd_line_options: OptionDict) -> None:
         unknown_options = []

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -2752,35 +2752,35 @@ class AllPlatformTests(BasePlatformTests):
         out = self.init(testdir, extra_args=['--profile-self', '--fatal-meson-warnings'])
         self.assertNotIn('[default: true]', out)
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value('default_library'), 'static')
-        self.assertEqual(obj.optstore.get_value('warning_level'), '1')
-        self.assertEqual(obj.optstore.get_value(OptionKey('set_sub_opt', '')), True)
-        self.assertEqual(obj.optstore.get_value(OptionKey('subp_opt', 'subp')), 'default3')
+        self.assertEqual(obj.optstore.get_value_for('default_library'), 'static')
+        self.assertEqual(obj.optstore.get_value_for('warning_level'), '1')
+        self.assertEqual(obj.optstore.get_value_for(OptionKey('set_sub_opt', '')), True)
+        self.assertEqual(obj.optstore.get_value_for(OptionKey('subp_opt', 'subp')), 'default3')
         self.wipe()
 
         # warning_level is special, it's --warnlevel instead of --warning-level
         # for historical reasons
         self.init(testdir, extra_args=['--warnlevel=2', '--fatal-meson-warnings'])
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value('warning_level'), '2')
+        self.assertEqual(obj.optstore.get_value_for('warning_level'), '2')
         self.setconf('--warnlevel=3')
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value('warning_level'), '3')
+        self.assertEqual(obj.optstore.get_value_for('warning_level'), '3')
         self.setconf('--warnlevel=everything')
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value('warning_level'), 'everything')
+        self.assertEqual(obj.optstore.get_value_for('warning_level'), 'everything')
         self.wipe()
 
         # But when using -D syntax, it should be 'warning_level'
         self.init(testdir, extra_args=['-Dwarning_level=2', '--fatal-meson-warnings'])
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value('warning_level'), '2')
+        self.assertEqual(obj.optstore.get_value_for('warning_level'), '2')
         self.setconf('-Dwarning_level=3')
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value('warning_level'), '3')
+        self.assertEqual(obj.optstore.get_value_for('warning_level'), '3')
         self.setconf('-Dwarning_level=everything')
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value('warning_level'), 'everything')
+        self.assertEqual(obj.optstore.get_value_for('warning_level'), 'everything')
         self.wipe()
 
         # Mixing --option and -Doption is forbidden
@@ -2804,15 +2804,15 @@ class AllPlatformTests(BasePlatformTests):
         # --default-library should override default value from project()
         self.init(testdir, extra_args=['--default-library=both', '--fatal-meson-warnings'])
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value('default_library'), 'both')
+        self.assertEqual(obj.optstore.get_value_for('default_library'), 'both')
         self.setconf('--default-library=shared')
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value('default_library'), 'shared')
+        self.assertEqual(obj.optstore.get_value_for('default_library'), 'shared')
         if self.backend is Backend.ninja:
             # reconfigure target works only with ninja backend
             self.build('reconfigure')
             obj = mesonbuild.coredata.load(self.builddir)
-            self.assertEqual(obj.optstore.get_value('default_library'), 'shared')
+            self.assertEqual(obj.optstore.get_value_for('default_library'), 'shared')
         self.wipe()
 
         # Should fail on unknown options
@@ -2849,22 +2849,22 @@ class AllPlatformTests(BasePlatformTests):
         # Test we can set subproject option
         self.init(testdir, extra_args=['-Dsubp:subp_opt=foo', '--fatal-meson-warnings'])
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value(OptionKey('subp_opt', 'subp')), 'foo')
+        self.assertEqual(obj.optstore.get_value_for(OptionKey('subp_opt', 'subp')), 'foo')
         self.wipe()
 
         # c_args value should be parsed with split_args
         self.init(testdir, extra_args=['-Dc_args=-Dfoo -Dbar "-Dthird=one two"', '--fatal-meson-warnings'])
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value(OptionKey('c_args')), ['-Dfoo', '-Dbar', '-Dthird=one two'])
+        self.assertEqual(obj.optstore.get_value_for(OptionKey('c_args')), ['-Dfoo', '-Dbar', '-Dthird=one two'])
 
         self.setconf('-Dc_args="foo bar" one two')
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value(OptionKey('c_args')), ['foo bar', 'one', 'two'])
+        self.assertEqual(obj.optstore.get_value_for(OptionKey('c_args')), ['foo bar', 'one', 'two'])
         self.wipe()
 
         self.init(testdir, extra_args=['-Dset_percent_opt=myoption%', '--fatal-meson-warnings'])
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value(OptionKey('set_percent_opt', '')), 'myoption%')
+        self.assertEqual(obj.optstore.get_value_for(OptionKey('set_percent_opt', '')), 'myoption%')
         self.wipe()
 
         # Setting a 2nd time the same option should override the first value
@@ -2875,19 +2875,19 @@ class AllPlatformTests(BasePlatformTests):
                                            '-Dc_args=-Dfoo', '-Dc_args=-Dbar',
                                            '-Db_lundef=false', '--fatal-meson-warnings'])
             obj = mesonbuild.coredata.load(self.builddir)
-            self.assertEqual(obj.optstore.get_value('bindir'), 'bar')
-            self.assertEqual(obj.optstore.get_value('buildtype'), 'release')
-            self.assertEqual(obj.optstore.get_value('b_sanitize'), ['thread'])
-            self.assertEqual(obj.optstore.get_value(OptionKey('c_args')), ['-Dbar'])
+            self.assertEqual(obj.optstore.get_value_for('bindir'), 'bar')
+            self.assertEqual(obj.optstore.get_value_for('buildtype'), 'release')
+            self.assertEqual(obj.optstore.get_value_for('b_sanitize'), ['thread'])
+            self.assertEqual(obj.optstore.get_value_for(OptionKey('c_args')), ['-Dbar'])
             self.setconf(['--bindir=bar', '--bindir=foo',
                           '-Dbuildtype=release', '-Dbuildtype=plain',
                           '-Db_sanitize=thread', '-Db_sanitize=address',
                           '-Dc_args=-Dbar', '-Dc_args=-Dfoo'])
             obj = mesonbuild.coredata.load(self.builddir)
-            self.assertEqual(obj.optstore.get_value('bindir'), 'foo')
-            self.assertEqual(obj.optstore.get_value('buildtype'), 'plain')
-            self.assertEqual(obj.optstore.get_value('b_sanitize'), ['address'])
-            self.assertEqual(obj.optstore.get_value(OptionKey('c_args')), ['-Dfoo'])
+            self.assertEqual(obj.optstore.get_value_for('bindir'), 'foo')
+            self.assertEqual(obj.optstore.get_value_for('buildtype'), 'plain')
+            self.assertEqual(obj.optstore.get_value_for('b_sanitize'), ['address'])
+            self.assertEqual(obj.optstore.get_value_for(OptionKey('c_args')), ['-Dfoo'])
             self.wipe()
         except KeyError:
             # Ignore KeyError, it happens on CI for compilers that does not
@@ -2901,25 +2901,25 @@ class AllPlatformTests(BasePlatformTests):
         # Verify default values when passing no args
         self.init(testdir)
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value('warning_level'), '0')
+        self.assertEqual(obj.optstore.get_value_for('warning_level'), '0')
         self.wipe()
 
         # verify we can override w/ --warnlevel
         self.init(testdir, extra_args=['--warnlevel=1'])
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value('warning_level'), '1')
+        self.assertEqual(obj.optstore.get_value_for('warning_level'), '1')
         self.setconf('--warnlevel=0')
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value('warning_level'), '0')
+        self.assertEqual(obj.optstore.get_value_for('warning_level'), '0')
         self.wipe()
 
         # verify we can override w/ -Dwarning_level
         self.init(testdir, extra_args=['-Dwarning_level=1'])
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value('warning_level'), '1')
+        self.assertEqual(obj.optstore.get_value_for('warning_level'), '1')
         self.setconf('-Dwarning_level=0')
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value('warning_level'), '0')
+        self.assertEqual(obj.optstore.get_value_for('warning_level'), '0')
         self.wipe()
 
     def test_feature_check_usage_subprojects(self):

--- a/unittests/datatests.py
+++ b/unittests/datatests.py
@@ -167,7 +167,7 @@ class DataTests(unittest.TestCase):
                 debug = False
             else:
                 raise RuntimeError(f'Invalid debug value {debug!r} in row:\n{m.group()}')
-            env.coredata.set_option(OptionKey('buildtype'), buildtype)
+            env.coredata.optstore.set_option(OptionKey('buildtype'), buildtype)
             self.assertEqual(env.coredata.optstore.get_value_for('buildtype'), buildtype)
             self.assertEqual(env.coredata.optstore.get_value_for('optimization'), opt)
             self.assertEqual(env.coredata.optstore.get_value_for('debug'), debug)

--- a/unittests/datatests.py
+++ b/unittests/datatests.py
@@ -168,9 +168,9 @@ class DataTests(unittest.TestCase):
             else:
                 raise RuntimeError(f'Invalid debug value {debug!r} in row:\n{m.group()}')
             env.coredata.set_option(OptionKey('buildtype'), buildtype)
-            self.assertEqual(env.coredata.optstore.get_value('buildtype'), buildtype)
-            self.assertEqual(env.coredata.optstore.get_value('optimization'), opt)
-            self.assertEqual(env.coredata.optstore.get_value('debug'), debug)
+            self.assertEqual(env.coredata.optstore.get_value_for('buildtype'), buildtype)
+            self.assertEqual(env.coredata.optstore.get_value_for('optimization'), opt)
+            self.assertEqual(env.coredata.optstore.get_value_for('debug'), debug)
 
     def test_cpu_families_documented(self):
         with open("docs/markdown/Reference-tables.md", encoding='utf-8') as f:

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -1166,7 +1166,7 @@ class LinuxlikeTests(BasePlatformTests):
         # option, adding the meson-uninstalled directory to it.
         PkgConfigInterface.setup_env({}, env, MachineChoice.HOST, uninstalled=True)
 
-        pkg_config_path = env.coredata.optstore.get_value('pkg_config_path')
+        pkg_config_path = env.coredata.optstore.get_value_for('pkg_config_path')
         self.assertEqual(pkg_config_path, [pkg_dir])
 
     def test_pkgconfig_uninstalled_env_added(self):

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -1144,7 +1144,7 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertPathExists(os.path.join(pkg_dir, 'librelativepath.pc'))
 
         env = get_fake_env(testdir, self.builddir, self.prefix)
-        env.coredata.set_options({OptionKey('pkg_config_path'): pkg_dir}, subproject='')
+        env.coredata.optstore.set_option(OptionKey('pkg_config_path'), pkg_dir)
         kwargs = {'required': True, 'silent': True}
         relative_path_dep = PkgConfigDependency('librelativepath', env, kwargs)
         self.assertTrue(relative_path_dep.found())
@@ -1160,7 +1160,7 @@ class LinuxlikeTests(BasePlatformTests):
         pkg_dir = os.path.join(testdir, 'pkgconfig')
 
         env = get_fake_env(testdir, self.builddir, self.prefix)
-        env.coredata.set_options({OptionKey('pkg_config_path'): pkg_dir}, subproject='')
+        env.coredata.optstore.set_option(OptionKey('pkg_config_path'), pkg_dir)
 
         # Regression test: This used to modify the value of `pkg_config_path`
         # option, adding the meson-uninstalled directory to it.
@@ -1195,8 +1195,7 @@ class LinuxlikeTests(BasePlatformTests):
 
         env = get_fake_env(testdir, self.builddir, self.prefix)
 
-        env.coredata.set_options({OptionKey('pkg_config_path'): external_pkg_config_path_dir},
-                                 subproject='')
+        env.coredata.optstore.set_option(OptionKey('pkg_config_path'), external_pkg_config_path_dir)
 
         newEnv = PkgConfigInterface.setup_env({}, env, MachineChoice.HOST, uninstalled=True)
 

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -261,7 +261,6 @@ class OptionTests(unittest.TestCase):
         cmd_line = {key: opt_value}
         optstore.initialize_from_top_level_project_call({}, cmd_line, {})
         self.assertEqual(optstore.get_value_object_and_value_for(key.as_build())[1], opt_value)
-        self.assertEqual(optstore.get_value(key.as_build()), opt_value)
         self.assertEqual(optstore.get_value_for(key.as_build()), opt_value)
 
     def test_build_to_host_subproject(self):
@@ -282,8 +281,6 @@ class OptionTests(unittest.TestCase):
         optstore.initialize_from_subproject_call(subp, spcall, {}, {}, {})
         self.assertEqual(optstore.get_value_object_and_value_for(key.evolve(subproject=subp,
                                                                             machine=MachineChoice.BUILD))[1], opt_value)
-        self.assertEqual(optstore.get_value(key.evolve(subproject=subp,
-                                                       machine=MachineChoice.BUILD)), opt_value)
         self.assertEqual(optstore.get_value_for(key.evolve(subproject=subp,
                                                            machine=MachineChoice.BUILD)), opt_value)
 
@@ -306,8 +303,6 @@ class OptionTests(unittest.TestCase):
 
         self.assertEqual(optstore.get_value_object_and_value_for(key)[1], opt_value)
         self.assertEqual(optstore.get_value_object_and_value_for(key.as_build())[1], def_value)
-        self.assertEqual(optstore.get_value(key), opt_value)
-        self.assertEqual(optstore.get_value(key.as_build()), def_value)
         self.assertEqual(optstore.get_value_for(key), opt_value)
         self.assertEqual(optstore.get_value_for(key.as_build()), def_value)
 
@@ -472,7 +467,7 @@ class OptionTests(unittest.TestCase):
                               deprecated={'true': '1'})
         optstore.add_system_option(name, do)
         optstore.set_option(OptionKey(name), True)
-        value = optstore.get_value(name)
+        value = optstore.get_value_for(name)
         self.assertEqual(value, '1')
 
     def test_pending_augment_validation(self):

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -306,11 +306,6 @@ class OptionTests(unittest.TestCase):
         self.assertEqual(optstore.get_value_for(key), opt_value)
         self.assertEqual(optstore.get_value_for(key.as_build()), def_value)
 
-    def test_b_default(self):
-        optstore = OptionStore(False)
-        value = optstore.get_default_for_b_option(OptionKey('b_vscrt'))
-        self.assertEqual(value, 'from_buildtype')
-
     def test_b_nonexistent(self):
         optstore = OptionStore(False)
         self.assertTrue(optstore.accept_as_pending_option(OptionKey('b_ndebug')))


### PR DESCRIPTION
Remove deadcode in coredata.py and options.py after all the options refactoring and cleanup.

Related: #15064 