### PR TITLE
Improve version check implementation

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -521,7 +521,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     def handle_meson_version(self, pv: str, location: mparser.BaseNode) -> None:
         if not mesonlib.version_compare(coredata.stable_version, pv):
             raise InterpreterException.from_node(f'Meson version is {coredata.version} but project requires {pv}', node=location)
-        mesonlib.project_meson_versions[self.subproject] = pv
+        mesonlib.project_meson_versions[self.subproject] = mesonlib.version_check_to_range([pv])
 
     def handle_meson_version_from_ast(self) -> None:
         if not self.ast.lines:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1361,7 +1361,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         else:
             # absent 'native' means 'both' for backwards compatibility
             tv = FeatureNew.get_target_version(self.subproject)
-            if FeatureNew.check_version(tv, '0.54.0'):
+            if FeatureNew.check_version(tv, '0.54'):
                 mlog.warning('add_languages is missing native:, assuming languages are wanted for both host and build.',
                              location=node)
 
@@ -2786,7 +2786,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                 if confdata_useless:
                     ifbase = os.path.basename(inputs_abs[0])
                     tv = FeatureNew.get_target_version(self.subproject)
-                    if FeatureNew.check_version(tv, '0.47.0'):
+                    if FeatureNew.check_version(tv, '0.47'):
                         mlog.warning('Got an empty configuration_data() object and found no '
                                      f'substitutions in the input file {ifbase!r}. If you want to '
                                      'copy a file to the build dir, use the \'copy:\' keyword '

--- a/mesonbuild/interpreter/primitives/string.py
+++ b/mesonbuild/interpreter/primitives/string.py
@@ -8,7 +8,7 @@ import os
 import typing as T
 
 from ... import mlog
-from ...mesonlib import version_compare_many, underscorify
+from ...mesonlib import version_check_to_range, version_compare_many, underscorify
 from ...interpreterbase import (
     InterpreterObject,
     MesonOperator,
@@ -211,20 +211,20 @@ class MesonVersionStringHolder(StringHolder):
     @InterpreterObject.method('version_compare')
     @typed_pos_args('str.version_compare', varargs=str, min_varargs=1)
     def version_compare_method(self, args: T.Tuple[T.List[str]], kwargs: TYPE_kwargs) -> bool:
-        unsupported = []
+        unsupported = False
         for constraint in args[0]:
-            if not constraint.strip().startswith('>'):
-                unsupported.append('non-upper-bounds (> or >=) constraints')
+            if constraint.strip().startswith('!'):
+                unsupported = True
+                break
         if len(args[0]) > 1:
             FeatureNew.single_use('meson.version().version_compare() with multiple arguments', '1.10.0',
                                   self.subproject, 'From 1.8.0 - 1.9.* it failed to match str.version_compare',
                                   location=self.current_node)
-            unsupported.append('multiple arguments')
-        else:
-            self.interpreter.tmp_meson_version = args[0][0]
         if unsupported:
-            mlog.debug('meson.version().version_compare() with', ' or '.join(unsupported),
+            mlog.debug('meson.version().version_compare() with != constraints',
                        'does not support overriding minimum meson_version checks.')
+        else:
+            self.interpreter.tmp_meson_version = version_check_to_range(args[0])
 
         return version_compare_many(self.held_object, args[0])[0]
 

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -35,6 +35,8 @@ if T.TYPE_CHECKING:
 
     CalleeArgs: TypeAlias = T.Tuple[mparser.BaseNode, T.Optional[T.List[TYPE_var]], T.Optional[TYPE_kwargs], SubProject]
 
+    MesonVersionTarget = str | mesonlib.NoProjectVersion | None
+
 
 def is_module(obj: object) -> TypeIs[ModuleObject]:
     return not hasattr(obj, 'current_node')
@@ -648,21 +650,21 @@ class FeatureCheckBase(metaclass=mesonlib.SimpleABC):
             self.feature_version = self.feature_version[:-2]
 
     @staticmethod
-    def get_target_version(subproject: str) -> T.Union[str, mesonlib.NoProjectVersion]:
+    def get_target_version(subproject: str) -> MesonVersionTarget:
         # Don't do any checks if project() has not been parsed yet
         if subproject not in mesonlib.project_meson_versions:
-            return ''
+            return None
         return mesonlib.project_meson_versions[subproject]
 
     @staticmethod
     @abc.abstractmethod
-    def check_version(target_version: T.Union[str, mesonlib.NoProjectVersion], feature_version: str) -> bool:
+    def check_version(target_version: MesonVersionTarget, feature_version: str) -> bool:
         pass
 
     def use(self, subproject: 'SubProject', location: T.Optional['mparser.BaseNode'] = None) -> None:
         tv = self.get_target_version(subproject)
         # No target version
-        if tv == '' and not self.unconditional:
+        if tv is None and not self.unconditional:
             return
         # Target version is new enough, don't warn
         if self.check_version(tv, self.feature_version) and not self.emit_notice:
@@ -705,15 +707,15 @@ class FeatureCheckBase(metaclass=mesonlib.SimpleABC):
         if '\n' in warning_str:
             mlog.warning(warning_str)
 
-    def log_usage_warning(self, tv: T.Union[str, mesonlib.NoProjectVersion], location: T.Optional['mparser.BaseNode']) -> None:
+    def log_usage_warning(self, tv: MesonVersionTarget, location: T.Optional['mparser.BaseNode']) -> None:
         raise InterpreterException('log_usage_warning not implemented')
 
     @staticmethod
-    def get_warning_str_prefix(tv: T.Union[str, mesonlib.NoProjectVersion]) -> str:
+    def get_warning_str_prefix(tv: MesonVersionTarget) -> str:
         raise InterpreterException('get_warning_str_prefix not implemented')
 
     @staticmethod
-    def get_notice_str_prefix(tv: T.Union[str, mesonlib.NoProjectVersion]) -> str:
+    def get_notice_str_prefix(tv: MesonVersionTarget) -> str:
         raise InterpreterException('get_notice_str_prefix not implemented')
 
     def __call__(self, f: TV_func) -> TV_func:
@@ -742,7 +744,7 @@ class FeatureNew(FeatureCheckBase):
     feature_registry = {}
 
     @staticmethod
-    def check_version(target_version: T.Union[str, mesonlib.NoProjectVersion], feature_version: str) -> bool:
+    def check_version(target_version: MesonVersionTarget, feature_version: str) -> bool:
         if isinstance(target_version, str):
             return mesonlib.version_compare_condition_with_min(target_version, feature_version)
         else:
@@ -751,17 +753,17 @@ class FeatureNew(FeatureCheckBase):
             return mesonlib.version_compare(feature_version, f'<{major}.0')
 
     @staticmethod
-    def get_warning_str_prefix(tv: T.Union[str, mesonlib.NoProjectVersion]) -> str:
+    def get_warning_str_prefix(tv: MesonVersionTarget) -> str:
         if isinstance(tv, str):
             return f'Project specifies a minimum meson_version \'{tv}\' but uses features which were added in newer versions:'
         else:
             return 'Project specifies no minimum version but uses features which were added in versions:'
 
     @staticmethod
-    def get_notice_str_prefix(tv: T.Union[str, mesonlib.NoProjectVersion]) -> str:
+    def get_notice_str_prefix(tv: MesonVersionTarget) -> str:
         return ''
 
-    def log_usage_warning(self, tv: T.Union[str, mesonlib.NoProjectVersion], location: T.Optional['mparser.BaseNode']) -> None:
+    def log_usage_warning(self, tv: MesonVersionTarget, location: T.Optional['mparser.BaseNode']) -> None:
         if isinstance(tv, str):
             prefix = f'Project targets {tv!r}'
         else:
@@ -786,7 +788,7 @@ class FeatureDeprecated(FeatureCheckBase):
     emit_notice = True
 
     @staticmethod
-    def check_version(target_version: T.Union[str, mesonlib.NoProjectVersion], feature_version: str) -> bool:
+    def check_version(target_version: MesonVersionTarget, feature_version: str) -> bool:
         if isinstance(target_version, str):
             # For deprecation checks we need to return the inverse of FeatureNew checks
             return not mesonlib.version_compare_condition_with_min(target_version, feature_version)
@@ -795,14 +797,14 @@ class FeatureDeprecated(FeatureCheckBase):
             return False
 
     @staticmethod
-    def get_warning_str_prefix(tv: T.Union[str, mesonlib.NoProjectVersion]) -> str:
+    def get_warning_str_prefix(tv: MesonVersionTarget) -> str:
         return 'Deprecated features used:'
 
     @staticmethod
-    def get_notice_str_prefix(tv: T.Union[str, mesonlib.NoProjectVersion]) -> str:
+    def get_notice_str_prefix(tv: MesonVersionTarget) -> str:
         return 'Future-deprecated features used:'
 
-    def log_usage_warning(self, tv: T.Union[str, mesonlib.NoProjectVersion], location: T.Optional['mparser.BaseNode']) -> None:
+    def log_usage_warning(self, tv: MesonVersionTarget, location: T.Optional['mparser.BaseNode']) -> None:
         if isinstance(tv, str):
             prefix = f'Project targets {tv!r}'
         else:
@@ -828,19 +830,19 @@ class FeatureBroken(FeatureCheckBase):
     unconditional = True
 
     @staticmethod
-    def check_version(target_version: T.Union[str, mesonlib.NoProjectVersion], feature_version: str) -> bool:
+    def check_version(target_version: MesonVersionTarget, feature_version: str) -> bool:
         # always warn for broken stuff
         return False
 
     @staticmethod
-    def get_warning_str_prefix(tv: T.Union[str, mesonlib.NoProjectVersion]) -> str:
+    def get_warning_str_prefix(tv: MesonVersionTarget) -> str:
         return 'Broken features used:'
 
     @staticmethod
-    def get_notice_str_prefix(tv: T.Union[str, mesonlib.NoProjectVersion]) -> str:
+    def get_notice_str_prefix(tv: MesonVersionTarget) -> str:
         return ''
 
-    def log_usage_warning(self, tv: T.Union[str, mesonlib.NoProjectVersion], location: T.Optional['mparser.BaseNode']) -> None:
+    def log_usage_warning(self, tv: MesonVersionTarget, location: T.Optional['mparser.BaseNode']) -> None:
         args = [
             'Project uses feature that was always broken,',
             'and is now deprecated since',

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -35,7 +35,7 @@ if T.TYPE_CHECKING:
 
     CalleeArgs: TypeAlias = T.Tuple[mparser.BaseNode, T.Optional[T.List[TYPE_var]], T.Optional[TYPE_kwargs], SubProject]
 
-    MesonVersionTarget = str | mesonlib.NoProjectVersion | None
+    MesonVersionTarget = mesonlib.Range[mesonlib.Version] | mesonlib.NoProjectVersion | None
 
 
 def is_module(obj: object) -> TypeIs[ModuleObject]:
@@ -745,7 +745,7 @@ class FeatureNew(FeatureCheckBase):
 
     @staticmethod
     def check_version(target_version: MesonVersionTarget, feature_version: str) -> bool:
-        if isinstance(target_version, str):
+        if isinstance(target_version, mesonlib.Range):
             return mesonlib.version_compare_condition_with_min(target_version, feature_version)
         else:
             # Warn for anything newer than the current semver base slot.
@@ -754,7 +754,7 @@ class FeatureNew(FeatureCheckBase):
 
     @staticmethod
     def get_warning_str_prefix(tv: MesonVersionTarget) -> str:
-        if isinstance(tv, str):
+        if isinstance(tv, mesonlib.Range) and tv.min is not None:
             return f'Project specifies a minimum meson_version \'{tv}\' but uses features which were added in newer versions:'
         else:
             return 'Project specifies no minimum version but uses features which were added in versions:'
@@ -764,8 +764,8 @@ class FeatureNew(FeatureCheckBase):
         return ''
 
     def log_usage_warning(self, tv: MesonVersionTarget, location: T.Optional['mparser.BaseNode']) -> None:
-        if isinstance(tv, str):
-            prefix = f'Project targets {tv!r}'
+        if isinstance(tv, mesonlib.Range) and tv.min is not None:
+            prefix = f"Project targets '{tv}'"
         else:
             prefix = 'Project does not target a minimum version'
         args = [
@@ -789,7 +789,7 @@ class FeatureDeprecated(FeatureCheckBase):
 
     @staticmethod
     def check_version(target_version: MesonVersionTarget, feature_version: str) -> bool:
-        if isinstance(target_version, str):
+        if isinstance(target_version, mesonlib.Range):
             # For deprecation checks we need to return the inverse of FeatureNew checks
             return not mesonlib.version_compare_condition_with_min(target_version, feature_version)
         else:
@@ -805,8 +805,8 @@ class FeatureDeprecated(FeatureCheckBase):
         return 'Future-deprecated features used:'
 
     def log_usage_warning(self, tv: MesonVersionTarget, location: T.Optional['mparser.BaseNode']) -> None:
-        if isinstance(tv, str):
-            prefix = f'Project targets {tv!r}'
+        if isinstance(tv, mesonlib.Range):
+            prefix = f"Project targets '{tv}'"
         else:
             prefix = 'Project does not target a minimum version'
         args = [

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -635,8 +635,17 @@ class FeatureCheckBase(metaclass=mesonlib.SimpleABC):
 
     def __init__(self, feature_name: str, feature_version: str, extra_message: str = ''):
         self.feature_name = feature_name
-        self.feature_version = feature_version
+        self.feature_version_for_msg = feature_version
         self.extra_message = extra_message
+        self.feature_version = feature_version
+        # Map versions in the constraint of the form '0.46.0' to '0.46', to
+        # ensure that '0.46' in project(meson_version: '>=0.46') allows
+        # using features in '0.46.0'.  Meson versioning is basically
+        # semver, i.e. '0.46.0' is the lowest version which satisfies the
+        # constraint '>=0.46', but meson.version_compare() is more like
+        # rpm versions for historical reasons.
+        while self.feature_version.endswith('.0'):
+            self.feature_version = self.feature_version[:-2]
 
     @staticmethod
     def get_target_version(subproject: str) -> T.Union[str, mesonlib.NoProjectVersion]:
@@ -660,18 +669,18 @@ class FeatureCheckBase(metaclass=mesonlib.SimpleABC):
             return
         # Feature is too new for target version or we want to emit notices, register it
         if subproject not in self.feature_registry:
-            self.feature_registry[subproject] = {self.feature_version: set()}
+            self.feature_registry[subproject] = {self.feature_version_for_msg: set()}
         register = self.feature_registry[subproject]
-        if self.feature_version not in register:
-            register[self.feature_version] = set()
+        if self.feature_version_for_msg not in register:
+            register[self.feature_version_for_msg] = set()
 
         feature_key = (self.feature_name, location)
-        if feature_key in register[self.feature_version]:
+        if feature_key in register[self.feature_version_for_msg]:
             # Don't warn about the same feature multiple times
             # FIXME: This is needed to prevent duplicate warnings, but also
             # means we won't warn about a feature used in multiple places.
             return
-        register[self.feature_version].add(feature_key)
+        register[self.feature_version_for_msg].add(feature_key)
         # Target version is new enough, don't warn even if it is registered for notice
         if self.check_version(tv, self.feature_version):
             return
@@ -729,7 +738,7 @@ class FeatureNew(FeatureCheckBase):
 
     # Class variable, shared across all instances
     #
-    # Format: {subproject: {feature_version: set(feature_names)}}
+    # Format: {subproject: {feature_version_for_msg: set(feature_names)}}
     feature_registry = {}
 
     @staticmethod
@@ -760,7 +769,7 @@ class FeatureNew(FeatureCheckBase):
         args = [
             prefix,
             'but uses feature introduced in',
-            f"'{self.feature_version}':",
+            f"'{self.feature_version_for_msg}':",
             f'{self.feature_name}.',
         ]
         if self.extra_message:
@@ -772,7 +781,7 @@ class FeatureDeprecated(FeatureCheckBase):
 
     # Class variable, shared across all instances
     #
-    # Format: {subproject: {feature_version: set(feature_names)}}
+    # Format: {subproject: {feature_version_for_msg: set(feature_names)}}
     feature_registry = {}
     emit_notice = True
 
@@ -801,7 +810,7 @@ class FeatureDeprecated(FeatureCheckBase):
         args = [
             prefix,
             'but uses feature deprecated since',
-            f"'{self.feature_version}':",
+            f"'{self.feature_version_for_msg}':",
             f'{self.feature_name}.',
         ]
         if self.extra_message:
@@ -814,7 +823,7 @@ class FeatureBroken(FeatureCheckBase):
 
     # Class variable, shared across all instances
     #
-    # Format: {subproject: {feature_version: set(feature_names)}}
+    # Format: {subproject: {feature_version_for_msg: set(feature_names)}}
     feature_registry = {}
     unconditional = True
 
@@ -835,7 +844,7 @@ class FeatureBroken(FeatureCheckBase):
         args = [
             'Project uses feature that was always broken,',
             'and is now deprecated since',
-            f"'{self.feature_version}':",
+            f"'{self.feature_version_for_msg}':",
             f'{self.feature_name}.',
         ]
         if self.extra_message:

--- a/mesonbuild/interpreterbase/interpreterbase.py
+++ b/mesonbuild/interpreterbase/interpreterbase.py
@@ -311,15 +311,19 @@ class InterpreterBase:
             res = result.operator_call(MesonOperator.BOOL, None)
             if not isinstance(res, bool):
                 raise InvalidCode(f'If clause {result!r} does not evaluate to true or false.')
-            if res:
-                prev_meson_version = mesonlib.project_meson_versions[self.subproject]
-                if self.tmp_meson_version:
-                    mesonlib.project_meson_versions[self.subproject] = self.tmp_meson_version
-                try:
+            prev_meson_version = mesonlib.project_meson_versions[self.subproject]
+            if self.tmp_meson_version and isinstance(prev_meson_version, mesonlib.Range):
+                always = prev_meson_version.always(self.tmp_meson_version)
+                if always is not None:
+                    mlog.warning(f"Conditional on version '{self.tmp_meson_version}' always evaluates to {str(always).lower()}",
+                                 location=self.current_node)
+                mesonlib.project_meson_versions[self.subproject] = prev_meson_version.intersect(self.tmp_meson_version)
+            try:
+                if res:
                     self.evaluate_codeblock(i.block)
-                finally:
-                    mesonlib.project_meson_versions[self.subproject] = prev_meson_version
-                return None
+                    return None
+            finally:
+                mesonlib.project_meson_versions[self.subproject] = prev_meson_version
         if not isinstance(node.elseblock, mparser.EmptyNode):
             self.evaluate_codeblock(node.elseblock.block)
         return None

--- a/mesonbuild/interpreterbase/interpreterbase.py
+++ b/mesonbuild/interpreterbase/interpreterbase.py
@@ -96,7 +96,7 @@ class InterpreterBase:
         # meson.version().compare_version(version_string)
         # If it was part of a if-clause, it is used to temporally override the
         # current meson version target within that if-block.
-        self.tmp_meson_version: T.Optional[str] = None
+        self.tmp_meson_version: T.Optional[mesonlib.Range[mesonlib.Version]] = None
 
     def handle_meson_version_from_ast(self) -> None:
         # do nothing in an AST interpreter

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -1093,6 +1093,18 @@ class Range(T.Generic[_V]):
         result.__post_init__()
         return result
 
+    def always(self, inner: Range[_V]) -> T.Optional[bool]:
+        """Check if inner is always true or always false given self.
+
+        Returns True if inner is always satisfied by any value in self,
+        False if no value in self satisfies inner, None if indeterminate."""
+        narrowed = self.intersect(inner)
+        if narrowed.is_empty:
+            return False
+        if narrowed == self:
+            return True
+        return None
+
 
 # note that Range is immutable, so no need to have Range() | None
 def version_check_to_range(checks: T.List[str], start: Range[Version] = Range()) -> Range[Version]:

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -31,7 +31,7 @@ from mesonbuild import mlog
 from .core import MesonException, HoldableObject
 
 if T.TYPE_CHECKING:
-    from typing_extensions import Literal, Protocol
+    from typing_extensions import Literal, Protocol, Self
 
     from .._typing import ImmutableListProtocol
     from ..build import ConfigurationData
@@ -46,6 +46,15 @@ if T.TYPE_CHECKING:
     class _VerPickleLoadable(Protocol):
 
         version: str
+
+    class Comparable(Protocol):
+        """Protocol for annotating comparable types."""
+        def __eq__(self, other: object) -> bool: ...
+        def __ne__(self, other: object) -> bool: ...
+        def __lt__(self, other: Self) -> bool: ...
+        def __le__(self, other: Self) -> bool: ...
+        def __ge__(self, other: Self) -> bool: ...
+        def __gt__(self, other: Self) -> bool: ...
 
     # A generic type for pickle_load. This allows any type that has either a
     # .version or a .environment to be passed.
@@ -80,6 +89,7 @@ __all__ = [
     'PerThreeMachine',
     'PerThreeMachineDefaultable',
     'ProgressBar',
+    'Range',
     'RealPathAction',
     'TemporaryDirectoryWinProof',
     'Version',
@@ -916,10 +926,10 @@ class Version:
                 for m in _VERSION_TOK_RE.finditer(s)]
 
     def __str__(self) -> str:
-        return '{} (V={})'.format(self._s, str(self._v))
+        return self._s
 
     def __repr__(self) -> str:
-        return f'<Version: {self._s}>'
+        return f'<Version: {self._s!r} V={self._v!r}>'
 
     def __lt__(self, other: object) -> bool:
         if isinstance(other, Version):
@@ -1012,6 +1022,75 @@ def version_compare_many(vstr1: str, conditions: T.Union[str, T.Iterable[str]]) 
         else:
             found.append(req)
     return not not_found, not_found, found
+
+
+_V = T.TypeVar('_V', bound='Comparable')
+
+@dataclasses.dataclass(order=False)
+class Range(T.Generic[_V]):
+    min: T.Optional[_V] = None
+    min_eq: bool = False
+    max: T.Optional[_V] = None
+    max_eq: bool = False
+    is_empty: bool = False
+
+    def __str__(self) -> str:
+        if self.is_empty:
+            return '(empty)'
+        if self.min is not None and self.max is not None and self.min == self.max:
+            return f'== {self.min}'
+        parts = []
+        if self.min is not None:
+            parts.append(f'>{"=" if self.min_eq else ""} {self.min}')
+        if self.max is not None:
+            parts.append(f'<{"=" if self.max_eq else ""} {self.max}')
+        return ', '.join(parts) if parts else '(any)'
+
+    def __contains__(self, x: _V) -> bool:
+        if self.is_empty:
+            return False
+        if self.min is not None and (x < self.min if self.min_eq else x <= self.min):
+            return False
+        if self.max is not None and (x > self.max if self.max_eq else x >= self.max):
+            return False
+        return True
+
+    def __post_init__(self) -> None:
+        if self.min is None or self.max is None:
+            return
+        self.is_empty = False
+        if self.min < self.max:
+            return
+        if self.min == self.max and self.min_eq and self.max_eq:
+            return
+        self.min = None
+        self.max = None
+        self.is_empty = True
+
+    def _intersect_min(self, v: _V, eq: bool) -> None:
+        if self.min is None or v > self.min:
+            self.min, self.min_eq = v, eq
+        elif v == self.min:
+            self.min_eq = eq and self.min_eq
+
+    def _intersect_max(self, v: _V, eq: bool) -> None:
+        if self.max is None or v < self.max:
+            self.max, self.max_eq = v, eq
+        elif v == self.max:
+            self.max_eq = eq and self.max_eq
+
+    def intersect(self, x: Range[_V]) -> Range[_V]:
+        if x.is_empty:
+            return copy.copy(x)
+        result = copy.copy(self)
+        if self.is_empty:
+            return result
+        if x.min is not None:
+            result._intersect_min(x.min, x.min_eq)
+        if x.max is not None:
+            result._intersect_max(x.max, x.max_eq)
+        result.__post_init__()
+        return result
 
 
 # determine if the minimum version satisfying the condition |condition| exceeds

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -1018,25 +1018,19 @@ def version_compare_many(vstr1: str, conditions: T.Union[str, T.Iterable[str]]) 
 # the minimum version for a feature |minimum|
 def version_compare_condition_with_min(condition: str, minimum: str) -> bool:
     if condition.startswith('>='):
-        cmpop = operator.le
         condition = condition[2:]
     elif condition.startswith('<='):
         return False
     elif condition.startswith('!='):
         return False
     elif condition.startswith('=='):
-        cmpop = operator.le
         condition = condition[2:]
     elif condition.startswith('='):
-        cmpop = operator.le
         condition = condition[1:]
     elif condition.startswith('>'):
-        cmpop = operator.lt
         condition = condition[1:]
     elif condition.startswith('<'):
         return False
-    else:
-        cmpop = operator.le
 
     # Declaring a project(meson_version: '>=0.46') and then using features in
     # 0.46.0 is valid, because (knowing the meson versioning scheme) '0.46.0' is
@@ -1052,7 +1046,7 @@ def version_compare_condition_with_min(condition: str, minimum: str) -> bool:
     if re.match(r'^\d+.\d+$', condition):
         condition += '.0'
 
-    return T.cast('bool', cmpop(Version(minimum), Version(condition)))
+    return Version(minimum) <= Version(condition)
 
 def search_version(text: str) -> str:
     # Usually of the type 4.1.4 but compiler output may contain

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -1003,7 +1003,7 @@ def _version_extract_cmpop(vstr2: str) -> T.Tuple[T.Callable[[T.Any, T.Any], boo
     else:
         cmpop = operator.eq
 
-    return (cmpop, vstr2)
+    return (cmpop, vstr2.strip())
 
 
 def version_compare(vstr1: str, vstr2: str) -> bool:
@@ -1093,25 +1093,39 @@ class Range(T.Generic[_V]):
         return result
 
 
+# note that Range is immutable, so no need to have Range() | None
+def version_check_to_range(checks: T.List[str], start: Range[Version] = Range()) -> Range[Version]:
+    for x in checks:
+        op, v = _version_extract_cmpop(x)
+        if op is operator.ge:
+            r = Range(min=Version(v), min_eq=True)
+        elif op is operator.gt:
+            r = Range(min=Version(v), min_eq=False)
+        elif op is operator.le:
+            r = Range(max=Version(v), max_eq=True)
+        elif op is operator.lt:
+            r = Range(max=Version(v), max_eq=False)
+        elif op is operator.eq:
+            r = Range(min=Version(v), max=Version(v), min_eq=True, max_eq=True)
+        elif op is operator.ne:
+            continue  # cop out
+        start = start.intersect(r)
+    return start
+
+
 # determine if the minimum version satisfying the condition |condition| exceeds
 # the minimum version for a feature |minimum|
-def version_compare_condition_with_min(condition: str, minimum: str) -> bool:
-    if condition.startswith('>='):
-        condition = condition[2:]
-    elif condition.startswith('<='):
-        return False
-    elif condition.startswith('!='):
-        return False
-    elif condition.startswith('=='):
-        condition = condition[2:]
-    elif condition.startswith('='):
-        condition = condition[1:]
-    elif condition.startswith('>'):
-        condition = condition[1:]
-    elif condition.startswith('<'):
-        return False
+def version_compare_condition_with_min(condition: T.Union[str, Range[Version]], minimum: str) -> bool:
+    if isinstance(condition, str):
+        condition = version_check_to_range([condition])
 
-    return Version(minimum) <= Version(condition)
+    if condition.min is None:
+        # A < constraint on the project version (max is not None) or a full
+        # range should always include versions older than minimum, return False.
+        # is_empty=True instead behaves like an absurdly high min and returns True.
+        return condition.is_empty
+    else:
+        return Version(minimum) <= condition.min
 
 def search_version(text: str) -> str:
     # Usually of the type 4.1.4 but compiler output may contain

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -1032,20 +1032,6 @@ def version_compare_condition_with_min(condition: str, minimum: str) -> bool:
     elif condition.startswith('<'):
         return False
 
-    # Declaring a project(meson_version: '>=0.46') and then using features in
-    # 0.46.0 is valid, because (knowing the meson versioning scheme) '0.46.0' is
-    # the lowest version which satisfies the constraint '>=0.46'.
-    #
-    # But this will fail here, because the minimum version required by the
-    # version constraint ('0.46') is strictly less (in our version comparison)
-    # than the minimum version needed for the feature ('0.46.0').
-    #
-    # Map versions in the constraint of the form '0.46' to '0.46.0', to embed
-    # this knowledge of the meson versioning scheme.
-    condition = condition.strip()
-    if re.match(r'^\d+.\d+$', condition):
-        condition += '.0'
-
     return Version(minimum) <= Version(condition)
 
 def search_version(text: str) -> str:

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -174,6 +174,7 @@ __all__ = [
     'typeslistify',
     'unique_list',
     'verbose_git',
+    'version_check_to_range',
     'version_compare',
     'version_compare_condition_with_min',
     'version_compare_many',
@@ -193,7 +194,7 @@ class NoProjectVersion:
 # TODO: this is such a hack, this really should be either in coredata or in the
 # interpreter
 # {subproject: project_meson_version}
-project_meson_versions: T.Dict[str, T.Union[str, NoProjectVersion]] = {}
+project_meson_versions: T.Dict[str, T.Union[Range[Version], NoProjectVersion]] = {}
 
 
 from glob import glob
@@ -1108,7 +1109,13 @@ def version_check_to_range(checks: T.List[str], start: Range[Version] = Range())
         elif op is operator.eq:
             r = Range(min=Version(v), max=Version(v), min_eq=True, max_eq=True)
         elif op is operator.ne:
-            continue  # cop out
+            v_ = Version(v)
+            # Do the best that we can, remove the extrema
+            r = Range()
+            if v_ == start.min:
+                r = Range(min=v_, min_eq=False)
+            if v_ == start.max:
+                r = r.intersect(Range(max=v_, max_eq=False))
         start = start.intersect(r)
     return start
 

--- a/test cases/common/295 redundant version check/meson.build
+++ b/test cases/common/295 redundant version check/meson.build
@@ -1,0 +1,33 @@
+# written by Benjamin Gilbert <bgilbert@backtick.net>
+project('t', 'c', meson_version: '>=0.60.0')
+if meson.version().version_compare('>=0.55.0')
+  v = 1
+endif
+if meson.version().version_compare('<0.60.0')
+  v = 2
+endif
+# narrowing: <0.60 is indeterminate, but >=0.40 is always true within >=0.50, <0.60
+if meson.version().version_compare('<99.0')
+  if meson.version().version_compare('>=0.40')
+    v = 3
+  endif
+endif
+
+# <= vs <, should not warn
+if meson.version().version_compare('<=99.0')
+  if meson.version().version_compare('<99.0')
+    v = 4
+  endif
+endif
+
+# hide warnings about multiple args to version_compare()
+if meson.version().version_compare('>1.10.0')
+  if meson.version().version_compare('<99.0')
+    if meson.version().version_compare('<99.0', '>=0.40')
+      v = 5
+    endif
+    if meson.version().version_compare('>=0.40', '<99.0')
+      v = 6
+    endif
+  endif
+endif

--- a/test cases/common/295 redundant version check/test.json
+++ b/test cases/common/295 redundant version check/test.json
@@ -1,0 +1,19 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/common/295 redundant version check/meson.build:3: WARNING: Conditional on version '>= 0.55.0' always evaluates to true"
+    },
+    {
+      "line": "test cases/common/295 redundant version check/meson.build:6: WARNING: Conditional on version '< 0.60.0' always evaluates to false"
+    },
+    {
+      "line": "test cases/common/295 redundant version check/meson.build:11: WARNING: Conditional on version '>= 0.40' always evaluates to true"
+    },
+    {
+      "line": "test cases/common/295 redundant version check/meson.build:26: WARNING: Conditional on version '>= 0.40, < 99.0' always evaluates to true"
+    },
+    {
+      "line": "test cases/common/295 redundant version check/meson.build:29: WARNING: Conditional on version '>= 0.40, < 99.0' always evaluates to true"
+    }
+  ]
+}

--- a/test cases/common/33 run program/test.json
+++ b/test cases/common/33 run program/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "test cases/common/33 run program/meson.build:1: WARNING: Project targets '>=0.1.0' but uses feature introduced in '0.47.0': check arg in run_command.",
+      "line": "test cases/common/33 run program/meson.build:1: WARNING: Project targets '>= 0.1.0' but uses feature introduced in '0.47.0': check arg in run_command.",
       "comment": "This triggers on line 1 -- the line with the project() function"
     }
   ]

--- a/test cases/common/44 pkgconfig-gen/test.json
+++ b/test cases/common/44 pkgconfig-gen/test.json
@@ -24,10 +24,10 @@
   ],
   "stdout": [
     {
-      "line": "test cases/common/44 pkgconfig-gen/meson.build:161: WARNING: Project targets '>=0.60.0' but uses feature introduced in '0.62.0': pkgconfig.generate implicit variable for builtin directories."
+      "line": "test cases/common/44 pkgconfig-gen/meson.build:161: WARNING: Project targets '>= 0.60.0' but uses feature introduced in '0.62.0': pkgconfig.generate implicit variable for builtin directories."
     },
     {
-      "line": "test cases/common/44 pkgconfig-gen/meson.build:171: WARNING: Project targets '>=0.60.0' but uses feature introduced in '0.62.0': pkgconfig.generate implicit variable for builtin directories.",
+      "line": "test cases/common/44 pkgconfig-gen/meson.build:171: WARNING: Project targets '>= 0.60.0' but uses feature introduced in '0.62.0': pkgconfig.generate implicit variable for builtin directories.",
       "count": 0
     },
     {

--- a/test cases/common/62 string arithmetic/test.json
+++ b/test cases/common/62 string arithmetic/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "test cases/common/62 string arithmetic/meson.build:25: WARNING: Project targets '>=0.62.0' but uses feature introduced in '0.63.0': multiline format strings."
+      "line": "test cases/common/62 string arithmetic/meson.build:25: WARNING: Project targets '>= 0.62.0' but uses feature introduced in '0.63.0': multiline format strings."
     }
   ]
 }

--- a/test cases/warning/1 version for string div/test.json
+++ b/test cases/warning/1 version for string div/test.json
@@ -2,7 +2,7 @@
   "stdout": [
     {
       "comment": "literal '/' appears in output, irrespective of os.path.sep, as that's the operator",
-      "line": "test cases/warning/1 version for string div/meson.build:3: WARNING: Project targets '>=0.48.0' but uses feature introduced in '0.49.0': / with string arguments."
+      "line": "test cases/warning/1 version for string div/meson.build:3: WARNING: Project targets '>= 0.48.0' but uses feature introduced in '0.49.0': / with string arguments."
     }
   ]
 }

--- a/test cases/warning/6 list add/test.json
+++ b/test cases/warning/6 list add/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "test cases/warning/6 list add/meson.build:4: WARNING: Project targets '>=0.59.0' but uses feature introduced in '0.60.0': list.<plus>. The right hand operand was not a list."
+      "line": "test cases/warning/6 list add/meson.build:4: WARNING: Project targets '>= 0.59.0' but uses feature introduced in '0.60.0': list.<plus>. The right hand operand was not a list."
     }
   ]
 }

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -2959,16 +2959,16 @@ class AllPlatformTests(BasePlatformTests):
         testdir = os.path.join(self.unit_test_dir, '40 featurenew subprojects')
         out = self.init(testdir)
         # Parent project warns correctly
