### PR TITLE
compilers: gnu: LTO cleanups and GCC incremental LTO support

### DIFF
--- a/docs/markdown/snippets/gcc_incremental_lto.md
+++ b/docs/markdown/snippets/gcc_incremental_lto.md
@@ -1,0 +1,4 @@
+## `-Db_thinlto_cache` now supported for GCC
+
+`-Db_thinlto_cache` is now supported for GCC 15's incremental LTO, as is
+`-Db_thinlto_cache_dir`.

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -351,6 +351,7 @@ def get_base_link_args(target: 'BuildTarget',
                 thinlto_cache_dir = get_option_value_for_target(env, target, OptionKey('b_thinlto_cache_dir'), '')
                 if thinlto_cache_dir == '':
                     thinlto_cache_dir = os.path.join(build_dir, 'meson-private', 'thinlto-cache')
+                    os.mkdir(thinlto_cache_dir)
             num_threads = get_option_value_for_target(env, target, OptionKey('b_lto_threads'), 0)
             lto_mode = get_option_value_for_target(env, target, OptionKey('b_lto_mode'), 'default')
             args.extend(linker.get_lto_link_args(


### PR DESCRIPTION
* Pass `-flto=N` at link-time too (originally part of https://github.com/mesonbuild/meson/pull/13659 because of conflicts) for https://github.com/mesonbuild/meson/issues/9536
* Refactor `get_lto_{compile,link}_args`
* Support GCC incremental LTO for https://github.com/mesonbuild/meson/issues/14428