### PR TITLE
MasmARMCompiler: Report MSVC-like argument syntax

### DIFF
--- a/mesonbuild/compilers/asm.py
+++ b/mesonbuild/compilers/asm.py
@@ -228,6 +228,10 @@ class MasmARMCompiler(ASMCompiler):
     id = 'armasm'
     _SUPPORTED_ARCHES = {'arm', 'aarch64'}
 
+    @staticmethod
+    def get_argument_syntax() -> str:
+        return 'msvc'
+
     def needs_static_linker(self) -> bool:
         return True
 


### PR DESCRIPTION
`armasm` is quite stripped-down in terms of supported features compared to its cousin `ml64`, but I think it makes sense to report `'msvc'` as the argument syntax. Currently the `Compiler.get_argument_syntax()` vfunc is not overriden and the base implementation returns `'other'`. This in turn causes the ninja backend to emit the `masm_COMPILER` rule with `deps = gcc` which causes some issues: https://github.com/mesonbuild/meson/blob/1.9.1/mesonbuild/backend/ninjabackend.py#L2649-L2654

Of course there are other ways to fix the issue, let me know what you think about this :)

See https://gitlab.gnome.org/GNOME/glib/-/issues/3814