-        self.assertRegex(out, "WARNING: Project targets '>=0.45'.*'0.47.0': dict")
+        self.assertRegex(out, "WARNING: Project targets '>= 0.45'.*'0.47.0': dict")
         # Subprojects warn correctly
-        self.assertRegex(out, r"foo\| .*WARNING: Project targets '>=0.40'.*'0.44.0': disabler")
-        self.assertRegex(out, r"baz\| .*WARNING: Project targets '!=0.40'.*'0.44.0': disabler")
+        self.assertRegex(out, r"foo\| .*WARNING: Project targets '>= 0.40'.*'0.44.0': disabler")
+        self.assertRegex(out, r"baz\| .*WARNING: Project does not target a minimum version.*'0.44.0': disabler")
         # Subproject has a new-enough meson_version, no warning
         self.assertNotRegex(out, "WARNING: Project targets.*Python")
         # Ensure a summary is printed in the subproject and the outer project
-        self.assertRegex(out, r"\| WARNING: Project specifies a minimum meson_version '>=0.40'")
+        self.assertRegex(out, r"\| WARNING: Project specifies a minimum meson_version '>= 0.40'")
         self.assertRegex(out, r"\| \* 0.44.0: {'disabler'}")
-        self.assertRegex(out, "WARNING: Project specifies a minimum meson_version '>=0.45'")
+        self.assertRegex(out, "WARNING: Project specifies a minimum meson_version '>= 0.45'")
         self.assertRegex(out, " * 0.47.0: {'dict'}")
 
     def test_configure_file_warnings(self):

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -39,6 +39,7 @@ from mesonbuild.interpreterbase import typed_pos_args, InvalidArguments, typed_k
 from mesonbuild.mesonlib import (
     LibType, MachineChoice, PerMachine, SimpleABC, Version, is_windows, is_osx,
     is_cygwin, is_openbsd, search_version, MesonException, python_command,
+    version_check_to_range,
 )
 from mesonbuild.options import OptionKey
 from mesonbuild.interpreter.type_checking import in_set_validator, NoneType
