### PR TITLE
cmake: fix ValueError for generated includes

### DIFF
--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -438,8 +438,10 @@ class ConverterTarget:
                 mlog.warning('CMake: path', mlog.bold(x.as_posix()), 'is inside the root project but', mlog.bold('not'), 'inside the subproject.')
                 mlog.warning(' --> Ignoring. This can lead to build errors.')
                 return None
-            if path_is_in_root(x, Path(self.env.get_build_dir())) and is_header:
+            if path_is_in_root(x, Path(self.env.get_build_dir()) / subdir) and is_header:
                 return x.relative_to(Path(self.env.get_build_dir()) / subdir)
+            if path_is_in_root(x, Path(self.env.get_build_dir())) and is_header:
+                return x.relative_to(Path(self.env.get_build_dir()))
             if path_is_in_root(x, root_src_dir):
                 return x.relative_to(root_src_dir)
             return x


### PR DESCRIPTION
Some projects are to be configured with just a plain header file that would be passed as a path in the CMake define (one such project is LVGL). In combination with the Meson configuration and configuration_data, such a header would be generated and passed to the CMake subproject options:

  lvgl_var.add_cmake_defines('LV_BUILD_CONF_PATH': lvgl_conf_h.full_path())

The CMake build project will take this file and add it to its include path. The `rel_path` is then called to ensure that such a path is relative if it is relative to the build directory.

The issue was that the code checked if the path is relative to the build directory, but then requested it to be relative to the build directory plus the subdir. This failed to generate a header with a ValueError exception.

The solution is here to correctly check if the path is relative to the subdir and, in such a case, use the subdir. The additional condition was added to cover just the plain build directory. This condition is the one that is now used in the demonstrated example.