### PR TITLE
Fix hd5f typo

### DIFF
--- a/mesonbuild/dependencies/hdf5.py
+++ b/mesonbuild/dependencies/hdf5.py
@@ -165,7 +165,7 @@ def hdf5_factory(env: 'Environment', kwargs: DependencyObjectKWs,
 
     if DependencyMethods.CONFIG_TOOL in methods:
         candidates.append(DependencyCandidate.from_dependency(
-            'hd5f', HDF5ConfigToolDependency, (env, kwargs)))
+            'hdf5', HDF5ConfigToolDependency, (env, kwargs)))
 
     return candidates
 


### PR DESCRIPTION
Typo introduced in refactoring in 63f47811eaba44ccacb8b94ee0a224d5d75dc14b.