### PR TITLE
vcstagger: suppress errors when running vcs_tag() outside of a vcs clone (eg. tarball)

### DIFF
--- a/mesonbuild/scripts/vcstagger.py
+++ b/mesonbuild/scripts/vcstagger.py
@@ -8,7 +8,7 @@ import typing as T
 
 def config_vcs_tag(infile: str, outfile: str, fallback: str, source_dir: str, replace_string: str, regex_selector: str, cmd: T.List[str]) -> None:
     try:
-        output = subprocess.check_output(cmd, cwd=source_dir)
+        output = subprocess.check_output(cmd, cwd=source_dir, stderr=subprocess.DEVNULL)
         new_string = re.search(regex_selector, output.decode()).group(1).rstrip('\r\n')
     except Exception:
         new_string = fallback


### PR DESCRIPTION
Instead of printing it out into the terminal, among other meson messages.

This is in response to https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/37706
which wrapped the `git` into a whole multi-line `python` call just to do exactly
what this PR does: not show an irrelevant error when building from a tarball.

/cc @dcbaker @eli-schwartz is this something that would be ok to merge into meson, or was there a reason to print that error in the upstream code, and we should instead work around it inside our project?