### PR TITLE
Convert BuildTarget arguments explicitly in the interpreter

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3254,7 +3254,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 compiler_name = self.compiler_to_rule_name(compiler)
         else:
             compiler_name = self.compiler_to_rule_name(compiler)
-        extra_deps = []
+        extra_deps = self.get_target_depend_files(target).copy()
         if compiler.get_language() == 'fortran':
             # Can't read source file to scan for deps if it's generated later
             # at build-time. Skip scanning for deps, and just set the module

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -115,7 +115,6 @@ if T.TYPE_CHECKING:
         vala_vapi: T.Optional[str]
         install_vala_vapi: bool
         install_vala_vapi_dir: T.Optional[str]
-        win_subsystem: str
 
         _allow_no_sources: bool
 
@@ -126,6 +125,7 @@ if T.TYPE_CHECKING:
         export_dynamic: bool
         pie: bool
         vs_module_defs: T.Union[str, File, CustomTarget, CustomTargetIndex]
+        win_subsystem: str
 
     class SharedModuleKeywordArguments(BuildTargetKeywordArguments, total=False):
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -144,6 +144,13 @@ if T.TYPE_CHECKING:
         pic: bool
         prelink: bool
 
+    class JarKeywordArguments(BuildTargetKeywordArguments, total=False):
+
+        java_args: T.List[str]
+        java_resources: T.Optional[StructuredSources]
+        main_class: str
+
+
 _T = T.TypeVar('_T')
 
 DEFAULT_STATIC_LIBRARY_NAMES: T.Mapping[str, T.Tuple[str, str]] = {
@@ -3329,7 +3336,7 @@ class Jar(BuildTarget):
     def __init__(self, name: str, subdir: str, subproject: str, for_machine: MachineChoice,
                  sources: T.List[SourceOutputs], structured_sources: T.Optional['StructuredSources'],
                  objects, environment: Environment, compilers: CompilerDict,
-                 kwargs):
+                 kwargs: JarKeywordArguments):
         super().__init__(name, subdir, subproject, for_machine, sources, structured_sources, objects,
                          environment, compilers, kwargs)
         for s in self.sources:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -896,7 +896,6 @@ class BuildTarget(Target):
             mlog.warning(f'Build target {name} has no sources. '
                          'This was never supposed to be allowed but did because of a bug, '
                          'support will be removed in a future release of Meson')
-        self.check_unknown_kwargs(kwargs)
         self.validate_install()
         self.check_module_linking()
 
@@ -984,23 +983,6 @@ class BuildTarget(Target):
                 raise InvalidArguments('Tried to install a target for the build machine in a cross build.')
             else:
                 mlog.warning('Installing target build for the build machine. This will fail in a cross build.')
-
-    def check_unknown_kwargs(self, kwargs: BuildTargetKeywordArguments) -> None:
-        # Override this method in derived classes that have more
-        # keywords.
-        self.check_unknown_kwargs_int(kwargs, self.known_kwargs)
-
-    def check_unknown_kwargs_int(self, kwargs: BuildTargetKeywordArguments, known_kwargs: T.Set[str]) -> None:
-        unknowns = []
-        for k in kwargs:
-            if k in {'language_args', 'install_vala_header', 'install_vala_vapi',
-                     'install_vala_gir', 'install_vala_header_dir',
-                     'install_vala_vapi_dir', 'install_vala_gir_dir'}:
-                continue
-            if k not in known_kwargs:
-                unknowns.append(k)
-        if len(unknowns) > 0:
-            mlog.warning('Unknown keyword argument(s) in target {}: {}.'.format(self.name, ', '.join(unknowns)))
 
     def process_objectlist(self, objects: T.List[ObjectTypes]) -> None:
         assert isinstance(objects, list)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -81,6 +81,7 @@ if T.TYPE_CHECKING:
         d_module_versions: T.List[T.Union[str, int]]
         d_unittest: bool
         dependencies: T.List[dependencies.Dependency]
+        depend_files: T.List[File]
         extra_files: T.List[File]
         gnu_symbol_visibility: Literal['default', 'internal', 'hidden', 'protected', 'inlineshidden', '']
         implicit_include_directories: bool

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -836,7 +836,7 @@ class BuildTarget(Target):
         self.link_language: T.Optional[Language] = kwargs.get('link_language')
         self.link_targets: T.List[BuildTargetTypes] = []
         self.link_whole_targets: T.List[StaticTargetTypes] = []
-        self.depend_files: T.List[File] = []
+        self.depend_files = kwargs.get('depend_files', [])
         self.link_depends: T.List[T.Union[File, BuildTargetTypes]] = []
         self.added_deps: T.Set[dependencies.Dependency] = set()
         self.name_prefix_set = False

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -49,6 +49,7 @@ if T.TYPE_CHECKING:
     from .linkers.linkers import StaticLinker
     from .mesonlib import ExecutableSerialisation, FileMode, FileOrString
     from .mparser import BaseNode
+    from .options import ElementaryOptionValues
 
     GeneratedTypes: TypeAlias = T.Union['CustomTarget', 'CustomTargetIndex', 'GeneratedList']
     LibTypes: TypeAlias = T.Union['SharedLibrary', 'StaticLibrary', 'CustomTarget', 'CustomTargetIndex']
