### PR TITLE
interpreter: validate argument to string.split() for empty string

### DIFF
--- a/mesonbuild/interpreter/primitives/string.py
+++ b/mesonbuild/interpreter/primitives/string.py
@@ -108,7 +108,10 @@ class StringHolder(ObjectHolder[str]):
     @typed_pos_args('str.split', optargs=[str])
     @InterpreterObject.method('split')
     def split_method(self, args: T.Tuple[T.Optional[str]], kwargs: TYPE_kwargs) -> T.List[str]:
-        return self.held_object.split(args[0])
+        delimiter = args[0]
+        if delimiter == '':
+            raise InvalidArguments('str.split() delimitier must not be an empty string')
+        return self.held_object.split(delimiter)
 
     @noKwargs
     @typed_pos_args('str.strip', optargs=[str])


### PR DESCRIPTION
The underlying Python implementation throws in this case, and I'm not sure what the correct result here would be if we allowed it. Convert to None and don't split? Split every character?

I've gone with throwing InvalidArguments, which maintains the current behavior of "doesn't work" but with a nicer output. Any other change would require a FeatureNew anyway, and can wait till 1.11.

Fixes: #15335