### PR TITLE
dependencies: add custom lookup logic for librt

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -469,6 +469,17 @@ providing them instead.
 
 `method` may be `auto`, `builtin` or `system`.
 
+## rt (librt)
+
+*(added 1.11.0)*
+
+Provides access to the POSIX Realtime Extensions interface (functions:
+shm_open, clock_getres, timer_create and others). On systems where this
+is not built into libc (mostly glibc < 2.34), tries to find an external
+library providing them instead.
+
+`method` may be `auto`, `builtin` or `system`.
+
 ## Fortran Coarrays
 
 *(added 0.50.0)*

--- a/docs/markdown/snippets/librt-dependency.md
+++ b/docs/markdown/snippets/librt-dependency.md
@@ -1,0 +1,8 @@
+## New custom dependency for librt
+
+```
+dependency('rt')
+```
+
+will now check for the functionality of librt.so, but first check if it is
+provided in the libc (for example in libc on OpenBSD or in musl libc on linux).

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -222,6 +222,7 @@ packages.defaults.update({
     'intl': 'misc',
     'atomic': 'misc',
     'dl': 'misc',
+    'rt': 'misc',
     'openssl': 'misc',
     'libcrypto': 'misc',
     'libssl': 'misc',

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -96,6 +96,27 @@ class DlSystemDependency(SystemDependency):
             self.is_found = True
 
 
+class RtBuiltinDependency(BuiltinDependency):
+    def __init__(self, name: str, env: 'Environment', kwargs: DependencyObjectKWs):
+        super().__init__(name, env, kwargs)
+        self.feature_since = ('1.11.0', "consider checking for `shm_open` with and without `find_library('rt')`")
+
+        if self.clib_compiler.has_function('shm_open', '#include <sys/mman.h>')[0]:
+            self.is_found = True
+
+
+class RtSystemDependency(SystemDependency):
+    def __init__(self, name: str, env: 'Environment', kwargs: DependencyObjectKWs):
+        super().__init__(name, env, kwargs)
+        self.feature_since = ('1.11.0', "consider checking for `shm_open` with and without `find_library('rt')`")
+
+        h = self.clib_compiler.has_header('sys/mman.h', '')
+        self.link_args = self.clib_compiler.find_library('rt', [], self.libtype)
+
+        if h[0] and self.link_args:
+            self.is_found = True
+
+
 class OpenMPDependency(SystemDependency):
     # Map date of specification release (which is the macro value) to a version.
     VERSIONS = {
@@ -611,6 +632,13 @@ packages['dl'] = dl_factory = DependencyFactory(
     [DependencyMethods.BUILTIN, DependencyMethods.SYSTEM],
     builtin_class=DlBuiltinDependency,
     system_class=DlSystemDependency,
+)
+
+packages['rt'] = rt_factory = DependencyFactory(
+    'rt',
+    [DependencyMethods.BUILTIN, DependencyMethods.SYSTEM],
+    builtin_class=RtBuiltinDependency,
+    system_class=RtSystemDependency,
 )
 
 packages['gpgme'] = gpgme_factory = DependencyFactory(


### PR DESCRIPTION
librt provides POSIX.1b Realtime Extensions interfaces.

librt lookup logic is like libdl, most modern platforms have this
functionality residing in libc itself, some platforms provide an
empty object file for linking compatibility, and older platforms
have this in librt itself.
