### PR TITLE
Allow using a version kwarg in has_tools of qt module.

### DIFF
--- a/docs/markdown/Qt6-module.md
+++ b/docs/markdown/Qt6-module.md
@@ -163,6 +163,8 @@ This method takes the following keyword arguments:
 - `tools`: string[]: *Since 1.6.0*. List of tools to check. Testable tools
   are `moc`, `uic`, `rcc` and `lrelease`. By default `tools` is set to `['moc',
   'uic', 'rcc', 'lrelease']`
+- `version` str | array[str]: *Since 1.11.0*. Specifies the required version,
+  a string containing a comparison operator followed by the version string.
 
 ## qml_module
 

--- a/docs/markdown/_include_qt_base.md
+++ b/docs/markdown/_include_qt_base.md
@@ -142,6 +142,8 @@ This method takes the following keyword arguments:
   `true` or an enabled [`feature`](Build-options.md#features) and some tools are
   missing Meson will abort.
 - `method` string: method used to find the Qt dependency (`auto` by default).
+- `version` str | array[str]: *Since 1.11.0*. Specifies the required version,
+  a string containing a comparison operator followed by the version string.
 
 ## Dependencies
 

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -48,6 +48,7 @@ foreach qt : ['qt4', 'qt5', 'qt6']
   qtdep = dependency(qt, modules : qt_modules, main : true, private_headers: true, required : required, method : get_option('method'))
   if qtdep.found()
     qtmodule = import(qt)
+    assert(qtmodule.has_tools(tools: ['moc'], method: get_option('method'), version: '>=4'))
     if get_option('expect_lrelease')
       assert(qtmodule.has_tools(), 'You may be missing a devel package. (qttools5-dev-tools on Debian based systems)')
     else


### PR DESCRIPTION
It is currently impossible to specify a version requirement when calling has_tools() on a Qt(4/5/6) module. This merge request adds that kwarg and forwards it to the dependency resolution.