### PR TITLE
VS 2026 solution version comment needs bumping

### DIFF
--- a/mesonbuild/backend/vs2026backend.py
+++ b/mesonbuild/backend/vs2026backend.py
@@ -20,7 +20,7 @@ class Vs2026Backend(Vs2010Backend):
     def __init__(self, build: T.Optional[Build], gen_lite: bool = False):
         super().__init__(build, gen_lite=gen_lite)
         self.sln_file_version = '12.00'
-        self.sln_version_comment = 'Version 17'
+        self.sln_version_comment = 'Version 18'
 
     def detect_toolset(self) -> None:
         if self.environment is not None:


### PR DESCRIPTION
#15244 isn't quite sufficient: the `sln_version_comment` for vs2026 needs bumping to 18 such that the "VS version selector" will open the correct version of the IDE (see #9628). Fortunately the version bump works despite the introduction of `slnx`!

Thanks
