### PR TITLE
compilers: fix clang-cl cross without setting many args on cc

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -565,9 +565,13 @@ class NinjaBackend(backends.Backend):
                                 filebase)
         with open(filename, 'w', encoding='utf-8') as f:
             f.write(dedent('''\
-                #include<stdio.h>
+                #include"incdetect2"
                 int dummy;
             '''))
+        filename_inc = os.path.join(self.environment.get_scratch_dir(),
+                                    'incdetect2')
+        with open(filename_inc, 'w', encoding='utf-8') as f:
+            pass
 
         # The output of cl dependency information is language
         # and locale dependent. Any attempt at converting it to
@@ -586,18 +590,18 @@ class NinjaBackend(backends.Backend):
                               stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (stdout, stderr) = pc.communicate()
 
-        # We want to match 'Note: including file: ' in the line
-        # 'Note: including file: d:\MyDir\include\stdio.h', however
+        # 'Note: including file: d:\build\meson-private\incdetect2', however
         # different locales have different messages with a different
-        # number of colons. Match up to the drive name 'd:\'.
+        # number of colons. Match up to the drive name 'd:\' or
+        # a relative path '.\'.
         # When used in cross compilation, the path separator is a
         # forward slash rather than a backslash so handle both; i.e.
-        # the path is /MyDir/include/stdio.h.
+        # the path is /build/meson-private/incdetect or ./incdetect2.
         # With certain cross compilation wrappings of MSVC, the paths
         # use backslashes, but without the leading drive name, so
         # allow the path to start with any path separator, i.e.
-        # \MyDir\include\stdio.h.
-        matchre = re.compile(rb"^(.*\s)([a-zA-Z]:[\\/]|[\\\/]).*stdio.h$")
+        # \build\meson-private\incdetect2
+        matchre = re.compile(rb"^(.*\s)([a-zA-Z]:[\\/]|\.?[\\/]).*incdetect2$")
 
         def detect_prefix(out: bytes) -> T.TextIO:
             for line in re.split(rb'\r?\n', out):

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -352,7 +352,7 @@ class CLikeCompiler(Compiler):
         if mode is CompileCheckMode.LINK:
             ld_value = self.environment.lookup_binary_entry(self.for_machine, self.language + '_ld')
             if ld_value is not None:
-                largs += self.use_linker_args(ld_value[0], self.version)
+                cargs += self.use_linker_args(ld_value[0], self.version)
 
             # Add LDFLAGS from the env
             sys_ld_args = self.environment.coredata.get_external_link_args(self.for_machine, self.language)


### PR DESCRIPTION
See the expanded commit messages for explanations.

Before:

```ini
[binaries]
c = ['clang-cl', '--target=' + target, '-fuse-ld=lld', '/winsysroot', root]
cpp = ['clang-cl', '--target=' + target, '-fuse-ld=lld', '/winsysroot', root]
# c_ld not set
# cpp_ld not set
```

After:

```ini
[binaries]
c = ['clang-cl', '--target=' + target]
cpp = ['clang-cl', '--target=' + target]
c_ld = 'lld-link'
cpp_ld = 'lld-link'
```

---

The `detect_vs_dep_prefix` change needs more testing. I tested this on:
- msvc-wine's wrapper
- native windows msvc
- clang-cl on linux

---

Closes #15851