@@ -99,7 +100,7 @@ if T.TYPE_CHECKING:
         name_prefix: T.Optional[str]
         name_suffix: T.Optional[str]
         native: MachineChoice
-        override_options: T.Dict[OptionKey, str]
+        override_options: T.Dict[str, ElementaryOptionValues]
         resources: T.List[str]
         swift_interoperability_mode: Literal['c', 'cpp']
         swift_module_name: str
@@ -776,7 +777,7 @@ class Target(HoldableObject, metaclass=SimpleABC):
     def get_id(self) -> str:
         return self.id
 
-    def get_override(self, name: str) -> T.Optional[str]:
+    def get_override(self, name: str) -> T.Optional[ElementaryOptionValues]:
         return self.raw_overrides.get(name, None)
 
     def is_linkable_target(self) -> bool:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -93,7 +93,7 @@ if T.TYPE_CHECKING:
         language_args: T.DefaultDict[Language, T.List[str]]
         link_args: T.List[str]
         link_early_args: T.List[str]
-        link_depends: T.List[T.Union[str, File, CustomTarget, CustomTargetIndex]]
+        link_depends: T.List[T.Union[File, BuildTargetTypes]]
         link_language: Language
         link_whole: T.List[StaticTargetTypes]
         link_with: T.List[BuildTargetTypes]

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1934,7 +1934,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     @typed_kwargs('build_target', *BUILD_TARGET_KWS)
     def func_build_target(self, node: mparser.BaseNode,
                           args: T.Tuple[str, SourcesVarargsType],
-                          kwargs: kwtypes.BuildTarget
+                          kwargs: kwtypes.BuildTargetFunc,
                           ) -> T.Union[build.Executable, build.StaticLibrary, build.SharedLibrary,
                                        build.SharedModule, build.BothLibraries, build.Jar]:
         target_type = kwargs['target_type']
@@ -3219,6 +3219,9 @@ class Interpreter(InterpreterBase, HoldableObject):
     def source_strings_to_files(self, sources: T.List['mesonlib.FileOrString'], strict: bool = False) -> T.List['mesonlib.FileOrString']: ... # noqa: F811
 
     @T.overload
+    def source_strings_to_files(self, sources: T.List[T.Union[mesonlib.FileOrString, build.BuildTargetTypes]]) -> T.List[T.Union[mesonlib.File, build.BuildTargetTypes]]: ...
+
+    @T.overload
     def source_strings_to_files(self, sources: T.List[T.Union[mesonlib.FileOrString, build.GeneratedTypes]]) -> T.List[T.Union[mesonlib.File, build.GeneratedTypes]]: ... # noqa: F811
 
     @T.overload
@@ -3413,7 +3416,8 @@ class Interpreter(InterpreterBase, HoldableObject):
 
         return depend_files, args
 
-    def __process_language_args(self, kwargs: T.Dict[str, T.List[mesonlib.FileOrString]]) -> None:
+    def __process_language_args(self, kwargs: kwtypes.BuildTarget
+                                ) -> T.Tuple[T.DefaultDict[Language, T.List[str]], T.List[mesonlib.File]]:
         """Convert split language args into a combined dictionary.
 
         The Meson DSL takes arguments in the form `<lang>_args : args`, but in the
@@ -3421,14 +3425,14 @@ class Interpreter(InterpreterBase, HoldableObject):
         This function extracts the arguments from the DSL format and prepares
         them for the IR.
         """
-        d = kwargs.setdefault('depend_files', [])
-        new_args: T.DefaultDict[str, T.List[str]] = collections.defaultdict(list)
+        deps: T.List[mesonlib.File] = []
+        new_args: T.DefaultDict[Language, T.List[str]] = collections.defaultdict(list)
 
         for l in compilers.all_languages:
-            deps, args = self.__convert_file_args(kwargs[f'{l}_args'])
+            deps, args = self.__convert_file_args(kwargs[f'{l}_args'])  # type: ignore[literal-required]
             new_args[l] = args
