### PR TITLE
clang-cl: Use -Werror=unused-command-line-argument for arguments detection

### DIFF
--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -477,7 +477,11 @@ class ClangClCompiler(VisualStudioLikeCompiler):
 
     def has_arguments(self, args: T.List[str], code: str, mode: CompileCheckMode) -> T.Tuple[bool, bool]:
         if mode != CompileCheckMode.LINK:
-            args = args + ['-Werror=unknown-argument', '-Werror=unknown-warning-option']
+            args = args + [
+                '-Werror=unknown-argument',
+                '-Werror=unknown-warning-option',
+                '-Werror=unused-command-line-argument',
+            ]
         return super().has_arguments(args, code, mode)
 
     def get_toolset_version(self) -> T.Optional[str]:


### PR DESCRIPTION
Fixes #15546