### PR TITLE
Make cython generated files less nested to avoid `MAX_PATH` issues on Windows

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1871,10 +1871,21 @@ class NinjaBackend(backends.Backend):
         ext = self.get_target_option(target, OptionKey('cython_language', machine=target.for_machine))
 
         pyx_sources = []  # Keep track of sources we're adding to build
+        pyx_count = 0
+        for src in target.get_sources():
+            if src.endswith('.pyx'):
+                pyx_count += 1
+        for gen in target.get_generated_sources():
+            for ssrc in gen.get_outputs():
+                if ssrc.endswith('.pyx'):
+                    pyx_count += 1
 
         for src in target.get_sources():
             if src.endswith('.pyx'):
-                output = os.path.join(self.get_target_private_dir(target), f'{src}.{ext}')
+                # Use basename to avoid too nested targets which can cause a
+                # problem with MAX_PATH on Windows
+                outname = os.path.basename(src.fname) if pyx_count == 1 else src.fname
+                output = os.path.join(self.get_target_private_dir(target), f'{outname}.{ext}')
                 element = NinjaBuildElement(
                     self.all_outputs, [output],
                     self.compiler_to_rule_name(cython),
@@ -1896,7 +1907,10 @@ class NinjaBackend(backends.Backend):
             for ssrc in gen.get_outputs():
                 ssrc = os.path.join(builddir, ssrc)
                 if ssrc.endswith('.pyx'):
-                    output = os.path.join(self.get_target_private_dir(target), f'{ssrc}.{ext}')
+                    # Use basename to avoid too nested targets which can cause
+                    # a problem with MAX_PATH on Windows
+                    outname = os.path.basename(ssrc) if pyx_count == 1 else ssrc
+                    output = os.path.join(self.get_target_private_dir(target), f'{outname}.{ext}')
                     element = NinjaBuildElement(
                         self.all_outputs, [output],
                         self.compiler_to_rule_name(cython),

--- a/test cases/cython/5 nested folders/meson.build
+++ b/test cases/cython/5 nested folders/meson.build
@@ -1,0 +1,25 @@
+project(
+  'nested folders',
+  ['c', 'cpp', 'cython'],
+  default_options : ['buildtype=release'],
+)
+
+if meson.backend() != 'ninja'
+  error('MESON_SKIP_TEST: Ninja backend required')
+endif
+
+py = import('python').find_installation()
+py_dep = py.dependency(required: false)
+
+if not py_dep.found()
+  error('MESON_SKIP_TEST: Python library not found.')
+endif
+
+metric = py.extension_module(
+  'metric',
+  'package/metrics/metric.pyx',
+  subdir: 'package/metrics',
+  install: true
+)
+
+subdir('package')

--- a/test cases/cython/5 nested folders/package/meson.build
+++ b/test cases/cython/5 nested folders/package/meson.build
@@ -1,0 +1,1 @@
+subdir('metrics')

--- a/test cases/cython/5 nested folders/package/metrics/_pairwise_distances_reduction/_radius_neighbors_classmode.pyx
+++ b/test cases/cython/5 nested folders/package/metrics/_pairwise_distances_reduction/_radius_neighbors_classmode.pyx
@@ -1,0 +1,2 @@
+def test():
+    pass

--- a/test cases/cython/5 nested folders/package/metrics/_pairwise_distances_reduction/meson.build
+++ b/test cases/cython/5 nested folders/package/metrics/_pairwise_distances_reduction/meson.build
@@ -1,0 +1,7 @@
+_radius_neighbors_classmode = py.extension_module(
+  '_radius_neighbors_classmode',
+  '_radius_neighbors_classmode.pyx',
+  subdir: 'package/metrics/_pairwise_distances_reduction',
+  override_options: ['cython_language=cpp'],
+  install: true
+)

--- a/test cases/cython/5 nested folders/package/metrics/gen.py
+++ b/test cases/cython/5 nested folders/package/metrics/gen.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import textwrap
+
+parser = argparse.ArgumentParser()
+parser.add_argument('output')
+args = parser.parse_args()
+
+with open(args.output, 'w') as f:
+    f.write(textwrap.dedent('''\
+        cpdef func():
+            return "Hello, World!"
+        '''))

--- a/test cases/cython/5 nested folders/package/metrics/meson.build
+++ b/test cases/cython/5 nested folders/package/metrics/meson.build
@@ -1,0 +1,13 @@
+generated_pyx = custom_target(
+  'generated_pyx',
+  input : 'gen.py',
+  output : 'generated.pyx',
+  command : [py, '@INPUT@', '@OUTPUT@'],
+)
+
+includestuff_ext = py.extension_module(
+  'generated_pyx',
+  generated_pyx
+)
+
+subdir('_pairwise_distances_reduction')

--- a/test cases/cython/5 nested folders/package/metrics/metric.pyx
+++ b/test cases/cython/5 nested folders/package/metrics/metric.pyx
@@ -1,0 +1,2 @@
+def test():
+    pass

--- a/test cases/cython/5 nested folders/test.json
+++ b/test cases/cython/5 nested folders/test.json
@@ -1,0 +1,20 @@
+{
+  "installed": [
+    {
+      "type": "python_lib",
+      "file": "usr/@PYTHON_PLATLIB@/package/metrics/metric"
+    },
+    {
+      "type": "py_implib",
+      "file": "usr/@PYTHON_PLATLIB@/package/metrics/metric"
+    },
+    {
+      "type": "python_lib",
+      "file": "usr/@PYTHON_PLATLIB@/package/metrics/_pairwise_distances_reduction/_radius_neighbors_classmode"
+    },
+    {
+      "type": "py_implib",
+      "file": "usr/@PYTHON_PLATLIB@/package/metrics/_pairwise_distances_reduction/_radius_neighbors_classmode"
+    }
+  ]
+}

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1059,6 +1059,38 @@ class AllPlatformTests(BasePlatformTests):
         self.assertBuildRelinkedOnlyTarget(name)
 
 
+    def test_cython_avoid_nested_generated_paths(self):
+        # Ensure that cython transpiled outputs are not in a too deeply nested folder
+        testdir = os.path.join("test cases/cython", "5 nested folders")
+        env = get_fake_env(testdir, self.builddir, self.prefix)
+        try:
+            detect_compiler_for(env, "cython", MachineChoice.HOST, True, "")
+        except EnvironmentException:
+            raise SkipTest("Cython is not installed")
+        self.init(testdir)
+
+        targets = self.introspect("--targets")
+
+        found = False
+        for target in targets:
+            for target_sources in target["target_sources"]:
+                for generated_source in target_sources.get("generated_sources", []):
+                    if generated_source.endswith(".pyx.c") or generated_source.endswith("pyx.cpp"):
+                        found = True
+                        parts = os.path.normpath(generated_source).split(os.sep)
+                        parent = parts[-2]
+                        # We want the pyx.c files to be directly under the .p folder,
+                        # for example:
+                        # libdir/foo.cpython-313-x86_64-linux-gnu.so.p/foo.pyx.c
+                        # rather than (additional libdir folder):
+                        # libdir/foo.cpython-313-x86_64-linux-gnu.so.p/libdir/foo.pyx.c
+                        self.assertTrue(
+                            parent.endswith(".p"),
+                            "pyx.c file should be directly under the .p folder,"
+                            f" got {generated_source!r}"
+                        )
+        self.assertTrue(found, "No cython transpiled outputs found")
+
     def test_internal_include_order(self):
         if mesonbuild.envconfig.detect_msys2_arch() and ('MESON_RSP_THRESHOLD' in os.environ):
             raise SkipTest('Test does not yet support gcc rsp files on msys2')


### PR DESCRIPTION
Fix https://github.com/mesonbuild/meson/issues/15123.

Followed https://github.com/mesonbuild/meson/issues/15123#issuecomment-3405833213 which recommends to special-case Cython.

- fixed the code, there are two different code paths
  + `.pyx` file
  + custom target that generated a `.pyx` file
- added a test to make sure that the generated `.pyx.c` is directly under the `.p` folder (something like `foo.cpython-313-x86_64-linux-gnu.so.p` on Linux)
- added a `pyx.c` `test cases/cython/2 generated sources/libdir/foo.pyx` to test one of the code path

I double-checked it seems to work fine with scikit-learn before our work-arounds to use a generator.
