### PR TITLE
cmdline: handle missing or corrupted cmd_line.txt file

### DIFF
--- a/mesonbuild/cmdline.py
+++ b/mesonbuild/cmdline.py
@@ -97,6 +97,11 @@ def update_cmd_line_file(build_dir: str, options: SharedCMDOptions) -> None:
     filename = get_cmd_line_file(build_dir)
     config = CmdLineFileParser()
     config.read(filename)
+    if 'options' not in config:
+        # file missing or corrupted, write it from scratch including
+        # the [properties] section
+        write_cmd_line_file(build_dir, options)
+        return
     for k, v in options.cmd_line_options.items():
         keystr = str(k)
         if v is not None:


### PR DESCRIPTION
If the cmd_line.txt file is missing, `read_cmd_line_file` will exit early but `update_cmd_line_file` will not and cause a KeyError when it accesses `config['options']`.

Detect this case and fall back to rewriting the file from scratch.  This is the same behavior as starting from an empty dictionary as far as the options are concerned, but it also ensures that the `[properties]` section is present.

This can happen if the user interrupts in the "Generating targets" phase, which is after `env.dump_coredata()` but before `write_cmd_line_file()`. Because the CoreData has been saved already, on a reconfigure run `first_invocation` is false and `update_cmd_line_file()` is called.

Fixes: #15574