### PR TITLE
cargo: fix proc-macro=true without crate_type

### DIFF
--- a/mesonbuild/cargo/manifest.py
+++ b/mesonbuild/cargo/manifest.py
@@ -357,7 +357,7 @@ class Library(BuildTarget):
                                  path=DefaultValue('src/lib.rs'),
                                  edition=DefaultValue(pkg.edition),
                                  crate_type=ConvertValue(lambda x: ['proc-macro'] if proc_macro else x,
-                                                         ['lib']))
+                                                         ['proc-macro'] if proc_macro else ['lib']))
 
 
 @dataclasses.dataclass

--- a/unittests/cargotests.py
+++ b/unittests/cargotests.py
@@ -499,6 +499,12 @@ class CargoTomlTest(unittest.TestCase):
         self.assertEqual(manifest.lib.crate_type, ['proc-macro'])
         self.assertEqual(manifest.lib.path, 'src/lib.rs')
 
+        del manifest_toml['lib']['crate-type']
+        manifest = Manifest.from_raw(manifest_toml, 'Cargo.toml')
+        self.assertEqual(manifest.lib.name, 'bits')
+        self.assertEqual(manifest.lib.crate_type, ['proc-macro'])
+        self.assertEqual(manifest.lib.path, 'src/lib.rs')
+
     def test_cargo_toml_targets(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             fname = os.path.join(tmpdir, 'Cargo.toml')


### PR DESCRIPTION
The default value is not passed further through the converter, therefore it must take proc-macro into account.

Apologies for the breakage, I have now expanded the testcase to cover both cases.