### PR TITLE
fix: incorrect pathes with queued generators in vsbackend

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -184,7 +184,7 @@ class Vs2010Backend(backends.Backend):
                     sole_output = os.path.join(target_private_dir, outfilelist[i])
                 else:
                     sole_output = ''
-                infilename = os.path.join(down, curfile.rel_to_builddir(self.build_to_src, target_private_dir))
+                infilename = os.path.join(down, curfile.rel_to_builddir(self.build_to_src, self.get_target_private_dir(target)))
                 deps = self.get_target_depend_files(genlist, True)
                 base_args = generator.get_arglist(infilename)
                 outfiles_rel = genlist.get_outputs_for(curfile)


### PR DESCRIPTION
This patch fixes issue #15552.
Generators, which get input files from other generators, built a wrong path of the output file. Now the needed parameter is the base of the build tree and not relative to the build tree.