### PR TITLE
Allow subprojects to be built for both the build and host machine (2nd part)

### DIFF
--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -280,7 +280,7 @@ when the workspace was created.
 ### workspace.package()
 
 ```meson
-pkg = ws.package([package_name])
+pkg = ws.package([package_name], ...)
 ```
 
 Returns a package object for the given package member.  If empty, returns
@@ -289,6 +289,11 @@ the object for the root package.
 Arguments:
 - `package_name`: (str, optional) Name of the package; not needed for the
   root package of a workspace
+
+Keyword arguments:
+- `native`: (`bool`) Whether the package is compiled for the
+host machine (false) or the build machine (true).  The argument is
+forwarded to Meson by methods such as `executable`, `library`, etc.
 
 Example usage:
 ```meson
@@ -301,7 +306,7 @@ pkg.executable(install: true)
 ### workspace.subproject()
 
 ```meson
-package = ws.subproject(package_name, api)
+package = ws.subproject(package_name, api, ...)
 ```
 
 Returns a `package` object for managing a specific package within the workspace.
@@ -309,6 +314,11 @@ Returns a `package` object for managing a specific package within the workspace.
 Positional arguments:
 - `package_name`: (`str`) The name of the package to retrieve
 - `api`: (`str`, optional) The version constraints for the package in Cargo format
+
+Keyword arguments:
+- `native`: (`bool`) Whether the subproject is compiled for the
+host machine (false) or the build machine (true).  Default is false
+(proc-macro crates are only built once).
 
 ## Package object
 

--- a/docs/markdown/snippets/subproject_and_override_program_native.md
+++ b/docs/markdown/snippets/subproject_and_override_program_native.md
@@ -1,0 +1,13 @@
+## subproject() and meson.override_find_program() now support the native keyword argument
+
+Subprojects may now be built for the host or build machine (or both). Therefore,
+in a cross compile setup, build-time dependencies can be built for the machine
+running the build. When a subproject is run for the build machine it will act
+just like a normal build == host setup, except that no targets will be installed.
+
+This necessarily means that `meson.override_find_program()` must differentiate
+between programs for the host and those for the build machine, as you may need
+two versions of the same program, which have different outputs based on the
+machine they are for. For backwards compatibility reasons the default is for the
+host machine. Inside a native subproject the host and build machine will both be
+the build machine.

--- a/docs/yaml/builtins/meson.yaml
+++ b/docs/yaml/builtins/meson.yaml
@@ -392,6 +392,15 @@ methods:
         type: exe | file | program
         description: The program to set as the override for `progname`.
 
+      native:
+        type: bool
+        since: 1.12.0
+        default: false
+        description : |
+          If set to `true`, the override is for the build machine, and will be returned
+          by `find_program(..., native : true)`, otherwise for the host machine. This
+          is an important distinction when cross compiling.
+
   - name: override_dependency
     returns: void
     since: 0.54.0

--- a/docs/yaml/functions/subproject.yaml
+++ b/docs/yaml/functions/subproject.yaml
@@ -65,3 +65,10 @@ kwargs:
     default: true
     description: |
       Works just the same as in [[dependency]].
+
+  native:
+    type: bool
+    since: 1.12.0
+    default: false
+    description : |
+      Whether to build this subproject for the host or build machine.

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -76,7 +76,7 @@ class IntrospectionInterpreter(AstInterpreter):
 
         self.cross_file = cross_file
         self.backend = backend
-        self.build_project = BuildProject(subproject, '', subproject)
+        self.build_project = BuildProject(subproject, '', subproject, MachineChoice.HOST)
         self.project_data: T.Dict[str, T.Any] = {}
         self.targets: T.List[IntrospectionBuildTarget] = []
         self.dependencies: T.List[IntrospectionDependency] = []

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -10,7 +10,7 @@ import os
 import typing as T
 
 from .. import compilers, environment, mesonlib
-from ..build import Executable, Jar, SharedLibrary, SharedModule, StaticLibrary
+from ..build import Executable, Jar, SharedLibrary, SharedModule, StaticLibrary, BuildProject
 from ..compilers import detect_compiler_for
 from ..interpreterbase import InvalidArguments, UnknownValue, Feature
 from ..interpreter import type_checking
@@ -76,6 +76,7 @@ class IntrospectionInterpreter(AstInterpreter):
 
         self.cross_file = cross_file
         self.backend = backend
+        self.build_project = BuildProject(subproject, '', subproject)
         self.project_data: T.Dict[str, T.Any] = {}
         self.targets: T.List[IntrospectionBuildTarget] = []
         self.dependencies: T.List[IntrospectionDependency] = []
@@ -263,8 +264,9 @@ class IntrospectionInterpreter(AstInterpreter):
         empty_sources: T.List[T.Any] = []
         # Passing the unresolved sources list causes errors
         kwargs_reduced['_allow_no_sources'] = True
-        target = targetclass(name, self.subdir, self.subproject, for_machine, empty_sources, None, objects,
-                             self.environment, self.coredata.compilers[for_machine], kwargs_reduced)
+        target = targetclass(name, self.subdir, for_machine, empty_sources, None, objects,
+                             self.environment, self.coredata.compilers[for_machine],
+                             self.build_project, kwargs_reduced)
         target.process_compilers_late()
 
         build_by_default: T.Union[UnknownValue, bool] = target.build_by_default

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -506,15 +506,11 @@ class IncludeDirs(HoldableObject):
         strlist: T.List[str] = []
         for idirs, add_src in [(self.incdirs, True), (self.extra_build_dirs, False)]:
             for idir in idirs:
-                bld_dir = os.path.normpath(os.path.join(self.curdir, idir))
-                if idir not in {'', '.'}:
-                    expdir = bld_dir
-                else:
-                    expdir = self.curdir
-                if build_root is None or os.path.isdir(os.path.join(build_root, expdir)):
-                    strlist.append(bld_dir)
+                dir = os.path.normpath(os.path.join(self.curdir, idir))
+                if build_root is None or os.path.isdir(os.path.join(build_root, dir)):
+                    strlist.append(dir)
                 if add_src:
-                    strlist.append(os.path.normpath(os.path.join(build_to_src, expdir)))
+                    strlist.append(os.path.normpath(os.path.join(build_to_src, dir)))
 
         return strlist
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -21,8 +21,8 @@ from . import mlog
 from . import programs
 from .mesonlib import (
     HoldableObject, SecondLevelHolder, SimpleABC, SubProject,
-    File, MesonException, MachineChoice, PerMachine, OrderedSet,
-    classify_unity_sources, ROOT_SUBPROJECT,
+    File, MesonException, MachineChoice, PerMachine,
+    OrderedSet, classify_unity_sources, ROOT_SUBPROJECT,
     get_filenames_templates_dict, substitute_values, has_path_sep,
     is_parent_path, relpath, PerMachineDefaultable,
     MesonBugException, EnvironmentVariables, pickle_load, lazy_property,
@@ -352,6 +352,7 @@ class Build:
             environment.is_cross_build(), {}, {})
 
         self.devenv: T.List[EnvironmentVariables] = []
+        self.machine_map = self.environment.machine_map
         self.modules: T.Set[str] = set()
         """Used to track which modules are enabled in all subprojects.
 
@@ -392,6 +393,10 @@ class Build:
 
     def merge(self, other: Build) -> None:
         for k, v in other.__dict__.items():
+            # This one is modified for build-only configs, but it is
+            # local.  No need to copy it.
+            if k == 'machine_map':
+                continue
             # These are not modified in subprojects
             if k in {'global_args', 'global_link_args'}:
                 continue
@@ -404,11 +409,11 @@ class Build:
                 self.__dict__[k] = v
 
     def ensure_static_linker(self, compiler: Compiler) -> None:
-        for_machine = compiler.for_machine if self.environment.is_cross_build() else MachineChoice.HOST
+        for_machine = self.machine_map[compiler.for_machine]
         if self.static_linker[for_machine] is None and compiler.needs_static_linker():
             self.static_linker[for_machine] = detect_static_linker(self.environment, compiler)
-            if not self.environment.is_cross_build():
-                self.static_linker[MachineChoice.BUILD] = self.static_linker[MachineChoice.HOST]
+            if self.machine_map.build is self.machine_map.host:
+                self.static_linker.build = self.static_linker.host
 
     def get_project(self) -> str:
         return self.projects[ROOT_SUBPROJECT].name

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -308,6 +308,10 @@ class BuildProject:
     project_args: PerMachine[T.Dict[Language, T.List[str]]] = field(default_factory=lambda: PerMachine({}, {}))
     project_link_args: PerMachine[T.Dict[Language, T.List[str]]] = field(default_factory=lambda: PerMachine({}, {}))
 
+    @lazy_property
+    def prefix(self) -> str:
+        return 'build.' if self.for_machine is MachineChoice.BUILD else ''
+
 
 # literally everything isn't dataclass stuff
 class Build:
@@ -490,6 +494,7 @@ class IncludeDirs(HoldableObject):
     curdir: str
     incdirs: T.List[str]
     is_system: bool
+    build_project: BuildProject
     extra_build_dirs: T.List[str] = field(default_factory=list)
 
     def abs_string_list(self, sourcedir: str, builddir: str) -> T.List[str]:
@@ -500,12 +505,14 @@ class IncludeDirs(HoldableObject):
             be added if this is unset
         :returns: A list of strings (without compiler argument)
         """
+        bsubdir = self.build_project.prefix + self.curdir
+
         strlist: T.List[str] = []
         for idir in self.incdirs:
             strlist.append(os.path.join(sourcedir, self.curdir, idir))
-            strlist.append(os.path.join(builddir, self.curdir, idir))
+            strlist.append(os.path.join(builddir, bsubdir, idir))
         for idir in self.extra_build_dirs:
-            strlist.append(os.path.join(builddir, self.curdir, idir))
+            strlist.append(os.path.join(builddir, bsubdir, idir))
         return strlist
 
     def rel_string_list(self, build_to_src: str, build_root: T.Optional[str] = None) -> T.List[str]:
@@ -517,13 +524,15 @@ class IncludeDirs(HoldableObject):
         :return: A list if strings (without compiler argument)
         """
         strlist: T.List[str] = []
+        bsubdir = self.build_project.prefix + self.curdir
+
         for idirs, add_src in [(self.incdirs, True), (self.extra_build_dirs, False)]:
             for idir in idirs:
-                dir = os.path.normpath(os.path.join(self.curdir, idir))
-                if build_root is None or os.path.isdir(os.path.join(build_root, dir)):
-                    strlist.append(dir)
+                bld_dir = os.path.normpath(os.path.join(bsubdir, idir))
+                if build_root is None or os.path.isdir(os.path.join(build_root, bld_dir)):
+                    strlist.append(bld_dir)
                 if add_src:
-                    strlist.append(os.path.normpath(os.path.join(build_to_src, dir)))
+                    strlist.append(os.path.normpath(os.path.join(build_to_src, self.curdir, idir)))
 
         return strlist
 
@@ -650,9 +659,9 @@ class Target(HoldableObject, metaclass=SimpleABC):
                 Target "{self.name}" has a path separator in its name.
                 This is not supported, it can cause unexpected failures and will become
                 a hard error in the future.'''))
-        self.builddir = self.subdir
+        self.builddir = self.build_project.prefix + self.subdir
         if self.build_subdir:
-            self.builddir = os.path.join(self.subdir, self.build_subdir)
+            self.builddir = os.path.join(self.builddir, self.build_subdir)
 
     # dataclass comparators?
     def __lt__(self, other: object) -> bool:
@@ -1585,7 +1594,8 @@ class BuildTarget(Target):
     def add_include_dirs(self, args: T.Sequence['IncludeDirs'], set_is_system: str = 'preserve') -> None:
         if set_is_system != 'preserve':
             is_system = set_is_system == 'system'
-            self.include_dirs.extend([IncludeDirs(x.curdir, x.incdirs, is_system, x.extra_build_dirs) for x in args])
+            self.include_dirs.extend([IncludeDirs(x.curdir, x.incdirs, is_system, x.build_project,
+                                                  x.extra_build_dirs) for x in args])
         else:
             self.include_dirs.extend(args)
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -303,6 +303,7 @@ class DepManifest:
 class BuildProject:
     name: str
     version: str
+    subproject: SubProject
     project_args: PerMachine[T.Dict[Language, T.List[str]]] = field(default_factory=lambda: PerMachine({}, {}))
     project_link_args: PerMachine[T.Dict[Language, T.List[str]]] = field(default_factory=lambda: PerMachine({}, {}))
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -304,6 +304,7 @@ class BuildProject:
     name: str
     version: str
     subproject: SubProject
+    for_machine: MachineChoice
     project_args: PerMachine[T.Dict[Language, T.List[str]]] = field(default_factory=lambda: PerMachine({}, {}))
     project_link_args: PerMachine[T.Dict[Language, T.List[str]]] = field(default_factory=lambda: PerMachine({}, {}))
 
@@ -320,7 +321,7 @@ class Build:
         self.project_name = 'name of master project'
         self.project_version: T.Optional[str] = None
         self.environment = environment
-        self.projects: T.Dict[SubProject, BuildProject] = {}
+        self.projects: PerMachine[T.Dict[SubProject, BuildProject]] = PerMachine({}, {})
         self.targets: dict[str, Target] = {}
         self.targetnames: T.Set[T.Tuple[str, str]] = set() # Set of executable names and their subdir
         self.global_args: PerMachine[T.Dict[Language, T.List[str]]] = PerMachine({}, {})
@@ -417,7 +418,7 @@ class Build:
                 self.static_linker.build = self.static_linker.host
 
     def get_project(self) -> str:
-        return self.projects[ROOT_SUBPROJECT].name
+        return self.projects.host[ROOT_SUBPROJECT].name
 
     def get_subproject_dir(self) -> str:
         return self.subproject_dir
@@ -898,7 +899,7 @@ class BuildTarget(Target):
             mlog.warning(f'Build target {name} has no sources. '
                          'This was never supposed to be allowed but did because of a bug, '
                          'support will be removed in a future release of Meson')
-        self.validate_install()
+        self.validate_cross()
         self.check_module_linking()
 
     @lazy_property
@@ -979,7 +980,13 @@ class BuildTarget(Target):
     def __str__(self) -> str:
         return f"{self.name}"
 
-    def validate_install(self) -> None:
+    def validate_cross(self) -> None:
+        if self.build_project.for_machine is MachineChoice.BUILD:
+            if self.for_machine is MachineChoice.HOST:
+                raise MesonBugException('Tried to build a target for the host machine in a build-only subproject.')
+            if self.install:
+                raise MesonBugException('Tried to build an installable target in a build-only subproject.')
+
         if self.for_machine is MachineChoice.BUILD and self.install:
             if self.environment.is_cross_build():
                 raise InvalidArguments('Tried to install a target for the build machine in a cross build.')

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -454,7 +454,8 @@ class Build:
         return d.get(compiler.get_language(), [])
 
     def get_project_args(self, compiler: 'Compiler', target: BuildTarget) -> T.List[str]:
-        args = self.projects[target.subproject].project_args[target.for_machine]
+        d = target.build_project
+        args = d.project_args[target.for_machine]
         if not args:
             return []
         return args.get(compiler.get_language(), [])
@@ -464,7 +465,8 @@ class Build:
         return d.get(compiler.get_language(), [])
 
     def get_project_link_args(self, compiler: 'Compiler', target: BuildTarget) -> T.List[str]:
-        link_args = self.projects[target.subproject].project_link_args[target.for_machine]
+        d = target.build_project
+        link_args = d.project_link_args[target.for_machine]
         if not link_args:
             return []
 
@@ -622,10 +624,10 @@ class Target(HoldableObject, metaclass=SimpleABC):
 
     name: str
     subdir: str
-    subproject: 'SubProject'
     build_by_default: bool
     for_machine: MachineChoice
     environment: Environment
+    build_project: BuildProject
     install: bool = False
     build_always_stale: bool = False
     extra_files: T.List[File] = field(default_factory=list)
@@ -720,6 +722,10 @@ class Target(HoldableObject, metaclass=SimpleABC):
         return my_id
 
     @lazy_property
+    def subproject(self) -> SubProject:
+        return self.build_project.subproject
+
+    @lazy_property
     def id(self) -> str:
         return self.construct_id_from_path(
             self.builddir, self.name, self.type_suffix())
@@ -752,18 +758,19 @@ class BuildTarget(Target):
             self,
             name: str,
             subdir: str,
-            subproject: SubProject,
             for_machine: MachineChoice,
             sources: T.List['SourceOutputs'],
             structured_sources: T.Optional[StructuredSources],
             objects: T.Sequence[ObjectTypes | GeneratedTypes],
             environment: Environment,
             compilers: CompilerDict,
+            build_project: BuildProject,
             kwargs: BuildTargetKeywordArguments):
-        super().__init__(name, subdir, subproject, kwargs.get('build_by_default', True),
+        super().__init__(name, subdir, kwargs.get('build_by_default', True),
                          for_machine, environment,
                          install=kwargs.get('install', False),
-                         build_subdir=kwargs.get('build_subdir', ''))
+                         build_subdir=kwargs.get('build_subdir', ''),
+                         build_project=build_project)
         self.original_kwargs = kwargs
         # all_compilers is a reference to Interpreter.compilers, as such we
         # cannot mutate it inside build. Use a Mapping to get help from the
@@ -2141,18 +2148,18 @@ class Executable(BuildTarget, LinkableTarget):
             self,
             name: str,
             subdir: str,
-            subproject: SubProject,
             for_machine: MachineChoice,
             sources: T.List['SourceOutputs'],
             structured_sources: T.Optional[StructuredSources],
             objects: T.Sequence[ObjectTypes | GeneratedTypes],
             environment: Environment,
             compilers: CompilerDict,
+            build_project: BuildProject,
             kwargs: ExecutableKeywordArguments):
         self.export_dynamic = kwargs.get('export_dynamic', False)
         self.rust_crate_type = kwargs.get('rust_crate_type', 'bin')
-        super().__init__(name, subdir, subproject, for_machine, sources, structured_sources, objects,
-                         environment, compilers, kwargs)
+        super().__init__(name, subdir, for_machine, sources, structured_sources, objects,
+                         environment, compilers, build_project, kwargs)
         self.win_subsystem = kwargs.get('win_subsystem') or 'console'
         self.pie = self._extract_pic_pie(kwargs, 'pie', 'b_pie')
         # Check for export_dynamic
@@ -2274,18 +2281,18 @@ class StaticLibrary(BuildTarget, LinkableTarget):
             self,
             name: str,
             subdir: str,
-            subproject: SubProject,
             for_machine: MachineChoice,
             sources: T.List['SourceOutputs'],
             structured_sources: T.Optional[StructuredSources],
             objects: T.Sequence[ObjectTypes | GeneratedTypes],
             environment: Environment,
             compilers: CompilerDict,
+            build_project: BuildProject,
             kwargs: StaticLibraryKeywordArguments):
         self.prelink = kwargs.get('prelink', False)
         self.rust_crate_type = kwargs.get('rust_crate_type', 'rlib')
-        super().__init__(name, subdir, subproject, for_machine, sources, structured_sources, objects,
-                         environment, compilers, kwargs)
+        super().__init__(name, subdir, for_machine, sources, structured_sources, objects,
+                         environment, compilers, build_project, kwargs)
         self.pic = self._extract_pic_pie(kwargs, 'pic', 'b_staticpic')
         if not self.pic:
             self.pie = self._extract_pic_pie(kwargs, 'pie', 'b_pie')
@@ -2456,16 +2463,16 @@ class SharedLibrary(BuildTarget, LinkableTarget):
             self,
             name: str,
             subdir: str,
-            subproject: SubProject,
             for_machine: MachineChoice,
             sources: T.List['SourceOutputs'],
             structured_sources: T.Optional[StructuredSources],
             objects: T.Sequence[ObjectTypes | GeneratedTypes],
             environment: Environment,
             compilers: CompilerDict,
+            build_project: BuildProject,
             kwargs: SharedLibraryKeywordArguments):
-        super().__init__(name, subdir, subproject, for_machine, sources, structured_sources, objects,
-                         environment, compilers, kwargs)
+        super().__init__(name, subdir, for_machine, sources, structured_sources, objects,
+                         environment, compilers, build_project, kwargs)
         # Max length 2, first element is compatibility_version, second is current_version
         self.darwin_versions: T.Optional[T.Tuple[str, str]] = None
         self.soversion: T.Optional[str] = None
@@ -2792,16 +2799,16 @@ class SharedModule(SharedLibrary):
             self,
             name: str,
             subdir: str,
-            subproject: SubProject,
             for_machine: MachineChoice,
             sources: T.List['SourceOutputs'],
             structured_sources: T.Optional[StructuredSources],
             objects: T.Sequence[ObjectTypes | GeneratedTypes],
             environment: Environment,
             compilers: CompilerDict,
+            build_project: BuildProject,
             kwargs: SharedModuleKeywordArguments):
-        super().__init__(name, subdir, subproject, for_machine, sources,
-                         structured_sources, objects, environment, compilers,
+        super().__init__(name, subdir, for_machine, sources,
+                         structured_sources, objects, environment, compilers, build_project,
                          # SharedModuleKeywordArguments is a subclass, it's annoying mypy can't figure this out
                          T.cast('SharedLibraryKeywordArguments', kwargs))
         # We need to set the soname in cases where build files link the module
@@ -2939,11 +2946,11 @@ class CustomTarget(Target, CustomTargetBase):
     def __init__(self,
                  name: T.Optional[str],
                  subdir: str,
-                 subproject: SubProject,
                  environment: Environment,
                  command: T.Sequence[CommandTypes],
                  sources: T.Sequence[CustomTargetSources],
                  outputs: T.List[str],
+                 build_project: BuildProject,
                  *,
                  build_always_stale: bool = False,
                  build_by_default: T.Optional[bool] = None,
@@ -2966,8 +2973,8 @@ class CustomTarget(Target, CustomTargetBase):
                  build_subdir: str = '',
                  ):
         # TODO expose keyword arg to make MachineChoice.HOST configurable
-        super().__init__(name, subdir, subproject, False, MachineChoice.HOST, environment,
-                         install, build_always_stale, build_subdir = build_subdir)
+        super().__init__(name, subdir, False, MachineChoice.HOST, environment,
+                         build_project, install, build_always_stale, build_subdir = build_subdir)
         self.sources = list(sources)
         self.outputs = substitute_values(
             outputs, get_filenames_templates_dict(
@@ -2979,7 +2986,7 @@ class CustomTarget(Target, CustomTargetBase):
         self.depend_files = list(depend_files or [])
         self.dependencies: T.List[T.Union[CustomTarget, BuildTarget]] = []
         # must be after depend_files and dependencies
-        c, df, d = flatten_command(command, self.subproject)
+        c, df, d = flatten_command(command, build_project.subproject)
         self.command = c
         self.depend_files.extend(df)
         self.dependencies.extend(d)
@@ -3170,7 +3177,6 @@ class CompileTarget(BuildTarget):
     def __init__(self,
                  name: str,
                  subdir: str,
-                 subproject: SubProject,
                  environment: Environment,
                  sources: T.List['SourceOutputs'],
                  output_templ: str,
@@ -3179,6 +3185,7 @@ class CompileTarget(BuildTarget):
                  compile_args: T.List[str],
                  include_directories: T.List[IncludeDirs],
                  dependencies: T.List[dependencies.Dependency],
+                 build_project: BuildProject,
                  depends: T.List[BuildTargetTypes]):
         compilers = {compiler.get_language(): compiler}
         kwargs: BuildTargetKeywordArguments = {
@@ -3187,8 +3194,9 @@ class CompileTarget(BuildTarget):
             'include_directories': include_directories,
             'dependencies': dependencies,
         }
-        super().__init__(name, subdir, subproject, compiler.for_machine,
-                         sources, None, [], environment, compilers, kwargs)
+        super().__init__(name, subdir, compiler.for_machine,
+                         sources, None, [], environment, compilers,
+                         build_project, kwargs)
         self.filename = name
         self.compiler = compiler
         self.output_templ = output_templ
@@ -3230,14 +3238,14 @@ class RunTarget(Target):
                  # the RunTarget case is used by gnome.yelp()
                  dependencies: T.Sequence[Target | CustomTargetIndex | GeneratedList | programs.Program],
                  subdir: str,
-                 subproject: SubProject,
                  environment: Environment,
+                 build_project: BuildProject,
                  env: T.Optional[EnvironmentVariables] = None,
                  default_env: bool = True):
         # These don't produce output artifacts
-        super().__init__(name, subdir, subproject, False, MachineChoice.BUILD, environment)
+        super().__init__(name, subdir, False, MachineChoice.BUILD, environment, build_project)
         self.dependencies = list(dependencies)
-        self.command, self.depend_files, d = flatten_command(command, subproject)
+        self.command, self.depend_files, d = flatten_command(command, build_project.subproject)
         self.dependencies.extend(d)
         self.absolute_paths = False
         self.env = env
@@ -3273,8 +3281,9 @@ class AliasTarget(RunTarget):
     typename = 'alias'
 
     def __init__(self, name: str, dependencies: T.Sequence[Target],
-                 subdir: str, subproject: SubProject, environment: Environment):
-        super().__init__(name, [], dependencies, subdir, subproject, environment)
+                 subdir: str, environment: Environment,
+                 build_project: BuildProject):
+        super().__init__(name, [], dependencies, subdir, environment, build_project)
 
     def __repr__(self) -> str:
         repr_str = "<{0} {1}>"
@@ -3284,12 +3293,12 @@ class Jar(BuildTarget):
     typename = 'jar'
     rust_crate_type = ''  # type: ignore[assignment]
 
-    def __init__(self, name: str, subdir: str, subproject: SubProject, for_machine: MachineChoice,
+    def __init__(self, name: str, subdir: str, for_machine: MachineChoice,
                  sources: T.List[SourceOutputs], structured_sources: T.Optional['StructuredSources'],
                  objects: T.Sequence[ObjectTypes | GeneratedTypes], environment: Environment, compilers: CompilerDict,
-                 kwargs: JarKeywordArguments):
-        super().__init__(name, subdir, subproject, for_machine, sources, structured_sources, objects,
-                         environment, compilers, kwargs)
+                 build_project: BuildProject, kwargs: JarKeywordArguments):
+        super().__init__(name, subdir, for_machine, sources, structured_sources, objects,
+                         environment, compilers, build_project, kwargs)
         for s in self.sources:
             if not s.endswith('.java'):
                 raise InvalidArguments(f'Jar source {s} is not a java file.')

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -412,8 +412,11 @@ class Build:
 
             if isinstance(v, PerMachine):
                 dest = self.__dict__[k]
+                if dest.host is dest.build:
+                    dest.host = v.build
+                elif v.host is not v.build:
+                    dest.host = v.host
                 dest.build = v.build
-                dest.host = v.host
             else:
                 self.__dict__[k] = v
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -343,8 +343,11 @@ class Build:
         self.dep_manifest: T.Dict[str, DepManifest] = {}
         self.test_setups: T.Dict[str, TestSetup] = {}
         self.test_setup_default_name: str | None = None
-        self.find_overrides: T.Dict[str, programs.Program] = {}
-        self.searched_programs: T.Set[str] = set() # The list of all programs that have been searched for.
+        self.find_overrides: PerMachine[T.Dict[str, programs.Program]] = PerMachineDefaultable.default(
+            environment.is_cross_build(), {}, {})
+        # The list of all programs that have been searched for.
+        self.searched_programs: PerMachine[T.Set[str]] = PerMachineDefaultable.default(
+            environment.is_cross_build(), set(), set())
 
         # If we are doing a cross build we need two caches, if we're doing a
         # build == host compilation the both caches should point to the same place.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -19,9 +19,10 @@ from . import coredata
 from . import dependencies
 from . import mlog
 from . import programs
+from .environment import MachineMap
 from .mesonlib import (
     HoldableObject, SecondLevelHolder, SimpleABC, SubProject,
-    File, MesonException, MachineChoice, PerMachine,
+    File, MesonException, MachineChoice, ThreeMachineChoice, PerMachine,
     OrderedSet, classify_unity_sources, ROOT_SUBPROJECT,
     get_filenames_templates_dict, substitute_values, has_path_sep,
     is_parent_path, relpath, PerMachineDefaultable,
@@ -399,6 +400,19 @@ class Build:
         for k, v in self.__dict__.items():
             other.__dict__[k] = copy.copy(v)
         return other
+
+    def copy_for_build_machine(self) -> Build:
+        """Create a build-only copy for build machine subprojects.
+
+        Build-only subprojects run with host==build configuration so that get_compiler(),
+        dependency() etc. look up the native (non-cross) environments.  However, note
+        that the environment is still a cross one so that the build-machine options,
+        dependencies, etc. are looked up.
+        """
+        new = self.copy()
+        new.machine_map = MachineMap(self.machine_map.build, self.machine_map.build,
+                                     ThreeMachineChoice(self.machine_map.host))
+        return new
 
     def merge(self, other: Build) -> None:
         for k, v in other.__dict__.items():

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -341,6 +341,7 @@ class Build:
         self.dep_manifest: T.Dict[str, DepManifest] = {}
         self.test_setups: T.Dict[str, TestSetup] = {}
         self.test_setup_default_name: str | None = None
+        self.find_overrides: T.Dict[str, programs.Program] = {}
         self.searched_programs: T.Set[str] = set() # The list of all programs that have been searched for.
 
         # If we are doing a cross build we need two caches, if we're doing a

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -796,14 +796,14 @@ class ConverterCustomTarget:
         mlog.log('  -- depends:      ', mlog.bold(str(self.depends)))
 
 class CMakeInterpreter:
-    def __init__(self, subdir: Path, env: 'Environment', backend: 'Backend'):
+    def __init__(self, subdir: Path, env: 'Environment', backend: 'Backend', for_machine: MachineChoice):
         self.subdir = subdir
         self.src_dir = Path(env.get_source_dir(), subdir)
         self.build_dir_rel = subdir / '__CMake_build'
         self.build_dir = Path(env.get_build_dir()) / self.build_dir_rel
         self.install_prefix = Path(T.cast('str', env.coredata.optstore.get_value_for(OptionKey('prefix'))))
         self.env = env
-        self.for_machine = MachineChoice.HOST # TODO make parameter
+        self.for_machine = for_machine
         self.backend_name = backend.name
         self.linkers: T.Set[str] = set()
         self.fileapi = CMakeFileAPI(self.build_dir)

--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -66,7 +66,6 @@ class PkgConfigInterface:
         Even when we use another implementation internally, external tools might
         still need the CLI implementation.
         '''
-        for_machine = for_machine if env.is_cross_build() else MachineChoice.HOST
         impl: T.Union[Literal[False], T.Optional[PkgConfigInterface]] # Help confused mypy
         impl = PkgConfigInterface.instance(env, for_machine, silent)
         if impl and not isinstance(impl, PkgConfigCLI):

--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -46,7 +46,6 @@ class PkgConfigInterface:
     def instance(env: Environment, for_machine: MachineChoice, silent: bool,
                  extra_paths: T.Optional[T.List[str]] = None) -> T.Optional[PkgConfigInterface]:
         '''Return a pkg-config implementation singleton'''
-        for_machine = for_machine if env.is_cross_build() else MachineChoice.HOST
         extra_paths_key = tuple(extra_paths) if extra_paths is not None else None
         impl = PkgConfigInterface.class_impl[for_machine].get(extra_paths_key, False)
         if impl is False:

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import itertools
 import os, re
 import typing as T
@@ -18,7 +19,7 @@ from . import options
 from .mesonlib import (
     MesonException, MachineChoice, Popen_safe, PerMachine,
     PerMachineDefaultable, PerThreeMachineDefaultable, split_args,
-    MesonBugException
+    MesonBugException, ThreeMachineChoice
 )
 from .options import OptionKey
 from . import mlog
@@ -36,6 +37,8 @@ if T.TYPE_CHECKING:
     from .compilers.compilers import Compiler, CompilerDict, Language
     from .options import OptionDict, ElementaryOptionValues
     from .wrap.wrap import Resolver
+
+    import enum
 
 
 NON_LANG_ENV_OPTIONS = [
@@ -76,6 +79,31 @@ def _get_env_var(for_machine: MachineChoice, is_cross: bool, var_name: str) -> T
         return None
     mlog.debug(f'Using {var!r} from environment with value: {value!r}')
     return value
+
+
+@dataclasses.dataclass
+class MachineMap:
+    # BUILD if cross compiling, HOST if not cross compiling
+    build: MachineChoice
+    # This is not entirely correct: it is possible in principle for
+    # the host machine to be originally configured as a target, and
+    # switched to be the host for a single subproject.  Ultimately,
+    # Environment should include N arbitrarily-named configurations,
+    # and kwargs['native'] would be supplanted by kwargs['for_machine']
+    # of type T.NewType('MachineChoice', str) after parameter parsing.
+    host: MachineChoice
+    target: ThreeMachineChoice
+
+    @T.overload
+    def __getitem__(self, machine: MachineChoice) -> MachineChoice:
+        ...
+
+    @T.overload
+    def __getitem__(self, machine: ThreeMachineChoice) -> ThreeMachineChoice:
+        ...
+
+    def __getitem__(self, machine: MachineChoice | ThreeMachineChoice) -> enum.IntEnum:
+        return [self.build, self.host, self.target][machine.value]
 
 
 class Environment:
@@ -120,6 +148,13 @@ class Environment:
             self.build_dir = ''
             self.scratch_dir = ''
             self.create_new_coredata(cmd_options)
+
+        # Store which machine is actually returned by self.machines after
+        # taking into account defaults
+        if self.coredata.cross_files:
+            self.machine_map = MachineMap(MachineChoice.BUILD, MachineChoice.HOST, ThreeMachineChoice.HOST)
+        else:
+            self.machine_map = MachineMap(MachineChoice.HOST, MachineChoice.HOST, ThreeMachineChoice.HOST)
 
         ## locally bind some unfrozen configuration
 
@@ -168,9 +203,7 @@ class Environment:
             binaries.build = BinaryTable(config.get('binaries', {}))
             properties.build = Properties(config.get('properties', {}))
             cmakevars.build = CMakeVariables(config.get('cmake', {}))
-            self._load_machine_file_options(
-                config, properties.build,
-                MachineChoice.BUILD if self.coredata.cross_files else MachineChoice.HOST)
+            self._load_machine_file_options(config, properties.build, self.machine_map.build)
 
         ## Read in cross file(s) to override host machine configuration
 
@@ -183,6 +216,7 @@ class Environment:
                 machines.host = MachineInfo.from_literal(config['host_machine'])
             if 'target_machine' in config:
                 machines.target = MachineInfo.from_literal(config['target_machine'])
+                self.machine_map.target = ThreeMachineChoice.TARGET
             # Keep only per machine options from the native file. The cross
             # file takes precedence over all other options.
             for key, value in list(self.options.items()):
@@ -430,7 +464,7 @@ class Environment:
                 self.coredata.optstore.set_option(k, v)
 
     def is_cross_build(self, when_building_for: MachineChoice = MachineChoice.HOST) -> bool:
-        return self.coredata.is_cross_build(when_building_for)
+        return self.machine_map[when_building_for] is not self.machine_map.build
 
     def dump_coredata(self) -> str:
         return coredata.save(self.coredata, self.get_build_dir())

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -908,7 +908,6 @@ class CompilerHolder(ObjectHolder['Compiler']):
         tg = build.CompileTarget(
             tg_name,
             self.interpreter.subdir,
-            self.subproject,
             self.environment,
             sources,
             kwargs['output'],
@@ -917,6 +916,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
             kwargs['compile_args'],
             self.interpreter.extract_incdirs(kwargs['include_directories']),
             kwargs['dependencies'],
+            self.interpreter.current_build_project(),
             kwargs['depends'])
         self.interpreter.add_target(tg.name, tg)
         # Expose this target as list of its outputs, so user can pass them to

--- a/mesonbuild/interpreter/decorators.py
+++ b/mesonbuild/interpreter/decorators.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2012-2021 The Meson development team
+
+from __future__ import annotations
+
+from functools import wraps
+import typing as T
+
+from ..interpreterbase import ObjectHolder
+from ..interpreterbase.decorators import get_callee_args
+from ..mesonlib import MesonBugException
+
+if T.TYPE_CHECKING:
+    from ..interpreterbase import TV_func
+    from .kwargs import MachineMapArgs
+
+
+def apply_machine_map(f: TV_func) -> TV_func:
+    """Enforce build-only subproject constraints on native/install kwargs.
+
+    Must be placed AFTER @typed_kwargs (so converters have run).
+    """
+    @wraps(f)
+    def wrapped(*wrapped_args: T.Any, **wrapped_kwargs: T.Any) -> T.Any:
+        # Import here to avoid circular imports at module load time
+        from . import Interpreter
+        from .mesonmain import MesonMain
+
+        # First argument could be Interpreter, InterpreterObject (with an interpreter
+        # attribute) or ModuleObject.  In the case of a ModuleObject it is the 2nd
+        # argument (ModuleState) that contains the needed information.
+        s: Interpreter
+        if not hasattr(wrapped_args[0], 'current_node'):
+            s = wrapped_args[1]._interpreter
+        elif isinstance(wrapped_args[0], (MesonMain, ObjectHolder)):
+            s = wrapped_args[0].interpreter
+        elif isinstance(wrapped_args[0], Interpreter):
+            s = wrapped_args[0]
+        else:
+            raise MesonBugException(f'cannot use @apply_machine_map if the object is a {type(wrapped_args[0])}')
+
+        _, _, kwargs, _ = get_callee_args(wrapped_args)
+        if 'native' in kwargs:
+            s.apply_machine_map_to_kwargs(T.cast('MachineMapArgs', kwargs))
+
+        return f(*wrapped_args, **wrapped_kwargs)
+    return T.cast('TV_func', wrapped)

--- a/mesonbuild/interpreter/dependencyfallbacks.py
+++ b/mesonbuild/interpreter/dependencyfallbacks.py
@@ -361,6 +361,7 @@ class DependencyFallbacksHolder(MesonInterpreterObject):
             kwargs['required'] = required and (i == last)
             func_kwargs: DoSubproject = {
                 'required': kwargs['required'],
+                'for_machine': self.for_machine,
                 'cmake_options': [],
                 'default_options': self.default_options,
                 'options': None,

--- a/mesonbuild/interpreter/dependencyfallbacks.py
+++ b/mesonbuild/interpreter/dependencyfallbacks.py
@@ -137,7 +137,7 @@ class DependencyFallbacksHolder(MesonInterpreterObject):
         return self._get_subproject_dep(subp_name, varname, kwargs)
 
     def _get_subproject(self, subp_name: str) -> T.Optional[SubprojectHolder]:
-        sub = self.interpreter.subprojects.get(subp_name)
+        sub = self.interpreter.subprojects[self.for_machine].get(subp_name)
         if sub and sub.found():
             return sub
         return None

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2994,7 +2994,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             absdir_build = os.path.join(absbase_build, a)
             if not os.path.isdir(absdir_src) and not os.path.isdir(absdir_build):
                 raise InvalidArguments(f'Include dir {a} does not exist.')
-        i = build.IncludeDirs(self.subdir, incdir_strings, is_system)
+        i = build.IncludeDirs(self.subdir, incdir_strings, is_system, self.current_build_project())
         return i
 
     @typed_pos_args('add_test_setup', str)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -19,8 +19,8 @@ from .. import envconfig
 from ..wrap import wrap, WrapMode
 from .. import mesonlib
 from ..mesonlib import (EnvironmentVariables, ExecutableSerialisation, MesonBugException, MesonException, HoldableObject,
-                        FileMode, MachineChoice, is_parent_path, listify,
-                        has_path_sep, path_has_root, path_is_in_root, PerMachine)
+                        FileMode, MachineChoice, PerMachine, PerMachineDefaultable, is_parent_path, listify,
+                        has_path_sep, path_has_root, path_is_in_root)
 from ..options import OptionKey
 from ..programs import ExternalProgram, NonExistingExternalProgram, Program
 from ..dependencies import Dependency
@@ -302,8 +302,9 @@ class Interpreter(InterpreterBase, HoldableObject):
         self.validated_cache: T.Set[str] = set()
         self.project_args_frozen = False
         self.global_args_frozen = False  # implies self.project_args_frozen
-        self.subprojects: T.Dict[str, SubprojectHolder] = {}
-        self.subproject_stack: T.List[str] = []
+        self.subprojects: PerMachine[T.Dict[str, SubprojectHolder]] = PerMachineDefaultable.default(
+            self.environment.is_cross_build(), {}, {})
+        self.subproject_stack: T.List[T.Tuple[str, MachineChoice]] = []
         self.configure_file_outputs: T.Dict[str, int] = {}
         # Passed from the outside, only used in subprojects.
         if invoker_method_default_options:
@@ -891,11 +892,24 @@ class Interpreter(InterpreterBase, HoldableObject):
                             exception: T.Optional[Exception] = None) -> SubprojectHolder:
         sub = SubprojectHolder(NullSubprojectInterpreter(), os.path.join(self.subproject_dir, subp_name),
                                disabled_feature=disabled_feature, exception=exception)
-        self.subprojects[subp_name] = sub
+        self.subprojects.host[subp_name] = sub
         return sub
 
     def create_build_subdir(self, subdir: str) -> None:
         os.makedirs(os.path.join(self.build.environment.get_build_dir(), subdir), exist_ok=True)
+
+    @staticmethod
+    def format_subproject_stack(stack: T.List[T.Tuple[str, MachineChoice]], join: str = ' => ') -> str:
+        prefix = ''
+        result = ''
+        for_build = False
+        for subp_name, machine in stack:
+            result += prefix + subp_name
+            if machine is MachineChoice.BUILD and not for_build:
+                result += ' (build)'
+                for_build = True
+            prefix = join
+        return result
 
     def do_subproject(self, subp_name: SubProject, kwargs: kwtypes.DoSubproject, force_method: T.Optional[wrap.Method] = None,
                       forced_options: T.Optional[OptionDict] = None) -> SubprojectHolder:
@@ -927,16 +941,16 @@ class Interpreter(InterpreterBase, HoldableObject):
         if has_path_sep(subp_name):
             mlog.warning('Subproject name has a path separator. This may cause unexpected behaviour.',
                          location=self.current_node)
-        if subp_name in self.subproject_stack:
-            fullstack = self.subproject_stack + [subp_name]
-            incpath = ' => '.join(fullstack)
+        fullstack = self.subproject_stack + [(subp_name, MachineChoice.HOST)]
+        if (subp_name, MachineChoice.HOST) in self.subproject_stack:
+            incpath = self.format_subproject_stack(fullstack)
             raise InvalidCode(f'Recursive include of subprojects: {incpath}.')
-        if subp_name in self.subprojects:
-            subproject = self.subprojects[subp_name]
+        if subp_name in self.subprojects.host:
+            subproject = self.subprojects.host[subp_name]
             if required and not subproject.found():
                 raise InterpreterException(f'Subproject "{subproject.subdir}" required but not found.')
             if kwargs['version']:
-                pv = self.build.projects[subp_name].version
+                pv = self.build.projects.host[subp_name].version
                 wanted = kwargs['version']
                 if pv == 'undefined' or not mesonlib.version_compare_many(pv, wanted)[0]:
                     raise InterpreterException(f'Subproject {subp_name} version is {pv} but {wanted} required.')
@@ -961,7 +975,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         self.create_build_subdir(subdir)
         self.global_args_frozen = True
 
-        stack = ':'.join(self.subproject_stack + [subp_name])
+        stack = self.format_subproject_stack(fullstack, ':')
         m = ['\nExecuting subproject', mlog.bold(stack)]
         if method != 'meson':
             m += ['method', mlog.bold(method)]
@@ -1026,7 +1040,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             subi.bound_holder_map = self.bound_holder_map
             subi.summary = self.summary
 
-            subi.subproject_stack = self.subproject_stack + [subp_name]
+            subi.subproject_stack = self.subproject_stack + [(subp_name, MachineChoice.HOST)]
             current_active = self.active_projectname
             with mlog.nested_warnings():
                 subi.run()
@@ -1041,16 +1055,16 @@ class Interpreter(InterpreterBase, HoldableObject):
             if pv == 'undefined' or not mesonlib.version_compare_many(pv, wanted)[0]:
                 raise InterpreterException(f'Subproject {subp_name} version is {pv} but {wanted} required.')
         self.active_projectname = current_active
-        self.subprojects.update(subi.subprojects)
-        self.subprojects[subp_name] = SubprojectHolder(subi, subdir, warnings=subi_warnings,
-                                                       callstack=self.subproject_stack)
+        self.subprojects.host.update(subi.subprojects.host)
+        self.subprojects.host[subp_name] = SubprojectHolder(subi, subdir, warnings=subi_warnings,
+                                                            callstack=self.subproject_stack)
         # Duplicates are possible when subproject uses files from project root
         if build_def_files:
             self.build_def_files.update(build_def_files)
         # We always need the subi.build_def_files, to propagate sub-sub-projects
         self.build_def_files.update(subi.get_build_def_files())
         self.build.merge(subi.build)
-        return self.subprojects[subp_name]
+        return self.subprojects.host[subp_name]
 
     def _do_subproject_cmake(self, subp_name: SubProject, subdir: str,
                              default_options: OptionDict,
@@ -1307,7 +1321,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             proj_license_files.append((ifname, i))
         self.build.dep_manifest[proj_name] = build.DepManifest(self.project_version, proj_license,
                                                                proj_license_files, self.subproject)
-        if self.subproject in self.build.projects:
+        if self.subproject in self.build.projects.host:
             raise InvalidCode('Second call to project().')
 
         # spdirname is the subproject_dir for this project, relative to self.subdir.
@@ -1339,8 +1353,8 @@ class Interpreter(InterpreterBase, HoldableObject):
         if self.cargo is None:
             self.load_root_cargo_lock_file()
 
-        self.build.projects[self.subproject] = build.BuildProject(proj_name, self.project_version,
-                                                                  self.subproject)
+        self.build.projects.host[self.subproject] = build.BuildProject(proj_name, self.project_version,
+                                                                       self.subproject, MachineChoice.HOST)
         mlog.log('Project name:', mlog.bold(proj_name))
         mlog.log('Project version:', mlog.bold(self.project_version))
 
@@ -1434,7 +1448,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     def _print_summary(self) -> None:
         # Add automatic 'Subprojects' section in main project.
         all_subprojects: dict[str, mlog.TV_Loggable | mlog.TV_LoggableList] = {}
-        for name, subp in sorted(self.subprojects.items()):
+        for name, subp in sorted(self.subprojects.host.items()):
             value: mlog.TV_LoggableList = [subp.found()]
             if subp.disabled_feature:
                 value += [f'Feature {subp.disabled_feature!r} disabled']
@@ -1443,7 +1457,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             elif subp.warnings > 0:
                 value += [f'{subp.warnings} warnings']
             if subp.callstack:
-                stack = ' => '.join(subp.callstack)
+                stack = self.format_subproject_stack(subp.callstack)
                 value += [f'(from {stack})']
             all_subprojects[name] = value
         if all_subprojects:
@@ -1464,7 +1478,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         mlog.log('')  # newline
         main_summary = self.summary.pop('', None)
         for subp_name, summary in sorted(self.summary.items()):
-            if self.subprojects[subp_name].found():
+            if self.subprojects.host[subp_name].found():
                 summary.dump()
         if main_summary:
             main_summary.dump()
@@ -1795,7 +1809,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                 version = version_func(progobj)
             elif isinstance(progobj, build.Executable):
                 if progobj.subproject:
-                    interp = self.subprojects[progobj.subproject].held_object
+                    interp = self.subprojects.host[progobj.subproject].held_object
                 else:
                     interp = self
                 assert isinstance(interp, Interpreter), 'for mypy'
@@ -3035,7 +3049,8 @@ class Interpreter(InterpreterBase, HoldableObject):
                                     args[0], kwargs)
 
     def current_build_project(self) -> build.BuildProject:
-        return self.build.projects[self.subproject]
+        for_machine = self.build.machine_map.host
+        return self.build.projects[for_machine][self.subproject]
 
     @FeatureNew('add_project_dependencies', '0.63.0')
     @typed_pos_args('add_project_dependencies', varargs=dependencies.Dependency)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -314,7 +314,6 @@ class Interpreter(InterpreterBase, HoldableObject):
         self.build_func_dict()
         self.build_holder_map()
         self.user_defined_options = user_defined_options
-        self.find_overrides: T.Dict[str, Program] = {}
         # Languages added in the current subproject
         self.compilers: PerMachine[CompilerDict] = PerMachine({}, {})
         self.parse_project()
@@ -786,7 +785,7 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     def _compiled_exe_error(self, cmd: T.Union[Program, build.Executable]) -> T.NoReturn:
         descr = cmd.name if isinstance(cmd, build.Executable) else cmd.description()
-        for name, exe in self.find_overrides.items():
+        for name, exe in self.build.find_overrides.items():
             if cmd == exe:
                 raise InterpreterException(f'Program {name!r} was overridden with the compiled executable {descr!r} and therefore cannot be used during configuration')
         raise InterpreterException(f'Program {descr!r} is a compiled executable and therefore cannot be used during configuration')
@@ -1020,7 +1019,6 @@ class Interpreter(InterpreterBase, HoldableObject):
             subi.holder_map = self.holder_map
             subi.bound_holder_map = self.bound_holder_map
             subi.summary = self.summary
-            subi.find_overrides = self.find_overrides
 
             subi.subproject_stack = self.subproject_stack + [subp_name]
             current_active = self.active_projectname
@@ -1676,8 +1674,8 @@ class Interpreter(InterpreterBase, HoldableObject):
         for name in command_names:
             if not isinstance(name, str):
                 continue
-            if name in self.find_overrides:
-                exe = self.find_overrides[name]
+            if name in self.build.find_overrides:
+                exe = self.build.find_overrides[name]
                 extra_info.append(mlog.blue('(overridden)'))
                 return exe
         return None
@@ -1690,9 +1688,9 @@ class Interpreter(InterpreterBase, HoldableObject):
     def add_find_program_override(self, name: str, exe: Program) -> None:
         if name in self.build.searched_programs:
             raise InterpreterException(f'Tried to override finding of executable "{name}" which has already been found.')
-        if name in self.find_overrides:
+        if name in self.build.find_overrides:
             raise InterpreterException(f'Tried to override executable "{name}" which has already been overridden.')
-        self.find_overrides[name] = exe
+        self.build.find_overrides[name] = exe
         if name == 'pkg-config' and isinstance(exe, ExternalProgram):
             from ..dependencies.pkgconfig import PkgConfigInterface
             PkgConfigInterface.set_program_override(exe, MachineChoice.HOST)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1339,7 +1339,8 @@ class Interpreter(InterpreterBase, HoldableObject):
         if self.cargo is None:
             self.load_root_cargo_lock_file()
 
-        self.build.projects[self.subproject] = build.BuildProject(proj_name, self.project_version)
+        self.build.projects[self.subproject] = build.BuildProject(proj_name, self.project_version,
+                                                                  self.subproject)
         mlog.log('Project name:', mlog.bold(proj_name))
         mlog.log('Project version:', mlog.bold(self.project_version))
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -348,6 +348,11 @@ class Interpreter(InterpreterBase, HoldableObject):
         self.builtin['target_machine'] = \
             OBJ.MachineHolder(self.build.environment.machines[self.build.machine_map.target], self)
 
+    def is_internal_machine(self, for_machine: MachineChoice) -> bool:
+        # Return whether applying the caller's effect to the build and
+        # host machine would duplicate the effect
+        return self.build.machine_map[for_machine] is MachineChoice.BUILD
+
     def apply_machine_map_to_kwargs(self, kwargs: kwtypes.BaseBuildTarget | kwtypes.MachineMapArgs) -> None:
         orig_for_machine: MachineChoice | None = kwargs.get('native', None)
         if orig_for_machine is not None:
@@ -2425,7 +2430,8 @@ class Interpreter(InterpreterBase, HoldableObject):
                               follow_symlinks=kwargs['follow_symlinks'],
                               install_tag=kwargs['install_tag'])
             ret_headers.append(h)
-            self.build.headers.append(h)
+            if not self.is_internal_machine(MachineChoice.HOST):
+                self.build.headers.append(h)
 
         return ret_headers
 
@@ -2454,7 +2460,8 @@ class Interpreter(InterpreterBase, HoldableObject):
 
         m = build.Man(sources, kwargs['install_dir'], install_mode,
                       self.subproject, kwargs['locale'], kwargs['install_tag'])
-        self.build.man.append(m)
+        if not self.is_internal_machine(MachineChoice.HOST):
+            self.build.man.append(m)
 
         return m
 
@@ -2467,8 +2474,8 @@ class Interpreter(InterpreterBase, HoldableObject):
     def func_install_emptydir(self, node: mparser.BaseNode, args: T.Tuple[str],
                               kwargs: kwtypes.FuncInstallEmptyDir) -> build.EmptyDir:
         d = build.EmptyDir(args[0], kwargs['install_mode'], self.subproject, kwargs['install_tag'])
-        self.build.emptydir.append(d)
-
+        if not self.is_internal_machine(MachineChoice.HOST):
+            self.build.emptydir.append(d)
         return d
 
     @FeatureNew('install_symlink', '0.61.0')
@@ -2486,7 +2493,8 @@ class Interpreter(InterpreterBase, HoldableObject):
         target = kwargs['pointing_to']
         l = build.SymlinkData(target, name, kwargs['install_dir'],
                               self.subproject, kwargs['install_tag'])
-        self.build.symlinks.append(l)
+        if not self.is_internal_machine(MachineChoice.HOST):
+            self.build.symlinks.append(l)
         return l
 
     @FeatureNew('structured_sources', '0.62.0')
@@ -2637,7 +2645,8 @@ class Interpreter(InterpreterBase, HoldableObject):
                            follow_symlinks)
             ret_data.append(d)
 
-        self.build.data.extend(ret_data)
+        if not self.is_internal_machine(MachineChoice.HOST):
+            self.build.data.extend(ret_data)
         return ret_data
 
     @typed_pos_args('install_subdir', str)
@@ -2681,7 +2690,8 @@ class Interpreter(InterpreterBase, HoldableObject):
             self.subproject,
             install_tag=kwargs['install_tag'],
             follow_symlinks=kwargs['follow_symlinks'])
-        self.build.install_dirs.append(idir)
+        if not self.is_internal_machine(MachineChoice.HOST):
+            self.build.install_dirs.append(idir)
         return idir
 
     def validate_build_subdir(self, build_subdir: str, target: str) -> None:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -355,8 +355,16 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     def apply_machine_map_to_kwargs(self, kwargs: kwtypes.BaseBuildTarget | kwtypes.MachineMapArgs) -> None:
         orig_for_machine: MachineChoice | None = kwargs.get('native', None)
-        if orig_for_machine is not None:
-            kwargs['native'] = self.build.machine_map[orig_for_machine]
+        if orig_for_machine is None:
+            return
+
+        for_machine = self.build.machine_map[orig_for_machine]
+        if for_machine is orig_for_machine:
+            return
+
+        if 'install' in kwargs and for_machine is MachineChoice.BUILD:
+            kwargs['install'] = False
+        kwargs['native'] = for_machine
 
     def build_func_dict(self) -> None:
         self.funcs.update({'add_global_arguments': self.func_add_global_arguments,
@@ -881,24 +889,33 @@ class Interpreter(InterpreterBase, HoldableObject):
     @typed_kwargs(
         'subproject',
         REQUIRED_KW,
+        NATIVE_KW.evolve(since='1.12.0'),
         DEFAULT_OPTIONS.evolve(since='0.38.0'),
         KwargInfo('version', ContainerTypeInfo(list, str), default=[], listify=True),
     )
     def func_subproject(self, nodes: mparser.BaseNode, args: T.Tuple[SubProject], kwargs: kwtypes.Subproject) -> SubprojectHolder:
+        # note that this does not use @apply_machine_map.  'for_machine'
+        # is only used by _do_subproject_meson to decide between
+        # Build.copy() and Build.copy_for_build_machine(), and copying
+        # a build-only subproject provides the correct result for "native:
+        # false".  This is needed so that it takes two *explicit* levels
+        # of "native: true" for the target_machine to become the build_machine.
         kw: kwtypes.DoSubproject = {
             'required': kwargs['required'],
             'default_options': kwargs['default_options'],
             'version': kwargs['version'],
             'options': None,
             'cmake_options': [],
+            'for_machine': kwargs['native'],
         }
         return self.do_subproject(args[0], kw)
 
     def disabled_subproject(self, subp_name: SubProject, disabled_feature: T.Optional[str] = None,
-                            exception: T.Optional[Exception] = None) -> SubprojectHolder:
+                            exception: T.Optional[Exception] = None,
+                            for_machine: MachineChoice = MachineChoice.HOST) -> SubprojectHolder:
         sub = SubprojectHolder(NullSubprojectInterpreter(), os.path.join(self.subproject_dir, subp_name),
                                disabled_feature=disabled_feature, exception=exception)
-        self.subprojects.host[subp_name] = sub
+        self.subprojects[for_machine][subp_name] = sub
         return sub
 
     def create_build_subdir(self, subdir: str) -> None:
@@ -920,9 +937,12 @@ class Interpreter(InterpreterBase, HoldableObject):
     def do_subproject(self, subp_name: SubProject, kwargs: kwtypes.DoSubproject, force_method: T.Optional[wrap.Method] = None,
                       forced_options: T.Optional[OptionDict] = None) -> SubprojectHolder:
         disabled, required, feature = extract_required_kwarg(kwargs, self.subproject)
+        kwargs.setdefault('for_machine', MachineChoice.HOST)
+        for_machine = self.build.machine_map[kwargs['for_machine']]
+
         if disabled:
             mlog.log('Subproject', mlog.bold(subp_name), ':', 'skipped: feature', mlog.bold(feature), 'disabled')
-            return self.disabled_subproject(subp_name, disabled_feature=feature)
+            return self.disabled_subproject(subp_name, disabled_feature=feature, for_machine=for_machine)
 
         default_options = kwargs['default_options']
 
@@ -947,16 +967,16 @@ class Interpreter(InterpreterBase, HoldableObject):
         if has_path_sep(subp_name):
             mlog.warning('Subproject name has a path separator. This may cause unexpected behaviour.',
                          location=self.current_node)
-        fullstack = self.subproject_stack + [(subp_name, MachineChoice.HOST)]
-        if (subp_name, MachineChoice.HOST) in self.subproject_stack:
+        fullstack = self.subproject_stack + [(subp_name, for_machine)]
+        if (subp_name, for_machine) in self.subproject_stack:
             incpath = self.format_subproject_stack(fullstack)
             raise InvalidCode(f'Recursive include of subprojects: {incpath}.')
-        if subp_name in self.subprojects.host:
-            subproject = self.subprojects.host[subp_name]
+        if subp_name in self.subprojects[for_machine]:
+            subproject = self.subprojects[for_machine][subp_name]
             if required and not subproject.found():
                 raise InterpreterException(f'Subproject "{subproject.subdir}" required but not found.')
             if kwargs['version']:
-                pv = self.build.projects.host[subp_name].version
+                pv = self.build.projects[for_machine][subp_name].version
                 wanted = kwargs['version']
                 if pv == 'undefined' or not mesonlib.version_compare_many(pv, wanted)[0]:
                     raise InterpreterException(f'Subproject {subp_name} version is {pv} but {wanted} required.')
@@ -985,6 +1005,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         m = ['\nExecuting subproject', mlog.bold(stack)]
         if method != 'meson':
             m += ['method', mlog.bold(method)]
+        m.extend(['for machine:', mlog.bold(for_machine.get_lower_case_name())])
         mlog.log(*m, '\n', nested=False)
 
         methods_map: T.Dict[wrap.Method, T.Callable[[SubProject, str, OptionDict, kwtypes.DoSubproject],
@@ -1029,10 +1050,16 @@ class Interpreter(InterpreterBase, HoldableObject):
                              build_def_files: T.Optional[T.List[str]] = None,
                              relaxations: T.Optional[T.Set[InterpreterRuleRelaxation]] = None,
                              cargo: T.Optional[cargo.Interpreter] = None) -> SubprojectHolder:
+        for_machine = kwargs['for_machine']
+        if for_machine is MachineChoice.BUILD:
+            new_build = self.build.copy_for_build_machine()
+        else:
+            new_build = self.build.copy()
+
         with mlog.nested(subp_name):
             if ast:
                 self._save_ast(subdir, ast)
-            new_build = self.build.copy()
+
             subi = Interpreter(new_build, self.backend, subp_name, subdir, self.subproject_dir,
                                default_options, ast=ast, relaxations=relaxations,
                                user_defined_options=self.user_defined_options,
@@ -1046,7 +1073,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             subi.bound_holder_map = self.bound_holder_map
             subi.summary = self.summary
 
-            subi.subproject_stack = self.subproject_stack + [(subp_name, MachineChoice.HOST)]
+            subi.subproject_stack = self.subproject_stack + [(subp_name, for_machine)]
             current_active = self.active_projectname
             with mlog.nested_warnings():
                 subi.run()
@@ -1061,26 +1088,27 @@ class Interpreter(InterpreterBase, HoldableObject):
             if pv == 'undefined' or not mesonlib.version_compare_many(pv, wanted)[0]:
                 raise InterpreterException(f'Subproject {subp_name} version is {pv} but {wanted} required.')
         self.active_projectname = current_active
-        self.subprojects.host.update(subi.subprojects.host)
-        self.subprojects.host[subp_name] = SubprojectHolder(subi, subdir, warnings=subi_warnings,
-                                                            callstack=self.subproject_stack)
+        self.subprojects[for_machine].update(subi.subprojects[for_machine])
+        self.subprojects[for_machine][subp_name] = SubprojectHolder(
+            subi, subdir, warnings=subi_warnings, callstack=self.subproject_stack)
         # Duplicates are possible when subproject uses files from project root
         if build_def_files:
             self.build_def_files.update(build_def_files)
         # We always need the subi.build_def_files, to propagate sub-sub-projects
         self.build_def_files.update(subi.get_build_def_files())
         self.build.merge(subi.build)
-        return self.subprojects.host[subp_name]
+        return self.subprojects[for_machine][subp_name]
 
     def _do_subproject_cmake(self, subp_name: SubProject, subdir: str,
                              default_options: OptionDict,
                              kwargs: kwtypes.DoSubproject) -> SubprojectHolder:
         from ..cmake import CMakeInterpreter
+        for_machine = kwargs['for_machine']
         with mlog.nested(subp_name):
             from ..modules.cmake import CMakeSubprojectOptions
             kw_opts = kwargs.get('options') or CMakeSubprojectOptions()
             cmake_options = kwargs.get('cmake_options', []) + kw_opts.cmake_options
-            cm_int = CMakeInterpreter(Path(subdir), self.build.environment, self.backend)
+            cm_int = CMakeInterpreter(Path(subdir), self.build.environment, self.backend, for_machine)
             cm_int.initialise(cmake_options)
             cm_int.analyse()
 
@@ -1327,7 +1355,9 @@ class Interpreter(InterpreterBase, HoldableObject):
             proj_license_files.append((ifname, i))
         self.build.dep_manifest[proj_name] = build.DepManifest(self.project_version, proj_license,
                                                                proj_license_files, self.subproject)
-        if self.subproject in self.build.projects.host:
+
+        for_machine = self.build.machine_map.host
+        if self.subproject in self.build.projects[for_machine]:
             raise InvalidCode('Second call to project().')
 
         # spdirname is the subproject_dir for this project, relative to self.subdir.
@@ -1359,9 +1389,13 @@ class Interpreter(InterpreterBase, HoldableObject):
         if self.cargo is None:
             self.load_root_cargo_lock_file()
 
-        self.build.projects.host[self.subproject] = build.BuildProject(proj_name, self.project_version,
-                                                                       self.subproject, MachineChoice.HOST)
-        mlog.log('Project name:', mlog.bold(proj_name))
+        build_project = build.BuildProject(proj_name, self.project_version, self.subproject, for_machine)
+        self.build.projects[for_machine][self.subproject] = build_project
+
+        extra_args: T.List[mlog.TV_Loggable] = []
+        if self.is_subproject() and for_machine is MachineChoice.BUILD:
+            extra_args.append('(for build machine)')
+        mlog.log('Project name:', mlog.bold(proj_name), *extra_args)
         mlog.log('Project version:', mlog.bold(self.project_version))
 
         self.add_languages(proj_langs, True, MachineChoice.HOST)
@@ -1451,10 +1485,10 @@ class Interpreter(InterpreterBase, HoldableObject):
         self.summary[self.subproject].add_section(
             section, values, bool_yn, list_sep, self.subproject)
 
-    def _print_summary(self) -> None:
+    def _print_subprojects(self, for_machine: MachineChoice) -> None:
         # Add automatic 'Subprojects' section in main project.
         all_subprojects: dict[str, mlog.TV_Loggable | mlog.TV_LoggableList] = {}
-        for name, subp in sorted(self.subprojects.host.items()):
+        for name, subp in sorted(self.subprojects[for_machine].items()):
             value: mlog.TV_LoggableList = [subp.found()]
             if subp.disabled_feature:
                 value += [f'Feature {subp.disabled_feature!r} disabled']
@@ -1467,7 +1501,13 @@ class Interpreter(InterpreterBase, HoldableObject):
                 value += [f'(from {stack})']
             all_subprojects[name] = value
         if all_subprojects:
-            self.summary_impl('Subprojects', all_subprojects, bool_yn=True, list_sep=' ')
+            self.summary_impl(f'Subprojects (for {for_machine.get_lower_case_name()} machine)', all_subprojects,
+                              bool_yn=True, list_sep=' ')
+
+    def _print_summary(self) -> None:
+        self._print_subprojects(MachineChoice.HOST)
+        if self.environment.is_cross_build():
+            self._print_subprojects(MachineChoice.BUILD)
         # Add automatic section with all user defined options
         if self.user_defined_options:
             values: dict[str, mlog.TV_Loggable | mlog.TV_LoggableList] = {}
@@ -1744,7 +1784,7 @@ class Interpreter(InterpreterBase, HoldableObject):
 
         extra_info: T.List[mlog.TV_Loggable] = []
         progobj = self.program_lookup(args, for_machine, default_options, required, search_dirs, wanted, version_arg, version_func, extra_info)
-        if progobj is None or not self.check_program_version(progobj, wanted, version_func, extra_info):
+        if progobj is None or not self.check_program_version(progobj, wanted, version_func, for_machine, extra_info):
             progobj = self.notfound_program(args)
 
         if isinstance(progobj, ExternalProgram) and not progobj.found():
@@ -1796,7 +1836,7 @@ class Interpreter(InterpreterBase, HoldableObject):
 
         if isinstance(progobj, ExternalProgram) and version_arg:
             progobj.version_arg = version_arg
-        if progobj and not self.check_program_version(progobj, wanted, version_func, extra_info):
+        if progobj and not self.check_program_version(progobj, wanted, version_func, for_machine, extra_info):
             progobj = None
 
         if progobj is None and fallback and required:
@@ -1810,13 +1850,14 @@ class Interpreter(InterpreterBase, HoldableObject):
     def check_program_version(self, progobj: Program,
                               wanted: T.Union[str, T.List[str]],
                               version_func: T.Optional[ProgramVersionFunc],
+                              for_machine: MachineChoice,
                               extra_info: T.List[mlog.TV_Loggable]) -> bool:
         if wanted:
             if version_func:
                 version = version_func(progobj)
             elif isinstance(progobj, build.Executable):
                 if progobj.subproject:
-                    interp = self.subprojects.host[progobj.subproject].held_object
+                    interp = self.subprojects[for_machine][progobj.subproject].held_object
                 else:
                     interp = self
                 assert isinstance(interp, Interpreter), 'for mypy'
@@ -1834,7 +1875,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     def find_program_fallback(self, fallback: SubProject, args: T.List[mesonlib.FileOrString],
                               for_machine: MachineChoice,
                               default_options: OptionDict,
-                              required: bool, extra_info: T.List[mlog.TV_Loggable]
+                              required: bool, extra_info: T.List[mlog.TV_Loggable],
                               ) -> T.Optional[Program]:
         mlog.log('Fallback to subproject', mlog.bold(fallback), 'which provides program',
                  mlog.bold(' '.join(str(a) for a in args)))
@@ -1844,6 +1885,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             'version': [],
             'cmake_options': [],
             'options': None,
+            'for_machine': for_machine,
         }
         self.do_subproject(fallback, sp_kwargs)
         return self.program_from_overrides(args, for_machine, extra_info)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2058,11 +2058,11 @@ class Interpreter(InterpreterBase, HoldableObject):
         tg = build.CustomTarget(
             kwargs['output'][0],
             self.subdir,
-            self.subproject,
             self.environment,
             cmd,
             self.source_strings_to_files(kwargs['input']),
             kwargs['output'],
+            self.current_build_project(),
             build_by_default=True,
             build_always_stale=True,
             install=install,
@@ -2189,11 +2189,11 @@ class Interpreter(InterpreterBase, HoldableObject):
         tg = build.CustomTarget(
             name,
             self.subdir,
-            self.subproject,
             self.environment,
             command,
             inputs,
             kwargs['output'],
+            self.current_build_project(),
             build_always_stale=build_always_stale,
             build_by_default=build_by_default,
             capture=kwargs['capture'],
@@ -2237,8 +2237,8 @@ class Interpreter(InterpreterBase, HoldableObject):
             raise InterpreterException('run_target does not have support for @DEPFILE@')
 
         name = args[0]
-        tg = build.RunTarget(name, all_args, kwargs['depends'], self.subdir, self.subproject, self.environment,
-                             kwargs['env'])
+        tg = build.RunTarget(name, all_args, kwargs['depends'], self.subdir, self.environment,
+                             self.current_build_project(), kwargs['env'])
         self.add_target(name, tg)
         return tg
 
@@ -2257,7 +2257,8 @@ class Interpreter(InterpreterBase, HoldableObject):
                 real_deps.append(d.static)
             else:
                 real_deps.append(d)
-        tg = build.AliasTarget(name, real_deps, self.subdir, self.subproject, self.environment)
+        tg = build.AliasTarget(name, real_deps, self.subdir, self.environment,
+                               self.current_build_project())
         self.add_target(name, tg)
         return tg
 
@@ -3927,30 +3928,30 @@ class Interpreter(InterpreterBase, HoldableObject):
         if targetclass is build.Executable:
             nkwargs = self.__convert_executable_kwargs(
                 node, T.cast('kwtypes.Executable', kwargs))
-            target = build.Executable(name, self.subdir, self.subproject, for_machine, srcs, struct, objs,
-                                      self.environment, self.compilers[for_machine], nkwargs)
+            target = build.Executable(name, self.subdir, for_machine, srcs, struct, objs,
+                                      self.environment, self.compilers[for_machine], self.current_build_project(), nkwargs)
         elif targetclass is build.StaticLibrary:
             nkwargs = self.__convert_static_library_kwargs(
                 node, T.cast('kwtypes.StaticLibrary', kwargs))
-            target = build.StaticLibrary(name, self.subdir, self.subproject, for_machine, srcs, struct, objs,
-                                         self.environment, self.compilers[for_machine], nkwargs)
+            target = build.StaticLibrary(name, self.subdir, for_machine, srcs, struct, objs,
+                                         self.environment, self.compilers[for_machine], self.current_build_project(), nkwargs)
         elif targetclass is build.SharedLibrary:
             nkwargs = self.__convert_shared_library_kwargs(
                 node, T.cast('kwtypes.SharedLibrary', kwargs))
-            target = build.SharedLibrary(name, self.subdir, self.subproject, for_machine, srcs, struct, objs,
-                                         self.environment, self.compilers[for_machine], nkwargs)
+            target = build.SharedLibrary(name, self.subdir, for_machine, srcs, struct, objs,
+                                         self.environment, self.compilers[for_machine], self.current_build_project(), nkwargs)
             target.shared_library_only = shared_library_only
         elif targetclass is build.SharedModule:
             nkwargs = self.__convert_shared_module_kwargs(
                 node, T.cast('kwtypes.SharedModule', kwargs))
-            target = build.SharedModule(name, self.subdir, self.subproject, for_machine, srcs, struct, objs,
-                                        self.environment, self.compilers[for_machine], nkwargs)
+            target = build.SharedModule(name, self.subdir, for_machine, srcs, struct, objs,
+                                        self.environment, self.compilers[for_machine], self.current_build_project(), nkwargs)
             target.shared_library_only = shared_library_only
         else:
             nkwargs = self.__convert_jar_kwargs(
                 node, T.cast('kwtypes.Jar', kwargs))
-            target = build.Jar(name, self.subdir, self.subproject, for_machine, srcs, struct, objs,
-                               self.environment, self.compilers[for_machine], nkwargs)
+            target = build.Jar(name, self.subdir, for_machine, srcs, struct, objs,
+                               self.environment, self.compilers[for_machine], self.current_build_project(), nkwargs)
 
         if objs and target.uses_rust():
             FeatureNew.single_use('objects in Rust targets', '1.8.0', self.subproject)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -340,11 +340,11 @@ class Interpreter(InterpreterBase, HoldableObject):
         self.build.environment.update_build_machine()
 
         self.builtin['build_machine'] = \
-            OBJ.MachineHolder(self.build.environment.machines.build, self)
+            OBJ.MachineHolder(self.build.environment.machines[self.build.machine_map.build], self)
         self.builtin['host_machine'] = \
-            OBJ.MachineHolder(self.build.environment.machines.host, self)
+            OBJ.MachineHolder(self.build.environment.machines[self.build.machine_map.host], self)
         self.builtin['target_machine'] = \
-            OBJ.MachineHolder(self.build.environment.machines.target, self)
+            OBJ.MachineHolder(self.build.environment.machines[self.build.machine_map.target], self)
 
     def build_func_dict(self) -> None:
         self.funcs.update({'add_global_arguments': self.func_add_global_arguments,

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -347,7 +347,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         self.builtin['target_machine'] = \
             OBJ.MachineHolder(self.build.environment.machines[self.build.machine_map.target], self)
 
-    def apply_machine_map_to_kwargs(self, kwargs: kwtypes.MachineMapArgs) -> None:
+    def apply_machine_map_to_kwargs(self, kwargs: kwtypes.BaseBuildTarget | kwtypes.MachineMapArgs) -> None:
         orig_for_machine: MachineChoice | None = kwargs.get('native', None)
         if orig_for_machine is not None:
             kwargs['native'] = self.build.machine_map[orig_for_machine]
@@ -1362,7 +1362,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     @typed_pos_args('add_languages', varargs=str)
     def func_add_languages(self, node: mparser.FunctionNode, args: T.Tuple[T.List[str]], kwargs: 'kwtypes.FuncAddLanguages') -> bool:
         disabled, required, feature = extract_required_kwarg(kwargs, self.subproject)
-        native = kwargs['native']
+        for_machine = kwargs['native']
 
         langs = self._validate_languages(args[0], required, node)
 
@@ -1370,8 +1370,9 @@ class Interpreter(InterpreterBase, HoldableObject):
             for lang in sorted(langs, key=compilers.sort_clink):
                 mlog.log('Compiler for language', mlog.bold(lang), 'skipped: feature', mlog.bold(feature), 'disabled')
             return False
-        if native is not None:
-            return self.add_languages(langs, required, native)
+        if for_machine is not None:
+            for_machine = self.build.machine_map[for_machine]
+            return self.add_languages(langs, required, for_machine)
         else:
             # absent 'native' means 'both' for backwards compatibility
             tv = FeatureNew.get_target_version(self.subproject)
@@ -3103,8 +3104,18 @@ class Interpreter(InterpreterBase, HoldableObject):
                                args: T.List[str], kwargs: 'kwtypes.FuncAddProjectArgs') -> None:
         self._add_arguments(node, argsdict, self.project_args_frozen, args, kwargs)
 
+    def is_dup_machine(self, for_machine: MachineChoice) -> bool:
+        # Return whether applying the caller's effect to the build and
+        # host machine would duplicate the effect
+        return \
+            for_machine is not MachineChoice.HOST and \
+            self.build.machine_map[for_machine] is self.build.machine_map.host
+
     def _add_arguments(self, node: mparser.FunctionNode, argsdict: T.Dict[Language, T.List[str]],
                        args_frozen: bool, args: T.List[str], kwargs: 'kwtypes.FuncAddProjectArgs') -> None:
+        if self.is_dup_machine(kwargs['native']):
+            return
+
         if args_frozen:
             msg = f'Tried to use \'{node.func_name.value}\' after a build target has been declared.\n' \
                   'This is not permitted. Please declare all arguments before your targets.'
@@ -3842,7 +3853,9 @@ class Interpreter(InterpreterBase, HoldableObject):
             mlog.debug('Unknown target type:', str(targetclass))
             raise RuntimeError('Unreachable code')
 
+        self.apply_machine_map_to_kwargs(kwargs)
         for_machine = kwargs['native']
+
         if kwargs.get('rust_crate_type') == 'proc-macro':
             # Silently force to native because that's the only sensible value
             # and rust_crate_type is deprecated any way.

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -797,9 +797,10 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     def _compiled_exe_error(self, cmd: T.Union[Program, build.Executable]) -> T.NoReturn:
         descr = cmd.name if isinstance(cmd, build.Executable) else cmd.description()
-        for name, exe in self.build.find_overrides.items():
-            if cmd == exe:
-                raise InterpreterException(f'Program {name!r} was overridden with the compiled executable {descr!r} and therefore cannot be used during configuration')
+        for for_machine in MachineChoice:
+            for name, exe in self.build.find_overrides[for_machine].items():
+                if cmd == exe:
+                    raise InterpreterException(f'Program {name!r} was overridden with the compiled executable {descr!r} and therefore cannot be used during configuration')
         raise InterpreterException(f'Program {descr!r} is a compiled executable and therefore cannot be used during configuration')
 
     def run_command_impl(self,
@@ -1696,31 +1697,32 @@ class Interpreter(InterpreterBase, HoldableObject):
         return None
 
     def program_from_overrides(self, command_names: T.List[mesonlib.FileOrString],
+                               for_machine: MachineChoice,
                                extra_info: T.List['mlog.TV_Loggable']
                                ) -> T.Optional[Program]:
         for name in command_names:
             if not isinstance(name, str):
                 continue
-            if name in self.build.find_overrides:
-                exe = self.build.find_overrides[name]
+            if name in self.build.find_overrides[for_machine]:
+                exe = self.build.find_overrides[for_machine][name]
                 extra_info.append(mlog.blue('(overridden)'))
                 return exe
         return None
 
-    def store_name_lookups(self, command_names: T.List[mesonlib.FileOrString]) -> None:
+    def store_name_lookups(self, command_names: T.List[mesonlib.FileOrString], for_machine: MachineChoice) -> None:
         for name in command_names:
             if isinstance(name, str):
-                self.build.searched_programs.add(name)
+                self.build.searched_programs[for_machine].add(name)
 
-    def add_find_program_override(self, name: str, exe: Program) -> None:
-        if name in self.build.searched_programs:
+    def add_find_program_override(self, name: str, exe: Program, for_machine: MachineChoice) -> None:
+        if name in self.build.searched_programs[for_machine]:
             raise InterpreterException(f'Tried to override finding of executable "{name}" which has already been found.')
-        if name in self.build.find_overrides:
+        if name in self.build.find_overrides[for_machine]:
             raise InterpreterException(f'Tried to override executable "{name}" which has already been overridden.')
-        self.build.find_overrides[name] = exe
+        self.build.find_overrides[for_machine][name] = exe
         if name == 'pkg-config' and isinstance(exe, ExternalProgram):
             from ..dependencies.pkgconfig import PkgConfigInterface
-            PkgConfigInterface.set_program_override(exe, MachineChoice.HOST)
+            PkgConfigInterface.set_program_override(exe, for_machine)
 
     def notfound_program(self, args: T.List[mesonlib.FileOrString]) -> ExternalProgram:
         return NonExistingExternalProgram(' '.join(
@@ -1754,7 +1756,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             return progobj
 
         # Only store successful lookups
-        self.store_name_lookups(args)
+        self.store_name_lookups(args, for_machine)
         if not silent:
             mlog.log('Program', mlog.bold(progobj.name), 'found:', mlog.green('YES'), *extra_info)
         return progobj
@@ -1768,7 +1770,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                        version_func: T.Optional[ProgramVersionFunc],
                        extra_info: T.List[mlog.TV_Loggable]
                        ) -> T.Optional[Program]:
-        progobj = self.program_from_overrides(args, extra_info)
+        progobj = self.program_from_overrides(args, for_machine, extra_info)
         if progobj:
             return progobj
 
@@ -1783,7 +1785,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         if wrap_mode != WrapMode.nofallback and self.environment.wrap_resolver:
             fallback = self.environment.wrap_resolver.find_program_provider(args)
         if fallback and wrap_mode == WrapMode.forcefallback:
-            return self.find_program_fallback(fallback, args, default_options, required, extra_info)
+            return self.find_program_fallback(fallback, args, for_machine, default_options, required, extra_info)
 
         progobj = self.program_from_file_for(for_machine, args)
         if progobj is None:
@@ -1801,7 +1803,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             progobj = self.notfound_program(args)
             mlog.log('Program', mlog.bold(progobj.get_name()), 'found:', mlog.red('NO'), *extra_info)
             extra_info.clear()
-            progobj = self.find_program_fallback(fallback, args, default_options, required, extra_info)
+            progobj = self.find_program_fallback(fallback, args, for_machine, default_options, required, extra_info)
 
         return progobj
 
@@ -1830,6 +1832,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         return True
 
     def find_program_fallback(self, fallback: SubProject, args: T.List[mesonlib.FileOrString],
+                              for_machine: MachineChoice,
                               default_options: OptionDict,
                               required: bool, extra_info: T.List[mlog.TV_Loggable]
                               ) -> T.Optional[Program]:
@@ -1843,7 +1846,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             'options': None,
         }
         self.do_subproject(fallback, sp_kwargs)
-        return self.program_from_overrides(args, extra_info)
+        return self.program_from_overrides(args, for_machine, extra_info)
 
     @typed_pos_args('find_program', varargs=(str, mesonlib.File), min_varargs=1)
     @typed_kwargs(

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -27,6 +27,7 @@ from ..dependencies import Dependency
 from ..depfile import DepFile
 from ..interpreterbase import ContainerTypeInfo, InterpreterBase, KwargInfo, typed_kwargs, typed_pos_args
 from ..interpreterbase import noPosargs, noKwargs, noArgsFlattening, noSecondLevelHolderResolving, unholder_return
+from .decorators import apply_machine_map
 from ..interpreterbase import InterpreterException, InvalidArguments, InvalidCode, SubdirDoneRequest
 from ..interpreterbase import Disabler, disablerIfNotFound
 from ..interpreterbase import FeatureNew, FeatureDeprecated, FeatureBroken, FeatureNewKwargs
@@ -345,6 +346,11 @@ class Interpreter(InterpreterBase, HoldableObject):
             OBJ.MachineHolder(self.build.environment.machines[self.build.machine_map.host], self)
         self.builtin['target_machine'] = \
             OBJ.MachineHolder(self.build.environment.machines[self.build.machine_map.target], self)
+
+    def apply_machine_map_to_kwargs(self, kwargs: kwtypes.MachineMapArgs) -> None:
+        orig_for_machine: MachineChoice | None = kwargs.get('native', None)
+        if orig_for_machine is not None:
+            kwargs['native'] = self.build.machine_map[orig_for_machine]
 
     def build_func_dict(self) -> None:
         self.funcs.update({'add_global_arguments': self.func_add_global_arguments,
@@ -1830,6 +1836,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         DEFAULT_OPTIONS.evolve(since='1.3.0')
     )
     @disablerIfNotFound
+    @apply_machine_map
     def func_find_program(self, node: mparser.BaseNode, args: T.Tuple[T.List[mesonlib.FileOrString]],
                           kwargs: 'kwtypes.FindProgram',
                           ) -> Program:
@@ -1848,6 +1855,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     @typed_pos_args('dependency', varargs=str, min_varargs=1)
     @typed_kwargs('dependency', *DEPENDENCY_KWS)
     @disablerIfNotFound
+    @apply_machine_map
     def func_dependency(self, node: mparser.BaseNode, args: T.Tuple[T.List[str]], kwargs: kwtypes.FuncDependency) -> Dependency:
         # Replace '' by empty list of names
         names = [n for n in args[0] if n]
@@ -1998,6 +2006,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         INSTALL_TAG_KW.evolve(since='1.7.0'),
         INSTALL_MODE_KW.evolve(since='1.7.0'),
     )
+    @apply_machine_map
     def func_vcs_tag(self, node: mparser.BaseNode, args: T.List['TYPE_var'], kwargs: 'kwtypes.VcsTag') -> build.CustomTarget:
         if kwargs['fallback'] is None:
             FeatureNew.single_use('Optional fallback in vcs_tag', '0.41.0', self.subproject, location=node)
@@ -2108,6 +2117,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         KwargInfo('console', bool, default=False, since='0.48.0'),
         KwargInfo('build_subdir', str, default='', since='1.10.0'),
     )
+    @apply_machine_map
     def func_custom_target(self, node: mparser.FunctionNode, args: T.Tuple[str],
                            kwargs: 'kwtypes.CustomTarget') -> build.CustomTarget:
         if kwargs['depfile'] and ('@BASENAME@' in kwargs['depfile'] or '@PLAINNAME@' in kwargs['depfile']):
@@ -2703,6 +2713,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         KwargInfo('macro_name', (str, NoneType), default=None, since='1.3.0'),
         KwargInfo('build_subdir', str, default='', since='1.10.0'),
     )
+    @apply_machine_map
     def func_configure_file(self, node: mparser.BaseNode, args: T.List[TYPE_var],
                             kwargs: kwtypes.ConfigureFile) -> mesonlib.File:
         actions = sorted(x for x in ('configuration', 'command', 'copy')
@@ -2996,22 +3007,26 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     @typed_pos_args('add_global_arguments', varargs=str)
     @typed_kwargs('add_global_arguments', NATIVE_KW, LANGUAGE_KW)
+    @apply_machine_map
     def func_add_global_arguments(self, node: mparser.FunctionNode, args: T.Tuple[T.List[str]], kwargs: 'kwtypes.FuncAddProjectArgs') -> None:
         self._add_global_arguments(node, self.build.global_args[kwargs['native']], args[0], kwargs)
 
     @typed_pos_args('add_global_link_arguments', varargs=str)
     @typed_kwargs('add_global_link_arguments', NATIVE_KW, LANGUAGE_KW)
+    @apply_machine_map
     def func_add_global_link_arguments(self, node: mparser.FunctionNode, args: T.Tuple[T.List[str]], kwargs: 'kwtypes.FuncAddProjectArgs') -> None:
         self._add_global_arguments(node, self.build.global_link_args[kwargs['native']], args[0], kwargs)
 
     @typed_pos_args('add_project_arguments', varargs=str)
     @typed_kwargs('add_project_arguments', NATIVE_KW, LANGUAGE_KW)
+    @apply_machine_map
     def func_add_project_arguments(self, node: mparser.FunctionNode, args: T.Tuple[T.List[str]], kwargs: 'kwtypes.FuncAddProjectArgs') -> None:
         self._add_project_arguments(node, self.current_build_project().project_args[kwargs['native']],
                                     args[0], kwargs)
 
     @typed_pos_args('add_project_link_arguments', varargs=str)
     @typed_kwargs('add_project_link_arguments', NATIVE_KW, LANGUAGE_KW)
+    @apply_machine_map
     def func_add_project_link_arguments(self, node: mparser.FunctionNode, args: T.Tuple[T.List[str]], kwargs: 'kwtypes.FuncAddProjectArgs') -> None:
         self._add_project_arguments(node, self.current_build_project().project_link_args[kwargs['native']],
                                     args[0], kwargs)
@@ -3022,6 +3037,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     @FeatureNew('add_project_dependencies', '0.63.0')
     @typed_pos_args('add_project_dependencies', varargs=dependencies.Dependency)
     @typed_kwargs('add_project_dependencies', NATIVE_KW, LANGUAGE_KW)
+    @apply_machine_map
     def func_add_project_dependencies(self, node: mparser.FunctionNode, args: T.Tuple[T.List[dependencies.Dependency]], kwargs: 'kwtypes.FuncAddProjectArgs') -> None:
         for_machine = kwargs['native']
         for lang in kwargs['language']:

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -1013,7 +1013,8 @@ class BuildTargetHolder(ObjectHolder[_BuildTarget]):
     @noKwargs
     @InterpreterObject.method('private_dir_include')
     def private_dir_include_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> build.IncludeDirs:
-        return build.IncludeDirs('', [], False, [self.interpreter.backend.get_target_private_dir(self._target_object)])
+        return build.IncludeDirs('', [], False, self.interpreter.current_build_project(),
+                                 [self.interpreter.backend.get_target_private_dir(self._target_object)])
 
     @noPosargs
     @noKwargs

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -26,7 +26,7 @@ from ..interpreterbase import (
 from ..interpreter.type_checking import NoneType, ENV_KW, ENV_SEPARATOR_KW, PKGCONFIG_DEFINE_KW
 from ..dependencies import Dependency, ExternalLibrary, InternalDependency
 from ..programs import Program
-from ..mesonlib import File, HoldableObject, listify, MesonException
+from ..mesonlib import File, HoldableObject, listify, MachineChoice, MesonException
 
 import typing as T
 
@@ -898,7 +898,7 @@ class SubprojectHolder(MesonInterpreterObject):
                  warnings: int = 0,
                  disabled_feature: T.Optional[str] = None,
                  exception: T.Optional[Exception] = None,
-                 callstack: T.Optional[T.List[str]] = None) -> None:
+                 callstack: T.Optional[T.List[T.Tuple[str, MachineChoice]]] = None) -> None:
         super().__init__()
         self.held_object = subinterpreter
         self.warnings = warnings

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -347,6 +347,7 @@ class Subproject(ExtractRequired):
 
     default_options: T.Dict[OptionKey, options.ElementaryOptionValues]
     version: T.List[str]
+    native: MachineChoice
 
 
 class DoSubproject(ExtractRequired):
@@ -355,6 +356,7 @@ class DoSubproject(ExtractRequired):
     version: T.List[str]
     cmake_options: T.List[str]
     options: T.Optional[CMakeSubprojectOptions]
+    for_machine: MachineChoice
 
 
 class BaseBuildTarget(TypedDict):

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -580,3 +580,9 @@ class FuncEnvironment(TypedDict):
 
     method: Literal['set', 'prepend', 'append']
     separator: str
+
+
+class MachineMapArgs(TypedDict):
+
+    native: NotRequired[MachineChoice]
+    install: NotRequired[bool]

--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -128,6 +128,8 @@ class MesonMain(MesonInterpreterObject):
             self,
             args: T.Tuple[T.Union[str, mesonlib.File, build.Executable, Program], T.List[build.CommandTypes]],
             kwargs: 'AddInstallScriptKW') -> None:
+        if self.interpreter.current_build_project().for_machine is MachineChoice.BUILD:
+            return
         script_args = self._process_script_args('add_install_script', args[1])
         script = self._find_source_script('add_install_script', args[0], script_args, allow_built_program=True)
         script.skip_if_destdir = kwargs['skip_if_destdir']
@@ -147,6 +149,8 @@ class MesonMain(MesonInterpreterObject):
             args: T.Tuple[T.Union[str, mesonlib.File, Program],
                           T.List[T.Union[str, mesonlib.File, Program]]],
             kwargs: 'TYPE_kwargs') -> None:
+        if self.interpreter.current_build_project().for_machine is MachineChoice.BUILD:
+            return
         script_args = self._process_script_args('add_postconf_script', args[1])
         script = self._find_source_script('add_postconf_script', args[0], script_args)
         self.build.postconf_scripts.append(script)

--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -265,7 +265,7 @@ class MesonMain(MesonInterpreterObject):
 
     def _can_run_host_binaries_impl(self) -> bool:
         return not (
-            self.build.environment.is_cross_build() and
+            self.build.machine_map.host is not self.build.machine_map.build and
             self.build.environment.need_exe_wrapper() and
             self.build.environment.exe_wrapper is None
         )
@@ -274,7 +274,7 @@ class MesonMain(MesonInterpreterObject):
     @noKwargs
     @InterpreterObject.method('is_cross_build')
     def is_cross_build_method(self, args: T.List['TYPE_var'], kwargs: 'TYPE_kwargs') -> bool:
-        return self.build.environment.is_cross_build()
+        return self.build.machine_map.host is not self.build.machine_map.build
 
     @typed_pos_args('meson.get_compiler', str)
     @typed_kwargs('meson.get_compiler', NATIVE_KW)

--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -326,9 +326,11 @@ class MesonMain(MesonInterpreterObject):
 
     @FeatureNew('meson.override_find_program', '0.46.0')
     @typed_pos_args('meson.override_find_program', str, (mesonlib.File, Program, build.Executable))
-    @noKwargs
+    @typed_kwargs('meson.override_find_program', NATIVE_KW.evolve(since='1.12.0'))
     @InterpreterObject.method('override_find_program')
-    def override_find_program_method(self, args: T.Tuple[str, T.Union[mesonlib.File, Program, build.Executable]], kwargs: 'TYPE_kwargs') -> None:
+    @apply_machine_map
+    def override_find_program_method(self, args: T.Tuple[str, T.Union[mesonlib.File, Program, build.Executable]],
+                                     kwargs: NativeKW) -> None:
         name, exe = args
         if isinstance(exe, mesonlib.File):
             abspath = exe.absolute_path(self.interpreter.environment.source_dir,
@@ -339,7 +341,7 @@ class MesonMain(MesonInterpreterObject):
             exe = build.LocalProgram(prog, self.interpreter.project_version, file=exe)
         elif isinstance(exe, build.Executable):
             exe = build.LocalProgram(exe, self.interpreter.project_version)
-        self.interpreter.add_find_program_override(name, exe)
+        self.interpreter.add_find_program_override(name, exe, kwargs['native'])
 
     @typed_kwargs(
         'meson.override_dependency',

--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -19,6 +19,7 @@ from ..interpreter.type_checking import ENV_KW, ENV_METHOD_KW, ENV_SEPARATOR_KW,
 from ..interpreterbase import (MesonInterpreterObject, FeatureNew, FeatureDeprecated, FeatureBroken,
                                typed_pos_args,  noArgsFlattening, noPosargs, noKwargs,
                                typed_kwargs, KwargInfo, InterpreterException, InterpreterObject)
+from .decorators import apply_machine_map
 from .primitives import MesonVersionString
 from .type_checking import NATIVE_KW, NoneType
 
@@ -279,6 +280,7 @@ class MesonMain(MesonInterpreterObject):
     @typed_pos_args('meson.get_compiler', str)
     @typed_kwargs('meson.get_compiler', NATIVE_KW)
     @InterpreterObject.method('get_compiler')
+    @apply_machine_map
     def get_compiler_method(self, args: T.Tuple[str], kwargs: 'NativeKW') -> 'Compiler':
         from ..compilers.compilers import all_languages
         lang = args[0]
@@ -343,6 +345,7 @@ class MesonMain(MesonInterpreterObject):
     @typed_pos_args('meson.override_dependency', str, dependencies.Dependency)
     @FeatureNew('meson.override_dependency', '0.54.0')
     @InterpreterObject.method('override_dependency')
+    @apply_machine_map
     def override_dependency_method(self, args: T.Tuple[str, dependencies.Dependency], kwargs: 'FuncOverrideDependency') -> None:
         name, dep = args
         if not name:
@@ -458,6 +461,7 @@ class MesonMain(MesonInterpreterObject):
     @typed_pos_args('meson.get_external_property', str, optargs=[object])
     @typed_kwargs('meson.get_external_property', NATIVE_KW)
     @InterpreterObject.method('get_external_property')
+    @apply_machine_map
     def get_external_property_method(self, args: T.Tuple[str, T.Optional[object]], kwargs: 'NativeKW') -> object:
         propname, fallback = args
         return self.__get_external_property_impl(propname, fallback, kwargs['native'])
@@ -466,6 +470,7 @@ class MesonMain(MesonInterpreterObject):
     @typed_pos_args('meson.has_external_property', str)
     @typed_kwargs('meson.has_external_property', NATIVE_KW)
     @InterpreterObject.method('has_external_property')
+    @apply_machine_map
     def has_external_property_method(self, args: T.Tuple[str], kwargs: 'NativeKW') -> bool:
         prop_name = args[0]
         return prop_name in self.interpreter.environment.properties[kwargs['native']]

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import abc
 import argparse
+import itertools
 import os
 import sys
 import shlex
@@ -394,7 +395,7 @@ def run(options: argparse.Namespace) -> int:
     extra_meson_args = []
     if options.include_subprojects:
         subproject_dir = os.path.join(src_root, b.subproject_dir)
-        for sub in b.projects:
+        for sub in set(itertools.chain(b.projects.host, b.projects.build)):
             if sub:
                 directory = wrap.get_directory(subproject_dir, sub)
                 subprojects[sub] = os.path.join(b.subproject_dir, directory)

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -12,6 +12,7 @@ project files and don't need this info."""
 
 from contextlib import redirect_stdout
 import dataclasses
+import itertools
 import json
 import os
 from pathlib import Path, PurePath
@@ -416,9 +417,12 @@ def list_projinfo(coredata: cdata.CoreData, builddata: build.Build, backend: bac
         'subproject_dir': builddata.subproject_dir,
     }
     subprojects = []
-    for k, build_proj in builddata.projects.items():
-        if not k:
+    seen = set([''])
+    for k, build_proj in itertools.chain(builddata.projects.host.items(),
+                                         builddata.projects.build.items()):
+        if k in seen:
             continue
+        seen.add(k)
         c: T.Dict[str, str] = {
             'name': k,
             'version': build_proj.version,

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -92,7 +92,7 @@ class ModuleState:
     def find_tool(self, name: str, depname: str, varname: str, required: bool = True,
                   wanted: T.Optional[str] = None, native: bool = True) -> Program:
         # Look in overrides in case it's built as subproject
-        progobj = self._interpreter.program_from_overrides([name], [])
+        progobj = self._interpreter.program_from_overrides([name], MachineChoice.HOST, [])
         if progobj is not None:
             return progobj
 

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -59,6 +59,7 @@ class ModuleState:
         self.project_args = interpreter.current_build_project().project_args.host
         self.current_node = interpreter.current_node
         self.machine_map = interpreter.build.machine_map
+        self.current_build_project = interpreter.current_build_project()
 
     def get_include_args(self, include_dirs: T.Iterable[T.Union[str, build.IncludeDirs]], implicit: bool = False, prefix: str = '-I') -> T.List[str]:
         srcdir = self.environment.get_source_dir()

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -58,6 +58,7 @@ class ModuleState:
         self.global_args = interpreter.build.global_args.host
         self.project_args = interpreter.current_build_project().project_args.host
         self.current_node = interpreter.current_node
+        self.machine_map = interpreter.build.machine_map
 
     def get_include_args(self, include_dirs: T.Iterable[T.Union[str, build.IncludeDirs]], implicit: bool = False, prefix: str = '-I') -> T.List[str]:
         srcdir = self.environment.get_source_dir()

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -92,7 +92,8 @@ class ModuleState:
     def find_tool(self, name: str, depname: str, varname: str, required: bool = True,
                   wanted: T.Optional[str] = None, native: bool = True) -> Program:
         # Look in overrides in case it's built as subproject
-        progobj = self._interpreter.program_from_overrides([name], MachineChoice.HOST, [])
+        for_machine = MachineChoice.BUILD if native else MachineChoice.HOST
+        progobj = self._interpreter.program_from_overrides([name], for_machine, [])
         if progobj is not None:
             return progobj
 

--- a/mesonbuild/modules/_qt.py
+++ b/mesonbuild/modules/_qt.py
@@ -456,11 +456,11 @@ class QtBaseModule(ExtensionModule):
             res_target = build.CustomTarget(
                 name,
                 state.subdir,
-                state.subproject,
                 state.environment,
                 cmd,
                 sources,
                 [f'{name}.cpp'],
+                state.current_build_project,
                 depend_files=qrc_deps,
                 depfile=f'{name}.d',
                 description='Compiling Qt resources {}',
@@ -475,11 +475,11 @@ class QtBaseModule(ExtensionModule):
                 res_target = build.CustomTarget(
                     name,
                     state.subdir,
-                    state.subproject,
                     state.environment,
                     cmd,
                     [rcc_file],
                     [f'{name}.cpp'],
+                    state.current_build_project,
                     depend_files=qrc_deps,
                     depfile=f'{name}.d',
                     description='Compiling Qt resources {}',
@@ -753,11 +753,11 @@ class QtBaseModule(ExtensionModule):
             lrelease_target = build.CustomTarget(
                 f'qt{self.qt_version}-compile-{ts}',
                 outdir,
-                state.subproject,
                 state.environment,
                 cmd,
                 [ts_file],
                 ['@BASENAME@.qm'],
+                state.current_build_project,
                 install=kwargs['install'],
                 install_dir=[kwargs['install_dir']],
                 install_tag=['i18n'],
@@ -893,11 +893,11 @@ class QtBaseModule(ExtensionModule):
         return build.CustomTarget(
             f'moc_collect_json_{target_name}',
             state.subdir,
-            state.subproject,
             state.environment,
             cmd,
             moc_json,
             [f'{target_name}_json_collect.json'],
+            state.current_build_project,
             description=f'Collecting json type information for {target_name}',
         )
 
@@ -942,12 +942,12 @@ class QtBaseModule(ExtensionModule):
         cacheloader_target = build.CustomTarget(
             f'cacheloader_{target_name}',
             state.subdir,
-            state.subproject,
             state.environment,
             cmd,
             [kwargs['qml_qrc']],
             #output name format matters here
             [f'{target_name}_qmlcache_loader.cpp'],
+            state.current_build_project,
             description=f'Qml cache loader for {target_name}',
         )
         output.append(cacheloader_target)
@@ -999,11 +999,11 @@ class QtBaseModule(ExtensionModule):
         return build.CustomTarget(
             f'typeregistrar_{target_name}',
             state.subdir,
-            state.subproject,
             state.environment,
             cmd,
             inputs,
             outputs,
+            state.current_build_project,
             install=kwargs['install'],
             install_dir=install_dir,
             install_tag=install_tag,

--- a/mesonbuild/modules/_qt.py
+++ b/mesonbuild/modules/_qt.py
@@ -14,7 +14,7 @@ from . import ModuleReturnValue, ExtensionModule
 from .. import build
 from .. import mlog
 from ..dependencies import DependencyMethods, find_external_dependency, Dependency, ExternalLibrary, InternalDependency
-from ..mesonlib import MachineChoice, MesonException, File, FileMode, version_compare, Popen_safe
+from ..mesonlib import MesonException, File, FileMode, version_compare, Popen_safe
 from ..interpreter import extract_required_kwarg
 from ..interpreter.type_checking import DEPENDENCY_METHOD_KW, INSTALL_DIR_KW, INSTALL_KW, REQUIRED_KW, NoneType
 from ..interpreterbase import ContainerTypeInfo, FeatureDeprecated, KwargInfo, noPosargs, FeatureNew, typed_kwargs, typed_pos_args
@@ -272,8 +272,9 @@ class QtBaseModule(ExtensionModule):
             return
         self._tools_detected = True
         mlog.log(f'Detecting Qt{self.qt_version} tools')
+        native = state.machine_map.host
         version = version or []
-        kwargs: DependencyObjectKWs = {'required': required, 'modules': ['Core'], 'method': method, 'native': MachineChoice.HOST, 'version': version}
+        kwargs: DependencyObjectKWs = {'required': required, 'modules': ['Core'], 'method': method, 'native': native, 'version': version}
         # Just pick one to make mypy happy
         qt = T.cast('QtPkgConfigDependency', find_external_dependency(f'qt{self.qt_version}', state.environment, kwargs))
         if qt.found():

--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -14,7 +14,7 @@ from ..options import OptionKey
 from ..cmake import TargetOptions, cmake_defines_to_args
 from ..dependencies.cmake import CMakeDependency
 from ..interpreter import SubprojectHolder
-from ..interpreter.type_checking import REQUIRED_KW, INSTALL_DIR_KW, INCLUDE_TYPE, NoneType, in_set_validator
+from ..interpreter.type_checking import NATIVE_KW, REQUIRED_KW, INSTALL_DIR_KW, INCLUDE_TYPE, NoneType, in_set_validator
 from ..interpreterbase import (
     FeatureNew,
 
@@ -59,6 +59,7 @@ if T.TYPE_CHECKING:
 
         options: T.Optional[CMakeSubprojectOptions]
         cmake_options: T.List[str]
+        native: mesonlib.MachineChoice
 
     class TargetKW(TypedDict):
 
@@ -425,6 +426,7 @@ class CmakeModule(ExtensionModule):
     @typed_kwargs(
         'cmake.subproject',
         REQUIRED_KW,
+        NATIVE_KW.evolve(since='1.12.0'),
         KwargInfo('options', (CMakeSubprojectOptions, NoneType), since='0.55.0'),
         KwargInfo(
             'cmake_options',
@@ -445,7 +447,7 @@ class CmakeModule(ExtensionModule):
             'cmake_options': kwargs_['cmake_options'],
             'default_options': {},
             'version': [],
-            'for_machine': mesonlib.MachineChoice.HOST,
+            'for_machine': kwargs_['native'],
         }
         subp = self.interpreter.do_subproject(subp_name, kw, force_method='cmake')
         if not subp.found():

--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -445,6 +445,7 @@ class CmakeModule(ExtensionModule):
             'cmake_options': kwargs_['cmake_options'],
             'default_options': {},
             'version': [],
+            'for_machine': mesonlib.MachineChoice.HOST,
         }
         subp = self.interpreter.do_subproject(subp_name, kw, force_method='cmake')
         if not subp.found():

--- a/mesonbuild/modules/codegen.py
+++ b/mesonbuild/modules/codegen.py
@@ -180,11 +180,11 @@ class LexHolder(ObjectHolder[LexGenerator]):
         target = CustomTarget(
             f'codegen-lex-{name}-{for_machine.get_lower_case_name()}',
             self.interpreter.subdir,
-            self.interpreter.subproject,
             self.interpreter.environment,
             command,
             [input],
             outputs,
+            self.interpreter.current_build_project(),
             backend=self.interpreter.backend,
             description='Generating lexer {{}} with {}'.format(self.held_object.name),
         )
@@ -255,11 +255,11 @@ class YaccHolder(ObjectHolder[YaccGenerator]):
         target = CustomTarget(
             f'codegen-yacc-{name}-{for_machine.get_lower_case_name()}',
             self.interpreter.subdir,
-            self.interpreter.subproject,
             self.interpreter.environment,
             command,
             [input],
             outputs,
+            self.interpreter.current_build_project(),
             backend=self.interpreter.backend,
             description='Generating parser {{}} with {}'.format(self.held_object.name),
         )

--- a/mesonbuild/modules/codegen.py
+++ b/mesonbuild/modules/codegen.py
@@ -9,6 +9,7 @@ import typing as T
 from . import ExtensionModule, ModuleInfo
 from ..build import CustomTarget, CustomTargetIndex, GeneratedList
 from ..compilers.compilers import lang_suffixes
+from ..interpreter.decorators import apply_machine_map
 from ..interpreter.interpreterobjects import extract_required_kwarg
 from ..interpreter.type_checking import NoneType, REQUIRED_KW, DISABLER_KW, NATIVE_KW
 from ..interpreterbase import (
@@ -297,6 +298,7 @@ class CodeGenModule(ExtensionModule):
         DISABLER_KW,
         NATIVE_KW
     )
+    @apply_machine_map
     @disablerIfNotFound
     def lex_method(self, state: ModuleState, args: T.Tuple, kwargs: FindLexKwargs) -> LexGenerator:
         disabled, required, feature = extract_required_kwarg(kwargs, state.subproject)
@@ -376,6 +378,7 @@ class CodeGenModule(ExtensionModule):
         DISABLER_KW,
         NATIVE_KW,
     )
+    @apply_machine_map
     @disablerIfNotFound
     def yacc_method(self, state: ModuleState, args: T.Tuple, kwargs: FindYaccKwargs) -> YaccGenerator:
         disabled, required, feature = extract_required_kwarg(kwargs, state.subproject)

--- a/mesonbuild/modules/codegen.py
+++ b/mesonbuild/modules/codegen.py
@@ -86,6 +86,7 @@ class _CodeGenerator(HoldableObject):
 
     name: str
     program: Program
+    for_machine: MachineChoice
     arguments: ImmutableListProtocol[str] = dataclasses.field(default_factory=list)
 
     def command(self) -> CommandList:
@@ -146,9 +147,8 @@ class LexHolder(ObjectHolder[LexGenerator]):
             ext = kwargs['source'].rsplit('.', 1)[1]
             is_cpp = ext in lang_suffixes['cpp']
 
-        for_machine = self.held_object.program.for_machine
-
         # Flex uses FlexLexer.h for C++ code
+        for_machine = self.held_object.for_machine
         if is_cpp and self.held_object.name in {'flex', 'win_flex'}:
             try:
                 comp = self.interpreter.environment.coredata.compilers[for_machine]['cpp']
@@ -250,7 +250,7 @@ class YaccHolder(ObjectHolder[YaccGenerator]):
         if kwargs['locations'] is not None:
             outputs.append(kwargs['locations'])
 
-        for_machine = self.held_object.program.for_machine
+        for_machine = self.held_object.for_machine
         target = CustomTarget(
             f'codegen-yacc-{name}-{for_machine.get_lower_case_name()}',
             self.interpreter.subdir,
@@ -302,7 +302,7 @@ class CodeGenModule(ExtensionModule):
         disabled, required, feature = extract_required_kwarg(kwargs, state.subproject)
         if disabled:
             mlog.log('generator lex skipped: feature', mlog.bold(feature), 'disabled')
-            return LexGenerator('lex', NonExistingExternalProgram('lex'))
+            return LexGenerator('lex', NonExistingExternalProgram('lex'), kwargs['native'])
 
         names: T.List[LexImpls] = []
         if kwargs['implementations']:
@@ -348,7 +348,7 @@ class CodeGenModule(ExtensionModule):
                 raise MesonException.from_node(
                     'Could not find a lex implementation. Tried: ', ", ".join(names),
                     node=state.current_node)
-            return LexGenerator(name, bin)
+            return LexGenerator(name, bin, kwargs['native'])
 
         lex_args: T.List[str] = []
         # This option allows compiling with MSVC
@@ -356,7 +356,7 @@ class CodeGenModule(ExtensionModule):
         if bin.name == 'win_flex' and state.environment.machines[kwargs['native']].is_windows():
             lex_args.append('--wincompat')
         lex_args.extend(['-o', '@OUTPUT0@'])
-        return LexGenerator(name, bin, T.cast('ImmutableListProtocol[str]', lex_args))
+        return LexGenerator(name, bin, kwargs['native'], T.cast('ImmutableListProtocol[str]', lex_args))
 
     @noPosargs
     @typed_kwargs(
@@ -381,7 +381,7 @@ class CodeGenModule(ExtensionModule):
         disabled, required, feature = extract_required_kwarg(kwargs, state.subproject)
         if disabled:
             mlog.log('generator yacc skipped: feature', mlog.bold(feature), 'disabled')
-            return YaccGenerator('yacc', NonExistingExternalProgram('yacc'))
+            return YaccGenerator('yacc', NonExistingExternalProgram('yacc'), kwargs['native'])
         names: T.List[YaccImpls]
         if kwargs['implementations']:
             names = kwargs['implementations']
@@ -409,7 +409,7 @@ class CodeGenModule(ExtensionModule):
                 raise MesonException.from_node(
                     'Could not find a yacc implementation. Tried: ', ", ".join(names),
                     node=state.current_node)
-            return YaccGenerator(name, bin)
+            return YaccGenerator(name, bin, kwargs['native'])
 
         yacc_args: T.List[str] = []
 
@@ -434,7 +434,7 @@ class CodeGenModule(ExtensionModule):
                          fatal=False)
             yacc_args.append('-H')
         yacc_args.extend(['-o', '@OUTPUT0@', '@INPUT@'])
-        return YaccGenerator(name, bin, T.cast('ImmutableListProtocol[str]', yacc_args))
+        return YaccGenerator(name, bin, kwargs['native'], T.cast('ImmutableListProtocol[str]', yacc_args))
 
 
 def initialize(interpreter: Interpreter) -> CodeGenModule:

--- a/mesonbuild/modules/external_project.py
+++ b/mesonbuild/modules/external_project.py
@@ -101,7 +101,7 @@ class ExternalProject(NewExtensionModule):
 
         self._configure(state)
 
-        self.targets = self._create_targets(extra_depends)
+        self.targets = self._create_targets(extra_depends, state.current_build_project)
 
     def _cygpath_convert(self, winpath: Path) -> Path:
         # On Cygwin, MSYS2 and GitBash, the configure command and the prefix
@@ -234,7 +234,7 @@ class ExternalProject(NewExtensionModule):
                 print(contents)
             raise MesonException(m)
 
-    def _create_targets(self, extra_depends: T.List[TargetDepends]) -> T.List['TYPE_var']:
+    def _create_targets(self, extra_depends: T.List[TargetDepends], build_project: build.BuildProject) -> T.List['TYPE_var']:
         cmd = self.env.get_build_command()
         cmd += ['--internal', 'externalproject',
                 '--name', self.name,
@@ -250,11 +250,11 @@ class ExternalProject(NewExtensionModule):
         self.target = build.CustomTarget(
             self.name,
             self.subdir.as_posix(),
-            self.subproject,
             self.env,
             cmd + ['@OUTPUT@', '@DEPFILE@'],
             [],
             [f'{self.name}.stamp'],
+            build_project,
             depfile=f'{self.name}.d',
             console=True,
             extra_depends=extra_depends,

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -308,11 +308,11 @@ class FSModule(ExtensionModule):
         ct = CustomTarget(
             dest,
             state.subdir,
-            state.subproject,
             state.environment,
             state.environment.get_build_command() + ['--internal', 'copy', '@INPUT@', '@OUTPUT@'],
             [src],
             [dest],
+            state.current_build_project,
             build_by_default=True,
             install=kwargs['install'],
             install_dir=[kwargs['install_dir']],

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -2314,7 +2314,8 @@ class GnomeModule(ExtensionModule):
         # - link with the correct library
         # - include the vapi and dependent vapi files in sources
         # - add relevant directories to include dirs
-        incs = [build.IncludeDirs(state.subdir, ['.'] + vapi_includes, False)]
+        incs = [build.IncludeDirs(state.subdir, ['.'] + vapi_includes, False,
+                state.current_build_project)]
         sources = [vapi_target] + vapi_depends
         rv = InternalDependency(None, incs, [], [], link_with, [], sources, [], [], {}, [], [], [])
         created_values.append(rv)

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -515,11 +515,11 @@ class GnomeModule(ExtensionModule):
         target_c = GResourceTarget(
             name,
             state.subdir,
-            state.subproject,
             state.environment,
             target_cmd,
             [input_file],
             [output],
+            state.current_build_project,
             build_by_default=kwargs['build_by_default'],
             depfile=depfile,
             depend_files=depend_files,
@@ -538,11 +538,11 @@ class GnomeModule(ExtensionModule):
         target_h = GResourceHeaderTarget(
             f'{target_name}_h',
             state.subdir,
-            state.subproject,
             state.environment,
             cmd,
             [input_file],
             [f'{target_name}.h'],
+            state.current_build_project,
             build_by_default=kwargs['build_by_default'],
             extra_depends=depends,
             install=install_header,
@@ -1016,11 +1016,11 @@ class GnomeModule(ExtensionModule):
         return GirTarget(
             girfile,
             state.subdir,
-            state.subproject,
             state.environment,
             scan_command,
             generated_files,
             [girfile],
+            state.current_build_project,
             build_by_default=kwargs['build_by_default'],
             extra_depends=depends,
             install=install,
@@ -1048,11 +1048,11 @@ class GnomeModule(ExtensionModule):
         return TypelibTarget(
             typelib_output,
             state.subdir,
-            state.subproject,
             state.environment,
             typelib_cmd,
             generated_files,
             [typelib_output],
+            state.current_build_project,
             install=install,
             install_dir=[install_dir],
             install_tag=['typelib'],
@@ -1291,11 +1291,11 @@ class GnomeModule(ExtensionModule):
         target_g = CustomTarget(
             targetname,
             state.subdir,
-            state.subproject,
             state.environment,
             cmd,
             [],
             ['gschemas.compiled'],
+            state.current_build_project,
             build_by_default=kwargs['build_by_default'],
             depend_files=state._interpreter.source_strings_to_files(kwargs['depend_files']),
             description='Compiling gschemas {}',
@@ -1366,8 +1366,8 @@ class GnomeModule(ExtensionModule):
         pot_args: CommandList = [itstool, '-o', pot_file]
         pot_args.extend(pot_sources)
         pottarget = build.RunTarget(f'help-{project_id}-pot', pot_args, [],
-                                    os.path.join(state.subdir, 'C'), state.subproject,
-                                    state.environment)
+                                    os.path.join(state.subdir, 'C'),
+                                    state.environment, state.current_build_project)
         targets.append(pottarget)
 
         for l in langs:
@@ -1399,8 +1399,8 @@ class GnomeModule(ExtensionModule):
                                     '--internal', 'exe', '--capture', po_path, '--',
                                     msgmerge, '-q', po_path, pot_file]
             potarget = build.RunTarget(f'help-{project_id}-{l}-update-po',
-                                       po_args, [pottarget], l_subdir, state.subproject,
-                                       state.environment)
+                                       po_args, [pottarget], l_subdir,
+                                       state.environment, state.current_build_project)
             targets.append(potarget)
             potargets.append(potarget)
 
@@ -1409,11 +1409,11 @@ class GnomeModule(ExtensionModule):
             gmotarget = CustomTarget(
                 f'help-{project_id}-{l}-gmo',
                 l_subdir,
-                state.subproject,
                 state.environment,
                 [msgfmt, '@INPUT@', '-o', '@OUTPUT@'],
                 [po_file],
                 [gmo_file],
+                state.current_build_project,
                 install_tag=['doc'],
                 description='Generating yelp doc {}',
             )
@@ -1422,11 +1422,11 @@ class GnomeModule(ExtensionModule):
             mergetarget = CustomTarget(
                 f'help-{project_id}-{l}',
                 l_subdir,
-                state.subproject,
                 state.environment,
                 [itstool, '-m', os.path.join(l_subdir, gmo_file), '--lang', l, '-o', '@OUTDIR@', '@INPUT@'],
                 sources_files,
                 sources,
+                state.current_build_project,
                 extra_depends=[gmotarget],
                 install=True,
                 install_dir=[l_install_dir],
@@ -1436,7 +1436,8 @@ class GnomeModule(ExtensionModule):
             targets.append(mergetarget)
 
         allpotarget = build.AliasTarget(f'help-{project_id}-update-po', potargets,
-                                        state.subdir, state.subproject, state.environment)
+                                        state.subdir, state.environment,
+                                        state.current_build_project)
         targets.append(allpotarget)
 
         return ModuleReturnValue(None, targets)
@@ -1571,16 +1572,17 @@ class GnomeModule(ExtensionModule):
         custom_target = CustomTarget(
             targetname,
             state.subdir,
-            state.subproject,
             state.environment,
             command + t_args,
             [],
             [f'{modulename}-decl.txt'],
+            state.current_build_project,
             build_always_stale=True,
             extra_depends=new_depends,
             description='Generating gtkdoc {}',
         )
-        alias_target = build.AliasTarget(targetname, [custom_target], state.subdir, state.subproject, state.environment)
+        alias_target = build.AliasTarget(targetname, [custom_target], state.subdir,
+                                         state.environment, state.current_build_project)
         if kwargs['check']:
             check_cmd = state.find_program('gtkdoc-check')
             check_env = ['DOC_MODULE=' + modulename,
@@ -1739,11 +1741,11 @@ class GnomeModule(ExtensionModule):
         cfile_custom_target = CustomTarget(
             output,
             state.subdir,
-            state.subproject,
             state.environment,
             c_cmd,
             xml_files,
             [output],
+            state.current_build_project,
             build_by_default=build_by_default,
             description='Generating gdbus source {}',
         )
@@ -1760,11 +1762,11 @@ class GnomeModule(ExtensionModule):
         hfile_custom_target = CustomTarget(
             output,
             state.subdir,
-            state.subproject,
             state.environment,
             hfile_cmd,
             xml_files,
             [output],
+            state.current_build_project,
             build_by_default=build_by_default,
             extra_depends=depends,
             install=install_header,
@@ -1792,11 +1794,11 @@ class GnomeModule(ExtensionModule):
             docbook_custom_target = CustomTarget(
                 output,
                 state.subdir,
-                state.subproject,
                 state.environment,
                 docbook_cmd,
                 xml_files,
                 outputs,
+                state.current_build_project,
                 build_by_default=build_by_default,
                 extra_depends=depends,
                 description='Generating gdbus docbook {}',
@@ -1814,11 +1816,11 @@ class GnomeModule(ExtensionModule):
             rst_custom_target = CustomTarget(
                 output,
                 state.subdir,
-                state.subproject,
                 state.environment,
                 cmd + ['--output-directory', '@OUTDIR@', '--generate-rst', rst, '@INPUT@'],
                 xml_files,
                 outputs,
+                state.current_build_project,
                 build_by_default=build_by_default,
                 description='Generating gdbus reStructuredText {}',
             )
@@ -1835,11 +1837,11 @@ class GnomeModule(ExtensionModule):
             markdown_custom_target = CustomTarget(
                 output,
                 state.subdir,
-                state.subproject,
                 state.environment,
                 cmd + ['--output-directory', '@OUTDIR@', '--generate-md', markdown, '@INPUT@'],
                 xml_files,
                 outputs,
+                state.current_build_project,
                 build_by_default=build_by_default,
                 description='Generating gdbus markdown {}',
             )
@@ -2074,11 +2076,11 @@ class GnomeModule(ExtensionModule):
         return CustomTarget(
             output,
             state.subdir,
-            state.subproject,
             state.environment,
             real_cmd,
             sources,
             [output],
+            state.current_build_project,
             capture=True,
             install=install,
             install_dir=[_install_dir],
@@ -2147,11 +2149,11 @@ class GnomeModule(ExtensionModule):
         header = CustomTarget(
             output + '_h',
             state.subdir,
-            state.subproject,
             state.environment,
             h_cmd,
             sources,
             [header_file],
+            state.current_build_project,
             install=install_header,
             install_dir=[kwargs['install_dir']] if kwargs['install_dir'] else [],
             install_tag=['devel'],
@@ -2169,11 +2171,11 @@ class GnomeModule(ExtensionModule):
         body = CustomTarget(
             output + '_c',
             state.subdir,
-            state.subproject,
             state.environment,
             c_cmd,
             sources,
             [f'{output}.c'],
+            state.current_build_project,
             capture=capture,
             depend_files=kwargs['depend_files'],
             extra_depends=extra_deps,
@@ -2297,11 +2299,11 @@ class GnomeModule(ExtensionModule):
         vapi_target = VapiTarget(
             vapi_output,
             state.subdir,
-            state.subproject,
             state.environment,
-            command=cmd,
-            sources=inputs,
-            outputs=[vapi_output],
+            cmd,
+            inputs,
+            [vapi_output],
+            state.current_build_project,
             extra_depends=vapi_depends,
             install=kwargs['install'],
             install_dir=[install_dir],

--- a/mesonbuild/modules/hotdoc.py
+++ b/mesonbuild/modules/hotdoc.py
@@ -26,6 +26,7 @@ if T.TYPE_CHECKING:
     from typing_extensions import TypedDict
 
     from . import ModuleState
+    from ..build import BuildProject
     from ..environment import Environment
     from ..interpreter import Interpreter
     from ..interpreter.kwargs import TargetDepends
@@ -326,7 +327,6 @@ class HotdocTargetBuilder:
 
         target = HotdocTarget(fullname,
                               subdir=self.subdir,
-                              subproject=self.state.subproject,
                               environment=self.state.environment,
                               hotdoc_conf=File.from_built_file(
                                   self.subdir, hotdoc_config_name),
@@ -337,6 +337,7 @@ class HotdocTargetBuilder:
                               extra_depends=self.extra_depends,
                               outputs=[fullname],
                               sources=[],
+                              build_project=self.state.current_build_project,
                               depfile=os.path.basename(depfile),
                               build_by_default=self.build_by_default)
 
@@ -382,10 +383,11 @@ class HotdocTargetHolder(_CustomTargetHolder['HotdocTarget']):
 
 
 class HotdocTarget(CustomTarget):
-    def __init__(self, name: str, subdir: str, subproject: mesonlib.SubProject, hotdoc_conf: File,
+    def __init__(self, name: str, subdir: str, hotdoc_conf: File,
                  extra_extension_paths: T.Set[str], extra_assets: T.List[str],
-                 subprojects: T.List['HotdocTarget'], environment: Environment, **kwargs: T.Any):
-        super().__init__(name, subdir, subproject, environment, **kwargs, absolute_paths=True)
+                 subprojects: T.List['HotdocTarget'], environment: Environment,
+                 build_project: BuildProject, **kwargs: T.Any):
+        super().__init__(name, subdir, environment, **kwargs, build_project=build_project, absolute_paths=True)
         self.hotdoc_conf = hotdoc_conf
         self.extra_extension_paths = extra_extension_paths
         self.extra_assets = extra_assets

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -134,6 +134,7 @@ class XgettextProgram:
         self.interpreter = interpreter
 
     def extract(self,
+                state: ModuleState,
                 name: str,
                 sources: T.List[SourcesType],
                 args: T.List[str],
@@ -168,11 +169,11 @@ class XgettextProgram:
         ct = build.CustomTarget(
             '',
             self.interpreter.subdir,
-            self.interpreter.subproject,
             self.interpreter.environment,
             command,
             inputs,
             [name],
+            state.current_build_project,
             depend_files = depend_files,
             extra_depends = depends,
             install = install,
@@ -332,11 +333,11 @@ class I18nModule(ExtensionModule):
         ct = build.CustomTarget(
             '',
             state.subdir,
-            state.subproject,
             state.environment,
             command,
             inputs,
             [kwargs['output']],
+            state.current_build_project,
             build_by_default=build_by_default,
             install=kwargs['install'],
             install_dir=[kwargs['install_dir']] if kwargs['install_dir'] is not None else None,
@@ -407,8 +408,8 @@ class I18nModule(ExtensionModule):
             potargs.append(extra_arg)
         if self.tools['xgettext'].found():
             potargs.append('--xgettext=' + self.tools['xgettext'].get_path())
-        pottarget = build.RunTarget(packagename + '-pot', potargs, [], state.subdir, state.subproject,
-                                    state.environment, default_env=False)
+        pottarget = build.RunTarget(packagename + '-pot', potargs, [], state.subdir,
+                                    state.environment, state.current_build_project, default_env=False)
         targets.append(pottarget)
 
         install = kwargs['install']
@@ -425,11 +426,11 @@ class I18nModule(ExtensionModule):
             gmotarget = build.CustomTarget(
                 f'{packagename}-{l}.mo',
                 path.join(state.subdir, l, 'LC_MESSAGES'),
-                state.subproject,
                 state.environment,
                 [self.tools['msgfmt'], '-o', '@OUTPUT@', '@INPUT@'],
                 [po_file],
                 [f'{packagename}.mo'],
+                state.current_build_project,
                 install=install,
                 # We have multiple files all installed as packagename+'.mo' in different install subdirs.
                 # What we really wanted to do, probably, is have a rename: kwarg, but that's not available
@@ -442,8 +443,8 @@ class I18nModule(ExtensionModule):
             targets.append(gmotarget)
             gmotargets.append(gmotarget)
 
-        allgmotarget = build.AliasTarget(packagename + '-gmo', gmotargets, state.subdir, state.subproject,
-                                         state.environment)
+        allgmotarget = build.AliasTarget(packagename + '-gmo', gmotargets, state.subdir,
+                                         state.environment, state.current_build_project)
         targets.append(allgmotarget)
 
         updatepoargs = state.environment.get_build_command() + ['--internal', 'gettext', 'update_po', pkg_arg]
@@ -459,8 +460,8 @@ class I18nModule(ExtensionModule):
         for tool in ['msginit', 'msgmerge']:
             if self.tools[tool].found():
                 updatepoargs.append(f'--{tool}=' + self.tools[tool].get_path())
-        updatepotarget = build.RunTarget(packagename + '-update-po', updatepoargs, [], state.subdir, state.subproject,
-                                         state.environment, default_env=False)
+        updatepotarget = build.RunTarget(packagename + '-update-po', updatepoargs, [], state.subdir,
+                                         state.environment, state.current_build_project, default_env=False)
         targets.append(updatepotarget)
 
         return ModuleReturnValue([gmotargets, pottarget, updatepotarget], targets)
@@ -520,11 +521,11 @@ class I18nModule(ExtensionModule):
         ct = build.CustomTarget(
             '',
             state.subdir,
-            state.subproject,
             state.environment,
             command,
             inputs,
             [kwargs['output']],
+            state.current_build_project,
             build_by_default=build_by_default,
             extra_depends=mo_targets,
             install=kwargs['install'],
@@ -559,7 +560,7 @@ class I18nModule(ExtensionModule):
             raise InvalidArguments('i18n.xgettext: "install_dir" keyword argument must be set when "install" is true.')
 
         xgettext_program = XgettextProgram(T.cast('ExternalProgram', self.tools[toolname]), self.interpreter)
-        return xgettext_program.extract(*args, **kwargs)
+        return xgettext_program.extract(state, *args, **kwargs)
 
 
 def initialize(interp: 'Interpreter') -> I18nModule:

--- a/mesonbuild/modules/icestorm.py
+++ b/mesonbuild/modules/icestorm.py
@@ -66,31 +66,31 @@ class IceStormModule(ExtensionModule):
         blif_target = build.CustomTarget(
             f'{proj_name}_blif',
             state.subdir,
-            state.subproject,
             state.environment,
             [self.tools['yosys'], '-q', '-p', 'synth_ice40 -blif @OUTPUT@', '@INPUT@'],
             all_sources,
             [f'{proj_name}.blif'],
+            state.current_build_project,
         )
 
         asc_target = build.CustomTarget(
             f'{proj_name}_asc',
             state.subdir,
-            state.subproject,
             state.environment,
             [self.tools['arachne'], '-q', '-d', '1k', '-p', '@INPUT@', '-o', '@OUTPUT@'],
             [constraint_file, blif_target],
             [f'{proj_name}.asc'],
+            state.current_build_project,
         )
 
         bin_target = build.CustomTarget(
             f'{proj_name}_bin',
             state.subdir,
-            state.subproject,
             state.environment,
             [self.tools['icepack'], '@INPUT@', '@OUTPUT@'],
             [asc_target],
             [f'{proj_name}.bin'],
+            state.current_build_project,
             build_by_default=True,
         )
 
@@ -99,8 +99,8 @@ class IceStormModule(ExtensionModule):
             [self.tools['iceprog'], bin_target],
             [],
             state.subdir,
-            state.subproject,
             state.environment,
+            state.current_build_project,
         )
 
         time_target = build.RunTarget(
@@ -108,8 +108,8 @@ class IceStormModule(ExtensionModule):
             [self.tools['icetime'], bin_target],
             [],
             state.subdir,
-            state.subproject,
             state.environment,
+            state.current_build_project,
         )
 
         return ModuleReturnValue(

--- a/mesonbuild/modules/java.py
+++ b/mesonbuild/modules/java.py
@@ -93,10 +93,11 @@ class JavaModule(NewExtensionModule):
                    if isinstance(s, str) else s for s in args[0]]
         target = CustomTarget(f'{prefix}-native-headers',
                               state.subdir,
-                              state.subproject,
                               state.environment,
                               command,
-                              sources=sources, outputs=headers, backend=state.backend)
+                              sources, headers,
+                              state.current_build_project,
+                              backend=state.backend)
 
         # It is only known that 1.8.0 won't pre-create the directory. 11 and 16
         # do not exhibit this behavior.

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -14,6 +14,7 @@ from ..dependencies import NotFoundDependency
 from ..dependencies.detect import get_dep_identifier, find_external_dependency
 from ..dependencies.python import BasicPythonExternalProgram, python_factory, _PythonDependencyBase
 from ..interpreter import extract_required_kwarg, primitives as P_OBJ
+from ..interpreter.decorators import apply_machine_map
 from ..interpreter.interpreterobjects import ProgramHolder
 from ..interpreter.type_checking import NoneType, DEPENDENCY_KWS, PRESERVE_PATH_KW, REQUIRED_KW, SHARED_MOD_KWS
 from ..interpreterbase import (
@@ -152,6 +153,7 @@ class PythonInstallation(ProgramHolder['PythonExternalProgram']):
         _LIMITED_API_KW,
         KwargInfo('install_dir', (str, bool, NoneType)),
     )
+    @apply_machine_map
     @InterpreterObject.method('extension_module')
     def extension_module_method(self, args: T.Tuple[str, T.List[BuildTargetSource]], kwargs: ExtensionModuleKw) -> 'SharedModule':
         target_kwargs = T.cast('SharedModuleKw', {k: v for k, v in kwargs.items() if k not in {'install_dir', 'subdir', 'limited_api'}})

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -21,7 +21,7 @@ from ..dependencies import Dependency
 from ..interpreter.decorators import apply_machine_map
 from ..interpreter.type_checking import (
     DEPENDENCIES_KW, LINK_WITH_KW, LINK_WHOLE_KW, SHARED_LIB_KWS, TEST_KWS, TEST_KWS_NO_ARGS,
-    OUTPUT_KW, INCLUDE_DIRECTORIES, SOURCES_VARARGS, NATIVE_KW, NoneType, in_set_validator,
+    NATIVE_KW, OUTPUT_KW, INCLUDE_DIRECTORIES, SOURCES_VARARGS, NoneType, in_set_validator,
     EXECUTABLE_KWS, LIBRARY_KWS, SHARED_MOD_KWS, _BASE_LANG_KW
 )
 from ..interpreterbase import ContainerTypeInfo, InterpreterException, KwargInfo, typed_kwargs, typed_pos_args, noKwargs, noPosargs
@@ -72,6 +72,12 @@ if T.TYPE_CHECKING:
         dependencies: T.List[T.Union[Dependency, ExternalLibrary]]
         language: T.Optional[Literal['c', 'cpp']]
         bindgen_version: T.List[str]
+
+    class FuncSubproject(TypedDict):
+        native: MachineChoice
+
+    class FuncPackage(TypedDict):
+        native: MachineChoice
 
     class FuncWorkspace(TypedDict):
         default_features: T.Optional[bool]
@@ -160,26 +166,39 @@ class RustWorkspace(ModuleObject):
         return sorted(package_names)
 
     @typed_pos_args('workspace.package', optargs=[str])
-    def package_method(self, state: 'ModuleState', args: T.List, kwargs: TYPE_kwargs) -> RustPackage:
+    @typed_kwargs(
+        'workspace.package',
+        NATIVE_KW.evolve(since='1.12.0'))
+    def package_method(self, state: 'ModuleState', args: T.List, kwargs: FuncPackage) -> RustPackage:
         """Returns a package object."""
         package_name = args[0] if args else None
-        return RustPackage(self, self.interpreter.cargo.load_package(self.ws, package_name))
+        return RustPackage(state, self, self.interpreter.cargo.load_package(self.ws, package_name),
+                           kwargs['native'])
 
-    def _do_subproject(self, pkg: cargo.PackageState) -> None:
+    def _do_subproject(self, state: ModuleState, pkg: cargo.PackageState, for_machine: MachineChoice) -> None:
+        # Unless the crate builds as both a procedural macro and something else,
+        # it can be built just once; the same dependency is used as an override
+        # for both the host and the build machine.  In that case, always build the
+        # subproject for the build machine to ensure that it is not run twice.
+        if pkg.manifest.lib.crate_type == ['proc-macro']:
+            for_machine = state.machine_map.build
+
         kw: _kwargs.DoSubproject = {
             'required': True,
             'version': None,
             'options': None,
             'cmake_options': [],
             'default_options': {},
-            'for_machine': MachineChoice.HOST,
+            'for_machine': for_machine,
         }
         subp_name = pkg.get_subproject_name()
         self.interpreter.do_subproject(subp_name, kw, force_method='cargo')
 
     @typed_pos_args('workspace.subproject', str, optargs=[str])
-    @noKwargs
-    def subproject_method(self, state: ModuleState, args: T.Tuple[str, T.Optional[str]], kwargs: TYPE_kwargs) -> RustSubproject:
+    @typed_kwargs(
+        'workspace.subproject',
+        NATIVE_KW.evolve(since='1.12.0'))
+    def subproject_method(self, state: ModuleState, args: T.Tuple[str, T.Optional[str]], kwargs: FuncSubproject) -> RustSubproject:
         """Returns a package object for a subproject package."""
         package_name = args[0]
         pkg = self.interpreter.cargo.resolve_package(package_name, args[1] or '')
@@ -189,15 +208,17 @@ class RustWorkspace(ModuleObject):
             else:
                 raise MesonException(f'Cargo package "{package_name}" not available')
 
-        self._do_subproject(pkg)
-        return RustSubproject(self, pkg)
+        self._do_subproject(state, pkg, kwargs['native'])
+        return RustSubproject(state, self, pkg, kwargs['native'])
 
 
 class RustCrate(ModuleObject):
     """Abstract base class for Rust crate representations."""
 
-    def __init__(self, rust_ws: RustWorkspace, package: cargo.PackageState) -> None:
+    def __init__(self, state: ModuleState, rust_ws: RustWorkspace, package: cargo.PackageState, for_machine: MachineChoice) -> None:
         super().__init__()
+
+        self.for_machine = state.machine_map[for_machine]
         self.rust_ws = rust_ws
         self.package = package
         self.methods.update({
@@ -245,7 +266,7 @@ class RustCrate(ModuleObject):
     @noKwargs
     def rust_args_method(self, state: ModuleState, args: T.List, kwargs: TYPE_kwargs) -> T.List[str]:
         """Returns rustc arguments for this package."""
-        return self.package.get_rustc_args(state.environment, state.subdir, mesonlib.MachineChoice.HOST)
+        return self.package.get_rustc_args(state.environment, state.subdir, self.for_machine)
 
     @noPosargs
     @noKwargs
@@ -263,8 +284,8 @@ class RustCrate(ModuleObject):
 class RustPackage(RustCrate):
     """Represents a Rust package within a workspace."""
 
-    def __init__(self, rust_ws: RustWorkspace, package: cargo.PackageState) -> None:
-        super().__init__(rust_ws, package)
+    def __init__(self, state: ModuleState, rust_ws: RustWorkspace, package: cargo.PackageState, for_machine: MachineChoice) -> None:
+        super().__init__(state, rust_ws, package, for_machine)
         if not package.cfg:
             raise MesonException(f"package {self.package.manifest.package.name}-{self.package.manifest.package.version} not configured")
         self.methods.update({
@@ -287,7 +308,7 @@ class RustPackage(RustCrate):
                     if dep_pkg.ws_subdir != self.rust_ws.subdir or \
                         is_parent_path(os.path.join(self.rust_ws.subdir, state.subproject_dir),
                                        dep_pkg.path):
-                        self.rust_ws._do_subproject(dep_pkg)
+                        self.rust_ws._do_subproject(state, dep_pkg, for_machine)
                     # Get the dependency name for this package (rust or proc-macro ABI)
                     depname = dep_pkg.get_rust_dependency_name()
                     dependency = state.overridden_dependency(depname, for_machine)
@@ -314,7 +335,7 @@ class RustPackage(RustCrate):
                   KwargInfo('system_dependencies', bool, default=True))
     def dependencies_method(self, state: ModuleState, args: T.List, kwargs: RustPackageDependencies) -> T.List[Dependency]:
         """Returns the dependencies for this package."""
-        return self._dependencies_method(state, kwargs, MachineChoice.HOST)
+        return self._dependencies_method(state, kwargs, self.for_machine)
 
     @staticmethod
     def validate_pos_args(name: str, args: T.Tuple[
@@ -327,7 +348,7 @@ class RustPackage(RustCrate):
         return None, args[0]
 
     def merge_kw_args(self, state: ModuleState, kwargs: T.Union[RustPackageExecutable, RustPackageLibrary]) -> None:
-        kwargs.setdefault('native', MachineChoice.HOST)
+        kwargs.setdefault('native', self.for_machine)
 
         deps = kwargs['dependencies']
         kwargs['dependencies'] = self._dependencies_method(state, {
@@ -407,20 +428,20 @@ class RustPackage(RustCrate):
         dep = args[0]
         rust_abi = self.package.abi_resolve_default(kwargs['rust_abi'])
         depname = self.package.get_dependency_name(rust_abi)
+        assert rust_abi in self.package.supported_abis()
 
-        if rust_abi == 'proc-macro':
+        if state.environment.is_cross_build() and self.package.manifest.lib.crate_type == ['proc-macro']:
             state.override_dependency(depname, dep, for_machine=MachineChoice.HOST)
             state.override_dependency(depname, dep, static=False, for_machine=MachineChoice.HOST)
-            if state.environment.is_cross_build():
-                state.override_dependency(depname, dep, for_machine=MachineChoice.BUILD)
-                state.override_dependency(depname, dep, static=False, for_machine=MachineChoice.BUILD)
+            state.override_dependency(depname, dep, for_machine=MachineChoice.BUILD)
+            state.override_dependency(depname, dep, static=False, for_machine=MachineChoice.BUILD)
             return
 
-        state.override_dependency(depname, dep)
+        state.override_dependency(depname, dep, for_machine=self.for_machine)
         if self.package.abi_has_static(rust_abi):
-            state.override_dependency(depname, dep, static=True)
+            state.override_dependency(depname, dep, static=True, for_machine=self.for_machine)
         if self.package.abi_has_shared(rust_abi):
-            state.override_dependency(depname, dep, static=False)
+            state.override_dependency(depname, dep, static=False, for_machine=self.for_machine)
 
     @typed_pos_args('package.library', optargs=[(str, StructuredSources), StructuredSources])
     @typed_kwargs(
@@ -532,8 +553,8 @@ class RustPackage(RustCrate):
 class RustSubproject(RustCrate):
     """Represents a Cargo subproject."""
 
-    def __init__(self, rust_ws: RustWorkspace, package: cargo.PackageState) -> None:
-        super().__init__(rust_ws, package)
+    def __init__(self, state: ModuleState, rust_ws: RustWorkspace, package: cargo.PackageState, for_machine: MachineChoice) -> None:
+        super().__init__(state, rust_ws, package, for_machine)
         self.methods.update({
             'dependency': self.dependency_method,
         })
@@ -544,7 +565,7 @@ class RustSubproject(RustCrate):
     def dependency_method(self, state: ModuleState, args: T.List, kwargs: FuncDependency) -> Dependency:
         """Returns dependency for the package with the given ABI."""
         depname = self.package.get_dependency_name(kwargs['rust_abi'])
-        return state.overridden_dependency(depname)
+        return state.overridden_dependency(depname, for_machine=self.for_machine)
 
 
 class RustModule(ExtensionModule):

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -666,10 +666,11 @@ class RustModule(ExtensionModule):
         sources.extend(base_target.generated)
 
         new_target = Executable(
-            name, base_target.subdir, state.subproject, base_target.for_machine,
+            name, base_target.subdir, base_target.for_machine,
             sources, base_target.structured_sources,
             base_target.objects, base_target.environment, base_target.compilers,
-            new_target_kwargs)
+            state.current_build_project, new_target_kwargs
+        )
         return new_target, tkwargs
 
     @typed_pos_args('rust.test', str, BuildTarget)
@@ -960,11 +961,11 @@ class RustModule(ExtensionModule):
         target = CustomTarget(
             f'rustmod-bindgen-{name}'.replace('/', '_'),
             state.subdir,
-            state.subproject,
             state.environment,
             cmd,
             [header],
             outputs,
+            state.current_build_project,
             depfile='@PLAINNAME@.d',
             extra_depends=depends,
             depend_files=depend_files,

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -18,6 +18,7 @@ from ..build import (BothLibraries, BuildTarget, CustomTargetIndex, Executable, 
 from ..compilers.compilers import are_asserts_disabled_for_subproject, lang_suffixes
 from ..compilers.rust import parse_target, RustSystemDependency
 from ..dependencies import Dependency
+from ..interpreter.decorators import apply_machine_map
 from ..interpreter.type_checking import (
     DEPENDENCIES_KW, LINK_WITH_KW, LINK_WHOLE_KW, SHARED_LIB_KWS, TEST_KWS, TEST_KWS_NO_ARGS,
     OUTPUT_KW, INCLUDE_DIRECTORIES, SOURCES_VARARGS, NATIVE_KW, NoneType, in_set_validator,
@@ -976,6 +977,7 @@ class RustModule(ExtensionModule):
     @FeatureNew('rust.compiler_target', '1.11.0')
     @noPosargs
     @typed_kwargs('rust.compiler_target', NATIVE_KW)
+    @apply_machine_map
     def compiler_target(self, state: ModuleState, args: T.List, kwargs: '_kwargs.NativeKW') -> str:
         """Returns the Rust target triple for the specified machine's Rust compiler."""
         for_machine = kwargs['native']

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -172,6 +172,7 @@ class RustWorkspace(ModuleObject):
             'options': None,
             'cmake_options': [],
             'default_options': {},
+            'for_machine': MachineChoice.HOST,
         }
         subp_name = pkg.get_subproject_name()
         self.interpreter.do_subproject(subp_name, kw, force_method='cargo')

--- a/mesonbuild/modules/wayland.py
+++ b/mesonbuild/modules/wayland.py
@@ -78,11 +78,11 @@ class WaylandModule(ExtensionModule):
             code = CustomTarget(
                 f'{name}-protocol',
                 state.subdir,
-                state.subproject,
                 state.environment,
                 [self.scanner_bin, f'{scope}-code', '@INPUT@', '@OUTPUT@'],
                 [xml_file],
                 [f'{name}-protocol.c'],
+                state.current_build_project,
                 backend=state.backend,
             )
             targets.append(code)
@@ -95,11 +95,11 @@ class WaylandModule(ExtensionModule):
                 header = CustomTarget(
                     f'{name}-{side}-protocol',
                     state.subdir,
-                    state.subproject,
                     state.environment,
                     command,
                     [xml_file],
                     [f'{name}-{side}-protocol.h'],
+                    state.current_build_project,
                     backend=state.backend,
                 )
                 targets.append(header)

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -207,11 +207,11 @@ class WindowsModule(ExtensionModule):
             res_targets.append(build.CustomTarget(
                 name_formatted,
                 state.subdir,
-                state.subproject,
                 state.environment,
                 command,
                 [src],
                 [output],
+                state.current_build_project,
                 depfile=depfile,
                 depfile_type=depfile_type,
                 depend_files=wrc_depend_files,

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -124,7 +124,8 @@ class WindowsModule(ExtensionModule):
         for d in wrc_depends:
             if isinstance(d, build.CustomTarget):
                 extra_args += state.get_include_args([
-                    build.IncludeDirs('', [], False, [self.interpreter.backend.get_target_dir(d)])
+                    build.IncludeDirs('', [], False, state.current_build_project,
+                                      [self.interpreter.backend.get_target_dir(d)])
                 ])
         extra_args += state.get_include_args(kwargs['include_directories'], kwargs['implicit_include_directories'])
 

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -81,6 +81,7 @@ __all__ = [
     'GitException',
     'LibType',
     'MachineChoice',
+    'ThreeMachineChoice',
     'EnvironmentException',
     'FileOrString',
     'GitException',

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -539,7 +539,7 @@ def classify_unity_sources(compilers: T.Iterable['Compiler'], sources: T.List[Fi
     return compsrclist
 
 
-MACHINE_NAMES = ['build', 'host']
+MACHINE_NAMES = ['build', 'host', 'target']
 MACHINE_PREFIXES = ['build.', '']
 
 
@@ -560,6 +560,23 @@ class MachineChoice(enum.IntEnum):
 
     def get_prefix(self) -> str:
         return MACHINE_PREFIXES[self.value]
+
+
+class ThreeMachineChoice(enum.IntEnum):
+
+    """Enum class representing any of the three abstract machine names:
+    the build, host, and target, machines.
+    """
+
+    BUILD = MachineChoice.BUILD.value
+    HOST = MachineChoice.HOST.value
+    TARGET = 2
+
+    def __str__(self) -> str:
+        return f'{self.get_lower_case_name()} machine'
+
+    def get_lower_case_name(self) -> str:
+        return MACHINE_NAMES[self.value]
 
 
 @dataclasses.dataclass(eq=False, order=False)
@@ -610,6 +627,12 @@ class PerThreeMachine(PerMachine[_T]):
     """
 
     target: _T
+
+    def __getitem__(self, machine: MachineChoice | ThreeMachineChoice) -> _T:
+        return [self.build, self.host, self.target][machine.value]
+
+    def __setitem__(self, machine: MachineChoice | ThreeMachineChoice, val: _T) -> None:
+        setattr(self, machine.get_lower_case_name(), val)
 
     def miss_defaulting(self) -> "PerThreeMachineDefaultable[T.Optional[_T]]":
         """Unset definition duplicated from their previous to None

--- a/run_tests.py
+++ b/run_tests.py
@@ -136,6 +136,7 @@ def _using_intelcl() -> bool:
 class FakeBuild:
     def __init__(self, env):
         self.environment = env
+        self.machine_map = env.machine_map
 
 def get_fake_options(prefix: str = '') -> SharedCMDOptions:
     opts = T.cast('SharedCMDOptions', argparse.Namespace())

--- a/test cases/cmake/2 advanced/meson.build
+++ b/test cases/cmake/2 advanced/meson.build
@@ -1,4 +1,4 @@
-project('cmakeSubTest_advanced', ['c', 'cpp'])
+project('cmakeSubTest_advanced', ['c', 'cpp'], meson_version: '>= 1.12.0')
 
 dep_test = dependency('ZLIB', method: 'cmake', required: false)
 if not dep_test.found()
@@ -45,3 +45,12 @@ else
   lib_version_ok = true
 endif
 assert(lib_version_ok, f'Shared library version @lib_file_name@ not picked up correctly')
+
+# Test the "normal" subproject call for the build machine
+sub_pro_b = cm.subproject('cmMod', native : true)
+sub_dep_b = sub_pro_b.dependency('cmModLib')
+sub_sta_b = sub_pro_b.dependency('cmModLibStatic')
+
+# Build some files
+exe1_b = executable('main1_b', ['main.cpp'], dependencies: [sub_dep_b], native : true)
+exe2_b = executable('main2_b', ['main.cpp'], dependencies: [sub_sta_b], native : true)

--- a/test cases/failing/103 no build get_external_property/meson.build
+++ b/test cases/failing/103 no build get_external_property/meson.build
@@ -1,3 +1,0 @@
-project('missing property')
-
-message(meson.get_external_property('nonexisting', native : true))

--- a/test cases/failing/103 no build get_external_property/test.json
+++ b/test cases/failing/103 no build get_external_property/test.json
@@ -1,7 +1,0 @@
-{
-  "stdout": [
-    {
-      "line": "test cases/failing/103 no build get_external_property/meson.build:3:14: ERROR: Unknown property for build machine: nonexisting"
-    }
-  ]
-}

--- a/test cases/native/10 native subproject/maingen.c
+++ b/test cases/native/10 native subproject/maingen.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+int main(void) {
+    printf("const char * gen_main(void) {\n");
+    printf("    return \"int main() \";\n");
+    printf("}\n");
+    return 0;
+}

--- a/test cases/native/10 native subproject/meson.build
+++ b/test cases/native/10 native subproject/meson.build
@@ -1,0 +1,31 @@
+project('native subproject', 'c', meson_version : '>= 1.12.0')
+
+# Test running a subproject for both host and build
+subproject('both', native : true)
+subproject('both', native : false)
+
+maingen = executable('maingen', 'maingen.c', native : true)
+meson.override_find_program('maingen', maingen, native : true)
+gen = subproject('buildtool', native : true).get_variable('e')
+
+ct = custom_target(
+  'generated',
+  command : [gen],
+  output : 'generated.c',
+  capture : true,
+)
+
+e = executable('testprog', ct, install : true)
+
+test('main', e)
+
+if meson.is_cross_build()
+  subproject('test installs', native : true)
+endif
+
+# Test a subproject configured from the main project, and then called as a nested subproject
+subproject('recursive-both', native : true)
+subproject('recursive-both', native : false)
+
+subproject('recursive-build-only', native : true)
+subproject('recursive-host-only', native : false)

--- a/test cases/native/10 native subproject/subprojects/both/main.c
+++ b/test cases/native/10 native subproject/subprojects/both/main.c
@@ -1,0 +1,3 @@
+int main(void) {
+    return 0;
+}

--- a/test cases/native/10 native subproject/subprojects/both/meson.build
+++ b/test cases/native/10 native subproject/subprojects/both/meson.build
@@ -1,0 +1,4 @@
+project('both', 'c')
+
+e = executable('main', 'main.c')
+test('main', e)

--- a/test cases/native/10 native subproject/subprojects/buildtool/buildtool.c
+++ b/test cases/native/10 native subproject/subprojects/buildtool/buildtool.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+const char * gen_main(void);
+
+int main() {
+    printf("%s", gen_main());
+    printf("{ return 0; }\n");
+    return 0;
+}

--- a/test cases/native/10 native subproject/subprojects/buildtool/meson.build
+++ b/test cases/native/10 native subproject/subprojects/buildtool/meson.build
@@ -1,0 +1,16 @@
+project('buildtool', 'c', meson_version : '>= 1.12.0')
+
+maingen = find_program('maingen')
+
+ct = custom_target(
+  'gen',
+  command : [maingen],
+  output : 'gen.c',
+  capture : true,
+)
+
+e = executable('buildtool', 'buildtool.c', ct)
+
+meson.override_find_program('buildtool', e)
+
+subproject('hostp', native : false)

--- a/test cases/native/10 native subproject/subprojects/buildtool/subprojects/hostp/hp.c
+++ b/test cases/native/10 native subproject/subprojects/buildtool/subprojects/hostp/hp.c
@@ -1,0 +1,3 @@
+int main(void) {
+    return 0;
+}

--- a/test cases/native/10 native subproject/subprojects/buildtool/subprojects/hostp/meson.build
+++ b/test cases/native/10 native subproject/subprojects/buildtool/subprojects/hostp/meson.build
@@ -1,0 +1,5 @@
+project('host project', 'c')
+
+e = executable('hp', 'hp.c')
+
+test('host project', e)

--- a/test cases/native/10 native subproject/subprojects/recursive-both/lib.c
+++ b/test cases/native/10 native subproject/subprojects/recursive-both/lib.c
@@ -1,0 +1,3 @@
+#include "recursive-both.h"
+
+int rcb(void) { return 7; }

--- a/test cases/native/10 native subproject/subprojects/recursive-both/lib.def
+++ b/test cases/native/10 native subproject/subprojects/recursive-both/lib.def
@@ -1,0 +1,2 @@
+EXPORTS
+    rcb

--- a/test cases/native/10 native subproject/subprojects/recursive-both/meson.build
+++ b/test cases/native/10 native subproject/subprojects/recursive-both/meson.build
@@ -1,0 +1,11 @@
+project('recursive-both', 'c')
+
+fs = import('fs')
+
+header = fs.copyfile('recursive-both.h.in', 'recursive-both.h')
+
+lib = library('lib', 'lib.c', header, vs_module_defs : 'lib.def')
+
+dep = declare_dependency(link_with : lib, sources : header, include_directories : '.')
+
+meson.override_dependency('recursive-both', dep)

--- a/test cases/native/10 native subproject/subprojects/recursive-both/recursive-both.h.in
+++ b/test cases/native/10 native subproject/subprojects/recursive-both/recursive-both.h.in
@@ -1,0 +1,1 @@
+int rcb(void);

--- a/test cases/native/10 native subproject/subprojects/recursive-build-only/main.c
+++ b/test cases/native/10 native subproject/subprojects/recursive-build-only/main.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include "recursive-both.h"
+
+int main(void) {
+    const int v = rcb();
+    printf("int main(void) {\n");
+    if (v == 7)
+        printf("  return 0;\n");
+    else
+        printf("  return 1;\n");
+    printf("}\n");
+    return 0;
+}

--- a/test cases/native/10 native subproject/subprojects/recursive-build-only/meson.build
+++ b/test cases/native/10 native subproject/subprojects/recursive-build-only/meson.build
@@ -1,0 +1,9 @@
+project('recursive-build-only', 'c')
+
+assert(meson.is_cross_build() == false, 'this project should never be considered a cross target')
+
+dep = dependency('recursive-both')
+
+exe = executable('main', 'main.c', dependencies : dep)
+
+meson.override_find_program('build-only-tool', exe)

--- a/test cases/native/10 native subproject/subprojects/recursive-host-only/meson.build
+++ b/test cases/native/10 native subproject/subprojects/recursive-host-only/meson.build
@@ -1,0 +1,16 @@
+project('recursive-host-only', 'c')
+
+subp = subproject('recursive-build-only', native : true)
+
+prog = subp.get_variable('exe')
+
+ct = custom_target(
+  'main.c',
+  output : 'main.c',
+  command : prog,
+  capture : true,
+)
+
+exe = executable('main', ct, native : true)
+
+test('main', exe)

--- a/test cases/native/10 native subproject/subprojects/test installs/meson.build
+++ b/test cases/native/10 native subproject/subprojects/test installs/meson.build
@@ -1,0 +1,11 @@
+project('test installs')
+
+install_emptydir('usr/share/foo')
+install_headers('header.h')
+install_man('man.1')
+install_data('header.h', install_dir : 'foo')
+install_symlink('link', install_dir : 'usr/bin', pointing_to : '/usr/bin/testprog')
+install_subdir('subdir', install_dir : 'share')
+
+meson.add_install_script('script.py')
+meson.add_postconf_script('script.py')

--- a/test cases/native/10 native subproject/subprojects/test installs/script.py
+++ b/test cases/native/10 native subproject/subprojects/test installs/script.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+
+# Do nothing
+exit(0)

--- a/test cases/native/10 native subproject/test.json
+++ b/test cases/native/10 native subproject/test.json
@@ -1,0 +1,6 @@
+{
+  "installed": [
+    {"type": "exe", "file": "usr/bin/testprog"},
+    {"type": "pdb", "file": "usr/bin/testprog"}
+  ]
+}

--- a/test cases/native/11 native dependency/main.c
+++ b/test cases/native/11 native dependency/main.c
@@ -1,0 +1,6 @@
+#include "lib.h"
+
+int main(void) {
+    const int v = foo() - 1;
+    return v;
+}

--- a/test cases/native/11 native dependency/meson.build
+++ b/test cases/native/11 native dependency/meson.build
@@ -1,0 +1,7 @@
+project('native dependency fallback', 'c', meson_version : '>= 1.12.0')
+
+d = dependency('made up', native : true)
+
+e = executable('main', 'main.c', dependencies : d, native : true)
+
+test('main', e)

--- a/test cases/native/11 native dependency/subprojects/made up/lib.c
+++ b/test cases/native/11 native dependency/subprojects/made up/lib.c
@@ -1,0 +1,1 @@
+int foo(void) { return 1; }

--- a/test cases/native/11 native dependency/subprojects/made up/lib.h
+++ b/test cases/native/11 native dependency/subprojects/made up/lib.h
@@ -1,0 +1,1 @@
+int foo(void);

--- a/test cases/native/11 native dependency/subprojects/made up/meson.build
+++ b/test cases/native/11 native dependency/subprojects/made up/meson.build
@@ -1,0 +1,7 @@
+project('made up', 'c', meson_version : '>= 1.12.0')
+
+s = static_library('lib', 'lib.c')
+
+dep = declare_dependency(link_with : s, include_directories : '.')
+
+meson.override_dependency('made up', dep)

--- a/test cases/rust/22 cargo subproject/meson.build
+++ b/test cases/rust/22 cargo subproject/meson.build
@@ -1,5 +1,11 @@
 project('cargo subproject', 'c')
 
+foo_dep = dependency('foo-0', native : true)
+exe = executable('app_native', 'main.c',
+  dependencies: foo_dep,
+  native : true,
+)
+
 foo_dep = dependency('foo-0')
 exe = executable('app', 'main.c',
   dependencies: foo_dep,

--- a/test cases/unit/116 empty project/expected_mods.json
+++ b/test cases/unit/116 empty project/expected_mods.json
@@ -194,6 +194,7 @@
       "mesonbuild.environment",
       "mesonbuild.interpreter",
       "mesonbuild.interpreter.compiler",
+      "mesonbuild.interpreter.decorators",
       "mesonbuild.interpreter.dependencyfallbacks",
       "mesonbuild.interpreter.interpreter",
       "mesonbuild.interpreter.interpreterobjects",
@@ -241,6 +242,6 @@
       "mesonbuild.wrap",
       "mesonbuild.wrap.wrap"
     ],
-    "count": 72
+    "count": 73
   }
 }

--- a/test cases/unit/136 native subproject introspect/meson.build
+++ b/test cases/unit/136 native subproject introspect/meson.build
@@ -1,0 +1,8 @@
+project('native subproject introspect', 'c')
+
+# The same subproject is configured for both the build machine (native : true)
+# and the host machine (native : false). In a cross build these are two
+# distinct configurations, so the library target it defines is introspected
+# twice: with the same name but a different id.
+subproject('recursive-both', native : true)
+subproject('recursive-both', native : false)

--- a/test cases/unit/136 native subproject introspect/subprojects/recursive-both/lib.c
+++ b/test cases/unit/136 native subproject introspect/subprojects/recursive-both/lib.c
@@ -1,0 +1,3 @@
+#include "recursive-both.h"
+
+int rcb(void) { return 7; }

--- a/test cases/unit/136 native subproject introspect/subprojects/recursive-both/lib.def
+++ b/test cases/unit/136 native subproject introspect/subprojects/recursive-both/lib.def
@@ -1,0 +1,2 @@
+EXPORTS
+    rcb

--- a/test cases/unit/136 native subproject introspect/subprojects/recursive-both/meson.build
+++ b/test cases/unit/136 native subproject introspect/subprojects/recursive-both/meson.build
@@ -1,0 +1,11 @@
+project('recursive-both', 'c')
+
+fs = import('fs')
+
+header = fs.copyfile('recursive-both.h.in', 'recursive-both.h')
+
+lib = library('lib', 'lib.c', header, vs_module_defs : 'lib.def')
+
+dep = declare_dependency(link_with : lib, sources : header, include_directories : '.')
+
+meson.override_dependency('recursive-both', dep)

--- a/test cases/unit/136 native subproject introspect/subprojects/recursive-both/recursive-both.h.in
+++ b/test cases/unit/136 native subproject introspect/subprojects/recursive-both/recursive-both.h.in
@@ -1,0 +1,1 @@
+int rcb(void);

--- a/test cases/unit/137 external property nonexisting/meson.build
+++ b/test cases/unit/137 external property nonexisting/meson.build
@@ -1,0 +1,4 @@
+project('missing property')
+
+assert(meson.get_external_property('existing', native : get_option('native')) == '42')
+message(meson.get_external_property('nonexisting', native : get_option('native')))

--- a/test cases/unit/137 external property nonexisting/meson_options.txt
+++ b/test cases/unit/137 external property nonexisting/meson_options.txt
@@ -1,0 +1,1 @@
+option('native', type : 'boolean', value: false)

--- a/test cases/unit/137 external property nonexisting/propfile
+++ b/test cases/unit/137 external property nonexisting/propfile
@@ -1,0 +1,2 @@
+[properties]
+existing = '42'

--- a/test cases/unit/69 cross/crossfile.in
+++ b/test cases/unit/69 cross/crossfile.in
@@ -1,3 +1,6 @@
+[binaries]
+c = @c_compiler@
+
 [host_machine]
 system = '@system@'
 cpu_family = '@cpu_family@'

--- a/test cases/unit/69 cross/meson.build
+++ b/test cases/unit/69 cross/meson.build
@@ -2,7 +2,14 @@ project('crosstest')
 
 add_languages('c', native: true)
 if get_option('generate')
+    cc = meson.get_compiler('c', native: true)
+    quoted = []
+    foreach part : cc.cmd_array()
+        quoted += '\'' + part + '\''
+    endforeach
+
     conf_data = configuration_data()
+    conf_data.set('c_compiler', '[' + ', '.join(quoted) + ']')
     conf_data.set('system', build_machine.system())
     conf_data.set('cpu', build_machine.cpu())
     conf_data.set('cpu_family', build_machine.cpu_family())

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -3376,6 +3376,29 @@ class AllPlatformTests(BasePlatformTests):
             name = entry['name']
             self.assertEqual(entry['subproject'], expected[name])
 
+    def test_introspection_target_native_subproject(self):
+        # When the same subproject is built for both the build machine
+        # (native : true) and the host machine (native : false) in a cross
+        # build, it is configured twice. The two copies of its 'lib' target
+        # share the same name and subproject but must have different ids.
+        crossdir = os.path.join(self.unit_test_dir, '69 cross')
+        # Reuse the cross test project to generate a native and a cross file
+        # describing this machine, so the configuration below is treated as a
+        # cross build (see test_identity_cross).
+        self.init(crossdir, extra_args=['-Dgenerate=true'])
+        self.meson_native_files = [os.path.join(self.builddir, "nativefile")]
+        self.meson_cross_files = [os.path.join(self.builddir, "crossfile")]
+
+        self.new_builddir()
+        testdir = os.path.join(self.unit_test_dir, '136 native subproject introspect')
+        self.init(testdir)
+        res = self.introspect('--targets')
+
+        ids = [entry['id'] for entry in res
+               if entry['name'] == 'lib' and entry['subproject'] == 'recursive-both']
+        self.assertEqual(len(ids), 2, 'subproject should be built for both machines')
+        self.assertEqual(len(set(ids)), 2, 'native and non-native targets must have different ids')
+
     def test_introspect_projectinfo_subproject_dir(self):
         testdir = os.path.join(self.common_test_dir, '75 custom subproject dir')
         self.init(testdir)

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -4120,7 +4120,7 @@ class AllPlatformTests(BasePlatformTests):
                 long comma list: alpha, alphacolor, apetag, audiofx, audioparsers, auparse,
                                  autodetect, avi
 
-              Subprojects
+              Subprojects (for host machine)
                 sub            : YES
                 sub2           : NO Problem encountered: This subproject failed
                 subsub         : YES (from sub2)

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -5008,7 +5008,7 @@ class AllPlatformTests(BasePlatformTests):
                            for_machine=MachineChoice.HOST, sources=[],
                            structured_sources=None,
                            objects=[], environment=env, compilers=env.coredata.compilers[MachineChoice.HOST],
-                           build_project=BuildProject('', '', SubProject('')), kwargs={})
+                           build_project=BuildProject('', '', SubProject(''), MachineChoice.HOST), kwargs={})
             target.process_compilers_late()
             return target.filename
 

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -21,6 +21,7 @@ from glob import glob
 from pathlib import (PurePath, Path)
 import typing as T
 
+from mesonbuild.build import BuildProject
 import mesonbuild.mlog
 import mesonbuild.depfile
 import mesonbuild.dependencies.base
@@ -34,7 +35,7 @@ from mesonbuild.mesonlib import (
     DirectoryLock, DirectoryLockAction, MachineChoice, is_windows, is_osx, is_cygwin, is_dragonflybsd,
     is_sunos, windows_proof_rmtree, python_command, version_compare, split_args, quote_arg,
     relpath, is_linux, git, search_version, do_conf_file, do_conf_str, default_prefix,
-    MesonException, EnvironmentException,
+    SubProject, MesonException, EnvironmentException,
     windows_proof_rm, first
 )
 from mesonbuild.options import OptionKey
@@ -5003,11 +5004,11 @@ class AllPlatformTests(BasePlatformTests):
         env = get_fake_env(testdir, self.builddir, self.prefix)
 
         def output_name(name, type_):
-            target = type_(name=name, subdir=None, subproject=None,
+            target = type_(name=name, subdir='',
                            for_machine=MachineChoice.HOST, sources=[],
                            structured_sources=None,
                            objects=[], environment=env, compilers=env.coredata.compilers[MachineChoice.HOST],
-                           kwargs={})
+                           build_project=BuildProject('', '', SubProject('')), kwargs={})
             target.process_compilers_late()
             return target.filename
 

--- a/unittests/machinefiletests.py
+++ b/unittests/machinefiletests.py
@@ -1014,6 +1014,45 @@ class CrossFileTests(BasePlatformTests):
                 break
         self.assertEqual(found, 2, 'Did not find all sections.')
 
+    def test_external_property_build_machine_native(self):
+        testdir = os.path.join(self.unit_test_dir, '137 external property nonexisting')
+        self.meson_native_files = [os.path.join(testdir, "propfile")]
+        out = self.init(testdir, allow_fail=True, extra_args=['-Dnative=true'])
+        self.assertIn('Unknown property for build machine: nonexisting', out)
+
+    def test_external_property_host_machine_native(self):
+        testdir = os.path.join(self.unit_test_dir, '137 external property nonexisting')
+        self.meson_native_files = [os.path.join(testdir, "propfile")]
+        out = self.init(testdir, allow_fail=True, extra_args=['-Dnative=false'])
+        self.assertIn('Unknown property for host machine: nonexisting', out)
+
+    def test_external_property_build_machine_cross(self):
+        # meson.get_external_property(..., native : true) refers to the build
+        # machine. In a cross build the build and host machines are distinct, so
+        # the error for a missing property must refer to the build machine.
+        crossdir = os.path.join(self.unit_test_dir, '69 cross')
+        # Reuse the cross test project to generate a native and a cross file
+        # describing this machine, so the configuration below is treated as a
+        # cross build (see test_identity_cross).
+        self.init(crossdir, extra_args=['-Dgenerate=true'])
+
+        nativefile = os.path.join(self.builddir, "nativefile")
+        crossfile = os.path.join(self.builddir, "crossfile")
+
+        self.new_builddir()
+        testdir = os.path.join(self.unit_test_dir, '137 external property nonexisting')
+        self.meson_native_files = [nativefile, os.path.join(testdir, "propfile")]
+        self.meson_cross_files = [crossfile]
+        out = self.init(testdir, allow_fail=True, extra_args=['-Dnative=true'])
+        self.assertIn('Unknown property for build machine: nonexisting', out)
+
+        self.new_builddir()
+        testdir = os.path.join(self.unit_test_dir, '137 external property nonexisting')
+        self.meson_native_files = [nativefile]
+        self.meson_cross_files = [crossfile, os.path.join(testdir, "propfile")]
+        out = self.init(testdir, allow_fail=True, extra_args=['-Dnative=false'])
+        self.assertIn('Unknown property for host machine: nonexisting', out)
+
     def test_project_options_native_only(self) -> None:
         # Do not load project options from a native file when doing a cross
         # build

--- a/unittests/machinefiletests.py
+++ b/unittests/machinefiletests.py
@@ -1018,7 +1018,7 @@ class CrossFileTests(BasePlatformTests):
         testdir = os.path.join(self.unit_test_dir, '137 external property nonexisting')
         self.meson_native_files = [os.path.join(testdir, "propfile")]
         out = self.init(testdir, allow_fail=True, extra_args=['-Dnative=true'])
-        self.assertIn('Unknown property for build machine: nonexisting', out)
+        self.assertIn('Unknown property for host machine: nonexisting', out)
 
     def test_external_property_host_machine_native(self):
         testdir = os.path.join(self.unit_test_dir, '137 external property nonexisting')


### PR DESCRIPTION
Building on #15395, actually add the functionality needed to build subproject for both machines. This is also propagated recursively to dependencies and subprojects of `native: true` subprojects.

Based on (and supersedes) #12258. Other than rebasing, the main logic changes are:

* reimplemented in the interpreter by rewriting the `native` and `install` keyword arguments. This ensures more easily that all created objects refer to the right machine; build targets check that they are for the build machine upon creation, and other objects then rely on the normal detection of mixed machines. It also simplifies the code, for exampe fixing project arguments
* rewritten the handling of the subproject stack, keeping a single stack but storing `(name, for_machine)` tuples in it. This makes it possible to present chains of subprojects more clearly as `a-0.1:b-2.0 (build):c-3.0`. Note that in such a scenario `c-3.0` is technically built for the *host* machine of `b-2.0 (build)` (which is the build machine of `a-0.1`). This is handled correctly by `copy_for_build_machine()` and `PerMachine`, but it messed up the old subproject stack handling.
* postconf scripts are not blocked. dist and postconf scripts should receive the subproject's roots, which is a separate change. This can be handled separately after #15395 is merged.

For now I've tested this on QEMU, by adding `native: true` to all subprojects linked to Rust procedural macro crates (such as `proc_macro2`, `quote`, `syn`) and removing it from the `dependency` and `static_library` invocations. All crates can find their dependencies correctly and there are no warnings about cross compilation breakage, including those that are only depended upon indirectly.

Fixes: #8043
Fixes: #8944 