### PR TITLE
Remove str from build.CustomTarget sources

### DIFF
--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -326,7 +326,8 @@ library.
 * `install_dir`: location to install the VAPI file (defaults to datadir/vala/vapi)
 * `metadata_dirs`: extra directories to include for metadata files
 * `packages`: VAPI packages that are depended upon
-* `sources`: the gir source to generate the VAPI from
+* `sources`: the gir source to generate the VAPI from (File objects
+  only supported *since 1.12.0*)
 * `vapi_dirs`: extra directories to include for VAPI files
 
 Returns a custom dependency that can be included when building other

--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -144,7 +144,7 @@ argument is the basename of the output files.
 * `nostdinc`: if true, don't include the standard marshallers from glib
 * `prefix`: the prefix to use for symbols
 * `skip_source`: if true, skip source location comments
-* `sources` [](str | File) *required*: the list of sources to use as inputs
+* `sources` [](str | File | CustomTarget | CustomTargetIndex | generator_output) *required*: the list of sources to use as inputs (build-time generated files only allowed *since 1.12.0*)
 * `stdinc`: if true, include the standard marshallers from glib
 * `valist_marshallers`: if true, generate va_list marshallers
 

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1958,8 +1958,6 @@ class Backend:
             for j in source_list_raw:
                 if isinstance(j, mesonlib.File):
                     source_list += [j.absolute_path(self.source_dir, self.build_dir)]
-                elif isinstance(j, str):
-                    source_list += [os.path.join(self.source_dir, target.subdir, j)]
                 elif isinstance(j, (build.CustomTarget, build.BuildTarget)):
                     source_list += [os.path.join(self.build_dir, j.get_builddir(), o) for o in j.get_outputs()]
             source_list = [os.path.normpath(s) for s in source_list]

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1967,17 +1967,17 @@ class Backend:
             compiler: T.List[str] = []
             if isinstance(target, build.CustomTarget):
                 tmp_compiler = target.command
-                for j in tmp_compiler:
-                    if isinstance(j, mesonlib.File):
-                        compiler += [j.absolute_path(self.source_dir, self.build_dir)]
-                    elif isinstance(j, str):
-                        compiler += [j]
-                    elif isinstance(j, (build.BuildTarget, build.CustomTarget)):
-                        compiler += j.get_outputs()
-                    elif isinstance(j, programs.Program):
-                        compiler += j.get_command()
+                for k in tmp_compiler:
+                    if isinstance(k, mesonlib.File):
+                        compiler += [k.absolute_path(self.source_dir, self.build_dir)]
+                    elif isinstance(k, str):
+                        compiler += [k]
+                    elif isinstance(k, (build.BuildTarget, build.CustomTarget)):
+                        compiler += k.get_outputs()
+                    elif isinstance(k, programs.Program):
+                        compiler += k.get_command()
                     else:
