### PR TITLE
tests: Fix skip condition for windows/msvc cplusplus

### DIFF
--- a/test cases/windows/19 msvc cplusplus define/meson.build
+++ b/test cases/windows/19 msvc cplusplus define/meson.build
@@ -4,7 +4,7 @@ cpp = meson.get_compiler('cpp')
 
 if cpp.get_id() != 'msvc'
   error('MESON_SKIP_TEST: test is only relevant for msvc')
-elif meson.project_version().version_compare('< 15.7')
+elif cpp.version().version_compare('< 15.7')
   error('MESON_SKIP_TEST: test is only relevant for msvc versions >= 15.7')
 endif
 


### PR DESCRIPTION
This is testing the Meson version when it should be testing the C++ Compiler version

As noted here: https://github.com/mesonbuild/meson/issues/15528#issuecomment-4011259223