### PR TITLE
rewrite: fix duplicate objects for globals

### DIFF
--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -188,6 +188,12 @@ class AstInterpreter(InterpreterBase):
         self.dataflow_dag = DataflowDAG()
         self.funcvals: T.Dict[BaseNode, T.Any] = {}
         self.tainted = False
+        self.predefined_vars = {
+            'meson': UnknownValue(),
+            'host_machine': UnknownValue(),
+            'build_machine': UnknownValue(),
+            'target_machine': UnknownValue()
+        }
         self.funcs.update({'project': self.func_do_nothing,
                            'test': self.func_do_nothing,
                            'benchmark': self.func_do_nothing,
@@ -486,8 +492,8 @@ class AstInterpreter(InterpreterBase):
         return ret
 
     def get_cur_value_if_defined(self, var_name: str) -> T.Union[BaseNode, UnknownValue, UndefinedVariable]:
-        if var_name in {'meson', 'host_machine', 'build_machine', 'target_machine'}:
-            return UnknownValue()
+        if var_name in self.predefined_vars:
+            return self.predefined_vars[var_name]
         ret: T.Union[BaseNode, UnknownValue, UndefinedVariable] = UndefinedVariable()
         for nesting, value in reversed(self.cur_assignments[var_name]):
             if len(self.nesting) >= len(nesting) and self.nesting[:len(nesting)] == nesting:

--- a/test cases/rewrite/10 duplicate globals/info.json
+++ b/test cases/rewrite/10 duplicate globals/info.json
@@ -1,0 +1,8 @@
+[
+  {
+    "type": "kwargs",
+    "function": "project",
+    "id": "/",
+    "operation": "info"
+  }
+]

--- a/test cases/rewrite/10 duplicate globals/meson.build
+++ b/test cases/rewrite/10 duplicate globals/meson.build
@@ -1,0 +1,5 @@
+project('a', 'c', license: 'MIT')
+set_variable(
+  'z',
+  '-Wl,--version-script,@0@/src/lib.sym'.format(meson.current_source_dir())
+)

--- a/unittests/rewritetests.py
+++ b/unittests/rewritetests.py
@@ -445,6 +445,16 @@ class RewriterTests(BasePlatformTests):
         out = self.rewrite(self.builddir, os.path.join(self.builddir, 'info.json'))
         self.assertEqualIgnoreOrder(out, expected)
 
+    def test_duplicate_globals(self):
+        self.prime('10 duplicate globals')
+        out = self.rewrite(self.builddir, os.path.join(self.builddir, 'info.json'))
+        expected = {
+            'kwargs': {
+                'project#/': {'license': 'MIT'}
+            }
+        }
+        self.assertEqualIgnoreOrder(out, expected)
+
     def test_tricky_dataflow(self):
         self.prime('8 tricky dataflow')
         out = self.rewrite(self.builddir, os.path.join(self.builddir, 'addSrc.json'))


### PR DESCRIPTION
Global objects are treated as UnknownValue(), but unlike other variables their object is created on every call to get_cur_value_if_defined() instead of coming from a dictionary.  This causes the dataflow DAG to have multiple objects from the same object.  Fix this by building the UnknownValues at interpreter construction time.

Fixes: #15261
Cc: @Volker-Weissmann 