### PR TITLE
templates: normalise source file name too in meson.build

### DIFF
--- a/mesonbuild/templates/sampleimpl.py
+++ b/mesonbuild/templates/sampleimpl.py
@@ -133,7 +133,7 @@ class FileImpl(SampleImpl):
 
     def __init__(self, args: Arguments):
         super().__init__(args)
-        self.sources = args.srcfiles if args.srcfiles else [Path(f'{self.name}.{self.source_ext}')]
+        self.sources = args.srcfiles if args.srcfiles else [Path(f'{self.lowercase_token}.{self.source_ext}')]
 
     def create_executable(self) -> None:
         source_name = f'{self.lowercase_token}.{self.source_ext}'


### PR DESCRIPTION
Otherwise, in a directory like `configure-file-int-repro`, we normalise the filename itself on disk as `configure_file_int_repro.c` but refer to `configure-file-int-repro.c` in meson.build.

Closes: https://github.com/mesonbuild/meson/issues/15416