### PR TITLE
Fix/add version checks for macOS linkers

### DIFF
--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -973,6 +973,13 @@ class LLVMLD64DynamicLinker(AppleDynamicLinker):
             return self._apply_prefix('-no_warn_duplicate_libraries')
         return []
 
+    def export_dynamic_args(self) -> T.List[str]:
+        # -export_dynamic existed before LLVM 13 but did not work properly
+        # on macOS until https://github.com/llvm/llvm-project/commit/3eb2fc4b
+        if mesonlib.version_compare(self.version, '>=13'):
+            return self._apply_prefix('-export_dynamic')
+        return []
+
 
 class GnuDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, DynamicLinker):
 


### PR DESCRIPTION
There are two issues with macOS linkers:

- `-no_warn_duplicate_libraries` should be used only if supported, excluding Xcode <= 14 and ld64.lld < 19
- export_dynamic is not supported properly with ld64.lld, because the check incorrectly uses ld64 version numbers in the hundreds

Fix both of them.

Fixes: #15553