### PR TITLE
Wrap `tarfile.fully_trusted_filter` in `staticmethod` for wrap file h…

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -59,7 +59,7 @@ ALL_TYPES = ['file', 'git', 'hg', 'svn', 'redirect']
 
 if sys.version_info >= (3, 14):
     import tarfile
-    tarfile.TarFile.extraction_filter = tarfile.fully_trusted_filter
+    tarfile.TarFile.extraction_filter = staticmethod(tarfile.fully_trusted_filter)
 
 if mesonlib.is_windows():
     from ..programs import ExternalProgram


### PR DESCRIPTION
…andling too

That's how it is done in the other two places and without that one argument too many is passed to the filter function:

```
  [...]
  File "/usr/lib/python3.14/site-packages/mesonbuild/wrap/wrap.py", line 607, in _get_file
    shutil.unpack_archive(path, extract_dir)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.14/shutil.py", line 1432, in unpack_archive
    func(filename, extract_dir, **kwargs)
    ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.14/shutil.py", line 1349, in _unpack_tarfile
    tarobj.extractall(extract_dir, filter=filter)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.14/tarfile.py", line 2409, in extractall
    tarinfo, unfiltered = self._get_extract_tarinfo(
                          ~~~~~~~~~~~~~~~~~~~~~~~~~^
        member, filter_function, path)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.14/tarfile.py", line 2496, in _get_extract_tarinfo
    filtered = filter_function(unfiltered, path)
TypeError: fully_trusted_filter() takes 2 positional arguments but 3 were given
```

This was added in https://github.com/mesonbuild/meson/commit/6b4f2c7964115fa5d12f8f2234715a2ee67ea8dd / https://github.com/mesonbuild/meson/issues/15142 @eli-schwartz 