### PR TITLE
compilers/apple: dynamically detect Homebrew prefix for OpenMP

### DIFF
--- a/mesonbuild/compilers/mixins/apple.py
+++ b/mesonbuild/compilers/mixins/apple.py
@@ -4,9 +4,38 @@
 """Provides mixins for Apple compilers."""
 
 from __future__ import annotations
+import functools
+import subprocess
 import typing as T
 
 from ...mesonlib import MesonException
+
+
+@functools.lru_cache(maxsize=None)
+def _get_libomp_prefix() -> T.Optional[str]:
+    """Call `brew --prefix libomp` once and cache it. Returns None if unavailable."""
+    try:
+        return subprocess.run(
+            ['brew', '--prefix', 'libomp'],
+            capture_output=True,
+            encoding='utf-8',
+            check=True,
+        ).stdout.strip()
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+
+
+def _get_homebrew_libomp_root(cpu_family: str, is_cross: bool) -> str:
+    """Return the libomp root, preferring dynamic detection with arch-based fallback."""
+    if not is_cross:
+        libomp_prefix = _get_libomp_prefix()
+        if libomp_prefix is not None:
+            return libomp_prefix
+    # Fallback: brew not on PATH, use historical defaults based on architecture
+    if cpu_family.startswith('x86'):
+        return '/usr/local/opt/libomp'
+    return '/opt/homebrew/opt/libomp'
+
 
 if T.TYPE_CHECKING:
     from ..._typing import ImmutableListProtocol
@@ -39,19 +68,12 @@ class AppleCompilerMixin(Compiler):
 
         :return: A list of arguments
         """
-        if self.info.cpu_family.startswith('x86'):
-            root = '/usr/local'
-        else:
-            root = '/opt/homebrew'
-        return self.__BASE_OMP_FLAGS + [f'-I{root}/opt/libomp/include']
+        root = _get_homebrew_libomp_root(self.info.cpu_family, self.is_cross)
+        return self.__BASE_OMP_FLAGS + [f'-I{root}/include']
 
     def openmp_link_flags(self) -> T.List[str]:
-        if self.info.cpu_family.startswith('x86'):
-            root = '/usr/local'
-        else:
-            root = '/opt/homebrew'
-
-        link = self.find_library('omp', [f'{root}/opt/libomp/lib'])
+        root = _get_homebrew_libomp_root(self.info.cpu_family, self.is_cross)
+        link = self.find_library('omp', [f'{root}/lib'])
         if not link:
             raise MesonException("Couldn't find libomp")
         return self.__BASE_OMP_FLAGS + link


### PR DESCRIPTION
Fixes: #15191 

This PR replaces the hardcoded Homebrew prefix paths (`/opt/homebrew` and `/usr/local`) for Apple Clang OpenMP detection with a dynamic check using `brew --prefix`. 

* I have implemented `@functools.lru_cache` to ensure the `brew --prefix` subprocess is only called once per run and the result is reused, preventing performance degradation.
* Extracted the path resolution logic into a standalone `_get_homebrew_libomp_root` helper function to eliminate duplicated if/else blocks between `openmp_flags` and `openmp_link_flags`.
* **Backward Compatibility:** I have kept the historical hardcoded fallback paths as a safety net. If `brew` is unavailable in the environment PATH, it will fall back to the architecture-based defaults.

### Testing
Since I am developing on Windows, I rely on the macOS CI runners to verify the Homebrew subprocess execution.