-                        raise RuntimeError(f'Type "{type(j).__name__}" is not supported in get_introspection_data. This is a bug')
+                        raise RuntimeError(f'Type "{type(k).__name__}" is not supported in get_introspection_data. This is a bug')
 
             return [{
                 'language': 'unknown',

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -1157,21 +1157,22 @@ class XCodeBackend(backends.Backend):
         target_dict.add_item('sourceTree', '<group>')
         source_files_dict = PbxDict()
         for s in t.sources:
-            if isinstance(s, mesonlib.File):
-                # If the file is in a folder, add it to the group representing that folder.
-                if '/' in s.fname:
-                    folder = '/'.join(s.fname.split('/')[:-1])
-                    folder_dict = objects_dict.get_item(self.foldermap[(folder, t)]).value.get_item('children').value
-                    temp = os.path.join(s.subdir, s.fname)
-                    folder_dict.add_item(self.fileref_ids[(tid, temp)], temp)
-                    if self.foldermap[(folder, t)] in folder_ids:
-                        continue
-                    if len(folder.split('/')) == 1:
-                        target_children.add_item(self.foldermap[(folder, t)], folder)
-                        folder_ids.add(self.foldermap[(folder, t)])
+            if not isinstance(s, mesonlib.File):
+                continue
+            # If the file is in a folder, add it to the group representing that folder.
+            if '/' in s.fname:
+                folder = '/'.join(s.fname.split('/')[:-1])
+                folder_dict = objects_dict.get_item(self.foldermap[(folder, t)]).value.get_item('children').value
+                temp = os.path.join(s.subdir, s.fname)
+                folder_dict.add_item(self.fileref_ids[(tid, temp)], temp)
+                if self.foldermap[(folder, t)] in folder_ids:
                     continue
-                s = os.path.join(s.subdir, s.fname)
-                target_children.add_item(self.fileref_ids[(tid, s)], s)
+                if len(folder.split('/')) == 1:
+                    target_children.add_item(self.foldermap[(folder, t)], folder)
+                    folder_ids.add(self.foldermap[(folder, t)])
+                continue
+            s = os.path.join(s.subdir, s.fname)
+            target_children.add_item(self.fileref_ids[(tid, s)], s)
         for o in t.objects:
             if isinstance(o, build.ExtractedObjects):
                 # Do not show built object files in the project tree.

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -591,10 +591,9 @@ class XCodeBackend(backends.Backend):
     def generate_target_file_maps_impl(self, targets) -> None:
         for tname, t in targets.items():
             for s in t.sources:
-                if isinstance(s, mesonlib.File):
-                    s = os.path.join(s.subdir, s.fname)
-                if not isinstance(s, str):
+                if not isinstance(s, mesonlib.File):
                     continue
+                s = os.path.join(s.subdir, s.fname)
                 k = (tname, s)
                 assert k not in self.buildfile_ids
                 self.buildfile_ids[k] = self.gen_id()
@@ -724,14 +723,10 @@ class XCodeBackend(backends.Backend):
                         fw_dict.add_item('fileRef', self.native_frameworks_fileref[f], f)
 
             for s in t.sources:
-                in_build_dir = False
-                if isinstance(s, mesonlib.File):
-                    if s.is_built:
-                        in_build_dir = True
-                    s = os.path.join(s.subdir, s.fname)
-
-                if not isinstance(s, str):
+                if not isinstance(s, mesonlib.File):
                     continue
+                in_build_dir = s.is_built
+                s = os.path.join(s.subdir, s.fname)
                 sdict = PbxDict()
                 k = (tname, s)
                 idval = self.buildfile_ids[k]
@@ -884,13 +879,10 @@ class XCodeBackend(backends.Backend):
                         fw_dict.add_item('path', f'System/Library/Frameworks/{f}.framework')
                         fw_dict.add_item('sourceTree', 'SDKROOT')
             for s in t.sources:
-                in_build_dir = False
-                if isinstance(s, mesonlib.File):
-                    if s.is_built:
-                        in_build_dir = True
-                    s = os.path.join(s.subdir, s.fname)
-                if not isinstance(s, str):
+                if not isinstance(s, mesonlib.File):
                     continue
+                in_build_dir = s.is_built
+                s = os.path.join(s.subdir, s.fname)
                 idval = self.fileref_ids[(tname, s)]
                 fullpath = os.path.join(self.environment.get_source_dir(), s)
                 src_dict = PbxDict()
@@ -999,12 +991,9 @@ class XCodeBackend(backends.Backend):
                 continue
             (srcs, ofilenames, cmd) = self.eval_custom_target_command(t)
             for s in t.sources:
-                if isinstance(s, mesonlib.File):
-                    s = os.path.join(s.subdir, s.fname)
-                elif isinstance(s, str):
-                    s = os.path.join(t.subdir, s)
-                else:
+                if not isinstance(s, mesonlib.File):
                     continue
+                s = os.path.join(s.subdir, s.fname)
                 custom_dict = PbxDict()
                 typestr = self.get_xcodetype(s)
                 custom_dict.add_item('isa', 'PBXFileReference')
@@ -1137,12 +1126,9 @@ class XCodeBackend(backends.Backend):
             source_file_children = PbxArray()
             source_files_dict.add_item('children', source_file_children)
             for s in t.sources:
-                if isinstance(s, mesonlib.File):
-                    s = os.path.join(s.subdir, s.fname)
-                elif isinstance(s, str):
-                    s = os.path.join(t.subdir, s)
-                else:
+                if not isinstance(s, mesonlib.File):
                     continue
+                s = os.path.join(s.subdir, s.fname)
                 source_file_children.add_item(self.fileref_ids[(tname, s)], s)
             source_files_dict.add_item('name', 'Source files')
             source_files_dict.add_item('sourceTree', '<group>')
@@ -1185,11 +1171,7 @@ class XCodeBackend(backends.Backend):
                         folder_ids.add(self.foldermap[(folder, t)])
                     continue
                 s = os.path.join(s.subdir, s.fname)
-            elif isinstance(s, str):
-                s = os.path.join(t.subdir, s)
-            else:
-                continue
-            target_children.add_item(self.fileref_ids[(tid, s)], s)
+                target_children.add_item(self.fileref_ids[(tid, s)], s)
         for o in t.objects:
             if isinstance(o, build.ExtractedObjects):
                 # Do not show built object files in the project tree.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -44,7 +44,7 @@ if T.TYPE_CHECKING:
     from ._typing import ImmutableListProtocol
     from .backend.backends import Backend
     from .compilers.compilers import Compiler, CompilerDict, Language
-    from .interpreter.interpreter import SourceOutputs, Interpreter
+    from .interpreter.interpreter import CustomTargetSources, SourceOutputs, Interpreter
     from .interpreter.interpreterobjects import Test, Doctest
     from .linkers.linkers import StaticLinker
     from .mesonlib import ExecutableSerialisation, FileMode, FileOrString
@@ -2993,9 +2993,7 @@ class CustomTarget(Target, CustomTargetBase, CommandBase):
                  command: T.Sequence[T.Union[
                      str, BuildTargetTypes, GeneratedList,
                      programs.Program, File]],
-                 sources: T.Sequence[T.Union[
-                     str, File, BuildTargetTypes, ExtractedObjects,
-                     GeneratedList, programs.Program]],
+                 sources: T.Sequence[CustomTargetSources],
                  outputs: T.List[str],
                  *,
                  build_always_stale: bool = False,
@@ -3593,9 +3591,7 @@ def get_sources_string_names(sources, backend):
     '''
     names = []
     for s in sources:
-        if isinstance(s, str):
-            names.append(s)
-        elif isinstance(s, (BuildTarget, CustomTarget, CustomTargetIndex, GeneratedList)):
+        if isinstance(s, (BuildTarget, CustomTarget, CustomTargetIndex, GeneratedList)):
             names += s.get_outputs()
         elif isinstance(s, ExtractedObjects):
             names += backend.determine_ext_objs(s)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -128,6 +128,9 @@ if T.TYPE_CHECKING:
     # Input source types passed to the build.Target classes
     SourceOutputs = T.Union[mesonlib.File, build.GeneratedTypes, build.BuildTarget,
                             build.ExtractedObjects, build.StructuredSources]
+    # Sources for custom targets, which can also include ExternalProgram
+    CustomTargetSources = T.Union[mesonlib.File, build.GeneratedTypes, build.BuildTarget,
+                                  build.ExtractedObjects, ExternalProgram]
 
     BuildTargetSource = T.Union[mesonlib.FileOrString, build.GeneratedTypes, build.StructuredSources]
 
@@ -3217,6 +3220,9 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     @T.overload
     def source_strings_to_files(self, sources: T.List[T.Union[mesonlib.FileOrString, build.GeneratedTypes]]) -> T.List[T.Union[mesonlib.File, build.GeneratedTypes]]: ... # noqa: F811
+
+    @T.overload
+    def source_strings_to_files(self, sources: T.List[kwtypes.CustomTargetInputs]) -> T.List['CustomTargetSources']: ... # noqa: F811
 
     @T.overload
     def source_strings_to_files(self, sources: T.List['SourceInputs'], strict: bool = True) -> T.List['SourceOutputs']: ... # noqa: F811

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -22,6 +22,8 @@ from ..programs import Program, ExternalProgram
 from .type_checking import PkgConfigDefineType, SourcesVarargsType
 
 TestArgs = T.Union[str, File, build.Target, ExternalProgram]
+CustomTargetInputs = T.Union[str, build.BuildTarget, build.GeneratedTypes,
+                             build.ExtractedObjects, ExternalProgram, File]
 RustAbi = Literal['rust', 'c']
 
 class NativeKW(TypedDict):
@@ -200,8 +202,7 @@ class CustomTarget(TypedDict):
     depfile: T.Optional[str]
     env: EnvironmentVariables
     feed: bool
-    input: T.List[T.Union[str, build.BuildTarget, build.GeneratedTypes,
-                          build.ExtractedObjects, ExternalProgram, File]]
+    input: T.List[CustomTargetInputs]
     install: bool
     install_dir: T.List[T.Union[str, T.Literal[False]]]
     install_mode: FileMode

--- a/mesonbuild/modules/_qt.py
+++ b/mesonbuild/modules/_qt.py
@@ -26,6 +26,7 @@ if T.TYPE_CHECKING:
     from ..dependencies.base import DependencyObjectKWs
     from ..interpreter import Interpreter
     from ..interpreter import kwargs
+    from ..interpreter.interpreter import CustomTargetSources
     from ..mesonlib import FileOrString
     from ..programs import CommandList, Program
     from typing_extensions import Literal
@@ -428,9 +429,11 @@ class QtBaseModule(ExtensionModule):
         DEPFILE_ARGS: T.List[str] = ['--depfile', '@DEPFILE@'] if self._rcc_supports_depfiles else []
 
         name = kwargs['name']
-        sources: T.List['FileOrString'] = []
+        sources: T.List[File] = []
         for s in kwargs['sources']:
-            if isinstance(s, (str, File)):
+            if isinstance(s, str):
+                sources.append(File.from_source_file(state.environment.source_dir, state.subdir, s))
+            elif isinstance(s, File):
                 sources.append(s)
             else:
                 # TODO: this could be fixed with dyndeps
@@ -464,10 +467,7 @@ class QtBaseModule(ExtensionModule):
         else:
             for rcc_file in sources:
                 qrc_deps = self._parse_qrc_deps(state, rcc_file)
-                if isinstance(rcc_file, str):
-                    basename = os.path.basename(rcc_file)
-                else:
-                    basename = os.path.basename(rcc_file.fname)
+                basename = os.path.basename(rcc_file.fname)
                 name = f'qt{self.qt_version}-{basename.replace(".", "_")}'
                 cmd = [self.tools['rcc'], '-name', '@BASENAME@', '-o', '@OUTPUT@', *extra_args, '@INPUT@', *DEPFILE_ARGS]
                 res_target = build.CustomTarget(
@@ -725,6 +725,7 @@ class QtBaseModule(ExtensionModule):
             if not self.tools['lrelease'].found():
                 raise MesonException('qt.compile_translations: ' +
                                      self.tools['lrelease'].name + ' not found')
+            ts_file: CustomTargetSources
             if qresource:
                 # In this case we know that ts_files is always a List[str], as
                 # it's generated above and no ts_files are passed in. However,
@@ -732,9 +733,13 @@ class QtBaseModule(ExtensionModule):
                 # what we're doing is safe
                 assert isinstance(ts, str), 'for mypy'
                 outdir = os.path.dirname(os.path.normpath(os.path.join(state.subdir, ts)))
-                ts = os.path.basename(ts)
+                ts_file = File.from_source_file(state.environment.source_dir, outdir, os.path.basename(ts))
+            elif isinstance(ts, str):
+                outdir = state.subdir
+                ts_file = File.from_source_file(state.environment.source_dir, state.subdir, ts)
             else:
                 outdir = state.subdir
+                ts_file = ts
             cmd: CommandList = [self.tools['lrelease'], '@INPUT@', '-qm', '@OUTPUT@']
             lrelease_target = build.CustomTarget(
                 f'qt{self.qt_version}-compile-{ts}',
@@ -742,7 +747,7 @@ class QtBaseModule(ExtensionModule):
                 state.subproject,
                 state.environment,
                 cmd,
-                [ts],
+                [ts_file],
                 ['@BASENAME@.qm'],
                 install=kwargs['install'],
                 install_dir=[kwargs['install_dir']],

--- a/mesonbuild/modules/_qt.py
+++ b/mesonbuild/modules/_qt.py
@@ -124,7 +124,7 @@ if T.TYPE_CHECKING:
 
         target_name: str
         qml_sources: T.Sequence[T.Union[FileOrString, build.GeneratedTypes]]
-        qml_qrc: T.Union[FileOrString, build.GeneratedTypes]
+        qml_qrc: File
         extra_args: T.List[str]
         module_prefix: str
         method: DependencyMethods
@@ -138,7 +138,7 @@ if T.TYPE_CHECKING:
         namespace: str
         typeinfo: str
         generate_qmltype: bool
-        collected_json: T.Optional[T.Union[FileOrString, build.CustomTarget]]
+        collected_json: T.Optional[T.Union[File, build.CustomTarget]]
         extra_args: T.List[str]
         method: DependencyMethods
         install: bool
@@ -951,9 +951,9 @@ class QtBaseModule(ExtensionModule):
         namespace: str = kwargs['namespace']
         typeinfo: str = kwargs['typeinfo']
         target_name: str = kwargs['target_name']
-        collected_json: T.Optional[T.Union[FileOrString, build.CustomTarget]] = kwargs['collected_json']
+        collected_json: T.Optional[T.Union[File, build.CustomTarget]] = kwargs['collected_json']
 
-        inputs: T.Sequence[T.Union[FileOrString, build.CustomTarget]] = [collected_json] if collected_json else []
+        inputs: T.Sequence[T.Union[File, build.CustomTarget]] = [collected_json] if collected_json else []
         outputs: T.List[str] = [f'{target_name}_qmltyperegistrations.cpp']
         install_dir: T.List[T.Union[str, Literal[False]]] = [False]
         install_tag: T.List[T.Union[str, None]] = [None]
@@ -1102,7 +1102,7 @@ class QtBaseModule(ExtensionModule):
             self.interpreter.install_data_impl(all_qml_files, module_install_dir,
                                                FileMode(), all_qml_basename, 'devel')
 
-        collected_json: T.Optional[T.Union[FileOrString, build.CustomTarget]] = None
+        collected_json: T.Optional[T.Union[File, build.CustomTarget]] = None
         if kwargs['moc_headers']:
             compile_moc_kwargs: MocCompilerKwArgs = {
                 'sources': [],

--- a/mesonbuild/modules/_qt.py
+++ b/mesonbuild/modules/_qt.py
@@ -326,14 +326,9 @@ class QtBaseModule(ExtensionModule):
         except Exception:
             raise MesonException(f'Unable to parse resource file {abspath}')
 
-    def _parse_qrc_deps(self, state: ModuleState,
-                        rcc_file_: T.Union[FileOrString, build.GeneratedTypes]) -> T.List[File]:
+    def _parse_qrc_deps(self, state: ModuleState, rcc_file_: FileOrString) -> T.List[File]:
         result: T.List[File] = []
-        inputs: T.Sequence['FileOrString'] = []
-        if isinstance(rcc_file_, (str, File)):
-            inputs = [rcc_file_]
-        else:
-            inputs = rcc_file_.get_outputs()
+        inputs: T.Sequence['FileOrString'] = [rcc_file_]
 
         for rcc_file in inputs:
             rcc_dirname, nodes = self._qrc_nodes(state, rcc_file)
@@ -438,7 +433,11 @@ class QtBaseModule(ExtensionModule):
             if isinstance(s, (str, File)):
                 sources.append(s)
             else:
-                sources.extend(s.get_outputs())
+                # TODO: this could be fixed with dyndeps
+                raise MesonException('Resource xml files generated at build-time cannot be used with '
+                                     'qt.compile_resources() because we need to scan the xml for '
+                                     'dependencies.\nUse configure_file() instead to generate it at '
+                                     'configure-time.')
         extra_args = kwargs['extra_args']
 
         # If a name was set generate a single .cpp file from all of the qrc

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -436,6 +436,7 @@ class GnomeModule(ExtensionModule):
                     ifile = os.path.join(input_file.subdir, input_file.fname)
 
             elif isinstance(input_file, (CustomTarget, CustomTargetIndex, GeneratedList)):
+                # TODO: this could be fixed with dyndeps
                 raise MesonException('Resource xml files generated at build-time cannot be used with '
                                      'gnome.compile_resources() in the current version of glib-compile-resources '
                                      'because we need to scan the xml for dependencies due to '

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -159,7 +159,7 @@ if T.TYPE_CHECKING:
         nostdinc: bool
         prefix: T.Optional[str]
         skip_source: bool
-        sources: T.List[FileOrString]
+        sources: T.List[CustomTargetInputs]
         stdinc: bool
         valist_marshallers: bool
 
@@ -2100,7 +2100,10 @@ class GnomeModule(ExtensionModule):
         KwargInfo('nostdinc', bool, default=False),
         KwargInfo('prefix', (str, NoneType)),
         KwargInfo('skip_source', bool, default=False),
-        KwargInfo('sources', ContainerTypeInfo(list, (str, mesonlib.File), allow_empty=False), listify=True, required=True),
+        KwargInfo('sources', ContainerTypeInfo(list, (str, mesonlib.File, CustomTarget, CustomTargetIndex, GeneratedList), allow_empty=False), listify=True, required=True,
+                  since_values={ContainerTypeInfo(list, (CustomTarget, CustomTargetIndex, GeneratedList), allow_empty=False): '1.12.0'},
+
+                  ),
         KwargInfo('stdinc', bool, default=False),
         KwargInfo('valist_marshallers', bool, default=False),
     )

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -43,6 +43,8 @@ if T.TYPE_CHECKING:
     from ..build import BuildTarget
     from ..compilers import Compiler
     from ..interpreter import Interpreter
+    from ..interpreter.interpreter import CustomTargetSources
+    from ..interpreter.kwargs import CustomTargetInputs
     from ..interpreterbase import TYPE_var, TYPE_kwargs
     from ..mesonlib import EnvironmentVariables, FileOrString
     from ..programs import Program, CommandList, CommandListEntry
@@ -393,7 +395,7 @@ class GnomeModule(ExtensionModule):
         KwargInfo('gresource_bundle', bool, default=False, since='0.37.0'),
         KwargInfo('source_dir', ContainerTypeInfo(list, str), default=[], listify=True),
     )
-    def compile_resources(self, state: 'ModuleState', args: T.Tuple[str, 'FileOrString'],
+    def compile_resources(self, state: 'ModuleState', args: T.Tuple[str, CustomTargetInputs],
                           kwargs: 'CompileResources') -> 'ModuleReturnValue':
         self.__print_gresources_warning(state)
         glib_version = self._get_native_glib_version(state)
@@ -403,8 +405,14 @@ class GnomeModule(ExtensionModule):
 
         source_dirs = kwargs['source_dir']
         dependencies = kwargs['dependencies']
+        target_name, input_file_arg = args
 
-        target_name, input_file = args
+        input_file: CustomTargetSources
+        if isinstance(input_file_arg, str):
+            input_file = mesonlib.File.from_source_file(state.environment.get_source_dir(),
+                                                        state.subdir, input_file_arg)
+        else:
+            input_file = input_file_arg
 
         # Validate dependencies
         subdirs: T.List[str] = []
@@ -442,8 +450,6 @@ class GnomeModule(ExtensionModule):
                                      'because we need to scan the xml for dependencies due to '
                                      '<https://bugzilla.gnome.org/show_bug.cgi?id=774368>\nUse '
                                      'configure_file() instead to generate it at configure-time.')
-            else:
-                ifile = os.path.join(state.subdir, input_file)
 
             depend_files, depends, subdirs = self._get_gresource_dependencies(
                 state, ifile, source_dirs, dependencies)
@@ -1385,11 +1391,11 @@ class GnomeModule(ExtensionModule):
                                         mesonlib.FileMode(), state.subproject, install_tag='doc')
                 targets.append(l_data)
 
-            po_file = l + '.po'
+            po_fname = l + '.po'
             po_args: CommandList = [
                 msgmerge, '-q', '-o',
-                os.path.join('@SOURCE_ROOT@', l_subdir, po_file),
-                os.path.join('@SOURCE_ROOT@', l_subdir, po_file), pot_file]
+                os.path.join('@SOURCE_ROOT@', l_subdir, po_fname),
+                os.path.join('@SOURCE_ROOT@', l_subdir, po_fname), pot_file]
             potarget = build.RunTarget(f'help-{project_id}-{l}-update-po',
                                        po_args, [pottarget], l_subdir, state.subproject,
                                        state.environment)
@@ -1397,6 +1403,7 @@ class GnomeModule(ExtensionModule):
             potargets.append(potarget)
 
             gmo_file = project_id + '-' + l + '.gmo'
+            po_file = mesonlib.File.from_source_file(state.environment.source_dir, l_subdir, l + '.po')
             gmotarget = CustomTarget(
                 f'help-{project_id}-{l}-gmo',
                 l_subdir,
@@ -1650,7 +1657,8 @@ class GnomeModule(ExtensionModule):
     def gdbus_codegen(self, state: 'ModuleState', args: T.Tuple[str, T.Optional[T.Union['FileOrString', build.GeneratedTypes]]],
                       kwargs: 'GdbusCodegen') -> ModuleReturnValue:
         namebase = args[0]
-        xml_files: T.List[T.Union['FileOrString', build.GeneratedTypes]] = [args[1]] if args[1] else []
+        xml_files: T.List[T.Union[mesonlib.File, build.GeneratedTypes]] = \
+            self.interpreter.source_strings_to_files([args[1]]) if args[1] else []
         cmd: CommandList = [self._find_tool(state, 'gdbus-codegen')]
         cmd.extend(kwargs['extra_args'])
 
@@ -1674,7 +1682,7 @@ class GnomeModule(ExtensionModule):
             cmd.extend(['--c-namespace', kwargs['namespace']])
         if kwargs['object_manager']:
             cmd.extend(['--c-generate-object-manager'])
-        xml_files.extend(kwargs['sources'])
+        xml_files.extend(self.interpreter.source_strings_to_files(kwargs['sources']))
         build_by_default = kwargs['build_by_default']
 
         # Annotations are a bit ugly in that they are a list of lists of strings...
@@ -1864,11 +1872,11 @@ class GnomeModule(ExtensionModule):
         basename = args[0]
 
         c_template = kwargs['c_template']
-        if isinstance(c_template, mesonlib.File):
-            c_template = c_template.absolute_path(state.environment.source_dir, state.environment.build_dir)
+        if isinstance(c_template, str):
+            c_template = mesonlib.File.from_source_file(state.environment.source_dir, state.subdir, c_template)
         h_template = kwargs['h_template']
-        if isinstance(h_template, mesonlib.File):
-            h_template = h_template.absolute_path(state.environment.source_dir, state.environment.build_dir)
+        if isinstance(h_template, str):
+            h_template = mesonlib.File.from_source_file(state.environment.source_dir, state.subdir, h_template)
 
         cmd: T.List[str] = []
         known_kwargs = ['comments', 'eprod', 'fhead', 'fprod', 'ftail',
@@ -1879,28 +1887,27 @@ class GnomeModule(ExtensionModule):
             if kwargs[arg]:                                         # type: ignore
                 cmd += ['--' + arg.replace('_', '-'), kwargs[arg]]  # type: ignore
 
+        sources = self.interpreter.source_strings_to_files(kwargs['sources'])
         targets: T.List[CustomTarget] = []
 
         h_target: T.Optional[CustomTarget] = None
         if h_template is not None:
-            h_output = os.path.basename(os.path.splitext(h_template)[0])
+            h_output = os.path.basename(os.path.splitext(h_template.fname)[0])
             # We always set template as the first element in the source array
             # so --template consumes it.
             h_cmd = cmd + ['--template', '@INPUT@']
-            h_sources: T.List[T.Union[FileOrString, 'build.GeneratedTypes']] = [h_template]
-            h_sources.extend(kwargs['sources'])
+            h_sources: T.List[CustomTargetSources] = [h_template, *sources]
             h_target = self._make_mkenum_impl(
                 state, h_sources, h_output, h_cmd, install=kwargs['install_header'],
                 install_dir=kwargs['install_dir'])
             targets.append(h_target)
 
         if c_template is not None:
-            c_output = os.path.basename(os.path.splitext(c_template)[0])
+            c_output = os.path.basename(os.path.splitext(c_template.fname)[0])
             # We always set template as the first element in the source array
             # so --template consumes it.
             c_cmd = cmd + ['--template', '@INPUT@']
-            c_sources: T.List[T.Union[FileOrString, 'build.GeneratedTypes']] = [c_template]
-            c_sources.extend(kwargs['sources'])
+            c_sources: T.List[CustomTargetSources] = [c_template, *sources]
 
             depends = kwargs['depends'].copy()
             if h_target is not None:
@@ -1912,7 +1919,7 @@ class GnomeModule(ExtensionModule):
         if c_template is None and h_template is None:
             generic_cmd = cmd + ['@INPUT@']
             target = self._make_mkenum_impl(
-                state, kwargs['sources'], basename, generic_cmd,
+                state, sources, basename, generic_cmd,
                 install=kwargs['install_header'],
                 install_dir=kwargs['install_dir'])
             return ModuleReturnValue(target, [target])
@@ -1997,7 +2004,8 @@ class GnomeModule(ExtensionModule):
             }'''))
         c_cmd.append('@INPUT@')
 
