### PR TITLE
modules/rust: Attempt to extract `--target` arguments from rustc command

### DIFF
--- a/test cases/unit/134 minimal bindgen/header.h
+++ b/test cases/unit/134 minimal bindgen/header.h
@@ -1,0 +1,6 @@
+#pragma once
+
+int func(int x) {
+    return x + 1;
+}
+

--- a/test cases/unit/134 minimal bindgen/meson.build
+++ b/test cases/unit/134 minimal bindgen/meson.build
@@ -1,0 +1,5 @@
+project('minimal bindgen', 'c', 'rust', meson_version : '>= 1.0.0')
+
+rust = import('rust')
+
+header_rs = rust.bindgen(input : 'header.h', output : 'header.rs')


### PR DESCRIPTION
This will look for `--target` and `--target=` in the configured rust command, but only if `--target` or `--target=` has not been passed in the bindgen_clang_args of the machine file.

TODO: still needs tests.

Fixes: #13591