### PR TITLE
ninjabackend: bring back historical "include_directories(is_system: true)" ordering

### DIFF
--- a/docs/yaml/functions/include_directories.yaml
+++ b/docs/yaml/functions/include_directories.yaml
@@ -19,6 +19,17 @@ description: |
   Each directory given is converted to two include paths: one that is
   relative to the source root and one relative to the build root.
 
+warnings:
+  - |
+    When `is_system : true` is used, the include directory order on the
+    command line is **reversed** compared to the order given in the
+    arguments: the *last* directory listed has the highest priority
+    (it appears first among the `-isystem` flags and is searched first
+    by the compiler).  This is the opposite of the default (`is_system :
+    false`), where the *first* directory listed has the highest priority.
+    This may be changed in future releases, but behavior will not change
+    as long as `meson_version` is not changed in `project()`.
+
 example: |
   For example, with the following source tree layout in
   `/home/user/project.git`:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3039,15 +3039,22 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         return (rel_obj, rel_src)
 
     @lru_cache(maxsize=None)
-    def generate_inc_dir(self, compiler: 'Compiler', inc: build.IncludeDirs
-                         ) -> ImmutableListProtocol[str]:
-        # We should iterate include dirs in reversed orders because
-        # -Ipath will add to begin of array. And without reverse
-        # flags will be added in reversed order.
-        args: T.List[str] = []
-        for p in inc.rel_string_list(self.build_to_src, self.build_dir):
-            args.extend(compiler.get_include_args(p, inc.is_system))
-        return args
+    def generate_inc_dir(self, compiler: 'Compiler', d: str, basedir: str, is_system: bool
+                         ) -> T.Tuple[ImmutableListProtocol[str], ImmutableListProtocol[str]]:
+        expdir = os.path.normpath(os.path.join(basedir, d))
+        srctreedir = os.path.normpath(os.path.join(self.build_to_src, expdir))
+        sargs = compiler.get_include_args(srctreedir, is_system)
+        # There may be include dirs where a build directory has not been
+        # created for some source dir. For example if someone does this:
+        #
+        # inc = include_directories('foo/bar/baz')
+        #
+        # But never subdir()s into the actual dir.
+        if os.path.isdir(os.path.join(self.environment.get_build_dir(), expdir)):
+            bargs = compiler.get_include_args(expdir, is_system)
+        else:
+            bargs = []
+        return (sargs, bargs)
 
     def _generate_single_compile(self, target: build.BuildTarget, compiler: Compiler) -> CompilerArgs:
         commands = self._generate_single_compile_base_args(target, compiler)
@@ -3086,10 +3093,36 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         # external deps and must maintain the order in which they are specified.
         # Hence, we must reverse the list so that the order is preserved.
         for i in reversed(target.get_include_dirs()):
-            # We should iterate include dirs in reversed orders because
-            # -Ipath will add to begin of array. And without reverse
-            # flags will be added in reversed order.
-            commands += self.generate_inc_dir(compiler, i)
+            basedir = i.curdir
+            # Each directory must be added to CompilerArgs individually
+            # via a separate ``commands +=`` call, in reversed order.
+            #
+            # CompilerArgs.__iadd__ prepends ``-I`` args (which are in
+            # CLikeCompilerArgs.prepend_prefixes) but appends ``-isystem``
+            # args (which are not).  When adding one directory at a time
+            # in reversed order, this produces the correct result for
+            # both flag types:
+            #
+            # - For ``-I`` (prepended): each flag is inserted at the
+            #   front, so reversed iteration produces the original
+            #   order — first-listed directory appears first on the
+            #   command line and is searched first.
+            #
+            # - For ``-isystem`` (appended): each flag is added at the
+            #   back, so reversed iteration produces a reversed sequence
+            #   on the command line — *last*-listed directory appears
+            #   first and is searched first.
+            #
+            # Adding all directories in a single ``commands +=`` call
+            # would break ``-isystem`` ordering: the whole list would be
+            # appended at once in the original (unreversed) order, making
+            # the *first*-listed directory appear first instead of last.
+            for d in reversed(i.incdirs):
+                sargs, bargs = self.generate_inc_dir(compiler, d, basedir, i.is_system)
+                commands += sargs
+                commands += bargs
+            for d in i.extra_build_dirs:
+                commands += compiler.get_include_args(d, i.is_system)
         # Add per-target compile args, f.ex, `c_args : ['-DFOO']`. We set these
         # near the end since these are supposed to override everything else.
         commands += self.escape_extra_args(target.get_extra_args(compiler.get_language()))

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -48,6 +48,16 @@ GROUP_FLAGS = re.compile(r'''^(?!-Wl,) .*\.so (?:\.[0-9]+)? (?:\.[0-9]+)? (?:\.[
                              \.a$''', re.X)
 
 class CLikeCompilerArgs(arglist.CompilerArgs):
