### PR TITLE
Review srcdir vs builddir

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -494,7 +494,7 @@ class Backend:
         for obj in objects:
             if isinstance(obj, str):
                 o = os.path.join(proj_dir_to_build_root,
-                                 self.build_to_src, target.get_builddir(), obj)
+                                 self.build_to_src, target.get_subdir(), obj)
                 obj_list.append(o)
             elif isinstance(obj, mesonlib.File):
                 if obj.is_built:
@@ -1458,9 +1458,9 @@ class Backend:
                     deps.append(i.rel_to_builddir(self.build_to_src))
             else:
                 if absolute_paths:
-                    deps.append(os.path.join(self.environment.get_source_dir(), target.subdir, i))
+                    deps.append(os.path.join(self.environment.get_source_dir(), target.get_subdir(), i))
                 else:
-                    deps.append(os.path.join(self.build_to_src, target.subdir, i))
+                    deps.append(os.path.join(self.build_to_src, target.get_subdir(), i))
         return deps
 
     def get_custom_target_output_dir(self, target: build.AnyTargetType) -> str:
@@ -1540,7 +1540,7 @@ class Backend:
                 if '@BUILD_ROOT@' in i:
                     i = i.replace('@BUILD_ROOT@', build_root)
                 if '@CURRENT_SOURCE_DIR@' in i:
-                    i = i.replace('@CURRENT_SOURCE_DIR@', os.path.join(source_root, target.subdir))
+                    i = i.replace('@CURRENT_SOURCE_DIR@', os.path.join(source_root, target.get_subdir()))
                 if '@DEPFILE@' in i:
                     if target.depfile is None:
                         msg = f'Custom target {target.name!r} has @DEPFILE@ but no depfile ' \
@@ -1601,7 +1601,7 @@ class Backend:
         if target.default_env:
             env.set('MESON_SOURCE_ROOT', [self.environment.get_source_dir()])
             env.set('MESON_BUILD_ROOT', [self.environment.get_build_dir()])
-            env.set('MESON_SUBDIR', [target.subdir])
+            env.set('MESON_SUBDIR', [target.get_subdir()])
             env.set('MESONINTROSPECT', [self.get_introspect_command()])
         return env
 
@@ -1938,7 +1938,7 @@ class Backend:
                 elif isinstance(j, str):
                     source_list += [os.path.join(self.source_dir, j)]
                 elif isinstance(j, (build.CustomTarget, build.BuildTarget)):
-                    source_list += [os.path.join(self.build_dir, j.get_subdir(), o) for o in j.get_outputs()]
+                    source_list += [os.path.join(self.build_dir, j.get_builddir(), o) for o in j.get_outputs()]
             source_list = [os.path.normpath(s) for s in source_list]
 
             compiler: T.List[str] = []

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1866,7 +1866,7 @@ class NinjaBackend(backends.Backend):
                 if isinstance(gen, GeneratedList):
                     ssrc = os.path.join(self.get_target_private_dir(target), ssrc)
                 else:
-                    ssrc = os.path.join(gen.get_subdir(), ssrc)
+                    ssrc = os.path.join(gen.get_builddir(), ssrc)
                 if ssrc.endswith('.pyx'):
                     output = os.path.join(self.get_target_private_dir(target), f'{ssrc}.{ext}')
                     element = NinjaBuildElement(
@@ -1879,7 +1879,7 @@ class NinjaBackend(backends.Backend):
                     # TODO: introspection?
                     cython_sources.append(output)
                 else:
-                    generated_sources[ssrc] = mesonlib.File.from_built_file(gen.get_subdir(), ssrc)
+                    generated_sources[ssrc] = mesonlib.File.from_built_file(gen.get_builddir(), ssrc)
                     # Following logic in L883-900 where we determine whether to add generated source
                     # as a header(order-only) dep to the .so compilation rule
                     if not compilers.is_source(ssrc) and \
@@ -2001,7 +2001,7 @@ class NinjaBackend(backends.Backend):
                     else:
                         for h in g.get_outputs():
                             if h.endswith('.rs'):
-                                main_rust_file = os.path.join(g.get_subdir(), h)
+                                main_rust_file = os.path.join(g.get_builddir(), h)
                                 break
                     if main_rust_file is not None:
                         break
@@ -2025,7 +2025,7 @@ class NinjaBackend(backends.Backend):
                 if isinstance(g, GeneratedList):
                     fname = os.path.join(self.get_target_private_dir(target), i)
                 else:
-                    fname = os.path.join(g.get_subdir(), i)
+                    fname = os.path.join(g.get_builddir(), i)
                 if main_rust_file is None and fname.endswith('.rs'):
                     main_rust_file = fname
                 orderdeps.append(fname)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1787,7 +1787,7 @@ class Vs2010Backend(backends.Backend):
                         self.add_additional_options(lang, inc_cl, file_args)
                         self.add_preprocessor_defines(lang, inc_cl, file_defines)
                         self.add_include_dirs(lang, inc_cl, file_inc_dirs)
-                        s = File.from_built_file(target.get_subdir(), s)
+                        s = File.from_built_file(target.get_builddir(), s)
                         ET.SubElement(inc_cl, 'ObjectFileName').text = "$(IntDir)" + \
                             self.object_filename_from_source(target, compiler, s)
             for lang, headers in pch_sources.items():

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -1813,7 +1813,7 @@ class XCodeBackend(backends.Backend):
             settings_dict.add_item('GCC_SYMBOLS_PRIVATE_EXTERN', 'NO')
             unquoted_headers = [self.get_target_private_dir_abs(target)]
             if target.implicit_include_directories:
-                unquoted_headers.append(os.path.join(self.environment.get_build_dir(), target.get_subdir()))
+                unquoted_headers.append(os.path.join(self.environment.get_build_dir(), target.get_builddir()))
                 unquoted_headers.append(os.path.join(self.environment.get_source_dir(), target.get_subdir()))
             unquoted_headers += headerdirs
             settings_dict.add_item('HEADER_SEARCH_PATHS', self.normalize_header_search_paths(unquoted_headers))

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1130,7 +1130,7 @@ class BuildTarget(Target):
                 self.link_depends.append(s)
             elif isinstance(s, str):
                 self.link_depends.append(
-                    File.from_source_file(self.environment.source_dir, self.subdir, s))
+                    File.from_source_file(self.environment.source_dir, self.get_subdir(), s))
             else:
                 self.link_depends.append(s)
 