@@ -1463,7 +1464,7 @@ class InternalTests(unittest.TestCase):
 
         with self.subTest('use before available'), \
                 mock.patch('sys.stdout', io.StringIO()) as out, \
-                mock.patch('mesonbuild.mesonlib.project_meson_versions', {'': '0.1'}):
+                mock.patch('mesonbuild.mesonlib.project_meson_versions', {'': version_check_to_range(['>=0.1'])}):
             # With Meson 0.1 it should trigger the "introduced" warning but not the "deprecated" warning
             _(None, mock.Mock(subproject=''), [], {'input': 'foo'})
             self.assertRegex(out.getvalue(), r'WARNING:.*introduced.*input arg in testfunc. It\'s awesome, use it')
@@ -1471,14 +1472,14 @@ class InternalTests(unittest.TestCase):
 
         with self.subTest('no warnings should be triggered'), \
                 mock.patch('sys.stdout', io.StringIO()) as out, \
-                mock.patch('mesonbuild.mesonlib.project_meson_versions', {'': '1.5'}):
+                mock.patch('mesonbuild.mesonlib.project_meson_versions', {'': version_check_to_range(['>=1.5'])}):
             # With Meson 1.5 it shouldn't trigger any warning
             _(None, mock.Mock(subproject=''), [], {'input': 'foo'})
             self.assertNotRegex(out.getvalue(), r'WARNING:.*')
 
         with self.subTest('use after deprecated'), \
                 mock.patch('sys.stdout', io.StringIO()) as out, \
