### PR TITLE
compilers: clike: Fix cc.get_define() on MSVC with -std:c11, on Unix

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -630,7 +630,12 @@ class CLikeCompiler(Compiler):
             raise mesonlib.MesonBugException('Delimiters not found in preprocessor output.')
         define_value = p.stdout[star_idx + len(delim_start):end_idx]
 
-        if define_value == sentinel_undef:
+        # Due to https://developercommunity.visualstudio.com/t/Inconsistent-whitespace-with-standard-pr/11023343,
+        # MSVC can end up producing an unexpected space after the sentinel_undef
+        # string (if building with -std:c11, and if the test source is written
+        # with unix newlines). To avoid treating this as an actual predefined
+        # macro, look for the buggy value as well.
+        if define_value in {sentinel_undef, sentinel_undef + ' '}:
             define_value = None
         else:
             # Merge string literals


### PR DESCRIPTION
If doing cc.get_define() with MSVC, for a symbol that isn't defined, then get_define() can end up returning sentinel_undef with a trailing space, as an actual defined string.

This happens if MSVC is called with -std:c11 (or -Zc:preprocessor, to opt in to the newer, standards conformant preprocessor mode) and the test source file is written with Unix newlines.

(This is observed if cross compiling with MSVC wrapped in Wine on Unix, but probably would appear the same if Meson was running in Cygwin/msys2 Python as well.)

This issue has been reported upstream to MSVC at [1].

[1] https://developercommunity.visualstudio.com/t/Inconsistent-whitespace-with-standard-pr/11023343