### PR TITLE
ci: gentoo: enable media-libs/freetype[harfbuzz]

### DIFF
--- a/ci/ciimage/gentoo/install.sh
+++ b/ci/ciimage/gentoo/install.sh
@@ -110,6 +110,7 @@ mkdir /etc/portage/profile || true
 cat <<-EOF > /etc/portage/package.use/ci
 	dev-cpp/gtkmm X
 	media-libs/libglvnd X
+	media-libs/freetype harfbuzz
 	x11-libs/cairo X
 	x11-libs/libxkbcommon X
 	dev-lang/rust clippy rustfmt


### PR DESCRIPTION
```
emerge: there are no ebuilds built with USE flags to satisfy ">=media-libs/freetype-2.5.0.1:2[harfbuzz,png,abi_x86_64(-)]".
!!! One of the following packages is required to complete your request:
- media-libs/freetype-2.14.1-r1::gentoo (Change USE: +harfbuzz)
(dependency required by "x11-libs/pango-1.57.0::gentoo" [binary])
(dependency required by "gnome-base/librsvg-2.60.0::gentoo" [binary])
(dependency required by "x11-themes/adwaita-icon-theme-legacy-46.2::gentoo" [binary])
(dependency required by "x11-themes/adwaita-icon-theme-48.1::gentoo" [binary])
(dependency required by "x11-libs/gtk+-3.24.51::gentoo" [binary])
(dependency required by "@selected" [set])
(dependency required by "@world" [argument])
```

This comes from the change we made now that the FT<->HB cycle is gone where pango now unconditionally depends on freetype[harfbuzz] because it's janky at runtime otherwise.

Bug: https://bugs.gentoo.org/712374
Bug: https://bugs.gentoo.org/962715