-                mock.patch('mesonbuild.mesonlib.project_meson_versions', {'': '2.0'}):
+                mock.patch('mesonbuild.mesonlib.project_meson_versions', {'': version_check_to_range(['>=2.0'])}):
             # With Meson 2.0 it should trigger the "deprecated" warning but not the "introduced" warning
             _(None, mock.Mock(subproject=''), [], {'input': 'foo'})
             self.assertRegex(out.getvalue(), r'WARNING:.*deprecated.*input arg in testfunc. It\'s terrible, don\'t use it')
@@ -1509,7 +1510,7 @@ class InternalTests(unittest.TestCase):
 
         _(None, mock.Mock(), tuple(), dict(native=True))
 
-    @mock.patch('mesonbuild.mesonlib.project_meson_versions', {'': '1.0'})
+    @mock.patch('mesonbuild.mesonlib.project_meson_versions', {'': version_check_to_range(['>=1.0'])})
     def test_typed_kwarg_since_values(self) -> None:
         @typed_kwargs(
             'testfunc',
@@ -1537,84 +1538,84 @@ class InternalTests(unittest.TestCase):
 
         with self.subTest('deprecated array string value'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'input': ['foo']})
-            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '1.0'.*deprecated since '0.9': "testfunc" keyword argument "input" value "foo".*""")
+            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '>= 1.0'.*deprecated since '0.9': "testfunc" keyword argument "input" value "foo".*""")
 
         with self.subTest('new array string value'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'input': ['bar']})
