### PR TITLE
env2mfile: improve generator target selection logic

### DIFF
--- a/mesonbuild/scripts/env2mfile.py
+++ b/mesonbuild/scripts/env2mfile.py
@@ -20,18 +20,20 @@ if T.TYPE_CHECKING:
 # Note: when adding arguments, please also add them to the completion
 # scripts in $MESONSRC/data/shell-completions/
 def add_arguments(parser: 'argparse.ArgumentParser') -> None:
+    action = parser.add_mutually_exclusive_group(required=True)
+    action.add_argument('--cross', default=False, action='store_true',
+                        help='Generate a cross compilation file.')
+    action.add_argument('--native', default=False, action='store_true',
+                        help='Generate a native compilation file.')
+    action.add_argument('--android', default=False, action='store_true',
+                        help='Generate cross files for Android toolchains.')
+
     parser.add_argument('--debarch', default=None,
                         help='The dpkg architecture to generate.')
     parser.add_argument('--gccsuffix', default="",
                         help='A particular gcc version suffix if necessary.')
     parser.add_argument('-o', required=True, dest='outfile',
                         help='The output file or directory (for Android).')
-    parser.add_argument('--cross', default=False, action='store_true',
-                        help='Generate a cross compilation file.')
-    parser.add_argument('--native', default=False, action='store_true',
-                        help='Generate a native compilation file.')
-    parser.add_argument('--android', default=False, action='store_true',
-                        help='Generate cross files for Android toolchains.')
     parser.add_argument('--use-for-build', default=False, action='store_true',
                         help='Use _FOR_BUILD envvars.')
     parser.add_argument('--system', default=None,
@@ -533,24 +535,19 @@ class AndroidDetector:
 
 
 def run(options: T.Any) -> None:
-    if options.cross and options.native:
-        sys.exit('You can only specify either --cross or --native, not both.')
-    if (options.cross or options.native) and options.android:
-        sys.exit('You can not specify either --cross or --native with --android.')
-    if not options.cross and not options.native and not options.android:
-        sys.exit('You must specify --cross, --native or --android.')
     mlog.notice('This functionality is experimental and subject to change.')
-    detect_cross = options.cross
-    if detect_cross:
+    if options.cross:
         if options.use_for_build:
             sys.exit('--use-for-build only makes sense for --native, not --cross')
         infos = detect_cross_env(options)
         write_system_info = True
         write_machine_file(infos, options.outfile, write_system_info)
-    elif options.android is None:
+    elif options.native:
         infos = detect_native_env(options)
         write_system_info = False
         write_machine_file(infos, options.outfile, write_system_info)
-    else:
+    elif options.android:
         ad = AndroidDetector(options)
         ad.detect_toolchains()
+    else:
+        raise ValueError("Encountered unreachable code-path")


### PR DESCRIPTION
There is currently a bug, where if you request --native, you'll end up with the android logic, as it does a options.android is None check, with options.android being False instead of None.

Clean the whole logic up a bit in order to make it more understandable.