### PR TITLE
clippy: don't print warnings/errors about subprojects

### DIFF
--- a/mesonbuild/scripts/clippy.py
+++ b/mesonbuild/scripts/clippy.py
@@ -32,6 +32,8 @@ class ClippyDriver:
         self.warned[machine] = True
 
     def __call__(self, target: T.Dict[str, T.Any]) -> T.Iterable[T.Coroutine[None, None, int]]:
+        if target['subproject']:
+            return
         for src_block in target['target_sources']:
             if 'compiler' in src_block and src_block['language'] == 'rust':
                 clippy = getattr(self.tools, src_block['machine'])


### PR DESCRIPTION
That code is not under the control of the developer asking for this information, so this is pure spam; simply skip it :)