### PR TITLE
Fix Boost modules with libraries

### DIFF
--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -439,8 +439,6 @@ class BoostDependency(SystemDependency):
         mlog.debug('  - potential library dirs: {}'.format([x.as_posix() for x in lib_dirs]))
         mlog.debug('  - potential include dirs: {}'.format([x.path.as_posix() for x in inc_dirs]))
 
-        must_have_library = ['boost_python']
-
         #   2. Find all boost libraries
         libs: T.List[BoostLibraryFile] = []
         for i in lib_dirs:
@@ -484,9 +482,6 @@ class BoostDependency(SystemDependency):
             not_found: T.List[str] = []
             for boost_modulename in not_found_as_libs:
                 assert boost_modulename.startswith('boost_')
-                if boost_modulename in must_have_library:
-                    not_found.append(boost_modulename)
-                    continue
                 include_subdir = boost_modulename.replace('boost_', 'boost/', 1)
                 headerdir_found = False
                 for inc_dir in inc_dirs:

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -451,10 +451,6 @@ class BoostDependency(SystemDependency):
                 break
         libs = sorted(set(libs))
 
-        any_libs_found = len(libs) > 0
-        if not any_libs_found:
-            return False
-
         modules = ['boost_' + x for x in self.modules]
         for inc in inc_dirs:
             mlog.debug(f'  - found boost {inc.version} include dir: {inc.path}')
@@ -465,7 +461,7 @@ class BoostDependency(SystemDependency):
                 mlog.debug(f'    - {j}')
 
             #   3. Select the libraries matching the requested modules
-            not_found_as_libs: T.List[str] = []
+            not_found: T.List[str] = []
             selected_modules: T.List[BoostLibraryFile] = []
             for mod in modules:
                 found = False
@@ -475,21 +471,7 @@ class BoostDependency(SystemDependency):
                         found = True
                         break
                 if not found:
-                    not_found_as_libs += [mod]
-
-            # If a lib is not found, but an include directory exists,
-            # assume it is a header only module.
-            not_found: T.List[str] = []
-            for boost_modulename in not_found_as_libs:
-                assert boost_modulename.startswith('boost_')
-                include_subdir = boost_modulename.replace('boost_', 'boost/', 1)
-                headerdir_found = False
-                for inc_dir in inc_dirs:
-                    if (inc_dir.path / include_subdir).is_dir():
-                        headerdir_found = True
-                        break
-                if not headerdir_found:
-                    not_found.append(boost_modulename)
+                    not_found += [mod]
 
             # log the result
             mlog.debug('  - found:')

--- a/test cases/failing/63 wrong boost module/meson.build
+++ b/test cases/failing/63 wrong boost module/meson.build
@@ -6,4 +6,4 @@ if not dependency('boost', required: false).found()
 endif
 
 # abc doesn't exist
-linkdep = dependency('boost', modules : ['thread', 'system', 'test', 'abc'])
+linkdep = dependency('boost', modules : ['thread', 'test', 'abc'])

--- a/test cases/frameworks/1 boost/meson.build
+++ b/test cases/frameworks/1 boost/meson.build
@@ -13,10 +13,10 @@ endif
 # within one project. The need to be independent of each other.
 # Use one without a library dependency and one with it.
 
-linkdep     = dependency('boost', static: s, modules : ['thread', 'system', 'date_time'])
+linkdep     = dependency('boost', static: s, modules : ['thread', 'date_time'])
 testdep     = dependency('boost', static: s, modules : ['unit_test_framework'])
 nomoddep    = dependency('boost', static: s)
-extralibdep = dependency('boost', static: s, modules : ['thread', 'system', 'date_time', 'log_setup', 'log', 'filesystem', 'regex'])
+extralibdep = dependency('boost', static: s, modules : ['thread', 'date_time', 'log_setup', 'log', 'filesystem', 'regex'])
 notfound    = dependency('boost', static: s, modules : ['this_should_not_exist_on_any_system'], required: false)
 
 assert(not notfound.found())


### PR DESCRIPTION
This PR suggests that meson temporarily revert some changes to the Boost dependency, pending a future fix.

As discussed in issue #15154, these changes don't work on Debian, Ubuntu, Red Hat, Arch, Gentoo, and Alpine.  That is a lot of Linux distributions.

With this PR, some systems fail to configure until `meson.build` is edited.  Without the PR, some systems incorrectly configure and then fail to build until some packages are installed.  Neither is great -- what to do? :man_shrugging: 
