### PR TITLE
test: ensure CustomTargetIndexes are rebuilt by "meson test" with no arguments

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3961,11 +3961,11 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
 
     def generate_ending(self) -> None:
         for targ, deps in [
-                ('all', self.get_build_by_default_targets()),
+                ('all', self.get_build_by_default_targets().values()),
                 ('meson-test-prereq', self.get_testlike_targets()),
                 ('meson-benchmark-prereq', self.get_testlike_targets(True))]:
             targetlist = []
-            for t in deps.values():
+            for t in deps:
                 # Add the first output of each target to the 'all' target so that
                 # they are all built
                 #Add archive file if shared library in AIX for build all.

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -416,7 +416,8 @@ class Vs2010Backend(backends.Backend):
 
     def generate_solution(self, sln_filename: str, projlist: T.List[Project]) -> None:
         default_projlist = self.get_build_by_default_targets()
-        default_projlist.update(self.get_testlike_targets())
+        for t in self.get_testlike_targets():
+            default_projlist[t.get_id()] = t
         sln_filename_tmp = sln_filename + '~'
         # Note using the utf-8 BOM requires the blank line, otherwise Visual Studio Version Selector fails.
         # Without the BOM, VSVS fails if there is a blank line.

--- a/test cases/unit/131 custom target index test/meson.build
+++ b/test cases/unit/131 custom target index test/meson.build
@@ -1,0 +1,16 @@
+# testcase by blue42u
+project('test')
+python3 = find_program('python3')
+
+gen_code = '''
+import sys, pathlib
+pathlib.Path(sys.argv[1]).write_text("foo")
+pathlib.Path(sys.argv[2]).write_text("bar")'''
+foobar_txt = custom_target(command: [python3, '-c', gen_code, '@OUTPUT@'], output: ['foo.txt', 'bar.txt'])
+
+test_code = '''
+import sys, pathlib
+sys.exit(0 if pathlib.Path(sys.argv[1]).read_text() == sys.argv[2] else 4)'''
+
+test('foo.txt', python3, args: ['-c', test_code, foobar_txt[0], 'foo'])
+test('bar.txt', python3, args: ['-c', test_code, foobar_txt[1], 'bar'])

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -4471,6 +4471,14 @@ class AllPlatformTests(BasePlatformTests):
         self.build()
         self.run_tests()
 
+    def test_custom_target_index_as_test_prereq(self):
+        if self.backend is not Backend.ninja:
+            raise SkipTest('ninja backend needed for "meson test" to build test dependencies')
+
+        testdir = os.path.join(self.unit_test_dir, '131 custom target index test')
+        self.init(testdir)
+        self.run_tests()
+
     @skipUnless(is_linux() and (re.search('^i.86$|^x86$|^x64$|^x86_64$|^amd64$', platform.processor()) is not None),
         'Requires ASM compiler for x86 or x86_64 platform currently only available on Linux CI runners')
     def test_nostdlib(self):


### PR DESCRIPTION
If a CustomTargetIndex is passed as an argument to a test, running meson test (with no test glob) does not automatically build the custom_target before running the test, because CustomTargetIndex outputs are not added as prerequisites to the meson-test-prereq and meson-benchmark-prereq targets.

Fixes: #14743