### PR TITLE
gnome: avoid backslashes on Windows when setting CC for g-ir-scanner

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import copy
 import itertools
+import pathlib
 import functools
 import os
 import subprocess
@@ -994,6 +995,10 @@ class GnomeModule(ExtensionModule):
         run_env = PkgConfigInterface.get_env(state.environment, MachineChoice.HOST, uninstalled=True)
         # g-ir-scanner uses Python's distutils to find the compiler, which uses 'CC'
         cc_exelist = state.environment.coredata.compilers.host['c'].get_exelist()
+        # g-ir-scanner uses distutils/setuptools which splits CC with both Posix
+        # and Windows rules to get the first argument, which breaks if there are
+        # backslashes, so best avoid them entirely.
+        cc_exelist = [pathlib.Path(exe).as_posix() for exe in cc_exelist]
         run_env.set('CC', [quote_arg(x) for x in cc_exelist], ' ')
         run_env.set('CFLAGS', [quote_arg(x) for x in env_flags], ' ')
         run_env.merge(kwargs['env'])


### PR DESCRIPTION
g-ir-scanner internally uses setuptools/distutils, which with the mingw target sometimes uses distutils.util.split_quoted() and shlex.split() to split env vars, which uses Posix splitting rules.

In other cases it just passes strings to the subprocess module which uses the Windows splitting rules.

This started being a problem with meson 1.10, since with 1.9 it passed 'CC=ccache cc' while with 1.10 it now passes
'CC=C:\msys64\clang64\bin/ccache.EXE cc' which results in is_cygwincc() in distutils failing to find ccache.

Since it's hard to fix this in distutils/setuptools (there is no Windows split function in the stdlib, and setuptools is barely maintained right now) just try to avoid backslashes, which unbreaks the common case of an absolute path being passed like "C:/msys64/clang64/bin/ccache.EXE".

Downstream report:
* https://github.com/msys2/MINGW-packages/issues/26812
* https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/9208#note_2627068