### PR TITLE
msetup: fix invalid directory message

### DIFF
--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -113,7 +113,7 @@ class MesonApp:
         return os.path.exists(fname)
 
     def validate_core_dirs(self, dir1: T.Optional[str], dir2: T.Optional[str]) -> T.Tuple[str, str]:
-        invalid_msg_prefix = f'Neither source directory {dir1!r} nor build directory {dir2!r}'
+        invalid_msg_prefix = f'Neither source directory {dir2!r} nor build directory {dir1!r}'
         if dir1 is None:
             if dir2 is None:
                 if not self.has_build_file('.') and self.has_build_file('..'):


### PR DESCRIPTION
Output currently is:

```
Neither source directory <build_dir> nor build directory <source_dir> contain a build file
```

which this commit fixes.

The method is only used here:

https://github.com/mesonbuild/meson/blob/6e67be7492d6982d2baf153387f9adbdb480d099/mesonbuild/msetup.py#L158

Where the first argument is the build folder, not the source folder.