-            d.extend(deps)
-        kwargs['language_args'] = new_args
+            deps.extend(deps)
+        return new_args, deps
 
     @staticmethod
     def _handle_rust_abi(abi: T.Optional[Literal['c', 'rust']],
@@ -3474,6 +3478,251 @@ class Interpreter(InterpreterBase, HoldableObject):
         nkwargs['rust_crate_type'] = 'cdylib'
         return nkwargs
 
+    def __convert_build_target_base_kwargs(self, kwargs: kwtypes.BuildTarget, final: build.BuildTargetKeywordArguments) -> None:
+        """Convert shared arguments for BuildTargets to the Build layer form.
+
+        This takes the raw DSL form, and builds a new dict in the form that the BuildTarget expects
+
+        :param kwargs: The arguments in raw DSL form
+        :param final: A new dictionary to fill in with the Build layer
+        :raises InvalidArguments: If one the PCH files doesn't exist
+        """
+        # copy common arguments directly
+        for arg in ('build_by_default', 'build_rpath', 'build_subdir', 'c_pch',
+                    'cpp_pch', 'd_debug', 'd_module_versions', 'd_unittest',
+                    'dependencies', 'gnu_symbol_visibility', 'install',
+                    'install_mode', 'install_rpath',
+                    'implicit_include_directories', 'link_args', 'link_early_args',
+                    'link_language', 'link_with', 'link_whole', 'name_prefix',
+                    'name_suffix', 'native', 'resources', 'vala_header',
+                    'vala_gir', 'vala_vapi', 'swift_interoperability_mode',
+                    'swift_module_name', 'rust_crate_type',
+                    'rust_dependency_map', 'override_options'):
+            final[arg] = kwargs[arg]
+
+        # this is not accessable from the DSL, so we need to initialize it
+        # ourselves
+        final['depend_files'] = []
+
+        # Check for non-existant PCH files
+        missing: T.List[str] = []
+        for each in itertools.chain(kwargs['c_pch'] or [], kwargs['cpp_pch'] or []):
+            if each is not None:
+                if not os.path.isfile(os.path.join(self.environment.source_dir, self.subdir, each)):
+                    missing.append(os.path.join(self.subdir, each))
+        if missing:
+            raise InvalidArguments('The following PCH files do not exist: {}'.format(', '.join(missing)))
+
+        final['link_depends'] = self.source_strings_to_files(kwargs['link_depends'])
+        final['install_tag'] = [kwargs['install_tag']]
+        final['extra_files'] = mesonlib.unique_list(self.source_strings_to_files(kwargs['extra_files']))
+
+        # Convert into IncludeDirs objects
+        final['include_directories'] = self.extract_incdirs(kwargs['include_directories'])
+        final['d_import_dirs'] = self.extract_incdirs(kwargs['d_import_dirs'], True)
+
+        # Convert language arguments
+        lang_args, deps = self.__process_language_args(kwargs)
+        final['language_args'] = lang_args
+        final['depend_files'].extend(deps)
+
+        # Rewrite `install_dir : [main, vala_header, vala_vapi, vala_gir]`
+        # Into split arguments
+        vala_keys = ('install_vala_header', 'install_vala_vapi', 'install_vala_gir')
+        if len(kwargs['install_dir']) > 1:
+            if any(kwargs[k] is not None for k in vala_keys):
+                raise InvalidArguments('Passing install_vala_* and more than one argument to install_dir are mutually exclusive')
+
+            install_dirs = kwargs['install_dir'].copy()
+            install_dir = install_dirs.pop(0)
+
+            for key in vala_keys:
+                action = install_dirs.pop(0) if install_dirs else False
+                if isinstance(action, bool):
+                    final[key] = action
+                else:
+                    final[key] = True
+                    final[f'{key}_dir'] = action
+            final['install_dir'] = [install_dir]
+
+            # This was previously allowed, and tested, so we need to allow it to keep working.
+            if final['vala_gir'] is None and final['install_vala_gir']:
+                final['install_vala_gir'] = False
+        else:
+            for key in vala_keys:
+                action = kwargs[key]
+                if action is None:
+                    action = False
+                if isinstance(action, bool):
+                    final[key] = action
+                else:
+                    final[key] = True
+                    final[f'{key}_dir'] = action
+            final['install_dir'] = [kwargs['install_dir'][0] if kwargs['install_dir'] else True]
+
+    def __convert_executable_kwargs(self, node: mparser.BaseNode, kwargs: kwtypes.Executable) -> build.ExecutableKeywordArguments:
+        """Convert Executable arguments from DSL form to the build layer form.
+
+        :param node: The Node being evaluated
+        :param kwargs: The DSL keyword arguments
+        :raises InvalidArguments: If both gui_app and win_subsystem are set
+        :raises InvalidArguments: If implib is false and export_dynamic is true
+        :raises InvalidArguments: If the rust_crate_type is set to anything except bin
+        :return: The keyword arguments as the Build layer expects
+        """
+        final: build.ExecutableKeywordArguments = {}
+        self.__convert_build_target_base_kwargs(kwargs, final)
+
+        # Exe exclusive arguments
+        for exe_arg in ('android_exe_type', 'pie', 'vs_module_defs'):
+            final[exe_arg] = kwargs[exe_arg]
+
+        # rewrite `gui_app` to `win_subsystem`
+        if kwargs['gui_app'] is not None:
+            if kwargs['win_subsystem'] is not None:
+                raise InvalidArguments.from_node(
+                    'Executable got both "gui_app", and "win_subsystem" arguments, which are mutually exclusive',
+                    node=node)
+            final['win_subsystem'] = 'windows' if kwargs['gui_app'] else 'console'
+        elif kwargs['win_subsystem'] is not None:
+            final['win_subsystem'] = kwargs['win_subsystem']
+        else:
+            final['win_subsystem'] = 'console'
+
+        # handle interactions between implib and export_dynamic
+        if kwargs['implib']:
+            if kwargs['export_dynamic'] is False:
+                FeatureDeprecated.single_use(
+                    'implib overrides explicit export_dynamic off', '1.3.0', self.subproject,
+                    'Do not set ths if want export_dynamic disabled if implib is enabled',
+                    location=node)
+            kwargs['export_dynamic'] = True
+        elif kwargs['export_dynamic']:
+            if kwargs['implib'] is False:
+                raise InvalidArguments.from_node(
+                    '"implib" keyword" must not be false if "export_dynamic" is set and not false.',
+                    node=node)
+        if kwargs['export_dynamic'] is None:
+            kwargs['export_dynamic'] = False
+        final['export_dynamic'] = kwargs['export_dynamic']
+
+        if isinstance(kwargs['implib'], bool):
+            final['implib'] = None
+        else:
+            final['implib'] = kwargs['implib']
+
+        # Handle executable speicific rust_crate_type
+        if kwargs['rust_crate_type'] not in {None, 'bin'}:
+            raise InvalidArguments.from_node(
+                'Crate type for executable must be "bin"', node=node)
+        final['rust_crate_type'] = 'bin'
+
+        return final
+
+    def __convert_static_library_kwargs(self, node: mparser.BaseNode, kwargs: kwtypes.StaticLibrary) -> build.StaticLibraryKeywordArguments:
+        """Convert StaticLibrary arguments to the Build format.
+
+        :param node: The Node currently be evaluated.
+        :param kwargs: The DSL form of the keyword arguments.
+        :return: The arguments in Build layer format.
+        """
+        final: build.StaticLibraryKeywordArguments = {}
+        self.__convert_build_target_base_kwargs(kwargs, final)
+
+        for arg in ('pic', 'prelink'):
+            final[arg] = kwargs[arg]
+
+        for lang in compilers.all_languages - {'java'}:
+            deps, args = self.__convert_file_args(kwargs.get(f'{lang}_static_args', []))  # type: ignore[arg-type]
+            final['language_args'][lang].extend(args)
+            final['depend_files'].extend(deps)
+        final['rust_crate_type'] = self._handle_rust_abi(
+            kwargs['rust_abi'], kwargs['rust_crate_type'], 'rlib', 'staticlib',
+            build.StaticLibrary.typename)
+
+        return final
+
+    def __convert_shared_library_kwargs(self, node: mparser.BaseNode, kwargs: kwtypes.SharedLibrary) -> build.SharedLibraryKeywordArguments:
+        """Convert SharedLibrary arguments to the Build format.
+
+        :param node: The Node currently be evaluated.
+        :param kwargs: The DSL form of the keyword arguments.
+        :return: The arguments in Build layer format.
+        """
+        final: build.SharedLibraryKeywordArguments = {}
+        self.__convert_build_target_base_kwargs(kwargs, final)
+
+        for arg in ('version', 'soversion', 'darwin_versions', 'shortname', 'vs_module_defs'):
+            final[arg] = kwargs[arg]
+
+        for lang in compilers.all_languages - {'java'}:
+            deps, args = self.__convert_file_args(kwargs.get(f'{lang}_shared_args', []))  # type: ignore[arg-type]
+            final['language_args'][lang].extend(args)
+            final['depend_files'].extend(deps)
+        final['rust_crate_type'] = self._handle_rust_abi(
+            kwargs['rust_abi'], kwargs['rust_crate_type'], 'dylib', 'cdylib',
+            build.SharedLibrary.typename, extra_valid_types={'proc-macro'})
+
+        return final
+
+    def __convert_shared_module_kwargs(self, node: mparser.BaseNode, kwargs: kwtypes.SharedModule) -> build.SharedModuleKeywordArguments:
+        """Convert SharedModule arguments to the Build format.
+
+        :param node: The Node currently be evaluated.
+        :param kwargs: The DSL form of the keyword arguments.
+        :return: The arguments in Build layer format.
+        """
+        final: build.SharedModuleKeywordArguments = {}
+        self.__convert_build_target_base_kwargs(kwargs, final)
+
+        for arg in ('vs_module_defs', ):
+            final[arg] = kwargs[arg]
+
+        for lang in compilers.all_languages - {'java'}:
+            deps, args = self.__convert_file_args(kwargs.get(f'{lang}_shared_args', []))  # type: ignore[arg-type]
+            final['language_args'][lang].extend(args)
+            final['depend_files'].extend(deps)
+        final['rust_crate_type'] = self._handle_rust_abi(
+            kwargs['rust_abi'], kwargs['rust_crate_type'], 'dylib', 'cdylib',
+            build.SharedModule.typename, extra_valid_types={'proc-macro'})
+
+        return final
+
+    def __convert_jar_kwargs(self, node: mparser.BaseNode, kwargs: kwtypes.Jar) -> build.JarKeywordArguments:
+        """Convert Jar arguments to the Build format.
+
+        :param node: The Node currently be evaluated.
+        :param kwargs: The DSL form of the keyword arguments.
+        :return: The arguments in Build layer format.
+        """
+        final: build.JarKeywordArguments = {}
+
+        # copy common arguments directly
+        for arg in ('build_by_default', 'build_subdir', 'dependencies',
+                    'install', 'install_mode', 'implicit_include_directories',
+                    'link_with', 'java_args', 'java_resources', 'main_class'):
+            final[arg] = kwargs[arg]
+
+        # this is not accessable from the DSL, so we need to initialize it
+        # ourselves
+        final['depend_files'] = []
+
+        # The build layer and interpreter don't agree here, and it's not clear
+        # that we're hanlding this correctly
+        final['install_dir'] = kwargs['install_dir']  # type: ignore[typeddict-item]
+        final['install_tag'] = [kwargs['install_tag']]
+        final['extra_files'] = mesonlib.unique_list(self.source_strings_to_files(kwargs['extra_files']))
+
+        # Convert into IncludeDirs objects
+        final['include_directories'] = self.extract_incdirs(kwargs['include_directories'])
+
+        # Convert language arguments
+        lang_args, deps = self.__process_language_args(kwargs)
+        final['language_args'] = lang_args
+        final['depend_files'].extend(deps)
+
+        return final
+
     @T.overload
     def build_target(self, node: mparser.BaseNode, args: T.Tuple[str, SourcesVarargsType],
                      kwargs: kwtypes.Executable, targetclass: T.Type[build.Executable]) -> build.Executable: ...
@@ -3513,6 +3762,8 @@ class Interpreter(InterpreterBase, HoldableObject):
         if targetclass is build.Executable and kwargs.get('android_exe_type') == 'application':
             m = self.environment.machines[for_machine]
             if m.is_android():
+                # Mypy can't figure this out for some reason
+                kwargs = T.cast('kwtypes.Executable', kwargs)
                 return self.build_target(node, args, self._exe_to_shlib_kwargs(kwargs), build.SharedLibrary)
 
         # Because who owns this isn't clear
@@ -3533,50 +3784,6 @@ class Interpreter(InterpreterBase, HoldableObject):
         sources = self.source_strings_to_files([
             s for s in raw_sources if not isinstance(s, (build.BuildTarget, build.ExtractedObjects))])
         objs = kwargs['objects']
-        # TODO: When we can do strings -> Files in the typed_kwargs validator, do this there too
-        kwargs['extra_files'] = mesonlib.unique_list(self.source_strings_to_files(kwargs['extra_files']))
-        self.__process_language_args(kwargs)
-        if targetclass is build.StaticLibrary:
-            kwargs = T.cast('kwtypes.StaticLibrary', kwargs)
-            for lang in compilers.all_languages - {'java'}:
-                deps, args = self.__convert_file_args(kwargs.get(f'{lang}_static_args', []))
-                kwargs['language_args'][lang].extend(args)
-                kwargs['depend_files'].extend(deps)
-            kwargs['rust_crate_type'] = self._handle_rust_abi(
-                kwargs['rust_abi'], kwargs['rust_crate_type'], 'rlib', 'staticlib', targetclass.typename)
-
-        elif targetclass is build.SharedLibrary:
-            kwargs = T.cast('kwtypes.SharedLibrary', kwargs)
-            for lang in compilers.all_languages - {'java'}:
-                deps, args = self.__convert_file_args(kwargs.get(f'{lang}_shared_args', []))
-                kwargs['language_args'][lang].extend(args)
-                kwargs['depend_files'].extend(deps)
-            kwargs['rust_crate_type'] = self._handle_rust_abi(
-                kwargs['rust_abi'], kwargs['rust_crate_type'], 'dylib', 'cdylib', targetclass.typename,
-                extra_valid_types={'proc-macro'})
-
-        elif targetclass is build.Executable:
-            kwargs = T.cast('kwtypes.Executable', kwargs)
-            if kwargs['rust_crate_type'] not in {None, 'bin'}:
-                raise InvalidArguments('Crate type for executable must be "bin"')
-            kwargs['rust_crate_type'] = 'bin'
-
-        if targetclass is not build.Jar:
-            self.check_for_jar_sources(sources, targetclass)
-            kwargs['include_directories'] = self.extract_incdirs(kwargs['include_directories'])
-            kwargs['d_import_dirs'] = self.extract_incdirs(kwargs['d_import_dirs'], True)
-            missing: T.List[str] = []
-            for each in itertools.chain(kwargs['c_pch'] or [], kwargs['cpp_pch'] or []):
-                if each is not None:
-                    if not os.path.isfile(os.path.join(self.environment.source_dir, self.subdir, each)):
-                        missing.append(os.path.join(self.subdir, each))
-            if missing:
-                raise InvalidArguments('The following PCH files do not exist: {}'.format(', '.join(missing)))
-
-        # Filter out kwargs from other target types. For example 'soversion'
-        # passed to library() when default_library == 'static'.
-        extra_excludes = {'language_args', 'install_vala_header', 'install_vala_vapi', 'install_vala_gir'}
-        kwargs = {k: v for k, v in kwargs.items() if k in targetclass.known_kwargs | extra_excludes}
 
         srcs: T.List['SourceInputs'] = []
         struct: T.Optional[build.StructuredSources] = build.StructuredSources()
@@ -3610,76 +3817,21 @@ class Interpreter(InterpreterBase, HoldableObject):
                     outputs.update(o)
 
         if targetclass is build.Executable:
-            kwargs = T.cast('kwtypes.Executable', kwargs)
-            if kwargs['gui_app'] is not None:
-                if kwargs['win_subsystem'] is not None:
-                    raise InvalidArguments.from_node(
-                        'Executable got both "gui_app", and "win_subsystem" arguments, which are mutually exclusive',
-                        node=node)
-                if kwargs['gui_app']:
-                    kwargs['win_subsystem'] = 'windows'
-            if kwargs['win_subsystem'] is None:
-                kwargs['win_subsystem'] = 'console'
-
-            if kwargs['implib']:
-                if kwargs['export_dynamic'] is False:
-                    FeatureDeprecated.single_use('implib overrides explicit export_dynamic off', '1.3.0', self.subproject,
-                                                 'Do not set ths if want export_dynamic disabled if implib is enabled',
-                                                 location=node)
-                kwargs['export_dynamic'] = True
-            elif kwargs['export_dynamic']:
-                if kwargs['implib'] is False:
-                    raise InvalidArguments('"implib" keyword" must not be false if "export_dynamic" is set and not false.')
-            if kwargs['export_dynamic'] is None:
-                kwargs['export_dynamic'] = False
-            if isinstance(kwargs['implib'], bool):
-                kwargs['implib'] = None
-
-        kwargs['install_tag'] = [kwargs['install_tag']]
+            nkwargs = self.__convert_executable_kwargs(node, kwargs)
+        elif targetclass is build.StaticLibrary:
+            nkwargs = self.__convert_static_library_kwargs(node, kwargs)
+        elif targetclass is build.SharedLibrary:
+            nkwargs = self.__convert_shared_library_kwargs(node, kwargs)
+        elif targetclass is build.SharedModule:
+            nkwargs = self.__convert_shared_module_kwargs(node, kwargs)
+        else:
+            nkwargs = self.__convert_jar_kwargs(node, kwargs)
 
         if targetclass is not build.Jar:
-            kwargs = T.cast('kwtypes.Executable | kwtypes.StaticLibrary | kwtypes.SharedLibrary | kwtypes.SharedModule', kwargs)
-            # The order of these keys matters!
-            vala_keys = ('install_vala_header', 'install_vala_vapi', 'install_vala_gir')
-
-            # Rewrite `install_dir : [main, vala_header, vala_vapi, vala_gir]`
-            # Into split arguments
-            if len(kwargs['install_dir']) > 1:
-                if any(kwargs[k] is not None for k in vala_keys):
-                    raise InvalidArguments('Passing install_vala_* and more than one argument to install_dir are mutually exclusive')
-
-                install_dir = kwargs['install_dir'].pop(0)
-
-                for key in vala_keys:
-                    action = kwargs['install_dir'].pop(0) if kwargs['install_dir'] else False
-                    if isinstance(action, bool):
-                        kwargs[key] = action
-                    else:
-                        kwargs[key] = True
-                        kwargs[f'{key}_dir'] = action
-                kwargs['install_dir'] = [install_dir]
-
-                # This was previously allowed, and tested, so we need to allow it to keep working.
-                if kwargs['vala_gir'] is None and kwargs['install_vala_gir']:
-                    kwargs['install_vala_gir'] = False
-            elif kwargs['install_dir']:
-                for key in vala_keys:
-                    action = kwargs[key]
-                    if action is None:
-                        action = False
-                    if isinstance(action, bool):
-                        kwargs[key] = action
-                    else:
-                        kwargs[key] = True
-                        kwargs[f'{key}_dir'] = action
-            else:
-                kwargs['install_dir'] = [True]
-
-            if kwargs['vala_gir'] is None and kwargs['install_vala_gir']:
-                raise InvalidArguments('Cannot set `install_vala_gir` without `vala_gir`')
+            self.check_for_jar_sources(sources, targetclass)
 
         target = targetclass(name, self.subdir, self.subproject, for_machine, srcs, struct, objs,
-                             self.environment, self.compilers[for_machine], kwargs)
+                             self.environment, self.compilers[for_machine], nkwargs)
         if objs and target.uses_rust():
             FeatureNew.single_use('objects in Rust targets', '1.8.0', self.subproject)
         if targetclass is build.SharedLibrary:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -19,7 +19,7 @@ from ..wrap import wrap, WrapMode
 from .. import mesonlib
 from ..mesonlib import (EnvironmentVariables, ExecutableSerialisation, MesonBugException, MesonException, HoldableObject,
                         FileMode, MachineChoice, is_parent_path, listify,
-                        extract_as_list, has_path_sep, path_has_root, path_is_in_root, PerMachine)
+                        has_path_sep, path_has_root, path_is_in_root, PerMachine)
 from ..options import OptionKey
 from ..programs import ExternalProgram, NonExistingExternalProgram, Program
 from ..dependencies import Dependency
