### PR TITLE
Validate the meson-test-run.xml file produced by run_project_tests against the JUnit XML schema definition

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,7 +53,7 @@ jobs:
       with:
         python-version: '3.x'
     # Pin mypy to version 1.19, so we retain the ability to lint for Python 3.10
-    - run: python -m pip install "mypy==1.19" strictyaml truststore types-PyYAML types-tqdm types-chevron
+    - run: python -m pip install "mypy==1.19" strictyaml truststore types-PyYAML types-tqdm types-chevron types-lxml
     - run: python run_mypy.py --allver
       env:
         PYTHONUNBUFFERED: 1

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -555,7 +555,7 @@ class ConsoleLogger(TestLogger):
         self.test_count = 0
         self.started_tests = 0
         self.spinner_index = 0
-        self.is_tty = os.isatty(1)
+        self.is_tty = sys.stdout.isatty()
         self.cols = 80
         if self.is_tty:
             try:
@@ -582,7 +582,10 @@ class ConsoleLogger(TestLogger):
 
     def print_progress(self, line: str) -> None:
         print(self.should_erase_line, line, sep='', end='\r')
-        self.should_erase_line = '\x1b[K'
+        if self.is_tty:
+            self.should_erase_line = '\x1b[K'
+        else:
+            self.should_erase_line = '\n'
 
     def request_update(self) -> None:
         self.update.set()

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -27,9 +27,20 @@ import subprocess
 import tempfile
 import time
 import typing as T
-import xml.etree.ElementTree as ET
 import collections
 import importlib.util
+
+# use lxml, if available, otherwise fallback to xml.etree
+try:
+    import lxml.etree as ET
+except ImportError:
+    # assert that happens somewhere in our CI (although not everywhere, as we
+    # don't want to have to always install lxml), so that the validation which
+    # requires it, gets run.
+    if os.environ.get('MESON_CI_JOBNAME', 'thirdparty') == 'linux-fedora-gcc':
+        raise
+
+    import xml.etree.ElementTree as ET  # type: ignore
 
 from mesonbuild import build
 from mesonbuild import environment
@@ -1374,6 +1385,12 @@ def _run_tests(all_tests: T.List[T.Tuple[str, T.List[TestDef], bool]],
     print("Total build time:         %.2fs" % build_time)
     print("Total test time:          %.2fs" % test_time)
     ET.ElementTree(element=junit_root).write(xmlname, xml_declaration=True, encoding='UTF-8')
+
+    # validate the JUnit XML output against the JUnit schema, if possible
+    if hasattr(ET, 'XMLSchema'):
+        junit_schema = ET.XMLSchema(file='./data/schema.xsd')
+        junit_schema.assertValid(junit_root)
+
     return passing_tests, failing_tests, skipped_tests
 
 def check_meson_commands_work(use_tmpdir: bool, extra_args: T.List[str]) -> None:

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -1360,6 +1360,7 @@ def _run_tests(all_tests: T.List[T.Tuple[str, T.List[TestDef], bool]],
                     mesonlib.windows_proof_rm(abspath)
                 else:
                     mesonlib.windows_proof_rmtree(abspath)
+
         conf_time += result.conftime
         build_time += result.buildtime
         test_time += result.testtime
@@ -1373,9 +1374,9 @@ def _run_tests(all_tests: T.List[T.Tuple[str, T.List[TestDef], bool]],
         if result.msg != '':
             ET.SubElement(current_test, 'failure', {'message': result.msg})
         stdoel = ET.SubElement(current_test, 'system-out')
-        stdoel.text = result.stdo
+        stdoel.text = mtest.replace_unencodable_xml_chars(result.stdo)
         stdeel = ET.SubElement(current_test, 'system-err')
-        stdeel.text = result.stde
+        stdeel.text = mtest.replace_unencodable_xml_chars(result.stde)
 
     # Reset, just in case
     safe_print = default_print


### PR DESCRIPTION
Validate the meson-test-run.xml file produced by run_project_tests against the JUnit XML schema definition.

Doing so reveals that `meson test` outputs an escape sequence into the log, so fix that.