### PR TITLE
vala: Remove space from --target-glib version

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -998,7 +998,7 @@ class Backend:
                         if dep.version_reqs is not None:
                             for req in dep.version_reqs:
                                 if req.startswith(('>=', '==')):
-                                    commands += ['--target-glib', req[2:]]
+                                    commands += ['--target-glib', req[2:].strip()]
                                     break
                     elif isinstance(dep, dependencies.InternalDependency) and dep.version is not None:
                         glib_version = dep.version.split('.')


### PR DESCRIPTION
If the dependency version contains a space:
dependency('glib-2.0', version: '>= 2.40.0')

Then the --target-glib version has a space:
--target-glib ' 2.40.0'