### PR TITLE
Add hex error code in meson test failure output

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -221,11 +221,14 @@ def returncode_to_status(retcode: int) -> str:
         return f'exit status {retcode}'
 
     signum = retcode - 128
-    try:
-        signame = signal.Signals(signum).name
-    except ValueError:
-        signame = 'SIGinvalid'
-    return f'(exit status {retcode} or signal {signum} {signame})'
+    if signum < 32:
+        try:
+            signame = signal.Signals(signum).name
+        except ValueError:
+            signame = 'SIGinvalid'
+        return f'(exit status {retcode} or signal {signum} {signame})'
+
+    return f'(exit status {retcode} or {hex(retcode)})'
 
 # TODO for Windows
 sh_quote: T.Callable[[str], str] = lambda x: x


### PR DESCRIPTION
On windows, the exit status can be hex code like 0xc0000005. But meson test shows it as decimal number and a signal number that does not make sense.
```
1/1 segv        FAIL            0.05s   (exit status 3221225477 or signal 3221225349 SIGinvalid)
>>> UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 MALLOC_PERTURB_=128 ASAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1 MESON_TEST_ITERATION=1 MSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 B:\tmp\segv\build\segv.exe
```

With this PR, if the exit status >= 128 + 32 (since signal must be 0-31 on POSIX), it shows exit status in hexadecimal instead of SIGinvalid.
```
1/1 segv        FAIL            0.01s   (exit status 3221225477 or 0xc0000005)
```