### PR TITLE
CI: remove hardcoded paths in cygwin workflow

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -45,14 +45,6 @@ jobs:
       # makes about file modes
       - run: icacls . /inheritance:r /T /C
 
-      - uses: actions/cache/restore@v4
-        id: restore-cache
-        with:
-          # should use 'pip3 cache dir' to discover this path
-          path: D:\cygwin\home\runneradmin\.cache\pip
-          key: cygwin-pip-${{ github.run_number }}
-          restore-keys: cygwin-pip-
-
       - run: git config --global core.autocrlf input
 
       - uses: actions/checkout@v4
@@ -85,6 +77,20 @@ jobs:
             vala
             zlib-devel
 
+      - name: Find pip cache dir
+        id: pip-cache
+        run: |
+          export PATH=/usr/bin:/usr/local/bin:$(cygpath ${SYSTEMROOT})/system32
+          echo "dir=$(cygpath -wa $(python3 -m pip cache dir))" >> "$GITHUB_OUTPUT"
+        shell: bash --noprofile --norc -o igncr -eo pipefail '{0}'
+
+      - uses: actions/cache/restore@v4
+        id: restore-cache
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: cygwin-pip-${{ github.run_number }}
+          restore-keys: cygwin-pip-
+
       - name: Run pip
         run: |
           export PATH=/usr/bin:/usr/local/bin:$(cygpath ${SYSTEMROOT})/system32
@@ -93,8 +99,7 @@ jobs:
 
       - uses: actions/cache/save@v4
         with:
-          # should use 'pip3 cache dir' to discover this path
-          path: D:\cygwin\home\runneradmin\.cache\pip
+          path: ${{ steps.pip-cache.outputs.dir }}
           key: cygwin-pip-${{ github.run_number }}
 
       - name: Run tests


### PR DESCRIPTION
This is kind of another attempt at the left-over bits of #14425, after we've delegated the choice of location for best performance to cygwin-install-action.

Also, per the suggestion in https://github.com/mesonbuild/meson/pull/14425#discussion_r2024605416, locate the pip cache dir programmatically, rather than hardcoding another (brittle) path.
