### PR TITLE
dependencies/mpi: Use Intel specific paths with LLVM based oneAPI compilers

### DIFF
--- a/mesonbuild/dependencies/configtool.py
+++ b/mesonbuild/dependencies/configtool.py
@@ -139,10 +139,10 @@ class ConfigToolDependency(ExternalDependency):
 
         return self.config is not None
 
-    def get_config_value(self, args: T.List[str], stage: str) -> T.List[str]:
+    def get_config_value(self, args: T.List[str], stage: str, required: bool = False) -> T.List[str]:
         p, out, err = Popen_safe_logged(self.config + args)
         if p.returncode != 0:
-            if self.required:
+            if self.required or required:
                 raise DependencyException(f'Could not generate {stage} for {self.name}.\n{err}')
             return []
         return split_args(out)

--- a/mesonbuild/dependencies/mpi.py
+++ b/mesonbuild/dependencies/mpi.py
@@ -131,8 +131,11 @@ class MPIConfigToolDependency(ConfigToolDependency):
 
         for comp, link in commands:
             try:
-                c_args = self.get_config_value([comp], 'compile_args')
-                l_args = self.get_config_value([link], 'link_args') if link is not None else c_args
+                # Set required=True to ensure that the next set of options is
+                # tried when the current ones fail, even if the dependency is
+                # not required
+                c_args = self.get_config_value([comp], 'compile_args', required=True)
+                l_args = self.get_config_value([link], 'link_args', required=True) if link is not None else c_args
             except DependencyException:
                 continue
             else:


### PR DESCRIPTION
Instead of just the old pre-oneAPI compilers.

Fixes: #15259