### PR TITLE
Avoid running overriden program to get its version

### DIFF
--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -364,9 +364,9 @@ class OverrideProgram(ExternalProgram):
     def __init__(self, name: str, version: str, command: T.Optional[T.List[str]] = None,
                  silent: bool = False, search_dirs: T.Optional[T.List[T.Optional[str]]] = None,
                  exclude_paths: T.Optional[T.List[str]] = None):
-        self.cached_version = version
         super().__init__(name, command=command, silent=silent,
                          search_dirs=search_dirs, exclude_paths=exclude_paths)
+        self.cached_version = version
 
 def find_external_program(env: 'Environment', for_machine: MachineChoice, name: str,
                           display_name: str, default_names: T.List[str],

--- a/test cases/common/182 find override/broken.py
+++ b/test cases/common/182 find override/broken.py
@@ -1,0 +1,3 @@
+#! /usr/bin/env python3
+
+raise SystemExit(1)

--- a/test cases/common/182 find override/meson.build
+++ b/test cases/common/182 find override/meson.build
@@ -1,4 +1,4 @@
-project('find program override', 'c')
+project('find program override', 'c', version: '1.0.0')
 
 gencodegen = find_program('gencodegen', required : false)
 six_prog = find_program('six_meson_exe', required : false)
@@ -29,3 +29,11 @@ assert(six_prog.full_path() == six_prog.path())
 prog = find_program('prog-version.py', 'prog-version', version: '>= 2.0')
 assert(prog.found())
 assert(prog.version() == '2.0')
+
+# Meson should not invoke the script to get its version, it uses current project
+# version.
+script = files('broken.py')
+meson.override_find_program('broken', script)
+prog = find_program('broken', version: '>= 1.0')
+assert(prog.found())
+assert(prog.version() == '1.0.0')


### PR DESCRIPTION
The parent `__init__` was setting cached_version back to None. This fixes a regression caused by
https://github.com/mesonbuild/meson/pull/8885.