### PR TITLE
unittests: Write temporary files to tmpdir unless on Windows

### DIFF
--- a/unittests/platformagnostictests.py
+++ b/unittests/platformagnostictests.py
@@ -207,8 +207,8 @@ class PlatformAgnosticTests(BasePlatformTests):
     def test_validate_dirs(self):
         testdir = os.path.join(self.common_test_dir, '1 trivial')
 
-        # Using parent as builddir should fail
-        self.builddir = os.path.dirname(self.builddir)
+        # Using parent as source directory should fail
+        self.builddir = os.path.dirname(os.getcwd())
         with self.assertRaises(subprocess.CalledProcessError) as cm:
             self.init(testdir)
         self.assertIn('cannot be a parent of source directory', cm.exception.stdout)


### PR DESCRIPTION
We write these files into the current directory to work around Windows virus scanners. Meanwhile, that forces a ton of writes to developer's SSDs that aren't useful, and can leave `tmp*` files all over their meson directory. Let's only write into cwd if we're on Windows, and give a developer a way to opt out.