### PR TITLE
Make Python module fully type safe

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -68,6 +68,7 @@ if T.TYPE_CHECKING:
         silent: bool
         tools: T.List[str]
         version_arg: str
+        build_config: str
 
     _MissingCompilerBase = Compiler
 else:

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -25,6 +25,8 @@ from ..mesonlib import MachineChoice
 from ..options import OptionKey
 from ..programs import ExternalProgram, NonExistingExternalProgram
 
+_T = T.TypeVar('_T')
+
 if T.TYPE_CHECKING:
     from typing_extensions import TypedDict, NotRequired
 
@@ -42,6 +44,7 @@ if T.TYPE_CHECKING:
         pure: T.Optional[bool]
         subdir: str
         install_tag: T.Optional[str]
+        preserve_path: bool
 
     class FindInstallationKw(ExtractRequired):
 
@@ -117,12 +120,16 @@ class PythonInstallation(ProgramHolder['PythonExternalProgram']):
         assert isinstance(prefix, str), 'for mypy'
 
         if python.build_config:
-            self.version = python.build_config['language']['version']
-            self.platform = python.build_config['platform']
-            self.suffix = python.build_config['abi']['extension_suffix']
-            self.limited_api_suffix = python.build_config['abi']['stable_abi_suffix']
-            self.link_libpython = python.build_config['libpython']['link_extensions']
-            self.is_pypy = python.build_config['implementation']['name'] == 'pypy'
+            def as_(obj: object, type_: T.Type[_T]) -> _T:
+                assert isinstance(obj, type_), 'for mypy'
+                return obj
+
+            self.version = as_(python.build_config['language']['version'], str)
+            self.platform = as_(python.build_config['platform'], str)
+            self.suffix = as_(python.build_config['abi']['extension_suffix'], str)
+            self.limited_api_suffix = as_(python.build_config['abi']['stable_abi_suffix'], str)
+            self.link_libpython = as_(python.build_config['libpython']['link_extensions'], bool)
+            self.is_pypy = as_(python.build_config['implementation']['name'], str) == 'pypy'
         else:
             self.version = info['version']
             self.platform = info['platform']
@@ -268,6 +275,7 @@ class PythonInstallation(ProgramHolder['PythonExternalProgram']):
             return dep
 
         build_config = self.interpreter.environment.coredata.optstore.get_value_for(OptionKey('python.build_config'))
+        assert isinstance(build_config, str), 'for mypy'
 
         new_kwargs = kwargs.copy()
         new_kwargs['required'] = False
@@ -402,7 +410,7 @@ class PythonModule(ExtensionModule):
 
     def _get_install_scripts(self) -> T.List[mesonlib.ExecutableSerialisation]:
         backend = self.interpreter.backend
-        ret = []
+        ret: T.List[mesonlib.ExecutableSerialisation] = []
         optlevel = self.interpreter.environment.coredata.optstore.get_value_for(OptionKey('python.bytecompile'))
         if optlevel == -1:
             return ret
@@ -412,7 +420,7 @@ class PythonModule(ExtensionModule):
         installdata = backend.create_install_data()
         py_files = []
 
-        def should_append(f, isdir: bool = False):
+        def should_append(f: str, isdir: bool = False) -> bool:
             # This uses the install_plan decorated names to see if the original source was propagated via
             # install_sources() or get_install_dir().
             return f.startswith(('{py_platlib}', '{py_purelib}')) and (f.endswith('.py') or isdir)
@@ -434,7 +442,6 @@ class PythonModule(ExtensionModule):
 
         for i in self.installations.values():
             if isinstance(i, PythonExternalProgram) and i.run_bytecompile[i.info['version']]:
-                i = T.cast('PythonExternalProgram', i)
                 manifest = f'python-{i.info["version"]}-installed.json'
                 manifest_json = []
                 for name, f in py_files:
@@ -471,6 +478,7 @@ class PythonModule(ExtensionModule):
 
     def _find_installation_impl(self, state: 'ModuleState', display_name: str, name_or_path: str, required: bool) -> MaybePythonProg:
         build_config = self.interpreter.environment.coredata.optstore.get_value_for(OptionKey('python.build_config'))
+        assert isinstance(build_config, str), 'for mypy'
 
         if not name_or_path:
             python = PythonExternalProgram('python3', mesonlib.python_command, build_config_path=build_config)

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -9,7 +9,7 @@ import typing as T
 from . import ExtensionModule, ModuleInfo
 from .. import mesonlib
 from .. import mlog