-            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '1.0'.*introduced in '1.1': "testfunc" keyword argument "input" value "bar".*""")
+            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '>= 1.0'.*introduced in '1.1': "testfunc" keyword argument "input" value "bar".*""")
 
         with self.subTest('deprecated dict string value'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'output': {'foo': 'a'}})
-            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '1.0'.*deprecated since '0.9': "testfunc" keyword argument "output" value "foo".*""")
+            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '>= 1.0'.*deprecated since '0.9': "testfunc" keyword argument "output" value "foo".*""")
 
         with self.subTest('deprecated dict string value with msg'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'output': {'foo2': 'a'}})
-            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '1.0'.*deprecated since '0.9': "testfunc" keyword argument "output" value "foo2" in dict keys. don't use it.*""")
+            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '>= 1.0'.*deprecated since '0.9': "testfunc" keyword argument "output" value "foo2" in dict keys. don't use it.*""")
 
         with self.subTest('new dict string value'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'output': {'bar': 'b'}})
-            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '1.0'.*introduced in '1.1': "testfunc" keyword argument "output" value "bar".*""")
+            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '>= 1.0'.*introduced in '1.1': "testfunc" keyword argument "output" value "bar".*""")
 
         with self.subTest('new dict string value with msg'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'output': {'bar2': 'a'}})
-            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '1.0'.*introduced in '1.1': "testfunc" keyword argument "output" value "bar2" in dict keys. use this.*""")
+            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '>= 1.0'.*introduced in '1.1': "testfunc" keyword argument "output" value "bar2" in dict keys. use this.*""")
 
         with self.subTest('new string type'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'foo': 'foo'})
