### PR TITLE
fix parsing cgit paths

### DIFF
--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -17,6 +17,7 @@ import pathlib
 import collections
 import urllib.parse
 import typing as T
+from pathlib import PurePath
 
 from . import builder, version
 from .cfg import eval_cfg
@@ -799,7 +800,7 @@ def _parse_git_url(url: str, branch: T.Optional[str] = None) -> T.Tuple[str, str
     query_branch = query['branch'][0] if 'branch' in query else ''
     branch = branch or query_branch
     revision = parts.fragment or branch
-    directory = os.path.basename(parts.path)
+    directory = PurePath(parts.path).name
     if directory.endswith('.git'):
         directory = directory[:-4]
     if branch:


### PR DESCRIPTION
Using os.path.basename on a string such as "/foo/bar/" returns an empty string, which breaks on e.g. Cgit git URLs.

The fix uses pathlibs Path class "parent" method, which gets the last component of the path, so "bar" for "/foo/bar/".