### PR TITLE
Fix mtest on OS/2

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1277,7 +1277,7 @@ async def read_decode(reader: asyncio.StreamReader,
             await queue.put(None)
 
 def run_with_mono(fname: str) -> bool:
-    return fname.endswith('.exe') and not (is_windows() or is_cygwin())
+    return fname.endswith('.exe') and not (is_windows() or is_cygwin() or is_os2())
 
 def check_testdata(objs: T.List[TestSerialisation]) -> T.List[TestSerialisation]:
     if not isinstance(objs, list):


### PR DESCRIPTION
Hi/2.

This PR is to fix mtest on OS/2.

1. Ignore `preexec_fn` which is not supported on OS/2.
2. `mono` is not necessary when running `.exe` on OS/2.

Review, please...
