### PR TITLE
ast/introspection: correct uses of subdir and source_root

### DIFF
--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -134,10 +134,9 @@ class IntrospectionInterpreter(AstInterpreter):
         self._add_languages(proj_langs, True, MachineChoice.BUILD)
 
     def do_subproject(self, dirname: SubProject) -> None:
-        subproject_dir_abs = os.path.join(self.environment.get_source_dir(), self.subproject_dir)
-        subpr = os.path.join(subproject_dir_abs, dirname)
+        subdir = os.path.join(self.environment.source_dir, self.subproject_dir, dirname)
         try:
-            subi = IntrospectionInterpreter(subpr, '', self.backend, cross_file=self.cross_file, subproject=dirname, subproject_dir=self.subproject_dir, env=self.environment, visitors=self.visitors)
+            subi = IntrospectionInterpreter(self.source_root, subdir, self.backend, cross_file=self.cross_file, subproject=dirname, subproject_dir=self.subproject_dir, env=self.environment, visitors=self.visitors)
             subi.analyze()
             subi.project_data['name'] = dirname
             self.project_data['subprojects'] += [subi.project_data]


### PR DESCRIPTION
source_root is supposed to be an alias for Environment.source_dir, and subdir is so supposed to be the current directory relative to Environment.source_dir. Environment.source_dir *always* points at the main project's source dir, *never* at a subproject. The current code makes the `source_root` mutable in the IntrospectionIntepreter, changing it to point at `subproject_dir/subproject/`, and then setting `subdir` to `''`.

This happens to work, but it isn't correct. And that becomes really evident if you replace `InterpreterBase.source_root` with `Environment.source_dir` (which I have done in another series).