### PR TITLE
cargo: Fix subproject name

### DIFF
--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -350,7 +350,7 @@ class Interpreter:
         return ast
 
     def interpret_workspace(self, ws: WorkspaceState, build: builder.Builder, subdir: str) -> mparser.CodeBlockNode:
-        name = os.path.dirname(subdir)
+        name = os.path.basename(subdir)
         subprojects_dir = os.path.join(subdir, 'subprojects')
         self.environment.wrap_resolver.load_and_merge(subprojects_dir, SubProject(name))
         ast: T.List[mparser.BaseNode] = []

--- a/test cases/rust/22 cargo subproject/subprojects/libname-1-rs/meson/meson.build
+++ b/test cases/rust/22 cargo subproject/subprojects/libname-1-rs/meson/meson.build
@@ -1,0 +1,1 @@
+assert(meson.project_name() == 'libname-1-rs')


### PR DESCRIPTION
In this context, the dirname of a directory is its parent so basename is the correct method.

Otherwise every subproject name is "subprojects" and can lead to mixups inside the interpreter.