### PR TITLE
docs: increase timeout for validate_links.py

### DIFF
--- a/docs/meson.build
+++ b/docs/meson.build
@@ -148,4 +148,4 @@ run_target('upload',
     depends: documentation,
 )
 
-test('validate_links', find_program('./validatelinks.py'), args: meson.current_source_dir() / 'markdown' / 'Users.md')
+test('validate_links', find_program('./validatelinks.py'), args: meson.current_source_dir() / 'markdown' / 'Users.md', timeout: 65)


### PR DESCRIPTION
The script internally has a timeout of 60s, so the default of 30 on the meson side is too aggressive. Crank it up to 65.