### PR TITLE
gnome: look up g-ir-scanner as a host tool

### DIFF
--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -82,7 +82,7 @@ class ModuleState:
                                                    wanted=wanted, silent=silent, for_machine=for_machine)
 
     def find_tool(self, name: str, depname: str, varname: str, required: bool = True,
-                  wanted: T.Optional[str] = None) -> T.Union[build.OverrideExecutable, ExternalProgram, 'OverrideProgram']:
+                  wanted: T.Optional[str] = None, native: bool = True) -> T.Union[build.OverrideExecutable, ExternalProgram, 'OverrideProgram']:
         # Look in overrides in case it's built as subproject
         progobj = self._interpreter.program_from_overrides([name], [])
         if progobj is not None:
@@ -94,7 +94,7 @@ class ModuleState:
             return ExternalProgram.from_entry(name, prog_list)
 
         # Check if pkgconfig has a variable
-        dep = self.dependency(depname, native=True, required=False, wanted=wanted)
+        dep = self.dependency(depname, native=native, required=False, wanted=wanted)
         if dep.found() and dep.type_name == 'pkgconfig':
             value = dep.get_variable(pkgconfig=varname)
             if value:

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -322,7 +322,7 @@ class GnomeModule(ExtensionModule):
         }
         depname = tool_map[tool]
         varname = tool.replace('-', '_')
-        return state.find_tool(tool, depname, varname)
+        return state.find_tool(tool, depname, varname, native=depname != "gobject-introspection-1.0")
 
     @typed_kwargs(
         'gnome.post_install',


### PR DESCRIPTION
g-ir-scanner emits architecture-dependent information. In a cross build, using the native one cannot work as it cannot use the host libraries it is supposed to inspect. While the host's g-ir-scanner might have the same problem, some distributions such as Debian provide a wrapper that employs qemu and report it from the host's .pc file. Other distributions also have such a wrapper but tend to inject it via the crossfile.

Link: https://bugs.debian.org/1060838