### PR TITLE
rust: search for native static libs in target libdir

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2377,8 +2377,9 @@ class StaticLibrary(BuildTarget):
                 #  and thus, machine_info kernel should be set to 'none'.
                 #  In that case, native_static_libs list is empty.
                 rustc = self.compilers['rust']
-                d = dependencies.InternalDependency('undefined', [], [],
-                                                    rustc.native_static_libs,
+                link_args = ['-L' + rustc.get_target_libdir() + '/self-contained']
+                link_args += rustc.native_static_libs
+                d = dependencies.InternalDependency('undefined', [], [], link_args,
                                                     [], [], [], [], [], {}, [], [], [],
                                                     '_rust_native_static_libs')
                 self.external_deps.append(d)

--- a/test cases/rust/28 self-contained/lib.rs
+++ b/test cases/rust/28 self-contained/lib.rs
@@ -1,0 +1,4 @@
+#[unsafe(export_name = "hello")]
+pub extern "C" fn hello() {
+    println!("Hello, world!");
+}

--- a/test cases/rust/28 self-contained/main.c
+++ b/test cases/rust/28 self-contained/main.c
@@ -1,0 +1,6 @@
+extern void hello(void);
+
+int main(void)
+{
+    hello();
+}

--- a/test cases/rust/28 self-contained/meson.build
+++ b/test cases/rust/28 self-contained/meson.build
@@ -1,0 +1,17 @@
+project('self-contained', meson_version : '>= 1.3.0')
+
+if not add_languages('c', native : false, required : false)
+  error('MESON_SKIP_TEST clang not installed')
+endif
+
+if not add_languages('rust', native : false, required : false)
+  error('MESON_SKIP_TEST Rust x86_64-unknown-linux-musl target not installed')
+endif
+
+if meson.get_compiler('c').find_library('libunwind', required : false).found()
+  error('MESON_SKIP_TEST libunwind is installed globally')
+endif
+
+lib = static_library('rust', 'lib.rs', rust_abi : 'c')
+
+executable('exe', 'main.c', link_with : lib)

--- a/test cases/rust/28 self-contained/test.json
+++ b/test cases/rust/28 self-contained/test.json
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "CC": "clang -target x86_64-unknown-linux-musl",
+    "RUSTC": "rustc --target x86_64-unknown-linux-musl"
+  }
+}


### PR DESCRIPTION
Sometimes, a Rust static library's native static libs refer to libraries installed in the rustc target libdir.  This is always the case for most musl targets (with the intention of making it easier to use them on non-musl systems), and other targets can also be configured to do this using e.g. the llvm-libunwind option when building the standard libraries for the target.  When rustc is responsible for linking it will always add the appropriate directory to the linker search path, but if we're not using Rust for linking, we have to tell the linker about that directory ourselves.

The added test demonstrates a scenario where this comes up: linking a static Rust library, built for musl, into a C executable.  -lunwind is in the native static libs list from the compiler, but it's referring to the libunwind.a in the self-contained directory.