### PR TITLE
Allow again specifying the crate name of a Cargo subproject in the rust_dependency_map

### DIFF
--- a/docs/yaml/functions/_build_target_base.yaml
+++ b/docs/yaml/functions/_build_target_base.yaml
@@ -333,6 +333,8 @@ kwargs:
       in the `dependencies` section of a Cargo.toml file, or
       `extern crate gtk4 as gtk` inside Rust code.
 
+      *Since 1.10.0*, the keys can be either crate names or target names.
+
   vala_header:
     type: str
     description: |

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1957,7 +1957,10 @@ class NinjaBackend(backends.Backend):
 
     @staticmethod
     def _get_rust_dependency_name(target: build.BuildTarget, dependency: LibTypes) -> str:
-        crate_name_raw = target.rust_dependency_map.get(dependency.name, dependency.name)
+        crate_name_raw = target.rust_dependency_map.get(dependency.name, None)
+        if crate_name_raw is None:
+            dependency_crate_name = NinjaBackend._get_rust_crate_name(dependency.name)
+            crate_name_raw = target.rust_dependency_map.get(dependency_crate_name, dependency.name)
         return NinjaBackend._get_rust_crate_name(crate_name_raw)
 
     def generate_rust_sources(self, target: build.BuildTarget) -> T.Tuple[T.List[str], str]:


### PR DESCRIPTION
rust: allow either crate names or target names in the dependency map
    
Since #15177, the target names provided by cargo subprojects have a suffix corresponding to the library API; for example, the target that used to be `gtk4` is now `gtk4+0_10`. This however is an implementation detail, and the change broke rust_dependency_maps that expected to use the crate name.
    
While the target name is preferrable, and will work great when Meson is able to create dependency maps by itself (as is the case for the Cargo interpreter), preserve the old behavior by checking also the entry corresponding to the result of `_get_rust_crate_name`.

Cc: @xclaesse, @elmarco 