### PR TITLE
pkgconfig: lookup PKG_CONFIG_EXECUTABLE

### DIFF
--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -249,6 +249,12 @@ class PkgConfigCLI(PkgConfigInterface):
             if validate(potential_pkgbin):
                 return
 
+        # else, look for a program that is called "pkgconf" (popular pkg-config alternative)
+        for potential_pkgbin in find_external_program(self.env, self.for_machine, "pkgconf", "pkgconf",
+                                                      self.env.default_pkgconfig, allow_default_for_cross=False):
+            if validate(potential_pkgbin):
+                return
+
         self.pkgbin = None
 
     def _check_pkgconfig(self, pkgbin: ExternalProgram) -> T.Optional[str]:


### PR DESCRIPTION
Before looking for "pkg-config" as a program in PATH, look for an environment variable called `PKG_CONFIG_EXECUTABLE`

`PKG_CONFIG_EXECUTABLE` is a convention (at least, in CMake) where the path to pkg-config is set.

Why is this useful? In Windows, where it is harder to compile pkg-config, [pkgconf](https://github.com/pkgconf/pkgconf) is often used as an alternative.

It's functionally identical, but has a different name. So you set `PKG_CONFIG_EXECUTABLE` to the path to pkgconf.exe.

*You CAN rename pkgconf to pkg-config and add it to PATH and then it's automatically detected by meson. BUT in my opinion this is messy, having to rename an executable and can lead to other issues.*

> Proof that CMake does this: [Modules/FindPkgConfig.cmake:486](https://github.com/Kitware/CMake/blob/def2f58710755c3b8b5225291666db90ffd9a3f0/Modules/FindPkgConfig.cmake#L486)