### PR TITLE
Full implementation of rust.workspace()

### DIFF
--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -416,6 +416,33 @@ Builds a proc-macro crate for a workspace package.
 
 Accepts all keyword arguments from [[shared_library]].
 
+#### package.override_dependency()
+
+```meson
+pkg.override_dependency(dep[, rust_abi: abi])
+```
+
+Keyword arguments:
+- `rust_abi`: (`str`, optional) The ABI to use for the dependency. Valid values are
+  `'rust'`, `'c'`, or `'proc-macro'`; the value must match the crate types and is
+  mandatory if more than one ABI is exposed by the crate.
+
+Make the crate available as a dependency to other crates.  This is the same
+as calling `meson.override_dependency`, but it computes the correct dependency
+name from `pkg`'s name, API version and ABI (Rust vs. C).
+
+It is typically used with `library() or `proc_macro()`, for example:
+
+```meson
+lib_pkg = cargo_ws.package('myproject-lib')
+lib = lib_pkg.library(install: false)
+lib_pkg.override_dependency(declare_dependency(link_with: lib))
+
+# Declares myproject-lib as a dependency in Cargo.toml
+exe_pkg = cargo_ws.package()
+exe_pkg.executable(install: true)
+```
+
 #### package.executable()
 
 ```meson

--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -172,6 +172,21 @@ Only a subset of [[shared_library]] keyword arguments are allowed:
 - link_with
 - override_options
 
+### to_system_dependency()
+
+*Since 1.11.0*
+
+```meson
+rustmod.to_system_dependency(dep[, name])
+```
+
+Create and return an internal dependency that wraps `dep` and
+defines `cfg(system_deps_have_NAME)`.  This is compatible with
+how the `system-deps` crate reports the availability of a system
+dependency to Rust code.
+
+If omitted, the name defaults to the name of the dependency.
+
 ### workspace()
 
 Basic usage:

--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -16,8 +16,8 @@ authors:
 
 The rust module provides helper to integrate rust code into Meson. The
 goal is to make using rust in Meson more pleasant, while still
-remaining mesonic, this means that it attempts to make Rust work more
-like Meson, rather than Meson work more like rust.
+remaining mesonic. Rust conventions are adopted in order to help the
+Meson user and Rust developer, rather than to make Meson work more like rust.
 
 ## Functions
 
@@ -336,6 +336,13 @@ all_features = pkg.all_features()
 Returns all defined features for a specific package or subproject.
 
 ### Packages only
+
+Package objects are able to extract information from `Cargo.toml` files,
+and provide methods to query how Cargo would build this package.  They
+also contain convenience wrappers for non-Rust-specific functions
+(`executable`, `library`, `meson.override_dependency`, etc.), that
+automatically add dependencies and compiler arguments from `Cargo.toml`
+information.
 
 #### package.rust_args()
 

--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -312,7 +312,35 @@ all_features = pkg.all_features()
 
 Returns all defined features for a specific package or subproject.
 
-### subproject.dependency()
+### Packages only
+
+#### package.rust_args()
+
+```meson
+args = pkg.rustc_args()
+```
+
+Returns rustc arguments for this package.
+
+#### package.env()
+
+```meson
+env_vars = pkg.env()
+```
+
+Returns environment variables for this package.
+
+#### package.rust_dependency_map()
+
+```meson
+dep_map = pkg.rust_dependency_map()
+```
+
+Returns rust dependency mapping for this package.
+
+### Subprojects only
+
+#### subproject.dependency()
 
 ```meson
 dep = subproject.dependency(...)

--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -274,12 +274,7 @@ Example usage:
 rustmod = import('rust')
 cargo_ws = rustmod.workspace()
 pkg = cargo_ws.package()
-
-executable('my_app', 'src/main.rs',
-  dependencies: pkg.dependencies(),
-  rust_args: pkg.rust_args(),
-  rust_dependency_map: pkg.rust_dependency_map(),
-)
+pkg.executable(install: true)
 ```
 
 ### workspace.subproject()
@@ -410,6 +405,26 @@ lib = pkg.proc_macro(...)
 Builds a proc-macro crate for a workspace package.
 
 Accepts all keyword arguments from [[shared_library]].
+
+#### package.executable()
+
+```meson
+exe = pkg.executable([target_name], [sources], ...)
+```
+
+Builds an executable target for a workspace package.  The method requires that the
+package has at least one `bin` section defined in its `Cargo.toml` file,
+or one binary discovered from the contents of the file system.
+
+Positional arguments:
+- `target_name`: (`str`, optional) Name of the binary target to build. If the package
+  has multiple `bin` sections in `Cargo.toml`, this argument is required and must
+  match one of the binary names. If omitted and there's only one binary, that binary
+  will be built automatically.
+- `sources`: (`StructuredSources`, optional) Source files for the executable.  If omitted,
+  uses the path specified in the corresponding `bin` section of `Cargo.toml`.
+
+Accepts all keyword arguments from [[executable]].
 
 ### Subprojects only
 

--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -241,6 +241,19 @@ packages = ws.packages()
 
 Returns a list of package names in the workspace.
 
+### workspace.package()
+
+```meson
+pkg = ws.package([package_name])
+```
+
+Returns a package object for the given package member.  If empty, returns
+the object for the root package.
+
+Arguments:
+- `package_name`: (str, optional) Name of the package; not needed for the
+  root package of a workspace
+
 ### workspace.subproject()
 
 ```meson
@@ -258,15 +271,15 @@ Positional arguments:
 The package object returned by `workspace.subproject()` provides methods
 for working with individual packages in a Cargo workspace.
 
-### subproject.name()
+### package.name(), subproject.name()
 
 ```meson
 name = pkg.name()
 ```
 
-Returns the name of the subproject.
+Returns the name of a package or subproject.
 
-### subproject.version()
+### package.version(), subproject.version()
 
 ```meson
 version = pkg.version()
@@ -274,7 +287,7 @@ version = pkg.version()
 
 Returns the normalized version number of the subproject.
 
-### subproject.api()
+### package.api(), subproject.api()
 
 ```meson
 api = pkg.api()
@@ -283,21 +296,21 @@ api = pkg.api()
 Returns the API version of the subproject, that is the version up to the first
 nonzero element.
 
-### subproject.features()
+### package.features(), subproject.features()
 
 ```meson
 features = pkg.features()
 ```
 
-Returns selected features for a specific subproject.
+Returns selected features for a specific package or subproject.
 
-### subproject.all_features()
+### package.all_features(), subproject.all_features()
 
 ```meson
 all_features = pkg.all_features()
 ```
 
-Returns all defined features for a specific subproject.
+Returns all defined features for a specific package or subproject.
 
 ### subproject.dependency()
 

--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -396,6 +396,16 @@ Accepts all keyword arguments from [[shared_library]] and [[static_library]].
 `rust_abi` must match the crate types and is mandatory if more than one
 ABI is exposed by the crate.
 
+#### package.shared_module()
+
+```meson
+lib = pkg.shared_module(...)
+```
+
+Builds the `cdylib` for a workspace package as a shared module.
+
+Accepts all keyword arguments from [[shared_module]].
+
 #### package.proc_macro()
 
 ```meson

--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -381,6 +381,36 @@ Keyword arguments:
 - `dev_dependencies`: (`bool`, default: false) Whether to include development dependencies (not yet implemented)
 - `system_dependencies`: (`bool`, default: true) Whether to include system dependencies
 
+#### package.library()
+
+```meson
+lib = pkg.library(...)
+```
+
+Builds library targets for a workspace package.  The method requires that
+the package's `Cargo.toml` file contains the `[lib]` section or that it
+is discovered from the contents of the file system.  Static vs. shared library is
+decided based on the crate types in `Cargo.toml`
+
+Positional arguments:
+- `target_name`: (`str`, optional) Name of the binary target to build.
+- `sources`: (`StructuredSources`, optional) Source files for the executable.  If omitted,
+  uses the path specified in the `[lib]` section of `Cargo.toml`.
+
+Accepts all keyword arguments from [[shared_library]] and [[static_library]].
+`rust_abi` must match the crate types and is mandatory if more than one
+ABI is exposed by the crate.
+
+#### package.proc_macro()
+
+```meson
+lib = pkg.proc_macro(...)
+```
+
+Builds a proc-macro crate for a workspace package.
+
+Accepts all keyword arguments from [[shared_library]].
+
 ### Subprojects only
 
 #### subproject.dependency()

--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -269,6 +269,19 @@ Arguments:
 - `package_name`: (str, optional) Name of the package; not needed for the
   root package of a workspace
 
+Example usage:
+```meson
+rustmod = import('rust')
+cargo_ws = rustmod.workspace()
+pkg = cargo_ws.package()
+
+executable('my_app', 'src/main.rs',
+  dependencies: pkg.dependencies(),
+  rust_args: pkg.rust_args(),
+  rust_dependency_map: pkg.rust_dependency_map(),
+)
+```
+
 ### workspace.subproject()
 
 ```meson
@@ -352,6 +365,21 @@ dep_map = pkg.rust_dependency_map()
 ```
 
 Returns rust dependency mapping for this package.
