### PR TITLE
Skip link check for pkg-config dependencies

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -783,7 +783,8 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         return args.copy()
 
     def find_library(self, libname: str, extra_dirs: T.List[str], libtype: LibType = LibType.PREFER_SHARED,
-                     lib_prefix_warning: bool = True, ignore_system_dirs: bool = False) -> T.Optional[T.List[str]]:
+                     lib_prefix_warning: bool = True, ignore_system_dirs: bool = False,
+                     skip_link_check: bool = False) -> T.Optional[T.List[str]]:
         raise EnvironmentException(f'Language {self.get_display_language()} does not support library finding.')
 
     def get_library_naming(self, libtype: LibType, strict: bool = False) -> T.Optional[T.Tuple[str, ...]]:

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -721,8 +721,9 @@ class CudaCompiler(Compiler):
         return self._to_host_flags(self.host_compiler.get_std_exe_link_args(), Phase.LINKER)
 
     def find_library(self, libname: str, extra_dirs: T.List[str], libtype: LibType = LibType.PREFER_SHARED,
-                     lib_prefix_warning: bool = True, ignore_system_dirs: bool = False) -> T.Optional[T.List[str]]:
-        return self.host_compiler.find_library(libname, extra_dirs, libtype, lib_prefix_warning, ignore_system_dirs)
+                     lib_prefix_warning: bool = True, ignore_system_dirs: bool = False,
+                     skip_link_check: bool = False) -> T.Optional[T.List[str]]:
+        return self.host_compiler.find_library(libname, extra_dirs, libtype, lib_prefix_warning, ignore_system_dirs, skip_link_check)
 
     def get_crt_compile_args(self, crt_val: str, buildtype: str) -> T.List[str]:
         return self._to_host_flags(self.host_compiler.get_crt_compile_args(crt_val, buildtype))

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -105,9 +105,10 @@ class FortranCompiler(CLikeCompiler, Compiler):
         return filename
 
     def find_library(self, libname: str, extra_dirs: T.List[str], libtype: LibType = LibType.PREFER_SHARED,
-                     lib_prefix_warning: bool = True, ignore_system_dirs: bool = False) -> T.Optional[T.List[str]]:
+                     lib_prefix_warning: bool = True, ignore_system_dirs: bool = False,
+                     skip_link_check: bool = False) -> T.Optional[T.List[str]]:
         code = 'stop; end program'
-        return self._find_library_impl(libname, extra_dirs, code, libtype, lib_prefix_warning, ignore_system_dirs)
+        return self._find_library_impl(libname, extra_dirs, code, libtype, lib_prefix_warning, ignore_system_dirs, skip_link_check)
 
     def has_multi_arguments(self, args: T.List[str]) -> T.Tuple[bool, bool]:
         return self._has_multi_arguments(args, 'stop; end program')

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -138,7 +138,7 @@ class CLikeCompiler(Compiler):
         warn_args: T.Dict[str, T.List[str]] = {}
 
     # TODO: Replace this manual cache with functools.lru_cache
-    find_library_cache: T.Dict[T.Tuple[T.Tuple[str, ...], str, T.Tuple[str, ...], str, LibType, bool], T.Optional[T.List[str]]] = {}
+    find_library_cache: T.Dict[T.Tuple[T.Tuple[str, ...], str, T.Tuple[str, ...], str, LibType, bool, bool], T.Optional[T.List[str]]] = {}
     find_framework_cache: T.Dict[T.Tuple[T.Tuple[str, ...], str, T.Tuple[str, ...], bool], T.Optional[T.List[str]]] = {}
     internal_libs = arglist.UNIXY_COMPILER_INTERNAL_LIBS
 
@@ -1097,7 +1097,8 @@ class CLikeCompiler(Compiler):
         return self.sizeof('void *', '')[0] == 8
 
     def _find_library_real(self, libname: str, extra_dirs: T.List[str], code: str, libtype: LibType,
-                           lib_prefix_warning: bool, ignore_system_dirs: bool) -> T.Optional[T.List[str]]:
+                           lib_prefix_warning: bool, ignore_system_dirs: bool,
+                           skip_link_check: bool = False) -> T.Optional[T.List[str]]:
         # First try if we can just add the library as -l.
         # Gcc + co seem to prefer builtin lib dirs to -L dirs.
         # Only try to find std libs if no extra dirs specified.
@@ -1140,8 +1141,12 @@ class CLikeCompiler(Compiler):
                 for trial in trials:
                     if not os.path.isfile(trial):
                         continue
+                    # When skip_link_check is True (e.g. for pkg-config
+                    # libraries which are trusted to be linkable), skip the
+                    # potentially expensive link check and just verify that the
+                    # file exists.
                     extra_args = [trial] + lcargs
-                    if self.links(code, extra_args=extra_args, disable_cache=True)[0]:
+                    if skip_link_check or self.links(code, extra_args=extra_args, disable_cache=True)[0]:
                         trial_result = trial
                         break
 
