### PR TITLE
compilers: remove get_toolset_version from VisualStudioLikeCompilers

### DIFF
--- a/mesonbuild/compilers/mixins/intel.py
+++ b/mesonbuild/compilers/mixins/intel.py
@@ -146,15 +146,6 @@ class IntelVisualStudioLikeCompiler(VisualStudioLikeCompiler):
             ])
         return args
 
-    def get_toolset_version(self) -> T.Optional[str]:
-        # ICL provides a cl.exe that returns the version of MSVC it tries to
-        # emulate, so we'll get the version from that and pass it to the same
-        # function the real MSVC uses to calculate the toolset version.
-        _, _, err = mesonlib.Popen_safe(['cl.exe'])
-        v1, v2, *_ = mesonlib.search_version(err).split('.')
-        version = int(v1 + v2)
-        return self._calculate_toolset_version(version)
-
     def openmp_flags(self) -> T.List[str]:
         return ['/Qopenmp']
 

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -14,7 +14,6 @@ import typing as T
 
 from ... import arglist
 from ... import mesonlib
-from ... import mlog
 from mesonbuild.compilers.compilers import CompileCheckMode
 from ...options import OptionKey
 from mesonbuild.linkers.linkers import ClangClDynamicLinker
@@ -305,42 +304,6 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
             return vs64_instruction_set_args.get(instruction_set, None)
         return vs32_instruction_set_args.get(instruction_set, None)
 
-    def _calculate_toolset_version(self, version: int) -> T.Optional[str]:
-        if version < 1310:
-            return '7.0'
-        elif version < 1400:
-            return '7.1' # (Visual Studio 2003)
-        elif version < 1500:
-            return '8.0' # (Visual Studio 2005)
-        elif version < 1600:
-            return '9.0' # (Visual Studio 2008)
-        elif version < 1700:
-            return '10.0' # (Visual Studio 2010)
-        elif version < 1800:
-            return '11.0' # (Visual Studio 2012)
-        elif version < 1900:
-            return '12.0' # (Visual Studio 2013)
-        elif version < 1910:
-            return '14.0' # (Visual Studio 2015)
-        elif version < 1920:
-            return '14.1' # (Visual Studio 2017)
-        elif version < 1930:
-            return '14.2' # (Visual Studio 2019)
-        elif version < 1940:
-            return '14.3' # (Visual Studio 2022)
-        elif version < 1950:
-            return '14.4' # (Visual Studio current preview version, might not be final)
-        mlog.warning(f'Could not find toolset for version {self.version!r}')
-        return None
-
-    def get_toolset_version(self) -> T.Optional[str]:
-        # See boost/config/compiler/visualc.cpp for up to date mapping
-        try:
-            version = int(''.join(self.version.split('.')[0:2]))
-        except ValueError:
-            return None
-        return self._calculate_toolset_version(version)
-
     def get_default_include_dirs(self) -> T.List[str]:
         if 'INCLUDE' not in os.environ:
             return []
@@ -448,10 +411,6 @@ class ClangClCompiler(VisualStudioLikeCompiler):
         if mode != CompileCheckMode.LINK:
             args = args + ['-Werror=unknown-argument', '-Werror=unknown-warning-option']
         return super().has_arguments(args, code, mode)
-
-    def get_toolset_version(self) -> T.Optional[str]:
-        # XXX: what is the right thing to do here?
-        return '14.1'
 
     def get_pch_base_name(self, header: str) -> str:
         return header

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -833,29 +833,6 @@ class InternalTests(unittest.TestCase):
                 for o, name in [(operator.lt, 'lt'), (operator.le, 'le'), (operator.eq, 'eq')]:
                     self.assertFalse(o(ver_a, ver_b), f'{ver_a} {name} {ver_b}')
 
-    def test_msvc_toolset_version(self):
-        '''
-        Ensure that the toolset version returns the correct value for this MSVC
-        '''
-        env = get_fake_env()
-        cc = detect_c_compiler(env, MachineChoice.HOST)
-        if cc.get_argument_syntax() != 'msvc':
-            raise unittest.SkipTest('Test only applies to MSVC-like compilers')
-        toolset_ver = cc.get_toolset_version()
-        self.assertIsNotNone(toolset_ver)
-        # Visual Studio 2015 and older versions do not define VCToolsVersion
-        # TODO: ICL doesn't set this in the VSC2015 profile either
-        if cc.id == 'msvc' and int(''.join(cc.version.split('.')[0:2])) < 1910:
-            return
-        if 'VCToolsVersion' in os.environ:
-            vctools_ver = os.environ['VCToolsVersion']
-        else:
-            self.assertIn('VCINSTALLDIR', os.environ)
-            # See https://devblogs.microsoft.com/cppblog/finding-the-visual-c-compiler-tools-in-visual-studio-2017/
-            vctools_ver = (Path(os.environ['VCINSTALLDIR']) / 'Auxiliary' / 'Build' / 'Microsoft.VCToolsVersion.default.txt').read_text(encoding='utf-8')
-        self.assertTrue(vctools_ver.startswith(toolset_ver),
-                        msg=f'{vctools_ver!r} does not start with {toolset_ver!r}')
-
     def test_split_args(self):
         split_args = mesonbuild.mesonlib.split_args
         join_args = mesonbuild.mesonlib.join_args


### PR DESCRIPTION
Unused since 08224dafcba1b694fb624553e7d84deb565aae22, because it only checks toolset version matches between the compiled libs, not the current toolchain.