### PR TITLE
feat(zig): support zig c++ with target

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -484,11 +484,11 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
                 # style ld, but for clang on "real" windows we'll use
                 # either link.exe or lld-link.exe
                 try:
-                    linker = guess_win_linker(env, compiler_for_detection, cls, version, for_machine, invoked_directly=False)
+                    linker = guess_win_linker(env, compiler, cls, version, for_machine, invoked_directly=False)
                 except MesonException:
                     pass
             if linker is None:
-                linker = guess_nix_linker(env, compiler_for_detection, cls, version, for_machine)
+                linker = guess_nix_linker(env, compiler, cls, version, for_machine)
 
             return cls(
                 ccache, compiler, version, for_machine, env,


### PR DESCRIPTION
meson currently doesnt' support `zig c++` with target, it will failed the detection.

we should skip the target options at detect time.

```
  Build started at 2026-01-08T17:45:36.039849
  Main binary: /opt/hostedtoolcache/Python/3.10.19/x64/bin/python
  Build Options: -Dbuildtype=release -Db_ndebug=if-release -Db_vscrt=md -Derrorlogs=True --native-file=/home/runner/work/bencode-py/bencode-py/.mesonpy-rcgv73aa/meson-python-native-file.ini
  Python system: Linux
  The Meson build system
  Version: 1.10.0
  Source dir: /home/runner/work/bencode-py/bencode-py
  Build dir: /home/runner/work/bencode-py/bencode-py/.mesonpy-rcgv73aa
  Build type: native build
  Project name: bencode2
  Project version: undefined
  -----------
  Detecting compiler via: `zig c++ --target x86_64-linux-gnu.2.17 --version` -> 1
  stderr:
  error: Unknown Clang option: '--target'
  -----------
  
  ../meson.build:1:0: ERROR: Unknown compiler(s): [['zig', 'c++', '--target', 'x86_64-linux-gnu.2.17']]
```
what we will got with this patch:

```
$ rm build -rf && CXX="zig c++ -target x86_64-linux-gnu.2.17" CC="zig cc -target x86_64-linux-gnu.2.17" python ~/proj/meson/meson.py setup build
The Meson build system
Version: 1.10.99
Source dir: /home/trim21/proj/bencode-py
Build dir: /home/trim21/proj/bencode-py/build
Build type: native build
Project name: bencode2
Project version: undefined
C++ compiler for the host machine: zig c++ -target x86_64-linux-gnu.2.17 (clang 20.1.2 "clang version 20.1.2 (https://github.com/ziglang/zig-bootstrap 7ef74e656cf8ddbd6bf891a8475892aa1afa6891)")
C++ linker for the host machine: zig c++ ld.zigcc 0.15.2
Host machine cpu family: x86_64
Host machine cpu: x86_64
Program python3 found: YES (/home/trim21/proj/bencode-py/.venv/bin/python)
Found pkg-config: YES (/usr/bin/pkg-config) 1.8.1
Found CMake: /usr/bin/cmake (3.31.6)
Run-time dependency nanobind found: NO  (tried pkg-config and cmake)
Looking for a fallback subproject for the dependency nanobind
Building fallback subproject with default_library=static

Executing subproject nanobind

nanobind| Project name: nanobind
nanobind| Project version: 2.9.2
nanobind| C++ compiler for the host machine: zig c++ -target x86_64-linux-gnu.2.17 (clang 20.1.2 "clang version 20.1.2 (https://github.com/ziglang/zig-bootstrap 7ef74e656cf8ddbd6bf891a8475892aa1afa6891)")
nanobind| C++ linker for the host machine: zig c++ ld.zigcc 0.15.2
nanobind| Program python3 found: YES (/home/trim21/proj/bencode-py/.venv/bin/python)
nanobind| Found pkg-config: YES (/usr/bin/pkg-config) 1.8.1
nanobind| Run-time dependency python found: YES 3.14
nanobind| Run-time dependency robin-map found: NO  (tried pkg-config and cmake)
nanobind| Looking for a fallback subproject for the dependency robin-map

Executing subproject nanobind:robin-map

robin-map| Project name: robin-map
robin-map| Project version: 1.4.0
robin-map| C++ compiler for the host machine: zig c++ -target x86_64-linux-gnu.2.17 (clang 20.1.2 "clang version 20.1.2 (https://github.com/ziglang/zig-bootstrap 7ef74e656cf8ddbd6bf891a8475892aa1afa6891)")
robin-map| C++ linker for the host machine: zig c++ ld.zigcc 0.15.2
robin-map| Build targets in project: 0
robin-map| Subproject robin-map finished.

nanobind| Dependency robin-map from subproject subprojects/robin-map-1.4.0 found: YES 1.4.0
nanobind| Build targets in project: 0
nanobind| Subproject nanobind finished.

Dependency nanobind from subproject subprojects/nanobind-2.9.2 found: YES 2.9.2
Build targets in project: 2

bencode2 undefined

  Subprojects
    nanobind : YES
    robin-map: YES (from nanobind)

Found ninja-1.13.0.git.kitware.jobserver-pipe-1 at /home/trim21/.local/bin/ninja
$ ninja -C build
ninja: Entering directory `build'
[5/5] Linking target __bencode.cpython-314-x86_64-linux-gnu.so
warning: ignoring deprecated linker optimization setting '1'
```


This is my first PR to meson, I'm not sure how to test this.

close https://github.com/mesonbuild/meson/issues/15451 https://github.com/mesonbuild/meson/issues/11886