### PR TITLE
Fix inverted RTTI logic in Intel C++ compiler

### DIFF
--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -733,7 +733,7 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
 
         if eh == 'none':
             args.append('-fno-exceptions')
-        if rtti:
+        if not rtti:
             args.append('-fno-rtti')
         if debugstl:
             args.append('-D_GLIBCXX_DEBUG=1')


### PR DESCRIPTION
Fixes #15220

## Description
The `IntelCPPCompiler` had inverted logic for the RTTI (Run-Time Type Information) option. It was adding `-fno-rtti` when RTTI was **enabled** (`rtti=True`) instead of when it was **disabled** (`rtti=False`).

## Changes
- Changed `if rtti:` to `if not rtti:` in `IntelCPPCompiler.get_option_compile_args()` (line 737)
- This makes the Intel compiler behavior consistent with GCC and Clang compilers

## Testing
- Python syntax validated successfully
- Logic now matches the implementation in `ClangCPPCompiler` and `GnuCPPCompiler`