+    # Note: ``-isystem`` is deliberately absent from prepend_prefixes.
+    # Because ``-isystem`` is appended by __iadd__ rather than
+    # prepended, the reversed iteration in the ninja backend causes
+    # directories listed *last* in include_directories() to appear
+    # *first* on the command line (and thus be searched first).  This
+    # is the opposite convention from ``-I``, where first-listed means
+    # first-searched.  Existing projects (e.g. systemd) rely on this
+    # ``-isystem`` ordering, so adding ``-isystem`` to prepend_prefixes
+    # would silently break them by reversing their include priority.
+    # See NinjaBackend._generate_single_compile_target_args().
     prepend_prefixes = ('-I', '-L')
     dedup2_prefixes = ('-I', '-isystem', '-L', '-D', '-U')
 

--- a/test cases/common/290 systemd regression/keyctl.c
+++ b/test cases/common/290 systemd regression/keyctl.c
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+#include <sys/keyctl.h>

--- a/test cases/common/290 systemd regression/meson.build
+++ b/test cases/common/290 systemd regression/meson.build
@@ -1,0 +1,48 @@
+# regression test - meson puts the directories in the reversed order for
+# "is_system: true", which is bad but happens for historical reasons.
+
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+project('test', 'c', meson_version: '>=0.62.0', version: '1.0')
+
+if host_machine.system() != 'linux'
+  error('MESON_SKIP_TEST: systemd include ordering regression test needs Linux')
+endif
+
+conf = configuration_data()
+config_h = configure_file(output : 'config.h', configuration : conf)
+userspace = declare_dependency(compile_args : ['-include', 'config.h'])
+
+system_includes = [
+        include_directories(
+                'uapi',
+                'override',
+                is_system : true,
+        ),
+]
+
+static_library(
+        'c-wrapper',
+        files('keyctl.c'),
+        include_directories : system_includes,
+        implicit_include_directories : false,
+        dependencies : [userspace],
+        c_args : ['-fvisibility=default'],
+        build_by_default : true)
+
+
+# second testcase, with separate include_directories
+
+system_includes = [
+        include_directories('uapi', is_system : true),
+        include_directories('override', is_system : true),
+]
+
+static_library(
+        'c-wrapper2',
+        files('keyctl.c'),
+        include_directories : system_includes,
+        implicit_include_directories : false,
+        dependencies : [userspace],
+        c_args : ['-fvisibility=default'],
+        build_by_default : true)

