### PR TITLE
vsenv: Use a python script to pickle env

### DIFF
--- a/mesonbuild/scripts/pickle_env.py
+++ b/mesonbuild/scripts/pickle_env.py
@@ -1,0 +1,8 @@
+import os
+import pickle
+import typing as T
+
+def run(args: T.List[str]) -> int:
+    with open(args[0], "wb") as f:
+        pickle.dump(dict(os.environ), f)
+    return 0


### PR DESCRIPTION
This is safer than parsing env from stdout