-        c_file = self._make_mkenum_impl(state, kwargs['sources'], body_filename, c_cmd)
+        sources = self.interpreter.source_strings_to_files(kwargs['sources'])
+        c_file = self._make_mkenum_impl(state, sources, body_filename, c_cmd)
 
         # .h file generation
         h_cmd = cmd.copy()
@@ -2039,7 +2047,7 @@ class GnomeModule(ExtensionModule):
         h_cmd.append('@INPUT@')
 
         h_file = self._make_mkenum_impl(
-            state, kwargs['sources'], hdr_filename, h_cmd,
+            state, sources, hdr_filename, h_cmd,
             install=kwargs['install_header'],
             install_dir=kwargs['install_dir'])
 
@@ -2048,7 +2056,7 @@ class GnomeModule(ExtensionModule):
     def _make_mkenum_impl(
             self,
             state: 'ModuleState',
-            sources: T.Sequence[T.Union[str, mesonlib.File, build.GeneratedTypes]],
+            sources: T.Sequence[CustomTargetSources],
             output: str,
             cmd: T.List[str],
             *,
@@ -2098,7 +2106,7 @@ class GnomeModule(ExtensionModule):
     )
     def genmarshal(self, state: 'ModuleState', args: T.Tuple[str], kwargs: 'GenMarshal') -> ModuleReturnValue:
         output = args[0]
