### PR TITLE
Build a shared library for find_library link tests

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -1149,11 +1149,45 @@ class CLikeCompiler(Compiler):
                 for trial in trials:
                     if not os.path.isfile(trial):
                         continue
+
+                    # Check if an argument to find_library is usable:
+                    # * user requested a static library specifically
+                    #   => assume they know what they're doing, no link test
+                    #      as some runtime libraries may be provided in such
+                    #      a way that they must be used together with another
+                    #      library, or require special options.
+                    #
+                    # * user requested a library without `static: true`
+                    #   => build a shared library and link against it. Shared
+                    #      libraries (on ELF platforms) can be underlinked
+                    #      so it's better than an executable, as we'll only fail
+                    #      if it's unusable for another reason.
+
+                    # Don't bother fishing for arguments if we've already
+                    # been told not to perform a test.
+                    if not skip_link_check:
+                        shared_link_args = self.get_std_shared_lib_link_args()
+                        extra_args = [trial] + lcargs + shared_link_args
+
+                        # Try to build the link test as PIC. We don't know if
+                        # the target library is itself PIC: if it's non-PIC,
+                        # PIC is fine, and if it is PIC, then PIC is needed,
+                        # so always use it.
+                        extra_args += self.get_pic_args()
+
+                        # If we were asked specifically for a static library, don't perform
+                        # a link test, because it might be a special toolchain library like
+                        # on RTEMS.
+                        skip_link_check |= (libtype == LibType.STATIC)
+
+                        # Don't bother with a link check if we don't know how to build
+                        # a shared library.
+                        skip_link_check |= (not shared_link_args)
+
                     # When skip_link_check is True (e.g. for pkg-config
                     # libraries which are trusted to be linkable), skip the
                     # potentially expensive link check and just verify that the
                     # file exists.
-                    extra_args = [trial] + lcargs
                     if skip_link_check or self.links(code, extra_args=extra_args, disable_cache=True)[0]:
                         trial_result = trial
                         break

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -1149,11 +1149,44 @@ class CLikeCompiler(Compiler):
                 for trial in trials:
                     if not os.path.isfile(trial):
                         continue
+
+                    # Check if an argument to find_library is usable:
+                    # * user requested a static library specifically
+                    #   => assume they know what they're doing, no link test
+                    #      as some runtime libraries may be provided in such
+                    #      a way that they must be used together with another
+                    #      library, or require special options.
+                    #
+                    # * user requested a library without `static: true`
+                    #   => build a shared library and link against it. Shared
+                    #      libraries (on ELF platforms) can be underlinked
+                    #      so it's better than an executable, as we'll only fail
+                    #      if it's unusable for another reason.
+
+                    # If we were asked specifically for a static library, don't perform
+                    # a link test, because it might be a special toolchain library.
+                    skip_link_check |= (libtype == LibType.STATIC)
+
+                    # Don't bother fishing for arguments if we've already
+                    # been told not to perform a test.
+                    if not skip_link_check:
+                        shared_link_args = self.get_std_shared_lib_link_args()
+                        extra_args = [trial] + lcargs + shared_link_args
+
+                        # Try to build the link test as PIC. We don't know if
+                        # the target library is itself PIC: if it's non-PIC,
+                        # PIC is fine, and if it is PIC, then PIC is needed,
+                        # so always use it.
+                        extra_args += self.get_pic_args()
+
+                        # Don't bother with a link check if we don't know how to build
+                        # a shared library.
+                        skip_link_check |= (not shared_link_args)
+
                     # When skip_link_check is True (e.g. for pkg-config
                     # libraries which are trusted to be linkable), skip the
                     # potentially expensive link check and just verify that the
                     # file exists.
-                    extra_args = [trial] + lcargs
                     if skip_link_check or self.links(code, extra_args=extra_args, disable_cache=True)[0]:
                         trial_result = trial
                         break

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -721,6 +721,90 @@ class InternalTests(unittest.TestCase):
             env.machines.host.system = 'windows'
             self._test_all_naming(cc, patterns, 'windows-mingw')
 
