### PR TITLE
tests: Skip limited API test on freethreading Python versions

### DIFF
--- a/test cases/python/9 extmodule limited api/meson.build
+++ b/test cases/python/9 extmodule limited api/meson.build
@@ -4,6 +4,10 @@ project('Python limited api', 'c',
 py_mod = import('python')
 py = py_mod.find_installation()
 
+if py.get_variable('Py_GIL_DISABLED', 0) == 1 and py.language_version().version_compare('<3.15')
+  error('MESON_SKIP_TEST: Freethreading Python does not support limited API')
+endif
+
 ext_mod_limited = py.extension_module('limited',
   'limited.c',
   limited_api: '3.7',


### PR DESCRIPTION
Skip the limited API test when the CPython version used indicates being built with GIL disabled, i.e. the freethreaded build. The freethreaded versions of Python 3.13 and 3.14 do not support the limited API, and attempting to build the test case results in compilation failures.

The check is limited to <3.15, so we don't forget to reenable it once limited API is supported.