### PR TITLE
rust: use the linker exe for the linker and not the rustc command list

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -1148,7 +1148,7 @@ def detect_rust_compiler(env: 'Environment', for_machine: MachineChoice) -> Rust
                         exelist=cc.linker.exelist, version=cc.linker.version,
                         **extra_args)  # type: ignore
                 else:
-                    linker = type(cc.linker)(compiler, env, for_machine, cc.LINKER_PREFIX,
+                    linker = type(cc.linker)(cc.linker.exelist, env, for_machine, cc.LINKER_PREFIX,
                                              always_args=always_args, system=cc.linker.system,
                                              version=cc.linker.version, **extra_args)
             elif 'link' in override[0]:


### PR DESCRIPTION
Starting with #15225 building rust code started failing with rust + llvm in MSYS2 with "lld: error: unknown argument: --allow-shlib-undefined". The problem is that LLVMDynamicLinker gets passed "rustc -C linker=clang" as the command line, and the code checking if arguments are supported fails, as it expects a linker, and LLVMDynamicLinker assumes everything goes if the command fails with an unrelated error.

Instead of passing the compiler commands, pass the linker instead.

My guess why this hasn't come up until now is that the linker was never invoked for rust before #15225 and only clang complains about --allow-shlib-undefined while gcc ignores it.
The code was added in ef9aeb188ea2bc.

Fixes #15425