@@ -1245,7 +1245,7 @@ class BuildTarget(Target):
         result: OrderedSet[str] = OrderedSet()
         for i in self.link_targets:
             if not isinstance(i, StaticLibrary):
-                result.add(i.get_subdir())
+                result.add(i.get_builddir())
             result.update(i.get_link_dep_subdirs())
         return result
 
@@ -1790,7 +1790,7 @@ class BuildTarget(Target):
             self.vs_module_defs = path
         else:
             # When passing output of a Custom Target
-            self.vs_module_defs = File.from_built_file(path.get_subdir(), path.get_filename())
+            self.vs_module_defs = File.from_built_file(path.get_builddir(), path.get_filename())
         self.process_link_depends([path])
 
     def extract_targets_as_list(self, kwargs: BuildTargetKeywordArguments, key: T.Literal['link_with', 'link_whole']) -> T.List[LibTypes]:
@@ -2035,7 +2035,7 @@ class Generator(HoldableObject):
         for e in files:
             if isinstance(e, (CustomTarget, CustomTargetIndex)):
                 output.depends.add(e)
-                fs = [File.from_built_file(e.get_subdir(), f) for f in e.get_outputs()]
+                fs = [File.from_built_file(e.get_builddir(), f) for f in e.get_outputs()]
             elif isinstance(e, GeneratedList):
                 if preserve_path_from:
                     raise InvalidArguments("generator.process: 'preserve_path_from' is not allowed if one input is a 'generated_list'.")

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -228,12 +228,12 @@ def list_targets(builddata: build.Build, installdata: backends.InstallData, back
         if not isinstance(target, build.Target):
             raise RuntimeError('The target object in `builddata.get_targets()` is not of type `build.Target`. Please file a bug with this error message.')
 
-        outdir = get_target_dir(builddata.environment.coredata, target.subdir)
+        outdir = get_target_dir(builddata.environment.coredata, target.get_builddir())
         t = {
             'name': target.get_basename(),
             'id': idname,
             'type': target.get_typename(),
-            'defined_in': os.path.normpath(os.path.join(src_dir, target.subdir, environment.build_filename)),
+            'defined_in': os.path.normpath(os.path.join(src_dir, target.get_subdir(), environment.build_filename)),
             'filename': [os.path.join(build_dir, outdir, x) for x in target.get_outputs()],
             'build_by_default': target.build_by_default,
             'target_sources': backend.get_introspection_data(idname, target),

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -829,8 +829,8 @@ class GnomeModule(ExtensionModule):
             if isinstance(inc, str):
                 ret += [f'--include={inc}']
             elif isinstance(inc, GirTarget):
-                gir_inc_dirs .append(os.path.join(state.environment.get_build_dir(), inc.get_subdir()))
-                ret.append(f"--include-uninstalled={os.path.join(inc.get_subdir(), inc.get_basename())}")
+                gir_inc_dirs .append(os.path.join(state.environment.get_build_dir(), inc.get_builddir()))
+                ret.append(f"--include-uninstalled={os.path.join(inc.get_builddir(), inc.get_basename())}")
                 depends.append(inc)
 
         return ret, gir_inc_dirs, depends

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -485,7 +485,7 @@ class I18nModule(ExtensionModule):
 
         mo_fnames = []
         for target in mo_targets:
-            mo_fnames.append(path.join(target.get_subdir(), target.get_outputs()[0]))
+            mo_fnames.append(path.join(target.get_builddir(), target.get_outputs()[0]))
 
         command: T.List[T.Union[str, build.BuildTargetTypes, ExternalProgram, mesonlib.File]] = []
         command.extend(state.environment.get_build_command())


### PR DESCRIPTION
Comparing the implementation of build_subdir with https://github.com/mesonbuild/meson/pull/12258, both of them introduced a similar separation between srcdir and builddir.  There were some differences in the choices of srcdir vs builddir; this commit tries to identify which are bugs in which implementation, and get the best of both worlds.
