### PR TITLE
ci: disable unitests for arch cuda

### DIFF
--- a/ci/ciimage/cuda/image.json
+++ b/ci/ciimage/cuda/image.json
@@ -1,6 +1,6 @@
 {
   "base_image": "archlinux:latest",
-  "args": ["--only", "cuda"],
+  "args": ["--only", "cuda", "--no-unittests"],
   "env": {
     "CI": "1",
     "MESON_CI_JOBNAME": "linux-cuda-gcc"


### PR DESCRIPTION
Because they're the same as the main arch image.

~~Needs https://github.com/mesonbuild/meson/pull/15348 to pass the CUDA builder~~ Merged