### PR TITLE
project tests: capture output for SKIP and UNEXRUN cases into meson-test-run.xml

### DIFF
--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -1295,14 +1295,15 @@ def _run_tests(all_tests: T.List[T.Tuple[str, T.List[TestDef], bool]],
             testcase_time = result.conftime + result.buildtime + result.testtime
             current_test.set('time', '%.3f' % testcase_time)
 
+        # skip
         if is_skipped and skip_as_expected:
             f.update_log(TestStatus.SKIP)
             if not t.skip_category:
                 safe_print(bold('Reason:'), skip_reason)
             ET.SubElement(current_test, 'skipped', {})
-            continue
 
-        if not skip_as_expected:
+        # unexrun/unexskip
+        elif not skip_as_expected:
             failing_tests += 1
             if is_skipped:
                 skip_msg = f'Test asked to be skipped ({skip_reason}), but was not expected to'
@@ -1315,10 +1316,9 @@ def _run_tests(all_tests: T.List[T.Tuple[str, T.List[TestDef], bool]],
             f.update_log(status)
             safe_print(bold('Reason:'), result.msg)
             ET.SubElement(current_test, 'failure', {'message': result.msg})
-            continue
 
-        # Handle Failed tests
-        if result.msg != '':
+        # failed
+        elif result.msg != '':
             f.update_log(TestStatus.ERROR)
             safe_print(bold('During:'), result.step.name)
             safe_print(bold('Reason:'), result.msg)
@@ -1356,6 +1356,10 @@ def _run_tests(all_tests: T.List[T.Tuple[str, T.List[TestDef], bool]],
                 safe_print("Cancelling the rest of the tests")
                 for f2 in futures:
                     f2.cancel()
+
+            ET.SubElement(current_test, 'failure', {'message': result.msg})
+
+        # success
         else:
             f.update_log(TestStatus.OK)
             passing_tests += 1
@@ -1367,16 +1371,18 @@ def _run_tests(all_tests: T.List[T.Tuple[str, T.List[TestDef], bool]],
                 else:
                     mesonlib.windows_proof_rmtree(abspath)
 
-        conf_time += result.conftime
-        build_time += result.buildtime
-        test_time += result.testtime
-        log_text_file(logfile, t.path, result)
-        if result.msg != '':
-            ET.SubElement(current_test, 'failure', {'message': result.msg})
-        stdoel = ET.SubElement(current_test, 'system-out')
-        stdoel.text = mtest.replace_unencodable_xml_chars(result.stdo)
-        stdeel = ET.SubElement(current_test, 'system-err')
-        stdeel.text = mtest.replace_unencodable_xml_chars(result.stde)
+        if result:
+            # track total runtime
+            conf_time += result.conftime
+            build_time += result.buildtime
+            test_time += result.testtime
+
+            # attach stdout and stderr child nodes to 'testcase' node
+            ET.SubElement(current_test, 'system-out').text = mtest.replace_unencodable_xml_chars(result.stdo)
+            ET.SubElement(current_test, 'system-err').text = mtest.replace_unencodable_xml_chars(result.stde)
+
+            # write stdout/stderr to log file (and terminal)
+            log_text_file(logfile, t.path, result)
 
     # Reset, just in case
     safe_print = default_print

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -1287,11 +1287,18 @@ def _run_tests(all_tests: T.List[T.Tuple[str, T.List[TestDef], bool]],
 
         current_suite = junit_root.find(f"./testsuite[@name='{t.category}']")
 
+        current_test = ET.SubElement(current_suite,
+                                     'testcase',
+                                     {'name': testname, 'classname': t.category})
+
+        if result:
+            testcase_time = result.conftime + result.buildtime + result.testtime
+            current_test.set('time', '%.3f' % testcase_time)
+
         if is_skipped and skip_as_expected:
             f.update_log(TestStatus.SKIP)
             if not t.skip_category:
                 safe_print(bold('Reason:'), skip_reason)
-            current_test = ET.SubElement(current_suite, 'testcase', {'name': testname, 'classname': t.category})
             ET.SubElement(current_test, 'skipped', {})
             continue
 
@@ -1307,7 +1314,6 @@ def _run_tests(all_tests: T.List[T.Tuple[str, T.List[TestDef], bool]],
 
             f.update_log(status)
             safe_print(bold('Reason:'), result.msg)
-            current_test = ET.SubElement(current_suite, 'testcase', {'name': testname, 'classname': t.category})
             ET.SubElement(current_test, 'failure', {'message': result.msg})
             continue
 
@@ -1364,13 +1370,7 @@ def _run_tests(all_tests: T.List[T.Tuple[str, T.List[TestDef], bool]],
         conf_time += result.conftime
         build_time += result.buildtime
         test_time += result.testtime
-        testcase_time = result.conftime + result.buildtime + result.testtime
         log_text_file(logfile, t.path, result)
-        current_test = ET.SubElement(
-            current_suite,
-            'testcase',
-            {'name': testname, 'classname': t.category, 'time': '%.3f' % testcase_time}
-        )
         if result.msg != '':
             ET.SubElement(current_test, 'failure', {'message': result.msg})
         stdoel = ET.SubElement(current_test, 'system-out')


### PR DESCRIPTION
As observed in https://github.com/mesonbuild/meson/pull/15534#issuecomment-3864626558 investigating CI result changes involving skipped tests is harder than it should be, because we don't record any information about those tests into the testlog.

Future work?
- The whole 'result is None' (sometimes) thing makes this code more complex than it needs to be. Maybe create an appropriate TestResult object instead in those cases?
- The XML log contains text which has GitHub ::group:: folding directives inside. This kind of indicates a confusion somewhere?
- Maybe the plaintext log is actually pretty useless now we're more intelligent about what we write to stdout?  Or should just be a capture of that?
- I think there's now a formal schema for JUnit XML, so perhaps we should verify our output against that? Certainly, this would help check I've added properties in the right way.