### PR TITLE
Fix: Add OpenMP 6.0 macro definition to implementation table

### DIFF
--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -99,6 +99,7 @@ class DlSystemDependency(SystemDependency):
 class OpenMPDependency(SystemDependency):
     # Map date of specification release (which is the macro value) to a version.
     VERSIONS = {
+        '202411': '6.0',
         '202111': '5.2',
         '202011': '5.1',
         '201811': '5.0',


### PR DESCRIPTION
This PR resolves issue #15182 by verifying the _OPENMP macro value for OpenMP 6.0 and updating the implementation table accordingly.