-from ..build import known_shmod_kwargs, CustomTarget, CustomTargetIndex, BuildTarget, GeneratedList, StructuredSources, ExtractedObjects, SharedModule
+from ..build import CustomTarget, CustomTargetIndex, BuildTarget, GeneratedList, StructuredSources, ExtractedObjects, SharedModule
 from ..dependencies import NotFoundDependency
 from ..dependencies.detect import get_dep_identifier, find_external_dependency
 from ..dependencies.python import BasicPythonExternalProgram, python_factory, _PythonDependencyBase
@@ -17,7 +17,7 @@ from ..interpreter import extract_required_kwarg, primitives as P_OBJ
 from ..interpreter.interpreterobjects import ProgramHolder
 from ..interpreter.type_checking import NoneType, DEPENDENCY_KWS, PRESERVE_PATH_KW, REQUIRED_KW, SHARED_MOD_KWS
 from ..interpreterbase import (
-    noPosargs, noKwargs, permittedKwargs, ContainerTypeInfo,
+    noPosargs, noKwargs, ContainerTypeInfo,
     InvalidArguments, typed_pos_args, typed_kwargs, KwargInfo,
     FeatureNew, disablerIfNotFound, InterpreterObject
 )
@@ -34,6 +34,7 @@ if T.TYPE_CHECKING:
     from ..interpreter import Interpreter
     from ..interpreter.interpreter import BuildTargetSource
     from ..interpreter.kwargs import ExtractRequired, SharedModule as SharedModuleKw, FuncDependency
+    from ..interpreter.type_checking import SourcesVarargsType
     from ..interpreterbase.baseobjects import TYPE_var, TYPE_kwargs
 
     class PyInstallKw(TypedDict):
@@ -52,14 +53,11 @@ if T.TYPE_CHECKING:
 
         # Yes, these are different between SharedModule and ExtensionModule
         install_dir: T.Union[str, bool, None]  # type: ignore[misc]
+        limited_api: str
         subdir: NotRequired[T.Optional[str]]
 
     MaybePythonProg = T.Union[NonExistingExternalProgram, 'PythonExternalProgram']
 
-
-mod_kwargs = {'subdir', 'limited_api'}
-mod_kwargs.update(known_shmod_kwargs)
-mod_kwargs -= {'name_prefix', 'name_suffix'}
 
 _MOD_KWARGS = [k for k in SHARED_MOD_KWS if
                k.name not in {'name_prefix', 'name_suffix', 'install_dir'}]
@@ -139,7 +137,6 @@ class PythonInstallation(ProgramHolder['PythonExternalProgram']):
         self.platlib_install_path = os.path.join(prefix, python.platlib)
         self.purelib_install_path = os.path.join(prefix, python.purelib)
 
-    @permittedKwargs(mod_kwargs)
     @typed_pos_args('python.extension_module', str, varargs=(str, mesonlib.File, CustomTarget, CustomTargetIndex, GeneratedList, StructuredSources, ExtractedObjects, BuildTarget))
     @typed_kwargs(
         'python.extension_module',
@@ -150,22 +147,24 @@ class PythonInstallation(ProgramHolder['PythonExternalProgram']):
     )
     @InterpreterObject.method('extension_module')
     def extension_module_method(self, args: T.Tuple[str, T.List[BuildTargetSource]], kwargs: ExtensionModuleKw) -> 'SharedModule':
+        target_kwargs = T.cast('SharedModuleKw', {k: v for k, v in kwargs.items() if k not in {'install_dir', 'subdir', 'limited_api'}})
+
         if kwargs['install_dir'] is not None:
             if kwargs['subdir'] is not None:
                 raise InvalidArguments('"subdir" and "install_dir" are mutually exclusive')
             # the build_target() method now expects this to be correct.
-            kwargs['install_dir'] = [kwargs['install_dir']]
+            target_kwargs['install_dir'] = [kwargs['install_dir']]
         else:
             # We want to remove 'subdir', but it may be None and we want to replace it with ''
             # It must be done this way since we don't allow both `install_dir`
             # and `subdir` to be set at the same time
-            subdir = kwargs.pop('subdir') or ''
+            subdir = kwargs.get('subdir') or ''
 
-            kwargs['install_dir'] = [self._get_install_dir_impl(False, subdir)]
+            target_kwargs['install_dir'] = [self._get_install_dir_impl(False, subdir)]
 
         target_suffix = self.suffix
 
-        new_deps = mesonlib.extract_as_list(kwargs, 'dependencies')
+        new_deps = kwargs['dependencies'].copy()
         pydep = next((dep for dep in new_deps if isinstance(dep, _PythonDependencyBase)), None)
         if pydep is None:
             pydep = self._dependency_method_impl({'native': kwargs['native']})
@@ -176,7 +175,7 @@ class PythonInstallation(ProgramHolder['PythonExternalProgram']):
                                   '0.63.0', self.subproject, 'use python_installation.dependency()',
                                   self.current_node)
 
