### PR TITLE
rust: Explicitly get rust dependency name for package dependencies

### DIFF
--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -249,6 +249,13 @@ class PackageState:
         else:
             raise MesonException(f'Unknown rust_abi: {rust_abi}')
 
+    def get_rust_dependency_name(self) -> str:
+        """Get the dependency name for a package with the rust or proc-macro ABI."""
+        supported_abis = self.supported_abis()
+        package_name = self.manifest.package.name
+        if 'rust' in supported_abis or 'proc-macro' in supported_abis:
+            return _dependency_name(package_name, self.manifest.package.api)
+        raise MesonException(f'Package {package_name} does not support rust or proc-macro ABI')
 
 @dataclasses.dataclass(frozen=True)
 class PackageKey:

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -274,8 +274,8 @@ class RustPackage(RustCrate):
                         is_parent_path(os.path.join(self.rust_ws.subdir, state.subproject_dir),
                                        dep_pkg.path):
                         self.rust_ws._do_subproject(dep_pkg)
-                    # Get the dependency name for this package
-                    depname = dep_pkg.get_dependency_name(None)
+                    # Get the dependency name for this package (rust or proc-macro ABI)
+                    depname = dep_pkg.get_rust_dependency_name()
                     dependency = state.overridden_dependency(depname, for_machine)
                     dependencies.append(dependency)
 


### PR DESCRIPTION
Fixes #15651

Explicitly avoids to take C ABI in account when configuring a crate rust dependencies.