### PR TITLE
Switch C# test to use gtk-sharp-3

### DIFF
--- a/ci/ciimage/arch/install.sh
+++ b/ci/ciimage/arch/install.sh
@@ -12,7 +12,7 @@ pkgs=(
   libelf gcc gcc-fortran gcc-objc vala rust bison flex cython go dlang-dmd
   mono boost qt5-base gtkmm3 gtest gmock protobuf gobject-introspection
   itstool glib2-devel gtk3 java-environment=8 gtk-doc llvm clang sdl2 graphviz
-  doxygen vulkan-headers vulkan-icd-loader vulkan-validation-layers openssh mercurial gtk-sharp-2 qt5-tools
+  doxygen vulkan-headers vulkan-icd-loader vulkan-validation-layers openssh mercurial gtk-sharp-3 qt5-tools
   libwmf cmake netcdf-fortran openmpi nasm gnustep-base gettext
   python-lxml hotdoc rust-bindgen qt6-base qt6-tools qt6-declarative wayland wayland-protocols
   intel-oneapi-mkl

--- a/ci/ciimage/fedora/install.sh
+++ b/ci/ciimage/fedora/install.sh
@@ -12,7 +12,7 @@ pkgs=(
   boost-python3-devel
   itstool gtk3-devel java-latest-openjdk-devel gtk-doc llvm-devel clang-devel SDL2-devel graphviz-devel zlib zlib-devel zlib-static
   #hdf5-openmpi-devel hdf5-devel netcdf-openmpi-devel netcdf-devel netcdf-fortran-openmpi-devel netcdf-fortran-devel scalapack-openmpi-devel
-  doxygen vulkan-devel vulkan-validation-layers-devel openssh lksctp-tools-devel objfw mercurial gtk-sharp2-devel libpcap-devel gpgme-devel
+  doxygen vulkan-devel vulkan-validation-layers-devel openssh lksctp-tools-devel objfw mercurial gtk-sharp3-devel libpcap-devel gpgme-devel
   qt5-qtbase-devel qt5-qttools-devel qt5-linguist qt5-qtbase-private-devel
   qt6-qtdeclarative-devel qt6-qtbase-devel qt6-qttools-devel qt6-linguist qt6-qtbase-private-devel
   libwmf-devel valgrind cmake openmpi-devel nasm gnustep-base-devel gettext-devel ncurses-devel

--- a/test cases/csharp/4 external dep/meson.build
+++ b/test cases/csharp/4 external dep/meson.build
@@ -1,9 +1,9 @@
 project('C# external library', 'cs')
-glib_sharp_2 = dependency('glib-sharp-2.0', required : false)
+glib_sharp_3 = dependency('glib-sharp-3.0', required : false)
 
-if not glib_sharp_2.found()
+if not glib_sharp_3.found()
   error('MESON_SKIP_TEST glib# not found.')
 endif
 
-e = executable('prog', 'prog.cs', dependencies: glib_sharp_2, install : true)
+e = executable('prog', 'prog.cs', dependencies: glib_sharp_3, install : true)
 test('libtest', e, args: [join_paths(meson.current_source_dir(), 'hello.txt')])


### PR DESCRIPTION
On Arch Linux, we are in the process to remove GTK2 from the repositories, so `gtk-sharp-2` package will be no longer available. The test runs fine with `glib-sharp-3.0` without further changes.