### PR TITLE
wrap: warn on deprecated wraps

### DIFF
--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -18,7 +18,8 @@ from . import mlog
 from .ast import IntrospectionInterpreter
 from .mesonlib import quiet_git, GitException, Popen_safe, MesonException, windows_proof_rmtree
 from .wrap.wrap import (Resolver, WrapException, ALL_TYPES,
-                        parse_patch_url, update_wrap_file, get_releases)
+                        parse_patch_url, update_wrap_file, get_releases,
+                        warn_if_deprecated)
 
 if T.TYPE_CHECKING:
     from typing_extensions import Protocol
@@ -154,6 +155,7 @@ class Runner:
         if not info:
             self.log('  -> Wrap not found in wrapdb')
             return True
+        warn_if_deprecated(self.wrap.name, info)
 
         # Determine current version
         try:

--- a/tools/regenerate_docs.py
+++ b/tools/regenerate_docs.py
@@ -128,6 +128,8 @@ def generate_wrapdb_table(output_dir: Path) -> None:
         f.write('| Project | Versions | Provided dependencies | Provided programs |\n')
         f.write('| ------- | -------- | --------------------- | ----------------- |\n')
         for name, info in releases.items():
+            if 'deprecated' in info:
+                continue
             versions = []
             added_tags = set()
             for v in info['versions']:


### PR DESCRIPTION
https://github.com/mesonbuild/wrapdb/pull/2529 adds a mechanism for marking wraps as deprecated in `releases.json`.  If a wrap is deprecated, hide it from `meson wrap list` and `meson wrap search` output, warn if it's passed to `meson wrap install` or `meson wrap info`, warn if it's present during `meson wrap status` or `meson wrap update`, and warn if it's automatically installed from `wrapdb.json`.

Omit deprecated wraps from the wrap list on the website.