### PR TITLE
compilers/gnu: add -Zomf option according to os2_emxomf option on OS/2

### DIFF
--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -658,7 +658,7 @@ class GnuCompiler(GnuLikeCompiler):
 
     def get_always_args(self) -> T.List[str]:
         args: T.List[str] = []
-        if self.info.is_os2() and self.get_linker_id() == 'emxomfld':
+        if self.info.is_os2() and self.environment.coredata.optstore.get_value_for(OptionKey('os2_emxomf')):
             args += ['-Zomf']
         return super().get_always_args() + args
 


### PR DESCRIPTION
If -Zomf is added to compile args according to linker id, conflicts occurs between archive type and object type when adding -Zomf to LDFLAGS or xx_link_args. That is, archive type is aout but object type is omf. This leads to link failure.

In addition, with this patch, it's possible to switch os2_emxomf option with --reconfigure option.