### PR TITLE
mesonmain: mark getting a language from another subproject as broken

### DIFF
--- a/docs/markdown/snippets/getting-language-from-other-project.md
+++ b/docs/markdown/snippets/getting-language-from-other-project.md
@@ -1,0 +1,6 @@
+## Using `meson.get_compiler()` to get a language from another project is marked broken
+
+Meson currently will return a compiler instance from the `meson.get_compiler()`
+call, if that language has been initialized in any project. This can result in
+situations where a project can only work as a subproject, or if a dependency is
+provided by a subproject rather than by a pre-built dependency.


### PR DESCRIPTION
Currently, you can call `meson.get_compiler('c')`, if you haven't initialized 'c' for your project, but a super-project or sub-project has initialized it. This happens because we check the wrong set of compilers (the global list vs the per-subproject one).

Because of how fragile this is, we can mark it as broken an move on.