### PR TITLE
Use a base class for the ASM Compilers, again

### DIFF
--- a/mesonbuild/compilers/asm.py
+++ b/mesonbuild/compilers/asm.py
@@ -11,10 +11,10 @@ from .mixins.metrowerks import MetrowerksCompiler, mwasmarm_instruction_set_args
 from .mixins.ti import TICompiler
 
 if T.TYPE_CHECKING:
-    from ..environment import Environment
     from ..linkers.linkers import DynamicLinker
     from ..mesonlib import MachineChoice
     from ..envconfig import MachineInfo
+    from ..environment import Environment
 
 nasm_optimization_args: T.Dict[str, T.List[str]] = {
     'plain': [],
@@ -31,6 +31,19 @@ class ASMCompiler(Compiler):
 
     """Shared base class for all ASM Compilers (Assemblers)"""
 
+    _SUPPORTED_ARCHES: T.Set[str] = set()
+
+    def __init__(self, ccache: T.List[str], exelist: T.List[str], version: str,
+                 for_machine: MachineChoice, info: MachineInfo,
+                 linker: T.Optional[DynamicLinker] = None,
+                 full_version: T.Optional[str] = None, is_cross: bool = False):
+        if self._SUPPORTED_ARCHES and info.cpu_family not in self._SUPPORTED_ARCHES:
+            raise EnvironmentException(f'ASM Compiler {self.id} does not support building for {info.cpu_family} CPU family.')
+        super().__init__(ccache, exelist, version, for_machine, info, linker, full_version, is_cross)
+
+    def sanity_check(self, work_dir: str, environment: Environment) -> None:
+        return None
+
 
 class NasmCompiler(ASMCompiler):
     language = 'nasm'
@@ -44,6 +57,8 @@ class NasmCompiler(ASMCompiler):
         'mt': ['/DEFAULTLIB:libucrt.lib', '/DEFAULTLIB:libvcruntime.lib', '/DEFAULTLIB:libcmt.lib'],
         'mtd': ['/DEFAULTLIB:libucrtd.lib', '/DEFAULTLIB:libvcruntimed.lib', '/DEFAULTLIB:libcmtd.lib'],
     }
