### PR TITLE
compilers: Don't pass Environment into compiler methods

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1349,7 +1349,7 @@ class Vs2010Backend(backends.Backend):
             ET.SubElement(clconf, 'OpenMPSupport').text = 'true'
         # CRT type; debug or release
         vscrt_type = self.get_target_option(target, 'b_vscrt')
-        vscrt_val = compiler.get_crt_val(vscrt_type, self.environment)
+        vscrt_val = compiler.get_crt_val(vscrt_type)
         if vscrt_val == 'mdd':
             ET.SubElement(type_config, 'UseDebugLibraries').text = 'true'
             ET.SubElement(clconf, 'RuntimeLibrary').text = 'MultiThreadedDebugDLL'

--- a/mesonbuild/compilers/asm.py
+++ b/mesonbuild/compilers/asm.py
@@ -148,16 +148,16 @@ class NasmCompiler(ASMCompiler):
                 parameter_list[idx] = i[:2] + os.path.normpath(os.path.join(build_dir, i[2:]))
         return parameter_list
 
-    def get_crt_compile_args(self, crt_val: str, env: Environment) -> T.List[str]:
+    def get_crt_compile_args(self, crt_val: str) -> T.List[str]:
         return []
 
     # Linking ASM-only objects into an executable or DLL
     # require this, otherwise it'll fail to find
     # _WinMain or _DllMainCRTStartup.
-    def get_crt_link_args(self, crt_val: str, env: Environment) -> T.List[str]:
+    def get_crt_link_args(self, crt_val: str) -> T.List[str]:
         if not isinstance(self.linker, VisualStudioLikeLinkerMixin):
             return []
-        return self.crt_args[self.get_crt_val(crt_val, env)]
+        return self.crt_args[self.get_crt_val(crt_val)]
 
 class YasmCompiler(NasmCompiler):
     id = 'yasm'
@@ -233,7 +233,7 @@ class MasmCompiler(ASMCompiler):
                 parameter_list[idx] = i[:2] + os.path.normpath(os.path.join(build_dir, i[2:]))
         return parameter_list
 
-    def get_crt_compile_args(self, crt_val: str, env: Environment) -> T.List[str]:
+    def get_crt_compile_args(self, crt_val: str) -> T.List[str]:
         return []
 
     def depfile_for_object(self, objfile: str) -> T.Optional[str]:
@@ -281,7 +281,7 @@ class MasmARMCompiler(ASMCompiler):
                 parameter_list[idx] = i[:2] + os.path.normpath(os.path.join(build_dir, i[2:]))
         return parameter_list
 
-    def get_crt_compile_args(self, crt_val: str, env: Environment) -> T.List[str]:
+    def get_crt_compile_args(self, crt_val: str) -> T.List[str]:
         return []
 
     def get_depfile_format(self) -> str:
@@ -309,7 +309,7 @@ class TILinearAsmCompiler(TICompiler, ASMCompiler):
     def get_always_args(self) -> T.List[str]:
         return []
 
-    def get_crt_compile_args(self, crt_val: str, env: Environment) -> T.List[str]:
+    def get_crt_compile_args(self, crt_val: str) -> T.List[str]:
         return []
 
     def get_depfile_suffix(self) -> str:
@@ -334,7 +334,7 @@ class MetrowerksAsmCompiler(MetrowerksCompiler, ASMCompiler):
             'everything': []}
         self.can_compile_suffixes.add('s')
 
