### PR TITLE
Allow building the same crate for both machines

### DIFF
--- a/docs/markdown/Rust.md
+++ b/docs/markdown/Rust.md
@@ -98,3 +98,11 @@ target is a proc macro or dylib, or it depends on a dylib, in which case [`-C
 prefer-dynamic`](https://doc.rust-lang.org/rustc/codegen-options/index.html#prefer-dynamic)
 will be passed to the Rust compiler, and the standard libraries will be
 dynamically linked.
+
+## Multiple targets for the same crate name
+
+For library targets that have `rust_abi: 'rust'`, the crate name is derived from the
+target name.  First, dashes, spaces and dots are replaced with underscores.  Second,
+*since 1.10.0* anything after the first `+` is dropped.  This allows creating multiple
+targets for the same crate name, for example when the same crate is built multiple
+times with different features, or for both the build and the host machine.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1949,8 +1949,9 @@ class NinjaBackend(backends.Backend):
     @staticmethod
     def _get_rust_crate_name(target_name: str) -> str:
         # Rustc replaces - with _. spaces or dots are not allowed, so we replace them with underscores
+        # Also +SUFFIX is dropped, which can be used to distinguish host from build crates
         crate_name = target_name.replace('-', '_').replace(' ', '_').replace('.', '_')
-        return crate_name
+        return crate_name.split('+', 1)[0]
 
     @staticmethod
     def _get_rust_dependency_name(target: build.BuildTarget, dependency: LibTypes) -> str:

--- a/test cases/rust/30 both machines/lib.rs
+++ b/test cases/rust/30 both machines/lib.rs
@@ -1,0 +1,3 @@
+pub fn answer() -> u32 {
+    42
+}

--- a/test cases/rust/30 both machines/meson.build
+++ b/test cases/rust/30 both machines/meson.build
@@ -1,0 +1,36 @@
+project(
+  'testproj',
+  'rust',
+  version : '0.1',
+  meson_version : '>= 1.9.0',
+  default_options : ['rust_std=2021'],
+)
+
+lib_host = static_library(
+  'lib',
+  'lib.rs',
+  rust_abi: 'rust'
+)
+
+lib_build = static_library(
+  'lib+build',
+  'lib.rs',
+  rust_abi: 'rust',
+  native: true,
+)
+
+exe_host = executable(
+  'test-host',
+  'test.rs',
+  link_with: lib_host,
+)
+
+exe_build = executable(
+  'test-build',
+  'test.rs',
+  link_with: lib_build,
+  native: true,
+)
+
+test('host', exe_host)
+test('build', exe_build)

--- a/test cases/rust/30 both machines/test.rs
+++ b/test cases/rust/30 both machines/test.rs
@@ -1,0 +1,5 @@
+use lib::answer;
+
+fn main() {
+    println!("The answer is {}.\n", answer());
+}


### PR DESCRIPTION
As a first step towards full support for cross compilation of Cargo subprojects, allow building the same crate for both the host and the build machine.

Right now the crate name must match the file name, but that means that the same file name is used for host and build rlibs. To allow that, drop anything after a `+` sign from the crate name. This convention is already in use, for example Fedora uses it to denote the features that packages support (e.g. `rust-$crate+$feature-devel`), so it makes sense for Meson to use it instead of reinventing something else.

Other than for cross compilation, this is also useful in some cases where the same crate can be compiled with multiple configurations. Using the "+SUFFIX" syntax avoids having to use a dependency map.

Extracted from #14952.