### PR TITLE
docs: Add vala_header, vala_vapi, and vala_gir to build_target docs

### DIFF
--- a/docs/yaml/functions/_build_target_base.yaml
+++ b/docs/yaml/functions/_build_target_base.yaml
@@ -328,3 +328,25 @@ kwargs:
 
       This allows renaming similar to the dependency renaming feature of cargo
       or `extern crate foo as bar` inside rust code.
+
+  vala_header:
+    type: str
+    description: |
+      On Vala targets, this provides a way to override the name of the generated
+      C compatible header for targets that generate them.
+
+      If it is not set the default will be calculated from the target's name.
+
+  vala_vapi:
+    type: str
+    description: |
+      On Vala targets, this provides a way to override the name of the generated
+      VAPI file.
+
+      If it is not set the default will be calculated from the target's name.
+
+  vala_gir:
+    type: str
+    description: |
+      If set, generates a GIR file with the given name. If this is unset then
+      no GIR file will be generated.


### PR DESCRIPTION
Which have existed for a *long* time, but are only documented in the Vala docs.