-            self.assertRegex(out.getvalue(), r"""WARNING: Project targets '1.0'.*introduced in '1.1': "testfunc" keyword argument "foo" of type str.*""")
+            self.assertRegex(out.getvalue(), r"""WARNING: Project targets '>= 1.0'.*introduced in '1.1': "testfunc" keyword argument "foo" of type str.*""")
 
         with self.subTest('new array of string type'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'foo': ['foo']})
-            self.assertRegex(out.getvalue(), r"""WARNING: Project targets '1.0'.*introduced in '1.2': "testfunc" keyword argument "foo" of type array\[str\].*""")
+            self.assertRegex(out.getvalue(), r"""WARNING: Project targets '>= 1.0'.*introduced in '1.2': "testfunc" keyword argument "foo" of type array\[str\].*""")
 
         with self.subTest('new dict of string type'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'foo': {'plop': 'foo'}})
-            self.assertRegex(out.getvalue(), r"""WARNING: Project targets '1.0'.*introduced in '1.3': "testfunc" keyword argument "foo" of type dict\[str\].*""")
+            self.assertRegex(out.getvalue(), r"""WARNING: Project targets '>= 1.0'.*introduced in '1.3': "testfunc" keyword argument "foo" of type dict\[str\].*""")
 
         with self.subTest('deprecated int value'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'foo': 1})
-            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '1.0'.*deprecated since '0.8': "testfunc" keyword argument "foo" of type int.*""")
+            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '>= 1.0'.*deprecated since '0.8': "testfunc" keyword argument "foo" of type int.*""")
 
         with self.subTest('deprecated array int value'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'foo': [1]})
-            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '1.0'.*deprecated since '0.9': "testfunc" keyword argument "foo" of type array\[int\].*""")
+            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '>= 1.0'.*deprecated since '0.9': "testfunc" keyword argument "foo" of type array\[int\].*""")
 
         with self.subTest('new list[str] value'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'tuple': ['foo', 42]})
-            self.assertRegex(out.getvalue(), r"""WARNING: Project targets '1.0'.*introduced in '1.1': "testfunc" keyword argument "tuple" of type array\[str\].*""")
-            self.assertRegex(out.getvalue(), r"""WARNING: Project targets '1.0'.*introduced in '1.2': "testfunc" keyword argument "tuple" of type array\[int\].*""")
+            self.assertRegex(out.getvalue(), r"""WARNING: Project targets '>= 1.0'.*introduced in '1.1': "testfunc" keyword argument "tuple" of type array\[str\].*""")
+            self.assertRegex(out.getvalue(), r"""WARNING: Project targets '>= 1.0'.*introduced in '1.2': "testfunc" keyword argument "tuple" of type array\[int\].*""")
 
         with self.subTest('deprecated array string value'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'input': 'foo'})
-            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '1.0'.*deprecated since '0.9': "testfunc" keyword argument "input" value "foo".*""")
+            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '>= 1.0'.*deprecated since '0.9': "testfunc" keyword argument "input" value "foo".*""")
 
         with self.subTest('new array string value'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'input': 'bar'})
-            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '1.0'.*introduced in '1.1': "testfunc" keyword argument "input" value "bar".*""")
+            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '>= 1.0'.*introduced in '1.1': "testfunc" keyword argument "input" value "bar".*""")
 
         with self.subTest('non string union'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'install_dir': False})
-            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '1.0'.*deprecated since '0.9': "testfunc" keyword argument "install_dir" value "False".*""")
+            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '>= 1.0'.*deprecated since '0.9': "testfunc" keyword argument "install_dir" value "False".*""")
 
         with self.subTest('deprecated string union'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'mode': 'deprecated'})
-            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '1.0'.*deprecated since '1.0': "testfunc" keyword argument "mode" value "deprecated".*""")
+            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '>= 1.0'.*deprecated since '1.0': "testfunc" keyword argument "mode" value "deprecated".*""")
 
         with self.subTest('new string union'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'mode': 'since'})
-            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '1.0'.*introduced in '1.1': "testfunc" keyword argument "mode" value "since".*""")
+            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '>= 1.0'.*introduced in '1.1': "testfunc" keyword argument "mode" value "since".*""")
 
         with self.subTest('new container'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'dict': ['a=b']})
-            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '1.0'.*introduced in '1.9': "testfunc" keyword argument "dict" of type list.*""")
+            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '>= 1.0'.*introduced in '1.9': "testfunc" keyword argument "dict" of type list.*""")
 
         with self.subTest('new container set to default'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'new_dict': {}})
