### PR TITLE
interpreter: support multiple version with meson.version().version_compare()

### DIFF
--- a/docs/markdown/snippets/meson_version_multiple_compare.md
+++ b/docs/markdown/snippets/meson_version_multiple_compare.md
@@ -1,0 +1,4 @@
+## `meson.version().version_compare()` now accepts multiple comparisons
+
+Multiple comparisons can now be passed to `meson.version().version_compare()`
+matching existing behavior of `str.version_compare()`.

--- a/test cases/unit/132 meson version multiple compare/meson.build
+++ b/test cases/unit/132 meson version multiple compare/meson.build
@@ -1,0 +1,19 @@
+project('meson version multiple compare', meson_version: '>= 0.1')
+
+if meson.version().version_compare('>9000', '<=9999')
+  error('This should not be executed')
+elif meson.version().version_compare('>=0.55', '<1.0') and false
+  error('This should not be executed')
+elif not meson.version().version_compare('>=0.55', '<=9999')
+  error('This should not be executed')
+elif meson.version().version_compare('>=0.55', '<=9999')
+  # This Should not produce warning even when using function not available in
+  # meson 0.1.
+  foo_dep = declare_dependency()
+  meson.override_dependency('foo', foo_dep)
+endif
+
+# This will error out if elif cause did not enter
+assert(foo_dep.found(), 'meson.version_compare did not work')
+
+subproject('foo')

--- a/test cases/unit/132 meson version multiple compare/subprojects/foo/meson.build
+++ b/test cases/unit/132 meson version multiple compare/subprojects/foo/meson.build
@@ -1,0 +1,8 @@
+project('foo', meson_version: '>= 0.1')
+
+if meson.version().version_compare('>= 0.55', '<=9999')
+  # This Should not produce warning even when using function not available in
+  # meson 0.1.
+  foo_dep = declare_dependency()
+  meson.override_dependency('foo2', foo_dep)
+endif


### PR DESCRIPTION
Allow `meson.version().version_compare()` to accept multiple comparisons like `str.version_compare()` does while maintaining the special behavior for `if meson.version().version_compare(...)` introduced in #7594.

Resolves: #15217