### PR TITLE
rust: Fix RUSTFLAGS being added as prefixed linker flags

### DIFF
--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -451,7 +451,9 @@ class RustCompiler(Compiler):
         return rustc_link_args(super().get_allow_undefined_link_args())
 
     def get_build_link_args(self, target: BuildTarget, build: build.Build) -> T.List[str]:
-        return rustc_link_args(super().get_build_link_args(target, build))
+        return rustc_link_args(build.get_project_link_args(self, target)
+                               + build.get_global_link_args(self, self.for_machine)) \
+            + self.environment.coredata.get_external_link_args(self.for_machine, self.get_language())
 
     def get_target_link_args(self, target: 'BuildTarget') -> T.List[str]:
         return rustc_link_args(super().get_target_link_args(target))

--- a/test cases/rust/37 rustflags env/clippy.toml
+++ b/test cases/rust/37 rustflags env/clippy.toml
@@ -1,0 +1,1 @@
+blacklisted-names = ["foo"]

--- a/test cases/rust/37 rustflags env/meson.build
+++ b/test cases/rust/37 rustflags env/meson.build
@@ -1,0 +1,28 @@
+project('rustprog', 'rust', default_options : ['b_ndebug=true'])
+
+e = executable('rust-program', 'prog.rs',
+  install : true
+)
+test('rusttest', e)
+
+e = executable('rust-dynamic', 'prog.rs',
+  override_options: {'rust_dynamic_std': true},
+  install : true
+)
+test('rusttest-dynamic', e)
+
+subdir('subdir')
+
+# this should fail due to debug_assert
+test(
+  'debug_assert_on',
+  executable(
+    'rust-program2',
+    'prog.rs',
+    override_options : ['b_ndebug=false'],
+  ),
+  should_fail : true,
+)
+
+rustc = meson.get_compiler('rust')
+assert(rustc.run('fn main(){}').returncode() == 0)

--- a/test cases/rust/37 rustflags env/prog.rs
+++ b/test cases/rust/37 rustflags env/prog.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let foo = "rust compiler is working";
+    debug_assert!(false, "debug_asserts on!");
+    println!("{}", foo);
+}

--- a/test cases/rust/37 rustflags env/subdir/meson.build
+++ b/test cases/rust/37 rustflags env/subdir/meson.build
@@ -1,0 +1,2 @@
+e = executable('rust-program2', 'prog.rs', install : true)
+test('rusttest2', e)

--- a/test cases/rust/37 rustflags env/subdir/prog.rs
+++ b/test cases/rust/37 rustflags env/subdir/prog.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("rust compiler is working");
+}

--- a/test cases/rust/37 rustflags env/test.json
+++ b/test cases/rust/37 rustflags env/test.json
@@ -1,0 +1,13 @@
+{
+  "env": {
+    "RUSTFLAGS": "-C force-frame-pointers=yes"
+  },
+  "installed": [
+    {"type": "exe", "file": "usr/bin/rust-program"},
+    {"type": "pdb", "file": "usr/bin/rust-program"},
+    {"type": "exe", "file": "usr/bin/rust-program2"},
+    {"type": "pdb", "file": "usr/bin/rust-program2"},
+    {"type": "exe", "file": "usr/bin/rust-dynamic"},
+    {"type": "pdb", "file": "usr/bin/rust-dynamic"}
+  ]
+}


### PR DESCRIPTION
Fix an issue where RUSTFLAGS is added as linker flags to `cc`.

"1 basic" ran with `RUSTFLAGS=-Cforce-frame-pointers=yes`:
```
[4/4] Compiling Rust source '../test cases/rust/1 basic/subdir/prog.rs'
FAILED: [code=1] subdir/rust-program2 
rustc -C linker=cc --color=always -C debug-assertions=no -C overflow-checks=no -C embed-bitcode=no --crate-type bin -Cdefault-linker-libraries -C link-arg=-Wl,--allow-shlib-undefined -C link-arg=-Cforce-frame-pointers=yes -g -Cforce-frame-pointers=yes --crate-name rust_program2 --emit dep-info=subdir/rust-program2.p/rust-program2.d --emit link=subdir/rust-program2 -C metadata=bdf6c15@@rust-program2@exe '../test cases/rust/1 basic/subdir/prog.rs'
error: linking with `cc` failed: exit status: 1
  |
  = note:  "cc" "-m64" "/home/*removed*/meson/b 06c574b6a1/subdir/rustc1UtRwy/symbols.o" "<2 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/{libstd-*,libpanic_unwind-*,libobject-*,libmemchr-*,libaddr2line-*,libgimli-*,libcfg_if-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_std_workspace_alloc-*,libminiz_oxide-*,libadler2-*,libunwind-*,liblibc-*,librustc_std_workspace_core-*,liballoc-*,libcore-*,libcompiler_builtins-*}.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-L" "/home/*removed*/meson/b 06c574b6a1/subdir/rustc1UtRwy/raw-dylibs" "-fuse-ld=lld" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "subdir/rust-program2" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-Wl,--allow-shlib-undefined" "-Cforce-frame-pointers=yes"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: cc: error: unrecognized command-line option '-Cforce-frame-pointers=yes'; did you mean '-fomit-frame-pointer'?
```

Many of the rust test will fail with `RUSTFLAGS` being set with flags that the `cc` linker will not understand.

Also add a test which is a copy of basic with `RUSTFLAGS` set.