--- a/test cases/common/290 systemd regression/override/linux/keyctl.h
+++ b/test cases/common/290 systemd regression/override/linux/keyctl.h
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#if 0 // removed for meson testsuite
+#include_next <linux/keyctl.h>  /* IWYU pragma: export */
+#endif
+
+#include <stdint.h>
+
+/* From linux/key.h */
+#ifndef KEY_POS_VIEW
+
+typedef int32_t key_serial_t;
+
+#  define KEY_POS_VIEW    0x01000000
+#  define KEY_POS_READ    0x02000000
+#  define KEY_POS_WRITE   0x04000000
+#  define KEY_POS_SEARCH  0x08000000
+#  define KEY_POS_LINK    0x10000000
+#  define KEY_POS_SETATTR 0x20000000
+#  define KEY_POS_ALL     0x3f000000
+
+#  define KEY_USR_VIEW    0x00010000
+#  define KEY_USR_READ    0x00020000
+#  define KEY_USR_WRITE   0x00040000
+#  define KEY_USR_SEARCH  0x00080000
+#  define KEY_USR_LINK    0x00100000
+#  define KEY_USR_SETATTR 0x00200000
+#  define KEY_USR_ALL     0x003f0000
+
+#  define KEY_GRP_VIEW    0x00000100
+#  define KEY_GRP_READ    0x00000200
+#  define KEY_GRP_WRITE   0x00000400
+#  define KEY_GRP_SEARCH  0x00000800
+#  define KEY_GRP_LINK    0x00001000
+#  define KEY_GRP_SETATTR 0x00002000
+#  define KEY_GRP_ALL     0x00003f00
+
+#  define KEY_OTH_VIEW    0x00000001
+#  define KEY_OTH_READ    0x00000002
+#  define KEY_OTH_WRITE   0x00000004
+#  define KEY_OTH_SEARCH  0x00000008
+#  define KEY_OTH_LINK    0x00000010
+#  define KEY_OTH_SETATTR 0x00000020
+#  define KEY_OTH_ALL     0x0000003f
+#else
+static_assert(KEY_OTH_ALL == 0x0000003f, "");
+#endif

--- a/test cases/common/290 systemd regression/override/sys/keyctl.h
+++ b/test cases/common/290 systemd regression/override/sys/keyctl.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#pragma once
+
+#include <linux/keyctl.h>       /* IWYU pragma: export */
+#include <stddef.h>
+
+#if !HAVE_KEYCTL
+long missing_keyctl(int cmd, unsigned long arg2, unsigned long arg3, unsigned long arg4, unsigned long arg5);
+#  define keyctl missing_keyctl
+#endif
+
+#if !HAVE_ADD_KEY
+key_serial_t missing_add_key(const char *type, const char *description, const void *payload, size_t plen, key_serial_t ringid);
+#  define add_key missing_add_key
+#endif
+
+#if !HAVE_REQUEST_KEY
+key_serial_t missing_request_key(const char *type, const char *description, const char *callout_info, key_serial_t destringid);
+#  define request_key missing_request_key
+#endif

--- a/test cases/common/290 systemd regression/test.json
+++ b/test cases/common/290 systemd regression/test.json
@@ -1,0 +1,3 @@
+{
+  "expect_skip_on_jobname": ["azure", "cygwin", "macos", "msys2", "windows"]
+}

