### PR TITLE
Do not require wheel for building

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=42"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
setuptools 70.1+ does not need wheel at all;

older versions would fetch wheel
when building wheels (but not sdists).