### PR TITLE
Add C23 and C2Y supported c_std versions for Apple compilers.

### DIFF
--- a/mesonbuild/compilers/mixins/apple.py
+++ b/mesonbuild/compilers/mixins/apple.py
@@ -67,7 +67,9 @@ class AppleCStdsMixin(Compiler):
 
     _C17_VERSION = '>=10.0.0'
     _C18_VERSION = '>=11.0.0'
-    _C2X_VERSION = '>=11.0.0'
+    _C2X_VERSION = '>=11.0.3'
+    _C23_VERSION = '>=17.0.0'
+    _C2Y_VERSION = '>=17.0.0'
 
 
 class AppleCPPStdsMixin(Compiler):


### PR DESCRIPTION
Xcode 16.3 upgraded Apple Clang to LLVM 19.1, adding support for C23 and C2Y.

This causes a [build failure](https://gitlab.gnome.org/GNOME/glib/-/issues/3799) on GNOME's glib so prompt action would be appreciated.