### PR TITLE
build: skip self-contained libs for Rust staticlibs when crt-static is disabled

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2365,7 +2365,13 @@ class StaticLibrary(BuildTarget):
                 #  and thus, machine_info kernel should be set to 'none'.
                 #  In that case, native_static_libs list is empty.
                 rustc = self.compilers['rust']
-                link_args = ['-L' + rustc.get_target_libdir() + '/self-contained']
+                if rustc.get_crt_static():
+                    # musl targets need self-contained for libc.a, libunwind.a etc.
+                    link_args = ['-L' + rustc.get_target_libdir() + '/self-contained']
+                else:
+                    # Avoid embedding self-contained libc.a into shared libraries —
+                    # creates a second musl instance with uninitialized __libc state.
+                    link_args = []
                 link_args += rustc.native_static_libs
                 d = dependencies.InternalDependency('undefined', [], [], link_args,
                                                     [], [], [], [], [], {}, [], [], [],

--- a/test cases/rust/39 shared-lib-no-static-libc/lib.rs
+++ b/test cases/rust/39 shared-lib-no-static-libc/lib.rs
@@ -1,0 +1,4 @@
+#[unsafe(export_name = "hello")]
+pub extern "C" fn hello() {
+    println!("Hello, world!");
+}

--- a/test cases/rust/39 shared-lib-no-static-libc/main.c
+++ b/test cases/rust/39 shared-lib-no-static-libc/main.c
@@ -1,0 +1,6 @@
+extern void shim_hello(void);
+
+int main(void) {
+    shim_hello();
+    return 0;
+}

--- a/test cases/rust/39 shared-lib-no-static-libc/meson.build
+++ b/test cases/rust/39 shared-lib-no-static-libc/meson.build
@@ -1,0 +1,19 @@
+project('shared-lib-no-static-libc', meson_version : '>= 1.3.0')
+
+if not add_languages('c', native : false, required : false)
+  error('MESON_SKIP_TEST clang not installed')
+endif
+
+if not add_languages('rust', native : false, required : false)
+  error('MESON_SKIP_TEST Rust x86_64-unknown-linux-musl target not installed')
+endif
+
+rust_lib = static_library('hello', 'lib.rs', rust_abi : 'c')
+
+shared = shared_library('hello_shared', 'shim.c',
+  link_whole : rust_lib)
+
+exe = executable('exe', 'main.c',
+  link_with : shared)
+
+test('no-embedded-libc', exe)

--- a/test cases/rust/39 shared-lib-no-static-libc/shim.c
+++ b/test cases/rust/39 shared-lib-no-static-libc/shim.c
@@ -1,0 +1,5 @@
+extern void hello(void);
+
+void shim_hello(void) {
+    hello();
+}

--- a/test cases/rust/39 shared-lib-no-static-libc/test.json
+++ b/test cases/rust/39 shared-lib-no-static-libc/test.json
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "CC": "clang -target x86_64-unknown-linux-musl",
+    "RUSTC": "rustc --target x86_64-unknown-linux-musl -C target-feature=-crt-static"
+  }
+}


### PR DESCRIPTION
On musl targets, meson unconditionally adds -L.../self-contained and native_static_libs (-lunwind -lc) when linking Rust staticlibs. When crt-static is disabled this causes libc.a to be embedded in shared libraries, creating a second isolated musl instance that crashes on dlopen due to uninitialized __libc state.

Only add self-contained and native_static_libs when crt-static is enabled. When disabled, the host libc and other native deps are satisfied dynamically.

Fixes: #15645