### PR TITLE
Move support for .def files to DynamicLinker

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3461,7 +3461,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 commands += linker.gen_import_library_args(self.get_import_filename(target))
             if target.pie:
                 commands += linker.get_pie_link_args()
-            if target.vs_module_defs and hasattr(linker, 'gen_vs_module_defs_args'):
+            if target.vs_module_defs:
                 commands += linker.gen_vs_module_defs_args(target.vs_module_defs.rel_to_builddir(self.build_to_src))
         elif isinstance(target, build.SharedLibrary):
             if isinstance(target, build.SharedModule):
@@ -3475,8 +3475,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 commands += linker.get_soname_args(
                     target.prefix, target.name, target.suffix,
                     target.soversion, target.darwin_versions)
-            # This is only visited when building for Windows using either GCC or Visual Studio
-            if target.vs_module_defs and hasattr(linker, 'gen_vs_module_defs_args'):
+            if target.vs_module_defs:
                 commands += linker.gen_vs_module_defs_args(target.vs_module_defs.rel_to_builddir(self.build_to_src))
             # This is only visited when building for Windows using either GCC or Visual Studio
             if target.import_filename:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1098,6 +1098,9 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
     def get_coverage_link_args(self) -> T.List[str]:
         return self.linker.get_coverage_args()
 
+    def gen_vs_module_defs_args(self, defsfile: str) -> T.List[str]:
+        return self.linker.gen_vs_module_defs_args(defsfile)
+
     def get_assert_args(self, disable: bool) -> T.List[str]:
         """Get arguments to enable or disable assertion.
 

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -172,13 +172,6 @@ class ClangCompiler(GnuLikeCompiler):
             # Shouldn't work, but it'll be checked explicitly in the OpenMP dependency.
             return []
 
-    def gen_vs_module_defs_args(self, defsfile: str) -> T.List[str]:
-        if isinstance(self.linker, VisualStudioLikeLinkerMixin):
-            # With MSVC, DLLs only export symbols that are explicitly exported,
-            # so if a module defs file is specified, we use that to export symbols
-            return ['-Wl,/DEF:' + defsfile]
-        return super().gen_vs_module_defs_args(defsfile)
-
     @classmethod
     def use_linker_args(cls, linker: str, version: str) -> T.List[str]:
         # Clang additionally can use a linker specified as a path, which GCC

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -409,16 +409,6 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
             vistype = 'hidden'
         return gnu_symbol_visibility_args[vistype]
 
-    def gen_vs_module_defs_args(self, defsfile: str) -> T.List[str]:
-        if not isinstance(defsfile, str):
-            raise RuntimeError('Module definitions file should be str')
-        # On Windows targets, .def files may be specified on the linker command
-        # line like an object file.
-        if self.info.is_windows() or self.info.is_cygwin():
-            return [defsfile]
-        # For other targets, discard the .def file.
-        return []
-
     @staticmethod
     def get_argument_syntax() -> str:
         return 'gcc'

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -192,13 +192,6 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
     def get_pic_args(self) -> T.List[str]:
         return [] # PIC is handled by the loader on Windows
 
-    def gen_vs_module_defs_args(self, defsfile: str) -> T.List[str]:
-        if not isinstance(defsfile, str):
-            raise RuntimeError('Module definitions file should be str')
-        # With MSVC, DLLs only export symbols that are explicitly exported,
-        # so if a module defs file is specified, we use that to export symbols
-        return ['/DEF:' + defsfile]
-
     def gen_pch_args(self, header: str, source: str, pchname: str) -> T.Tuple[str, T.List[str]]:
         objname = os.path.splitext(source)[0] + '.obj'
         return objname, ['/Yc' + header, '/Fp' + pchname, '/Fo' + objname]

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -385,6 +385,9 @@ class RustCompiler(Compiler):
     def get_coverage_link_args(self) -> T.List[str]:
         return rustc_link_args(super().get_coverage_link_args())
 
+    def gen_vs_module_defs_args(self, defsfile: str) -> T.List[str]:
+        return rustc_link_args(super().gen_vs_module_defs_args(defsfile))
+
     def get_profile_generate_args(self) -> T.List[str]:
         return ['-C', 'profile-generate']
 

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -66,6 +66,9 @@ class StaticLinker:
     def get_coverage_link_args(self) -> T.List[str]:
         return []
 
+    def gen_vs_module_defs_args(self) -> T.List[str]:
+        return []
+
     def build_rpath_args(self, build_dir: str, from_dir: str, target: BuildTarget,
                          extra_paths: T.Optional[T.List[str]] = None
                          ) -> T.Tuple[T.List[str], T.Set[bytes]]:


### PR DESCRIPTION
.def files are a linker concept, and they should not be shoehorned into the Compiler. Making the compiler forward to DynamicLinker removes hasattr duck typing and gets Rust support (almost) for free.
