### PR TITLE
boost: allow headers only installation

### DIFF
--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -455,6 +455,14 @@ class BoostDependency(SystemDependency):
 
         any_libs_found = len(libs) > 0
         if not any_libs_found:
+            if not self.modules:
+                inc = inc_dirs[0]
+                self.version = inc.version
+                self.compile_args = ['-I' + inc.path.as_posix()]
+                self.compile_args += self._extra_compile_args()
+                self.compile_args = list(mesonlib.OrderedSet(self.compile_args))
+                mlog.debug(f'  - final compile args: {self.compile_args}')
+                return True
             return False
 
         modules = ['boost_' + x for x in self.modules]


### PR DESCRIPTION
Fix #15154 

I'm not really sure if this is good enough, just some thought, and @eli-schwartz suggested me to submit it.