### PR TITLE
rust: do not raise exception on rust.bindgen with no Rust language in the project

### DIFF
--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -456,7 +456,7 @@ class RustModule(ExtensionModule):
 
         # Look for --target in the rust command itself if there isn't one passed in clang_args
         target_arg = parse_target(clang_args)
-        if not target_arg:
+        if not target_arg and 'rust' in state._interpreter.compilers.host:
             rust_args = state._interpreter.compilers.host['rust'].get_exe_args()
             target_arg = parse_target(rust_args)
             if target_arg:
@@ -583,7 +583,10 @@ class RustModule(ExtensionModule):
         if self._bindgen_rust_target and '--rust-target' not in cmd:
             cmd.extend(['--rust-target', self._bindgen_rust_target])
         if self._bindgen_set_std and '--rust-edition' not in cmd:
-            rust_std = state.environment.coredata.optstore.get_value_for('rust_std')
+            try:
+                rust_std = state.environment.coredata.optstore.get_value_for('rust_std')
+            except KeyError:
+                rust_std = 'none'
             assert isinstance(rust_std, str), 'for mypy'
             if rust_std != 'none':
                 cmd.extend(['--rust-edition', rust_std])

--- a/test cases/unit/134 minimal bindgen/meson.build
+++ b/test cases/unit/134 minimal bindgen/meson.build
@@ -1,5 +1,9 @@
-project('minimal bindgen', 'c', 'rust', meson_version : '>= 1.0.0')
+project('minimal bindgen', 'c', meson_version : '>= 1.0.0')
+
+if get_option('add_rust_language')
+  add_languages('rust', required: true, native: false)
+  add_languages('rust', required: true, native: true)
+endif
 
 rust = import('rust')
-
 header_rs = rust.bindgen(input : 'header.h', output : 'header.rs')

--- a/test cases/unit/134 minimal bindgen/meson.options
+++ b/test cases/unit/134 minimal bindgen/meson.options
@@ -1,0 +1,1 @@
+option('add_rust_language', type: 'boolean', value: false)

--- a/unittests/machinefiletests.py
+++ b/unittests/machinefiletests.py
@@ -1031,7 +1031,7 @@ class CrossFileTests(BasePlatformTests):
         with self.subTest('compiler only'):
             self.new_builddir()
             config = self.helper_create_cross_file({'binaries': {'rust': [rustc, f'--target={build_tuple}']}})
-            self.init(testcase, extra_args=['--cross-file', config])
+            self.init(testcase, extra_args=['-Dadd_rust_language=true', '--cross-file', config])
             check_target(build_tuple)
 
         with self.subTest('properties and compiler'):
@@ -1040,5 +1040,13 @@ class CrossFileTests(BasePlatformTests):
                 'binaries': {'rust': [rustc, f'--target={build_tuple}']},
                 'properties': {'bindgen_clang_arguments': [f'--target={host_tuple}']},
             })
-            self.init(testcase, extra_args=['--cross-file', config])
+            self.init(testcase, extra_args=['-Dadd_rust_language=true', '--cross-file', config])
             check_target(host_tuple, build_tuple)
+
+        with self.subTest('unused compiler'):
+            self.new_builddir()
+            config = self.helper_create_cross_file({
+                'binaries': {'rust': [rustc, f'--target={build_tuple}']},
+            })
+            self.init(testcase, extra_args=['--cross-file', config])
+            check_target(None, build_tuple)


### PR DESCRIPTION
This worked fine in 1.7.0, default to no edition and no checking for the target name in rustc's arguments.

Fixes: #15356