### PR TITLE
compilers: Deduplicate OpenMP linker arguments

### DIFF
--- a/docs/markdown/snippets/dedup_openmp_ld_args.md
+++ b/docs/markdown/snippets/dedup_openmp_ld_args.md
@@ -1,0 +1,3 @@
+## Deduplication of OpenMP linker arguments
+
+Meson now deduplicates linker arguments `-fopenmp` and `-qopenmp`.

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -55,7 +55,7 @@ class CLikeCompilerArgs(arglist.CompilerArgs):
     # https://github.com/mesonbuild/meson/pull/4593#pullrequestreview-182016038
     dedup1_prefixes = ('-l', '-Wl,-l', '-Wl,-rpath,', '-Wl,-rpath-link,')
     dedup1_suffixes = ('.lib', '.dll', '.so', '.dylib', '.a')
-    dedup1_args = ('-c', '-S', '-E', '-pipe', '-pthread', '-Wl,--export-dynamic')
+    dedup1_args = ('-c', '-S', '-E', '-pipe', '-pthread', '-Wl,--export-dynamic', '-fopenmp', '-qopenmp')
 
     def to_native(self, copy: bool = False) -> T.List[str]:
         # This seems to be allowed, but could never work?


### PR DESCRIPTION
The OpenMP dependency passes `-fopenmp` to the linker, so mark it for deduplication along with `-qopenmp` (for icx/icpx).

Partial fix for #15503. Related to #13516.

I looked briefly into adding tests for this, but I didn't see an easy enough way to do it. Suggestions welcome.