### PR TITLE
accept subproject whose wraps cause duplicate provides

### DIFF
--- a/test cases/common/288 multiple provides/meson.build
+++ b/test cases/common/288 multiple provides/meson.build
@@ -1,0 +1,3 @@
+project('wraptest')
+
+subproject('subproject')

--- a/test cases/common/288 multiple provides/subprojects/libfoobar/meson.build
+++ b/test cases/common/288 multiple provides/subprojects/libfoobar/meson.build
@@ -1,0 +1,3 @@
+project('foobar')
+
+foobar_dep = declare_dependency()

--- a/test cases/common/288 multiple provides/subprojects/subproject/meson.build
+++ b/test cases/common/288 multiple provides/subprojects/subproject/meson.build
@@ -1,0 +1,3 @@
+project('subproject')
+
+dependency('foobar')

--- a/test cases/common/288 multiple provides/subprojects/subproject/subprojects/test-subproject.wrap
+++ b/test cases/common/288 multiple provides/subprojects/subproject/subprojects/test-subproject.wrap
@@ -1,0 +1,7 @@
+[wrap-file]
+directory = libfoobar
+source_filename = foobar-1.0.tar.gz
+
+[provide]
+dependency_names=foobar
+foobar=foobar_dep

--- a/test cases/common/288 multiple provides/subprojects/test.wrap
+++ b/test cases/common/288 multiple provides/subprojects/test.wrap
@@ -1,0 +1,7 @@
+[wrap-file]
+directory = libfoobar
+source_filename = foobar-1.0.tar.gz
+
+[provide]
+dependency_names=foobar
+foobar=foobar_dep


### PR DESCRIPTION
Since commit 56e84d3, add_wrap is called instead of using setdefault() by hand.  However, this causes the error for "Multiple wrap files provide..." to trigger incorrectly.  To avoid this add a flag to `add_wrap()` that signals that the add is part of `_merge_wraps`.

However, like after commit 56e84d3, do not add the "provides" unless the wrap itself is used.  This ensures that the "provides" set is synchronized with the meson.build file that will be used.

Testcase by George Sedov.

Fixes: #15175