### PR TITLE
mdist: fix failure to create tar files the user asked to create

### DIFF
--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -41,6 +41,9 @@ archive_extension = {'bztar': '.tar.bz2',
                      'xztar': '.tar.xz',
                      'zip': '.zip'}
 
+if sys.version_info >= (3, 14):
+    tarfile.TarFile.extraction_filter = staticmethod(tarfile.fully_trusted_filter)
+
 # Note: when adding arguments, please also add them to the completion
 # scripts in $MESONSRC/data/shell-completions/
 def add_arguments(parser: argparse.ArgumentParser) -> None:

--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, InitVar
-import os, subprocess
+import sys, os, subprocess
 import argparse
 import asyncio
 import fnmatch
@@ -60,6 +60,9 @@ if T.TYPE_CHECKING:
         save: bool
 
 ALL_TYPES_STRING = ', '.join(ALL_TYPES)
+
+if sys.version_info >= (3, 14):
+    tarfile.TarFile.extraction_filter = staticmethod(tarfile.fully_trusted_filter)
 
 def read_archive_files(path: Path, base_path: Path) -> T.Set[Path]:
     if path.suffix == '.zip':

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -57,6 +57,10 @@ WHITELIST_SUBDOMAIN = 'wrapdb.mesonbuild.com'
 
 ALL_TYPES = ['file', 'git', 'hg', 'svn', 'redirect']
 
+if sys.version_info >= (3, 14):
+    import tarfile
+    tarfile.TarFile.extraction_filter = tarfile.fully_trusted_filter
+
 if mesonlib.is_windows():
     from ..programs import ExternalProgram
     from ..mesonlib import version_compare


### PR DESCRIPTION
Python added a "feature" to assume tarfile extraction is meant solely for "data", i.e. it ignores many useful features of tar such as symlinks, ownership, or permission modes that are uncommon on Windows. Revert this entirely, as Meson is a "fully trusted" application. It can already execute arbitrary programs, tar files are not vulnerabilities.

In theory "tar" mode exists and is not "data", but we are fully trusted so why split hairs?

Fixes: https://github.com/mesonbuild/meson/issues/15142