### PR TITLE
ninja: Fix multiline arguments

### DIFF
--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -611,8 +611,7 @@ class Interpreter:
             'CARGO_PKG_VERSION_PRE': version_arr[3],
             'CARGO_PKG_AUTHORS': ','.join(pkg.manifest.package.authors),
             'CARGO_PKG_NAME': pkg.manifest.package.name,
-            # FIXME: description can contain newlines which breaks ninja.
-            #'CARGO_PKG_DESCRIPTION': pkg.manifest.package.description or '',
+            'CARGO_PKG_DESCRIPTION': pkg.manifest.package.description or '',
             'CARGO_PKG_HOMEPAGE': pkg.manifest.package.homepage or '',
             'CARGO_PKG_REPOSITORY': pkg.manifest.package.repository or '',
             'CARGO_PKG_LICENSE': pkg.manifest.package.license or '',

--- a/test cases/common/27 multiline string/meson.build
+++ b/test cases/common/27 multiline string/meson.build
@@ -35,3 +35,17 @@ int main(void) {
 }'''
 
 assert(cc.compiles(prog), 'multiline test compile failed')
+
+# Test we can pass multiline strings as compiler arguments.
+if not get_option('backend').startswith('vs')
+  helloworld = '''
+Hello
+World
+'''
+  exe = executable('multiline', 'multiline.c',
+    c_args: ['-DHELLO_WORLD_STRING="' + helloworld + '"']
+  )
+  if not meson.is_cross_build()
+    test('multiline run', files('test_multiline.py'), args: [exe])
+  endif
+endif

--- a/test cases/common/27 multiline string/multiline.c
+++ b/test cases/common/27 multiline string/multiline.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+int main(void)
+{
+    printf("%s", HELLO_WORLD_STRING);
+    return 0;
+}

--- a/test cases/common/27 multiline string/test_multiline.py
+++ b/test cases/common/27 multiline string/test_multiline.py
@@ -1,0 +1,11 @@
+#! /usr/bin/env python3
+
+import sys
+import subprocess
+
+output = subprocess.check_output(sys.argv[1:], universal_newlines=True, encoding='utf-8')
+
+assert output == '''
+Hello
+World
+'''


### PR DESCRIPTION
When using a custom_target() and an argument contains a newline, the command gets wrapped and written into a pickle file. However, when it's a compiler argument, the ninja backend was raising an error.