### PR TITLE
Allow to use deterministic mtime in jar

### DIFF
--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -91,6 +91,7 @@ class BasePlatformTests(TestCase):
         cls.unit_test_dir = os.path.join(src_root, 'test cases/unit')
         cls.rewrite_test_dir = os.path.join(src_root, 'test cases/rewrite')
         cls.linuxlike_test_dir = os.path.join(src_root, 'test cases/linuxlike')
+        cls.java_test_dir = os.path.join(src_root, 'test cases/java')
         cls.objc_test_dir = os.path.join(src_root, 'test cases/objc')
         cls.objcpp_test_dir = os.path.join(src_root, 'test cases/objcpp')
         cls.darwin_test_dir = os.path.join(src_root, 'test cases/darwin')


### PR DESCRIPTION
When updating a `.jar` file, we use the `SOURCE_DATE_EPOCH` env variable to determine the mtime value of the manifest file.

See https://reproducible-builds.org/ for why this is good.

This branch will fail if an incompatible jar version (e.g. openjdk < 17) is used. This is probably preferable to silently generating non-deterministic build results. And it keeps the code simpler.