### PR TITLE
interpreter: Move validation of BuildTarget(extra_files) to Interpreter

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1296,17 +1296,7 @@ class BuildTarget(Target):
                                         (str, bool))
         self.install_mode = kwargs.get('install_mode', None)
         self.install_tag = stringlistify(kwargs.get('install_tag', [None]))
-        extra_files = kwargs.get('extra_files', [])
-        for i in extra_files:
-            # TODO: use an OrderedSet instead of a list?
-            if i in self.extra_files:
-                continue
-            # TODO: this prevents built `File` objects from being used as
-            # extra_files.
-            trial = os.path.join(self.environment.get_source_dir(), i.subdir, i.fname)
-            if not os.path.isfile(trial):
-                raise InvalidArguments(f'Tried to add non-existing extra file {i}.')
-            self.extra_files.append(i)
+        self.extra_files = kwargs.get('extra_files', [])
         self.install_rpath: str = kwargs.get('install_rpath', '')
         self.build_rpath = kwargs.get('build_rpath', '')
         self.resources = kwargs.get('resources', [])

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3405,7 +3405,8 @@ class Interpreter(InterpreterBase, HoldableObject):
         sources = self.source_strings_to_files(sources)
         objs = kwargs['objects']
         kwargs['dependencies'] = extract_as_list(kwargs, 'dependencies')
-        kwargs['extra_files'] = self.source_strings_to_files(kwargs['extra_files'])
+        # TODO: When we can do strings -> Files in the typed_kwargs validator, do this there too
+        kwargs['extra_files'] = mesonlib.unique_list(self.source_strings_to_files(kwargs['extra_files']))
         self.check_sources_exist(os.path.join(self.source_root, self.subdir), sources)
         if targetclass not in {build.Executable, build.SharedLibrary, build.SharedModule, build.StaticLibrary, build.Jar}:
             mlog.debug('Unknown target type:', str(targetclass))

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -588,11 +588,24 @@ def _target_install_convertor(val: object) -> bool:
     return bool(val)
 
 
+def _extra_files_validator(args: T.List[T.Union[File, str]]) -> T.Optional[str]:
+    generated = [a for a in args if isinstance(a, File) and a.is_built]
+    if generated:
+        return 'extra_files contains generated files: {}'.format(', '.join(f"{f.fname}" for f in generated))
+    return None
+
+
 # Applies to all build_target like classes
 _ALL_TARGET_KWS: T.List[KwargInfo] = [
     OVERRIDE_OPTIONS_KW,
     KwargInfo('build_by_default', bool, default=True, since='0.38.0'),
-    KwargInfo('extra_files', ContainerTypeInfo(list, (str, File)), default=[], listify=True),
+    KwargInfo(
+        'extra_files',
+        ContainerTypeInfo(list, (str, File)),
+        default=[],
+        listify=True,
+        validator=_extra_files_validator,
+    ),
     KwargInfo(
         'install',
         object,


### PR DESCRIPTION
This gets us to the point that the build layer can assume it's getting valid inputs.