@@ -3530,7 +3530,6 @@ class Interpreter(InterpreterBase, HoldableObject):
                    if not isinstance(s, (build.BuildTarget, build.ExtractedObjects))]
         sources = self.source_strings_to_files(sources)
         objs = kwargs['objects']
-        kwargs['dependencies'] = extract_as_list(kwargs, 'dependencies')
         # TODO: When we can do strings -> Files in the typed_kwargs validator, do this there too
         kwargs['extra_files'] = mesonlib.unique_list(self.source_strings_to_files(kwargs['extra_files']))
         self.check_sources_exist(os.path.join(self.source_root, self.subdir), sources)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3225,6 +3225,10 @@ class Interpreter(InterpreterBase, HoldableObject):
     def source_strings_to_files(self, sources: T.List[kwtypes.CustomTargetInputs]) -> T.List['CustomTargetSources']: ... # noqa: F811
 
     @T.overload
+    def source_strings_to_files(self, sources: T.List[T.Union[mesonlib.FileOrString, build.GeneratedTypes, build.StructuredSources]]
+                                ) -> T.List[T.Union[mesonlib.File, build.GeneratedTypes, build.StructuredSources]]: ... # noqa: F811
+
+    @T.overload
     def source_strings_to_files(self, sources: T.List['SourceInputs'], strict: bool = True) -> T.List['SourceOutputs']: ... # noqa: F811
 
     @T.overload
