### PR TITLE
install_headers: add support install_tag kwarg

### DIFF
--- a/docs/markdown/snippets/install_man_headers_custom_tag.md
+++ b/docs/markdown/snippets/install_man_headers_custom_tag.md
@@ -1,0 +1,6 @@
+## install_man and install_headers: add support for install_tag kwarg
+
+`install_man` and `install_headers` now support the `install_tag` keyword argument,
+allowing selection of installed files via `meson install --tags`. Previously,
+`install_man` always used the `man` tag and `install_headers` always used the
+`devel` tag, with no way to override them.

--- a/docs/markdown/snippets/install_man_kwargs.md
+++ b/docs/markdown/snippets/install_man_kwargs.md
@@ -1,5 +1,0 @@
-## install_man: add support install_tag kwarg
-
-By default install_man uses 'man' tag for its files which not always is desirable,
-for example if project uses plugin functionality and plugin wants to install its own man files
-it was not possible using `meson install --tags xxx`.

--- a/docs/yaml/functions/install_headers.yaml
+++ b/docs/yaml/functions/install_headers.yaml
@@ -85,3 +85,11 @@ kwargs:
     description: |
       If true, dereferences links and copies their target instead.  The default
       value will become false in the future.
+
+  install_tag:
+    type: str
+    since: 1.11.0
+    description: |
+      A string used by the `meson install --tags` command
+      to install only a subset of the files. By default these files have the `devel`
+      install tag which means they are installed explicitly or when no tags given at all.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1853,7 +1853,7 @@ class Backend:
 
             for f in h.get_sources():
                 abspath = f.absolute_path(srcdir, builddir)
-                i = InstallDataBase(abspath, outdir, outdir_name, h.get_custom_install_mode(), h.subproject, tag='devel', follow_symlinks=h.follow_symlinks)
+                i = InstallDataBase(abspath, outdir, outdir_name, h.get_custom_install_mode(), h.subproject, tag=h.install_tag, follow_symlinks=h.follow_symlinks)
                 d.headers.append(i)
 
     def generate_man_install(self, d: InstallData) -> None:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -246,6 +246,11 @@ class Headers(HoldableObject):
     custom_install_mode: 'FileMode'
     subproject: str
     follow_symlinks: T.Optional[bool] = None
+    install_tag: T.Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.install_tag is None:
+            self.install_tag = 'devel'
 
     # TODO: we really don't need any of these methods, but they're preserved to
     # keep APIs relying on them working.

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2337,6 +2337,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         INSTALL_MODE_KW.evolve(since='0.47.0'),
         INSTALL_DIR_KW,
         INSTALL_FOLLOW_SYMLINKS,
+        INSTALL_TAG_KW.evolve(since='1.11.0'),
     )
     def func_install_headers(self, node: mparser.BaseNode,
                              args: T.Tuple[T.List['mesonlib.FileOrString']],
@@ -2364,7 +2365,8 @@ class Interpreter(InterpreterBase, HoldableObject):
         for childdir in dirs:
             h = build.Headers(dirs[childdir], os.path.join(install_subdir, childdir), kwargs['install_dir'],
                               install_mode, self.subproject,
-                              follow_symlinks=kwargs['follow_symlinks'])
+                              follow_symlinks=kwargs['follow_symlinks'],
+                              install_tag=kwargs['install_tag'])
             ret_headers.append(h)
             self.build.headers.append(h)
 

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -148,6 +148,7 @@ class FuncInstallHeaders(TypedDict):
     install_mode: FileMode
     subdir: T.Optional[str]
     follow_symlinks: T.Optional[bool]
+    install_tag: T.Optional[str]
 
 
 class FuncInstallMan(TypedDict):


### PR DESCRIPTION
By default install_headers uses 'devel' tag for its files. Make it possible to customize the desired tag for install_headers.

Fixes: #15557