### PR TITLE
Reinstate possibility to pass a single test to run_project_tests.py --only

### DIFF
--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -1571,6 +1571,13 @@ def setup_symlinks() -> None:
     except OSError:
         print('symlinks are not supported on this system')
 
+def validate_only(s: str) -> str:
+    split = s.split('/', 1)
+    if split[0] not in ALL_TESTS:
+        raise argparse.ArgumentTypeError(f'invalid category {split[0]!r}; must be one of {", ".join(ALL_TESTS)}')
+    return s
+
+
 if __name__ == '__main__':
     if under_ci and not raw_ci_jobname:
         raise SystemExit('Running under CI but $MESON_CI_JOBNAME is not set (set to "thirdparty" if you are running outside of the github org)')
@@ -1599,7 +1606,7 @@ if __name__ == '__main__':
                         help='Stop running if test case fails')
     parser.add_argument('--no-unittests', action='store_true',
                         help='Not used, only here to simplify run_tests.py')
-    parser.add_argument('--only', default=[], choices=ALL_TESTS,
+    parser.add_argument('--only', default=[], type=validate_only,
                         help='name of test(s) to run, in format "category[/name]" where category is one of: ' + ', '.join(ALL_TESTS), nargs='+')
     parser.add_argument('-v', default=False, action='store_true',
                         help='Verbose mode')


### PR DESCRIPTION
~~This reverts commit 7f2dd413c9522e64b1c6c595c3c946dcadf7693e.~~ Prior to commit 7f2dd413c9522e64b1c6c595c3c946dcadf7693e, it was possible to run a single test with

   ./run_project_tests.sh --only='common/1 trivial'

while it is not possible afterwards.

~~Suggest a replacement, and remove the `category/name` case from the help message.~~ Fix it while preserving the fast failure.