@@ -3513,26 +3517,24 @@ class Interpreter(InterpreterBase, HoldableObject):
 
         # Because who owns this isn't clear
         kwargs = kwargs.copy()
-        name, sources = args
+        name, raw_sources = args
         # Avoid mutating, since there could be other references to sources
-        sources = sources + kwargs['sources']
-        if any(isinstance(s, build.BuildTarget) for s in sources):
+        raw_sources = raw_sources + T.cast('SourcesVarargsType', kwargs['sources'])
+        if any(isinstance(s, build.BuildTarget) for s in raw_sources):
             FeatureBroken.single_use('passing references to built targets as a source file', '1.1.0', self.subproject,
                                      'Consider using `link_with` or `link_whole` if you meant to link, or dropping them as otherwise they are ignored.',
                                      node)
-        if any(isinstance(s, build.ExtractedObjects) for s in sources):
+        if any(isinstance(s, build.ExtractedObjects) for s in raw_sources):
             FeatureBroken.single_use('passing object files as sources', '1.1.0', self.subproject,
                                      'Pass these to the `objects` keyword instead, they are ignored when passed as sources.',
                                      node)
         # Go ahead and drop these here, since they're only allowed through for
         # backwards compatibility anyway
-        sources = [s for s in sources
-                   if not isinstance(s, (build.BuildTarget, build.ExtractedObjects))]
-        sources = self.source_strings_to_files(sources)
+        sources = self.source_strings_to_files([
+            s for s in raw_sources if not isinstance(s, (build.BuildTarget, build.ExtractedObjects))])
         objs = kwargs['objects']
         # TODO: When we can do strings -> Files in the typed_kwargs validator, do this there too
         kwargs['extra_files'] = mesonlib.unique_list(self.source_strings_to_files(kwargs['extra_files']))
