### PR TITLE
tests: Update cygwin expectations

### DIFF
--- a/test cases/frameworks/11 gir subproject/test.json
+++ b/test cases/frameworks/11 gir subproject/test.json
@@ -9,5 +9,5 @@
     {"type": "expr", "file": "usr/lib/?libgirlib.so"},
     {"type": "file", "platform": "cygwin", "file": "usr/lib/libgirsubproject.dll.a"}
   ],
-  "expect_skip_on_jobname": ["azure", "cygwin", "macos", "msys2", "pypy", "windows"]
+  "expect_skip_on_jobname": ["azure", "macos", "msys2", "pypy", "windows"]
 }

--- a/test cases/frameworks/7 gnome/test.json
+++ b/test cases/frameworks/7 gnome/test.json
@@ -37,5 +37,5 @@
     {"type": "file", "file": "usr/include/simple-resources.h"},
     {"type": "file", "file": "usr/include/generated-gdbus.h"}
   ],
-  "expect_skip_on_jobname": ["azure", "cygwin", "macos", "msys2", "pypy", "windows"]
+  "expect_skip_on_jobname": ["azure", "macos", "msys2", "pypy", "windows"]
 }


### PR DESCRIPTION
The gnome and gir subproject tests do run on cygwin