### PR TITLE
python: Allow custom targets as install sources

### DIFF
--- a/docs/markdown/snippets/python_install_sources_non_file.md
+++ b/docs/markdown/snippets/python_install_sources_non_file.md
@@ -1,0 +1,5 @@
+## `python_installation.install_sources()` now supports custom targets
+
+Previously, `python_installation.install_sources()` only supported
+`File` and `str` type sources. Now, you can use it with any file-like
+variables, including those produced by `custom_target()`.

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -326,6 +326,9 @@ class PythonInstallation(_ExternalProgramHolder['PythonExternalProgram']):
         state = self.held_object.state
         content_files = []
         for s in sources:
+            if not isinstance(s, (File, str)):
+                FeatureNew.single_use('python_installation.install_sources with non-File/str source', '1.11.0',
+                                      self.subproject, location=self.current_node)
             if isinstance(s, Target):
                 s.build_by_default = True
             if isinstance(s, (CustomTarget, CustomTargetIndex)):

--- a/test cases/python/12 install_sources non-file/meson.build
+++ b/test cases/python/12 install_sources non-file/meson.build
@@ -1,0 +1,13 @@
+project('install_sources non-file')
+
+py = import('python').find_installation()
+
+custom = custom_target(
+    output: 'gluon.py',
+    command: [
+        find_program('touch'),
+        '@OUTPUT@',
+    ],
+)
+
+py.install_sources(custom)


### PR DESCRIPTION
I'm trying to convert a Python project to use Meson, but some of my Python sources need to be generated at build time. Most Meson functions that take file arguments also accept the file-like objects returned by `custom_target()` and similar, but `python_installation.install_sources()` gives an error if you call it with any paths that aren't `File` or `str` types. https://github.com/mesonbuild/meson/issues/7372#issuecomment-796623302 offers a workaround, but allowing any file-like paths in `python_installation.install_sources()` seems like a better solution.

I'm not sure if this would be considered a bug fix or a new feature, so to be safe, I treated it as a feature and followed the instructions at [`mesonbuild.com/Contributing.html#special-procedure-for-new-features`](https://mesonbuild.com/Contributing.html#special-procedure-for-new-features).

---

I'm completely unfamiliar with the Meson code base, so I copied most of the code from `mesonbuild/modules/_qt.py`:

https://github.com/mesonbuild/meson/blob/1a8a4434fb2189cabd88ee382268d12093be7a73/mesonbuild/modules/_qt.py#L756-L774

This function requires a `ModuleState`, but I couldn't find one exposed in `PythonInstallation`, so I modified `PythonExternalProgram` to save the `state` there. But this causes the tests to fail with a `This class is unpicklable` error, so I'm unsure how to proceed. Any suggestions?