### PR TITLE
fix rustc -l argument on Windows

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2050,14 +2050,8 @@ class NinjaBackend(backends.Backend):
             if rustc.has_verbatim():
                 modifiers.append('+verbatim')
             else:
-                # undo the effects of -l without verbatim
-                badname = not is_library(libname)
-                libname, ext = os.path.splitext(libname)
-                if libname.startswith('lib'):
-                    libname = libname[3:]
-                else:
-                    badname = True
-                if badname:
+                libname = rustc.lib_file_to_l_arg(self.environment, libname)
+                if libname is None:
                     raise MesonException(f"rustc does not implement '-l{type_}:+verbatim'; cannot link to '{orig_libname}' due to nonstandard name")
 
             if modifiers:


### PR DESCRIPTION
On Windows, rustc searches both FOO.lib and libFOO.a when passed -lfoo. This means that the check for nonstandard names is too struct, and indeed it breaks passing for example -lkernel32 (which adds kernel32.lib to the link).

Fix this by special casing Windows.  Extract the logic to the Rust compiler class for clarity.

This fixes a semantic conflict between PRs #14991 and #15024.