### PR TITLE
Workaround typelib generation for vala libraries

### DIFF
--- a/docs/markdown/Vala.md
+++ b/docs/markdown/Vala.md
@@ -341,8 +341,8 @@ To then generate a typelib file use a custom target with the
 
 ```meson
 g_ir_compiler = find_program('g-ir-compiler')
-custom_target('foo typelib', command: [g_ir_compiler, '--output', '@OUTPUT@', '@INPUT@'],
-              input: meson.current_build_dir() / 'Foo-1.0.gir',
+typelib_input = meson.current_build_dir() / 'Foo-1.0.gir'
+custom_target('foo typelib', command: [g_ir_compiler, '--output', '@OUTPUT@', typelib_input],
               output: 'Foo-1.0.typelib',
               depends: foo_lib,
               install: true,


### PR DESCRIPTION
Vala documentation is misleading on generate typelib

This PR tries to offer a working solution meanwhile a better approach is available

relates #2296