### PR TITLE
Document system() == "android" as a fully supported value

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -162,7 +162,7 @@ These are provided by the `.system()` method call.
 
 | Value               | Comment                         |
 | -----               | -------                         |
-| android             | By convention only, subject to change |
+| android             | |
 | cygwin              | Cygwin or MSYS2 environment on Windows |
 | darwin              | Either OSX or iOS |
 | dragonfly           | DragonFly BSD |


### PR DESCRIPTION
In #6233 the "android" `system` name was documented as "subject to change". The main argument for this was that there was no clear reference for what the value "should" be, because most Android builds are cross-compiling, and Python's `platform.system` is not used. At that time, Python didn't officially support Android anyway.

However, Python has supported Android since version 3.13, which came out more than a year ago, and it now defines "Android" as a [possible value of `platform.system`](https://docs.python.org/3.13/library/platform.html#platform.system). In this context, I've successfully built NumPy and several other Meson-based Python packages that depend on it, and never had to make any changes to Meson itself (see the PRs linked to https://github.com/mesonbuild/meson-python/pull/824).

So I think the time has come for Meson to say that this value is no longer subject to change, and it's safe for people to rely on it.