### PR TITLE
Default pyright settings so LSP doesn't give errors by default

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,13 @@
+{
+  "reportOptionalMemberAccess": false,
+  "reportArgumentType": false,
+  "reportUninitializedInstanceVariable": false,
+  "reportReturnType": false,
+  "reportMissingTypeArgument": false,
+  "reportAttributeAccessIssue": false,
+  "reportAssignmentType": false,
+  "reportOperatorIssue": false,
+  "reportPossiblyUnboundVariable": false,
+  "reportOptionalOperand": false,
+  "reportCallIssue": false,
+}


### PR DESCRIPTION
This commit disables some pyright features so devs can edit meson source without tweaking the lsp. Currently pyright gives 270 errors on zed editor without any changes to lsp settings.