-    def get_crt_compile_args(self, crt_val: str, env: Environment) -> T.List[str]:
+    def get_crt_compile_args(self, crt_val: str) -> T.List[str]:
         return []
 
     def get_optimization_args(self, optimization_level: str) -> T.List[str]:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -344,7 +344,7 @@ def get_base_compile_args(target: 'BuildTarget', compiler: 'Compiler', env: 'Env
         crt_val = env.coredata.get_option_for_target(target, 'b_vscrt')
         assert isinstance(crt_val, str)
         try:
-            args += compiler.get_crt_compile_args(crt_val, env)
+            args += compiler.get_crt_compile_args(crt_val)
         except AttributeError:
             pass
     except KeyError:
@@ -432,7 +432,7 @@ def get_base_link_args(target: 'BuildTarget',
         crt_val = env.coredata.get_option_for_target(target, 'b_vscrt')
         assert isinstance(crt_val, str)
         try:
-            crtargs = linker.get_crt_link_args(crt_val, env)
+            crtargs = linker.get_crt_link_args(crt_val)
             assert isinstance(crtargs, list)
             args += crtargs
         except AttributeError:
@@ -1160,7 +1160,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         """
         return []
 
-    def get_crt_val(self, crt_val: str, env: Environment) -> str:
+    def get_crt_val(self, crt_val: str) -> str:
         if crt_val in options.MSCRT_VALS:
             return crt_val
         assert crt_val in {'from_buildtype', 'static_from_buildtype'}
@@ -1172,7 +1172,8 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
             rel = 'mt'
 
         # Match what build type flags used to do.
-        buildtype = env.coredata.optstore.get_value_for('buildtype')
+        buildtype = self.environment.coredata.optstore.get_value_for('buildtype')
+        assert isinstance(buildtype, str), 'for mypy'
         if buildtype == 'plain':
             return 'none'
         elif buildtype == 'debug':
@@ -1183,10 +1184,10 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
             assert buildtype == 'custom'
             raise EnvironmentException('Requested C runtime based on buildtype, but buildtype is "custom".')
 
-    def get_crt_compile_args(self, crt_val: str, env: Environment) -> T.List[str]:
+    def get_crt_compile_args(self, crt_val: str) -> T.List[str]:
         raise EnvironmentException('This compiler does not support Windows CRT selection')
 
-    def get_crt_link_args(self, crt_val: str, env: Environment) -> T.List[str]:
+    def get_crt_link_args(self, crt_val: str) -> T.List[str]:
         raise EnvironmentException('This compiler does not support Windows CRT selection')
 
     def get_compile_only_args(self) -> T.List[str]:

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -725,17 +725,17 @@ class CudaCompiler(Compiler):
                      skip_link_check: bool = False) -> T.Optional[T.List[str]]:
         return self.host_compiler.find_library(libname, extra_dirs, libtype, lib_prefix_warning, ignore_system_dirs, skip_link_check)
 
-    def get_crt_compile_args(self, crt_val: str, env: Environment) -> T.List[str]:
-        return self._to_host_flags(self.host_compiler.get_crt_compile_args(crt_val, env))
+    def get_crt_compile_args(self, crt_val: str) -> T.List[str]:
+        return self._to_host_flags(self.host_compiler.get_crt_compile_args(crt_val))
 
-    def get_crt_link_args(self, crt_val: str, env: Environment) -> T.List[str]:
+    def get_crt_link_args(self, crt_val: str) -> T.List[str]:
         # nvcc defaults to static, release version of msvc runtime and provides no
         # native option to override it; override it with /NODEFAULTLIB
         host_link_arg_overrides = []
-        host_crt_compile_args = self.host_compiler.get_crt_compile_args(crt_val, env)
+        host_crt_compile_args = self.host_compiler.get_crt_compile_args(crt_val)
         if any(arg in {'/MDd', '/MD', '/MTd'} for arg in host_crt_compile_args):
             host_link_arg_overrides += ['/NODEFAULTLIB:LIBCMT.lib']
-        return self._to_host_flags(host_link_arg_overrides + self.host_compiler.get_crt_link_args(crt_val, env), Phase.LINKER)
+        return self._to_host_flags(host_link_arg_overrides + self.host_compiler.get_crt_link_args(crt_val), Phase.LINKER)
 
     def get_target_link_args(self, target: 'BuildTarget') -> T.List[str]:
         return self._to_host_flags(super().get_target_link_args(target), Phase.LINKER)

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -371,10 +371,10 @@ class DmdLikeCompilerMixin(CompilerMixinBase):
 
         return clike_debug_args[is_debug] + ddebug_args
 
-    def _get_crt_args(self, crt_val: str, env: Environment) -> T.List[str]:
+    def _get_crt_args(self, crt_val: str) -> T.List[str]:
         if not self.info.is_windows():
             return []
-        return self.mscrt_args[self.get_crt_val(crt_val, env)]
+        return self.mscrt_args[self.get_crt_val(crt_val)]
 
     def get_soname_args(self, prefix: str, shlib_name: str, suffix: str, soversion: str,
                         darwin_versions: T.Tuple[str, str]) -> T.List[str]:
@@ -527,10 +527,10 @@ class DCompiler(Compiler):
             return ['-m32']
         return []
 
-    def get_crt_compile_args(self, crt_val: str, env: Environment) -> T.List[str]:
+    def get_crt_compile_args(self, crt_val: str) -> T.List[str]:
         return []
 
-    def get_crt_link_args(self, crt_val: str, env: Environment) -> T.List[str]:
+    def get_crt_link_args(self, crt_val: str) -> T.List[str]:
         return []
 
     def _get_compile_extra_args(self, extra_args: T.Union[T.List[str], T.Callable[[CompileCheckMode], T.List[str]], None] = None) -> T.List[str]:
@@ -718,8 +718,8 @@ class LLVMDCompiler(DmdLikeCompilerMixin, DCompiler):
     def get_pic_args(self) -> T.List[str]:
         return ['-relocation-model=pic']
 
-    def get_crt_link_args(self, crt_val: str, env: Environment) -> T.List[str]:
-        return self._get_crt_args(crt_val, env)
+    def get_crt_link_args(self, crt_val: str) -> T.List[str]:
+        return self._get_crt_args(crt_val)
 
     def unix_args_to_native(self, args: T.List[str]) -> T.List[str]:
         return self._unix_args_to_native(args, self.info, self.linker.id)
@@ -803,8 +803,8 @@ class DmdDCompiler(DmdLikeCompilerMixin, DCompiler):
             return ['-m32']
         return []
 
-    def get_crt_compile_args(self, crt_val: str, env: Environment) -> T.List[str]:
-        return self._get_crt_args(crt_val, env)
+    def get_crt_compile_args(self, crt_val: str) -> T.List[str]:
+        return self._get_crt_args(crt_val)
 
     def unix_args_to_native(self, args: T.List[str]) -> T.List[str]:
         return self._unix_args_to_native(args, self.info, self.linker.id)

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -21,7 +21,6 @@ if T.TYPE_CHECKING:
     from ...options import MutableKeyedOptionDictType
     from ...dependencies import Dependency  # noqa: F401
     from ...build import BuildTarget
-    from ...environment import Environment
     from ..compilers import Compiler
 
     CompilerMixinBase = Compiler
@@ -91,16 +90,16 @@ class ClangCompiler(GnuLikeCompiler):
         # All Clang backends can also do LLVM IR
         self.can_compile_suffixes.add('ll')
 
-    def get_crt_compile_args(self, crt_val: str, env: Environment) -> T.List[str]:
+    def get_crt_compile_args(self, crt_val: str) -> T.List[str]:
         if not isinstance(self.linker, VisualStudioLikeLinkerMixin):
             return []
-        crt_val = self.get_crt_val(crt_val, env)
+        crt_val = self.get_crt_val(crt_val)
         return self.CRT_D_ARGS[crt_val]
 
-    def get_crt_link_args(self, crt_val: str, env: Environment) -> T.List[str]:
+    def get_crt_link_args(self, crt_val: str) -> T.List[str]:
         if not isinstance(self.linker, VisualStudioLikeLinkerMixin):
             return []
-        crt_val = self.get_crt_val(crt_val, env)
+        crt_val = self.get_crt_val(crt_val)
         return self.CRT_ARGS[crt_val]
 
     def get_colorout_args(self, colortype: str) -> T.List[str]:

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -333,8 +333,8 @@ class CLikeCompiler(Compiler):
             try:
                 crt_val = self.environment.coredata.optstore.get_value_for('b_vscrt')
                 assert isinstance(crt_val, str), 'for mypy'
-                cargs += self.get_crt_compile_args(crt_val, self.environment)
-                largs += self.get_crt_link_args(crt_val, self.environment)
+                cargs += self.get_crt_compile_args(crt_val)
+                largs += self.get_crt_link_args(crt_val)
             except (KeyError, AttributeError):
                 pass
 
@@ -1242,11 +1242,11 @@ class CLikeCompiler(Compiler):
         # TODO: should probably check for macOS?
         return self._find_framework_impl(name, extra_dirs, allow_system)
 
-    def get_crt_compile_args(self, crt_val: str, env: Environment) -> T.List[str]:
+    def get_crt_compile_args(self, crt_val: str) -> T.List[str]:
         # TODO: does this belong here or in GnuLike or maybe PosixLike?
         return []
 
-    def get_crt_link_args(self, crt_val: str, env: Environment) -> T.List[str]:
+    def get_crt_link_args(self, crt_val: str) -> T.List[str]:
         # TODO: does this belong here or in GnuLike or maybe PosixLike?
         return []
 

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -20,7 +20,6 @@ from mesonbuild.linkers.linkers import ClangClDynamicLinker, MSVCDynamicLinker
 
 if T.TYPE_CHECKING:
     from ...build import BuildTarget
-    from ...environment import Environment
     from .clike import CLikeCompiler as Compiler
 else:
     # This is a bit clever, for mypy we pretend that these mixins descend from
@@ -317,8 +316,8 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
             return []
         return os.environ['INCLUDE'].split(os.pathsep)
 
-    def get_crt_compile_args(self, crt_val: str, env: Environment) -> T.List[str]:
-        crt_val = self.get_crt_val(crt_val, env)
+    def get_crt_compile_args(self, crt_val: str) -> T.List[str]:
+        crt_val = self.get_crt_val(crt_val)
         return self.crt_args[crt_val]
 
     def has_func_attribute(self, name: str) -> T.Tuple[bool, bool]:

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -394,17 +394,17 @@ class RustCompiler(Compiler):
             args.append('--edition=' + std)
         return args
 
-    def get_crt_compile_args(self, crt_val: str, env: Environment) -> T.List[str]:
+    def get_crt_compile_args(self, crt_val: str) -> T.List[str]:
         # Rust handles this for us, we don't need to do anything
         return []
 
-    def get_crt_link_args(self, crt_val: str, env: Environment) -> T.List[str]:
+    def get_crt_link_args(self, crt_val: str) -> T.List[str]:
         if not isinstance(self.linker, VisualStudioLikeLinkerMixin):
             return []
         # Rustc always use non-debug Windows runtime. Inject the one selected
         # by Meson options instead.
         # https://github.com/rust-lang/rust/issues/39016
-        return self.MSVCRT_ARGS[self.get_crt_val(crt_val, env)]
+        return self.MSVCRT_ARGS[self.get_crt_val(crt_val)]
 
     def get_colorout_args(self, colortype: str) -> T.List[str]:
         if colortype in {'always', 'never', 'auto'}:

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -606,7 +606,7 @@ class BoostDependency(SystemDependency):
         try:
             crt_val = self.env.coredata.optstore.get_value_for('b_vscrt')
             assert isinstance(crt_val, str)
-            vscrt = self.clib_compiler.get_crt_compile_args(crt_val, self.env)[0]
+            vscrt = self.clib_compiler.get_crt_compile_args(crt_val)[0]
         except (KeyError, IndexError, AttributeError):
             pass
 


### PR DESCRIPTION
Compilers and Linkers already have an Environment reference, so passing them in complicates the API needlessly.