-            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '1.0'.*introduced in '1.1': "testfunc" keyword argument "new_dict" of type dict.*""")
+            self.assertRegex(out.getvalue(), r"""WARNING:.Project targets '>= 1.0'.*introduced in '1.1': "testfunc" keyword argument "new_dict" of type dict.*""")
 
         with self.subTest('new container default'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {})
-            self.assertNotRegex(out.getvalue(), r"""WARNING:.Project targets '1.0'.*introduced in '1.1': "testfunc" keyword argument "new_dict" of type dict.*""")
+            self.assertNotRegex(out.getvalue(), r"""WARNING:.Project targets '>= 1.0'.*introduced in '1.1': "testfunc" keyword argument "new_dict" of type dict.*""")
 
     def test_typed_kwarg_evolve(self) -> None:
         k = KwargInfo('foo', str, required=True, default='foo')

--- a/unittests/versiontests.py
+++ b/unittests/versiontests.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+from mesonbuild.mesonlib import (
+    Version, version_compare, version_compare_many,
+    version_compare_condition_with_min, search_version,
+)
+
+
+class VersionComparisonTests(unittest.TestCase):
+
+    def test_version_ordering(self):
+        LT = -1
+        EQ = 0
+        #GT = 1
+
+        # mostly from RPM tests
+        tests = [
+            ("1.0", "1.0", EQ),
+            ("1_0", "1_0", EQ),
+            ("1_0", "1.0", EQ),
+            ("1.0", "2.0", LT),
+            ("2.0", "2.0.0", LT),
+            ("2.0", "2.0.1", LT),
+            ("2.0.1", "2.0.1", EQ),
+            ("2.0.1", "2.0.1a", LT),
+            ("2.0.1a", "2.0.1a", EQ),
+            ("2.10", "3.111", LT),
+            ("2.456", "2.1000", LT),
+            ("1.2rc1", "1.2.0", LT),
+            ("5.5p1", "5.5p1", EQ),
+            ("5.5p1", "5.5p2", LT),
+            ("5.5p1", "5.5p10", LT),
+            ("10xyz", "10.1xyz", LT),
+            ("xyz10", "xyz10", EQ),
+            ("xyz10", "xyz10.1", LT),
+            ("xyz.4", "8", LT),
+            ("xyz.4", "2", LT),
+            ("5.5p2", "5.6p1", LT),
+            ("5.6p1", "6.5p1", LT),
+            ("6.0", "6.0.rc1", LT),
+            ("10a2", "10b2", LT),
+            ("1.0aa", "1.0aa", EQ),
+            ("1.0a", "1.0aa", LT),
+            ("10.0001", "10.1", EQ),
+            ("10.0001", "10.0039", LT),
+            ("1.05", "1.5", EQ),
+            ("2a", "2.0", LT),
+        ]
+
+        for (a, b, result) in tests:
+            with self.subTest(f'({a!r}, {b!r})'):
+                ver_a = Version(a)
+                ver_b = Version(b)
+
+                self.assertEqual(ver_a <= ver_b, result <= 0, f'{ver_a} <= {ver_b}')
+                self.assertEqual(ver_a < ver_b, result < 0, f'{ver_a} <= {ver_b}')
+                self.assertEqual(ver_a > ver_b, result > 0, f'{ver_a} <= {ver_b}')
+                self.assertEqual(ver_a >= ver_b, result >= 0, f'{ver_a} <= {ver_b}')
+
+                self.assertEqual(ver_a == ver_b, result == 0, f'{ver_a} <= {ver_b}')
+                self.assertEqual(ver_b == ver_a, result == 0, f'{ver_a} <= {ver_b}')
+                self.assertEqual(ver_a != ver_b, result != 0, f'{ver_a} <= {ver_b}')
+                self.assertEqual(ver_b != ver_a, result != 0, f'{ver_a} <= {ver_b}')
+
+                self.assertEqual(ver_b <= ver_a, -result <= 0, f'{ver_a} <= {ver_b}')
+                self.assertEqual(ver_b < ver_a, -result < 0, f'{ver_a} <= {ver_b}')
+                self.assertEqual(ver_b > ver_a, -result > 0, f'{ver_a} <= {ver_b}')
+                self.assertEqual(ver_b >= ver_a, -result >= 0, f'{ver_a} <= {ver_b}')
+
+    def test_version_compare(self):
+        """Test version_compare with operator prefixes."""
+        self.assertTrue(version_compare('1.0', '>=1.0'))
+        self.assertTrue(version_compare('1.1', '>=1.0'))
+        self.assertFalse(version_compare('0.9', '>=1.0'))
+
+        self.assertTrue(version_compare('1.0', '<=1.0'))
+        self.assertTrue(version_compare('0.9', '<=1.0'))
+        self.assertFalse(version_compare('1.1', '<=1.0'))
+
+        self.assertTrue(version_compare('1.0', '>0.9'))
+        self.assertFalse(version_compare('1.0', '>1.0'))
+
+        self.assertTrue(version_compare('1.0', '<1.1'))
+        self.assertFalse(version_compare('1.0', '<1.0'))
+
+        self.assertTrue(version_compare('1.0', '==1.0'))
+        self.assertFalse(version_compare('1.0', '==1.1'))
+
+        self.assertTrue(version_compare('1.0', '!=1.1'))
+        self.assertFalse(version_compare('1.0', '!=1.0'))
+
+        # bare version and = means ==
+        self.assertTrue(version_compare('1.0', '1.0'))
+        self.assertFalse(version_compare('1.0', '1.1'))
+        self.assertTrue(version_compare('1.0', '=1.0'))
+        self.assertFalse(version_compare('1.0', '=1.1'))
+
+    def test_version_compare_many(self):
+        result, not_found, found = version_compare_many('1.5', ['>=1.0', '<2.0'])
+        self.assertTrue(result)
+        self.assertEqual(not_found, [])
+        self.assertEqual(found, ['>=1.0', '<2.0'])
+
+        result, not_found, found = version_compare_many('0.5', ['>=1.0', '<2.0'])
+        self.assertFalse(result)
+        self.assertEqual(not_found, ['>=1.0'])
+        self.assertEqual(found, ['<2.0'])
+
+        result, not_found, found = version_compare_many('2.5', ['>=1.0', '<2.0'])
+        self.assertFalse(result)
+        self.assertEqual(not_found, ['<2.0'])
+        self.assertEqual(found, ['>=1.0'])
+
+        # string condition is treated as single-element list
+        result, not_found, found = version_compare_many('1.0', '>=1.0')
+        self.assertTrue(result)
+        self.assertEqual(not_found, [])
+        self.assertEqual(found, ['>=1.0'])
+
+    def test_version_compare_condition_with_min(self):
+        # >= condition: minimum must be <= condition version
+        self.assertTrue(version_compare_condition_with_min('>=0.46.0', '0.46.0'))
+        self.assertTrue(version_compare_condition_with_min('>=0.50.0', '0.46.0'))
+        self.assertFalse(version_compare_condition_with_min('>=0.40.0', '0.46.0'))
+
+        # > condition: minimum must be strictly < condition version
+        self.assertFalse(version_compare_condition_with_min('>0.46.0', '0.46.0'))
+        self.assertTrue(version_compare_condition_with_min('>0.50.0', '0.46.0'))
+        self.assertFalse(version_compare_condition_with_min('>0.45.0', '0.46.0'))
+
+        # == condition: minimum must be <= condition version
+        self.assertTrue(version_compare_condition_with_min('==0.46.0', '0.46.0'))
+        self.assertTrue(version_compare_condition_with_min('==0.50.0', '0.46.0'))
+        self.assertFalse(version_compare_condition_with_min('==0.40.0', '0.46.0'))
+
+        # = or bare condition is the same as ==
+        self.assertTrue(version_compare_condition_with_min('=0.46.0', '0.46.0'))
+        self.assertTrue(version_compare_condition_with_min('0.46.0', '0.46.0'))
+        self.assertFalse(version_compare_condition_with_min('0.40.0', '0.46.0'))
+
+        # < and <= conditions always return False (includes versions older than minimum)
+        self.assertFalse(version_compare_condition_with_min('<1.0.0', '0.46.0'))
+        self.assertFalse(version_compare_condition_with_min('<=1.0.0', '0.46.0'))
+        self.assertFalse(version_compare_condition_with_min('<0.30.0', '0.46.0'))
+        self.assertFalse(version_compare_condition_with_min('<=0.30.0', '0.46.0'))
+
+        # != condition always returns False
+        self.assertFalse(version_compare_condition_with_min('!=0.40.0', '0.46.0'))
+
+        # two-component version in condition is mapped to three-component
+        # e.g. '>=0.46' is treated as '>=0.46.0'
+        self.assertTrue(version_compare_condition_with_min('>=0.46', '0.46.0'))
+        self.assertFalse(version_compare_condition_with_min('>=0.46', '0.46.1'))
+        self.assertTrue(version_compare_condition_with_min('>=0.46.0', '0.46'))
+        self.assertTrue(version_compare_condition_with_min('>=0.46.1', '0.46'))
+
+    def test_search_version(self):
+        self.assertEqual(search_version('foo 1.2.3'), '1.2.3')
+        self.assertEqual(search_version('1.2.3'), '1.2.3')
+        self.assertEqual(search_version('foo 2026.03.20 1.2.3'), '1.2.3')
+        self.assertEqual(search_version('2026.03.20 1.2.3'), '1.2.3')
+        self.assertEqual(search_version('foo 2026.03.20'), '2026.03.20')
+        self.assertEqual(search_version('2026.03.20'), '2026.03.20')
+        self.assertEqual(search_version('2026.03'), '2026.03')
+        self.assertEqual(search_version('2026.03 1.2.3'), '1.2.3')
+        self.assertEqual(search_version('foo v1.2.3'), '1.2.3')
+        self.assertEqual(search_version('2026'), 'unknown version')

--- a/unittests/versiontests.py
+++ b/unittests/versiontests.py
@@ -3,8 +3,9 @@
 import unittest
 
 from mesonbuild.mesonlib import (
-    Version, version_compare, version_compare_many,
-    version_compare_condition_with_min, search_version,
+    Range, Version, version_compare,
+    version_compare_many, version_compare_condition_with_min,
+    search_version,
 )
 
 
@@ -156,6 +157,160 @@ class VersionComparisonTests(unittest.TestCase):
         self.assertFalse(version_compare_condition_with_min('>=0.46', '0.46.1'))
         self.assertTrue(version_compare_condition_with_min('>=0.46.0', '0.46'))
         self.assertTrue(version_compare_condition_with_min('>=0.46.1', '0.46'))
+
+    def test_range_contains(self):
+        """Test Range.__contains__."""
+        # unbounded range contains everything
+        r = Range()
+        self.assertIn(5, r)
+        self.assertIn(0, r)
+
+        # min only, inclusive
+        r = Range(min=3, min_eq=True)
+        self.assertIn(3, r)
+        self.assertIn(5, r)
+        self.assertNotIn(2, r)
+
+        # min only, exclusive
+        r = Range(min=3, min_eq=False)
+        self.assertNotIn(3, r)
+        self.assertIn(4, r)
+        self.assertNotIn(2, r)
+
+        # max only, inclusive
+        r = Range(max=7, max_eq=True)
+        self.assertIn(7, r)
+        self.assertIn(5, r)
+        self.assertNotIn(8, r)
+
+        # max only, exclusive
+        r = Range(max=7, max_eq=False)
+        self.assertNotIn(7, r)
+        self.assertIn(6, r)
+        self.assertNotIn(8, r)
+
+        # both bounds, inclusive
+        r = Range(min=3, min_eq=True, max=7, max_eq=True)
+        self.assertIn(3, r)
+        self.assertIn(5, r)
+        self.assertIn(7, r)
+        self.assertNotIn(2, r)
+        self.assertNotIn(8, r)
+
+        # both bounds, exclusive
+        r = Range(min=3, min_eq=False, max=7, max_eq=False)
+        self.assertNotIn(3, r)
+        self.assertIn(5, r)
+        self.assertNotIn(7, r)
+
+        # empty range contains nothing
+        r = Range(min=5, min_eq=False, max=5, max_eq=False)
+        self.assertNotIn(5, r)
+
+        # min == max, both inclusive -> single point, not empty
+        r = Range(min=5, max=5, min_eq=True, max_eq=True)
+        self.assertIn(5, r)
+
+    def test_range_init_trivial(self):
+        """Test that __post_init__ detects trivial ranges."""
+        r = Range()
+        self.assertFalse(r.is_empty)
+
+        # min > max
+        r = Range(min=7, max=3, min_eq=True, max_eq=True)
+        self.assertTrue(r.is_empty)
+
+        # min == max, not both inclusive -> empty
+        r = Range(min=5, max=5, min_eq=True, max_eq=False)
+        self.assertTrue(r.is_empty)
+
+        r = Range(min=5, max=5, min_eq=False, max_eq=True)
+        self.assertTrue(r.is_empty)
+
+        r = Range(min=5, max=5, min_eq=False, max_eq=False)
+        self.assertTrue(r.is_empty)
+
+        # min == max, both inclusive -> single point, not empty
+        r = Range(min=5, max=5, min_eq=True, max_eq=True)
+        self.assertFalse(r.is_empty)
+
+    def test_range_intersect(self):
+        """Test Range.intersect."""
+        # intersect two overlapping ranges
+        a = Range(min=1, min_eq=True, max=10, max_eq=True)
+        b = Range(min=5, min_eq=True, max=15, max_eq=True)
+        r = a.intersect(b)
+        self.assertIn(5, r)
+        self.assertIn(10, r)
+        self.assertNotIn(4, r)
+        self.assertNotIn(11, r)
+
+        # intersect does not mutate original
+        self.assertIn(4, a)
+
+        # intersect narrows unbounded range
+        a = Range()
+        b = Range(min=3, min_eq=True, max=7, max_eq=False)
+        r = a.intersect(b)
+        self.assertIn(3, r)
+        self.assertIn(6, r)
+        self.assertNotIn(2, r)
+        self.assertNotIn(7, r)
+
+        # intersect non-overlapping ranges produces empty
+        a = Range(min=1, min_eq=True, max=3, max_eq=True)
+        b = Range(min=5, min_eq=True, max=7, max_eq=True)
+        r = a.intersect(b)
+        self.assertTrue(r.is_empty)
+
+        # intersect with matching boundary tightens eq
+        a = Range(min=5, min_eq=True)
+        b = Range(min=5, min_eq=False)
+        r = a.intersect(b)
+        self.assertEqual(5, r.min)
+        self.assertNotIn(5, r)
+
+        a = Range(max=5, max_eq=True)
+        b = Range(max=5, max_eq=False)
+        r = a.intersect(b)
+        self.assertEqual(5, r.max)
+        self.assertIn(4, r)
+
+        # intersecting empty range stays empty
+        a = Range(min=7, max=3, min_eq=True, max_eq=True)
+        self.assertTrue(a.is_empty)
+        b = Range(min=1, min_eq=True, max=10, max_eq=True)
+        r = a.intersect(b)
+        self.assertTrue(r.is_empty)
+
+        b = Range()
+        r = a.intersect(b)
+        self.assertTrue(r.is_empty)
+
+        a = Range()
+        b = Range(min=7, max=3, min_eq=True, max_eq=True)
+        r = a.intersect(b)
+        self.assertTrue(r.is_empty)
+
+    def test_range_str(self):
+        """Test Range.__str__."""
+        self.assertEqual(str(Range()), '(any)')
+        self.assertEqual(str(Range(min=3, min_eq=True)), '>= 3')
+        self.assertEqual(str(Range(min=3, min_eq=False)), '> 3')
+        self.assertEqual(str(Range(max=7, max_eq=True)), '<= 7')
+        self.assertEqual(str(Range(max=7, max_eq=False)), '< 7')
+        self.assertEqual(str(Range(min=3, min_eq=True, max=7, max_eq=False)), '>= 3, < 7')
+        self.assertEqual(str(Range(min=5, max=5, min_eq=True, max_eq=True)), '== 5')
+        # empty range
+        r = Range(min=7, max=3, min_eq=True, max_eq=True)
+        self.assertEqual(str(r), '(empty)')
+
+    def test_range_str_version(self):
+        """Test Range.__str__ with Version objects."""
+        r = Range(min=Version('0.46.0'), min_eq=True)
+        self.assertEqual(str(r), '>= 0.46.0')
+        r = Range(min=Version('1.0'), min_eq=True, max=Version('2.0'), max_eq=False)
+        self.assertEqual(str(r), '>= 1.0, < 2.0')
 
     def test_search_version(self):
         self.assertEqual(search_version('foo 1.2.3'), '1.2.3')

--- a/unittests/versiontests.py
+++ b/unittests/versiontests.py
@@ -292,6 +292,42 @@ class VersionComparisonTests(unittest.TestCase):
         r = a.intersect(b)
         self.assertTrue(r.is_empty)
 
+    def test_range_always(self):
+        """Range.always checks if inner is always true/false given outer."""
+        outer = Range(min=5, min_eq=True, max=10, max_eq=True)
+        unbounded = Range()
+        empty = Range(min=7, max=3, min_eq=True, max_eq=True)
+
+        # inner fully contains outer => true
+        self.assertTrue(outer.always(Range(min=3, min_eq=True)))
+        self.assertTrue(outer.always(Range(max=12, max_eq=True)))
+        self.assertTrue(outer.always(unbounded))
+
+        # inner same as outer => true
+        self.assertTrue(outer.always(Range(min=5, min_eq=True, max=10, max_eq=True)))
+
+        # inner doesn't overlap outer => false
+        self.assertFalse(outer.always(Range(min=11, min_eq=True)))
+        self.assertFalse(outer.always(Range(max=4, max_eq=True)))
+
+        # inner partially overlaps => indeterminate
+        self.assertIsNone(outer.always(Range(min=7, min_eq=True)))
+        self.assertIsNone(outer.always(Range(max=8, max_eq=True)))
+
+        # exclusive boundaries count as a partial overlap
+        self.assertIsNone(outer.always(Range(min=5, min_eq=False)))
+        self.assertIsNone(outer.always(Range(max=10, max_eq=False)))
+
+        # outer is unbounded
+        self.assertIsNone(unbounded.always(Range(min=5, min_eq=True)))
+        self.assertTrue(unbounded.always(unbounded))
+        self.assertFalse(unbounded.always(empty))
+
+        # outer is empty => always false (intersection is empty)
+        self.assertFalse(empty.always(Range(min=5, min_eq=True)))
+        self.assertFalse(empty.always(unbounded))
+        self.assertFalse(empty.always(empty))
+
     def test_range_str(self):
         """Test Range.__str__."""
         self.assertEqual(str(Range()), '(any)')

--- a/unittests/versiontests.py
+++ b/unittests/versiontests.py
@@ -125,8 +125,8 @@ class VersionComparisonTests(unittest.TestCase):
         self.assertTrue(version_compare_condition_with_min('>=0.50.0', '0.46.0'))
         self.assertFalse(version_compare_condition_with_min('>=0.40.0', '0.46.0'))
 
-        # > condition: minimum must be strictly < condition version
-        self.assertFalse(version_compare_condition_with_min('>0.46.0', '0.46.0'))
+        # > condition: minimum must be <= condition version
+        self.assertTrue(version_compare_condition_with_min('>0.46.0', '0.46.0'))
         self.assertTrue(version_compare_condition_with_min('>0.50.0', '0.46.0'))
         self.assertFalse(version_compare_condition_with_min('>0.45.0', '0.46.0'))
 

--- a/unittests/versiontests.py
+++ b/unittests/versiontests.py
@@ -149,9 +149,10 @@ class VersionComparisonTests(unittest.TestCase):
         # != condition always returns False
         self.assertFalse(version_compare_condition_with_min('!=0.40.0', '0.46.0'))
 
-        # two-component version in condition is mapped to three-component
-        # e.g. '>=0.46' is treated as '>=0.46.0'
-        self.assertTrue(version_compare_condition_with_min('>=0.46', '0.46.0'))
+        # test behavior of two-component versions
+        # '0.46.0' is mangled to '0.46' so that '>=0.46.0' works, but this is
+        # not done by version_compare_condition_with_min
+        self.assertFalse(version_compare_condition_with_min('>=0.46', '0.46.0'))
         self.assertFalse(version_compare_condition_with_min('>=0.46', '0.46.1'))
         self.assertTrue(version_compare_condition_with_min('>=0.46.0', '0.46'))
         self.assertTrue(version_compare_condition_with_min('>=0.46.1', '0.46'))


### PR DESCRIPTION
This introduces a Range class that makes it possible to track the current nesting of `if meson.version().version_compare('...')` conditionals. The new class also simplifies the implementation of `version_compare_condition_with_min` and of warning for redundant version checks.