### PR TITLE
linkers: fix passing a .def file to lld-link via clang/clang++

### DIFF
--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -1489,7 +1489,7 @@ class VisualStudioLikeLinkerMixin(DynamicLinkerBase):
     def gen_vs_module_defs_args(self, defsfile: str) -> T.List[str]:
         # With MSVC, DLLs only export symbols that are explicitly exported,
         # so if a module defs file is specified, we use that to export symbols
-        return ['/DEF:' + defsfile]
+        return self._apply_prefix(['/DEF:' + defsfile])
 
     def get_soname_args(self, prefix: str, shlib_name: str, suffix: str,
                         soversion: str, darwin_versions: T.Tuple[str, str]


### PR DESCRIPTION
While clang-cl is able to handle /DEF:... just fine, the same is not true when using clang++ together with lld-link.  This results in a failure:

    [2/3] Linking target qga/vss-win32/qga-vss.dll
    FAILED: qga/vss-win32/qga-vss.dll qga/vss-win32/qga-vss.pdb
    "clang++"  -Wl,/OUT:qga/vss-win32/qga-vss.dll qga/vss-win32/qga-vss.dll.p/requester.cpp.obj qga/vss-win32/qga-vss.dll.p/provider.cpp.obj qga/vss-win32/qga-vss.dll.p/install.cpp.obj qga/vss-win32/qga-vss.dll.p/vss-debug.cpp.obj "-Wl,/nodefaultlib:libcmt" "-Wl,/nologo" "-Wl,/DEBUG" "-Wl,/PDB:qga\vss-win32\qga-vss.pdb" "-Wl,/DLL" "/DEF:..\qga\vss-win32\qga-vss.def" "-Wl,/IMPLIB:qga\vss-win32\qga-vss.lib" "-std=gnu++14" "-fuse-ld=lld" "-lws2_32" "-lole32" "-loleaut32" "-lshlwapi" "-luuid" "-lkernel32" "-luser32" "-lgdi32" "-lwinspool" "-lshell32" "-lcomdlg32" "-ladvapi32"
    clang++: error: no such file or directory: /DEF:..qgavss-win32qga-vss.def

This is due to a missing call to _apply_prefix.

Fixes: b1b229871 ("compilers: forward gen_vs_module_defs_args to linker", 2025-11-23)
Reported-by: Konstantin Kostiuk <kkostiuk@redhat.com>