### PR TITLE
add clippy-json target

### DIFF
--- a/docs/markdown/Rust.md
+++ b/docs/markdown/Rust.md
@@ -91,6 +91,13 @@ write files into the source directory). [See the upstream
 docs](https://rust-analyzer.github.io/book/non_cargo_based_projects.html) for
 more information on how to configure that.
 
+### Clippy
+You can use the "clippy-json" build target as rust-analyer's "check command" to recieve clippy diagnostics in your editor. 
+
+Without overriding the check command, the LSP will function in a limited state, only showing certain errors (for example, no borrow checking errors are shown).
+
+[Non cargo based projects](https://rust-analyzer.github.io/book/non_cargo_based_projects.html) shows how to override the check command, you probably want to set it to `ninja clippy-json -C build`.
+
 ## Linking with standard libraries
 
 Meson will link the Rust standard libraries (e.g. libstd) statically, unless the

--- a/docs/markdown/snippets/clippy-json.md
+++ b/docs/markdown/snippets/clippy-json.md
@@ -1,0 +1,7 @@
+## New "clippy-json" Ninja Target For rust-analyzer
+
+A new `clippy-json` ninja target will now be generated for rust projects.
+
+rust-analyzer supports non-cargo based projects so long as you provide it with a `rust-project.json` file and a custom "check command" to provide compiler errors.  Meson already for some time has generated a `rust-project.json` file for rust-analyzer, but had no way to hook up its rustc/clippy output to rust-analyzer.
+
+To use the new feature, you need to override the rust-analyzer check command as shown [in the rust-analyzer documentation](https://rust-analyzer.github.io/book/non_cargo_based_projects.html), and set it to a `ninja invocation along the lines of `ninja clippy-json -C build`.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -4022,6 +4022,28 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         elem.add_dep(list(self.all_structured_sources))
         self.add_build(elem)
 
+    def generate_clippy_json_prereq(self) -> None:
+        if 'clippy-json-prereq' in self.all_outputs or not self.have_language('rust'):
+            return
+
+        elem = self.create_phony_target('clippy-json-prereq', 'CUSTOM_COMMAND', 'PHONY')
+        for crate in self.rust_crates.values():
+            if crate.crate_type in {'rlib', 'dylib', 'proc-macro'}:
+                elem.add_dep(crate.target_name)
+        elem.add_dep(list(self.all_structured_sources))
+        self.add_build(elem)
+
+    def generate_clippy_json(self) -> None:
+        if 'clippy-json' in self.all_outputs or not self.have_language('rust'):
+            return
+
+        cmd = self.environment.get_build_command() + \
+            ['--internal', 'clippy', self.environment.build_dir, '--error-format=json']
+        elem = self.create_phony_target('clippy-json', 'CUSTOM_COMMAND', 'PHONY')
+        elem.add_item('COMMAND', cmd)
+        elem.add_item('pool', 'console')
+        self.add_build(elem)
+
     def generate_rustdoc(self) -> None:
         if 'rustdoc' in self.all_outputs or not self.have_language('rust'):
             return
@@ -4111,6 +4133,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         self.generate_clangformat()
         self.generate_clangtidy()
         self.generate_clippy()
+        self.generate_clippy_json_prereq()
+        self.generate_clippy_json()
         self.generate_rustdoc()
         self.generate_tags('etags', 'TAGS')
         self.generate_tags('ctags', 'ctags')


### PR DESCRIPTION
Add a clippy-json target to the ninja script.

This is useful for rust-analyzer, which requires an "external check command" to function when not using cargo.