### PR TITLE
docs: fix use of list[str].

### DIFF
--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -195,7 +195,7 @@ workspace.
 
 Keyword arguments:
 - `default_features`: (`bool`, optional) Whether to enable default features.
-- `features`: (`list[str]`, optional) List of additional features to enable globally.
+- `features`: (`array[str]`, optional) List of additional features to enable globally.
 
 A project that wishes to use Cargo subprojects should have `Cargo.lock` and `Cargo.toml`
 files in the root source directory, and should call this function before using

--- a/docs/yaml/functions/_build_target_base.yaml
+++ b/docs/yaml/functions/_build_target_base.yaml
@@ -106,7 +106,7 @@ kwargs:
       flags here for all platforms.
 
   link_early_args:
-    type: list[str]
+    type: array[str]
     description: |
       Flags to use during linking. These are just like link_args,
       except that they are inserted into the linker command line


### PR DESCRIPTION
The correct type for use in docs/yaml is "array[str]", not "list[str]". Fix it so that CI works.

Use the right name even in Rust-module.md, even though it does not use the automatic converter.