### PR TITLE
Fix linker selection for icx and ifx on windows

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -507,7 +507,9 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
             target = 'x86' if 'IA-32' in err else 'x86_64'
             cls = c.IntelLLVMClCCompiler if lang == 'c' else cpp.IntelLLVMClCPPCompiler
             env.add_lang_args(cls.language, cls, for_machine)
-            linker = linkers.MSVCDynamicLinker(env, for_machine, [], version=version)
+            linker = linker = guess_win_linker(
+                    env, ['link'], cls, version,
+                    for_machine)
             return cls(
                 compiler, version, for_machine, env, target,
                 linker=linker)
@@ -798,7 +800,7 @@ def detect_fortran_compiler(env: 'Environment', for_machine: MachineChoice) -> C
                 env.add_lang_args(cls.language, cls, for_machine)
                 linker = guess_win_linker(
                     env, ['link'], cls, version,
-                    for_machine )
+                    for_machine)
                 return cls(
                     compiler, version, for_machine, env,
                     target, linker=linker)


### PR DESCRIPTION
Use Microsoft linker for icx and ifx on windows, rather than xilink, which is intended for the classic Intel compilers.

On Windows, ifx and icx meson builds currently use xilink.exe, which is for the previous IL0 compiler technology.  The typical linker used for those compilers is just the standard Microsoft linker link.exe.  Otherwise builds with meson that use the current Intel llvm compilers on Windows now receive a link time warning.

See https://www.intel.com/content/www/us/en/developer/articles/guide/porting-guide-for-icc-users-to-dpcpp-or-icx.html under "Linking, IPO and PGO changes" and https://www.intel.com/content/www/us/en/developer/articles/guide/porting-guide-for-ifort-to-ifx.html under "PGO, IPO and Linking Changes" for more information.

If link time optimisation/interprocedural optimisation is being used by icx or ifx, then the relevant llvm linker needs to be invoked, (perhaps through the compiler driver) but that's not handled by meson on Windows at the moment (or for ifx on Linux).