--- a/test cases/common/290 systemd regression/uapi/linux/keyctl.h
+++ b/test cases/common/290 systemd regression/uapi/linux/keyctl.h
@@ -1,0 +1,136 @@
+/* SPDX-License-Identifier: GPL-2.0+ WITH Linux-syscall-note */
+/* keyctl.h: keyctl command IDs
+ *
+ * Copyright (C) 2004, 2008 Red Hat, Inc. All Rights Reserved.
+ * Written by David Howells (dhowells@redhat.com)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version
+ * 2 of the License, or (at your option) any later version.
+ */
+
+#ifndef _LINUX_KEYCTL_H
+#define _LINUX_KEYCTL_H
+
+#include <linux/types.h>
+
+/* special process keyring shortcut IDs */
+#define KEY_SPEC_THREAD_KEYRING		-1	/* - key ID for thread-specific keyring */
+#define KEY_SPEC_PROCESS_KEYRING	-2	/* - key ID for process-specific keyring */
+#define KEY_SPEC_SESSION_KEYRING	-3	/* - key ID for session-specific keyring */
+#define KEY_SPEC_USER_KEYRING		-4	/* - key ID for UID-specific keyring */
+#define KEY_SPEC_USER_SESSION_KEYRING	-5	/* - key ID for UID-session keyring */
+#define KEY_SPEC_GROUP_KEYRING		-6	/* - key ID for GID-specific keyring */
+#define KEY_SPEC_REQKEY_AUTH_KEY	-7	/* - key ID for assumed request_key auth key */
+#define KEY_SPEC_REQUESTOR_KEYRING	-8	/* - key ID for request_key() dest keyring */
+
+/* request-key default keyrings */
+#define KEY_REQKEY_DEFL_NO_CHANGE		-1
+#define KEY_REQKEY_DEFL_DEFAULT			0
+#define KEY_REQKEY_DEFL_THREAD_KEYRING		1
+#define KEY_REQKEY_DEFL_PROCESS_KEYRING		2
+#define KEY_REQKEY_DEFL_SESSION_KEYRING		3
+#define KEY_REQKEY_DEFL_USER_KEYRING		4
+#define KEY_REQKEY_DEFL_USER_SESSION_KEYRING	5
+#define KEY_REQKEY_DEFL_GROUP_KEYRING		6
+#define KEY_REQKEY_DEFL_REQUESTOR_KEYRING	7
+
+/* keyctl commands */
+#define KEYCTL_GET_KEYRING_ID		0	/* ask for a keyring's ID */
+#define KEYCTL_JOIN_SESSION_KEYRING	1	/* join or start named session keyring */
+#define KEYCTL_UPDATE			2	/* update a key */
+#define KEYCTL_REVOKE			3	/* revoke a key */
+#define KEYCTL_CHOWN			4	/* set ownership of a key */
+#define KEYCTL_SETPERM			5	/* set perms on a key */
+#define KEYCTL_DESCRIBE			6	/* describe a key */
+#define KEYCTL_CLEAR			7	/* clear contents of a keyring */
+#define KEYCTL_LINK			8	/* link a key into a keyring */
+#define KEYCTL_UNLINK			9	/* unlink a key from a keyring */
+#define KEYCTL_SEARCH			10	/* search for a key in a keyring */
+#define KEYCTL_READ			11	/* read a key or keyring's contents */
+#define KEYCTL_INSTANTIATE		12	/* instantiate a partially constructed key */
+#define KEYCTL_NEGATE			13	/* negate a partially constructed key */
+#define KEYCTL_SET_REQKEY_KEYRING	14	/* set default request-key keyring */
+#define KEYCTL_SET_TIMEOUT		15	/* set key timeout */
+#define KEYCTL_ASSUME_AUTHORITY		16	/* assume request_key() authorisation */
+#define KEYCTL_GET_SECURITY		17	/* get key security label */
+#define KEYCTL_SESSION_TO_PARENT	18	/* apply session keyring to parent process */
+#define KEYCTL_REJECT			19	/* reject a partially constructed key */
+#define KEYCTL_INSTANTIATE_IOV		20	/* instantiate a partially constructed key */
+#define KEYCTL_INVALIDATE		21	/* invalidate a key */
+#define KEYCTL_GET_PERSISTENT		22	/* get a user's persistent keyring */
+#define KEYCTL_DH_COMPUTE		23	/* Compute Diffie-Hellman values */
+#define KEYCTL_PKEY_QUERY		24	/* Query public key parameters */
+#define KEYCTL_PKEY_ENCRYPT		25	/* Encrypt a blob using a public key */
+#define KEYCTL_PKEY_DECRYPT		26	/* Decrypt a blob using a public key */
+#define KEYCTL_PKEY_SIGN		27	/* Create a public key signature */
+#define KEYCTL_PKEY_VERIFY		28	/* Verify a public key signature */
+#define KEYCTL_RESTRICT_KEYRING		29	/* Restrict keys allowed to link to a keyring */
+#define KEYCTL_MOVE			30	/* Move keys between keyrings */
+#define KEYCTL_CAPABILITIES		31	/* Find capabilities of keyrings subsystem */
+#define KEYCTL_WATCH_KEY		32	/* Watch a key or ring of keys for changes */
+
+/* keyctl structures */
+struct keyctl_dh_params {
+	union {
+#ifndef __cplusplus
+		__s32 private;
+#endif
+		__s32 priv;
+	};
+	__s32 prime;
+	__s32 base;
+};
+
+struct keyctl_kdf_params {
+	char *hashname;
+	char *otherinfo;
+	__u32 otherinfolen;
+	__u32 __spare[8];
+};
+
+#define KEYCTL_SUPPORTS_ENCRYPT		0x01
+#define KEYCTL_SUPPORTS_DECRYPT		0x02
+#define KEYCTL_SUPPORTS_SIGN		0x04
+#define KEYCTL_SUPPORTS_VERIFY		0x08
+
+struct keyctl_pkey_query {
+	__u32		supported_ops;	/* Which ops are supported */
+	__u32		key_size;	/* Size of the key in bits */
+	__u16		max_data_size;	/* Maximum size of raw data to sign in bytes */
+	__u16		max_sig_size;	/* Maximum size of signature in bytes */
+	__u16		max_enc_size;	/* Maximum size of encrypted blob in bytes */
+	__u16		max_dec_size;	/* Maximum size of decrypted blob in bytes */
+	__u32		__spare[10];
+};
+
+struct keyctl_pkey_params {
+	__s32		key_id;		/* Serial no. of public key to use */
+	__u32		in_len;		/* Input data size */
+	union {
+		__u32		out_len;	/* Output buffer size (encrypt/decrypt/sign) */
+		__u32		in2_len;	/* 2nd input data size (verify) */
+	};
+	__u32		__spare[7];
+};
+
+#define KEYCTL_MOVE_EXCL	0x00000001 /* Do not displace from the to-keyring */
+
+/*
+ * Capabilities flags.  The capabilities list is an array of 8-bit integers;
+ * each integer can carry up to 8 flags.
+ */
+#define KEYCTL_CAPS0_CAPABILITIES	0x01 /* KEYCTL_CAPABILITIES supported */
+#define KEYCTL_CAPS0_PERSISTENT_KEYRINGS 0x02 /* Persistent keyrings enabled */
+#define KEYCTL_CAPS0_DIFFIE_HELLMAN	0x04 /* Diffie-Hellman computation enabled */
+#define KEYCTL_CAPS0_PUBLIC_KEY		0x08 /* Public key ops enabled */
+#define KEYCTL_CAPS0_BIG_KEY		0x10 /* big_key-type enabled */
+#define KEYCTL_CAPS0_INVALIDATE		0x20 /* KEYCTL_INVALIDATE supported */
+#define KEYCTL_CAPS0_RESTRICT_KEYRING	0x40 /* KEYCTL_RESTRICT_KEYRING supported */
+#define KEYCTL_CAPS0_MOVE		0x80 /* KEYCTL_MOVE supported */
+#define KEYCTL_CAPS1_NS_KEYRING_NAME	0x01 /* Keyring names are per-user_namespace */
+#define KEYCTL_CAPS1_NS_KEY_TAG		0x02 /* Key indexing can include a namespace tag */
+#define KEYCTL_CAPS1_NOTIFICATIONS	0x04 /* Keys generate watchable notifications */
+
+#endif /*  _LINUX_KEYCTL_H */


