### PR TITLE
install_man: add support install_tag kwarg

### DIFF
--- a/docs/markdown/snippets/install_man_kwargs.md
+++ b/docs/markdown/snippets/install_man_kwargs.md
@@ -1,0 +1,5 @@
+## install_man: add support install_tag kwarg
+
+By default install_man uses 'man' tag for its files which not always is desirable,
+for example if project uses plugin functionality and plugin wants to install its own man files
+it was not possible using `meson install --tags xxx`.

--- a/docs/yaml/functions/install_man.yaml
+++ b/docs/yaml/functions/install_man.yaml
@@ -6,6 +6,7 @@ description: |
   overridden by specifying it with the `install_dir` keyword argument.
 
   *(since 0.49.0)* [manpages are no longer compressed implicitly][install_man_49].
+  *(since 1.11.0)* install_man supports `install_tag` kwarg
 
   [install_man_49]:
   https://mesonbuild.com/Release-notes-for-0-49-0.html#manpages-are-no-longer-compressed-implicitly
@@ -31,6 +32,14 @@ kwargs:
   install_dir:
     type: str
     description: Where to install to.
+
+  install_tag:
+    type: str
+    since: 1.11.0
+    description: |
+      A string used by the `meson install --tags` command
+      to install only a subset of the files. By default these files have `man` install
+      tag which means they are installed explicitly or when no tags given at all
 
   locale:
     type: str

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1871,7 +1871,8 @@ class Backend:
                 srcabs = f.absolute_path(self.environment.get_source_dir(), self.environment.get_build_dir())
                 dstname = os.path.join(subdir, os.path.basename(fname))
                 dstabs = dstname.replace('{mandir}', manroot)
-                i = InstallDataBase(srcabs, dstabs, dstname, m.get_custom_install_mode(), m.subproject, tag='man')
+                tag = m.install_tag or 'man'
+                i = InstallDataBase(srcabs, dstabs, dstname, m.get_custom_install_mode(), m.subproject, tag=tag)
                 d.man.append(i)
 
     def generate_emptydir_install(self, d: InstallData) -> None:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -272,6 +272,7 @@ class Man(HoldableObject):
     custom_install_mode: 'FileMode'
     subproject: str
     locale: T.Optional[str]
+    install_tag: T.Optional[str] = None
 
     def get_custom_install_dir(self) -> T.Optional[str]:
         return self.custom_install_dir

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2372,6 +2372,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         KwargInfo('locale', (str, NoneType), since='0.58.0'),
         INSTALL_MODE_KW.evolve(since='0.47.0'),
         INSTALL_DIR_KW,
+        INSTALL_TAG_KW.evolve(since='1.11.0')
     )
     def func_install_man(self, node: mparser.BaseNode,
                          args: T.Tuple[T.List['mesonlib.FileOrString']],
@@ -2389,7 +2390,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                 raise InvalidArguments('Man file must have a file extension of a number between 1 and 9')
 
         m = build.Man(sources, kwargs['install_dir'], install_mode,
-                      self.subproject, kwargs['locale'])
+                      self.subproject, kwargs['locale'], kwargs['install_tag'])
         self.build.man.append(m)
 
         return m


### PR DESCRIPTION
By default install_man uses 'man' tag for it files which not always is desirable, for example if project uses plugin functionality and plugin wants to install its own man files it was not possible using `meson install --tags xxx`.

With this patch is now possible set desired install_tag for install_man command.

Additionally patch aligns functionality with other commands ( such as install_data, executable, shared_library )

for example it now to have expected `meson install --tag ...` behavior: 
```meson
...

install_man(plugin1_man, install_tag:'plugin-1')
install_man(plugin2_man, install_tag:'plugin-2')


```

Fixes: #15399

