### PR TITLE
man: add mention of `meson-reference(3)` to SEE ALSO

### DIFF
--- a/man/meson.1
+++ b/man/meson.1
@@ -682,3 +682,5 @@ could not rebuild the required targets.
 https://mesonbuild.com/
 
 https://wrapdb.mesonbuild.com/
+
+.MR meson-reference 3


### PR DESCRIPTION
i didn't know meson provided this page, and for a long time thought muon did, since only their docs mentions it at all