-        limited_api_version = kwargs.pop('limited_api')
+        limited_api_version = kwargs.get('limited_api')
         allow_limited_api = self.interpreter.environment.coredata.optstore.get_value_for(OptionKey('python.allow_limited_api'))
         if limited_api_version != '' and allow_limited_api:
 
@@ -185,19 +184,20 @@ class PythonInstallation(ProgramHolder['PythonExternalProgram']):
             limited_api_version_hex = self._convert_api_version_to_py_version_hex(limited_api_version, pydep.version)
             limited_api_definition = f'-DPy_LIMITED_API={limited_api_version_hex}'
 
-            new_c_args = mesonlib.extract_as_list(kwargs, 'c_args')
+            new_c_args = kwargs['c_args'].copy()
             new_c_args.append(limited_api_definition)
-            kwargs['c_args'] = new_c_args
+            target_kwargs['c_args'] = new_c_args
 
-            new_cpp_args = mesonlib.extract_as_list(kwargs, 'cpp_args')
+            new_cpp_args = kwargs['cpp_args'].copy()
             new_cpp_args.append(limited_api_definition)
-            kwargs['cpp_args'] = new_cpp_args
+            target_kwargs['cpp_args'] = new_cpp_args
 
             # On Windows, the limited API DLL is python3.dll, not python3X.dll.
             for_machine = kwargs['native']
             if self.interpreter.environment.machines[for_machine].is_windows():
                 pydep_copy = copy.copy(pydep)
-                pydep_copy.find_libpy_windows(self.env, limited_api=True)
+                if isinstance(pydep_copy, _PythonDependencyBase):
+                    pydep_copy.find_libpy_windows(self.env, limited_api=True)
                 if not pydep_copy.found():
                     raise mesonlib.MesonException('Python dependency supporting limited API not found')
 
@@ -214,7 +214,7 @@ class PythonInstallation(ProgramHolder['PythonExternalProgram']):
                 python_windows_debug_link_exception = f'/NODEFAULTLIB:python{pyver}_d.lib'
                 python_windows_release_link_exception = f'/NODEFAULTLIB:python{pyver}.lib'
 
-                new_link_args = mesonlib.extract_as_list(kwargs, 'link_args')
+                new_link_args = kwargs['link_args'].copy()
 
                 is_debug = self.interpreter.environment.coredata.optstore.get_value_for('debug')
                 if is_debug:
@@ -222,24 +222,26 @@ class PythonInstallation(ProgramHolder['PythonExternalProgram']):
                 else:
                     new_link_args.append(python_windows_release_link_exception)
 
-                kwargs['link_args'] = new_link_args
+                target_kwargs['link_args'] = new_link_args
 
-        kwargs['dependencies'] = new_deps
+        target_kwargs['dependencies'] = new_deps
 
         # msys2's python3 has "-cpython-36m.dll", we have to be clever
         # FIXME: explain what the specific cleverness is here
         split, target_suffix = target_suffix.rsplit('.', 1)
         args = (args[0] + split, args[1])
 
-        kwargs['name_prefix'] = ''
-        kwargs['name_suffix'] = target_suffix
+        target_kwargs['name_prefix'] = ''
+        target_kwargs['name_suffix'] = target_suffix
 
         if kwargs['gnu_symbol_visibility'] == '' and \
                 (self.is_pypy or mesonlib.version_compare(self.version, '>=3.9')):
-            kwargs['gnu_symbol_visibility'] = 'inlineshidden'
+            target_kwargs['gnu_symbol_visibility'] = 'inlineshidden'
 
         kwargs.setdefault('rust_abi', 'c')
-        return self.interpreter.build_target(self.current_node, args, kwargs, SharedModule)
+        return self.interpreter.build_target(
+            self.current_node, T.cast('T.Tuple[str, SourcesVarargsType]', args),
+            target_kwargs, SharedModule)
 
     def _convert_api_version_to_py_version_hex(self, api_version: str, detected_version: str) -> str:
         python_api_version_format = re.compile(r'[0-9]\.[0-9]{1,2}')

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -67,6 +67,7 @@ modules = [
     'mesonbuild/modules/keyval.py',
     'mesonbuild/modules/modtest.py',
     'mesonbuild/modules/pkgconfig.py',
+    'mesonbuild/modules/python.py',
     'mesonbuild/modules/_qt.py',
     'mesonbuild/modules/qt4.py',
     'mesonbuild/modules/qt5.py',


### PR DESCRIPTION
This is cleanups made possible by the fully typed build_target arguments.

The first patch moves some things that apply to jar into the shared-with-jar state. This was hidden by the `allow_unknown=True`.

Then there's some cleanups for the simd module since we can now be sure that no extra keyword arguments are passed

Finally, we can clean up the python module and get the fully type safe.