### PR TITLE
utils: fix @INPUT@ and @OUTPUT@ in the same command

### DIFF
--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -325,6 +325,9 @@ class InternalTests(unittest.TestCase):
         # Check substitutions
         cmd = ['some', 'ordinary', 'strings']
         self.assertEqual(substfunc(cmd, d), cmd)
+        cmd = ['@INPUT@ @OUTPUT@']
+        self.assertEqual(substfunc(cmd, d),
+                         [f'{inputs[0]} {outputs[0]}'])
         cmd = ['@INPUT@.out', '@OUTPUT@', 'strings']
         self.assertEqual(substfunc(cmd, d),
                          [inputs[0] + '.out'] + outputs + cmd[2:])


### PR DESCRIPTION
Even if there is a single input or output, @INPUT@ and @OUTPUT@ cannot appear in the same argument because "@INTPUT@ in vv" and "@OUTPUT@ in vv" appear in "elif" branches of the same conditional. Switch to handling single-input and single-output in the replace local function, so that the previously unhandled case goes through the regular expression substitution and the bug is fixed.

Fixes: #15566