### PR TITLE
dependencies mpi: add -show-compile-info and -show-link-info for mpich

### DIFF
--- a/mesonbuild/dependencies/mpi.py
+++ b/mesonbuild/dependencies/mpi.py
@@ -120,16 +120,12 @@ class MPIConfigToolDependency(ConfigToolDependency):
         if not self.is_found:
             return
 
-        # --showme for OpenMPI
-        # -compile_info/-link_info for MPICH and IntelMPI
-        # -show for Intel
-        commands: T.List[T.Tuple[str, T.Optional[str]]] = [
-            ('--showme:compile', '--showme:link'),
-            ('-compile_info', '-link_info'),
-            ('-show', None)
-        ]
-
-        for comp, link in commands:
+        for comp, link in [
+            ('--showme:compile', '--showme:link'),  # for OpenMPI
+            ('-show-compile-info', '-show-link-info'),  # for MPICH and Intel MPI
+            ('-compile_info', '-link_info'),  # for older MPICH and Intel MPI
+            ('-show', None),
+        ]:
             try:
                 # Set required=True to ensure that the next set of options is
                 # tried when the current ones fail, even if the dependency is


### PR DESCRIPTION
Using `dependency('mpi')` with the MPICH compiler wrappers currently results in compiler warnings about unused command-line arguments. This is because Meson current discovers the compile and link arguments with `-compile_info` and `-link_info`:

https://github.com/mesonbuild/meson/blob/0ac8ebb050ebd73acd363fce1cca272283a23b4e/mesonbuild/dependencies/mpi.py#L112-L123

The `-compile_info` and `-link_info` flags actually return complete (and identical) compile + link commands, causing link flags to get mixed into Meson's compile command:
```
❯ mpicc -compile_info
icx -I/opt/aurora/26.26.0/spack/unified/1.1.1/install/linux-x86_64/mpich-5.0.0.aurora_test.3c70a61-hlkigtk/include -L/opt/aurora/26.26.0/spack/unified/1.1.1/install/linux-x86_64/mpich-5.0.0.aurora_test.3c70a61-hlkigtk/lib -Wl,-rpath -Wl,/opt/aurora/26.26.0/spack/unified/1.1.1/install/linux-x86_64/mpich-5.0.0.aurora_test.3c70a61-hlkigtk/lib -lmpi
```

The newer `-show-compile-info` instead just shows the compile flags (likewise for `-show-link-info`):

```
❯ mpicc -show-compile-info
-I/opt/aurora/26.26.0/spack/unified/1.1.1/install/linux-x86_64/mpich-5.0.0.aurora_test.3c70a61-hlkigtk/include
```

Per pmodels/mpich#1045 (specifically https://github.com/pmodels/mpich/commit/f8e9f16ec9367f4dded573bddbc6076508e9308e), it appears that `-show-compile-info` and `-show-link-info` are the preferred ways to get the compile and link flags in recent MPICH/Intel MPI, and that `-compile_info` and `-link_info` were kept for legacy reasons.

<details><summary>Summary of command output for completeness</summary>
<p>

```
❯ mpicc --version
Intel(R) oneAPI DPC++/C++ Compiler 2025.3.2 (2025.3.2.20260112)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /opt/aurora/26.26.0/oneapi/compiler/2025.3/bin/compiler
Configuration file: /opt/aurora/26.26.0/oneapi/compiler/2025.3/bin/compiler/../icx.cfg

❯ mpicc -compile_info
icx -I/opt/aurora/26.26.0/spack/unified/1.1.1/install/linux-x86_64/mpich-5.0.0.aurora_test.3c70a61-hlkigtk/include -L/opt/aurora/26.26.0/spack/unified/1.1.1/install/linux-x86_64/mpich-5.0.0.aurora_test.3c70a61-hlkigtk/lib -Wl,-rpath -Wl,/opt/aurora/26.26.0/spack/unified/1.1.1/install/linux-x86_64/mpich-5.0.0.aurora_test.3c70a61-hlkigtk/lib -lmpi

❯ mpicc -show-compile-info
-I/opt/aurora/26.26.0/spack/unified/1.1.1/install/linux-x86_64/mpich-5.0.0.aurora_test.3c70a61-hlkigtk/include

❯ mpicc -link-info        
icx -I/opt/aurora/26.26.0/spack/unified/1.1.1/install/linux-x86_64/mpich-5.0.0.aurora_test.3c70a61-hlkigtk/include -L/opt/aurora/26.26.0/spack/unified/1.1.1/install/linux-x86_64/mpich-5.0.0.aurora_test.3c70a61-hlkigtk/lib -Wl,-rpath -Wl,/opt/aurora/26.26.0/spack/unified/1.1.1/install/linux-x86_64/mpich-5.0.0.aurora_test.3c70a61-hlkigtk/lib -lmpi

❯ mpicc -show-link-info
-L/opt/aurora/26.26.0/spack/unified/1.1.1/install/linux-x86_64/mpich-5.0.0.aurora_test.3c70a61-hlkigtk/lib -Wl,-rpath -Wl,/opt/aurora/26.26.0/spack/unified/1.1.1/install/linux-x86_64/mpich-5.0.0.aurora_test.3c70a61-hlkigtk/lib -lmpi
```

</p>
</details> 

With this patch, I confirm that the compile and link arguments are no longer mixed in the Meson build.