### PR TITLE
options: the parent of a yielding option can be falsy

### DIFF
--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -935,7 +935,7 @@ class OptionStore:
                 # Subproject is set to yield, but top level
                 # project does not have an option of the same
                 pass
-        valobj.yielding = bool(valobj.parent)
+        valobj.yielding = valobj.parent is not None
 
         self.options[key] = valobj
         self.project_options.add(key)

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -482,3 +482,16 @@ class OptionTests(unittest.TestCase):
         stored_value = optstore.get_value_for(key)
         self.assertIsInstance(stored_value, bool)
         self.assertTrue(stored_value)
+
+    def test_yielding_boolean_option_with_falsy_parent(self):
+        """Test that yielding is correctly initialized when parent option value is False."""
+        optstore = OptionStore(False)
+        name = 'someoption'
+        subproject_name = 'sub'
+        parent_option = UserBooleanOption(name, 'A parent boolean option', False, yielding=True)
+        optstore.add_project_option(OptionKey(name, ''), parent_option)
+
+        child_option = UserBooleanOption(name, 'A child boolean option', True, yielding=True)
+        child_key = OptionKey(name, subproject_name)
+        optstore.add_project_option(child_key, child_option)
+        self.assertTrue(optstore.options[child_key].yielding)


### PR DESCRIPTION
Fixes: #15258