### PR TITLE
python: switch default rust_abi for extension modules to C

### DIFF
--- a/docs/markdown/Python-module.md
+++ b/docs/markdown/Python-module.md
@@ -143,6 +143,9 @@ Note that Cython support uses `extension_module`, see [the reference for Cython]
 if one is not explicitly provided. To support older versions, the user may need to
 add `dependencies : py_installation.dependency()`, see [[dependency]].
 
+*Since 1.11.0* `rust_abi`, if unset, will default to `'c'` so that Rust
+extension modules produce a `cdylib` crate.
+
 **Returns**: a [[@build_tgt]] object
 
 #### `dependency()`

--- a/docs/markdown/snippets/python-extension-module-rust-abi.md
+++ b/docs/markdown/snippets/python-extension-module-rust-abi.md
@@ -1,0 +1,7 @@
+## Python extension modules default to C ABI for Rust
+
+`py.extension_module()` now defaults `rust_abi` to `'c'`, so that Rust
+extension modules produce a `cdylib` instead of a `dylib`.  This is the
+correct crate type for Python extension modules written in Rust, and
+previously had to be specified manually via `rust_crate_type: 'cdylib'`
+or `rust_abi: 'c'`.

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -239,6 +239,7 @@ class PythonInstallation(ProgramHolder['PythonExternalProgram']):
                 (self.is_pypy or mesonlib.version_compare(self.version, '>=3.9')):
             kwargs['gnu_symbol_visibility'] = 'inlineshidden'
 
+        kwargs.setdefault('rust_abi', 'c')
         return self.interpreter.build_target(self.current_node, args, kwargs, SharedModule)
 
     def _convert_api_version_to_py_version_hex(self, api_version: str, detected_version: str) -> str:


### PR DESCRIPTION
A Rust-ABI Python extension module makes no sense; add `rust_abi: c` automatically.