-        sources = kwargs['sources']
+        sources = self.interpreter.source_strings_to_files(kwargs['sources'])
 
         new_genmarshal = mesonlib.version_compare(self._get_native_glib_version(state), '>= 2.53.3')
 
@@ -2234,9 +2242,10 @@ class GnomeModule(ExtensionModule):
         INSTALL_DIR_KW,
         KwargInfo(
             'sources',
-            ContainerTypeInfo(list, (str, GirTarget), allow_empty=False),
+            ContainerTypeInfo(list, (str, mesonlib.File, GirTarget), allow_empty=False),
             listify=True,
             required=True,
+            since_values={ContainerTypeInfo(list, (mesonlib.File), allow_empty=False): '1.12.0'},
         ),
         KwargInfo('vapi_dirs', ContainerTypeInfo(list, str), listify=True, default=[]),
         KwargInfo('metadata_dirs', ContainerTypeInfo(list, str), listify=True, default=[]),
@@ -2256,18 +2265,20 @@ class GnomeModule(ExtensionModule):
         cmd += pkg_cmd
         cmd += ['--metadatadir=' + source_dir]
 
-        inputs = kwargs['sources']
-
+        inputs: T.List[T.Union[mesonlib.File, GirTarget]] = []
         link_with: T.List[build.LibTypes] = []