+
+    _SUPPORTED_ARCHES = {'x86', 'x86_64'}
 
     def __init__(self, ccache: T.List[str], exelist: T.List[str], version: str,
                  for_machine: 'MachineChoice', info: 'MachineInfo',
@@ -99,10 +114,6 @@ class NasmCompiler(ASMCompiler):
 
     def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
         return ['-MD', outfile, '-MQ', outtarget]
-
-    def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
-        if self.info.cpu_family not in {'x86', 'x86_64'}:
-            raise EnvironmentException(f'ASM compiler {self.id!r} does not support {self.info.cpu_family} CPU family')
 
     def get_pic_args(self) -> T.List[str]:
         return []
@@ -160,6 +171,8 @@ class MasmCompiler(ASMCompiler):
     language = 'masm'
     id = 'ml'
 
+    _SUPPORTED_ARCHES = {'x86', 'x86_64'}
+
     def get_compile_only_args(self) -> T.List[str]:
         return ['/c']
 
@@ -187,10 +200,6 @@ class MasmCompiler(ASMCompiler):
             return ['/Zi']
         return []
 
-    def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
-        if self.info.cpu_family not in {'x86', 'x86_64'}:
-            raise EnvironmentException(f'ASM compiler {self.id!r} does not support {self.info.cpu_family} CPU family')
-
     def get_pic_args(self) -> T.List[str]:
         return []
 
@@ -217,6 +226,7 @@ class MasmCompiler(ASMCompiler):
 class MasmARMCompiler(ASMCompiler):
     language = 'masm'
     id = 'armasm'
+    _SUPPORTED_ARCHES = {'arm', 'aarch64'}
 
     def needs_static_linker(self) -> bool:
         return True
@@ -237,10 +247,6 @@ class MasmARMCompiler(ASMCompiler):
         if is_debug:
             return ['-g']
         return []
-
-    def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
-        if self.info.cpu_family not in {'arm', 'aarch64'}:
-            raise EnvironmentException(f'ASM compiler {self.id!r} does not support {self.info.cpu_family} CPU family')
 
     def get_pic_args(self) -> T.List[str]:
         return []
@@ -267,6 +273,7 @@ class MasmARMCompiler(ASMCompiler):
 # https://downloads.ti.com/docs/esd/SPRUI04/
 class TILinearAsmCompiler(TICompiler, ASMCompiler):
     language = 'linearasm'
+    _SUPPORTED_ARCHES = {'c6000'}
 
     def __init__(self, ccache: T.List[str], exelist: T.List[str], version: str,
                  for_machine: MachineChoice, info: MachineInfo,
@@ -283,10 +290,6 @@ class TILinearAsmCompiler(TICompiler, ASMCompiler):
 
     def get_crt_compile_args(self, crt_val: str, buildtype: str) -> T.List[str]:
         return []
-
-    def sanity_check(self, work_dir: str, environment: Environment) -> None:
-        if self.info.cpu_family not in {'c6000'}:
-            raise EnvironmentException(f'TI Linear ASM compiler {self.id!r} does not support {self.info.cpu_family} CPU family')
 
     def get_depfile_suffix(self) -> str:
         return 'd'
@@ -325,21 +328,15 @@ class MetrowerksAsmCompiler(MetrowerksCompiler, ASMCompiler):
 
 class MetrowerksAsmCompilerARM(MetrowerksAsmCompiler):
     id = 'mwasmarm'
+    _SUPPORTED_ARCHES = {'arm'}
 
     def get_instruction_set_args(self, instruction_set: str) -> T.Optional[T.List[str]]:
         return mwasmarm_instruction_set_args.get(instruction_set, None)
 
-    def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
-        if self.info.cpu_family not in {'arm'}:
-            raise EnvironmentException(f'ASM compiler {self.id!r} does not support {self.info.cpu_family} CPU family')
-
 
 class MetrowerksAsmCompilerEmbeddedPowerPC(MetrowerksAsmCompiler):
     id = 'mwasmeppc'
+    _SUPPORTED_ARCHES = {'ppc'}
 
     def get_instruction_set_args(self, instruction_set: str) -> T.Optional[T.List[str]]:
         return mwasmeppc_instruction_set_args.get(instruction_set, None)
-
-    def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
-        if self.info.cpu_family not in {'ppc'}:
-            raise EnvironmentException(f'ASM compiler {self.id!r} does not support {self.info.cpu_family} CPU family')

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -23,6 +23,7 @@ import typing as T
 
 if T.TYPE_CHECKING:
     from .compilers import Compiler
+    from .asm import ASMCompiler
     from .c import CCompiler
     from .cpp import CPPCompiler
     from .fortran import FortranCompiler
@@ -1334,6 +1335,7 @@ def detect_nasm_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
             continue
 
         version = search_version(output)
+        comp_class: T.Type[ASMCompiler]
         if 'NASM' in output:
             comp_class = NasmCompiler
             env.add_lang_args(comp_class.language, comp_class, for_machine)
@@ -1366,7 +1368,7 @@ def detect_masm_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
         info = env.machines[for_machine]
 
     from .asm import MasmCompiler, MasmARMCompiler
-    comp_class: T.Type[Compiler]
+    comp_class: T.Type[ASMCompiler]
     if info.cpu_family == 'x86':
         comp = ['ml']
         comp_class = MasmCompiler
@@ -1400,7 +1402,7 @@ def detect_masm_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
 def detect_linearasm_compiler(env: Environment, for_machine: MachineChoice) -> Compiler:
     from .asm import TILinearAsmCompiler
     comp = ['cl6x']
-    comp_class: T.Type[Compiler] = TILinearAsmCompiler
+    comp_class: T.Type[ASMCompiler] = TILinearAsmCompiler
     arg = '-h'
     info = env.machines[for_machine]
     cc = detect_c_compiler(env, for_machine)


### PR DESCRIPTION
This was previously reverted due to regressions, but should now be cleaned up and ready for merge.