### PR TITLE
compilers: use GCC-style sanitizer arguments with clang-cl

### DIFF
--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -438,6 +438,14 @@ class ClangClCompiler(VisualStudioLikeCompiler):
         self.can_compile_suffixes.add('s')
         self.can_compile_suffixes.add('sx')
 
+    def sanitizer_compile_args(self, target: T.Optional[BuildTarget], value: T.List[str]) -> T.List[str]:
+        if not value:
+            return value
+        args = ['/clang:-fsanitize=' + ','.join(value)]
+        if 'address' in value:
+            args.append('/clang:-fno-omit-frame-pointer')
+        return args
+
     def has_arguments(self, args: T.List[str], code: str, mode: CompileCheckMode) -> T.Tuple[bool, bool]:
         if mode != CompileCheckMode.LINK:
             args = args + [


### PR DESCRIPTION
clang-cl does not support MSVC syntax for setting sanitizers at the moment - from `Visual Studio 2026 Developer PowerShell v18.3.2` (`Visual Studio Build Tools 2026`) with `C++ Clang tools for Windows (20.1.8 - x64/x86)` installed
```
The Meson build system
Version: 1.10.99
Source dir: <SOURCE_DIR>
Build dir: <BUILD_DIR>
Build type: native build
Project name: <PROJECT_NAME>
Project version: <PROJECT_VERSION>
C compiler for the host machine: clang-cl (clang-cl 20.1.8)
C linker for the host machine: lld-link lld-link 20.1.8
Host machine cpu family: x86_64
Host machine cpu: x86_64

...

ERROR: Compiler clang-cl does not support sanitizer arguments ['/fsanitize=undefined']
```

With this change meson uses `-fsanitize` instead of `/fsanitize` argument when interacting with clang-cl