-        for i in inputs:
+        i: CustomTargetInputs
+        for i in kwargs['sources']:
             if isinstance(i, str):
                 cmd.append(os.path.join(source_dir, i))
+                i = mesonlib.File.from_source_file(state.environment.source_dir, state.subdir, i)
             elif isinstance(i, GirTarget):
                 link_with += self._get_vapi_link_with(i)
                 subdir = os.path.join(state.environment.get_build_dir(),
                                       i.get_subdir())
                 gir_file = os.path.join(subdir, i.get_outputs()[0])
                 cmd.append(gir_file)
+            inputs.append(i)
 
         vapi_output = library + '.vapi'
         datadir = state.environment.coredata.optstore.get_value_for(OptionKey('datadir'))

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -972,7 +972,7 @@ class GnomeModule(ExtensionModule):
             state: 'ModuleState',
             girfile: str,
             scan_command: T.Sequence[T.Union['FileOrString', Executable, Program]],
-            generated_files: T.Sequence[T.Union[str, mesonlib.File, build.GeneratedTypes]],
+            generated_files: T.Sequence[build.GeneratedTypes],
             depends: T.Sequence[T.Union['FileOrString', build.BuildTarget, 'build.GeneratedTypes', build.StructuredSources]],
             env_flags: T.Sequence[str],
             kwargs: GenerateGir) -> GirTarget:
