### PR TITLE
Drop support for python < 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ build system.
  - [Ninja](https://ninja-build.org) (version 1.8.2 or newer)
 
 Latest Meson version supporting previous Python versions:
+- Python 3.9: **1.11**
+- Python 3.8: **1.11**
+- Python 3.7: **1.11**
 - Python 3.6: **0.61.5**
 - Python 3.5: **0.56.2**
 - Python 3.4: **0.45.1**

--- a/docs/markdown/FAQ.md
+++ b/docs/markdown/FAQ.md
@@ -345,7 +345,10 @@ bug fixes.
 
 - python 3.5: [supported through Meson 0.56.2](Release-notes-for-0.56.0.md#python-35-support-will-be-dropped-in-the-next-release)
 - python 3.6: [supported through Meson 0.61.5](Release-notes-for-0.61.0.md#python-36-support-will-be-dropped-in-the-next-release)
-- python 3.7: currently actively supported by Meson
+- python 3.7: [supported through Meson 1.11.x](Release-notes-for-1.11.0.md#last-major-version-supporting-python-37-38-and-39)
+- python 3.8: [supported through Meson 1.11.x](Release-notes-for-1.11.0.md#last-major-version-supporting-python-37-38-and-39)
+- python 3.9: [supported through Meson 1.11.x](Release-notes-for-1.11.0.md#last-major-version-supporting-python-37-38-and-39)
+- python 3.10: Currently supported
 
 We encourage projects to support a wide range of Meson versions if they are not
 actually using the latest features anyway. In many, many cases it is quite

--- a/docs/markdown/snippets/python-310-required.md
+++ b/docs/markdown/snippets/python-310-required.md
@@ -1,0 +1,5 @@
+## Last major version supporting Python 3.7, 3.8, and 3.9
+
+Python older than 3.10 is now EOL, and Meson will drop support for these
+versions in the next major release, and will freely use features from 3.8, 3.9
+and 3.10. Support for these versions will remain for the 1.11.x series.

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -187,7 +187,7 @@ class CommandLineParser:
         # support for old python. If this is already the oldest supported version, then
         # this can never be true and does nothing.
         pending_python_deprecation_notice = \
-            command in {'setup', 'compile', 'test', 'install'} and sys.version_info < (3, 7)
+            command in {'setup', 'compile', 'test', 'install'} and sys.version_info < (3, 10)
 
         try:
             return options.run_func(options)
@@ -198,8 +198,8 @@ class CommandLineParser:
                 mlog.warning('Running the setup command as `meson [options]` instead of '
                              '`meson setup [options]` is ambiguous and deprecated.', fatal=False)
             if pending_python_deprecation_notice:
-                mlog.notice('You are using Python 3.6 which is EOL. Starting with v0.62.0, '
-                            'Meson will require Python 3.7 or newer', fatal=False)
+                mlog.notice(f'You are using Python 3.{sys.version_info.minor} which is EOL. Starting with v1.12.0, '
+                            'Meson will require Python 3.10 or newer', fatal=False)
             mlog.shutdown()
 
 def run_script_command(script_name: str, script_args: T.List[str]) -> int:


### PR DESCRIPTION
It's time, there are nice features added by 3.8, 3.9, and 3.10. We're also forced to pin mypy, meaning we don't get access to mypy and typeshed fixes.

Closes: #14326