### PR TITLE
linkers/detect: fall back to explicit *_ld path when bare linker name fails

### DIFF
--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -69,24 +69,20 @@ def guess_win_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
     if extra_args is not None:
         check_args.extend(extra_args)
 
-    p, o, _ = Popen_safe(compiler + check_args)
+    if value is not None and invoked_directly:
+        compiler = value
+
+    p, o, e = Popen_safe(compiler + check_args)
     if 'LLD' in o.split('\n', maxsplit=1)[0]:
         if 'compatible with GNU linkers' in o:
             return linkers.LLVMDynamicLinker(
                 compiler, env, for_machine, comp_class.LINKER_PREFIX,
                 override, version=search_version(o))
-        elif not invoked_directly:
+        if not invoked_directly:
             return linkers.ClangClDynamicLinker(
                 env, for_machine, override, exelist=compiler, prefix=comp_class.LINKER_PREFIX,
                 version=search_version(o), direct=False, machine=None,
                 rsp_syntax=rsp_syntax)
-
-    if value is not None and invoked_directly:
-        compiler = value
-        # We've already handled the non-direct case above
-
-    p, o, e = Popen_safe(compiler + check_args)
-    if 'LLD' in o.split('\n', maxsplit=1)[0]:
         return linkers.ClangClDynamicLinker(
             env, for_machine, [],
             prefix=comp_class.LINKER_PREFIX if use_linker_prefix else [],


### PR DESCRIPTION
## Problem

When Meson detects an MSVC compiler, `_detect_c_or_cpp_compiler` calls:

```python
guess_win_linker(env, ['link'], cls, version, for_machine)
```

Inside `guess_win_linker`, the first probe is:

```python
Popen_safe(['link', '/logo', '--version', ...])
```

This works in a VS Developer Shell (which puts link.exe on PATH), but raises `FileNotFoundError` when using a bundled MSVC toolchain that is not on PATH — even when the user has specified the full path to link.exe via `c_ld` / `cpp_ld` in a native or cross file.

## Fix

Catch `FileNotFoundError` on the first probe. If an explicit `*_ld` binary was provided, retry the probe with that path directly. The existing two-probe logic is otherwise unchanged.

## Repro

Set `c_ld = /path/to/link.exe` in a native file, ensure that directory is not on PATH, and run `meson setup`. Before this fix:

```
FileNotFoundError: [WinError 2] The system cannot find the file specified
  File "mesonbuild/linkers/detect.py", line 71, in guess_win_linker
```