@@ -1025,7 +1025,7 @@ class GnomeModule(ExtensionModule):
     @staticmethod
     def _make_typelib_target(state: 'ModuleState', typelib_output: str,
                              typelib_cmd: T.Sequence[T.Union[str, CustomTarget, Program]],
-                             generated_files: T.Sequence[T.Union[str, mesonlib.File, build.GeneratedTypes]],
+                             generated_files: T.Sequence[build.GeneratedTypes],
                              kwargs: GenerateGir) -> TypelibTarget:
         install = kwargs['install_typelib']
         if install is None:

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -27,15 +27,14 @@ if T.TYPE_CHECKING:
     from . import ModuleState
     from ..build import Target
     from ..interpreter import Interpreter
+    from ..interpreter.interpreter import CustomTargetSources
+    from ..interpreter.kwargs import CustomTargetInputs
     from ..interpreterbase import TYPE_var
     from ..programs import Program
 
     class MergeFile(TypedDict):
 
-        input: T.List[T.Union[
-            str, build.BuildTarget, build.CustomTarget, build.CustomTargetIndex,
-            build.ExtractedObjects, build.GeneratedList, Program,
-            mesonlib.File]]
+        input: T.List[CustomTargetInputs]
         output: str
         build_by_default: bool
         install: bool
