### PR TITLE
Update apt sources before install

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: Install package
         run: |
+          sudo apt-get update
           sudo apt-get -y install python3-pip ninja-build libjson-glib-dev
           pip install hotdoc chevron strictyaml aiohttp
 


### PR DESCRIPTION
Without this, the apt cache may be out of sync, causing broken package links during install.