@@ -1153,15 +1158,16 @@ class CLikeCompiler(Compiler):
         return None
 
     def _find_library_impl(self, libname: str, extra_dirs: T.List[str], code: str, libtype: LibType,
-                           lib_prefix_warning: bool, ignore_system_dirs: bool) -> T.Optional[T.List[str]]:
+                           lib_prefix_warning: bool, ignore_system_dirs: bool,
+                           skip_link_check: bool = False) -> T.Optional[T.List[str]]:
         # These libraries are either built-in or invalid
         if libname in self.ignore_libs:
             return []
         if isinstance(extra_dirs, str):
             extra_dirs = [extra_dirs]
-        key = (tuple(self.exelist), libname, tuple(extra_dirs), code, libtype, ignore_system_dirs)
+        key = (tuple(self.exelist), libname, tuple(extra_dirs), code, libtype, ignore_system_dirs, skip_link_check)
         if key not in self.find_library_cache:
-            value = self._find_library_real(libname, extra_dirs, code, libtype, lib_prefix_warning, ignore_system_dirs)
+            value = self._find_library_real(libname, extra_dirs, code, libtype, lib_prefix_warning, ignore_system_dirs, skip_link_check)
             self.find_library_cache[key] = value
         else:
             value = self.find_library_cache[key]
@@ -1170,9 +1176,10 @@ class CLikeCompiler(Compiler):
         return value.copy()
 
     def find_library(self, libname: str, extra_dirs: T.List[str], libtype: LibType = LibType.PREFER_SHARED,
-                     lib_prefix_warning: bool = True, ignore_system_dirs: bool = False) -> T.Optional[T.List[str]]:
+                     lib_prefix_warning: bool = True, ignore_system_dirs: bool = False,
+                     skip_link_check: bool = False) -> T.Optional[T.List[str]]:
         code = 'int main(void) { return 0; }\n'
-        return self._find_library_impl(libname, extra_dirs, code, libtype, lib_prefix_warning, ignore_system_dirs)
+        return self._find_library_impl(libname, extra_dirs, code, libtype, lib_prefix_warning, ignore_system_dirs, skip_link_check)
 
     def find_framework_paths(self) -> T.List[str]:
         '''

--- a/mesonbuild/compilers/mixins/emscripten.py
+++ b/mesonbuild/compilers/mixins/emscripten.py
@@ -75,9 +75,10 @@ class EmscriptenMixin(Compiler):
         return wrap_js_includes(super().get_dependency_link_args(dep))
 
     def find_library(self, libname: str, extra_dirs: T.List[str], libtype: LibType = LibType.PREFER_SHARED,
-                     lib_prefix_warning: bool = True, ignore_system_dirs: bool = False) -> T.Optional[T.List[str]]:
+                     lib_prefix_warning: bool = True, ignore_system_dirs: bool = False,
+                     skip_link_check: bool = False) -> T.Optional[T.List[str]]:
         if not libname.endswith('.js'):
-            return super().find_library(libname, extra_dirs, libtype, lib_prefix_warning)
+            return super().find_library(libname, extra_dirs, libtype, lib_prefix_warning, ignore_system_dirs, skip_link_check)
         if os.path.isabs(libname):
             if os.path.exists(libname):
                 return [libname]

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -144,7 +144,8 @@ class ValaCompiler(Compiler):
         return sourcename, f'{os.path.splitext(sourcename)[0]}.c', binname
 
     def find_library(self, libname: str, extra_dirs: T.List[str], libtype: LibType = LibType.PREFER_SHARED,
-                     lib_prefix_warning: bool = True, ignore_system_dirs: bool = False) -> T.Optional[T.List[str]]:
+                     lib_prefix_warning: bool = True, ignore_system_dirs: bool = False,
+                     skip_link_check: bool = False) -> T.Optional[T.List[str]]:
         if extra_dirs and isinstance(extra_dirs, str):
             extra_dirs = [extra_dirs]
         # Valac always looks in the default vapi dir, so only search there if

--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -488,8 +488,12 @@ class PkgConfigDependency(ExternalDependency):
                 if lib in libs_found:
                     continue
                 if self.clib_compiler:
+                    # Libraries from pkg-config are trusted to be linkable, so
+                    # we skip the potentially expensive link check for
+                    # performance reasons.
                     args = self.clib_compiler.find_library(
-                        lib[2:], libpaths, self.libtype, lib_prefix_warning=False)
+                        lib[2:], libpaths, self.libtype, lib_prefix_warning=False,
+                        skip_link_check=True)
                 # If the project only uses a non-clib language such as D, Rust,
                 # C#, Python, etc, all we can do is limp along by adding the
                 # arguments as-is and then adding the libpaths at the end.


### PR DESCRIPTION
pkg-config files should to be trusted to work, so skip a potentially costly link check for such dependencies.

Fixes: #15513