### PR TITLE
Add AIX -X32_64 option to AIX ar in meson.

### DIFF
--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -1660,7 +1660,7 @@ class AIXDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
     def get_command_to_archive_shlib(self) -> T.List[str]:
         # Archive shared library object and remove the shared library object,
         # since it already exists in the archive.
-        command = ['ar', '-r', '-s', '-v', '$out', '$in', '&&', 'rm', '-f', '$in']
+        command = ['ar', '-X32_64', '-r', '-s', '-v', '$out', '$in', '&&', 'rm', '-f', '$in']
         return command
 
     def get_link_whole_for(self, args: T.List[str]) -> T.List[str]:


### PR DESCRIPTION
This is a patch which adds -X32_64 to ar in AIX so we need not export OBJECT_MODE.

One example of when this is useful is when we build postgresql where if one forgets to set OBJECT_MODE then one gets this error below.

```
[265/2503] Archiving AIX shared library
FAILED: src/interfaces/ecpg/pgtypeslib/libpgtypes.a 
ar -r -s src/interfaces/ecpg/pgtypeslib/libpgtypes.a src/interfaces/ecpg/pgtypeslib/libpgtypes.so.3.19 && rm -f src/interfaces/ecpg/pgtypeslib/libpgtypes.so.3.19
ar: Creating an archive file src/interfaces/ecpg/pgtypeslib/libpgtypes.a.
ar: 0707-126 src/interfaces/ecpg/pgtypeslib/libpgtypes.so.3.19 is not valid with the current object file mode.
```

This PR fixes the same.

Link for ar documentation

https://www.ibm.com/docs/en/aix/7.2.0?topic=formats-ar-file-format-big