-        self.check_sources_exist(os.path.join(self.source_root, self.subdir), sources)
         self.__process_language_args(kwargs)
         if targetclass is build.StaticLibrary:
             kwargs = T.cast('kwtypes.StaticLibrary', kwargs)
@@ -3692,14 +3694,6 @@ class Interpreter(InterpreterBase, HoldableObject):
             dep = self.build.stdlibs[target.for_machine].get(l, None)
             if dep:
                 target.add_deps([dep])
-
-    def check_sources_exist(self, subdir, sources):
-        for s in sources:
-            if not isinstance(s, str):
-                continue # This means a generated source and they always exist.
-            fname = os.path.join(subdir, s)
-            if not os.path.isfile(fname):
-                raise InterpreterException(f'Tried to add non-existing source file {s}.')
 
     def check_for_jar_sources(self, sources, targetclass):
         for s in sources:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3695,12 +3695,15 @@ class Interpreter(InterpreterBase, HoldableObject):
             if dep:
                 target.add_deps([dep])
 
-    def check_for_jar_sources(self, sources, targetclass):
+    def check_for_jar_sources(self, sources: T.Union[T.List[str], T.Sequence[T.Union[mesonlib.File, build.BuildTargetTypes, build.GeneratedList, build.StructuredSources]]],
+                              targetclass: T.Type[build.BuildTarget]) -> None:
         for s in sources:
             if isinstance(s, (str, mesonlib.File)) and compilers.is_java(s):
                 raise InvalidArguments(f'Build target of type "{targetclass.typename}" cannot build java source: "{s}". Use "{build.Jar.typename}" instead.')
             elif isinstance(s, build.StructuredSources):
                 self.check_for_jar_sources(s.as_list(), targetclass)
