### PR TITLE
cmake: fix include directory path for subproject's subproject

### DIFF
--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -441,7 +441,7 @@ class ConverterTarget:
             if path_is_in_root(x, Path(self.env.get_build_dir()) / subdir) and is_header:
                 return x.relative_to(Path(self.env.get_build_dir()) / subdir)
             if path_is_in_root(x, Path(self.env.get_build_dir())) and is_header:
-                return x.relative_to(Path(self.env.get_build_dir()))
+                return Path(*([".."] * len(subdir.parts))) / x.relative_to(Path(self.env.get_build_dir()))
             if path_is_in_root(x, root_src_dir):
                 return x.relative_to(root_src_dir)
             return x


### PR DESCRIPTION
This is a follow-up to the e167a6d8d229f909d3a629055d3fc93d1f2833af fix.

The path is used in `subproject/{name}/meson.build` and thus just removing the build directory path prefix won't work correctly. It would be interpreted relative to that subproject directory (where the actual meson.build is placed). The correct solution is to point to the root of the build directory relative to the sub-directory.

The chosen code won't work if `..` is present in the `subdir`, but that should not be the case.

The issue could be reproduced if a project that uses a CMake subproject is used as a subproject as well. In that case, the include path points to the subproject sub-directory in the build directory.