@@ -57,9 +56,7 @@ if T.TYPE_CHECKING:
 
     class ItsJoinFile(TypedDict):
 
-        input: T.List[T.Union[
-            str, build.BuildTarget, build.GeneratedTypes,
-            build.ExtractedObjects, Program, mesonlib.File]]
+        input: T.List[CustomTargetInputs]
         output: str
         build_by_default: bool
         install: bool
@@ -329,13 +326,14 @@ class I18nModule(ExtensionModule):
 
         install_tag = [kwargs['install_tag']] if kwargs['install_tag'] is not None else None
 
+        inputs: T.List[CustomTargetSources] = self.interpreter.source_strings_to_files(kwargs['input'])
         ct = build.CustomTarget(
             '',
             state.subdir,
             state.subproject,
             state.environment,
             command,
-            kwargs['input'],
+            inputs,
             [kwargs['output']],
             build_by_default=build_by_default,
             install=kwargs['install'],
@@ -516,13 +514,14 @@ class I18nModule(ExtensionModule):
 
         install_tag = [kwargs['install_tag']] if kwargs['install_tag'] is not None else None
 
+        inputs: T.List[CustomTargetSources] = self.interpreter.source_strings_to_files(kwargs['input'])
         ct = build.CustomTarget(
             '',
             state.subdir,
             state.subproject,
             state.environment,
             command,
-            kwargs['input'],
+            inputs,
             [kwargs['output']],
             build_by_default=build_by_default,
             extra_depends=mo_targets,

--- a/mesonbuild/modules/icestorm.py
+++ b/mesonbuild/modules/icestorm.py
@@ -61,6 +61,7 @@ class IceStormModule(ExtensionModule):
         proj_name, arg_sources = args
         all_sources = self.interpreter.source_strings_to_files(
             list(itertools.chain(arg_sources, kwargs['sources'])))
+        constraint_file = self.interpreter.source_strings_to_files([kwargs['constraint_file']])[0]
 
         blif_target = build.CustomTarget(
             f'{proj_name}_blif',
@@ -78,7 +79,7 @@ class IceStormModule(ExtensionModule):
             state.subproject,
             state.environment,
             [self.tools['arachne'], '-q', '-d', '1k', '-p', '@INPUT@', '-o', '@OUTPUT@'],
-            [kwargs['constraint_file'], blif_target],
+            [constraint_file, blif_target],
             [f'{proj_name}.asc'],
         )
 

--- a/mesonbuild/modules/java.py
+++ b/mesonbuild/modules/java.py
@@ -89,12 +89,14 @@ class JavaModule(NewExtensionModule):
 
         prefix = classes[0] if not package else package
 
+        sources = [mesonlib.File.from_source_file(state.environment.source_dir, state.subdir, s)
+                   if isinstance(s, str) else s for s in args[0]]
         target = CustomTarget(f'{prefix}-native-headers',
                               state.subdir,
                               state.subproject,
                               state.environment,
                               command,
-                              sources=args[0], outputs=headers, backend=state.backend)
+                              sources=sources, outputs=headers, backend=state.backend)
 
         # It is only known that 1.8.0 won't pre-create the directory. 11 and 16
         # do not exhibit this behavior.

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -152,10 +152,10 @@ class WindowsModule(ExtensionModule):
 
         res_targets: T.List[build.CustomTarget] = []
 
-        def get_names() -> T.Iterable[T.Tuple[str, str, T.Union[str, mesonlib.File, build.CustomTargetIndex]]]:
+        def get_names() -> T.Iterable[T.Tuple[str, str, T.Union[mesonlib.File, build.CustomTargetIndex]]]:
             for src in args[0]:
                 if isinstance(src, str):
-                    yield os.path.join(state.subdir, src), src, src
+                    yield os.path.join(state.subdir, src), src, mesonlib.File.from_source_file(state.environment.source_dir, state.subdir, src)
                 elif isinstance(src, mesonlib.File):
                     yield src.relative_name(), src.fname, src
                 elif isinstance(src, build.CustomTargetIndex):

--- a/test cases/frameworks/7 gnome/genmarshal/meson.build
+++ b/test cases/frameworks/7 gnome/genmarshal/meson.build
@@ -2,8 +2,10 @@ m_list = configure_file(input: 'marshaller.list',
   output: 'm.list',
   copy: true)
 
+ct_list = fs.copyfile('marshaller.list', 'ct.list')
+
 idx = 0
-mlists = ['marshaller.list', files('marshaller.list'), m_list]
+mlists = ['marshaller.list', files('marshaller.list'), m_list, ct_list]
 
 foreach mlist : mlists
   marshallers = gnome.genmarshal('marshaller-@0@'.format(idx),

--- a/test cases/frameworks/7 gnome/meson.build
+++ b/test cases/frameworks/7 gnome/meson.build
@@ -43,6 +43,7 @@ if res.returncode() == 0
 endif
 
 gnome = import('gnome')
+fs = import('fs')
 gio = dependency('gio-2.0')
 giounix = dependency('gio-unix-2.0')
 glib = dependency('glib-2.0')

--- a/test cases/frameworks/7 gnome/test.json
+++ b/test cases/frameworks/7 gnome/test.json
@@ -12,6 +12,8 @@
     {"type": "file", "file": "usr/include/subdir-3/marshaller-3.h"},
     {"type": "file", "file": "usr/include/subdir-4/marshaller-4.h"},
     {"type": "file", "file": "usr/include/subdir-5/marshaller-5.h"},
+    {"type": "file", "file": "usr/include/subdir-6/marshaller-6.h"},
+    {"type": "file", "file": "usr/include/subdir-7/marshaller-7.h"},
     {"type": "expr", "file": "usr/lib/?libpython_gir_lib.so"},
     {"type": "file", "platform": "cygwin", "file": "usr/lib/libpython_gir_lib.dll.a"},
     {"type": "expr", "file": "usr/lib/?libgir_lib.so"},


### PR DESCRIPTION
This is inspired by #14885, which reported that a source of type `str` to a custom target would be exported to the introspection data as os.path.join(meson_root, relative_path).

However, considering that the testcase for it had to use `i18n.merge_file`, I checked instead whether `str` sources could be removed altogether. It seems like they can, and the hardest part is actually getting `mypy` to comply.

~~I'm still not 100% sure about the handling of the `get_outputs()` case in the qt module, so I'm marking this as draft until I write a testcase for that.~~

Fixes: #2748 