### PR TITLE
Add closing backtick to the install_headers docs

### DIFF
--- a/docs/yaml/functions/install_headers.yaml
+++ b/docs/yaml/functions/install_headers.yaml
@@ -11,7 +11,7 @@ description: |
 
   Please note that this can only install static files from the source tree.
   Generated files are installed via the `install_dir:` kwarg on the respective
-  generators, such as `custom_target()` or `configure_file().
+  generators, such as `custom_target()` or `configure_file()`.
 
 example: |
   For example, this will install `common.h` and `kola.h` into


### PR DESCRIPTION
This commit adds a closing backtick to the mention of `configure_file()`, that way it shows up correctly as preformatted