### PR TITLE
Fixes for changed path handling in Python 3.13 on Windows

### DIFF
--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -260,7 +260,7 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
         for arg in args:
             if arg.startswith(('/LIBPATH:', '-LIBPATH:')):
                 result.append('-L' + arg[9:])
-            elif arg.endswith(('.a', '.lib')) and not os.path.isabs(arg):
+            elif arg.endswith(('.a', '.lib')) and not mesonlib.path_has_root(arg):
                 result.append('-l' + arg)
             else:
                 result.append(arg)

--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from .base import ExternalDependency, DependencyException, sort_libpaths, DependencyTypeName
 from ..mesonlib import (EnvironmentVariables, OrderedSet, PerMachine, Popen_safe, Popen_safe_logged, MachineChoice,
-                        join_args, MesonException)
+                        join_args, MesonException, path_has_root)
 from ..options import OptionKey
 from ..programs import find_external_program, ExternalProgram
 from .. import mlog
@@ -420,7 +420,7 @@ class PkgConfigDependency(ExternalDependency):
         for arg in raw_link_args:
             if arg.startswith('-L') and not arg.startswith(('-L-l', '-L-L')):
                 path = arg[2:]
-                if not os.path.isabs(path):
+                if not path_has_root(path):
                     # Resolve the path as a compiler in the build directory would
                     path = os.path.join(self.env.get_build_dir(), path)
                 prefix_libpaths.add(path)

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -11,10 +11,10 @@ import platform
 import sys
 
 from . import mesonlib
-from .mesonlib import EnvironmentException, HoldableObject, Popen_safe
+from .mesonlib import EnvironmentException, HoldableObject, lazy_property, Popen_safe
 from .programs import ExternalProgram
 from . import mlog
-from pathlib import Path
+from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
 
 if T.TYPE_CHECKING:
     from .options import ElementaryOptionValues
@@ -317,6 +317,13 @@ class MachineInfo(HoldableObject):
         Machine is cygwin?
         """
         return self.system == 'cygwin'
+
+    @lazy_property
+    def pure_path_class(self) -> T.Type[PurePath]:
+        """Get the appropriate PurePath class for this machine."""
+        if self.is_windows():
+            return PureWindowsPath
+        return PurePosixPath
 
     def is_linux(self) -> bool:
         """

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -197,6 +197,9 @@ class Environment:
         self.properties = properties.default_missing()
         self.cmakevars = cmakevars.default_missing()
 
+        # Set host machine info for machine-aware handling of directory options
+        self.coredata.optstore.set_host_machine(self.machines.host)
+
         # Take default value from env if not set in cross/native files or command line.
         self._set_default_options_from_env()
         self._set_default_binaries_from_env()

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -11,7 +11,7 @@ import re
 
 from .base import ArLikeLinker, RSPFileSyntax
 from .. import mesonlib
-from ..mesonlib import EnvironmentException, MesonException
+from ..mesonlib import EnvironmentException, MesonException, path_has_root
 from ..arglist import CompilerArgs
 
 if T.TYPE_CHECKING:
@@ -612,7 +612,7 @@ def order_rpaths(rpath_list: T.List[str]) -> T.List[str]:
 def evaluate_rpath(p: str, build_dir: str, from_dir: str) -> str:
     if p == from_dir:
         return '' # relpath errors out in this case
-    elif os.path.isabs(p):
+    elif path_has_root(p):
         return p # These can be outside of build dir.
     else:
         return os.path.relpath(os.path.join(build_dir, p), os.path.join(build_dir, from_dir))

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -18,7 +18,7 @@ import re
 from . import build, tooldetect
 from .backend.backends import InstallData
 from .mesonlib import (MesonException, Popen_safe, RealPathAction, is_windows,
-                       is_aix, setup_vsenv, pickle_load, is_osx)
+                       is_aix, setup_vsenv, path_has_root, pickle_load, is_osx)
 from .options import OptionKey
 from .scripts import depfixer, destdir_join
 from .scripts.meson_exe import run_exe
@@ -267,7 +267,7 @@ def restore_selinux_contexts() -> None:
               'Standard error:', err, sep='\n')
 
 def get_destdir_path(destdir: str, fullprefix: str, path: str) -> str:
-    if os.path.isabs(path):
+    if path_has_root(path):
         output = destdir_join(destdir, path)
     else:
         output = os.path.join(fullprefix, path)
@@ -443,7 +443,7 @@ class Installer:
 
     def do_symlink(self, target: str, link: str, destdir: str, full_dst_dir: str) -> bool:
         abs_target = target
-        if not os.path.isabs(target):
+        if not path_has_root(target):
             abs_target = os.path.join(full_dst_dir, target)
         elif not os.path.exists(abs_target):
             abs_target = destdir_join(destdir, abs_target)
@@ -543,7 +543,7 @@ class Installer:
         destdir = self.options.destdir
         if destdir is None:
             destdir = os.environ.get('DESTDIR')
-        if destdir and not os.path.isabs(destdir):
+        if destdir and not path_has_root(destdir):
             destdir = os.path.join(d.build_dir, destdir)
         # Override in the env because some scripts could use it and require an
         # absolute path.

--- a/mesonbuild/scripts/cleantrees.py
+++ b/mesonbuild/scripts/cleantrees.py
@@ -9,10 +9,12 @@ import shutil
 import pickle
 import typing as T
 
+from ..mesonlib import path_has_root
+
 def rmtrees(build_dir: str, trees: T.List[str]) -> None:
     for t in trees:
         # Never delete trees outside of the builddir
-        if os.path.isabs(t):
+        if path_has_root(t):
             print(f'Cannot delete dir with absolute path {t!r}')
             continue
         bt = os.path.join(build_dir, t)


### PR DESCRIPTION
This PR is a combination of two parts that intersect:

1) Python 3.13 changed the definition of `os.path.isabs` on Windows, to include only paths that have a drive as well. We need to audit all of Meson to see what really needs the old definition (and I've started), but in the meanwhile this is breaking many tests, for example due to incorrect joining of `\abc\def` paths to destdirs.

2) When cross-compiling (e.g., from Linux to Windows), directory options like prefix, bindir, and libdir should accept paths in the host machine's format, not the build machine's format.  This means that when cross-compiling from Linux to Windows, `--prefix=C:\Windows` would incorrectly fail because os.path.isabs() returns False for Windows paths on Linux. Replace os.path.isabs() and pathlib.PurePath() with PureWindowsPath for Windows hosts, PurePosixPath otherwise.

The reason why these intersect, is that the new definition of `os.path.isabs` basically makes it impossible to cross-compile from Windows to a POSIX platform. That's because `prefix` must be absolute but also must be a POSIX path, making it impossible in Python 3.13 to pass a valid prefix for this cross compilation scenario, that passes `os.path.isabs`.

So, the second part of the work (the last two commits) becomes much more important for 3.13.

Fixes: #7577