### PR TITLE
compilers: Fix compiler checks on `.cc` files for MSVC

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -82,7 +82,7 @@ lang_suffixes: T.Mapping[Language, T.Tuple[str, ...]] = {
 }
 # Some compilers only recognize files with specific suffixes.
 compiler_suffixes: T.Mapping[str, T.Tuple[str, ...]] = {
-    'msvc': ('c', 'cxx', 'cpp', 'obj', 'lib', 'def'),
+    'msvc': ('c', 'cc', 'cxx', 'cpp', 'obj', 'lib', 'def'),
 }
 all_languages: mesonlib.OrderedSet[Language] = mesonlib.OrderedSet(sorted(lang_suffixes))
 c_cpp_suffixes = {'h'}


### PR DESCRIPTION
MSVC accepts `.cc` files.  Do not refuse to run compiler checks on source files with a `.cc` extension.

Fixes https://github.com/mesonbuild/meson/pull/15422, which was backported to 1.10.1 in 273c49ae76d5a0c8a088389526e8dc1cfcec3555.

cc @nirbheek 