### PR TITLE
Allow dependencies in sourceset if_false

### DIFF
--- a/docs/markdown/SourceSet-module.md
+++ b/docs/markdown/SourceSet-module.md
@@ -82,7 +82,7 @@ and to query it. The source set becomes immutable after any method but
 ```meson
 source_set.add([when: varnames_and_deps],
                [if_true: sources_and_deps],
-               [if_false: list_of_alt_sources])
+               [if_false: list_of_alt_sources_and_deps])
 source_set.add(sources_and_deps)
 ```
 
@@ -100,7 +100,7 @@ and all dependencies are found, the rule will evaluate to true;
 argument in its result. Otherwise, that is if any of the strings in
 the positional arguments evaluate to false or any dependency is not
 found, `apply()` will instead use the contents of the `if_false`
-keyword argument.
+keyword argument. *Since 1.11.0* Dependencies in `if_false` are supported.
 
 Dependencies can also appear in `sources_and_deps`. In this case, a
 missing dependency will simply be ignored and will *not* disable the
@@ -109,7 +109,7 @@ build targets.
 
 **Note**: It is generally better to avoid mixing source sets and
 disablers. This is because disablers will cause the rule to be dropped
-altogether, and the `list_of_alt_sources` would not be taken into
+altogether, and the `list_of_alt_sources_and_deps` would not be taken into
 account anymore.
 
 #### `add_all()`

--- a/mesonbuild/modules/sourceset.py
+++ b/mesonbuild/modules/sourceset.py
@@ -26,7 +26,7 @@ if T.TYPE_CHECKING:
 
         when: T.List[T.Union[str, dependencies.Dependency]]
         if_true: T.List[T.Union[mesonlib.FileOrString, build.GeneratedTypes, dependencies.Dependency]]
-        if_false: T.List[T.Union[mesonlib.FileOrString, build.GeneratedTypes]]
+        if_false: T.List[T.Union[mesonlib.FileOrString, build.GeneratedTypes, dependencies.Dependency]]
 
     class AddAllKw(TypedDict):
 
@@ -65,6 +65,10 @@ class SourceSetRule(T.NamedTuple):
 
     if_false: T.List[T.Union[mesonlib.FileOrString, build.GeneratedTypes]]
     """Source files added when this rule's conditions are false"""
+
+    if_false_deps: T.List[dependencies.Dependency]
+    """Dependencies added when this rule's conditions are false, but
+       that do not make the condition true if they're absent"""
 
 
 class SourceFiles(T.NamedTuple):
@@ -138,7 +142,7 @@ class SourceSetImpl(SourceSet, MutableModuleObject):
         ),
         KwargInfo(
             'if_false',
-            ContainerTypeInfo(list, (str, mesonlib.File, build.GeneratedList, build.CustomTarget, build.CustomTargetIndex)),
+            ContainerTypeInfo(list, (str, mesonlib.File, build.GeneratedList, build.CustomTarget, build.CustomTargetIndex, dependencies.Dependency)),
             listify=True,
             default=[],
         ),
@@ -157,8 +161,11 @@ class SourceSetImpl(SourceSet, MutableModuleObject):
             raise InterpreterException('add called with both positional and keyword arguments')
         keys, dependencies = self.check_conditions(when)
         sources, extra_deps = self.check_source_files(if_true)
-        if_false, _ = self.check_source_files(if_false)
-        self.rules.append(SourceSetRule(keys, dependencies, sources, extra_deps, [], if_false))
+        if_false_sources, if_false_deps = self.check_source_files(if_false)
+        if len(if_false_deps) > 0:
+            FeatureNew.single_use('sourceset.add Dependency in if_false', '1.11.0',
+                                  state.subproject, location=state.current_node)
+        self.rules.append(SourceSetRule(keys, dependencies, sources, extra_deps, [], if_false_sources, if_false_deps))
 
     @typed_pos_args('sourceset.add_all', varargs=SourceSet)
     @typed_kwargs(
@@ -184,7 +191,7 @@ class SourceSetImpl(SourceSet, MutableModuleObject):
         keys, dependencies = self.check_conditions(when)
         for s in if_true:
             s.frozen = True
-        self.rules.append(SourceSetRule(keys, dependencies, [], [], if_true, []))
+        self.rules.append(SourceSetRule(keys, dependencies, [], [], if_true, [], []))
 
     def collect(self, enabled_fn: T.Callable[[str], bool],
                 all_sources: bool,
@@ -202,6 +209,7 @@ class SourceSetImpl(SourceSet, MutableModuleObject):
                 if not all_sources:
                     continue
             into.sources.update(entry.if_false)
+            into.deps.update(entry.if_false_deps)
         return into
 
     @noKwargs

--- a/test cases/common/291 source set if_false deps/a.c
+++ b/test cases/common/291 source set if_false deps/a.c
@@ -1,0 +1,5 @@
+#include "all.h"
+
+int a(void) {
+    return 1;
+}

--- a/test cases/common/291 source set if_false deps/all.h
+++ b/test cases/common/291 source set if_false deps/all.h
@@ -1,0 +1,2 @@
+int a(void);
+int b(void);

--- a/test cases/common/291 source set if_false deps/b.c
+++ b/test cases/common/291 source set if_false deps/b.c
@@ -1,0 +1,5 @@
+#include "all.h"
+
+int b(void) {
+    return 2;
+}

--- a/test cases/common/291 source set if_false deps/main.c
+++ b/test cases/common/291 source set if_false deps/main.c
@@ -1,0 +1,3 @@
+#include "all.h"
+
+int main(void) { return b() - a() - a(); }

--- a/test cases/common/291 source set if_false deps/meson.build
+++ b/test cases/common/291 source set if_false deps/meson.build
@@ -1,0 +1,21 @@
+project('a', 'c', meson_version: '>=1.11.0')
+
+ssmod = import('sourceset')
+
+a_lib = declare_dependency(link_with: [static_library('a', files('a.c'))])
+b_lib = declare_dependency(link_with: [static_library('b', files('b.c'))])
+
+ss = ssmod.source_set()
+ss.add(files('main.c'))
+
+ss.add(when: 'TRUE', if_true: [a_lib], if_false: [])
+ss.add(when: 'FALSE', if_true: [], if_false: [b_lib])
+
+ssconfig = ss.apply({'TRUE': true, 'FALSE': false})
+
+executable(
+    'exe',
+    sources: ssconfig.sources(),
+    dependencies: ssconfig.dependencies(),
+)
+


### PR DESCRIPTION
When using sourceset right now there is no way to provide dependencies in add's `if_false`. So, something like this:
```meson
ss.add(when: 'CONDITION',
           if_true: [a_dep],
           if_false: [b_dep],
)
```
is not possible now.

With this PR its fixed.

Idk what changes to docs are needed. I would add `*since*`  if I knew in what version (if at all) it would be added