### PR TITLE
docs: add note for custom_target character replacement

### DIFF
--- a/docs/yaml/functions/custom_target.yaml
+++ b/docs/yaml/functions/custom_target.yaml
@@ -137,6 +137,9 @@ kwargs:
       '-arg1', '-arg2']` rather than as a string `'commandname -arg1
       -arg2'` as the latter will *not* work.
 
+      *Note:* due to an [issue with path handling](https://github.com/mesonbuild/meson/issues/1564)
+      any backslash (`\`) characters are rewritten as slash (`/`).
+
   depend_files:
     type: array[str | file]
     description: |


### PR DESCRIPTION
Added note about implicit backslash character replacement within all `custom_target` command arguments.

https://github.com/mesonbuild/meson/blob/64e3f46032701730518c060aba0448a136ce7bfe/mesonbuild/backend/backends.py#L1583-L1601

This behaviour leads to some extremely confusing and hard to debug build issues. The root issue (#1564) appears to be long running and has some contention around previous attempts to resolve. While this remains active it seems sensible to make side effects of the current workaround clear.