### PR TITLE
`env` crashes meson with value of list of list of strings

### DIFF
--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -249,7 +249,7 @@ def env_convertor_with_method(value: _FullEnvInitValueType,
     elif isinstance(value, list):
         return EnvironmentVariables(dict(split_equal_string(v) for v in listify(value)), init_method, separator)
     elif isinstance(value, dict):
-        return EnvironmentVariables(value, init_method, separator)
+        return EnvironmentVariables({k: listify(dv) for k, dv in value.items()}, init_method, separator)
     elif value is None:
         return EnvironmentVariables()
     return value

--- a/test cases/common/50 custom target chain/meson.build
+++ b/test cases/common/50 custom target chain/meson.build
@@ -14,6 +14,7 @@ infile = files('data_source.txt')[0]
 mytarget = custom_target('bindat',
   output : 'data.dat',
   command : [python, comp, infile, '@OUTPUT@'],
+  env: {'SOME_ENV_VAR': ['garbage', ['in', 'garbage', 'out']]},
 )
 
 mytarget2 = custom_target('bindat2',


### PR DESCRIPTION
A listify is performed in the validator but not the converter. Make the two match.

Fixes: #15459 