### PR TITLE
machine files: Support using ~ in machine files as a constant

### DIFF
--- a/docs/markdown/snippets/machine_file_home_variable.md
+++ b/docs/markdown/snippets/machine_file_home_variable.md
@@ -1,0 +1,20 @@
+## Machine files now expand `~` as the user's home directory
+
+A new constant `~` has been added which can be used in machine files (native
+and cross files) to refer to the user's home directory. This is useful for
+specifying paths to SDKs and toolchains that are commonly installed into `~`,
+such as Qt, the Android SDK/NDK, or user-installed frameworks on macOS:
+
+```ini
+[constants]
+toolchain = ~ / 'Android/sdk/ndk/27.1.12297006/toolchains/llvm/prebuilt/linux-x86_64'
+
+[binaries]
+c = toolchain / 'bin/clang'
+cpp = toolchain / 'bin/clang++'
+ar = toolchain / 'bin/llvm-ar'
+```
+
+Note that `~` can be used anywhere in the machine file. In the above example,
+the purpose of defining a new constant called `toolchain` is to not have to
+repeat yourself when using the path multiple times.

--- a/mesonbuild/machinefile.py
+++ b/mesonbuild/machinefile.py
@@ -15,10 +15,14 @@ from .mesonlib import MesonException
 if T.TYPE_CHECKING:
     from .options import ElementaryOptionValues
 
+
+HOMEDIR = os.path.expanduser('~')
+
+
 class MachineFileParser():
     def __init__(self, filenames: T.List[str], sourcedir: str) -> None:
         self.parser = CmdLineFileParser()
-        self.constants: T.Dict[str, ElementaryOptionValues] = {'True': True, 'False': False}
+        self.constants: T.Dict[str, ElementaryOptionValues] = {'True': True, 'False': False, '~': HOMEDIR}
         self.sections: T.Dict[str, T.Dict[str, ElementaryOptionValues]] = {}
 
         for fname in filenames:
@@ -53,7 +57,7 @@ class MachineFileParser():
             # Windows paths...
             value = value.replace('\\', '\\\\')
             try:
-                ast = mparser.Parser(value, 'machinefile').parse()
+                ast = mparser.Parser(value, 'machinefile', machinefile=True).parse()
                 if not ast.lines:
                     raise MesonException('value cannot be empty')
                 res = self._evaluate_statement(ast.lines[0])

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -95,10 +95,12 @@ class Token(T.Generic[TV_TokenTypes]):
         return NotImplemented
 
 
-IDENT_RE = re.compile('[_a-zA-Z][_0-9a-zA-Z]*')
+IDENT_RE_STR = r'[_a-zA-Z][_0-9a-zA-Z]*'
+IDENT_RE = re.compile(IDENT_RE_STR)
+IDENT_RE_MACHINEFILE = re.compile(IDENT_RE_STR + '|~')
 
 class Lexer:
-    def __init__(self, code: str):
+    def __init__(self, code: str, *, machinefile: bool = False):
         if code.startswith(codecs.BOM_UTF8.decode('utf-8')):
             line, *_ = code.split('\n', maxsplit=1)
             raise ParseException('Builder file must be encoded in UTF-8 (with no BOM)', line, lineno=0, colno=0)
@@ -116,7 +118,7 @@ class Lexer:
             ('whitespace', re.compile(r'[ \t]+')),
             ('multiline_fstring', re.compile(r"f'''(.|\n)*?'''", re.M)),
             ('fstring', re.compile(r"f'([^'\\]|(\\.))*'")),
-            ('id', IDENT_RE),
+            ('id', IDENT_RE_MACHINEFILE if machinefile else IDENT_RE),
             ('number', re.compile(r'0[bB][01]+|0[oO][0-7]+|0[xX][0-9a-fA-F]+|0|[1-9]\d*')),
             ('eol_cont', re.compile(r'\\[ \t]*(#.*)?\n')),
             ('multiline_string', re.compile(r"'''(.|\n)*?'''", re.M)),
