### PR TITLE
In framework tests: '7 gnome' and '11 gir', import the actual python module used

### DIFF
--- a/test cases/frameworks/11 gir subproject/meson.build
+++ b/test cases/frameworks/11 gir subproject/meson.build
@@ -7,7 +7,7 @@ endif
 
 python3 = import('python3')
 py3 = python3.find_python()
-if run_command(py3, '-c', 'import gi;', check: false).returncode() != 0
+if run_command(py3, '-c', 'import gi.repository;', check: false).returncode() != 0
     error('MESON_SKIP_TEST python3-gi not found')
 endif
 

--- a/test cases/frameworks/7 gnome/meson.build
+++ b/test cases/frameworks/7 gnome/meson.build
@@ -17,7 +17,7 @@ endif
 
 python3 = import('python')
 py3 = python3.find_installation()
-if run_command(py3, '-c', 'import gi;', check: false).returncode() != 0
+if run_command(py3, '-c', 'import gi.repository;', check: false).returncode() != 0
     error('MESON_SKIP_TEST python3-gi not found')
 endif
 


### PR DESCRIPTION
per https://github.com/mesonbuild/meson/pull/15534#issuecomment-3865545647, import the actual python module used in these tests.

This can avoid false positives, if `site-packages/gi/` happens to exist due to `site-package/gi/overrides/` being created by some girepository package, even if pygobject isn't installed.