### PR TITLE
pkgconfig: Improve handling of empty string deps

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -150,6 +150,8 @@ class DependenciesHelper:
                     self.add_version_reqs(obj.name, obj.version_reqs)
             elif isinstance(obj, str):
                 name, version_req = self.split_version_req(obj)
+                if name is None:
+                    continue
                 processed_reqs.append(name)
                 self.add_version_reqs(name, [version_req] if version_req is not None else None)
             elif isinstance(obj, dependencies.Dependency) and not obj.found():
@@ -298,10 +300,11 @@ class DependenciesHelper:
             # foo, bar' is ok, but 'foo,bar' is not.
             self.version_reqs[name].update(version_reqs)
 
-    def split_version_req(self, s: str) -> T.Tuple[str, T.Optional[str]]:
+    def split_version_req(self, s: str) -> T.Tuple[T.Optional[str], T.Optional[str]]:
         stripped_str = s.strip()
         if not stripped_str:
-            raise mesonlib.MesonException(f'required dependency must not be empty, "{s}" was provided.')
+            mlog.warning('Required dependency was found to be an empty string. Did you mean to pass an empty array?')
+            return None, None
         for op in ['>=', '<=', '!=', '==', '=', '>', '<']:
             pos = stripped_str.find(op)
             if pos < 0:

--- a/test cases/common/44 pkgconfig-gen/meson.build
+++ b/test cases/common/44 pkgconfig-gen/meson.build
@@ -193,3 +193,11 @@ simple7 = library('simple7', include_directories: 'inc1')
 dep = declare_dependency(include_directories: 'inc2')
 install_headers('inc1/inc1.h', 'inc2/inc2.h')
 pkgg.generate(simple7, libraries: dep)
+
+# Regression test: empty string passed to requires.private should not
+# fail the build
+pkgg.generate(
+  name : 'emptytest',
+  description : 'Check that requires.private can be an empty string',
+  requires_private: '',
+)

--- a/test cases/common/44 pkgconfig-gen/test.json
+++ b/test cases/common/44 pkgconfig-gen/test.json
@@ -16,6 +16,7 @@
     {"type": "file", "file": "usr/lib/pkgconfig/simple5.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/simple6.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/simple7.pc"},
+    {"type": "file", "file": "usr/lib/pkgconfig/emptytest.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/ct.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/ct0.pc"},
     {"type": "file", "file": "usr/share/pkgconfig/libhello_nolib.pc"}


### PR DESCRIPTION
Fix the original bug fix for #13950 to only warn about empty required strings, instead of failing the entire build. This will simplify the workflow for users that build the string from a possibly empty list, and save them the need for the added if-check.