### PR TITLE
i18n module: add msgfmt_args argument to i18n.gettext

### DIFF
--- a/docs/markdown/i18n-module.md
+++ b/docs/markdown/i18n-module.md
@@ -17,6 +17,8 @@ argument which is the name of the gettext module.
 
 * `args`: list of extra arguments to pass to `xgettext` when
   generating the pot file
+* `msgfmt_args`: (*Added 1.12.0*) list of extra arguments to pass to `msgfmt` when
+  building the translations
 * `data_dirs`: (*Added 0.36.0*) list of directories to be set for
   `GETTEXTDATADIRS` env var (Requires gettext 0.19.8+), used for local
   its files

--- a/docs/markdown/snippets/i18n_msgfmt_args.md
+++ b/docs/markdown/snippets/i18n_msgfmt_args.md
@@ -1,0 +1,12 @@
+## Added `msgfmt_args` arg to `i18n.gettext`
+
+`i18n.gettext` now supports the `msgfmt_args` argument.
+This argument can be used to pass additional arguments to
+`msgfmt` when building the translations.
+
+```meson
+i18n = import('i18n')
+i18n.gettext('mycatalog',
+             args : ['-k_', '-kN_'],
+             msgfmt_args : ['--use-fuzzy'])
+```

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -48,6 +48,7 @@ if T.TYPE_CHECKING:
     class Gettext(TypedDict):
 
         args: T.List[str]
+        msgfmt_args: T.List[str]
         data_dirs: T.List[str]
         install: bool
         install_dir: T.Optional[str]
@@ -81,6 +82,14 @@ _ARGS: KwargInfo[T.List[str]] = KwargInfo(
     ContainerTypeInfo(list, str),
     default=[],
     listify=True,
+)
+
+_MSGFMT_ARGS: KwargInfo[T.List[str]] = KwargInfo(
+    'msgfmt_args',
+    ContainerTypeInfo(list, str),
+    default=[],
+    listify=True,
+    since='1.12.0',
 )
 
 _DATA_DIRS: KwargInfo[T.List[str]] = KwargInfo(
@@ -350,6 +359,7 @@ class I18nModule(ExtensionModule):
     @typed_kwargs(
         'i18n.gettext',
         _ARGS,
+        _MSGFMT_ARGS,
         _DATA_DIRS.evolve(since='0.36.0'),
         INSTALL_KW.evolve(default=True),
         INSTALL_DIR_KW.evolve(since='0.50.0'),
@@ -422,12 +432,15 @@ class I18nModule(ExtensionModule):
             if isinstance(install_dir, OptionString):
                 name = path.join(install_dir.optname, l, 'LC_MESSAGES')
                 mo_install_dir = OptionString(mo_install_dir, name)
+
+            gmobasecmd: list[str | Program] = [self.tools['msgfmt'], '-o', '@OUTPUT@', '@INPUT@']
+
             gmotarget = build.CustomTarget(
                 f'{packagename}-{l}.mo',
                 path.join(state.subdir, l, 'LC_MESSAGES'),
                 state.subproject,
                 state.environment,
-                [self.tools['msgfmt'], '-o', '@OUTPUT@', '@INPUT@'],
+                [*gmobasecmd, *kwargs['msgfmt_args']],
                 [po_file],
                 [f'{packagename}.mo'],
                 install=install,

--- a/test cases/frameworks/6 gettext/po/meson.build
+++ b/test cases/frameworks/6 gettext/po/meson.build
@@ -1,4 +1,4 @@
 langs = ['fi', 'de', 'ru']
 
-gettext_targets = i18n.gettext('intltest', languages : langs)
+gettext_targets = i18n.gettext('intltest', languages : langs, msgfmt_args : ['--use-fuzzy'])
 mo_targets = gettext_targets[0]


### PR DESCRIPTION
This allows passing additional arguments like `--use-fuzzy` to msgfmt whenn building the translations.

---

This is a fairly simple addition so I just modified the existing (only?) test for `i18n.gettext`. Let me know if I should make a dedicated test.