+
+#### package.dependencies()
+
+```meson
+deps = pkg.dependencies(...)
+```
+
+Returns a list of dependency objects for all the dependencies required by this
+Rust package, including both Rust crate dependencies and system dependencies.
+The returned dependencies can be used directly in build target declarations.
+
+Keyword arguments:
+- `dependencies`: (`bool`, default: true) Whether to include regular Rust crate dependencies
+- `dev_dependencies`: (`bool`, default: false) Whether to include development dependencies (not yet implemented)
+- `system_dependencies`: (`bool`, default: true) Whether to include system dependencies
 
 ### Subprojects only
 

--- a/docs/markdown/Rust.md
+++ b/docs/markdown/Rust.md
@@ -150,9 +150,28 @@ cargo_ws = rustmod.workspace(
     features: ['feature1', 'feature2'])
 ```
 
-### Limitations
+Finally, the workspace object is able to build targets specified in `lib`
+or `bin` sections, extracting compiler arguments for dependencies and
+diagnostics from the Cargo.toml file.  The simplest case is that of building
+a simple binary crate:
 
-All your own crates must be built using the usual Meson functions such as
-[[static_library]] or [[executable]].  In the future, workspace object
-functionality will be extended to help building rustc command lines
-based on features, dependency names, and so on.
+```meson
+cargo_ws.package().executable(install: true)
+```
+
+For a workspace:
+
+```meson
+pkg_lib = cargo_ws.package('myproject-lib')
+lib = pkg_lib.library(install: false)
+pkg_lib.override_dependency(declare_dependency(link_with: lib))
+
+cargo_ws.package().executable(install: true)
+```
+
+Sources are automatically discovered, but can be specified as a
+[[@structured_src]] if they are partly generated.
+
+It is still possible to use keyword arguments to link non-Rust build targets,
+or even to use the usual Meson functions such as [[static_library]] or
+[[executable]].

--- a/docs/markdown/snippets/cargo-workspace-object.md
+++ b/docs/markdown/snippets/cargo-workspace-object.md
@@ -6,8 +6,9 @@ This guarantees that features are resolved according to what is
 in the `Cargo.toml` file, and in fact enables configuration of
 features for the build.
 
-The returned object also allows retrieving features and dependencies
-for Cargo subprojects.
+The returned object allows retrieving features and dependencies
+for Cargo subprojects, and contains method to build targets
+declared in `Cargo.toml` files.
 
 While Cargo subprojects remain experimental, the Meson project will
 try to keep the workspace object reasonably backwards-compatible.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1576,10 +1576,10 @@ class BuildTarget(Target):
                 self.link_whole_targets.extend(dep.whole_libraries)
                 if dep.get_compile_args() or dep.get_link_args():
                     # Those parts that are external.
-                    extpart = dependencies.InternalDependency(dep.version,
-                                                              compile_args=dep.get_compile_args(),
-                                                              link_args=dep.get_link_args(),
-                                                              name=dep.name)
+                    extpart = type(dep)(dep.version,
+                                        compile_args=dep.get_compile_args(),
+                                        link_args=dep.get_link_args(),
+                                        name=dep.name)
                     self.external_deps.append(extpart)
                 # Deps of deps.
                 self.add_deps(dep.ext_deps)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1576,12 +1576,10 @@ class BuildTarget(Target):
                 self.link_whole_targets.extend(dep.whole_libraries)
                 if dep.get_compile_args() or dep.get_link_args():
                     # Those parts that are external.
-                    extpart = dependencies.InternalDependency('undefined',
-                                                              [],
-                                                              dep.get_compile_args(),
-                                                              dep.get_link_args(),
-                                                              [], [], [], [], [], {}, [], [], [],
-                                                              dep.name)
+                    extpart = dependencies.InternalDependency(dep.version,
+                                                              compile_args=dep.get_compile_args(),
+                                                              link_args=dep.get_link_args(),
+                                                              name=dep.name)
                     self.external_deps.append(extpart)
                 # Deps of deps.
                 self.add_deps(dep.ext_deps)
@@ -2373,9 +2371,8 @@ class StaticLibrary(BuildTarget):
                     # creates a second musl instance with uninitialized __libc state.
                     link_args = []
                 link_args += rustc.native_static_libs
-                d = dependencies.InternalDependency('undefined', [], [], link_args,
-                                                    [], [], [], [], [], {}, [], [], [],
-                                                    '_rust_native_static_libs')
+                d = dependencies.InternalDependency(version='undefined', link_args=link_args,
+                                                    name='_rust_native_static_libs')
                 self.external_deps.append(d)
 
         default_prefix, default_suffix = self.determine_default_prefix_and_suffix()

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -305,6 +305,21 @@ class Interpreter:
             for feature in self.features:
                 self._enable_feature(pkg, feature)
 
+    def load_package(self, ws: WorkspaceState, package_name: T.Optional[str]) -> PackageState:
+        if package_name is None:
+            if not ws.workspace.root_package:
+                raise MesonException('no root package in workspace')
+            path = '.'
+        else:
+            try:
+                path = ws.packages_to_member[package_name]
+            except KeyError:
+                raise MesonException(f'workspace member "{package_name}" not found')
+
+        if is_parent_path(self.subprojects_dir, path):
+            raise MesonException('argument to package() cannot be a subproject')
+        return ws.packages[path]
+
     def interpret(self, subdir: str, project_root: T.Optional[str] = None) -> mparser.CodeBlockNode:
         filename = os.path.join(self.environment.source_dir, subdir, 'Cargo.toml')
         build = builder.Builder(filename)

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -25,7 +25,9 @@ from .cfg import eval_cfg
 from .toml import load_toml
 from .manifest import Manifest, CargoLock, CargoLockPackage, Workspace, fixup_meson_varname
 from ..interpreterbase import SubProject
-from ..mesonlib import is_parent_path, MesonException, MachineChoice, unique_list, version_compare
+from ..mesonlib import (
+    is_parent_path, lazy_property, MesonException, MachineChoice,
+    unique_list, version_compare)
 from .. import coredata, mlog
 from ..wrap.wrap import PackageDefinition
 
@@ -108,6 +110,12 @@ class PackageState:
     # meson dep name for git sources, where the wrap is named after the
     # git directory rather than the crate name + api version).
     subproject_name: T.Optional[str] = None
+
+    @lazy_property
+    def path(self) -> T.Optional[str]:
+        if not self.ws_subdir:
+            return None
+        return os.path.normpath(os.path.join(self.ws_subdir, self.ws_member))
 
     def get_env_dict(self, environment: Environment, subdir: str) -> T.Dict[str, str]:
         """Get environment variables for this package."""

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -831,9 +831,6 @@ class Interpreter:
             'rust_args': build.identifier(_extra_args_varname()),
         }
 
-        depname_suffix = '' if lib_type == 'c' else '-rs'
-        depname = _dependency_name(pkg.manifest.package.name, pkg.manifest.package.api, depname_suffix)
-
         if lib_type == 'proc-macro':
             lib = build.method('proc_macro', build.identifier('pkg_obj'), posargs, kwargs)
         else:
@@ -861,11 +858,9 @@ class Interpreter:
             ),
             build.method(
                 'override_dependency',
-                build.identifier('meson'),
-                [
-                    build.string(depname),
-                    build.identifier('dep'),
-                ],
+                build.identifier('pkg_obj'),
+                [build.identifier('dep')],
+                {'rust_abi': build.string(lib_type)}
             ),
         ]
 

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -104,6 +104,10 @@ class PackageState:
     ws_member: T.Optional[str] = None
     # Package configuration state
     cfg: T.Optional[PackageConfiguration] = None
+    # Subproject name as known to the wrap resolver (may differ from the
+    # meson dep name for git sources, where the wrap is named after the
+    # git directory rather than the crate name + api version).
+    subproject_name: T.Optional[str] = None
 
     def get_env_dict(self, environment: Environment, subdir: str) -> T.Dict[str, str]:
         """Get environment variables for this package."""
@@ -199,6 +203,8 @@ class PackageState:
         return abis
 
     def get_subproject_name(self) -> SubProject:
+        if self.subproject_name is not None:
+            return SubProject(self.subproject_name)
         dep = _dependency_name(self.manifest.package.name, self.manifest.package.api)
         return SubProject(dep)
 
@@ -493,6 +499,7 @@ class Interpreter:
         ws = self._get_workspace(manifest, subdir, downloaded=downloaded)
         member = ws.packages_to_member[package_name]
         pkg = self._require_workspace_member(ws, member)
+        pkg.subproject_name = subp_name
         return pkg
 
     def _prepare_package(self, pkg: PackageState) -> None:

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -12,6 +12,7 @@ import re
 import typing as T
 
 from .. import options
+from ..dependencies import InternalDependency
 from ..mesonlib import EnvironmentException, MesonException, Popen_safe_logged, version_compare
 from ..linkers.linkers import VisualStudioLikeLinkerMixin
 from ..options import OptionKey
@@ -105,6 +106,11 @@ def rustc_link_args(args: T.List[str]) -> T.List[str]:
         rustc_args.append('-C')
         rustc_args.append(f'link-arg={arg}')
     return rustc_args
+
+
+class RustSystemDependency(InternalDependency):
+    pass
+
 
 class RustCompiler(Compiler):
 
@@ -359,6 +365,8 @@ class RustCompiler(Compiler):
         return opts
 
     def get_dependency_compile_args(self, dep: 'Dependency') -> T.List[str]:
+        if isinstance(dep, RustSystemDependency):
+            return dep.get_compile_args()
         # Rust doesn't have dependency compile arguments so simply return
         # nothing here. Dependencies are linked and all required metadata is
         # provided by the linker flags.

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -305,29 +305,31 @@ class InternalDependency(Dependency):
 
     type_name = DependencyTypeName('internal')
 
-    def __init__(self, version: str, incdirs: T.List['IncludeDirs'], compile_args: T.List[str],
-                 link_args: T.List[str],
-                 libraries: T.List[LibTypes],
-                 whole_libraries: T.List[T.Union[StaticLibrary, CustomTarget, CustomTargetIndex]],
-                 sources: T.Sequence[T.Union[mesonlib.File, GeneratedTypes, StructuredSources]],
-                 extra_files: T.Sequence[mesonlib.File],
-                 ext_deps: T.List[Dependency], variables: T.Dict[str, str],
-                 d_module_versions: T.List[T.Union[str, int]], d_import_dirs: T.List['IncludeDirs'],
-                 objects: T.List['ExtractedObjects'],
+    def __init__(self, version: str, incdirs: T.Optional[T.List['IncludeDirs']] = None,
+                 compile_args: T.Optional[T.List[str]] = None,
+                 link_args: T.Optional[T.List[str]] = None,
+                 libraries: T.Optional[T.List[LibTypes]] = None,
+                 whole_libraries: T.Optional[T.List[T.Union[StaticLibrary, CustomTarget, CustomTargetIndex]]] = None,
+                 sources: T.Optional[T.Sequence[T.Union[mesonlib.File, GeneratedTypes, StructuredSources]]] = None,
+                 extra_files: T.Optional[T.Sequence[mesonlib.File]] = None,
+                 ext_deps: T.Optional[T.List[Dependency]] = None, variables: T.Optional[T.Dict[str, str]] = None,
+                 d_module_versions: T.Optional[T.List[T.Union[str, int]]] = None,
+                 d_import_dirs: T.Optional[T.List['IncludeDirs']] = None,
+                 objects: T.Optional[T.List['ExtractedObjects']] = None,
                  name: T.Optional[str] = None):
         super().__init__({'native': MachineChoice.HOST})  # TODO: does the native key actually matter
         self.version = version
         self.is_found = True
-        self.include_directories = incdirs
-        self.compile_args = compile_args
-        self.link_args = link_args
-        self.libraries = libraries
-        self.whole_libraries = whole_libraries
-        self.sources = list(sources)
-        self.extra_files = list(extra_files)
-        self.ext_deps = ext_deps
-        self.variables = variables
-        self.objects = objects
+        self.include_directories = incdirs or []
+        self.compile_args = compile_args or []
+        self.link_args = link_args or []
+        self.libraries = libraries or []
+        self.whole_libraries = whole_libraries or []
+        self.sources = list(sources or [])
+        self.extra_files = list(extra_files or [])
+        self.ext_deps = ext_deps or []
+        self.variables = variables or {}
+        self.objects = objects or []
         if d_module_versions:
             self.d_features['versions'] = d_module_versions
         if d_import_dirs:

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -22,7 +22,7 @@ from ..options import OptionKey
 #from ..interpreterbase import FeatureDeprecated, FeatureNew
 
 if T.TYPE_CHECKING:
-    from typing_extensions import Literal, Required, TypedDict, TypeAlias
+    from typing_extensions import Literal, Required, Self, TypedDict, TypeAlias
 
     from ..compilers.compilers import Language, Compiler
     from ..environment import Environment
@@ -361,7 +361,7 @@ class InternalDependency(Dependency):
     def get_partial_dependency(self, *, compile_args: bool = False,
                                link_args: bool = False, links: bool = False,
                                includes: bool = False, sources: bool = False,
-                               extra_files: bool = False) -> InternalDependency:
+                               extra_files: bool = False) -> Self:
         final_compile_args = self.compile_args.copy() if compile_args else []
         final_link_args = self.link_args.copy() if link_args else []
         final_libraries = self.libraries.copy() if links else []
@@ -372,7 +372,7 @@ class InternalDependency(Dependency):
         final_deps = [d.get_partial_dependency(
             compile_args=compile_args, link_args=link_args, links=links,
             includes=includes, sources=sources) for d in self.ext_deps]
-        return InternalDependency(
+        return type(self)(
             self.version, final_includes, final_compile_args,
             final_link_args, final_libraries, final_whole_libraries,
             final_sources, final_extra_files, final_deps, self.variables, [], [], [], self.name)

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -38,6 +38,7 @@ class ModuleState:
         self.source_root = interpreter.environment.get_source_dir()
         self.build_to_src = relpath(interpreter.environment.get_source_dir(),
                                     interpreter.environment.get_build_dir())
+        self.subproject_dir = interpreter.subproject_dir
         self.subproject = interpreter.subproject
         self.subdir = interpreter.subdir
         self.root_subdir = interpreter.root_subdir

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -120,7 +120,7 @@ class ModuleState:
             raise mesonlib.MesonException(f'dependency "{depname}" was not overridden for the {for_machine}')
 
     def dependency(self, depname: str, native: bool = False, required: bool = True,
-                   wanted: T.Optional[str] = None) -> 'Dependency':
+                   wanted: T.Optional[T.Union[str, T.List[str]]] = None) -> 'Dependency':
         kwargs: T.Dict[str, object] = {'native': native, 'required': required}
         if wanted:
             kwargs['version'] = wanted

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -161,6 +161,9 @@ class RustCrate(ModuleObject):
             'features': self.features_method,
             'name': self.name_method,
             'version': self.version_method,
+            'rust_args': self.rust_args_method,
+            'env': self.env_method, # type: ignore[dict-item]
+            'rust_dependency_map': self.rust_dependency_map_method, # type: ignore[dict-item]
         })
 
     @noPosargs
@@ -192,6 +195,24 @@ class RustCrate(ModuleObject):
     def features_method(self, state: ModuleState, args: T.List, kwargs: TYPE_kwargs) -> T.List[str]:
         """Returns chosen features for specific package."""
         return sorted(list(self.package.cfg.features))
+
+    @noPosargs
+    @noKwargs
+    def rust_args_method(self, state: ModuleState, args: T.List, kwargs: TYPE_kwargs) -> T.List[str]:
+        """Returns rustc arguments for this package."""
+        return self.package.get_rustc_args(state.environment, state.subdir, mesonlib.MachineChoice.HOST)
+
+    @noPosargs
+    @noKwargs
+    def env_method(self, state: ModuleState, args: T.List, kwargs: TYPE_kwargs) -> T.Dict[str, str]:
+        """Returns environment variables for this package."""
+        return self.package.get_env_dict(state.environment, state.subdir)
+
+    @noPosargs
+    @noKwargs
+    def rust_dependency_map_method(self, state: ModuleState, args: T.List, kwargs: TYPE_kwargs) -> T.Dict[str, str]:
+        """Returns rust dependency mapping for this package."""
+        return self.package.cfg.get_dependency_map(self.package.manifest)
 
 
 class RustPackage(RustCrate):

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -23,7 +23,7 @@ from ..interpreter.type_checking import (
 )
 from ..interpreterbase import ContainerTypeInfo, InterpreterException, KwargInfo, typed_kwargs, typed_pos_args, noKwargs, noPosargs, permittedKwargs
 from ..interpreter.interpreterobjects import Doctest
-from ..mesonlib import File, MachineChoice, MesonException, PerMachine
+from ..mesonlib import (is_parent_path, File, MachineChoice, MesonException, PerMachine)
 from ..programs import ExternalProgram, NonExistingExternalProgram
 
 if T.TYPE_CHECKING:
@@ -123,6 +123,10 @@ class RustWorkspace(ModuleObject):
             'package': self.package_method,
             'subproject': self.subproject_method,
         })
+
+    @property
+    def subdir(self) -> str:
+        return self.ws.subdir
 
     @noPosargs
     @noKwargs
@@ -248,6 +252,10 @@ class RustPackage(RustCrate):
         if kwargs['dependencies']:
             for dep_key, dep_pkg in cfg.dep_packages.items():
                 if dep_pkg.manifest.lib:
+                    if dep_pkg.ws_subdir != self.rust_ws.subdir or \
+                        is_parent_path(os.path.join(self.rust_ws.subdir, state.subproject_dir),
+                                       dep_pkg.path):
+                        self.rust_ws._do_subproject(dep_pkg)
                     # Get the dependency name for this package
                     depname = dep_pkg.get_dependency_name(None)
                     dependency = state.overridden_dependency(depname, for_machine)

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -19,7 +19,8 @@ from ..compilers.rust import parse_target, RustSystemDependency
 from ..dependencies import Dependency
 from ..interpreter.type_checking import (
     DEPENDENCIES_KW, LINK_WITH_KW, LINK_WHOLE_KW, SHARED_LIB_KWS, TEST_KWS, TEST_KWS_NO_ARGS,
-    OUTPUT_KW, INCLUDE_DIRECTORIES, SOURCES_VARARGS, NoneType, in_set_validator
+    OUTPUT_KW, INCLUDE_DIRECTORIES, SOURCES_VARARGS, NoneType, in_set_validator,
+    LIBRARY_KWS, _BASE_LANG_KW
 )
 from ..interpreterbase import ContainerTypeInfo, InterpreterException, KwargInfo, typed_kwargs, typed_pos_args, noKwargs, noPosargs, permittedKwargs
 from ..interpreter.interpreterobjects import Doctest
@@ -81,6 +82,8 @@ if T.TYPE_CHECKING:
         dev_dependencies: bool
         system_dependencies: bool
 
+    class RustPackageLibrary(_kwargs.Library):
+        pass
 
 RUST_TEST_KWS: T.List[KwargInfo] = [
      KwargInfo(
@@ -92,6 +95,10 @@ RUST_TEST_KWS: T.List[KwargInfo] = [
      ),
      KwargInfo('is_parallel', bool, default=False),
 ]
+
+# The native argument should be passed to the "package" method
+LIBRARY_KWS_NO_NATIVE = [kwi for kwi in LIBRARY_KWS if kwi.name != 'native']
+SHARED_LIB_KWS_NO_NATIVE = [kwi for kwi in SHARED_LIB_KWS if kwi.name != 'native']
 
 
 def no_spaces_validator(arg: T.Optional[T.Union[str, T.List]]) -> T.Optional[str]:
@@ -242,6 +249,8 @@ class RustPackage(RustCrate):
         super().__init__(rust_ws, package)
         self.methods.update({
             'dependencies': self.dependencies_method,
+            'library': self.library_method,
+            'proc_macro': self.proc_macro_method,
         })
 
     def _dependencies_method(self, state: ModuleState, kwargs: RustPackageDependencies,
@@ -283,6 +292,129 @@ class RustPackage(RustCrate):
     def dependencies_method(self, state: ModuleState, args: T.List, kwargs: RustPackageDependencies) -> T.List[Dependency]:
         """Returns the dependencies for this package."""
         return self._dependencies_method(state, kwargs, MachineChoice.HOST)
+
+    @staticmethod
+    def validate_pos_args(name: str, args: T.Tuple[
+            T.Optional[T.Union[str, StructuredSources]],
+            T.Optional[StructuredSources]]) -> T.Tuple[T.Optional[str], T.Optional[StructuredSources]]:
+        if isinstance(args[0], str):
+            return args[0], args[1]
+        if args[1] is not None:
+            raise MesonException(f"{name} only accepts one StructuredSources parameter")
+        return None, args[0]
+
+    def merge_kw_args(self, state: ModuleState, kwargs: RustPackageLibrary) -> None:
+        kwargs.setdefault('native', MachineChoice.HOST)
+
+        deps = kwargs['dependencies']
+        kwargs['dependencies'] = self._dependencies_method(state, {
+            'dependencies': True,
+            'dev_dependencies': False,
+            'system_dependencies': True,
+        }, kwargs['native'])
+        kwargs['dependencies'].extend(deps)
+
+        depmap = kwargs['rust_dependency_map']
+        kwargs['rust_dependency_map'] = \
+            self.package.cfg.get_dependency_map(self.package.manifest)
+        kwargs['rust_dependency_map'].update(depmap)
+
+        rust_args = kwargs['rust_args']
+        kwargs['rust_args'] = \
+            self.package.get_rustc_args(state.environment, state.subdir, kwargs['native'])
+        kwargs['rust_args'].extend(rust_args)
+
+        kwargs['override_options'].setdefault('rust_std', self.package.manifest.package.edition)
+
+    def _library_method(self, state: ModuleState, args: T.Tuple[
+            T.Optional[T.Union[str, StructuredSources]],
+            T.Optional[StructuredSources]], kwargs: RustPackageLibrary,
+            static: bool, shared: bool) -> T.Union[BothLibraries, SharedLibrary, StaticLibrary]:
+        tgt_args = self.validate_pos_args('package.library', args)
+        if not self.package.manifest.lib:
+            raise MesonException("no [lib] section in Cargo package")
+
+        sources: T.Union[StructuredSources, str]
+        tgt_name, sources = tgt_args
+        if not tgt_name:
+            rust_abi: RUST_ABI
+            if kwargs['rust_crate_type'] is not None:
+                rust_abi = 'rust' if kwargs['rust_crate_type'] in {'lib', 'rlib', 'dylib', 'proc-macro'} else 'c'
+            else:
+                rust_abi = kwargs['rust_abi']
+            tgt_name = self.package.library_name(rust_abi)
+        if not sources:
+            sources = self.package.manifest.lib.path
+
+        lib_args: T.Tuple[str, SourcesVarargsType] = (tgt_name, [sources])
+        self.merge_kw_args(state, kwargs)
+
+        if static and shared:
+            return state._interpreter.build_both_libraries(state.current_node, lib_args, kwargs)
+        elif shared:
+            return state._interpreter.build_target(state.current_node, lib_args,
+                                                   T.cast('_kwargs.SharedLibrary', kwargs),
+                                                   SharedLibrary)
+        else:
+            return state._interpreter.build_target(state.current_node, lib_args,
+                                                   T.cast('_kwargs.StaticLibrary', kwargs),
+                                                   StaticLibrary)
+
+    def _proc_macro_method(self, state: 'ModuleState', args: T.Tuple[
+            T.Optional[T.Union[str, StructuredSources]],
+            T.Optional[StructuredSources]], kwargs: RustPackageLibrary) -> SharedLibrary:
+        kwargs['native'] = MachineChoice.BUILD
+        kwargs['rust_abi'] = None
+        kwargs['rust_crate_type'] = 'proc-macro'
+        kwargs['rust_args'] = kwargs['rust_args'] + ['--extern', 'proc_macro']
+        result = self._library_method(state, args, kwargs, shared=True, static=False)
+        return T.cast('SharedLibrary', result)
+
+    @typed_pos_args('package.library', optargs=[(str, StructuredSources), StructuredSources])
+    @typed_kwargs(
+        'package.library',
+        *LIBRARY_KWS_NO_NATIVE,
+        DEPENDENCIES_KW,
+        LINK_WITH_KW,
+        LINK_WHOLE_KW,
+        _BASE_LANG_KW.evolve(name='rust_args'),
+    )
+    def library_method(self, state: ModuleState, args: T.Tuple[
+            T.Optional[T.Union[str, StructuredSources]],
+            T.Optional[StructuredSources]], kwargs: RustPackageLibrary) -> T.Union[BothLibraries, SharedLibrary, StaticLibrary]:
+        if not self.package.manifest.lib:
+            raise MesonException("no [lib] section in Cargo package")
+        if kwargs['rust_crate_type'] is not None:
+            static = kwargs['rust_crate_type'] in {'lib', 'rlib', 'staticlib'}
+            shared = kwargs['rust_crate_type'] in {'dylib', 'cdylib', 'proc-macro'}
+        else:
+            rust_abi = self.package.abi_resolve_default(kwargs['rust_abi'])
+            static = self.package.abi_has_static(rust_abi)
+            shared = self.package.abi_has_shared(rust_abi)
+            if rust_abi == 'proc-macro':
+                kwargs['rust_crate_type'] = 'proc-macro'
+                kwargs['rust_abi'] = None
+            else:
+                kwargs['rust_abi'] = rust_abi
+        return self._library_method(state, args, kwargs, static=static, shared=shared)
+
+    @typed_pos_args('package.proc_macro', optargs=[(str, StructuredSources), StructuredSources])
+    @typed_kwargs(
+        'package.proc_macro',
+        *SHARED_LIB_KWS_NO_NATIVE,
+        DEPENDENCIES_KW,
+        LINK_WITH_KW,
+        LINK_WHOLE_KW,
+        _BASE_LANG_KW.evolve(name='rust_args'),
+    )
+    def proc_macro_method(self, state: 'ModuleState', args: T.Tuple[
+            T.Optional[T.Union[str, StructuredSources]],
+            T.Optional[StructuredSources]], kwargs: RustPackageLibrary) -> SharedLibrary:
+        if not self.package.manifest.lib:
+            raise MesonException("no [lib] section in Cargo package")
+        if 'proc-macro' not in self.package.manifest.lib.crate_type:
+            raise MesonException("not a procedural macro crate")
+        return self._proc_macro_method(state, args, kwargs)
 
 
 class RustSubproject(RustCrate):

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -13,14 +13,15 @@ from mesonbuild.interpreterbase.decorators import FeatureNew
 from . import ExtensionModule, ModuleReturnValue, ModuleInfo, ModuleObject
 from .. import mesonlib, mlog
 from ..build import (BothLibraries, BuildTarget, CustomTargetIndex, Executable, ExtractedObjects, GeneratedList,
-                     CustomTarget, InvalidArguments, Jar, StructuredSources, SharedLibrary, StaticLibrary)
+                     CustomTarget, InvalidArguments, Jar, StructuredSources, SharedLibrary, StaticLibrary,
+                     SharedModule)
 from ..compilers.compilers import are_asserts_disabled_for_subproject, lang_suffixes
 from ..compilers.rust import parse_target, RustSystemDependency
 from ..dependencies import Dependency
 from ..interpreter.type_checking import (
     DEPENDENCIES_KW, LINK_WITH_KW, LINK_WHOLE_KW, SHARED_LIB_KWS, TEST_KWS, TEST_KWS_NO_ARGS,
     OUTPUT_KW, INCLUDE_DIRECTORIES, SOURCES_VARARGS, NoneType, in_set_validator,
-    EXECUTABLE_KWS, LIBRARY_KWS, _BASE_LANG_KW
+    EXECUTABLE_KWS, LIBRARY_KWS, SHARED_MOD_KWS, _BASE_LANG_KW
 )
 from ..interpreterbase import ContainerTypeInfo, InterpreterException, KwargInfo, typed_kwargs, typed_pos_args, noKwargs, noPosargs, permittedKwargs
 from ..interpreter.interpreterobjects import Doctest
@@ -103,6 +104,7 @@ RUST_TEST_KWS: T.List[KwargInfo] = [
 EXECUTABLE_KWS_NO_NATIVE = [kwi for kwi in EXECUTABLE_KWS if kwi.name != 'native']
 LIBRARY_KWS_NO_NATIVE = [kwi for kwi in LIBRARY_KWS if kwi.name != 'native']
 SHARED_LIB_KWS_NO_NATIVE = [kwi for kwi in SHARED_LIB_KWS if kwi.name != 'native']
+SHARED_MOD_KWS_NO_NATIVE = [kwi for kwi in SHARED_MOD_KWS if kwi.name != 'native']
 
 
 def no_spaces_validator(arg: T.Optional[T.Union[str, T.List]]) -> T.Optional[str]:
@@ -255,6 +257,7 @@ class RustPackage(RustCrate):
             'dependencies': self.dependencies_method,
             'library': self.library_method,
             'proc_macro': self.proc_macro_method,
+            'shared_module': self.shared_module_method,
             'executable': self.executable_method,
         })
 
@@ -334,7 +337,8 @@ class RustPackage(RustCrate):
     def _library_method(self, state: ModuleState, args: T.Tuple[
             T.Optional[T.Union[str, StructuredSources]],
             T.Optional[StructuredSources]], kwargs: RustPackageLibrary,
-            static: bool, shared: bool) -> T.Union[BothLibraries, SharedLibrary, StaticLibrary]:
+            static: bool, shared: bool,
+            shared_mod: bool = False) -> T.Union[BothLibraries, SharedLibrary, StaticLibrary]:
         tgt_args = self.validate_pos_args('package.library', args)
         if not self.package.manifest.lib:
             raise MesonException("no [lib] section in Cargo package")
@@ -353,6 +357,11 @@ class RustPackage(RustCrate):
 
         lib_args: T.Tuple[str, SourcesVarargsType] = (tgt_name, [sources])
         self.merge_kw_args(state, kwargs)
+
+        if shared_mod:
+            return state._interpreter.build_target(state.current_node, lib_args,
+                                                   T.cast('_kwargs.SharedModule', kwargs),
+                                                   SharedModule)
 
         if static and shared:
             return state._interpreter.build_both_libraries(state.current_node, lib_args, kwargs)
@@ -420,6 +429,28 @@ class RustPackage(RustCrate):
         if 'proc-macro' not in self.package.manifest.lib.crate_type:
             raise MesonException("not a procedural macro crate")
         return self._proc_macro_method(state, args, kwargs)
+
+    @typed_pos_args('package.shared_module', optargs=[(str, StructuredSources), StructuredSources])
+    @typed_kwargs(
+        'package.shared_module',
+        *SHARED_MOD_KWS_NO_NATIVE,
+        DEPENDENCIES_KW,
+        LINK_WITH_KW,
+        LINK_WHOLE_KW,
+        _BASE_LANG_KW.evolve(name='rust_args'),
+    )
+    def shared_module_method(self, state: 'ModuleState', args: T.Tuple[
+            T.Optional[T.Union[str, StructuredSources]],
+            T.Optional[StructuredSources]], kwargs: RustPackageLibrary) -> SharedModule:
+        if not self.package.manifest.lib:
+            raise MesonException("no [lib] section in Cargo package")
+        if 'cdylib' not in self.package.manifest.lib.crate_type:
+            raise MesonException("not a cdylib crate")
+
+        kwargs['rust_abi'] = None
+        kwargs['rust_crate_type'] = 'cdylib'
+        result = self._library_method(state, args, kwargs, shared=True, static=False, shared_mod=True)
+        return T.cast('SharedModule', result)
 
     @typed_pos_args('package.executable', optargs=[(str, StructuredSources), StructuredSources])
     @typed_kwargs(

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -20,7 +20,7 @@ from ..dependencies import Dependency
 from ..interpreter.type_checking import (
     DEPENDENCIES_KW, LINK_WITH_KW, LINK_WHOLE_KW, SHARED_LIB_KWS, TEST_KWS, TEST_KWS_NO_ARGS,
     OUTPUT_KW, INCLUDE_DIRECTORIES, SOURCES_VARARGS, NoneType, in_set_validator,
-    LIBRARY_KWS, _BASE_LANG_KW
+    EXECUTABLE_KWS, LIBRARY_KWS, _BASE_LANG_KW
 )
 from ..interpreterbase import ContainerTypeInfo, InterpreterException, KwargInfo, typed_kwargs, typed_pos_args, noKwargs, noPosargs, permittedKwargs
 from ..interpreter.interpreterobjects import Doctest
@@ -82,6 +82,9 @@ if T.TYPE_CHECKING:
         dev_dependencies: bool
         system_dependencies: bool
 
+    class RustPackageExecutable(_kwargs.Executable):
+        pass
+
     class RustPackageLibrary(_kwargs.Library):
         pass
 
@@ -97,6 +100,7 @@ RUST_TEST_KWS: T.List[KwargInfo] = [
 ]
 
 # The native argument should be passed to the "package" method
+EXECUTABLE_KWS_NO_NATIVE = [kwi for kwi in EXECUTABLE_KWS if kwi.name != 'native']
 LIBRARY_KWS_NO_NATIVE = [kwi for kwi in LIBRARY_KWS if kwi.name != 'native']
 SHARED_LIB_KWS_NO_NATIVE = [kwi for kwi in SHARED_LIB_KWS if kwi.name != 'native']
 
@@ -251,6 +255,7 @@ class RustPackage(RustCrate):
             'dependencies': self.dependencies_method,
             'library': self.library_method,
             'proc_macro': self.proc_macro_method,
+            'executable': self.executable_method,
         })
 
     def _dependencies_method(self, state: ModuleState, kwargs: RustPackageDependencies,
@@ -303,7 +308,7 @@ class RustPackage(RustCrate):
             raise MesonException(f"{name} only accepts one StructuredSources parameter")
         return None, args[0]
 
-    def merge_kw_args(self, state: ModuleState, kwargs: RustPackageLibrary) -> None:
+    def merge_kw_args(self, state: ModuleState, kwargs: T.Union[RustPackageExecutable, RustPackageLibrary]) -> None:
         kwargs.setdefault('native', MachineChoice.HOST)
 
         deps = kwargs['dependencies']
@@ -415,6 +420,43 @@ class RustPackage(RustCrate):
         if 'proc-macro' not in self.package.manifest.lib.crate_type:
             raise MesonException("not a procedural macro crate")
         return self._proc_macro_method(state, args, kwargs)
+
+    @typed_pos_args('package.executable', optargs=[(str, StructuredSources), StructuredSources])
+    @typed_kwargs(
+        'package.executable',
+        *EXECUTABLE_KWS_NO_NATIVE,
+        DEPENDENCIES_KW,
+        LINK_WITH_KW,
+        LINK_WHOLE_KW,
+        _BASE_LANG_KW.evolve(name='rust_args'),
+    )
+    def executable_method(self, state: 'ModuleState', args: T.Tuple[
+            T.Optional[T.Union[str, StructuredSources]],
+            T.Optional[StructuredSources]], kwargs: RustPackageExecutable) -> Executable:
+        """Builds executable targets from workspace bins."""
+        tgt_args = self.validate_pos_args('package.executable', args)
+        if not self.package.manifest.bin:
+            raise MesonException("no [[bin]] section in Cargo package")
+
+        sources: T.Union[StructuredSources, str]
+        tgt_name, sources = tgt_args
+        # If there's more than one binary, the first argument must be specified
+        # and must be one of the keys in pkg.bin
+        if not tgt_name:
+            if len(self.package.manifest.bin) > 1:
+                raise MesonException("Package has multiple binaries, you must specify which one to build as the first argument")
+            # Single binary, use it
+            tgt_name = next(iter(self.package.manifest.bin.keys()))
+        else:
+            if tgt_name not in self.package.manifest.bin:
+                raise MesonException(f"Binary '{tgt_name}' not found.")
+
+        if not sources:
+            sources = self.package.manifest.bin[tgt_name].path
+
+        exe_args: T.Tuple[str, SourcesVarargsType] = (tgt_name, [sources])
+        self.merge_kw_args(state, kwargs)
+        return state._interpreter.build_target(state.current_node, exe_args, kwargs, Executable)
 
 
 class RustSubproject(RustCrate):

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -660,6 +660,12 @@ class RustModule(ExtensionModule):
             self.interpreter.cargo.features = cargo_features
 
         ws = self.interpreter.cargo.load_workspace(state.root_subdir)
+
+        # Cargo projects may not have a subprojects directory, because
+        # dependencies are declared in Cargo.toml rather than .wrap files.
+        # Create it now so that the wrap resolver can download the crates there
+        os.makedirs(self.interpreter.environment.wrap_resolver.subdir_root, exist_ok=True)
+
         return RustWorkspace(self.interpreter, ws)
 
 

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -259,6 +259,7 @@ class RustPackage(RustCrate):
             'proc_macro': self.proc_macro_method,
             'shared_module': self.shared_module_method,
             'executable': self.executable_method,
+            'override_dependency': self.override_dependency_method,
         })
 
     def _dependencies_method(self, state: ModuleState, kwargs: RustPackageDependencies,
@@ -383,6 +384,28 @@ class RustPackage(RustCrate):
         kwargs['rust_args'] = kwargs['rust_args'] + ['--extern', 'proc_macro']
         result = self._library_method(state, args, kwargs, shared=True, static=False)
         return T.cast('SharedLibrary', result)
+
+    @typed_pos_args('package.override_dependency', Dependency)
+    @typed_kwargs('package.override_dependency',
+                  KwargInfo('rust_abi', (str, NoneType), default=None, validator=in_set_validator({'rust', 'c', 'proc-macro'})))
+    def override_dependency_method(self, state: ModuleState, args: T.Tuple[Dependency], kwargs: FuncDependency) -> None:
+        dep = args[0]
+        rust_abi = self.package.abi_resolve_default(kwargs['rust_abi'])
+        depname = self.package.get_dependency_name(rust_abi)
+
+        if rust_abi == 'proc-macro':
+            state.override_dependency(depname, dep, for_machine=MachineChoice.HOST)
+            state.override_dependency(depname, dep, static=False, for_machine=MachineChoice.HOST)
+            if state.environment.is_cross_build():
+                state.override_dependency(depname, dep, for_machine=MachineChoice.BUILD)
+                state.override_dependency(depname, dep, static=False, for_machine=MachineChoice.BUILD)
+            return
+
+        state.override_dependency(depname, dep)
+        if self.package.abi_has_static(rust_abi):
+            state.override_dependency(depname, dep, static=True)
+        if self.package.abi_has_shared(rust_abi):
+            state.override_dependency(depname, dep, static=False)
 
     @typed_pos_args('package.library', optargs=[(str, StructuredSources), StructuredSources])
     @typed_kwargs(

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -15,7 +15,7 @@ from .. import mesonlib, mlog
 from ..build import (BothLibraries, BuildTarget, CustomTargetIndex, Executable, ExtractedObjects, GeneratedList,
                      CustomTarget, InvalidArguments, Jar, StructuredSources, SharedLibrary, StaticLibrary)
 from ..compilers.compilers import are_asserts_disabled_for_subproject, lang_suffixes
-from ..compilers.rust import parse_target
+from ..compilers.rust import parse_target, RustSystemDependency
 from ..dependencies import Dependency
 from ..interpreter.type_checking import (
     DEPENDENCIES_KW, LINK_WITH_KW, LINK_WHOLE_KW, SHARED_LIB_KWS, TEST_KWS, TEST_KWS_NO_ARGS,
@@ -262,6 +262,7 @@ class RustModule(ExtensionModule):
             'doctest': self.doctest,
             'bindgen': self.bindgen,
             'proc_macro': self.proc_macro,
+            'to_system_dependency': self.to_system_dependency,
             'workspace': self.workspace,
         })
 
@@ -669,6 +670,21 @@ class RustModule(ExtensionModule):
         kwargs['rust_args'] = kwargs['rust_args'] + ['--extern', 'proc_macro']
         target = state._interpreter.build_target(state.current_node, args, kwargs, SharedLibrary)
         return target
+
+    @FeatureNew('rust.to_system_dependency', '1.11.0')
+    @typed_pos_args('rust.to_system_dependency', Dependency, optargs=[str])
+    @noKwargs
+    def to_system_dependency(self, state: ModuleState, args: T.Tuple[Dependency, T.Optional[str]], kwargs: TYPE_kwargs) -> Dependency:
+        dep, depname = args
+        if not dep.found():
+            return dep
+        if not depname:
+            if not dep.name:
+                raise MesonException("rust.to_system_dependency() called with an unnamed dependency and no explicit name")
+            depname = dep.name
+        depname = re.sub(r'[^a-zA-Z0-9]', '_', depname)
+        rust_args = ['--cfg', f'system_deps_have_{depname}']
+        return RustSystemDependency(dep.version, compile_args=rust_args, ext_deps=[dep], name=dep.name)
 
     @FeatureNew('rust.workspace', '1.11.0')
     @noPosargs

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -76,6 +76,12 @@ if T.TYPE_CHECKING:
     class FuncDependency(TypedDict):
         rust_abi: T.Optional[RUST_ABI]
 
+    class RustPackageDependencies(TypedDict):
+        dependencies: bool
+        dev_dependencies: bool
+        system_dependencies: bool
+
+
 RUST_TEST_KWS: T.List[KwargInfo] = [
      KwargInfo(
          'rust_args',
@@ -93,6 +99,16 @@ def no_spaces_validator(arg: T.Optional[T.Union[str, T.List]]) -> T.Optional[str
         return 'must not contain spaces due to limitations of rustdoc'
     return None
 
+def dep_to_system_dependency(dep: Dependency, depname: str) -> Dependency:
+    if not dep.found():
+        return dep
+    if not depname:
+        if not dep.name:
+            raise MesonException("rust.to_system_dependency() called with an unnamed dependency and no explicit name")
+        depname = dep.name
+    depname = re.sub(r'[^a-zA-Z0-9]', '_', depname)
+    rust_args = ['--cfg', f'system_deps_have_{depname}']
+    return RustSystemDependency(dep.version, compile_args=rust_args, ext_deps=[dep], name=dep.name)
 
 class RustWorkspace(ModuleObject):
     """Represents a Rust workspace, controlling the build of packages
@@ -220,6 +236,45 @@ class RustPackage(RustCrate):
 
     def __init__(self, rust_ws: RustWorkspace, package: cargo.PackageState) -> None:
         super().__init__(rust_ws, package)
+        self.methods.update({
+            'dependencies': self.dependencies_method,
+        })
+
+    def _dependencies_method(self, state: ModuleState, kwargs: RustPackageDependencies,
+                             for_machine: MachineChoice) -> T.List[Dependency]:
+        dependencies: T.List[Dependency] = []
+        cfg = self.package.cfg
+
+        if kwargs['dependencies']:
+            for dep_key, dep_pkg in cfg.dep_packages.items():
+                if dep_pkg.manifest.lib:
+                    # Get the dependency name for this package
+                    depname = dep_pkg.get_dependency_name(None)
+                    dependency = state.overridden_dependency(depname, for_machine)
+                    dependencies.append(dependency)
+
+        if kwargs['dev_dependencies']:
+            raise MesonException('dev_dependencies is not implemented yet')
+
+        if kwargs['system_dependencies']:
+            for name, sys_dep in self.package.manifest.system_dependencies.items():
+                if sys_dep.enabled(cfg.features):
+                    # System dependencies use the original dependency name from Cargo.toml
+                    dependency = state.dependency(sys_dep.name, native=(for_machine == MachineChoice.BUILD),
+                                                  required=not sys_dep.optional,
+                                                  wanted=sys_dep.meson_version)
+                    dependencies.append(dep_to_system_dependency(dependency, name))
+
+        return dependencies
+
+    @noPosargs
+    @typed_kwargs('package.dependencies',
+                  KwargInfo('dependencies', bool, default=True),
+                  KwargInfo('dev_dependencies', bool, default=False),
+                  KwargInfo('system_dependencies', bool, default=True))
+    def dependencies_method(self, state: ModuleState, args: T.List, kwargs: RustPackageDependencies) -> T.List[Dependency]:
+        """Returns the dependencies for this package."""
+        return self._dependencies_method(state, kwargs, MachineChoice.HOST)
 
 
 class RustSubproject(RustCrate):
@@ -676,15 +731,7 @@ class RustModule(ExtensionModule):
     @noKwargs
     def to_system_dependency(self, state: ModuleState, args: T.Tuple[Dependency, T.Optional[str]], kwargs: TYPE_kwargs) -> Dependency:
         dep, depname = args
-        if not dep.found():
-            return dep
-        if not depname:
-            if not dep.name:
-                raise MesonException("rust.to_system_dependency() called with an unnamed dependency and no explicit name")
-            depname = dep.name
-        depname = re.sub(r'[^a-zA-Z0-9]', '_', depname)
-        rust_args = ['--cfg', f'system_deps_have_{depname}']
-        return RustSystemDependency(dep.version, compile_args=rust_args, ext_deps=[dep], name=dep.name)
+        return dep_to_system_dependency(dep, depname)
 
     @FeatureNew('rust.workspace', '1.11.0')
     @noPosargs

--- a/test cases/rust/31 rust.workspace package/meson.build
+++ b/test cases/rust/31 rust.workspace package/meson.build
@@ -6,6 +6,13 @@ cargo_ws = rust.workspace()
 # Test workspace.packages() method
 assert(cargo_ws.packages() == ['answer', 'hello', 'package_test'])
 
+main_pkg = cargo_ws.package()
+assert(main_pkg.name() == 'package_test')
+assert(main_pkg.version() == '0.1.0')
+assert(main_pkg.api() == '0.1')
+assert(main_pkg.all_features() == ['answer', 'default', 'feature1', 'feature2'])
+assert(main_pkg.features() == ['default', 'feature1'])
+
 hello_rs = cargo_ws.subproject('hello')
 assert(hello_rs.name() == 'hello')
 assert(hello_rs.version() == '1.0.0')
@@ -24,6 +31,14 @@ e = executable('package-test', 'src/main.rs',
   dependencies: [hello_rs.dependency(), answer_rs.dependency()],
 )
 test('package-test', e)
+
+# failure test cases for package()
+testcase expect_error('argument to package() cannot be a subproject')
+  cargo_ws.package('hello')
+endtestcase
+testcase expect_error('workspace member "nonexistent" not found')
+  cargo_ws.package('nonexistent')
+endtestcase
 
 # failure test cases for dependency()
 testcase expect_error('package.dependency.*must be one of c, proc-macro, rust.*', how: 're')

--- a/test cases/rust/31 rust.workspace package/meson.build
+++ b/test cases/rust/31 rust.workspace package/meson.build
@@ -29,6 +29,8 @@ assert(answer_rs.features() == ['default', 'large'])
 
 e = executable('package-test', 'src/main.rs',
   dependencies: [hello_rs.dependency(), answer_rs.dependency()],
+  rust_args: main_pkg.rust_args(),
+  rust_dependency_map: main_pkg.rust_dependency_map(),
 )
 test('package-test', e)
 

--- a/test cases/rust/31 rust.workspace package/meson.build
+++ b/test cases/rust/31 rust.workspace package/meson.build
@@ -20,19 +20,19 @@ assert(hello_rs.api() == '1')
 assert(hello_rs.all_features() == ['default', 'goodbye'])
 assert(hello_rs.features() == ['default', 'goodbye'])
 
-answer_rs = cargo_ws.subproject('answer', '2')
-assert(answer_rs.name() == 'answer')
-assert(answer_rs.version() == '2.1.0')
-assert(answer_rs.api() == '2')
-assert(answer_rs.all_features() == ['default', 'large'])
-assert(answer_rs.features() == ['default', 'large'])
-
 e = executable('package-test', 'src/main.rs',
   dependencies: main_pkg.dependencies(),
   rust_args: main_pkg.rust_args(),
   rust_dependency_map: main_pkg.rust_dependency_map(),
 )
 test('package-test', e)
+
+answer_rs = cargo_ws.subproject('answer', '2')
+assert(answer_rs.name() == 'answer')
+assert(answer_rs.version() == '2.1.0')
+assert(answer_rs.api() == '2')
+assert(answer_rs.all_features() == ['default', 'large'])
+assert(answer_rs.features() == ['default', 'large'])
 
 # failure test cases for package()
 testcase expect_error('argument to package() cannot be a subproject')

--- a/test cases/rust/31 rust.workspace package/meson.build
+++ b/test cases/rust/31 rust.workspace package/meson.build
@@ -28,7 +28,7 @@ assert(answer_rs.all_features() == ['default', 'large'])
 assert(answer_rs.features() == ['default', 'large'])
 
 e = executable('package-test', 'src/main.rs',
-  dependencies: [hello_rs.dependency(), answer_rs.dependency()],
+  dependencies: main_pkg.dependencies(),
   rust_args: main_pkg.rust_args(),
   rust_dependency_map: main_pkg.rust_dependency_map(),
 )

--- a/test cases/rust/31 rust.workspace package/subprojects/answer-2.1/meson.build
+++ b/test cases/rust/31 rust.workspace package/subprojects/answer-2.1/meson.build
@@ -4,6 +4,10 @@ rust = import('rust')
 cargo_ws = rust.workspace()
 assert(cargo_ws.packages() == ['answer'])
 
+answer_pkg = cargo_ws.package()
+assert(answer_pkg.all_features() == ['default', 'large'])
+assert(answer_pkg.features() == ['default', 'large'])
+
 l = static_library('answer', 'src/lib.rs', rust_args: ['--cfg', 'feature="large"'])
 dep = declare_dependency(link_with: l)
 meson.override_dependency('answer-2-rs', dep)

--- a/test cases/rust/31 rust.workspace package/subprojects/answer-2.1/meson.build
+++ b/test cases/rust/31 rust.workspace package/subprojects/answer-2.1/meson.build
@@ -8,6 +8,8 @@ answer_pkg = cargo_ws.package()
 assert(answer_pkg.all_features() == ['default', 'large'])
 assert(answer_pkg.features() == ['default', 'large'])
 
-l = static_library('answer', 'src/lib.rs', rust_args: ['--cfg', 'feature="large"'])
+l = static_library('answer', 'src/lib.rs',
+                   rust_args: answer_pkg.rust_args(),
+                   rust_dependency_map: answer_pkg.rust_dependency_map())
 dep = declare_dependency(link_with: l)
 meson.override_dependency('answer-2-rs', dep)

--- a/test cases/rust/32 rust.workspace workspace/Cargo.lock
+++ b/test cases/rust/32 rust.workspace workspace/Cargo.lock
@@ -11,9 +11,14 @@ name = "hello"
 version = "1.0.0"
 
 [[package]]
+name = "more"
+version = "0.1.0"
+
+[[package]]
 name = "workspace_test"
 version = "0.1.0"
 dependencies = [
  "answer",
  "hello",
+ "more",
 ]

--- a/test cases/rust/32 rust.workspace workspace/Cargo.toml
+++ b/test cases/rust/32 rust.workspace workspace/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["."]
+members = [".", "more"]
 
 [package]
 name = "workspace_test"
@@ -14,3 +14,4 @@ feature2 = []
 [dependencies]
 hello = { version = "1.0", path = "subprojects/hello-1.0", optional = true }
 answer = { version = "2.1", path = "subprojects/answer-2.1", optional = true }
+more = { path = "more" }

--- a/test cases/rust/32 rust.workspace workspace/meson.build
+++ b/test cases/rust/32 rust.workspace workspace/meson.build
@@ -6,6 +6,13 @@ cargo_ws = rust.workspace()
 # Test workspace.packages() method
 assert(cargo_ws.packages() == ['answer', 'hello', 'workspace_test'])
 
+main_pkg = cargo_ws.package()
+assert(main_pkg.name() == 'workspace_test')
+assert(main_pkg.version() == '0.1.0')
+assert(main_pkg.api() == '0.1')
+assert(main_pkg.all_features() == ['answer', 'default', 'feature1', 'feature2'])
+assert(main_pkg.features() == ['default', 'feature1'])
+
 hello_rs = cargo_ws.subproject('hello')
 assert(hello_rs.name() == 'hello')
 assert(hello_rs.version() == '1.0.0')
@@ -24,6 +31,14 @@ e = executable('workspace-test', 'src/main.rs',
   dependencies: [hello_rs.dependency(), answer_rs.dependency()],
 )
 test('workspace-test', e)
+
+# failure test cases for package()
+testcase expect_error('argument to package() cannot be a subproject')
+  cargo_ws.package('hello')
+endtestcase
+testcase expect_error('workspace member "nonexistent" not found')
+  cargo_ws.package('nonexistent')
+endtestcase
 
 # failure test cases for dependency()
 testcase expect_error('package.dependency.*must be one of c, proc-macro, rust.*', how: 're')

--- a/test cases/rust/32 rust.workspace workspace/meson.build
+++ b/test cases/rust/32 rust.workspace workspace/meson.build
@@ -4,7 +4,7 @@ rust = import('rust')
 cargo_ws = rust.workspace()
 
 # Test workspace.packages() method
-assert(cargo_ws.packages() == ['answer', 'hello', 'workspace_test'])
+assert(cargo_ws.packages() == ['answer', 'hello', 'more', 'workspace_test'])
 
 main_pkg = cargo_ws.package()
 assert(main_pkg.name() == 'workspace_test')
@@ -27,8 +27,10 @@ assert(answer_rs.api() == '2')
 assert(answer_rs.all_features() == ['default', 'large'])
 assert(answer_rs.features() == ['default', 'large'])
 
+subdir('more')
+
 e = executable('workspace-test', 'src/main.rs',
-  dependencies: [hello_rs.dependency(), answer_rs.dependency()],
+  dependencies: [hello_rs.dependency(), answer_rs.dependency(), more_dep],
 )
 test('workspace-test', e)
 

--- a/test cases/rust/32 rust.workspace workspace/meson.build
+++ b/test cases/rust/32 rust.workspace workspace/meson.build
@@ -20,13 +20,6 @@ assert(hello_rs.api() == '1')
 assert(hello_rs.all_features() == ['default', 'goodbye'])
 assert(hello_rs.features() == ['default', 'goodbye'])
 
-answer_rs = cargo_ws.subproject('answer', '2')
-assert(answer_rs.name() == 'answer')
-assert(answer_rs.version() == '2.1.0')
-assert(answer_rs.api() == '2')
-assert(answer_rs.all_features() == ['default', 'large'])
-assert(answer_rs.features() == ['default', 'large'])
-
 subdir('more')
 
 e = executable('workspace-test', 'src/main.rs',
@@ -35,6 +28,13 @@ e = executable('workspace-test', 'src/main.rs',
   rust_dependency_map: main_pkg.rust_dependency_map(),
 )
 test('workspace-test', e)
+
+answer_rs = cargo_ws.subproject('answer', '2')
+assert(answer_rs.name() == 'answer')
+assert(answer_rs.version() == '2.1.0')
+assert(answer_rs.api() == '2')
+assert(answer_rs.all_features() == ['default', 'large'])
+assert(answer_rs.features() == ['default', 'large'])
 
 # failure test cases for package()
 testcase expect_error('argument to package() cannot be a subproject')

--- a/test cases/rust/32 rust.workspace workspace/meson.build
+++ b/test cases/rust/32 rust.workspace workspace/meson.build
@@ -30,7 +30,7 @@ assert(answer_rs.features() == ['default', 'large'])
 subdir('more')
 
 e = executable('workspace-test', 'src/main.rs',
-  dependencies: [hello_rs.dependency(), answer_rs.dependency(), more_dep],
+  dependencies: main_pkg.dependencies(),
   rust_args: main_pkg.rust_args(),
   rust_dependency_map: main_pkg.rust_dependency_map(),
 )

--- a/test cases/rust/32 rust.workspace workspace/meson.build
+++ b/test cases/rust/32 rust.workspace workspace/meson.build
@@ -31,6 +31,8 @@ subdir('more')
 
 e = executable('workspace-test', 'src/main.rs',
   dependencies: [hello_rs.dependency(), answer_rs.dependency(), more_dep],
+  rust_args: main_pkg.rust_args(),
+  rust_dependency_map: main_pkg.rust_dependency_map(),
 )
 test('workspace-test', e)
 

--- a/test cases/rust/32 rust.workspace workspace/more/Cargo.toml
+++ b/test cases/rust/32 rust.workspace workspace/more/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "more"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["rlib"]

--- a/test cases/rust/32 rust.workspace workspace/more/meson.build
+++ b/test cases/rust/32 rust.workspace workspace/more/meson.build
@@ -9,4 +9,4 @@ l = static_library('more', 'src/lib.rs',
   rust_dependency_map: more_pkg.rust_dependency_map(),
 )
 more_dep = declare_dependency(link_with: l)
-meson.override_dependency('more-0.1-rs', more_dep)
+more_pkg.override_dependency(more_dep)

--- a/test cases/rust/32 rust.workspace workspace/more/meson.build
+++ b/test cases/rust/32 rust.workspace workspace/more/meson.build
@@ -9,3 +9,4 @@ l = static_library('more', 'src/lib.rs',
   rust_dependency_map: more_pkg.rust_dependency_map(),
 )
 more_dep = declare_dependency(link_with: l)
+meson.override_dependency('more-0.1-rs', more_dep)

--- a/test cases/rust/32 rust.workspace workspace/more/meson.build
+++ b/test cases/rust/32 rust.workspace workspace/more/meson.build
@@ -4,5 +4,8 @@ assert(more_pkg.name() == 'more')
 assert(more_pkg.features() == ['default'])
 assert(more_pkg.all_features() == ['default'])
 
-l = static_library('more', 'src/lib.rs')
+l = static_library('more', 'src/lib.rs',
+  rust_args: more_pkg.rust_args(),
+  rust_dependency_map: more_pkg.rust_dependency_map(),
+)
 more_dep = declare_dependency(link_with: l)

--- a/test cases/rust/32 rust.workspace workspace/more/meson.build
+++ b/test cases/rust/32 rust.workspace workspace/more/meson.build
@@ -1,0 +1,8 @@
+more_pkg = cargo_ws.package('more')
+
+assert(more_pkg.name() == 'more')
+assert(more_pkg.features() == ['default'])
+assert(more_pkg.all_features() == ['default'])
+
+l = static_library('more', 'src/lib.rs')
+more_dep = declare_dependency(link_with: l)

--- a/test cases/rust/32 rust.workspace workspace/more/src/lib.rs
+++ b/test cases/rust/32 rust.workspace workspace/more/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn do_something() {
+    println!("Doing something in more crate");
+}

--- a/test cases/rust/32 rust.workspace workspace/src/main.rs
+++ b/test cases/rust/32 rust.workspace workspace/src/main.rs
@@ -5,4 +5,5 @@ fn main() {
     println!("{}", farewell());
     println!("{}", answer::answer());
     println!("{}", answer::large_answer());
+    more::do_something();
 }

--- a/test cases/rust/32 rust.workspace workspace/subprojects/answer-2.1/meson.build
+++ b/test cases/rust/32 rust.workspace workspace/subprojects/answer-2.1/meson.build
@@ -4,6 +4,10 @@ rust = import('rust')
 cargo_ws = rust.workspace()
 assert(cargo_ws.packages() == ['answer'])
 
+answer_pkg = cargo_ws.package()
+assert(answer_pkg.all_features() == ['default', 'large'])
+assert(answer_pkg.features() == ['default', 'large'])
+
 l = static_library('answer', 'src/lib.rs', rust_args: ['--cfg', 'feature="large"'])
 dep = declare_dependency(link_with: l)
 meson.override_dependency('answer-2-rs', dep)

--- a/test cases/rust/32 rust.workspace workspace/subprojects/answer-2.1/meson.build
+++ b/test cases/rust/32 rust.workspace workspace/subprojects/answer-2.1/meson.build
@@ -8,6 +8,8 @@ answer_pkg = cargo_ws.package()
 assert(answer_pkg.all_features() == ['default', 'large'])
 assert(answer_pkg.features() == ['default', 'large'])
 
-l = static_library('answer', 'src/lib.rs', rust_args: ['--cfg', 'feature="large"'])
+l = static_library('answer', 'src/lib.rs',
+                   rust_args: answer_pkg.rust_args(),
+                   rust_dependency_map: answer_pkg.rust_dependency_map())
 dep = declare_dependency(link_with: l)
 meson.override_dependency('answer-2-rs', dep)


### PR DESCRIPTION
For the spec see #14639.

This adds a Cargo package object that can provide rustc arguments and dependencies&mdash;but also nice shortcuts `pkg.executable()`, `pkg.library()`, `pkg.proc_macro()`, `pkg.shared_module()` that can basically reduce a Rust crate to just:

```
project('something', 'rust')
cargo = import('rust').workspace()
cargo.package().executable(install: true)
```

[Here](https://gitlab.com/bonzini/libblkio/-/commit/b14230d59d7fcf9323cfad1969307a9418dcb449) is an example of using it for a cdylib composed of three crates.

Based on #15158.
Fixes: #14639 