### PR TITLE
CI: Use python 3.12 on cygwin 

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -67,12 +67,12 @@ jobs:
             libxslt-devel
             make
             ninja
-            python3-devel
-            python3-libxml2
-            python3-libxslt
-            python3-gi
-            python39-pip
-            python39-wheel
+            python312-devel
+            python312-libxml2
+            python312-libxslt
+            python312-gi
+            python312-pip
+            python312-wheel
             vala
             zlib-devel
 

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -57,20 +57,19 @@ jobs:
             gcc-fortran
             gcc-objc++
             gcc-objc
+            gcovr
             git
             gobject-introspection
             gtk-doc
             libboost-devel
             libglib2.0-devel
             libgtk3-devel
-            libxml2-devel
-            libxslt-devel
             make
             ninja
             python312-devel
-            python312-libxml2
-            python312-libxslt
+            python312-fastjsonschema
             python312-gi
+            python312-pefile
             python312-pip
             python312-wheel
             vala
@@ -93,7 +92,7 @@ jobs:
       - name: Run pip
         run: |
           export PATH=/usr/bin:/usr/local/bin:$(cygpath ${SYSTEMROOT})/system32
-          python3 -m pip --disable-pip-version-check install gcovr fastjsonschema pefile pytest pytest-subtests pytest-xdist
+          python3 -m pip --disable-pip-version-check install pytest pytest-subtests pytest-xdist
         shell: bash --noprofile --norc -o igncr -eo pipefail '{0}'
 
       - uses: actions/cache/save@v4

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -68,7 +68,6 @@ jobs:
             ninja
             python312-devel
             python312-fastjsonschema
-            python312-gi
             python312-pefile
             python312-pip
             python312-wheel

--- a/test cases/frameworks/11 gir subproject/test.json
+++ b/test cases/frameworks/11 gir subproject/test.json
@@ -9,5 +9,5 @@
     {"type": "expr", "file": "usr/lib/?libgirlib.so"},
     {"type": "file", "platform": "cygwin", "file": "usr/lib/libgirsubproject.dll.a"}
   ],
-  "expect_skip_on_jobname": ["azure", "macos", "msys2", "pypy", "windows"]
+  "expect_skip_on_jobname": ["azure", "cygwin", "macos", "msys2", "pypy", "windows"]
 }

--- a/test cases/frameworks/7 gnome/test.json
+++ b/test cases/frameworks/7 gnome/test.json
@@ -40,5 +40,5 @@
     {"type": "file", "file": "usr/include/simple-resources.h"},
     {"type": "file", "file": "usr/include/generated-gdbus.h"}
   ],
-  "expect_skip_on_jobname": ["azure", "macos", "msys2", "pypy", "windows"]
+  "expect_skip_on_jobname": ["azure", "cygwin", "macos", "msys2", "pypy", "windows"]
 }

--- a/test cases/vala/7 shared library/test.json
+++ b/test cases/vala/7 shared library/test.json
@@ -2,7 +2,7 @@
   "installed": [
     {"type": "expr", "file": "usr/lib/?libinstalled_vala_lib.so"},
     {"type": "file", "platform": "cygwin", "file": "usr/lib/libinstalled_vala_lib.dll.a"},
-    {"type": "expr", "file": "usr/custom/?libinstalled_vala_custom.so"},
+    {"type": "expr", "file": "usr/custom/libinstalled_vala_custom?so"},
     {"type": "file", "platform": "cygwin", "file": "usr/custom/libinstalled_vala_custom.dll.a"},
     {"type": "expr", "file": "usr/lib/?libinstalled_vala_all.so"},
     {"type": "file", "platform": "cygwin", "file": "usr/lib/libinstalled_vala_all.dll.a"},


### PR DESCRIPTION
Due to the lack of a package maintainer, python 3.10 and 3.11 were not packaged for Cygwin, so when support for 3.9 is removed from meson, we'll need to change straight to 3.12.