@@ -717,8 +719,8 @@ MULDIV_MAP: T.Mapping[str, ARITH_OPERATORS] = {
 # 10 plain token
 
 class Parser:
-    def __init__(self, code: str, filename: str):
-        self.lexer = Lexer(code)
+    def __init__(self, code: str, filename: str, *, machinefile: bool = False):
+        self.lexer = Lexer(code, machinefile=machinefile)
         self.stream = self.lexer.lex(filename)
         self.current: Token = Token('eof', '', 0, 0, 0, (0, 0), None)
         self.previous = self.current

--- a/test cases/failing/137 ~ in meson.build/meson.build
+++ b/test cases/failing/137 ~ in meson.build/meson.build
@@ -1,0 +1,3 @@
+project('tilde in meson.build')
+
+home = ~

--- a/test cases/failing/137 ~ in meson.build/test.json
+++ b/test cases/failing/137 ~ in meson.build/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/137 ~ in meson.build/meson.build:3:7: ERROR: lexer: unrecognized token '~'"
+    }
+  ]
+}

--- a/test cases/failing/138 ~ in meson.options/meson.build
+++ b/test cases/failing/138 ~ in meson.options/meson.build
@@ -1,0 +1,1 @@
+project('tilde in meson.options')

--- a/test cases/failing/138 ~ in meson.options/meson.options
+++ b/test cases/failing/138 ~ in meson.options/meson.options
@@ -1,0 +1,1 @@
+option(~, type : 'boolean', value : false)

--- a/test cases/failing/138 ~ in meson.options/test.json
+++ b/test cases/failing/138 ~ in meson.options/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/138 ~ in meson.options/meson.options:1:7: ERROR: lexer: unrecognized token '~'"
+    }
+  ]
+}

--- a/test cases/failing/139 ~ in meson.options value/meson.build
+++ b/test cases/failing/139 ~ in meson.options value/meson.build
@@ -1,0 +1,1 @@
+project('tilde in meson.options')

--- a/test cases/failing/139 ~ in meson.options value/meson.options
+++ b/test cases/failing/139 ~ in meson.options value/meson.options
@@ -1,0 +1,1 @@
+option('opt1', type : 'string', value : ~)

--- a/test cases/failing/139 ~ in meson.options value/test.json
+++ b/test cases/failing/139 ~ in meson.options value/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/139 ~ in meson.options value/meson.options:1:40: ERROR: lexer: unrecognized token '~'"
+    }
+  ]
+}

--- a/unittests/machinefiletests.py
+++ b/unittests/machinefiletests.py
@@ -13,7 +13,7 @@ import threading
 import sys
 from itertools import chain
 from unittest import mock, skipIf, SkipTest, TestCase
-from pathlib import Path
+from pathlib import Path, PurePath
 import typing as T
 
 import mesonbuild.mlog
@@ -60,6 +60,38 @@ class MachineFileStoreTests(TestCase):
     def test_loading(self):
         store = machinefile.MachineFileStore([cross_dir / 'ubuntu-armhf.txt'], [], str(cross_dir))
         self.assertIsNotNone(store)
+
+    def test_home_variable(self):
+        """Test that ~ expands to the user's home directory."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.ini', delete=False) as f:
+            f.write(textwrap.dedent('''\
+                [constants]
+                toolchain = ~ / 'sdk'
+
+                [binaries]
+                c = ~ / 'bin' / 'gcc'
+                cpp = toolchain / 'bin' / 'g++'
+                '''))
+            fname = f.name
+
+        try:
+            parser = machinefile.MachineFileParser([fname], '/tmp')
+            if sys.platform in ('linux', 'darwin'):
+                home = PurePath(os.environ['HOME'])
+            elif sys.platform in ('win32', 'cygwin'):
+                # Even with MSYS2 and Cygwin, we must use the windows-native homedir
+                # https://github.com/mesonbuild/meson/pull/15524#issuecomment-3864016608
+                if 'USER' not in os.environ:
+                    raise SkipTest('No USER in env')
+                home = PurePath('C:\\', 'Users', os.environ['USER'])
+            else:
+                raise SkipTest('Don\'t know how to get homedir')
+
+            # Check that ~ expands correctly in binaries section
+            self.assertEqual(parser.sections['binaries']['c'], str(home / 'bin' / 'gcc'))
+            self.assertEqual(parser.sections['binaries']['cpp'], str(home / 'sdk' / 'bin' / 'g++'))
+        finally:
+            os.unlink(fname)
 
 class NativeFileTests(BasePlatformTests):
 


### PR DESCRIPTION
The constant will expand to the user's home directory. This is useful when distributing machine files alongside instructions on how to install SDKs like Qt which install into ~/Qt or Android SDK which goes into ~/Android, and so on.