+        self._test_find_library_undefined(cc)
+
+    def _test_find_library_undefined(self, cc):
+        '''
+        find_library checks if its argument both exists and can be
+        linked against, but it must tolerate underlinked static
+        libraries.
+
+        https://github.com/mesonbuild/meson/issues/15601
+        '''
+        def create_static_lib_with_undefined(name):
+            src = name.with_suffix('.c')
+            out = name.with_suffix('.o')
+            with src.open('w', encoding='utf-8') as f:
+                f.write('extern int get_cookie();')
+                f.write('int meson_foobar (void) { return get_cookie(); }')
+            # use of x86_64 is hardcoded in run_tests.py:get_fake_env()
+            if is_osx():
+                subprocess.check_call(['clang', '-c', str(src), '-o', str(out), '-arch', 'x86_64'])
+            else:
+                subprocess.check_call(['gcc', '-c', str(src), '-o', str(out)])
+            subprocess.check_call(['ar', 'csr', str(name), str(out)])
+
+        def create_static_lib_empty(name):
+            with name.open('w', encoding='utf-8') as f:
+                f.write("garbage")
+
+        # The test relies on some open-coded toolchain invocations for
+        # library creation in create_static_lib_with_undefined.
+        if is_windows() or is_cygwin():
+            return
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p1 = Path(tmpdir)
+            create_static_lib_with_undefined(p1 / 'libfoo.a')
+
+            code = 'int meson_foobar (void); int main(void) { return meson_foobar(); }'
+
+            # Check that we always tolerate undefined references in a static
+            # library regardless of the library type.
+            for type in (LibType.STATIC, LibType.PREFER_STATIC, LibType.PREFER_SHARED):
+                found = cc._find_library_real('foo', [tmpdir],
+                                              code,
+                                              type, lib_prefix_warning=True, ignore_system_dirs=False)
+                self.assertEqual(os.path.basename(found[0]), 'libfoo.a')
+
+            # Check that we reject broken static libraries unless we were
+            # told to only find a static library.
+            create_static_lib_empty(p1 / 'libbar.a')
+
+            # We have a broken static library *and* we indicated we want a static
+            # library, so we don't perform a link test.
+            found = cc._find_library_real('bar', [tmpdir],
+                                          code,
+                                          LibType.STATIC, lib_prefix_warning=True, ignore_system_dirs=False)
+            self.assertEqual(os.path.basename(found[0]), 'libbar.a')
+
+            # We have a broken static library we're testing against but we only said
+            # we'd prefer static, not that it must be static: the heuristic
+            # says it likely isn't a special toolchain library, so we perform a
+            # link test.
+            found = cc._find_library_real('bar', [tmpdir],
+                                          code,
+                                          LibType.PREFER_STATIC, lib_prefix_warning=True, ignore_system_dirs=False)
+            self.assertIsNone(found, 'Unexpectedly found a library with PREFER_STATIC, link test expected to reject it')
+
+            # We have a broken static library we're testing against but we only said
+            # we'd prefer shared, not that it must be shared: the heuristic
+            # says it likely isn't a special toolchain library, so we perform a
+            # link test.
+            found = cc._find_library_real('bar', [tmpdir],
+                                          code,
+                                          LibType.PREFER_SHARED, lib_prefix_warning=True, ignore_system_dirs=False)
+            self.assertIsNone(found, 'Unexpectedly found a library with PREFER_SHARED, link test expected to reject it')
+
+            # We asked for a shared library and we only got a broken
+            # static one. We only tolerate them being broken if people
+            # explicitly ask for it w/ static: true, so we perform a link
+            # test.
+            found = cc._find_library_real('bar', [tmpdir],
+                                          code,
+                                          LibType.SHARED, lib_prefix_warning=True, ignore_system_dirs=False)
+            self.assertIsNone(found, "Unexpectedly found a library with SHARED")
+
     @skipIfNoPkgconfig
     def test_pkgconfig_parse_libs(self):
         '''

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -729,6 +729,90 @@ class InternalTests(unittest.TestCase):
             env.machines.host.system = 'windows'
             self._test_all_naming(cc, patterns, 'windows-mingw')
 
+        self._test_find_library_undefined(cc)
+
+    def _test_find_library_undefined(self, cc):
+        '''
+        find_library checks if its argument both exists and can be
+        linked against, but it must tolerate underlinked static
+        libraries.
+
+        https://github.com/mesonbuild/meson/issues/15601
+        '''
+        def create_static_lib_with_undefined(name):
+            src = name.with_suffix('.c')
+            out = name.with_suffix('.o')
+            with src.open('w', encoding='utf-8') as f:
+                f.write('extern int get_cookie();')
+                f.write('int meson_foobar (void) { return get_cookie(); }')
+            # use of x86_64 is hardcoded in run_tests.py:get_fake_env()
+            if is_osx():
+                subprocess.check_call(['clang', '-c', str(src), '-o', str(out), '-arch', 'x86_64'])
+            else:
+                subprocess.check_call(['gcc', '-c', str(src), '-o', str(out)])
+            subprocess.check_call(['ar', 'csr', str(name), str(out)])
+
+        def create_static_lib_empty(name):
+            with name.open('w', encoding='utf-8') as f:
+                f.write("garbage")
+
+        # The test relies on some open-coded toolchain invocations for
+        # library creation in create_static_lib_with_undefined.
+        if is_windows() or is_cygwin():
+            return
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p1 = Path(tmpdir)
+            create_static_lib_with_undefined(p1 / 'libfoo.a')
+
+            code = 'int meson_foobar (void); int main(void) { return meson_foobar(); }'
+
+            # Check that we always tolerate undefined references in a static
+            # library regardless of the library type.
+            for type in (LibType.STATIC, LibType.PREFER_STATIC, LibType.PREFER_SHARED):
+                found = cc._find_library_real('foo', [tmpdir],
+                                              code,
+                                              type, lib_prefix_warning=True, ignore_system_dirs=False)
+                self.assertEqual(os.path.basename(found[0]), 'libfoo.a')
+
+            # Check that we reject broken static libraries unless we were
+            # told to only find a static library.
+            create_static_lib_empty(p1 / 'libbar.a')
+
+            # We have a broken static library *and* we indicated we want a static
+            # library, so we don't perform a link test.
+            found = cc._find_library_real('bar', [tmpdir],
+                                          code,
+                                          LibType.STATIC, lib_prefix_warning=True, ignore_system_dirs=False)
+            self.assertEqual(os.path.basename(found[0]), 'libbar.a')
+
+            # We have a broken static library we're testing against but we only said
+            # we'd prefer static, not that it must be static: the heuristic
+            # says it likely isn't a special toolchain library, so we perform a
+            # link test.
+            found = cc._find_library_real('bar', [tmpdir],
+                                          code,
+                                          LibType.PREFER_STATIC, lib_prefix_warning=True, ignore_system_dirs=False)
+            self.assertIsNone(found, 'Unexpectedly found a library with PREFER_STATIC, link test expected to reject it')
+
+            # We have a broken static library we're testing against but we only said
+            # we'd prefer shared, not that it must be shared: the heuristic
+            # says it likely isn't a special toolchain library, so we perform a
+            # link test.
+            found = cc._find_library_real('bar', [tmpdir],
+                                          code,
+                                          LibType.PREFER_SHARED, lib_prefix_warning=True, ignore_system_dirs=False)
+            self.assertIsNone(found, 'Unexpectedly found a library with PREFER_SHARED, link test expected to reject it')
+
+            # We asked for a shared library and we only got a broken
+            # static one. We only tolerate them being broken if people
+            # explicitly ask for it w/ static: true, so we perform a link
+            # test.
+            found = cc._find_library_real('bar', [tmpdir],
+                                          code,
+                                          LibType.SHARED, lib_prefix_warning=True, ignore_system_dirs=False)
+            self.assertIsNone(found, 'Unexpectedly found a library with SHARED')
+
     @skipIfNoPkgconfig
     def test_pkgconfig_parse_libs(self):
         '''


