### PR TITLE
templates: respect parameters

### DIFF
--- a/mesonbuild/templates/cpptemplates.py
+++ b/mesonbuild/templates/cpptemplates.py
@@ -35,9 +35,12 @@ hello_cpp_meson_template = '''project(
 dependencies = [{dependencies}
 ]
 
+sources = [{source_files}
+]
+
 exe = executable(
   '{exe_name}',
-  '{source_name}',
+  [sources],
   install : true,
   dependencies : dependencies,
 )
@@ -121,9 +124,13 @@ dependencies = [{dependencies}
 # not the executables that use the library.
 lib_args = ['-DBUILDING_{utoken}']
 
+sources = [{source_files}
+
+]
+
 lib = library(
   '{lib_name}',
-  '{source_file}',
+  [sources],
   install : true,
   cpp_shared_args : lib_args,
   gnu_symbol_visibility : 'hidden',

--- a/mesonbuild/templates/ctemplates.py
+++ b/mesonbuild/templates/ctemplates.py
@@ -71,9 +71,12 @@ lib_args = ['-DBUILDING_{utoken}']
 dependencies = [{dependencies}
 ]
 
+sources = [{source_files}
+]
+
 lib = library(
   '{lib_name}',
-  '{source_file}',
+  [sources],
   install : true,
   c_shared_args : lib_args,
   gnu_symbol_visibility : 'hidden',
@@ -133,9 +136,12 @@ hello_c_meson_template = '''project(
 dependencies = [{dependencies}
 ]
 
+sources = [{source_files}
+]
+
 exe = executable(
   '{exe_name}',
-  '{source_name}',
+  [sources],
   dependencies : dependencies,
   install : true,
 )

--- a/mesonbuild/templates/dlangtemplates.py
+++ b/mesonbuild/templates/dlangtemplates.py
@@ -35,9 +35,13 @@ hello_d_meson_template = '''project(
 dependencies = [{dependencies}
 ]
 
+sources = [{source_files}
+
+]
+
 exe = executable(
   '{exe_name}',
-  '{source_name}',
+  [sources],
   dependencies : dependencies,
   install : true,
 )
@@ -84,10 +88,13 @@ lib_d_meson_template = '''project(
 dependencies = [{dependencies}
 ]
 
+sources = [{source_files}
+
+]
 
 stlib = static_library(
   '{lib_name}',
-  '{source_file}',
+  [sources],
   install : true,
   gnu_symbol_visibility : 'hidden',
   dependencies : dependencies,

--- a/mesonbuild/templates/javatemplates.py
+++ b/mesonbuild/templates/javatemplates.py
@@ -35,9 +35,13 @@ hello_java_meson_template = '''project(
 dependencies = [{dependencies}
 ]
 
+sources = [{source_files}
+
+]
+
 exe = jar(
   '{exe_name}',
-  '{source_name}',
+  [sources],
   main_class : '{exe_name}',
   dependencies : dependencies,
   install : true,
@@ -86,9 +90,13 @@ lib_java_meson_template = '''project(
 dependencies = [{dependencies}
 ]
 
+sources = [{source_files}
+
+]
+
 jarlib = jar(
   '{class_name}',
-  '{source_file}',
+  [sources],
   dependencies : dependencies,
   main_class : '{class_name}',
   install : true,

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -2525,7 +2525,7 @@ class AllPlatformTests(BasePlatformTests):
 
         for lang in langs:
             for target_type in ('executable', 'library'):
-                with self.subTest(f'Language: {lang}; type: {target_type}'):
+                with self.subTest(f'Language: {lang}; type: {target_type}; fresh: yes'):
                     if is_windows() and lang == 'fortran' and target_type == 'library':
                         # non-Gfortran Windows Fortran compilers do not do shared libraries in a Fortran standard way
                         # see "test cases/fortran/6 dynamic"
@@ -2540,17 +2540,44 @@ class AllPlatformTests(BasePlatformTests):
                                   workdir=tmpdir)
                         self._run(ninja,
                                   workdir=os.path.join(tmpdir, 'builddir'))
-                # test directory with existing code file
-                if lang in {'c', 'cpp', 'd'}:
-                    with tempfile.TemporaryDirectory() as tmpdir:
-                        with open(os.path.join(tmpdir, 'foo.' + lang), 'w', encoding='utf-8') as f:
-                            f.write('int main(void) {}')
-                        self._run(self.meson_command + ['init', '-b'], workdir=tmpdir)
-                elif lang in {'java'}:
-                    with tempfile.TemporaryDirectory() as tmpdir:
-                        with open(os.path.join(tmpdir, 'Foo.' + lang), 'w', encoding='utf-8') as f:
-                            f.write('public class Foo { public static void main() {} }')
-                        self._run(self.meson_command + ['init', '-b'], workdir=tmpdir)
+
+                with self.subTest(f'Language: {lang}; type: {target_type}; fresh: no'):
+                    # test directory with existing code file
+                    if lang in {'c', 'cpp', 'd'}:
+                        with tempfile.TemporaryDirectory() as tmpdir:
+                            with open(os.path.join(tmpdir, 'foo.' + lang), 'w', encoding='utf-8') as f:
+                                f.write('int main(void) {}')
+                            self._run(self.meson_command + ['init', '-b'], workdir=tmpdir)
+
+                        # Check for whether we're doing source collection by repeating
+                        # with a bogus file we should pick up (and then fail to compile).
+                        with tempfile.TemporaryDirectory() as tmpdir:
+                            with open(os.path.join(tmpdir, 'bar.' + lang), 'w', encoding='utf-8') as f:
+                                f.write('#error bar')
+                            self._run(self.meson_command + ['init'], workdir=tmpdir)
+                            self._run(self.setup_command + ['--backend=ninja', 'builddir'],
+                                    workdir=tmpdir)
+                            with self.assertRaises(subprocess.CalledProcessError):
+                                self._run(ninja,
+                                        workdir=os.path.join(tmpdir, 'builddir'))
+
+                    elif lang in {'java'}:
+                        with tempfile.TemporaryDirectory() as tmpdir:
+                            with open(os.path.join(tmpdir, 'Foo.' + lang), 'w', encoding='utf-8') as f:
+                                f.write('public class Foo { public static void main() {} }')
+                            self._run(self.meson_command + ['init', '-b'], workdir=tmpdir)
+
+                        # Check for whether we're doing source collection by repeating
+                        # with a bogus file we should pick up (and then fail to compile).
+                        with tempfile.TemporaryDirectory() as tmpdir:
+                            with open(os.path.join(tmpdir, 'Bar.' + lang), 'w', encoding='utf-8') as f:
+                                f.write('public class Bar { public private static void main() {} }')
+                            self._run(self.meson_command + ['init'], workdir=tmpdir)
+                            self._run(self.setup_command + ['--backend=ninja', 'builddir'],
+                                    workdir=tmpdir)
+                            with self.assertRaises(subprocess.CalledProcessError):
+                                self._run(ninja,
+                                        workdir=os.path.join(tmpdir, 'builddir'))
 
     def test_compiler_run_command(self):
         '''


### PR DESCRIPTION
Respect collected sources for `meson init` as well as --executable. This regressed in 9f0ac314ba0c54cc18c2499845324efc14c1849e (part of https://github.com/mesonbuild/meson/pull/14086, it's easier to see how with the whole PR).

Also, add subtests (distinguishing between empty directories and those with some file(s) within). We already had some of these but they weren't marked as such.

Test `meson init` with a broken source file in the source directory as we should fail with that, not ignore the file.

It's easier to test with a broken file than a working one as we can assert the build should fail, it'll pass with just the 1 example file we generate.

Closes: https://github.com/mesonbuild/meson/issues/15286