### PR TITLE
Update Azure image from win2019 to win2022

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,28 +54,28 @@ variables:
 
 jobs:
 
-- job: vs2019
+- job: vs2022
   timeoutInMinutes: 120
   pool:
-    vmImage: windows-2019
+    vmImage: windows-2022
 
   strategy:
     matrix:
-        vc2019x64ninja:
+        vc2022x64ninja:
           arch: x64
-          compiler: msvc2019
+          compiler: msvc2022
           backend: ninja
           ifort: true
-        vc2019x64vs:
+        vc2022x64vs:
           arch: x64
-          compiler: msvc2019
-          backend: vs2019
+          compiler: msvc2022
+          backend: vs2022
           # mysteriously, several tests fail because vs cannot find
           # executables such as cmd.exe ???
           ifort: false
-        vc2019arm64ninjacross:
+        vc2022arm64ninjacross:
           arch: arm64
-          compiler: msvc2019
+          compiler: msvc2022
           backend: ninja
           extraargs: --cross arm64cl.txt --cross-only
           # ifort doesn't support arm64
@@ -105,7 +105,7 @@ jobs:
     displayName: insert ifort into environment
     inputs:
       filename: ci/intel-scripts/activate_windows.bat
-      arguments: vs2019
+      arguments: vs2022
       modifyEnvironment: True
     condition: eq(variables.ifort, 'true')
   - task: PowerShell@2

--- a/ci/run.ps1
+++ b/ci/run.ps1
@@ -49,7 +49,7 @@ function DownloadFile([String] $Source, [String] $Destination) {
 
 if (($env:backend -eq 'ninja') -and ($env:arch -ne 'arm64')) { $dmd = $true } else { $dmd = $false }
 
-DownloadFile -Source https://github.com/mesonbuild/cidata/releases/download/ci5/ci_data.zip -Destination $env:AGENT_WORKFOLDER\ci_data.zip
+DownloadFile -Source https://github.com/mesonbuild/cidata/releases/download/ci7/ci_data.zip -Destination $env:AGENT_WORKFOLDER\ci_data.zip
 echo "Extracting ci_data.zip"
 Expand-Archive $env:AGENT_WORKFOLDER\ci_data.zip -DestinationPath $env:AGENT_WORKFOLDER\ci_data
 & "$env:AGENT_WORKFOLDER\ci_data\install.ps1" -Arch $env:arch -Compiler $env:compiler -Boost $true -DMD $dmd


### PR DESCRIPTION
The 2019 one is deprecated and will be removed.

https://github.com/actions/runner-images/issues/12045