### PR DESCRIPTION
Prior to commit a6ddf2534 ("backend/ninja: Extend IncludeDirs.rel_string_list for backend use"), when include_directories() was called with `is_system: true` and multiple directories, the resulting `-isystem` flags appeared on the command line in the opposite order from what was specified: the last-listed directory was searched first by the compiler. This was the opposite convention from non-system -I includes, where the first-listed directory is searched first.

The asymmetry was not intentional; it was a side effect of how `CompilerArgs.__iadd__` handles flags that are not in prepend_prefixes:

- `-I` is in CLikeCompilerArgs.prepend_prefixes, so `__iadd__` prepends it.  The ninja backend iterates directories in reversed order and adds them one at a time; the prepend-on-each-add counteracts the reversal, producing the original order.

- `-isystem` was not in prepend_prefixes, so `__iadd__` appended it. The same reversed one-at-a-time iteration then produced a reversed sequence — the last-listed directory ended up first on the command line.

Commit a6ddf25634 changed generate_inc_dir to add all directories in a single bulk commands += call instead of one at a time.  This preserved the correct order for -I (the double reversal in `__iadd__` still works for a bulk add) but silently broke -isystem, because appending a list at once preserves input order rather than reversing it.

Undo the changes a6ddf25634 to preserve the previous behavior. Adding -isystem to prepend_prefixes would also make the ordering consistent, but projects that relied on the old reversed behaviour would silently break.