### PR TITLE
Avoid revisiting targets in BuildTarget.get_dependencies

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1489,22 +1489,25 @@ class BuildTarget(Target):
         # get_internal_static_libraries(): Installed static libraries include
         # objects from all their dependencies already.
         result: OrderedSet[BuildTargetTypes] = OrderedSet()
+        visited: T.Set[BuildTargetTypes] = set()
         for t in itertools.chain(self.link_targets, self.link_whole_targets):
             if t not in result:
                 result.add(t)
                 if isinstance(t, StaticLibrary):
-                    t.get_dependencies_recurse(result, handled_by_rustc=self.uses_rust())
+                    t.get_dependencies_recurse(result, visited, handled_by_rustc=self.uses_rust())
         return result
 
-    def get_dependencies_recurse(self, result: OrderedSet[BuildTargetTypes], include_internals: bool = True, handled_by_rustc: bool = False) -> None:
+    def get_dependencies_recurse(self, result: OrderedSet[BuildTargetTypes], visited: T.Set[BuildTargetTypes],
+                                 include_internals: bool = True, handled_by_rustc: bool = False) -> None:
         # self is always a static library because we don't need to pull dependencies
         # of shared libraries. If self is installed (not internal) it already
         # include objects extracted from all its internal dependencies so we can
         # skip them.
         include_internals = include_internals and self.is_internal()
         for t in self.link_targets:
-            if t in result:
+            if t in visited:
                 continue
+            visited.add(t)
             uses_rust_abi = isinstance(t, BuildTarget) and t.uses_rust_abi()
             if not handled_by_rustc and uses_rust_abi:
                 # Rules for including libraries via Rust rlibs and staticlibs are complex:
@@ -1528,10 +1531,10 @@ class BuildTarget(Target):
             else:
                 result.add(t)
             if isinstance(t, StaticLibrary):
-                t.get_dependencies_recurse(result, include_internals, handled_by_rustc and uses_rust_abi)
+                t.get_dependencies_recurse(result, visited, include_internals, handled_by_rustc and uses_rust_abi)
         for t in self.link_whole_targets:
             uses_rust_abi = isinstance(t, BuildTarget) and t.uses_rust_abi()
-            t.get_dependencies_recurse(result, include_internals, handled_by_rustc and uses_rust_abi)
+            t.get_dependencies_recurse(result, visited, include_internals, handled_by_rustc and uses_rust_abi)
 
     def get_sources(self) -> T.List[File]:
         return self.sources
@@ -2932,7 +2935,8 @@ class CustomTargetBase:
 
     rust_crate_type = ''
 
-    def get_dependencies_recurse(self, result: OrderedSet[BuildTargetTypes], include_internals: bool = True) -> None:
+    def get_dependencies_recurse(self, result: OrderedSet[BuildTargetTypes], visited: T.Set[BuildTargetTypes],
+                                 include_internals: bool = True) -> None:
         pass
 
     def get_internal_static_libraries(self) -> OrderedSet[StaticTargetTypes]:


### PR DESCRIPTION
I just added some new internal static libraries to our project, and this unexpectedly revealed another algorithm issue which slows down Ninja rules generation significantly for us.

`BuildTarget.get_dependencies_recurse` does not record targets that are not added to the result set. With many transitively dependent internal static libraries, this leads to degenerate behavior where the same internal targets are checked over and over.

Fix this by not revisiting already visited targets. See also the fix in `get_all_link_deps` (1d2430ef8be88d73db68f4b96c767fd915696bb1).

Fixes #15617.