+            elif isinstance(s, (build.GeneratedList, build.CustomTarget, build.CustomTargetIndex)):
+                self.check_for_jar_sources(s.get_outputs(), targetclass)
 
     def is_subproject(self) -> bool:
         return self.subproject != ''

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -359,7 +359,7 @@ class _BaseBuildTarget(TypedDict):
     install_tag: T.Optional[str]
     install_rpath: str
     implicit_include_directories: bool
-    link_depends: T.List[T.Union[str, File, build.GeneratedTypes]]
+    link_depends: T.List[T.Union[str, File, build.BuildTargetTypes]]
     link_language: T.Optional[Language]
     link_whole: T.List[build.StaticTargetTypes]
     link_with: T.List[build.BuildTargetTypes]

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -393,8 +393,8 @@ class _BuildTarget(_BaseBuildTarget):
     swift_module_name: str
     sources: SourcesVarargsType
     link_args: T.List[str]
-    c_pch: T.List[str]
-    cpp_pch: T.List[str]
+    c_pch: T.Optional[T.Tuple[str, T.Optional[str]]]
+    cpp_pch: T.Optional[T.Tuple[str, T.Optional[str]]]
     c_args: T.List[str]
     cpp_args: T.List[str]
     cuda_args: T.List[str]

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -443,6 +443,7 @@ class _SharedLibMixin(TypedDict):
     soversion: T.Optional[str]
     version: T.Optional[str]
     vs_module_defs: T.Optional[T.Union[str, File, build.CustomTarget, build.CustomTargetIndex]]
