### PR TITLE
fix: replace 3 bare except clauses with except Exception

### DIFF
--- a/test cases/unit/111 replace unencodable xml chars/script.py
+++ b/test cases/unit/111 replace unencodable xml chars/script.py
@@ -18,7 +18,7 @@ try:
         '\ufdd9\ufdda\ufddb\ufddc\ufddd\ufdde\ufddf\ufde0\ufde1'
         '\ufde2\ufde3\ufde4\ufde5\ufde6\ufde7\ufde8\ufde9\ufdea'
         '\ufdeb\ufdec\ufded\ufdee\ufdef\ufffe\uffff')
-except:
+except Exception:
     pass
 
 # Cover for potential encoding issues
@@ -33,5 +33,5 @@ try:
             '\U000bfffe\U000bffff\U000cfffe\U000cffff'
             '\U000dfffe\U000dffff\U000efffe\U000effff'
             '\U000ffffe\U000fffff\U0010fffe\U0010ffff')
-except:
+except Exception:
     pass

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1063,7 +1063,7 @@ class InternalTests(unittest.TestCase):
             try:
                 from jsonschema import validate, ValidationError as JsonSchemaFailure
                 fast = False
-            except:
+            except Exception:
                 if IS_CI:
                     raise
                 raise unittest.SkipTest('neither Python fastjsonschema nor jsonschema module not found.')


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance. Bare except catches SystemExit, KeyboardInterrupt, and GeneratorExit which is rarely intended.