### PR TITLE
get_llvm_tool_names: recognise LLVM 22

### DIFF
--- a/mesonbuild/tooldetect.py
+++ b/mesonbuild/tooldetect.py
@@ -138,6 +138,8 @@ def get_llvm_tool_names(tool: str) -> T.List[str]:
     # unless it becomes a stable release.
     suffixes = [
         '', # base (no suffix)
+        '-22.1', '22.1',
+        '-22', '22',
         '-21.1', '21.1',
         '-21',  '21',
         '-20.1', '20.1',
@@ -165,7 +167,7 @@ def get_llvm_tool_names(tool: str) -> T.List[str]:
         '-3.7', '37',
         '-3.6', '36',
         '-3.5', '35',
-        '-20',    # Debian development snapshot
+        #'-20',    # Debian development snapshot
         '-devel', # FreeBSD development snapshot
     ]
     names: T.List[str] = []


### PR DESCRIPTION
Homebrew recently updated to LLVM 22 which meant we had test failures from our list in get_llvm_tool_names.

Also, comment out the Debian entry to not have '20' twice.