+    shortname: str
 
 
 class SharedLibrary(_BuildTarget, _SharedLibMixin, _LibraryMixin):

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -353,7 +353,7 @@ class _BaseBuildTarget(TypedDict):
     dependencies: T.List[Dependency]
     extra_files: T.List[FileOrString]
     gnu_symbol_visibility: str
-    include_directories: T.List[build.IncludeDirs]
+    include_directories: T.List[T.Union[str, build.IncludeDirs]]
     install: bool
     install_mode: FileMode
     install_tag: T.Optional[str]

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -376,7 +376,7 @@ class _BaseBuildTarget(TypedDict):
     vala_gir: T.Optional[str]
 
 
-class _BuildTarget(_BaseBuildTarget):
+class BuildTarget(_BaseBuildTarget):
 
     """Arguments shared by non-JAR functions"""
 
@@ -394,6 +394,7 @@ class _BuildTarget(_BaseBuildTarget):
     swift_module_name: str
     sources: SourcesVarargsType
     link_args: T.List[str]
+    link_early_args: T.List[str]
     c_pch: T.Optional[T.Tuple[str, T.Optional[str]]]
     cpp_pch: T.Optional[T.Tuple[str, T.Optional[str]]]
     c_args: T.List[str]
@@ -417,7 +418,7 @@ class _LibraryMixin(TypedDict):
     rust_abi: T.Optional[RustAbi]
 
 
-class Executable(_BuildTarget):
+class Executable(BuildTarget):
 
     export_dynamic: T.Optional[bool]
     gui_app: T.Optional[bool]
@@ -434,7 +435,7 @@ class _StaticLibMixin(TypedDict):
     pic: T.Optional[bool]
 
 
-class StaticLibrary(_BuildTarget, _StaticLibMixin, _LibraryMixin):
+class StaticLibrary(BuildTarget, _StaticLibMixin, _LibraryMixin):
     pass
 
 
@@ -447,16 +448,16 @@ class _SharedLibMixin(TypedDict):
     shortname: str
 
 
-class SharedLibrary(_BuildTarget, _SharedLibMixin, _LibraryMixin):
+class SharedLibrary(BuildTarget, _SharedLibMixin, _LibraryMixin):
     pass
 
 
-class SharedModule(_BuildTarget, _LibraryMixin):
+class SharedModule(BuildTarget, _LibraryMixin):
 
     vs_module_defs: T.Optional[T.Union[str, File, build.CustomTarget, build.CustomTargetIndex]]
 
 
-class Library(_BuildTarget, _SharedLibMixin, _StaticLibMixin, _LibraryMixin):
+class Library(BuildTarget, _SharedLibMixin, _StaticLibMixin, _LibraryMixin):
 
     """For library, both_library, and as a base for build_target"""
 
@@ -490,7 +491,7 @@ class Library(_BuildTarget, _SharedLibMixin, _StaticLibMixin, _LibraryMixin):
     masm_shared_args: NotRequired[T.List[str]]
 
 
-class BuildTarget(Library):
+class BuildTargetFunc(Library):
 
     target_type: Literal['executable', 'shared_library', 'static_library',
                          'shared_module', 'both_libraries', 'library', 'jar']

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -350,6 +350,7 @@ class _BaseBuildTarget(TypedDict):
 
     build_by_default: bool
     build_rpath: str
+    build_subdir: str
     dependencies: T.List[Dependency]
     extra_files: T.List[FileOrString]
     gnu_symbol_visibility: str

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -1016,6 +1016,7 @@ BUILD_TARGET_KWS = [
     *_EXCLUSIVE_STATIC_LIB_KWS,
     *EXCLUSIVE_EXECUTABLE_KWS,
     *_SHARED_STATIC_ARGS,
+    _VS_MODULE_DEFS_KW,
     RUST_ABI_KW.evolve(since='1.10.0'),
     *[a.evolve(deprecated='1.3.0', deprecated_message='The use of "jar" in "build_target()" is deprecated, and this argument is only used by jar()')
       for a in _EXCLUSIVE_JAR_KWS],


### PR DESCRIPTION
This allows us to have a fully functional conversion with type checking of the kwargs dictionaries between the DSL level and and the Build level of abstractions. Apart from fixing a number of incorrect or incomplete annotations, this gets us to the point that we can (mostly) validate the type checking.

This is set as draft because I'm sure there are regressions that don't show up on my system but will light CI up like a christmas tree.