### PR TITLE
ninjabackend: use an import library if shared library in OS/2 for build all

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -4062,6 +4062,11 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                         t.get_outputs()[0] = linker.get_archive_name(t.get_outputs()[0])
                 targetlist.append(os.path.join(self.get_target_dir(t), t.get_outputs()[0]))
 
+                # Add an import library if shared library in OS/2 for build all
+                if isinstance(t, build.SharedLibrary):
+                    if self.environment.machines[t.for_machine].is_os2():
+                        targetlist.append(os.path.join(self.get_target_dir(t), t.import_filename))
+
             elem = NinjaBuildElement(self.all_outputs, targ, 'phony', targetlist)
             self.add_build(elem)
 


### PR DESCRIPTION
This fixes the problem that a DLL is generated but an import library does not on OS/2 when there is no the executable linking against the DLL.