### PR TITLE
rust: work around unintuitive behavior of -l:-bundle

### DIFF
--- a/test cases/rust/29 rlib link subdir/cdep/f.c
+++ b/test cases/rust/29 rlib link subdir/cdep/f.c
@@ -1,0 +1,1 @@
+int f() { return 42; }

--- a/test cases/rust/29 rlib link subdir/cdep/meson.build
+++ b/test cases/rust/29 rlib link subdir/cdep/meson.build
@@ -1,0 +1,1 @@
+cdep = static_library('f', 'f.c')

--- a/test cases/rust/29 rlib link subdir/f-sys.rs
+++ b/test cases/rust/29 rlib link subdir/f-sys.rs
@@ -1,0 +1,3 @@
+extern "C" {
+    pub fn f() -> ::std::os::raw::c_int;
+}

--- a/test cases/rust/29 rlib link subdir/main.rs
+++ b/test cases/rust/29 rlib link subdir/main.rs
@@ -1,0 +1,1 @@
+fn main() { assert_eq!(unsafe { ::f_sys::f() }, 42); }

--- a/test cases/rust/29 rlib link subdir/meson.build
+++ b/test cases/rust/29 rlib link subdir/meson.build
@@ -1,0 +1,21 @@
+project(
+  'rlib-link-subdir',
+  ['c', 'rust'],
+  default_options: ['rust_std=2021']
+)
+
+subdir('cdep')
+f_sys = static_library(
+  'f_sys',
+  'f-sys.rs',
+  link_with: cdep,
+  rust_abi: 'rust',
+)
+
+exe = executable(
+  'main',
+  'main.rs',
+  link_with: f_sys,
+)
+
+test('basic', exe)


### PR DESCRIPTION
When a Rust target depends on an intermediate Rust library (.rlib) which itself has a dependency on a native static library, Meson's generated rustc command line failed to collect and propagate the search paths for these indirect native dependencies, leading to a linker error:

error: linking with `cc` failed: exit status: 1
  = note: rust-lld: error: unable to find library -l:libf.a
          collect2: error: ld returned 1 exit status

The root cause is that the intermediate .rlib's metadata correctly stores the requirement to link the native library (via the -l flag), but it does not store the library's search path (the -L flag); the responsibility for providing the search path is therefore deferred to the final link command.

Ensures that search paths for all transitive dependencies are collected, allowing the final linker invocation to find and correctly link the required native libraries.

Cc @nertpinx