### PR TITLE
dependencies: Fix leftover `system_class=` reference in docs

### DIFF
--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -151,7 +151,7 @@ or only included in very recent versions of the dependency? We can use the
 foo_factory = DependencyFactory(
     'foo',
     [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM],
-    system_class=FooSystemDependency,
+    system=FooSystemDependency,
 )
 ```
 


### PR DESCRIPTION
The `system_class` parameter has been renamed to `system` in 63f47811eaba44ccacb8b94ee0a224d5d75dc14b.  Fix the one remaining reference to the old name in docs.

CC @dcbaker 