### PR TITLE
CI: drop llvm/objfw for the 32bit MSYS2 jobs

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -84,8 +84,8 @@ jobs:
             mingw-w64-${{ matrix.MSYS2_ARCH }}-python-setuptools
             mingw-w64-${{ matrix.MSYS2_ARCH }}-python-pip
             mingw-w64-${{ matrix.MSYS2_ARCH }}-python-fastjsonschema
-            mingw-w64-${{ matrix.MSYS2_ARCH }}-objfw
-            mingw-w64-${{ matrix.MSYS2_ARCH }}-llvm
+            mingw-w64-${{ matrix.MSYS2_ARCH }}-${{ matrix.MSYSTEM != 'MINGW32' && 'objfw' || 'ninja' }}
+            mingw-w64-${{ matrix.MSYS2_ARCH }}-${{ matrix.MSYSTEM != 'MINGW32' && 'llvm' || 'ninja' }}
             mingw-w64-${{ matrix.MSYS2_ARCH }}-${{ matrix.TOOLCHAIN }}
 
       - name: Install dependencies

--- a/test cases/frameworks/15 llvm/test.json
+++ b/test cases/frameworks/15 llvm/test.json
@@ -12,7 +12,7 @@
       ]
     }
   },
-  "expect_skip_on_jobname": ["azure", "cygwin", "windows"],
+  "expect_skip_on_jobname": ["azure", "cygwin", "windows", "msys2-gccx86ninja"],
   "tools": {
     "cmake": ">=3.11"
   }


### PR DESCRIPTION
The MSYS2 MINGW32 env has recently removed those packages. This makes CI green again.

(the ternary hack is there since GHA doesn't support "if" in expressions nor nested expressions)