### PR TITLE
cmake: Fix version kwarg being added to static_library targets

### DIFF
--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -1182,11 +1182,12 @@ class CMakeInterpreter:
                 'objects': [method(x, 'extract_all_objects') for x in objec_libs],
             }
 
-            # Only set version if we know it
-            if tgt.version:
-                tgt_kwargs['version'] = tgt.version
-            if tgt.soversion:
-                tgt_kwargs['soversion'] = tgt.soversion
+            # Only set version if we know it and this is not a static lib
+            if tgt_func != 'static_library':
+                if tgt.version:
+                    tgt_kwargs['version'] = tgt.version
+                if tgt.soversion:
+                    tgt_kwargs['soversion'] = tgt.soversion
 
             # Only set if installed and only override if it is set
             if install_tgt and tgt.install_dir:

--- a/test cases/cmake/2 advanced/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/2 advanced/subprojects/cmMod/CMakeLists.txt
@@ -12,6 +12,7 @@ configure_file("config.h.in" "${CMAKE_CURRENT_BINARY_DIR}/config.h" @ONLY)
 
 add_library(cmModLib       SHARED lib/cmMod.cpp)
 add_library(cmModLibStatic STATIC lib/cmMod.cpp)
+set_target_properties(cmModLibStatic PROPERTIES SOVERSION 1)
 include(GenerateExportHeader)
 generate_export_header(cmModLib)
 


### PR DESCRIPTION
I have encountered an issue where, in some CMake subprojects, the `version` kwarg gets added to some `static_library` targets. This then causes the generated `meson.build` file to fail processing, as `version` is not a valid kwarg for static targets.

To fix this, I have added a small check around the part where that kwarg is added to ensure the target is not a static library.

Hopefully, since this is a minor bugfix, it can be slotted in for 1.10.0, but I understand if this is not possible since feature freeze has technically passed.