### PR TITLE
fix crate name in rust-project.json

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1943,7 +1943,7 @@ class NinjaBackend(backends.Backend):
 
         crate = RustCrate(
             len(self.rust_crates),
-            name,
+            self._get_rust_crate_name(name),
             main_rust_file,
             crate_type,
             target_name,


### PR DESCRIPTION
Include the real crate name, with "_" instead of "-" and without the Meson-specific "+foo" suffix.