### PR TITLE
build: Also extend all_compilers when extending compilers

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1047,8 +1047,11 @@ class BuildTarget(Target):
                 for lang in target_langs:
                     # Rust is always linked through a C-ABI target, so do not add
                     # the compiler here
-                    if lang != 'rust' and lang in link_langs and lang not in self.compilers:
-                        self.compilers[lang] = t.all_compilers[lang]
+                    if lang != 'rust' and lang in link_langs:
+                        if lang not in self.all_compilers:
+                            self.all_compilers[lang] = t.all_compilers[lang]
+                        if lang not in self.compilers:
+                            self.compilers[lang] = t.all_compilers[lang]
 
         if not self.compilers:
             # No source files or parent targets, target consists of only object
@@ -1116,6 +1119,8 @@ class BuildTarget(Target):
                 # dealing with compiled C code.
                 if comp.language == 'vala':
                     continue
+                if comp.language not in self.all_compilers:
+                    self.all_compilers[comp.language] = comp
                 if comp.language not in self.compilers:
                     self.compilers[comp.language] = comp
         if sources:

--- a/test cases/common/289 subproject with foreign lang/intlib.cpp
+++ b/test cases/common/289 subproject with foreign lang/intlib.cpp
@@ -1,0 +1,15 @@
+#include <cstdio>
+
+#if defined _WIN32
+
+extern "C" int __declspec(dllimport) pcre2_function(void);
+
+#else
+
+extern "C" int pcre2_function(void);
+
+#endif
+
+int internal_function(void) {
+    return pcre2_function();
+}

--- a/test cases/common/289 subproject with foreign lang/meson.build
+++ b/test cases/common/289 subproject with foreign lang/meson.build
@@ -1,0 +1,9 @@
+project('depfallback', 'cpp')
+
+subp = subproject('pcre2')
+
+lib = static_library('intlib', 'intlib.cpp',
+  link_with: subp.get_variable('pcre2_lib'))
+
+executable('p2test', 'p2test.cpp',
+  link_with: lib)

--- a/test cases/common/289 subproject with foreign lang/p2test.cpp
+++ b/test cases/common/289 subproject with foreign lang/p2test.cpp
@@ -1,0 +1,7 @@
+#include<cstdio>
+
+int internal_function(void);
+
+int main() {
+    return internal_function();
+}

--- a/test cases/common/289 subproject with foreign lang/subprojects/pcre2/meson.build
+++ b/test cases/common/289 subproject with foreign lang/subprojects/pcre2/meson.build
@@ -1,0 +1,3 @@
+project('pcre2', 'c')
+
+pcre2_lib = shared_library('pcre2', 'pcre.c')

--- a/test cases/common/289 subproject with foreign lang/subprojects/pcre2/pcre.c
+++ b/test cases/common/289 subproject with foreign lang/subprojects/pcre2/pcre.c
@@ -1,0 +1,15 @@
+#include<stdlib.h>
+
+#ifdef _WIN32
+
+int __declspec(dllexport) pcre2_function(void);
+
+#else
+
+int pcre2_function(void);
+
+#endif
+
+int pcre2_function(void) {
+    return 0;
+}


### PR DESCRIPTION
This fixes a regression introduced with #15450.

Fixes: #15536
Superseeds: #15537