### PR TITLE
build: Propagate link_language instead of internals

### DIFF
--- a/test cases/unit/133 promote link_language/consumer.c
+++ b/test cases/unit/133 promote link_language/consumer.c
@@ -1,0 +1,5 @@
+#include "header.h"
+
+int passInt(void) {
+    return makeInt();
+}

--- a/test cases/unit/133 promote link_language/header.h
+++ b/test cases/unit/133 promote link_language/header.h
@@ -1,0 +1,10 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int makeInt(void);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+

--- a/test cases/unit/133 promote link_language/lib.cpp
+++ b/test cases/unit/133 promote link_language/lib.cpp
@@ -1,0 +1,5 @@
+#include "header.h"
+
+int makeInt(void) {
+    return 1;
+}

--- a/test cases/unit/133 promote link_language/meson.build
+++ b/test cases/unit/133 promote link_language/meson.build
@@ -1,0 +1,12 @@
+project('promote link_language', 'c', 'cpp')
+
+cxx = meson.get_compiler('cpp')
+
+lib = library('cxxlib-w-c-linkage', 'lib.cpp',
+  cpp_args: cxx.get_supported_arguments(['-fno-exceptions', '-fno-rtti', '/EHc']),
+  link_language : 'c',
+)
+
+con = library('consumer', 'consumer.c',
+  link_with: lib
+)

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -5426,6 +5426,20 @@ class AllPlatformTests(BasePlatformTests):
             olddata = newdata
             oldmtime = newmtime
 
+    def test_link_language_promotion(self):
+        if self.backend is Backend.vs:
+            raise SkipTest('target introspection is lacking linker details')
+        testdir = os.path.join(self.unit_test_dir, '133 promote link_language')
+        self.init(testdir)
+        cintrospection = self.introspect('--compilers')
+        clinker = cintrospection['host']['c']['linker_exelist']
+
+        tintrospection = self.introspect('--targets')
+        consumer = next(t for t in tintrospection if t['name'] == 'consumer')
+        linker_src = next(s for s in consumer['target_sources'] if 'linker' in s)
+
+        self.assertEqual(clinker, linker_src['linker'])
+
     def __test_multi_stds(self, test_c: bool = True, test_objc: bool = False) -> None:
         assert test_c or test_objc, 'must test something'
         testdir = os.path.join(self.unit_test_dir, '115 c cpp stds')


### PR DESCRIPTION
If a build target has link_language set, use that instead of propagating the language the target was written in.

This fixes the issue, that if you have a build target with cpp sources but with link_language being set to 'c', targets which link against the build target will be linked with the cpp linker, even tho that isn't necessary.

---

The non-link_language branch has some special casing for rust, which *might* have to be replicated in the new branch too. I'm not quite sure what exactly is does, so I'd appreciate some feedback on if that is necessary.