### PR TITLE
Add 'limited_api' argument to dependency method

### DIFF
--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -283,7 +283,7 @@ class PythonInstallation(_ExternalProgramHolder['PythonExternalProgram']):
         'python_installation.dependency',
         *DEPENDENCY_KWS,
         KwargInfo('embed', bool, default=False, since='0.53.0'),
-        KwargInfo('limited_api', str, default='', since='1.11.0'), # 1.11.0 is a placeholder for the next version.
+        KwargInfo('limited_api', bool, default=False, since='1.11.0'), # 1.11.0 is a placeholder for the next version.
     )
     @disablerIfNotFound
     @InterpreterObject.method('dependency')


### PR DESCRIPTION
Fixes https://github.com/mesonbuild/meson/issues/15431.

If possible I would love to get this change in version 1.11 but I can understand it it cannot make it into meson by then.