### PR TITLE
Remove echomsg from vim indent file

### DIFF
--- a/data/syntax-highlighting/vim/indent/meson.vim
+++ b/data/syntax-highlighting/vim/indent/meson.vim
@@ -34,8 +34,6 @@ set cpo&vim
 let s:maxoff = 50	" maximum number of lines to look backwards for ()
 
 function GetMesonIndent(lnum)
-  echom getline(line("."))
-
   " If this line is explicitly joined: If the previous line was also joined,
   " line it up with that one, otherwise add two 'shiftwidth'
   if getline(a:lnum - 1) =~ '\\$'


### PR DESCRIPTION
Fixes #15455

echomsg doesn't do anything in vim anyway, so I removed it.