### PR TITLE
gnome: look up vapigen using pkg-config

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -308,20 +308,19 @@ class GnomeModule(ExtensionModule):
     @staticmethod
     def _find_tool(state: 'ModuleState', tool: str) -> Program:
         tool_map = {
-            'gio-querymodules': 'gio-2.0',
-            'glib-compile-schemas': 'gio-2.0',
-            'glib-compile-resources': 'gio-2.0',
-            'gdbus-codegen': 'gio-2.0',
-            'glib-genmarshal': 'glib-2.0',
-            'glib-mkenums': 'glib-2.0',
-            'g-ir-scanner': 'gobject-introspection-1.0',
-            'g-ir-compiler': 'gobject-introspection-1.0',
-            'vapigen': 'vapigen',
+            'gio-querymodules': ('gio-2.0', False),
+            'glib-compile-schemas': ('gio-2.0', True),
+            'glib-compile-resources': ('gio-2.0', True),
+            'gdbus-codegen': ('gio-2.0', True),
+            'glib-genmarshal': ('glib-2.0', True),
+            'glib-mkenums': ('glib-2.0', True),
+            'g-ir-scanner': ('gobject-introspection-1.0', False),
+            'g-ir-compiler': ('gobject-introspection-1.0', False),
+            'vapigen': ('vapigen', False),
         }
-        native_deps = {'gio-2.0', 'glib-2.0'}
-        depname = tool_map[tool]
+        depname, native = tool_map[tool]
         varname = tool.replace('-', '_')
-        return state.find_tool(tool, depname, varname, native=depname in native_deps)
+        return state.find_tool(tool, depname, varname, native=native)
 
     @typed_kwargs(
         'gnome.post_install',


### PR DESCRIPTION
vapigen has architecture-dependent search path. In a cross build, using the native one cannot work as it cannot locate the host libraries it is supposed to use. On most distributions, vapigen.pc names location of vapigen (often suffixed with an appropriate version). On Debian, vapigen.pc points at an architecture-specific wrapper that adapts the search path for the desired architecture. It is never wrong to consult vapigen.pc and it also helps users with multiple vala installations selecting the right one. Thus prefer locating vapigen via its pc file over searching $PATH while retaining the override mechanisms available.

Link: https://bugs.debian.org/1061107
Link: https://salsa.debian.org/gnome-team/vala/-/merge_requests/3
Related: 62a5e3a82a61 ("env2mfile: Use a cross vapigen on Debian if available")
Thanks: Simon McVittie
Thanks: Eli Schwartz