### PR TITLE
docs(summary): Correct example output

### DIFF
--- a/docs/yaml/functions/summary.yaml
+++ b/docs/yaml/functions/summary.yaml
@@ -47,18 +47,17 @@ example: |
   My Project 1.0
 
     Directories
-      prefix         : /opt/gnome
       bindir         : bin
       libdir         : lib/x86_64-linux-gnu
       datadir        : share
 
     Configuration
-      Some boolean   : False
-      Another boolean: True
+      Some boolean   : false
+      Another boolean: true
       Some string    : Hello World
-      An array        : string
+      An array       : string
                        1
-                       True
+                       true
   ```
 
 arg_flattening: false


### PR DESCRIPTION
The sample output for the `summary()` example failed to jibe with reality in several ways:

- 'prefix' was not included in the inputs, so it isn't displayed
- Boolean values are printed lowercase ('true', not 'True')
- The array formatting would be properly aligned