### PR TITLE
ninjabackend: do not fail if only the build machine uses C++

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3297,11 +3297,11 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
     def target_uses_import_std(self, target: build.BuildTarget) -> bool:
         if 'cpp' not in target.compilers:
             return False
-        if 'cpp_importstd' not in self.environment.coredata.optstore:
+        try:
+            if self.environment.coredata.get_option_for_target(target, 'cpp_importstd') == 'true':
+                return True
+        except KeyError:
             return False
-        if self.environment.coredata.get_option_for_target(target, 'cpp_importstd') == 'false':
-            return False
-        return True
 
     def handle_cpp_import_std(self, target: build.BuildTarget, compiler):
         istd_args = []


### PR DESCRIPTION
This is caused by the introduction of the cpp_importstd option; while target_uses_import_std() tries to protect from the option not existing, this does not work if cpp_importstd exists but build.cpp_importstd does not, and get_option_for_target() wants to look at the latter.

Just return false on a KeyError for simplicity.

Fixes: #15497

Cc @jpakkane because it's caused by `import std support`. As an aside, `cpp_importstd` should have been a boolean option (not combo) but this should be fixed separately because I'm not sure how that would be dealt with when meson uses pickled coredata.