### PR TITLE
Add ifx to list of default Fortran compilers on Windows

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -48,7 +48,7 @@ if is_windows():
     # There is currently no pgc++ for Windows, only for  Mac and Linux.
     defaults['cpp'] = ['icl', 'cl', 'c++', 'g++', 'clang++', 'clang-cl']
     # the binary flang-new will be renamed to flang in the foreseeable future
-    defaults['fortran'] = ['ifort', 'gfortran', 'flang-new', 'flang', 'pgfortran', 'g95']
+    defaults['fortran'] = ['ifort', 'ifx', 'gfortran', 'flang-new', 'flang', 'pgfortran', 'g95']
     defaults['objc'] = ['clang', 'clang-cl', 'gcc']
     defaults['objcpp'] = ['clang++', 'clang-cl', 'g++']
     defaults['cs'] = ['csc', 'mcs']


### PR DESCRIPTION
Intel's oneAPI installation, as of 2025.3, no longer provides the classic ifort compiler, only the newer llvm-based ifx compiler.

Simply adding ifx to the list of defaults allowed me to compile a legacy project that used to be built with ifort, with no other changes. If any further testing is required for this change I'm happy to contribute, but I'm new to both meson and Fortran so I would need some guidance.