### PR DESCRIPTION
Build a shared library for find_library link tests

Build a shared library (as I promised before) so that undefined references
are tolerated.

We also make sure to use PIC if we can because linking non-PIC against a
PIC object will fail, while linking PIC against a non-PIC object should
be fine.

There are some conditions:

* Only do this if get_std_shared_lib_link_args gives us some non-empty argument
  because some platforms only support static linking.

* Don't do this when `static` is passed to `find_library`.

  If `static` is passed, we don't perform any link check at all because we
  assume the user knows what they're doing, e.g. it may be a runtime toolchain
  component which requires special options to link with, or must be used in
  combination with another library.

  We don't try to handle the case (i.e. we allow and let it fail later when
  building) where we have some real dummy static library that is corrupt or for
  the wrong architecture or whathaveyou because the attempts in #15601 to find
  a reliable method failed: we hit I think two different riscv ld bugs there.

  Unfortunately, the PIC change wasn't enough to fix the RTEMS case, so we
  have to punt on static libaries overall still. The real motivating case for
  this work was a broken linker script (libatomic.so) anyway.

  We may still want to add a toggle for people to override this for a toolchain,
  possibly for non-ELF targets where I'm not sure the shared library behaviour
  is always the same. If we add such a toggle, we could look at dropping the
  static requirement again.

In summary, what changed:

* Use a more robust method for testing (build a shared library) rather than a
  shortcut (linker option that doesn't work if the target is itself not a
  shared library).

* Be (very) lenient for static libraries, as we were in the past.

---

In 4f43a402504aa57ffa3f7b6091f5fdccfd2a3000 I claimed that we were building
a shared library for the new find_library link test, but I changed my mind
while working on it [0] and went for a cute trick instead:

> I should say as a correction to the commit message:
>> We can workaround that by building a shared library as a test rather
>> than an executable,
> We're not doing that, I thought we were going to have to, and I had it
> to begin with, but in the end, we have a nicer solution where we just
> pass the right flags.

In the end, the cute trick didn't work (#15601) for static libraries where
-Wl,--allow-shlib-undefined doesn't help. I considered -Wl,-z,defs, but we
want something portable to all linkers. Relying on the ELF behaviour of
shared libraries seems best here, so do that.

[0] https://github.com/mesonbuild/meson/pull/15134#issuecomment-3471775666

Fixes: https://github.com/mesonbuild/meson/issues/15601
Fixes: 4f43a402504aa57ffa3f7b6091f5fdccfd2a3000