### PR TITLE
type safe option value getters

### DIFF
--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -296,7 +296,7 @@ class IntrospectionInterpreter(AstInterpreter):
         return new_target
 
     def build_library(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> T.Union[IntrospectionBuildTarget, UnknownValue]:
-        default_library = self.coredata.optstore.get_value_for(OptionKey('default_library', subproject=self.subproject))
+        default_library = self.coredata.optstore.get_value_for_untyped(OptionKey('default_library', subproject=self.subproject))
         if default_library == 'shared':
             return self.build_target(node, args, kwargs, SharedLibrary)
         elif default_library == 'static':

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -296,7 +296,7 @@ class IntrospectionInterpreter(AstInterpreter):
         return new_target
 
     def build_library(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> T.Union[IntrospectionBuildTarget, UnknownValue]:
-        default_library = self.coredata.optstore.get_value_for_untyped(OptionKey('default_library', subproject=self.subproject))
+        default_library = self.coredata.optstore.get_value_for(OptionKey('default_library', subproject=self.subproject), str)
         if default_library == 'shared':
             return self.build_target(node, args, kwargs, SharedLibrary)
         elif default_library == 'static':

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -381,7 +381,7 @@ class Backend:
         if isinstance(target, build.RunTarget):
             # this produces no output, only a dummy top-level name
             dirname = ''
-        elif self.environment.coredata.optstore.get_value_for(OptionKey('layout')) == 'mirror':
+        elif self.environment.coredata.optstore.get_value_for_untyped(OptionKey('layout')) == 'mirror':
             dirname = target.get_builddir()
         else:
             dirname = 'meson-out'
@@ -1302,7 +1302,7 @@ class Backend:
     def generate_depmf_install(self, d: InstallData) -> None:
         depmf_path = self.build.dep_manifest_name
         if depmf_path is None:
-            option_dir = self.environment.coredata.optstore.get_value_for(OptionKey('licensedir'))
+            option_dir = self.environment.coredata.optstore.get_value_for_untyped(OptionKey('licensedir'))
             assert isinstance(option_dir, str), 'for mypy'
             if option_dir:
                 depmf_path = os.path.join(option_dir, 'depmf.json')
@@ -1661,7 +1661,7 @@ class Backend:
                 # TODO go through all candidates, like others
                 strip_bin = [detect.defaults['strip'][0]]
 
-        umask = self.environment.coredata.optstore.get_value_for(OptionKey('install_umask'))
+        umask = self.environment.coredata.optstore.get_value_for_untyped(OptionKey('install_umask'))
         assert isinstance(umask, (str, int)), 'for mypy'
 
         d = InstallData(self.environment.get_source_dir(),
@@ -1694,7 +1694,7 @@ class Backend:
         bindir = Path(prefix, self.environment.get_bindir())
         libdir = Path(prefix, self.environment.get_libdir())
         incdir = Path(prefix, self.environment.get_includedir())
-        _ldir = self.environment.coredata.optstore.get_value_for(OptionKey('localedir'))
+        _ldir = self.environment.coredata.optstore.get_value_for_untyped(OptionKey('localedir'))
         assert isinstance(_ldir, str), 'for mypy'
         localedir = Path(prefix, _ldir)
         dest_path = Path(prefix, outdir, Path(fname).name) if outdir else Path(prefix, fname)
@@ -2120,4 +2120,4 @@ class Backend:
             key = name
         else:
             raise MesonBugException('Internal error: invalid option type.')
-        return self.environment.coredata.optstore.get_option_for_target(target, key)
+        return self.environment.coredata.optstore.get_option_for_target_untyped(target, key)

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -973,7 +973,7 @@ class Backend:
         # Compile args added from the env: CFLAGS/CXXFLAGS, etc, or the cross
         # file. We want these to override all the defaults, but not the
         # per-target compile args.
-        commands += self.environment.coredata.get_external_args(target.for_machine, compiler.get_language())
+        commands += self.environment.coredata.optstore.get_external_args(target.for_machine, compiler.get_language())
         # Using both /Z7 or /ZI and /Zi at the same times produces a compiler warning.
         # We do not add /Z7 or /ZI by default. If it is being used it is because the user has explicitly enabled it.
         # /Zi needs to be removed in that case to avoid cl's warning to that effect (D9025 : overriding '/Zi' with '/ZI')

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -2120,4 +2120,4 @@ class Backend:
             key = name
         else:
             raise MesonBugException('Internal error: invalid option type.')
-        return self.environment.coredata.get_option_for_target(target, key)
+        return self.environment.coredata.optstore.get_option_for_target(target, key)

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -2111,6 +2111,7 @@ class Backend:
             return target.subproject != ''
         raise MesonException(f'Internal error: invalid option type for "unity": {val}')
 
+    # TODO: get rid of this
     def get_target_option(self, target: build.BuildTarget, name: T.Union[str, OptionKey]) -> ElementaryOptionValues:
         if isinstance(name, str):
             key = OptionKey(name, subproject=target.subproject)

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -954,8 +954,8 @@ class Backend:
             commands += compiler.get_werror_args()
         # Add compile args for c_* or cpp_* build options set on the
         # command-line or default_options inside project().
-        commands += compiler.get_option_compile_args(target, target.subproject)
-        commands += compiler.get_option_std_args(target, target.subproject)
+        commands += compiler.get_option_compile_args(target)
+        commands += compiler.get_option_std_args(target)
 
         optimization = self.get_target_option(target, 'optimization')
         assert isinstance(optimization, str), 'for mypy'

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -381,7 +381,7 @@ class Backend:
         if isinstance(target, build.RunTarget):
             # this produces no output, only a dummy top-level name
             dirname = ''
-        elif self.environment.coredata.optstore.get_value_for_untyped(OptionKey('layout')) == 'mirror':
+        elif self.environment.coredata.optstore.get_value_for(OptionKey('layout'), str) == 'mirror':
             dirname = target.get_builddir()
         else:
             dirname = 'meson-out'
@@ -1302,8 +1302,7 @@ class Backend:
     def generate_depmf_install(self, d: InstallData) -> None:
         depmf_path = self.build.dep_manifest_name
         if depmf_path is None:
-            option_dir = self.environment.coredata.optstore.get_value_for_untyped(OptionKey('licensedir'))
-            assert isinstance(option_dir, str), 'for mypy'
+            option_dir = self.environment.coredata.optstore.get_value_for(OptionKey('licensedir'), str)
             if option_dir:
                 depmf_path = os.path.join(option_dir, 'depmf.json')
             else:
@@ -1694,8 +1693,7 @@ class Backend:
         bindir = Path(prefix, self.environment.get_bindir())
         libdir = Path(prefix, self.environment.get_libdir())
         incdir = Path(prefix, self.environment.get_includedir())
-        _ldir = self.environment.coredata.optstore.get_value_for_untyped(OptionKey('localedir'))
-        assert isinstance(_ldir, str), 'for mypy'
+        _ldir = self.environment.coredata.optstore.get_value_for(OptionKey('localedir'), str)
         localedir = Path(prefix, _ldir)
         dest_path = Path(prefix, outdir, Path(fname).name) if outdir else Path(prefix, fname)
         if bindir in dest_path.parents or sbindir in dest_path.parents:

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -26,7 +26,7 @@ from .. import mlog
 from .. import compilers
 from ..compilers import detect, lang_suffixes
 from ..mesonlib import (
-    File, MachineChoice, MesonException, MesonBugException, OrderedSet,
+    File, MachineChoice, MesonException, OrderedSet,
     ExecutableSerialisation, EnvironmentException, FileMode,
     classify_unity_sources, get_compiler_for_source,
     get_rsp_threshold, unique_list
@@ -42,7 +42,6 @@ if T.TYPE_CHECKING:
     from ..environment import Environment
     from ..interpreter import Test
     from ..linkers import StaticLinker
-    from ..options import ElementaryOptionValues
 
     from typing_extensions import Literal, TypedDict, NotRequired, TypeAlias
 
@@ -443,8 +442,7 @@ class Backend:
         abs_files: T.List[str] = []
         result: T.List[mesonlib.File] = []
         compsrcs = classify_unity_sources(target.compilers.values(), unity_src)
-        unity_size = self.get_target_option(target, 'unity_size')
-        assert isinstance(unity_size, int), 'for mypy'
+        unity_size = self.environment.coredata.optstore.get_option_for_target(target, OptionKey('unity_size'), int)
 
         def init_language_file(suffix: str, unity_file_number: int) -> T.TextIO:
             unity_src = self.get_unity_source_file(target, suffix, unity_file_number)
@@ -807,7 +805,7 @@ class Backend:
         object_suffix = machine.get_object_suffix()
         # For the TASKING compiler, in case of LTO or prelinking the object suffix has to be .mil
         if compiler.get_id() == 'tasking':
-            use_lto = self.get_target_option(target, 'b_lto')
+            use_lto = self.environment.coredata.optstore.get_option_for_target(target, OptionKey('b_lto'), bool)
             if use_lto or (isinstance(target, build.StaticLibrary) and target.prelink):
                 if not source.rsplit('.', 1)[1] in lang_suffixes['c']:
                     if isinstance(target, build.StaticLibrary) and not target.prelink:
@@ -859,8 +857,8 @@ class Backend:
         if self.is_unity(extobj.target):
             compsrcs = classify_unity_sources(extobj.target.compilers.values(), sources)
             sources = []
-            unity_size = self.get_target_option(extobj.target, 'unity_size')
-            assert isinstance(unity_size, int), 'for mypy'
+            unity_size = self.environment.coredata.optstore.get_option_for_target(
+                extobj.target, OptionKey('unity_size'), int)
 
             for comp, srcs in compsrcs.items():
                 if comp.language in LANGS_CANT_UNITY:
@@ -911,10 +909,8 @@ class Backend:
         return pch_rel_to_build
 
     def target_uses_pch(self, target: build.BuildTarget) -> bool:
-        try:
-            return T.cast('bool', self.get_target_option(target, 'b_pch'))
-        except (KeyError, AttributeError):
-            return False
+        return self.environment.coredata.optstore.get_option_for_target(
+            target, OptionKey('b_pch'), bool, default=False)
 
     @staticmethod
     def escape_extra_args(args: T.List[str]) -> T.List[str]:
@@ -945,24 +941,25 @@ class Backend:
         # Add things like /NOLOGO or -pipe; usually can't be overridden
         commands += compiler.get_always_args()
         # warning_level is a string, but mypy can't determine that
-        commands += compiler.get_warn_args(T.cast('str', self.get_target_option(target, 'warning_level')))
+        commands += compiler.get_warn_args(self.environment.coredata.optstore.get_option_for_target(
+            target, OptionKey('warning_level'), str))
         # Add -Werror if werror=true is set in the build options set on the
         # command-line or default_options inside project(). This only sets the
         # action to be done for warnings if/when they are emitted, so it's ok
         # to set it after or get_warn_args().
-        if self.get_target_option(target, 'werror'):
+        if self.environment.coredata.optstore.get_option_for_target(target, OptionKey('werror'), bool):
             commands += compiler.get_werror_args()
         # Add compile args for c_* or cpp_* build options set on the
         # command-line or default_options inside project().
         commands += compiler.get_option_compile_args(target)
         commands += compiler.get_option_std_args(target)
 
-        optimization = self.get_target_option(target, 'optimization')
-        assert isinstance(optimization, str), 'for mypy'
+        optimization = self.environment.coredata.optstore.get_option_for_target(
+            target, OptionKey('optimization'), str)
         commands += compiler.get_optimization_args(optimization)
 
-        debug = self.get_target_option(target, 'debug')
-        assert isinstance(debug, bool), 'for mypy'
+        debug = self.environment.coredata.optstore.get_option_for_target(
+            target, OptionKey('debug'), bool)
         commands += compiler.get_debug_args(debug)
 
         # Add compile args added using add_project_arguments()
@@ -1751,8 +1748,8 @@ class Backend:
                 # TODO: Create GNUStrip/AppleStrip/etc. hierarchy for more
                 #       fine-grained stripping of static archives.
                 can_strip = not isinstance(t, build.StaticLibrary)
-                should_strip = can_strip and self.get_target_option(t, 'strip')
-                assert isinstance(should_strip, bool), 'for mypy'
+                should_strip = can_strip and self.environment.coredata.optstore.get_option_for_target(
+                    t, OptionKey('strip'), bool)
                 # Install primary build output (library/executable/jar, etc)
                 # Done separately because of strip/aliases/rpath
                 if first_outdir is not False:
@@ -2102,7 +2099,7 @@ class Backend:
     def is_unity(self, target: build.BuildTarget) -> bool:
         if isinstance(target, build.CompileTarget):
             return False
-        val = self.get_target_option(target, 'unity')
+        val = self.environment.coredata.optstore.get_option_for_target(target, OptionKey('unity'), str)
         if val == 'on':
             return True
         if val == 'off':
@@ -2110,13 +2107,3 @@ class Backend:
         if val == 'subprojects':
             return target.subproject != ''
         raise MesonException(f'Internal error: invalid option type for "unity": {val}')
-
-    # TODO: get rid of this
-    def get_target_option(self, target: build.BuildTarget, name: T.Union[str, OptionKey]) -> ElementaryOptionValues:
-        if isinstance(name, str):
-            key = OptionKey(name, subproject=target.subproject)
-        elif isinstance(name, OptionKey):
-            key = name
-        else:
-            raise MesonBugException('Internal error: invalid option type.')
-        return self.environment.coredata.optstore.get_option_for_target_untyped(target, key)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3413,12 +3413,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
     def target_uses_import_std(self, target: build.BuildTarget) -> bool:
         if 'cpp' not in target.compilers:
             return False
-        try:
-            if self.environment.coredata.optstore.get_option_for_target_untyped(target, 'cpp_importstd') == 'true':
-                return True
-        except KeyError:
-            pass
-        return False
+        return self.environment.coredata.optstore.get_option_for_target(
+            target, OptionKey('cpp_importstd'), str, default='false') == 'true'
 
     def handle_cpp_import_std(self, target: build.BuildTarget, compiler: Compiler) -> T.Tuple[T.List[str], T.List[File]]:
         istd_args: T.List[str] = []

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3419,7 +3419,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         if 'cpp' not in target.compilers:
             return False
         try:
-            if self.environment.coredata.get_option_for_target(target, 'cpp_importstd') == 'true':
+            if self.environment.coredata.optstore.get_option_for_target(target, 'cpp_importstd') == 'true':
                 return True
         except KeyError:
             pass

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -693,7 +693,7 @@ class NinjaBackend(backends.Backend):
                     self.allow_thin_archives[for_machine] = False
 
         ninja = tooldetect.detect_ninja_command_and_version(log=True)
-        if self.environment.coredata.optstore.get_value_for_untyped(OptionKey('vsenv')):
+        if self.environment.coredata.optstore.get_value_for(OptionKey('vsenv'), bool):
             builddir = Path(self.environment.get_build_dir())
             try:
                 # For prettier printing, reduce to a relative path. If
@@ -718,8 +718,7 @@ class NinjaBackend(backends.Backend):
             outfile.write('# Do not edit by hand.\n\n')
             outfile.write('ninja_required_version = 1.8.2\n\n')
 
-            num_pools = self.environment.coredata.optstore.get_value_for_untyped('backend_max_links')
-            assert isinstance(num_pools, int)
+            num_pools = self.environment.coredata.optstore.get_value_for(OptionKey('backend_max_links'), int)
             if num_pools > 0:
                 outfile.write(f'''pool link_pool
   depth = {num_pools}
@@ -748,9 +747,7 @@ class NinjaBackend(backends.Backend):
             mlog.log_timestamp("Install generated")
             self.generate_dist()
             mlog.log_timestamp("Dist generated")
-            key = OptionKey('b_coverage')
-            if key in self.environment.coredata.optstore and\
-                    self.environment.coredata.optstore.get_value_for_untyped('b_coverage'):
+            if self.environment.coredata.optstore.get_value_for(OptionKey('b_coverage'), bool, default=False):
                 gcovr_exe, gcovr_version, lcov_exe, lcov_version, genhtml_exe, llvm_cov_exe = tooldetect.find_coverage_tools(self.environment.coredata)
                 mlog.debug(f'Using {gcovr_exe} ({gcovr_version}), {lcov_exe} and {llvm_cov_exe} for code coverage')
                 if gcovr_exe or (lcov_exe and genhtml_exe):
@@ -1446,9 +1443,9 @@ class NinjaBackend(backends.Backend):
     def generate_tests(self) -> None:
         self.serialize_tests()
         cmd = self.environment.get_build_command(True) + ['test', '--no-rebuild']
-        if not self.environment.coredata.optstore.get_value_for_untyped(OptionKey('stdsplit')):
+        if not self.environment.coredata.optstore.get_value_for(OptionKey('stdsplit'), bool):
             cmd += ['--no-stdsplit']
-        if self.environment.coredata.optstore.get_value_for_untyped(OptionKey('errorlogs')):
+        if self.environment.coredata.optstore.get_value_for(OptionKey('errorlogs'), bool):
             cmd += ['--print-errorlogs']
         elem = self.create_phony_target('test', 'CUSTOM_COMMAND', ['all', 'meson-test-prereq', 'PHONY'])
         elem.add_item('COMMAND', cmd)
@@ -2503,8 +2500,7 @@ class NinjaBackend(backends.Backend):
         return options
 
     def generate_static_link_rules(self) -> None:
-        num_pools = self.environment.coredata.optstore.get_value_for_untyped('backend_max_links')
-        assert isinstance(num_pools, int)
+        num_pools = self.environment.coredata.optstore.get_value_for(OptionKey('backend_max_links'), int)
         if 'java' in self.environment.coredata.compilers.host:
             self.generate_java_link()
         for for_machine in MachineChoice:
@@ -2552,8 +2548,7 @@ class NinjaBackend(backends.Backend):
             self.add_rule(NinjaRule(rule, cmdlist, args, description, **options, extra=pool))
 
     def generate_dynamic_link_rules(self) -> None:
-        num_pools = self.environment.coredata.optstore.get_value_for_untyped('backend_max_links')
-        assert isinstance(num_pools, int)
+        num_pools = self.environment.coredata.optstore.get_value_for(OptionKey('backend_max_links'), int)
         for for_machine in MachineChoice:
             complist = self.environment.coredata.compilers[for_machine]
             for langname, compiler in complist.items():
@@ -4136,9 +4131,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         if extra_arg:
             target_name += f'-{extra_arg}'
             extra_args.append(f'--{extra_arg}')
-        colorout = self.environment.coredata.optstore.get_value_for_untyped('b_colorout') \
-            if OptionKey('b_colorout') in self.environment.coredata.optstore else 'always'
-        assert isinstance(colorout, str), 'for mypy'
+        colorout = self.environment.coredata.optstore.get_value_for(OptionKey('b_colorout'), str, default='always')
         extra_args.extend(['--color', colorout])
         if not os.path.exists(os.path.join(self.environment.source_dir, '.clang-' + name)) and \
                 not os.path.exists(os.path.join(self.environment.source_dir, '_clang-' + name)):
@@ -4246,8 +4239,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         if ctlist:
             elem.add_dep(self.generate_custom_target_clean(ctlist))
 
-        if OptionKey('b_coverage') in self.environment.coredata.optstore and \
-           self.environment.coredata.optstore.get_value_for_untyped('b_coverage'):
+        if self.environment.coredata.optstore.get_value_for(OptionKey('b_coverage'), bool, default=False):
             self.generate_gcov_clean()
             elem.add_dep('clean-gcda')
             elem.add_dep('clean-gcno')

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1886,13 +1886,13 @@ class NinjaBackend(backends.Backend):
         args: T.List[str] = []
         args += cython.get_always_args()
         debug = self.get_target_option(target, 'debug')
-        assert isinstance(debug, bool)
+        assert isinstance(debug, bool), 'for mypy'
         args += cython.get_debug_args(debug)
-        optimization = self.get_target_option(target, 'optimization')
-        assert isinstance(optimization, str)
-        args += cython.get_optimization_args(optimization)
-        args += cython.get_option_compile_args(target, target.subproject)
-        args += cython.get_option_std_args(target, target.subproject)
+        opt = self.get_target_option(target, 'optimization')
+        assert isinstance(opt, str), 'for mypy'
+        args += cython.get_optimization_args(opt)
+        args += cython.get_option_compile_args(target)
+        args += cython.get_option_std_args(target)
         args += self.build.get_global_args(cython, target.for_machine)
         args += self.build.get_project_args(cython, target)
         args += target.get_extra_args('cython')
@@ -3430,8 +3430,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 mod_file = 'gcm.cache/std.gcm'
                 mod_obj_file = 'std.o'
                 elem = NinjaBuildElement(self.all_outputs, [mod_file, mod_obj_file], 'CUSTOM_COMMAND', [])
-                compile_args = compiler.get_option_compile_args(target, target.subproject)
-                compile_args += compiler.get_option_std_args(target, target.subproject)
+                compile_args = compiler.get_option_compile_args(target)
+                compile_args += compiler.get_option_std_args(target)
                 compile_args += ['-c', '-fmodules', '-fsearch-include-path', 'bits/std.cc']
                 elem.add_item('COMMAND', compiler.exelist + compile_args)
                 self.add_build(elem)
@@ -3448,8 +3448,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                     raise SystemExit('VS std import header could not be located.')
                 in_file_str = str(in_file)
                 elem = NinjaBuildElement(self.all_outputs, [mod_file, mod_obj_file], 'CUSTOM_COMMAND', [in_file_str])
-                compile_args = compiler.get_option_compile_args(target, target.subproject)
-                compile_args += compiler.get_option_std_args(target, target.subproject)
+                compile_args = compiler.get_option_compile_args(target)
+                compile_args += compiler.get_option_std_args(target)
                 compile_args += ['/nologo', '/c', '/O2', in_file_str]
                 elem.add_item('COMMAND', compiler.exelist + compile_args)
                 self.add_build(elem)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -693,7 +693,7 @@ class NinjaBackend(backends.Backend):
                     self.allow_thin_archives[for_machine] = False
 
         ninja = tooldetect.detect_ninja_command_and_version(log=True)
-        if self.environment.coredata.optstore.get_value_for(OptionKey('vsenv')):
+        if self.environment.coredata.optstore.get_value_for_untyped(OptionKey('vsenv')):
             builddir = Path(self.environment.get_build_dir())
             try:
                 # For prettier printing, reduce to a relative path. If
@@ -718,7 +718,7 @@ class NinjaBackend(backends.Backend):
             outfile.write('# Do not edit by hand.\n\n')
             outfile.write('ninja_required_version = 1.8.2\n\n')
 
-            num_pools = self.environment.coredata.optstore.get_value_for('backend_max_links')
+            num_pools = self.environment.coredata.optstore.get_value_for_untyped('backend_max_links')
             assert isinstance(num_pools, int)
             if num_pools > 0:
                 outfile.write(f'''pool link_pool
@@ -750,7 +750,7 @@ class NinjaBackend(backends.Backend):
             mlog.log_timestamp("Dist generated")
             key = OptionKey('b_coverage')
             if key in self.environment.coredata.optstore and\
-                    self.environment.coredata.optstore.get_value_for('b_coverage'):
+                    self.environment.coredata.optstore.get_value_for_untyped('b_coverage'):
                 gcovr_exe, gcovr_version, lcov_exe, lcov_version, genhtml_exe, llvm_cov_exe = tooldetect.find_coverage_tools(self.environment.coredata)
                 mlog.debug(f'Using {gcovr_exe} ({gcovr_version}), {lcov_exe} and {llvm_cov_exe} for code coverage')
                 if gcovr_exe or (lcov_exe and genhtml_exe):
@@ -1446,9 +1446,9 @@ class NinjaBackend(backends.Backend):
     def generate_tests(self) -> None:
         self.serialize_tests()
         cmd = self.environment.get_build_command(True) + ['test', '--no-rebuild']
-        if not self.environment.coredata.optstore.get_value_for(OptionKey('stdsplit')):
+        if not self.environment.coredata.optstore.get_value_for_untyped(OptionKey('stdsplit')):
             cmd += ['--no-stdsplit']
-        if self.environment.coredata.optstore.get_value_for(OptionKey('errorlogs')):
+        if self.environment.coredata.optstore.get_value_for_untyped(OptionKey('errorlogs')):
             cmd += ['--print-errorlogs']
         elem = self.create_phony_target('test', 'CUSTOM_COMMAND', ['all', 'meson-test-prereq', 'PHONY'])
         elem.add_item('COMMAND', cmd)
@@ -2503,7 +2503,7 @@ class NinjaBackend(backends.Backend):
         return options
 
     def generate_static_link_rules(self) -> None:
-        num_pools = self.environment.coredata.optstore.get_value_for('backend_max_links')
+        num_pools = self.environment.coredata.optstore.get_value_for_untyped('backend_max_links')
         assert isinstance(num_pools, int)
         if 'java' in self.environment.coredata.compilers.host:
             self.generate_java_link()
@@ -2552,7 +2552,7 @@ class NinjaBackend(backends.Backend):
             self.add_rule(NinjaRule(rule, cmdlist, args, description, **options, extra=pool))
 
     def generate_dynamic_link_rules(self) -> None:
-        num_pools = self.environment.coredata.optstore.get_value_for('backend_max_links')
+        num_pools = self.environment.coredata.optstore.get_value_for_untyped('backend_max_links')
         assert isinstance(num_pools, int)
         for for_machine in MachineChoice:
             complist = self.environment.coredata.compilers[for_machine]
@@ -3419,7 +3419,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         if 'cpp' not in target.compilers:
             return False
         try:
-            if self.environment.coredata.optstore.get_option_for_target(target, 'cpp_importstd') == 'true':
+            if self.environment.coredata.optstore.get_option_for_target_untyped(target, 'cpp_importstd') == 'true':
                 return True
         except KeyError:
             pass
@@ -4136,7 +4136,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         if extra_arg:
             target_name += f'-{extra_arg}'
             extra_args.append(f'--{extra_arg}')
-        colorout = self.environment.coredata.optstore.get_value_for('b_colorout') \
+        colorout = self.environment.coredata.optstore.get_value_for_untyped('b_colorout') \
             if OptionKey('b_colorout') in self.environment.coredata.optstore else 'always'
         assert isinstance(colorout, str), 'for mypy'
         extra_args.extend(['--color', colorout])
@@ -4247,7 +4247,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             elem.add_dep(self.generate_custom_target_clean(ctlist))
 
         if OptionKey('b_coverage') in self.environment.coredata.optstore and \
-           self.environment.coredata.optstore.get_value_for('b_coverage'):
+           self.environment.coredata.optstore.get_value_for_untyped('b_coverage'):
             self.generate_gcov_clean()
             elem.add_dep('clean-gcda')
             elem.add_dep('clean-gcno')

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1217,9 +1217,8 @@ class NinjaBackend(backends.Backend):
         cpp = target.compilers['cpp']
         if cpp.get_id() != 'msvc':
             return False
-        cppversion = self.get_target_option(target, OptionKey('cpp_std',
-                                                              machine=target.for_machine,
-                                                              subproject=target.subproject))
+        cppversion = self.environment.coredata.optstore.get_option_for_target(
+            target, OptionKey('cpp_std', machine=target.for_machine, subproject=target.subproject), str)
         if cppversion not in ('latest', 'c++latest', 'vc++latest'):
             return False
         if not mesonlib.current_vs_supports_modules():
@@ -1805,9 +1804,9 @@ class NinjaBackend(backends.Backend):
             valac_outputs.append(vala_c_file)
 
         args = self.generate_basic_compiler_args(target, valac)
-        b_colorout = self.get_target_option(target, 'b_colorout')
-        assert isinstance(b_colorout, str)
-        args += valac.get_colorout_args(b_colorout)
+        args += valac.get_colorout_args(
+            self.environment.coredata.optstore.get_option_for_target(
+                target, OptionKey('b_colorout'), str))
         # Tell Valac to output everything in our private directory. Sadly this
         # means it will also preserve the directory components of Vala sources
         # found inside the build tree (generated sources).
@@ -1885,19 +1884,18 @@ class NinjaBackend(backends.Backend):
 
         args: T.List[str] = []
         args += cython.get_always_args()
-        debug = self.get_target_option(target, 'debug')
-        assert isinstance(debug, bool), 'for mypy'
-        args += cython.get_debug_args(debug)
-        opt = self.get_target_option(target, 'optimization')
-        assert isinstance(opt, str), 'for mypy'
-        args += cython.get_optimization_args(opt)
+        args += cython.get_debug_args(self.environment.coredata.optstore.get_option_for_target(
+            target, OptionKey('debug'), bool))
+        args += cython.get_optimization_args(self.environment.coredata.optstore.get_option_for_target(
+            target, OptionKey('optimization'), str))
         args += cython.get_option_compile_args(target)
         args += cython.get_option_std_args(target)
         args += self.build.get_global_args(cython, target.for_machine)
         args += self.build.get_project_args(cython, target)
         args += target.get_extra_args('cython')
 
-        ext = self.get_target_option(target, OptionKey('cython_language', machine=target.for_machine))
+        ext = self.environment.coredata.optstore.get_option_for_target(
+            target, OptionKey('cython_language', machine=target.for_machine), str)
 
         pyx_sources = []  # Keep track of sources we're adding to build
         pyx_count = 0
@@ -2257,7 +2255,7 @@ class NinjaBackend(backends.Backend):
             # against are dynamic or this is a dynamic library itself,
             # otherwise we'll end up with multiple implementations of libstd.
             has_rust_shared_deps = True
-        elif self.get_target_option(target, 'rust_dynamic_std'):
+        elif self.environment.coredata.optstore.get_option_for_target(target, OptionKey('rust_dynamic_std'), bool):
             if target.rust_crate_type == 'staticlib':
                 # staticlib crates always include a copy of the Rust libstd,
                 # therefore it is not possible to also link it dynamically.
@@ -3309,7 +3307,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         # then compilation rule name is a special one to output MIL files
         # instead of object files for .c files
         if compiler.get_id() == 'tasking':
-            target_lto = self.get_target_option(target, OptionKey('b_lto', machine=target.for_machine, subproject=target.subproject))
+            target_lto = self.environment.coredata.optstore.get_option_for_target(target, OptionKey('b_lto', target.subproject, target.for_machine), bool)
             if ((isinstance(target, build.StaticLibrary) and target.prelink) or target_lto) and src.rsplit('.', 1)[1] in compilers.lang_suffixes['c']:
                 compiler_name = self.get_compiler_rule_name('tasking_mil_compile', compiler.for_machine)
             else:
@@ -3862,11 +3860,10 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         # Add things like /NOLOGO; usually can't be overridden
         commands += linker.get_linker_always_args()
         # Add buildtype linker args: optimization level, etc.
-        optimization = self.get_target_option(target, 'optimization')
-        assert isinstance(optimization, str)
-        commands += linker.get_optimization_link_args(optimization)
+        commands += linker.get_optimization_link_args(
+            self.environment.coredata.optstore.get_option_for_target(target, OptionKey('optimization'), str))
         # Add /DEBUG and the pdb filename when using MSVC
-        if self.get_target_option(target, 'debug'):
+        if self.environment.coredata.optstore.get_option_for_target(target, OptionKey('debug'), bool):
             commands += self.get_link_debugfile_args(linker, target)
             debugfile = self.get_link_debugfile_name(linker, target)
             if debugfile is not None:
@@ -3958,7 +3955,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         all_deps = [*dep_targets, *extra_objs, *custom_target_libraries]
         elem.add_dep(all_deps)
         if linker.get_id() == 'tasking':
-            if any(x.endswith('.ma') for x in all_deps) and not self.get_target_option(target, OptionKey('b_lto', target.subproject, target.for_machine)):
+            if (any(x.endswith('.ma') for x in all_deps) and not
+                    self.environment.coredata.optstore.get_option_for_target(target, OptionKey('b_lto', target.subproject, target.for_machine), bool)):
                 raise MesonException(f'Tried to link the target named \'{target.name}\' with a MIL archive without LTO enabled! This causes the compiler to ignore the archive.')
 
         # Compiler args must be included in TI C28x linker commands.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -642,7 +642,7 @@ class NinjaBackend(backends.Backend):
         # cpp_args in a native file) so that cl.exe can locate system headers
         # even when the INCLUDE environment variable is not set — for example,
         # when using a bundled MSVC toolchain outside a VS Developer Shell.
-        extra_args = self.environment.coredata.get_external_args(
+        extra_args = self.environment.coredata.optstore.get_external_args(
             MachineChoice.HOST, compiler.language)
         pc = subprocess.Popen(compiler.get_exelist() +
                               ['/showIncludes', '/c', filebase] + extra_args,

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1422,7 +1422,7 @@ class Vs2010Backend(backends.Backend):
         # Exception handling has to be set in the xml in addition to the "AdditionalOptions" because otherwise
         # cl will give warning D9025: overriding '/Ehs' with cpp_eh value
         if 'cpp' in target.compilers:
-            eh = self.environment.coredata.get_option_for_target(target, OptionKey('cpp_eh', machine=target.for_machine))
+            eh = self.environment.coredata.optstore.get_option_for_target(target, OptionKey('cpp_eh', machine=target.for_machine))
             if eh == 'a':
                 ET.SubElement(clconf, 'ExceptionHandling').text = 'Async'
             elif eh == 's':

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1059,9 +1059,8 @@ class Vs2010Backend(backends.Backend):
         # Compile args added from the env or cross file: CFLAGS/CXXFLAGS, etc. We want these
         # to override all the defaults, but not the per-target compile args.
         for lang in file_args.keys():
-            l_args = self.get_target_option(target, OptionKey(f'{lang}_args', machine=target.for_machine))
-            assert isinstance(l_args, list), 'for mypy'
-            file_args[lang] += l_args
+            file_args[lang] += self.environment.coredata.optstore.get_option_for_target(
+                target, OptionKey(f'{lang}_args', target.subproject, target.for_machine), list)
         for args in file_args.values():
             # This is where Visual Studio will insert target_args, target_defines,
             # etc, which are added later from external deps (see below).
@@ -1249,13 +1248,8 @@ class Vs2010Backend(backends.Backend):
         return (nmake_base_meson_command, exe_search_paths)
 
     def get_target_whole_program_opt(self, target: build.BuildTarget) -> str:
-        lto = False
-        pgo = 'off'
-        try:
-            lto = self.get_target_option(target, 'b_lto')
-            pgo = self.get_target_option(target, 'b_pgo')
-        except KeyError:
-            pass
+        lto = self.environment.coredata.optstore.get_option_for_target(target, OptionKey('b_lto'), bool, default=False)
+        pgo = self.environment.coredata.optstore.get_option_for_target(target, OptionKey('b_pgo'), str, default='off')
 
         if pgo == 'off':
             return 'true' if lto else 'false'
@@ -1367,8 +1361,8 @@ class Vs2010Backend(backends.Backend):
         if True in ((dep.name == 'openmp') for dep in target.get_external_deps()):
             ET.SubElement(clconf, 'OpenMPSupport').text = 'true'
         # CRT type; debug or release
-        vscrt_type = self.get_target_option(target, 'b_vscrt')
-        assert isinstance(vscrt_type, str), 'for mypy'
+        vscrt_type = self.environment.coredata.optstore.get_option_for_target(
+            target, OptionKey('b_vscrt'), str)
         vscrt_val = compiler.get_crt_val(vscrt_type)
         if vscrt_val == 'mdd':
             ET.SubElement(type_config, 'UseDebugLibraries').text = 'true'
@@ -1424,10 +1418,11 @@ class Vs2010Backend(backends.Backend):
         ET.SubElement(clconf, 'PreprocessorDefinitions').text = ';'.join(target_defines)
         ET.SubElement(clconf, 'FunctionLevelLinking').text = 'true'
         # Warning level
-        warning_level = T.cast('str', self.get_target_option(target, 'warning_level'))
+        warning_level = self.environment.coredata.optstore.get_option_for_target(
+            target, OptionKey('warning_level'), str)
         warning_level = 'EnableAllWarnings' if warning_level == 'everything' else 'Level' + str(1 + int(warning_level))
         ET.SubElement(clconf, 'WarningLevel').text = warning_level
-        if self.get_target_option(target, 'werror'):
+        if self.environment.coredata.optstore.get_option_for_target(target, OptionKey('werror'), bool):
             ET.SubElement(clconf, 'TreatWarningAsError').text = 'true'
         # Optimization flags
         o_flags = split_o_flags_args(build_args)
@@ -1461,7 +1456,7 @@ class Vs2010Backend(backends.Backend):
         link = ET.SubElement(compiles, 'Link')
         extra_link_args = compiler.compiler_args()
         extra_link_args += compiler.get_optimization_link_args(self.optimization)
-        if self.get_target_option(target, 'werror'):
+        if self.environment.coredata.optstore.get_option_for_target(target, OptionKey('werror'), bool):
             extra_link_args += compiler.get_linker_fatal_warnings()
         # Generate Debug info
         if self.debug:
@@ -1607,8 +1602,8 @@ class Vs2010Backend(backends.Backend):
         # /nologo
         ET.SubElement(link, 'SuppressStartupBanner').text = 'true'
         # /release
-        addchecksum = self.get_target_option(target, 'buildtype') != 'debug'
-        if addchecksum:
+        buildtype = self.environment.coredata.optstore.get_option_for_target(target, OptionKey('buildtype'), str)
+        if buildtype != 'debug':
             ET.SubElement(link, 'SetChecksum').text = 'true'
 
     # Visual studio doesn't simply allow the src files of a project to be added with the 'Condition=...' attribute,

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1408,7 +1408,7 @@ class Vs2010Backend(backends.Backend):
         # Exception handling has to be set in the xml in addition to the "AdditionalOptions" because otherwise
         # cl will give warning D9025: overriding '/Ehs' with cpp_eh value
         if 'cpp' in target.compilers:
-            eh = self.environment.coredata.optstore.get_option_for_target_untyped(target, OptionKey('cpp_eh', machine=target.for_machine))
+            eh = self.environment.coredata.optstore.get_option_for_target(target, OptionKey('cpp_eh', machine=target.for_machine), str)
             if eh == 'a':
                 ET.SubElement(clconf, 'ExceptionHandling').text = 'Async'
             elif eh == 's':

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -290,20 +290,20 @@ class Vs2010Backend(backends.Backend):
         else:
             raise MesonException('Unsupported Visual Studio platform: ' + build_machine)
 
-        buildtype = self.environment.coredata.optstore.get_value_for(OptionKey('buildtype'))
+        buildtype = self.environment.coredata.optstore.get_value_for_untyped(OptionKey('buildtype'))
         assert isinstance(buildtype, str), 'for mypy'
         self.buildtype = buildtype
 
-        optimization = self.environment.coredata.optstore.get_value_for(OptionKey('optimization'))
+        optimization = self.environment.coredata.optstore.get_value_for_untyped(OptionKey('optimization'))
         assert isinstance(optimization, str), 'for mypy'
         self.optimization = optimization
 
-        debug = self.environment.coredata.optstore.get_value_for(OptionKey('debug'))
+        debug = self.environment.coredata.optstore.get_value_for_untyped(OptionKey('debug'))
         assert isinstance(debug, bool), 'for mypy'
         self.debug = debug
 
         try:
-            sanitize = self.environment.coredata.optstore.get_value_for(OptionKey('b_sanitize'))
+            sanitize = self.environment.coredata.optstore.get_value_for_untyped(OptionKey('b_sanitize'))
             assert isinstance(sanitize, list), 'for mypy'
         except KeyError:
             sanitize = []
@@ -449,7 +449,7 @@ class Vs2010Backend(backends.Backend):
             ofile.write('# Visual Studio %s\n' % self.sln_version_comment)
             prj_templ = 'Project("{%s}") = "%s", "%s", "{%s}"\n'
             for prj in projlist:
-                if self.environment.coredata.optstore.get_value_for(OptionKey('layout')) == 'mirror':
+                if self.environment.coredata.optstore.get_value_for_untyped(OptionKey('layout')) == 'mirror':
                     self.generate_solution_dirs(ofile, prj[1].parents)
                 target = self.build.targets[prj[0]]
                 lang = 'default'
@@ -561,7 +561,7 @@ class Vs2010Backend(backends.Backend):
         replace_if_different(sln_filename, sln_filename_tmp)
 
     def generate_projects(self, vslite_ctx: _VSLITE_CTX | None = None) -> T.List[Project]:
-        startup_project = self.environment.coredata.optstore.get_value_for('backend_startup_project')
+        startup_project = self.environment.coredata.optstore.get_value_for_untyped('backend_startup_project')
         projlist: T.List[Project] = []
         startup_idx = 0
         for (i, (name, target)) in enumerate(self.build.targets.items()):
@@ -1422,7 +1422,7 @@ class Vs2010Backend(backends.Backend):
         # Exception handling has to be set in the xml in addition to the "AdditionalOptions" because otherwise
         # cl will give warning D9025: overriding '/Ehs' with cpp_eh value
         if 'cpp' in target.compilers:
-            eh = self.environment.coredata.optstore.get_option_for_target(target, OptionKey('cpp_eh', machine=target.for_machine))
+            eh = self.environment.coredata.optstore.get_option_for_target_untyped(target, OptionKey('cpp_eh', machine=target.for_machine))
             if eh == 'a':
                 ET.SubElement(clconf, 'ExceptionHandling').text = 'Async'
             elif eh == 's':
@@ -1899,7 +1899,7 @@ class Vs2010Backend(backends.Backend):
             # build system as possible.
             self.add_target_deps(root, target)
         self._prettyprint_vcxproj_xml(ET.ElementTree(root), ofname)
-        if self.environment.coredata.optstore.get_value_for(OptionKey('layout')) == 'mirror':
+        if self.environment.coredata.optstore.get_value_for_untyped(OptionKey('layout')) == 'mirror':
             self.gen_vcxproj_filters(target, ofname)
         return True
 
@@ -2068,9 +2068,9 @@ class Vs2010Backend(backends.Backend):
                 meson_build_dir_for_buildtype = build_dir_tail[:-2] + buildtype # Get the buildtype suffixed 'builddir_[debug/release/etc]' from 'builddir_vs', for example.
                 proj_to_build_dir_for_buildtype = str(os.path.join(proj_to_multiconfigured_builds_parent_dir, meson_build_dir_for_buildtype))
                 test_cmd = f'{nmake_base_meson_command} test -C "{proj_to_build_dir_for_buildtype}" --no-rebuild'
-                if not self.environment.coredata.optstore.get_value_for(OptionKey('stdsplit')):
+                if not self.environment.coredata.optstore.get_value_for_untyped(OptionKey('stdsplit')):
                     test_cmd += ' --no-stdsplit'
-                if self.environment.coredata.optstore.get_value_for(OptionKey('errorlogs')):
+                if self.environment.coredata.optstore.get_value_for_untyped(OptionKey('errorlogs')):
                     test_cmd += ' --print-errorlogs'
                 condition = f'\'$(Configuration)|$(Platform)\'==\'{buildtype}|{self.platform}\''
                 prop_group = ET.SubElement(root, 'PropertyGroup', Condition=condition)
@@ -2092,9 +2092,9 @@ class Vs2010Backend(backends.Backend):
             ET.SubElement(midl, 'ProxyFileName').text = '%(Filename)_p.c'
             # FIXME: No benchmarks?
             test_command = self.environment.get_build_command() + ['test', '--no-rebuild']
-            if not self.environment.coredata.optstore.get_value_for(OptionKey('stdsplit')):
+            if not self.environment.coredata.optstore.get_value_for_untyped(OptionKey('stdsplit')):
                 test_command += ['--no-stdsplit']
-            if self.environment.coredata.optstore.get_value_for(OptionKey('errorlogs')):
+            if self.environment.coredata.optstore.get_value_for_untyped(OptionKey('errorlogs')):
                 test_command += ['--print-errorlogs']
             self.serialize_tests()
             self.add_custom_build(root, 'run_tests', '"%s"' % ('" "'.join(test_command)))

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -290,24 +290,10 @@ class Vs2010Backend(backends.Backend):
         else:
             raise MesonException('Unsupported Visual Studio platform: ' + build_machine)
 
-        buildtype = self.environment.coredata.optstore.get_value_for_untyped(OptionKey('buildtype'))
-        assert isinstance(buildtype, str), 'for mypy'
-        self.buildtype = buildtype
-
-        optimization = self.environment.coredata.optstore.get_value_for_untyped(OptionKey('optimization'))
-        assert isinstance(optimization, str), 'for mypy'
-        self.optimization = optimization
-
-        debug = self.environment.coredata.optstore.get_value_for_untyped(OptionKey('debug'))
-        assert isinstance(debug, bool), 'for mypy'
-        self.debug = debug
-
-        try:
-            sanitize = self.environment.coredata.optstore.get_value_for_untyped(OptionKey('b_sanitize'))
-            assert isinstance(sanitize, list), 'for mypy'
-        except KeyError:
-            sanitize = []
-        self.sanitize = sanitize
+        self.buildtype = self.environment.coredata.optstore.get_value_for(OptionKey('buildtype'), str)
+        self.optimization = self.environment.coredata.optstore.get_value_for(OptionKey('optimization'), str)
+        self.debug = self.environment.coredata.optstore.get_value_for(OptionKey('debug'), bool)
+        self.sanitize = self.environment.coredata.optstore.get_value_for(OptionKey('b_sanitize'), list, default=[])
 
         sln_filename = os.path.join(self.environment.get_build_dir(), self.build.project_name + '.sln')
         projlist = self.generate_projects(vslite_ctx)
@@ -449,7 +435,7 @@ class Vs2010Backend(backends.Backend):
             ofile.write('# Visual Studio %s\n' % self.sln_version_comment)
             prj_templ = 'Project("{%s}") = "%s", "%s", "{%s}"\n'
             for prj in projlist:
-                if self.environment.coredata.optstore.get_value_for_untyped(OptionKey('layout')) == 'mirror':
+                if self.environment.coredata.optstore.get_value_for(OptionKey('layout'), str) == 'mirror':
                     self.generate_solution_dirs(ofile, prj[1].parents)
                 target = self.build.targets[prj[0]]
                 lang = 'default'
@@ -561,7 +547,7 @@ class Vs2010Backend(backends.Backend):
         replace_if_different(sln_filename, sln_filename_tmp)
 
     def generate_projects(self, vslite_ctx: _VSLITE_CTX | None = None) -> T.List[Project]:
-        startup_project = self.environment.coredata.optstore.get_value_for_untyped('backend_startup_project')
+        startup_project = self.environment.coredata.optstore.get_value_for(OptionKey('backend_startup_project'), str)
         projlist: T.List[Project] = []
         startup_idx = 0
         for (i, (name, target)) in enumerate(self.build.targets.items()):
@@ -1899,7 +1885,7 @@ class Vs2010Backend(backends.Backend):
             # build system as possible.
             self.add_target_deps(root, target)
         self._prettyprint_vcxproj_xml(ET.ElementTree(root), ofname)
-        if self.environment.coredata.optstore.get_value_for_untyped(OptionKey('layout')) == 'mirror':
+        if self.environment.coredata.optstore.get_value_for(OptionKey('layout'), str) == 'mirror':
             self.gen_vcxproj_filters(target, ofname)
         return True
 
@@ -2068,9 +2054,9 @@ class Vs2010Backend(backends.Backend):
                 meson_build_dir_for_buildtype = build_dir_tail[:-2] + buildtype # Get the buildtype suffixed 'builddir_[debug/release/etc]' from 'builddir_vs', for example.
                 proj_to_build_dir_for_buildtype = str(os.path.join(proj_to_multiconfigured_builds_parent_dir, meson_build_dir_for_buildtype))
                 test_cmd = f'{nmake_base_meson_command} test -C "{proj_to_build_dir_for_buildtype}" --no-rebuild'
-                if not self.environment.coredata.optstore.get_value_for_untyped(OptionKey('stdsplit')):
+                if not self.environment.coredata.optstore.get_value_for(OptionKey('stdsplit'), bool):
                     test_cmd += ' --no-stdsplit'
-                if self.environment.coredata.optstore.get_value_for_untyped(OptionKey('errorlogs')):
+                if self.environment.coredata.optstore.get_value_for(OptionKey('errorlogs'), bool):
                     test_cmd += ' --print-errorlogs'
                 condition = f'\'$(Configuration)|$(Platform)\'==\'{buildtype}|{self.platform}\''
                 prop_group = ET.SubElement(root, 'PropertyGroup', Condition=condition)
@@ -2092,9 +2078,9 @@ class Vs2010Backend(backends.Backend):
             ET.SubElement(midl, 'ProxyFileName').text = '%(Filename)_p.c'
             # FIXME: No benchmarks?
             test_command = self.environment.get_build_command() + ['test', '--no-rebuild']
-            if not self.environment.coredata.optstore.get_value_for_untyped(OptionKey('stdsplit')):
+            if not self.environment.coredata.optstore.get_value_for(OptionKey('stdsplit'), bool):
                 test_command += ['--no-stdsplit']
-            if self.environment.coredata.optstore.get_value_for_untyped(OptionKey('errorlogs')):
+            if self.environment.coredata.optstore.get_value_for(OptionKey('errorlogs'), bool):
                 test_command += ['--print-errorlogs']
             self.serialize_tests()
             self.add_custom_build(root, 'run_tests', '"%s"' % ('" "'.join(test_command)))

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1044,10 +1044,8 @@ class Vs2010Backend(backends.Backend):
                 file_args[l] += comp.get_always_args()
                 file_args[l] += compilers.get_base_compile_args(
                     target, comp, self.environment)
-                file_args[l] += comp.get_option_compile_args(
-                    target, target.subproject)
-                file_args[l] += comp.get_option_std_args(
-                    target, target.subproject)
+                file_args[l] += comp.get_option_compile_args(target)
+                file_args[l] += comp.get_option_std_args(target)
 
         # Add compile args added using add_project_arguments()
         for l, comp in target.compilers.items():
@@ -1496,7 +1494,7 @@ class Vs2010Backend(backends.Backend):
         # to be after all internal and external libraries so that unresolved
         # symbols from those can be found here. This is needed when the
         # *_winlibs that we want to link to are static mingw64 libraries.
-        extra_link_args += compiler.get_option_link_args(target, target.subproject)
+        extra_link_args += compiler.get_option_link_args(target)
         (additional_libpaths, additional_links, extra_link_args) = self.split_link_args(extra_link_args.to_native())
 
         # Add more libraries to be linked if needed

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -263,7 +263,7 @@ class XCodeBackend(backends.Backend):
     def __init__(self, build: T.Optional[build.Build]):
         super().__init__(build)
         self.project_uid = self.environment.coredata.lang_guids['default'].replace('-', '')[:24]
-        self.buildtype = T.cast('str', self.environment.coredata.optstore.get_value_for_untyped(OptionKey('buildtype')))
+        self.buildtype = self.environment.coredata.optstore.get_value_for(OptionKey('buildtype'), str)
         self.project_conflist = self.gen_id()
         self.maingroup_id = self.gen_id()
         self.all_id = self.gen_id()
@@ -305,7 +305,7 @@ class XCodeBackend(backends.Backend):
 
     @functools.lru_cache(maxsize=None)
     def get_target_dir_cached(self, target: build.Target) -> str:
-        dirname = os.path.join(target.get_subdir(), T.cast('str', self.environment.coredata.optstore.get_value_for_untyped(OptionKey('buildtype'))))
+        dirname = os.path.join(target.get_subdir(), self.environment.coredata.optstore.get_value_for(OptionKey('buildtype'), str))
         return dirname
 
     def get_custom_target_output_dir(self, target: build.AnyTargetType) -> str:

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -1762,9 +1762,9 @@ class XCodeBackend(backends.Backend):
                 if compiler is None:
                     continue
                 # Start with warning args
-                warn_level = self.get_target_option(target, 'warning_level')
-                assert isinstance(warn_level, str), 'for mypy'
-                warn_args = compiler.get_warn_args(warn_level)
+                warn_args = compiler.get_warn_args(
+                    self.environment.coredata.optstore.get_option_for_target(
+                        target, OptionKey('warning_level'), str))
                 std_args = compiler.get_option_compile_args(target)
                 std_args += compiler.get_option_std_args(target)
                 # Add compile args added using add_project_arguments()
@@ -1815,13 +1815,11 @@ class XCodeBackend(backends.Backend):
             if target.suffix:
                 suffix = '.' + target.suffix
                 settings_dict.add_item('EXECUTABLE_SUFFIX', suffix)
-            debug = self.get_target_option(target, 'debug')
-            assert isinstance(debug, bool), 'for mypy'
-            settings_dict.add_item('GCC_GENERATE_DEBUGGING_SYMBOLS', BOOL2XCODEBOOL[debug])
+            settings_dict.add_item('GCC_GENERATE_DEBUGGING_SYMBOLS', BOOL2XCODEBOOL[
+                self.environment.coredata.optstore.get_option_for_target(target, OptionKey('debug'), bool)])
             settings_dict.add_item('GCC_INLINES_ARE_PRIVATE_EXTERN', 'NO')
-            opt = self.get_target_option(target, 'optimization')
-            assert isinstance(opt, str), 'for mypy'
-            opt_flag = OPT2XCODEOPT[opt]
+            opt_flag = OPT2XCODEOPT[
+                self.environment.coredata.optstore.get_option_for_target(target, OptionKey('optimization'), str)]
             if opt_flag is not None:
                 settings_dict.add_item('GCC_OPTIMIZATION_LEVEL', opt_flag)
             if target.has_pch:

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -1762,11 +1762,11 @@ class XCodeBackend(backends.Backend):
                 if compiler is None:
                     continue
                 # Start with warning args
-                _warn_level = self.get_target_option(target, 'warning_level')
-                assert isinstance(_warn_level, str), 'for mypy'
-                warn_args = compiler.get_warn_args(_warn_level)
-                std_args = compiler.get_option_compile_args(target, target.subproject)
-                std_args += compiler.get_option_std_args(target, target.subproject)
+                warn_level = self.get_target_option(target, 'warning_level')
+                assert isinstance(warn_level, str), 'for mypy'
+                warn_args = compiler.get_warn_args(warn_level)
+                std_args = compiler.get_option_compile_args(target)
+                std_args += compiler.get_option_std_args(target)
                 # Add compile args added using add_project_arguments()
                 pargs = self.build.get_project_args(compiler, target)
                 # Add compile args added using add_global_arguments()

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -263,7 +263,7 @@ class XCodeBackend(backends.Backend):
     def __init__(self, build: T.Optional[build.Build]):
         super().__init__(build)
         self.project_uid = self.environment.coredata.lang_guids['default'].replace('-', '')[:24]
-        self.buildtype = T.cast('str', self.environment.coredata.optstore.get_value_for(OptionKey('buildtype')))
+        self.buildtype = T.cast('str', self.environment.coredata.optstore.get_value_for_untyped(OptionKey('buildtype')))
         self.project_conflist = self.gen_id()
         self.maingroup_id = self.gen_id()
         self.all_id = self.gen_id()
@@ -305,7 +305,7 @@ class XCodeBackend(backends.Backend):
 
     @functools.lru_cache(maxsize=None)
     def get_target_dir_cached(self, target: build.Target) -> str:
-        dirname = os.path.join(target.get_subdir(), T.cast('str', self.environment.coredata.optstore.get_value_for(OptionKey('buildtype'))))
+        dirname = os.path.join(target.get_subdir(), T.cast('str', self.environment.coredata.optstore.get_value_for_untyped(OptionKey('buildtype'))))
         return dirname
 
     def get_custom_target_output_dir(self, target: build.AnyTargetType) -> str:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1820,8 +1820,7 @@ class BuildTarget(Target):
             self.vs_module_defs = File.from_built_file(path.get_builddir(), path.get_filename())
 
     def _default_library_type(self) -> _LibraryType:
-        bl_type = self.environment.coredata.optstore.get_value_for_untyped(OptionKey('default_both_libraries'))
-        assert isinstance(bl_type, str), 'for mypy'
+        bl_type = self.environment.coredata.optstore.get_value_for(OptionKey('default_both_libraries'), str)
         return T.cast('_LibraryType', bl_type)
 
     def _extract_link_with(self, kwargs: BuildTargetKeywordArguments) -> list[LinkableTargetTypes]:
@@ -1849,7 +1848,7 @@ class BuildTarget(Target):
 
     def determine_rpath_dirs(self) -> T.Tuple[str, ...]:
         result: OrderedSet[str]
-        if self.environment.coredata.optstore.get_value_for_untyped(OptionKey('layout')) == 'mirror':
+        if self.environment.coredata.optstore.get_value_for(OptionKey('layout'), str) == 'mirror':
             # Need a copy here
             result = OrderedSet(self.get_link_dep_subdirs())
         else:
@@ -2276,7 +2275,7 @@ class Executable(BuildTarget, LinkableTarget):
             machine.is_windows()
             and ('cs' in self.compilers or self.uses_rust() or self.get_using_msvc())
             # .pdb file is created only when debug symbols are enabled
-            and self.environment.coredata.optstore.get_value_for_untyped(OptionKey("debug"))
+            and self.environment.coredata.optstore.get_value_for(OptionKey("debug"), bool)
         )
         if create_debug_file:
             # If the target is has a standard exe extension (i.e. 'foo.exe'),
@@ -2412,7 +2411,7 @@ class StaticLibrary(BuildTarget, LinkableTarget):
                     suffix = 'rlib'
                 elif self.rust_crate_type == 'staticlib':
                     suffix = 'a'
-            elif self.environment.machines[self.for_machine].is_os2() and self.environment.coredata.optstore.get_value_for_untyped(OptionKey('os2_emxomf')):
+            elif self.environment.machines[self.for_machine].is_os2() and self.environment.coredata.optstore.get_value_for(OptionKey('os2_emxomf'), str):
                 suffix = 'lib'
             else:
                 suffix = 'a'
@@ -2630,8 +2629,7 @@ class SharedLibrary(BuildTarget, LinkableTarget):
                 # Import library is called foo.dll.lib
                 import_filename_tpl = '{0.prefix}{0.name}.dll.lib'
                 # .pdb file is only created when debug symbols are enabled
-                create_debug_file = self.environment.coredata.optstore.get_value_for_untyped(OptionKey("debug"))
-                assert isinstance(create_debug_file, bool), 'for mypy'
+                create_debug_file = self.environment.coredata.optstore.get_value_for(OptionKey("debug"), bool)
             elif self.get_using_msvc():
                 # Shared library is of the form foo.dll
                 prefix = prefix if prefix is not None else ''
@@ -2639,8 +2637,7 @@ class SharedLibrary(BuildTarget, LinkableTarget):
                 import_suffix = import_suffix if import_suffix is not None else 'lib'
                 import_filename_tpl = '{0.prefix}{0.name}.' + import_suffix
                 # .pdb file is only created when debug symbols are enabled
-                create_debug_file = self.environment.coredata.optstore.get_value_for_untyped(OptionKey("debug"))
-                assert isinstance(create_debug_file, bool), 'for mypy'
+                create_debug_file = self.environment.coredata.optstore.get_value_for(OptionKey("debug"), bool)
             # Assume GCC-compatible naming
             else:
                 # Shared library is of the form libfoo.dll
@@ -2687,7 +2684,7 @@ class SharedLibrary(BuildTarget, LinkableTarget):
             suffix = suffix if suffix is not None else 'dll'
             # Import library is called foo_dll.a or foo_dll.lib
             if import_suffix is None:
-                import_suffix = '_dll.lib' if self.environment.coredata.optstore.get_value_for_untyped(OptionKey('os2_emxomf')) else '_dll.a'
+                import_suffix = '_dll.lib' if self.environment.coredata.optstore.get_value_for(OptionKey('os2_emxomf'), bool) else '_dll.a'
             import_filename_tpl = '{0.prefix}{0.name}' + import_suffix
             filename_tpl = '{0.shortname}' if self.shortname else '{0.prefix}{0.name}'
             if self.soversion:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1085,7 +1085,7 @@ class BuildTarget(Target):
 
                 # In the case of cython it's possible that we have an
                 # implementation detail language
-                if self.uses_cython() and lang == self.environment.coredata.optstore.get_option_for_target_untyped(self, 'cython_language'):
+                if self.uses_cython() and lang == self.environment.coredata.optstore.get_option_for_target(self, OptionKey('cython_language'), str):
                     self.compilers[lang] = self.environment.coredata.compilers[self.for_machine][lang]
                     is_error = False
 
@@ -1223,8 +1223,7 @@ class BuildTarget(Target):
         if 'vala' in self.compilers and 'c' not in self.compilers:
             self.compilers['c'] = self.all_compilers['c']
         if 'cython' in self.compilers:
-            _value = self.environment.coredata.optstore.get_option_for_target_untyped(self, 'cython_language')
-            assert isinstance(_value, str), 'for mypy'
+            _value = self.environment.coredata.optstore.get_option_for_target(self, OptionKey('cython_language'), str)
             value = T.cast('Language', _value)
             try:
                 self.compilers[value] = self.all_compilers[value]
@@ -1418,13 +1417,8 @@ class BuildTarget(Target):
             assert isinstance(a, bool), 'for mypy'
             return a
 
-        k = OptionKey(option)
-        if k in self.environment.coredata.optstore:
-            val = self.environment.coredata.optstore.get_option_for_target_untyped(self, k)
-            assert isinstance(val, bool), 'for mypy'
-            return val
-
-        return False
+        return self.environment.coredata.optstore.get_option_for_target(
+            self, OptionKey(option), bool, default=False)
 
     def install_dir_names(self) -> T.List[T.Optional[str]]:
         install_dir_names: T.List[T.Optional[str]]
@@ -2384,8 +2378,7 @@ class StaticLibrary(BuildTarget, LinkableTarget):
         return 'static' if bl == 'auto' else bl
 
     def determine_default_prefix_and_suffix(self) -> T.Tuple[str, str]:
-        scheme = self.environment.coredata.optstore.get_option_for_target_untyped(self, 'namingscheme')
-        assert isinstance(scheme, str), 'for mypy'
+        scheme = self.environment.coredata.optstore.get_option_for_target(self, OptionKey('namingscheme'), str)
         if scheme == 'platform':
             schemename = self.get_platform_scheme_name()
             prefix, suffix = DEFAULT_STATIC_LIBRARY_NAMES[schemename]
@@ -2417,9 +2410,7 @@ class StaticLibrary(BuildTarget, LinkableTarget):
                 suffix = 'a'
                 if 'c' in self.compilers and self.compilers['c'].get_id() == 'tasking' and not self.prelink:
                     key = OptionKey('b_lto', self.subproject, self.for_machine)
-                    v = self.environment.coredata.optstore.get_option_for_target_untyped(self, key)
-                    assert isinstance(v, bool), 'for mypy'
-                    if v:
+                    if self.environment.coredata.optstore.get_option_for_target(self, key, bool):
                         suffix = 'ma'
         return (prefix, suffix)
 
@@ -2592,8 +2583,7 @@ class SharedLibrary(BuildTarget, LinkableTarget):
         return self.environment.get_shared_lib_dir(), '{libdir_shared}'
 
     def determine_naming_info(self) -> T.Tuple[str, str, str, str, bool]:
-        scheme = self.environment.coredata.optstore.get_option_for_target_untyped(self, 'namingscheme')
-        assert isinstance(scheme, str), 'for mypy'
+        scheme = self.environment.coredata.optstore.get_option_for_target(self, OptionKey('namingscheme'), str)
 
         prefix: str | None
         suffix: str | None

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1917,7 +1917,7 @@ class BuildTarget(Target):
         args: T.List[str] = []
         for lang in LANGUAGES_USING_LDFLAGS:
             try:
-                args += self.environment.coredata.get_external_link_args(self.for_machine, lang)
+                args += self.environment.coredata.optstore.get_external_link_args(self.for_machine, lang)
             except KeyError:
                 pass
         return self.get_rpath_dirs_from_link_args(args)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1085,7 +1085,7 @@ class BuildTarget(Target):
 
                 # In the case of cython it's possible that we have an
                 # implementation detail language
-                if self.uses_cython() and lang == self.environment.coredata.optstore.get_option_for_target(self, 'cython_language'):
+                if self.uses_cython() and lang == self.environment.coredata.optstore.get_option_for_target_untyped(self, 'cython_language'):
                     self.compilers[lang] = self.environment.coredata.compilers[self.for_machine][lang]
                     is_error = False
 
@@ -1223,7 +1223,7 @@ class BuildTarget(Target):
         if 'vala' in self.compilers and 'c' not in self.compilers:
             self.compilers['c'] = self.all_compilers['c']
         if 'cython' in self.compilers:
-            _value = self.environment.coredata.optstore.get_option_for_target(self, 'cython_language')
+            _value = self.environment.coredata.optstore.get_option_for_target_untyped(self, 'cython_language')
             assert isinstance(_value, str), 'for mypy'
             value = T.cast('Language', _value)
             try:
@@ -1420,7 +1420,7 @@ class BuildTarget(Target):
 
         k = OptionKey(option)
         if k in self.environment.coredata.optstore:
-            val = self.environment.coredata.optstore.get_option_for_target(self, k)
+            val = self.environment.coredata.optstore.get_option_for_target_untyped(self, k)
             assert isinstance(val, bool), 'for mypy'
             return val
 
@@ -1820,7 +1820,7 @@ class BuildTarget(Target):
             self.vs_module_defs = File.from_built_file(path.get_builddir(), path.get_filename())
 
     def _default_library_type(self) -> _LibraryType:
-        bl_type = self.environment.coredata.optstore.get_value_for(OptionKey('default_both_libraries'))
+        bl_type = self.environment.coredata.optstore.get_value_for_untyped(OptionKey('default_both_libraries'))
         assert isinstance(bl_type, str), 'for mypy'
         return T.cast('_LibraryType', bl_type)
 
@@ -1849,7 +1849,7 @@ class BuildTarget(Target):
 
     def determine_rpath_dirs(self) -> T.Tuple[str, ...]:
         result: OrderedSet[str]
-        if self.environment.coredata.optstore.get_value_for(OptionKey('layout')) == 'mirror':
+        if self.environment.coredata.optstore.get_value_for_untyped(OptionKey('layout')) == 'mirror':
             # Need a copy here
             result = OrderedSet(self.get_link_dep_subdirs())
         else:
@@ -2276,7 +2276,7 @@ class Executable(BuildTarget, LinkableTarget):
             machine.is_windows()
             and ('cs' in self.compilers or self.uses_rust() or self.get_using_msvc())
             # .pdb file is created only when debug symbols are enabled
-            and self.environment.coredata.optstore.get_value_for(OptionKey("debug"))
+            and self.environment.coredata.optstore.get_value_for_untyped(OptionKey("debug"))
         )
         if create_debug_file:
             # If the target is has a standard exe extension (i.e. 'foo.exe'),
@@ -2385,7 +2385,7 @@ class StaticLibrary(BuildTarget, LinkableTarget):
         return 'static' if bl == 'auto' else bl
 
     def determine_default_prefix_and_suffix(self) -> T.Tuple[str, str]:
-        scheme = self.environment.coredata.optstore.get_option_for_target(self, 'namingscheme')
+        scheme = self.environment.coredata.optstore.get_option_for_target_untyped(self, 'namingscheme')
         assert isinstance(scheme, str), 'for mypy'
         if scheme == 'platform':
             schemename = self.get_platform_scheme_name()
@@ -2412,13 +2412,13 @@ class StaticLibrary(BuildTarget, LinkableTarget):
                     suffix = 'rlib'
                 elif self.rust_crate_type == 'staticlib':
                     suffix = 'a'
-            elif self.environment.machines[self.for_machine].is_os2() and self.environment.coredata.optstore.get_value_for(OptionKey('os2_emxomf')):
+            elif self.environment.machines[self.for_machine].is_os2() and self.environment.coredata.optstore.get_value_for_untyped(OptionKey('os2_emxomf')):
                 suffix = 'lib'
             else:
                 suffix = 'a'
                 if 'c' in self.compilers and self.compilers['c'].get_id() == 'tasking' and not self.prelink:
                     key = OptionKey('b_lto', self.subproject, self.for_machine)
-                    v = self.environment.coredata.optstore.get_option_for_target(self, key)
+                    v = self.environment.coredata.optstore.get_option_for_target_untyped(self, key)
                     assert isinstance(v, bool), 'for mypy'
                     if v:
                         suffix = 'ma'
@@ -2593,7 +2593,7 @@ class SharedLibrary(BuildTarget, LinkableTarget):
         return self.environment.get_shared_lib_dir(), '{libdir_shared}'
 
     def determine_naming_info(self) -> T.Tuple[str, str, str, str, bool]:
-        scheme = self.environment.coredata.optstore.get_option_for_target(self, 'namingscheme')
+        scheme = self.environment.coredata.optstore.get_option_for_target_untyped(self, 'namingscheme')
         assert isinstance(scheme, str), 'for mypy'
 
         prefix: str | None
@@ -2630,7 +2630,7 @@ class SharedLibrary(BuildTarget, LinkableTarget):
                 # Import library is called foo.dll.lib
                 import_filename_tpl = '{0.prefix}{0.name}.dll.lib'
                 # .pdb file is only created when debug symbols are enabled
-                create_debug_file = self.environment.coredata.optstore.get_value_for(OptionKey("debug"))
+                create_debug_file = self.environment.coredata.optstore.get_value_for_untyped(OptionKey("debug"))
                 assert isinstance(create_debug_file, bool), 'for mypy'
             elif self.get_using_msvc():
                 # Shared library is of the form foo.dll
@@ -2639,7 +2639,7 @@ class SharedLibrary(BuildTarget, LinkableTarget):
                 import_suffix = import_suffix if import_suffix is not None else 'lib'
                 import_filename_tpl = '{0.prefix}{0.name}.' + import_suffix
                 # .pdb file is only created when debug symbols are enabled
-                create_debug_file = self.environment.coredata.optstore.get_value_for(OptionKey("debug"))
+                create_debug_file = self.environment.coredata.optstore.get_value_for_untyped(OptionKey("debug"))
                 assert isinstance(create_debug_file, bool), 'for mypy'
             # Assume GCC-compatible naming
             else:
@@ -2687,7 +2687,7 @@ class SharedLibrary(BuildTarget, LinkableTarget):
             suffix = suffix if suffix is not None else 'dll'
             # Import library is called foo_dll.a or foo_dll.lib
             if import_suffix is None:
-                import_suffix = '_dll.lib' if self.environment.coredata.optstore.get_value_for(OptionKey('os2_emxomf')) else '_dll.a'
+                import_suffix = '_dll.lib' if self.environment.coredata.optstore.get_value_for_untyped(OptionKey('os2_emxomf')) else '_dll.a'
             import_filename_tpl = '{0.prefix}{0.name}' + import_suffix
             filename_tpl = '{0.shortname}' if self.shortname else '{0.prefix}{0.name}'
             if self.soversion:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1085,7 +1085,7 @@ class BuildTarget(Target):
 
                 # In the case of cython it's possible that we have an
                 # implementation detail language
-                if self.uses_cython() and lang == self.environment.coredata.get_option_for_target(self, 'cython_language'):
+                if self.uses_cython() and lang == self.environment.coredata.optstore.get_option_for_target(self, 'cython_language'):
                     self.compilers[lang] = self.environment.coredata.compilers[self.for_machine][lang]
                     is_error = False
 
@@ -1223,7 +1223,7 @@ class BuildTarget(Target):
         if 'vala' in self.compilers and 'c' not in self.compilers:
             self.compilers['c'] = self.all_compilers['c']
         if 'cython' in self.compilers:
-            _value = self.environment.coredata.get_option_for_target(self, 'cython_language')
+            _value = self.environment.coredata.optstore.get_option_for_target(self, 'cython_language')
             assert isinstance(_value, str), 'for mypy'
             value = T.cast('Language', _value)
             try:
@@ -1420,7 +1420,7 @@ class BuildTarget(Target):
 
         k = OptionKey(option)
         if k in self.environment.coredata.optstore:
-            val = self.environment.coredata.get_option_for_target(self, k)
+            val = self.environment.coredata.optstore.get_option_for_target(self, k)
             assert isinstance(val, bool), 'for mypy'
             return val
 
@@ -2385,7 +2385,7 @@ class StaticLibrary(BuildTarget, LinkableTarget):
         return 'static' if bl == 'auto' else bl
 
     def determine_default_prefix_and_suffix(self) -> T.Tuple[str, str]:
-        scheme = self.environment.coredata.get_option_for_target(self, 'namingscheme')
+        scheme = self.environment.coredata.optstore.get_option_for_target(self, 'namingscheme')
         assert isinstance(scheme, str), 'for mypy'
         if scheme == 'platform':
             schemename = self.get_platform_scheme_name()
@@ -2418,7 +2418,7 @@ class StaticLibrary(BuildTarget, LinkableTarget):
                 suffix = 'a'
                 if 'c' in self.compilers and self.compilers['c'].get_id() == 'tasking' and not self.prelink:
                     key = OptionKey('b_lto', self.subproject, self.for_machine)
-                    v = self.environment.coredata.get_option_for_target(self, key)
+                    v = self.environment.coredata.optstore.get_option_for_target(self, key)
                     assert isinstance(v, bool), 'for mypy'
                     if v:
                         suffix = 'ma'
@@ -2593,7 +2593,7 @@ class SharedLibrary(BuildTarget, LinkableTarget):
         return self.environment.get_shared_lib_dir(), '{libdir_shared}'
 
     def determine_naming_info(self) -> T.Tuple[str, str, str, str, bool]:
-        scheme = self.environment.coredata.get_option_for_target(self, 'namingscheme')
+        scheme = self.environment.coredata.optstore.get_option_for_target(self, 'namingscheme')
         assert isinstance(scheme, str), 'for mypy'
 
         prefix: str | None

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -703,7 +703,7 @@ class Interpreter:
             machine = MachineChoice.HOST
         rustc = T.cast('RustCompiler', self.environment.coredata.compilers[machine]['rust'])
         cfgs = rustc.get_cfgs().copy()
-        rustflags = self.environment.coredata.get_external_args(machine, 'rust')
+        rustflags = self.environment.coredata.optstore.get_external_args(machine, 'rust')
         rustflags_i = iter(rustflags)
         for i in rustflags_i:
             if i == '--cfg':

--- a/mesonbuild/cmake/common.py
+++ b/mesonbuild/cmake/common.py
@@ -59,13 +59,13 @@ blacklist_cmake_defs = [
 
 def cmake_is_debug(env: 'Environment') -> bool:
     if 'b_vscrt' in env.coredata.optstore:
-        is_debug = env.coredata.optstore.get_value_for('buildtype') == 'debug'
-        if env.coredata.optstore.get_value_for('b_vscrt') in {'mdd', 'mtd'}:
+        is_debug = env.coredata.optstore.get_value_for_untyped('buildtype') == 'debug'
+        if env.coredata.optstore.get_value_for_untyped('b_vscrt') in {'mdd', 'mtd'}:
             is_debug = True
         return is_debug
     else:
         # Don't directly assign to is_debug to make mypy happy
-        debug_opt = env.coredata.optstore.get_value_for('debug')
+        debug_opt = env.coredata.optstore.get_value_for_untyped('debug')
         assert isinstance(debug_opt, bool)
         return debug_opt
 
@@ -122,7 +122,7 @@ def _cmake_get_generator_args(backend_name: str) -> ImmutableListProtocol[str]:
     return args
 
 def cmake_get_generator_args(env: 'Environment') -> T.List[str]:
-    backend_name = env.coredata.optstore.get_value_for(OptionKey('backend'))
+    backend_name = env.coredata.optstore.get_value_for_untyped(OptionKey('backend'))
     assert isinstance(backend_name, str)
     return list(_cmake_get_generator_args(backend_name))
 

--- a/mesonbuild/cmake/common.py
+++ b/mesonbuild/cmake/common.py
@@ -58,16 +58,11 @@ blacklist_cmake_defs = [
 ]
 
 def cmake_is_debug(env: 'Environment') -> bool:
-    if 'b_vscrt' in env.coredata.optstore:
-        is_debug = env.coredata.optstore.get_value_for_untyped('buildtype') == 'debug'
-        if env.coredata.optstore.get_value_for_untyped('b_vscrt') in {'mdd', 'mtd'}:
-            is_debug = True
+    if vcrt := env.coredata.optstore.get_value_for(OptionKey('b_vscrt'), str, default=''):
+        is_debug = env.coredata.optstore.get_value_for(OptionKey('buildtype'), str) == 'debug'
+        is_debug |= vcrt in {'mdd', 'mtd'}
         return is_debug
-    else:
-        # Don't directly assign to is_debug to make mypy happy
-        debug_opt = env.coredata.optstore.get_value_for_untyped('debug')
-        assert isinstance(debug_opt, bool)
-        return debug_opt
+    return env.coredata.optstore.get_value_for(OptionKey('debug'), bool)
 
 class CMakeException(MesonException):
     pass
@@ -122,8 +117,7 @@ def _cmake_get_generator_args(backend_name: str) -> ImmutableListProtocol[str]:
     return args
 
 def cmake_get_generator_args(env: 'Environment') -> T.List[str]:
-    backend_name = env.coredata.optstore.get_value_for_untyped(OptionKey('backend'))
-    assert isinstance(backend_name, str)
+    backend_name = env.coredata.optstore.get_value_for(OptionKey('backend'), str)
     return list(_cmake_get_generator_args(backend_name))
 
 def cmake_defines_to_args(raw: T.List[T.Dict[str, TYPE_var]], permissive: bool = False) -> T.List[str]:

--- a/mesonbuild/cmake/executor.py
+++ b/mesonbuild/cmake/executor.py
@@ -52,7 +52,7 @@ class CMakeExecutor:
             self.cmakebin = None
             return
 
-        prefpath = self.environment.coredata.optstore.get_value_for(
+        prefpath = self.environment.coredata.optstore.get_value_for_untyped(
             OptionKey(name='cmake_prefix_path', machine=for_machine))
         assert isinstance(prefpath, list)
         self.prefix_paths = prefpath

--- a/mesonbuild/cmake/executor.py
+++ b/mesonbuild/cmake/executor.py
@@ -52,9 +52,8 @@ class CMakeExecutor:
             self.cmakebin = None
             return
 
-        prefpath = self.environment.coredata.optstore.get_value_for_untyped(
-            OptionKey(name='cmake_prefix_path', machine=for_machine))
-        assert isinstance(prefpath, list)
+        prefpath = self.environment.coredata.optstore.get_value_for(
+            OptionKey(name='cmake_prefix_path', machine=for_machine), list)
         self.prefix_paths = prefpath
         if self.prefix_paths:
             self.extra_cmake_args += ['-DCMAKE_PREFIX_PATH={}'.format(';'.join(self.prefix_paths))]

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -800,7 +800,7 @@ class CMakeInterpreter:
         self.src_dir = Path(env.get_source_dir(), subdir)
         self.build_dir_rel = subdir / '__CMake_build'
         self.build_dir = Path(env.get_build_dir()) / self.build_dir_rel
-        self.install_prefix = Path(T.cast('str', env.coredata.optstore.get_value_for(OptionKey('prefix'))))
+        self.install_prefix = Path(T.cast('str', env.coredata.optstore.get_value_for_untyped(OptionKey('prefix'))))
         self.env = env
         self.for_machine = for_machine
         self.backend_name = backend.name
@@ -850,12 +850,12 @@ class CMakeInterpreter:
         cmake_args = []
         cmake_args += cmake_get_generator_args(self.env)
         cmake_args += [f'-DCMAKE_INSTALL_PREFIX={self.install_prefix}']
-        libdir = self.env.coredata.optstore.get_value_for(OptionKey('libdir'))
+        libdir = self.env.coredata.optstore.get_value_for_untyped(OptionKey('libdir'))
         cmake_args += [f'-DCMAKE_INSTALL_LIBDIR={libdir}']
         cmake_args += extra_cmake_options
         if not any(arg.startswith('-DCMAKE_BUILD_TYPE=') for arg in cmake_args):
             # Our build type is favored over any CMAKE_BUILD_TYPE environment variable
-            buildtype = T.cast('str', self.env.coredata.optstore.get_value_for(OptionKey('buildtype')))
+            buildtype = T.cast('str', self.env.coredata.optstore.get_value_for_untyped(OptionKey('buildtype')))
             if buildtype in BUILDTYPE_MAP:
                 cmake_args += [f'-DCMAKE_BUILD_TYPE={BUILDTYPE_MAP[buildtype]}']
         trace_args = self.trace.trace_args()

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -800,7 +800,7 @@ class CMakeInterpreter:
         self.src_dir = Path(env.get_source_dir(), subdir)
         self.build_dir_rel = subdir / '__CMake_build'
         self.build_dir = Path(env.get_build_dir()) / self.build_dir_rel
-        self.install_prefix = Path(T.cast('str', env.coredata.optstore.get_value_for_untyped(OptionKey('prefix'))))
+        self.install_prefix = Path(env.coredata.optstore.get_value_for(OptionKey('prefix'), str))
         self.env = env
         self.for_machine = for_machine
         self.backend_name = backend.name
@@ -850,12 +850,12 @@ class CMakeInterpreter:
         cmake_args = []
         cmake_args += cmake_get_generator_args(self.env)
         cmake_args += [f'-DCMAKE_INSTALL_PREFIX={self.install_prefix}']
-        libdir = self.env.coredata.optstore.get_value_for_untyped(OptionKey('libdir'))
+        libdir = self.env.coredata.optstore.get_value_for(OptionKey('libdir'), str)
         cmake_args += [f'-DCMAKE_INSTALL_LIBDIR={libdir}']
         cmake_args += extra_cmake_options
         if not any(arg.startswith('-DCMAKE_BUILD_TYPE=') for arg in cmake_args):
             # Our build type is favored over any CMAKE_BUILD_TYPE environment variable
-            buildtype = T.cast('str', self.env.coredata.optstore.get_value_for_untyped(OptionKey('buildtype')))
+            buildtype = self.env.coredata.optstore.get_value_for(OptionKey('buildtype'), str)
             if buildtype in BUILDTYPE_MAP:
                 cmake_args += [f'-DCMAKE_BUILD_TYPE={BUILDTYPE_MAP[buildtype]}']
         trace_args = self.trace.trace_args()

--- a/mesonbuild/compilers/asm.py
+++ b/mesonbuild/compilers/asm.py
@@ -92,7 +92,7 @@ class NasmCompiler(ASMCompiler):
             define = 'MACHO'
         elif self.info.is_os2():
             cpu = ''
-            if self.environment.coredata.optstore.get_value_for(OptionKey('os2_emxomf')):
+            if self.environment.coredata.optstore.get_value_for_untyped(OptionKey('os2_emxomf')):
                 plat = 'obj2'
                 define = 'OBJ2'
             else:

--- a/mesonbuild/compilers/asm.py
+++ b/mesonbuild/compilers/asm.py
@@ -92,7 +92,7 @@ class NasmCompiler(ASMCompiler):
             define = 'MACHO'
         elif self.info.is_os2():
             cpu = ''
-            if self.environment.coredata.optstore.get_value_for_untyped(OptionKey('os2_emxomf')):
+            if self.environment.coredata.optstore.get_value_for(OptionKey('os2_emxomf'), bool):
                 plat = 'obj2'
                 define = 'OBJ2'
             else:

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -41,7 +41,7 @@ if T.TYPE_CHECKING:
     from ..dependencies import Dependency
     from ..environment import Environment
     from ..linkers.linkers import DynamicLinker
-    from ..mesonlib import MachineChoice
+    from ..mesonlib import MachineChoice, SubProject
     from .compilers import CompileCheckMode
     from ..build import BuildTarget
 
@@ -127,15 +127,17 @@ class ClangCCompiler(ClangCStds, ClangCompiler, CCompiler):
                 gnu_winlibs)
         return opts
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
-        args = []
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
+        args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
         if std != 'none':
             args.append('-std=' + std)
         return args
 
-    def get_option_link_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_link_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         if self.info.is_windows() or self.info.is_cygwin():
             retval = self.get_compileropt_value('winlibs', target, subproject)
             assert isinstance(retval, list)
@@ -212,15 +214,16 @@ class ArmclangCCompiler(ArmclangCompiler, CCompiler):
         std_opt.set_versions(['c90', 'c99', 'c11'], gnu=True)
         return opts
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
-        args = []
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
+        args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
         if std != 'none':
             args.append('-std=' + std)
         return args
 
-    def get_option_link_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_link_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         return []
 
 
@@ -255,8 +258,9 @@ class GnuCCompiler(GnuCStds, GnuCompiler, CCompiler):
                 gnu_winlibs)
         return opts
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
-        args = []
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
+        args: T.List[str] = []
         key = OptionKey('c_std', machine=self.for_machine)
         std = self.get_compileropt_value(key, target, subproject)
         assert isinstance(std, str)
@@ -264,8 +268,9 @@ class GnuCCompiler(GnuCStds, GnuCompiler, CCompiler):
             args.append('-std=' + std)
         return args
 
-    def get_option_link_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_link_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         if self.info.is_windows() or self.info.is_cygwin():
+            target, subproject = self._get_subproject_and_target(target)
             # without a typeddict mypy can't figure this out
             retval = self.get_compileropt_value('winlibs', target, subproject)
 
@@ -308,7 +313,8 @@ class NvidiaHPC_CCompiler(PGICompiler, CCompiler):
         std_opt.set_versions(cppstd_choices, gnu=True)
         return opts
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
@@ -382,7 +388,8 @@ class IntelCCompiler(IntelGnuLikeCompiler, CCompiler):
         std_opt.set_versions(stds, gnu=True)
         return opts
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
@@ -409,7 +416,8 @@ class VisualStudioLikeCCompilerMixin(CompilerMixinBase):
             msvc_winlibs)
         return opts
 
-    def get_option_link_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         retval = self.get_compileropt_value('winlibs', target, subproject)
         assert isinstance(retval, list)
         libs: T.List[str] = retval.copy()
@@ -444,8 +452,9 @@ class VisualStudioCCompiler(MSVCCompiler, VisualStudioLikeCCompilerMixin, CCompi
         std_opt.set_versions(stds, gnu=True, gnu_deprecated=True)
         return opts
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
-        args = []
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
+        args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
 
         # As of MVSC 16.8, /std:c11 and /std:c17 are the only valid C standard options.
@@ -465,7 +474,8 @@ class ClangClCCompiler(ClangCStds, ClangClCompiler, VisualStudioLikeCCompilerMix
                            env, linker=linker, full_version=full_version)
         ClangClCompiler.__init__(self, target)
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
         if std != "none":
@@ -493,7 +503,8 @@ class IntelClCCompiler(IntelVisualStudioLikeCompiler, VisualStudioLikeCCompilerM
         std_opt.set_versions(['c89', 'c99', 'c11'])
         return opts
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
@@ -526,8 +537,9 @@ class ArmCCompiler(ArmCompiler, CCompiler):
         std_opt.set_versions(['c89', 'c99', 'c11'])
         return opts
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
-        args = []
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
+        args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
         if std != 'none':
@@ -559,8 +571,9 @@ class CcrxCCompiler(CcrxCompiler, CCompiler):
     def get_no_stdinc_args(self) -> T.List[str]:
         return []
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
-        args = []
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
+        args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
         if std == 'c89':
@@ -607,8 +620,9 @@ class Xc16CCompiler(Xc16Compiler, CCompiler):
     def get_no_stdinc_args(self) -> T.List[str]:
         return []
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
-        args = []
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
+        args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
         if std != 'none':
@@ -702,8 +716,9 @@ class TICCompiler(TICompiler, CCompiler):
     def get_no_stdinc_args(self) -> T.List[str]:
         return []
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
-        args = []
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
+        args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
         if std != 'none':
@@ -736,8 +751,9 @@ class MetrowerksCCompilerARM(MetrowerksCompiler, CCompiler):
         self._update_language_stds(opts, ['c99'])
         return opts
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
-        args = []
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
+        args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
         if std != 'none':
@@ -764,8 +780,9 @@ class MetrowerksCCompilerEmbeddedPowerPC(MetrowerksCompiler, CCompiler):
         self._update_language_stds(opts, ['c99'])
         return opts
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
-        args = []
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
+        args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
         if std != 'none':

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -8,7 +8,6 @@ import os.path
 import typing as T
 
 from .. import options
-from ..options import OptionKey
 from .. import mlog
 from ..mesonlib import MesonException, version_compare
 from .c_function_attributes import C_FUNC_ATTRIBUTES
@@ -130,8 +129,8 @@ class ClangCCompiler(ClangCStds, ClangCompiler, CCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append('-std=' + std)
         return args
@@ -139,12 +138,8 @@ class ClangCCompiler(ClangCStds, ClangCompiler, CCompiler):
     def get_option_link_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         if self.info.is_windows() or self.info.is_cygwin():
-            retval = self.get_compileropt_value('winlibs', target, subproject)
-            assert isinstance(retval, list)
-            libs: T.List[str] = retval.copy()
-            for l in libs:
-                assert isinstance(l, str)
-            return libs
+            key = self.form_compileropt_key('winlibs', subproject)
+            return self.environment.coredata.optstore.get_option_for_maybe_target(target, key, list).copy()
         return []
 
 
@@ -217,8 +212,8 @@ class ArmclangCCompiler(ArmclangCompiler, CCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append('-std=' + std)
         return args
@@ -261,9 +256,8 @@ class GnuCCompiler(GnuCStds, GnuCompiler, CCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        key = OptionKey('c_std', machine=self.for_machine)
-        std = self.get_compileropt_value(key, target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append('-std=' + std)
         return args
@@ -271,14 +265,8 @@ class GnuCCompiler(GnuCStds, GnuCompiler, CCompiler):
     def get_option_link_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         if self.info.is_windows() or self.info.is_cygwin():
             target, subproject = self._get_subproject_and_target(target)
-            # without a typeddict mypy can't figure this out
-            retval = self.get_compileropt_value('winlibs', target, subproject)
-
-            assert isinstance(retval, list)
-            libs: T.List[str] = retval.copy()
-            for l in libs:
-                assert isinstance(l, str)
-            return libs
+            key = self.form_compileropt_key('winlibs', subproject)
+            return self.environment.coredata.optstore.get_option_for_maybe_target(target, key, list).copy()
         return []
 
     def get_pch_use_args(self, pch_dir: str, header: str) -> T.List[str]:
@@ -316,8 +304,8 @@ class NvidiaHPC_CCompiler(PGICompiler, CCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append('-std=' + std)
         return args
@@ -391,8 +379,8 @@ class IntelCCompiler(IntelGnuLikeCompiler, CCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append('-std=' + std)
         return args
@@ -418,12 +406,8 @@ class VisualStudioLikeCCompilerMixin(CompilerMixinBase):
 
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
-        retval = self.get_compileropt_value('winlibs', target, subproject)
-        assert isinstance(retval, list)
-        libs: T.List[str] = retval.copy()
-        for l in libs:
-            assert isinstance(l, str)
-        return libs
+        key = self.form_compileropt_key('winlibs', subproject)
+        return self.environment.coredata.optstore.get_option_for_maybe_target(target, key, list).copy()
 
 
 class VisualStudioCCompiler(MSVCCompiler, VisualStudioLikeCCompilerMixin, CCompiler):
@@ -455,7 +439,8 @@ class VisualStudioCCompiler(MSVCCompiler, VisualStudioLikeCCompilerMixin, CCompi
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
 
         # As of MVSC 16.8, /std:c11 and /std:c17 are the only valid C standard options.
         if std in {'c11'}:
@@ -476,8 +461,8 @@ class ClangClCCompiler(ClangCStds, ClangClCompiler, VisualStudioLikeCCompilerMix
 
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != "none":
             return [f'/clang:-std={std}']
         return []
@@ -506,8 +491,8 @@ class IntelClCCompiler(IntelVisualStudioLikeCompiler, VisualStudioLikeCCompilerM
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std == 'c89':
             mlog.log("ICL doesn't explicitly implement c89, setting the standard to 'none', which is close.", once=True)
         elif std != 'none':
@@ -540,8 +525,8 @@ class ArmCCompiler(ArmCompiler, CCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append('--' + std)
         return args
@@ -574,8 +559,8 @@ class CcrxCCompiler(CcrxCompiler, CCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std == 'c89':
             args.append('-lang=c')
         elif std == 'c99':
@@ -623,8 +608,8 @@ class Xc16CCompiler(Xc16Compiler, CCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append('-ansi')
             args.append('-std=' + std)
@@ -719,8 +704,8 @@ class TICCompiler(TICompiler, CCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append('--' + std)
         return args
@@ -754,8 +739,8 @@ class MetrowerksCCompilerARM(MetrowerksCompiler, CCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append('-lang')
             args.append(std)
@@ -783,7 +768,8 @@ class MetrowerksCCompilerEmbeddedPowerPC(MetrowerksCompiler, CCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         assert isinstance(std, str)
         if std != 'none':
             args.append('-lang ' + std)

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1440,8 +1440,8 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
         :return: a tuple of arguments, the first is the executable and compiler
             arguments, the second is linker arguments
         """
-        cargs = list(self.environment.coredata.get_external_args(self.for_machine, self.language))
-        largs = list(self.environment.coredata.get_external_link_args(self.for_machine, self.language))
+        cargs = list(self.environment.coredata.optstore.get_external_args(self.for_machine, self.language))
+        largs = list(self.environment.coredata.optstore.get_external_link_args(self.for_machine, self.language))
         return self.exelist_no_ccache + self.get_always_args() + self.get_output_args(binname) + [sourcename] + cargs, largs
 
     @abc.abstractmethod
@@ -1587,7 +1587,7 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
 
         if mode is CompileCheckMode.COMPILE:
             # Add DFLAGS from the env
-            args += self.environment.coredata.get_external_args(self.for_machine, self.language)
+            args += self.environment.coredata.optstore.get_external_args(self.for_machine, self.language)
         elif mode is CompileCheckMode.LINK:
             # Add LDFLAGS from the env
             args += self.environment.coredata.get_external_link_args(self.for_machine, self.language)

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1197,7 +1197,7 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
         # override all the defaults but not the per-target link args.
         return build.get_project_link_args(self, target) \
             + build.get_global_link_args(self, self.for_machine) \
-            + self.environment.coredata.get_external_link_args(self.for_machine, self.get_language())
+            + self.environment.coredata.optstore.get_external_link_args(self.for_machine, self.get_language())
 
     def get_target_link_args(self, target: 'BuildTarget') -> T.List[str]:
         return target.link_args
@@ -1590,7 +1590,7 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
             args += self.environment.coredata.optstore.get_external_args(self.for_machine, self.language)
         elif mode is CompileCheckMode.LINK:
             # Add LDFLAGS from the env
-            args += self.environment.coredata.get_external_link_args(self.for_machine, self.language)
+            args += self.environment.coredata.optstore.get_external_link_args(self.for_machine, self.language)
         # extra_args must override all other arguments, so we add them last
         args += extra_args
         return args

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -34,7 +34,7 @@ if T.TYPE_CHECKING:
     from ..environment import Environment
     from ..linkers import RSPFileSyntax
     from ..linkers.linkers import DynamicLinker
-    from ..mesonlib import MachineChoice
+    from ..mesonlib import MachineChoice, SubProject
     from ..dependencies import Dependency
 
     # See the comment on `lang_suffixes` if modifying this list.
@@ -715,14 +715,21 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
     def get_options(self) -> 'MutableKeyedOptionDictType':
         return {}
 
-    def get_option_compile_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    @staticmethod
+    def _get_subproject_and_target(target: BuildTarget | SubProject | None) -> tuple[BuildTarget | None, SubProject | None]:
+        # Avoid circular imports by not checking for BuildTarget
+        if target is None or isinstance(target, str):
+            return None, target
+        return target, target.subproject
+
+    def get_option_compile_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         return []
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         return []
 
-    def get_option_link_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
-        return self.linker.get_option_link_args(target, subproject)
+    def get_option_link_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        return self.linker.get_option_link_args(target)
 
     def check_header(self, hname: str, prefix: str, *,
                      extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1676,18 +1676,6 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
     def form_compileropt_key(self, basename: str, subproject: T.Optional[SubProject] = None) -> OptionKey:
         return OptionKey(f'{self.language}_{basename}', subproject=subproject, machine=self.for_machine)
 
-    def get_compileropt_value(self,
-                              key: T.Union[str, OptionKey],
-                              target: T.Optional[BuildTarget],
-                              subproject: T.Optional[str] = None
-                              ) -> options.ElementaryOptionValues:
-        if isinstance(key, str):
-            key = self.form_compileropt_key(key)
-        if target:
-            return self.environment.coredata.optstore.get_option_for_target_untyped(target, key)
-        else:
-            return self.environment.coredata.optstore.get_value_for_untyped(key.evolve(subproject=subproject))
-
     def _update_language_stds(self, opts: MutableKeyedOptionDictType, value: T.List[str]) -> None:
         key = self.form_compileropt_key('std')
         std = opts[key]

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1673,8 +1673,8 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
         """
         raise EnvironmentException(f'{self.get_id()} does not support preprocessor')
 
-    def form_compileropt_key(self, basename: str) -> OptionKey:
-        return OptionKey(f'{self.language}_{basename}', machine=self.for_machine)
+    def form_compileropt_key(self, basename: str, subproject: T.Optional[SubProject] = None) -> OptionKey:
+        return OptionKey(f'{self.language}_{basename}', subproject=subproject, machine=self.for_machine)
 
     def get_compileropt_value(self,
                               key: T.Union[str, OptionKey],

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -251,19 +251,6 @@ def option_enabled(boptions: T.Set[OptionKey],
     return env.coredata.optstore.get_option_for_target(target, option, bool, default=False)
 
 
-# TODO: delete this
-def get_option_value_for_target(env: 'Environment', target: 'BuildTarget', opt: OptionKey, fallback: '_T') -> '_T':
-    """Get the value of an option, or the fallback value."""
-    try:
-        v = env.coredata.optstore.get_option_for_target_untyped(target, opt)
-    except (KeyError, AttributeError):
-        return fallback
-
-    assert isinstance(v, type(fallback)), f'Should have {type(fallback)!r} but was {type(v)!r}'
-    # Mypy doesn't understand that the above assert ensures that v is type _T
-    return v
-
-
 def are_asserts_disabled(target: 'BuildTarget', env: 'Environment') -> bool:
     """Should debug assertions be disabled
 
@@ -290,8 +277,8 @@ def get_base_compile_args(target: 'BuildTarget', compiler: 'Compiler', env: 'Env
     lto = False
     try:
         if env.coredata.optstore.get_option_for_target(target, OptionKey('b_lto'), bool):
-            num_threads = get_option_value_for_target(env, target, OptionKey('b_lto_threads'), 0)
-            ltomode = get_option_value_for_target(env, target, OptionKey('b_lto_mode'), 'default')
+            num_threads = env.coredata.optstore.get_option_for_target(target, OptionKey('b_lto_threads'), int, default=0)
+            ltomode = env.coredata.optstore.get_option_for_target(target, OptionKey('b_lto_mode'), str, default='default')
             args.extend(compiler.get_lto_compile_args(
                 target=target,
                 threads=num_threads,
@@ -353,22 +340,19 @@ def get_base_link_args(target: 'BuildTarget',
                        env: 'Environment') -> T.List[str]:
     args: T.List[str] = []
     build_dir = env.get_build_dir()
-    if env.coredata.optstore.get_option_for_target_untyped(target, 'werror'):
+    if env.coredata.optstore.get_option_for_target(target, OptionKey('werror'), bool):
         args.extend(linker.get_linker_fatal_warnings())
     try:
-        if env.coredata.optstore.get_option_for_target(target, OptionKey('b_lto'), bool):
-            if env.coredata.optstore.get_option_for_target(target, OptionKey('werror'), bool):
-                args.extend(linker.get_werror_args())
-
+        if env.coredata.optstore.get_option_for_target(target, OptionKey('b_lto'), bool, default=False):
             thinlto_cache_dir = None
             cachedir_key = OptionKey('b_thinlto_cache')
-            if get_option_value_for_target(env, target, cachedir_key, False):
-                thinlto_cache_dir = get_option_value_for_target(env, target, OptionKey('b_thinlto_cache_dir'), '')
+            if env.coredata.optstore.get_option_for_target(target, cachedir_key, bool, default=False):
+                thinlto_cache_dir = env.coredata.optstore.get_option_for_target(target, OptionKey('b_thinlto_cache_dir'), str, default='')
                 if thinlto_cache_dir == '':
                     thinlto_cache_dir = os.path.join(build_dir, 'meson-private', 'thinlto-cache')
-                    os.makedirs(thinlto_cache_dir, exist_ok=True)
-            num_threads = get_option_value_for_target(env, target, OptionKey('b_lto_threads'), 0)
-            lto_mode = get_option_value_for_target(env, target, OptionKey('b_lto_mode'), 'default')
+                    os.mkdir(thinlto_cache_dir)
+            num_threads = env.coredata.optstore.get_option_for_target(target, OptionKey('b_lto_threads'), int, default=0)
+            lto_mode = env.coredata.optstore.get_option_for_target(target, OptionKey('b_lto_mode'), str, default='default')
             args.extend(linker.get_lto_link_args(
                 target=target,
                 threads=num_threads,

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -239,22 +239,19 @@ clike_debug_args: T.Dict[bool, T.List[str]] = {
 }
 
 
+# TODO: Can we delete this?
 def option_enabled(boptions: T.Set[OptionKey],
                    target: 'BuildTarget',
                    env: 'Environment',
                    option: T.Union[str, OptionKey]) -> bool:
     if isinstance(option, str):
         option = OptionKey(option)
-    try:
-        if option not in boptions:
-            return False
-        ret = env.coredata.optstore.get_option_for_target_untyped(target, option)
-        assert isinstance(ret, bool), 'must return bool'  # could also be str
-        return ret
-    except KeyError:
+    if option not in boptions:
         return False
+    return env.coredata.optstore.get_option_for_target(target, option, bool, default=False)
 
 
+# TODO: delete this
 def get_option_value_for_target(env: 'Environment', target: 'BuildTarget', opt: OptionKey, fallback: '_T') -> '_T':
     """Get the value of an option, or the fallback value."""
     try:
@@ -274,9 +271,10 @@ def are_asserts_disabled(target: 'BuildTarget', env: 'Environment') -> bool:
     :param env: the environment
     :return: whether to disable assertions or not
     """
-    return (env.coredata.optstore.get_option_for_target_untyped(target, 'b_ndebug') == 'true' or
-            (env.coredata.optstore.get_option_for_target_untyped(target, 'b_ndebug') == 'if-release' and
-             env.coredata.optstore.get_option_for_target_untyped(target, 'buildtype') in {'release', 'plain'}))
+    key = OptionKey('b_ndebug', target.subproject, target.for_machine)
+    return (env.coredata.optstore.get_option_for_target(target, key, str) == 'true' or
+            (env.coredata.optstore.get_option_for_target(target, key, str) == 'if-release' and
+             env.coredata.optstore.get_option_for_target(target, key.evolve(name='buildtype'), str) in {'release', 'plain'}))
 
 
 def are_asserts_disabled_for_subproject(subproject: str, env: 'Environment') -> bool:
@@ -286,11 +284,12 @@ def are_asserts_disabled_for_subproject(subproject: str, env: 'Environment') -> 
              env.coredata.optstore.get_value_for(key.evolve(name='buildtype'), str) in {'release', 'plain'}))
 
 
+# TODO: remove use of try/except, use default= instead
 def get_base_compile_args(target: 'BuildTarget', compiler: 'Compiler', env: 'Environment') -> T.List[str]:
     args: T.List[str] = []
     lto = False
     try:
-        if env.coredata.optstore.get_option_for_target_untyped(target, 'b_lto'):
+        if env.coredata.optstore.get_option_for_target(target, OptionKey('b_lto'), bool):
             num_threads = get_option_value_for_target(env, target, OptionKey('b_lto_threads'), 0)
             ltomode = get_option_value_for_target(env, target, OptionKey('b_lto_mode'), 'default')
             args.extend(compiler.get_lto_compile_args(
@@ -301,14 +300,12 @@ def get_base_compile_args(target: 'BuildTarget', compiler: 'Compiler', env: 'Env
     except (KeyError, AttributeError):
         pass
     try:
-        clrout = env.coredata.optstore.get_option_for_target_untyped(target, 'b_colorout')
-        assert isinstance(clrout, str)
+        clrout = env.coredata.optstore.get_option_for_target(target, OptionKey('b_colorout'), str)
         args += compiler.get_colorout_args(clrout)
     except KeyError:
         pass
     try:
-        sanitize = env.coredata.optstore.get_option_for_target_untyped(target, 'b_sanitize')
-        assert isinstance(sanitize, list)
+        sanitize = env.coredata.optstore.get_option_for_target(target, OptionKey('b_sanitize'), list)
         if sanitize == ['none']:
             sanitize = []
         sanitize_args = compiler.sanitizer_compile_args(target, sanitize)
@@ -321,7 +318,7 @@ def get_base_compile_args(target: 'BuildTarget', compiler: 'Compiler', env: 'Env
     except KeyError:
         pass
     try:
-        pgo_val = env.coredata.optstore.get_option_for_target_untyped(target, 'b_pgo')
+        pgo_val = env.coredata.optstore.get_option_for_target(target, OptionKey('b_pgo'), str)
         if pgo_val == 'generate':
             args.extend(compiler.get_profile_generate_args())
         elif pgo_val == 'use':
@@ -329,7 +326,7 @@ def get_base_compile_args(target: 'BuildTarget', compiler: 'Compiler', env: 'Env
     except (KeyError, AttributeError):
         pass
     try:
-        if env.coredata.optstore.get_option_for_target_untyped(target, 'b_coverage'):
+        if env.coredata.optstore.get_option_for_target(target, OptionKey('b_coverage'), bool):
             args += compiler.get_coverage_args()
     except (KeyError, AttributeError):
         pass
@@ -341,8 +338,8 @@ def get_base_compile_args(target: 'BuildTarget', compiler: 'Compiler', env: 'Env
     bitcode = option_enabled(compiler.base_options, target, env, 'b_bitcode')
     args.extend(compiler.get_embed_bitcode_args(bitcode, lto))
     try:
-        crt_val = env.coredata.optstore.get_option_for_target_untyped(target, 'b_vscrt')
-        assert isinstance(crt_val, str)
+        crt_val = env.coredata.optstore.get_option_for_target(target, OptionKey('b_vscrt'), str)
+        # TODO: Is this attributeError posible?
         try:
             args += compiler.get_crt_compile_args(crt_val)
         except EnvironmentException:
@@ -359,8 +356,8 @@ def get_base_link_args(target: 'BuildTarget',
     if env.coredata.optstore.get_option_for_target_untyped(target, 'werror'):
         args.extend(linker.get_linker_fatal_warnings())
     try:
-        if env.coredata.optstore.get_option_for_target_untyped(target, 'b_lto'):
-            if env.coredata.optstore.get_option_for_target_untyped(target, 'werror'):
+        if env.coredata.optstore.get_option_for_target(target, OptionKey('b_lto'), bool):
+            if env.coredata.optstore.get_option_for_target(target, OptionKey('werror'), bool):
                 args.extend(linker.get_werror_args())
 
             thinlto_cache_dir = None
@@ -382,8 +379,7 @@ def get_base_link_args(target: 'BuildTarget',
     except (KeyError, AttributeError):
         pass
     try:
-        sanitizer = env.coredata.optstore.get_option_for_target_untyped(target, 'b_sanitize')
-        assert isinstance(sanitizer, list)
+        sanitizer = env.coredata.optstore.get_option_for_target(target, OptionKey('b_sanitize'), list)
         if sanitizer == ['none']:
             sanitizer = []
         sanitizer_args = linker.sanitizer_link_args(target, sanitizer)
@@ -396,7 +392,7 @@ def get_base_link_args(target: 'BuildTarget',
     except KeyError:
         pass
     try:
-        pgo_val = env.coredata.optstore.get_option_for_target_untyped(target, 'b_pgo')
+        pgo_val = env.coredata.optstore.get_option_for_target(target, OptionKey('b_pgo'), str)
         if pgo_val == 'generate':
             args.extend(linker.get_profile_generate_args())
         elif pgo_val == 'use':
@@ -404,7 +400,7 @@ def get_base_link_args(target: 'BuildTarget',
     except (KeyError, AttributeError):
         pass
     try:
-        if env.coredata.optstore.get_option_for_target_untyped(target, 'b_coverage'):
+        if env.coredata.optstore.get_option_for_target(target, OptionKey('b_coverage'), bool):
             args += linker.get_coverage_link_args()
     except (KeyError, AttributeError):
         pass
@@ -431,12 +427,9 @@ def get_base_link_args(target: 'BuildTarget',
             args.extend(linker.get_allow_undefined_link_args())
 
     try:
-        crt_val = env.coredata.optstore.get_option_for_target_untyped(target, 'b_vscrt')
-        assert isinstance(crt_val, str)
+        crt_val = env.coredata.optstore.get_option_for_target(target, OptionKey('b_vscrt'), str)
         try:
-            crtargs = linker.get_crt_link_args(crt_val)
-            assert isinstance(crtargs, list)
-            args += crtargs
+            args += linker.get_crt_link_args(crt_val)
         except EnvironmentException:
             pass
     except KeyError:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -248,7 +248,7 @@ def option_enabled(boptions: T.Set[OptionKey],
     try:
         if option not in boptions:
             return False
-        ret = env.coredata.optstore.get_option_for_target(target, option)
+        ret = env.coredata.optstore.get_option_for_target_untyped(target, option)
         assert isinstance(ret, bool), 'must return bool'  # could also be str
         return ret
     except KeyError:
@@ -258,7 +258,7 @@ def option_enabled(boptions: T.Set[OptionKey],
 def get_option_value_for_target(env: 'Environment', target: 'BuildTarget', opt: OptionKey, fallback: '_T') -> '_T':
     """Get the value of an option, or the fallback value."""
     try:
-        v = env.coredata.optstore.get_option_for_target(target, opt)
+        v = env.coredata.optstore.get_option_for_target_untyped(target, opt)
     except (KeyError, AttributeError):
         return fallback
 
@@ -274,23 +274,23 @@ def are_asserts_disabled(target: 'BuildTarget', env: 'Environment') -> bool:
     :param env: the environment
     :return: whether to disable assertions or not
     """
-    return (env.coredata.optstore.get_option_for_target(target, 'b_ndebug') == 'true' or
-            (env.coredata.optstore.get_option_for_target(target, 'b_ndebug') == 'if-release' and
-             env.coredata.optstore.get_option_for_target(target, 'buildtype') in {'release', 'plain'}))
+    return (env.coredata.optstore.get_option_for_target_untyped(target, 'b_ndebug') == 'true' or
+            (env.coredata.optstore.get_option_for_target_untyped(target, 'b_ndebug') == 'if-release' and
+             env.coredata.optstore.get_option_for_target_untyped(target, 'buildtype') in {'release', 'plain'}))
 
 
 def are_asserts_disabled_for_subproject(subproject: str, env: 'Environment') -> bool:
     key = OptionKey('b_ndebug', subproject)
-    return (env.coredata.optstore.get_value_for(key) == 'true' or
-            (env.coredata.optstore.get_value_for(key) == 'if-release' and
-             env.coredata.optstore.get_value_for(key.evolve(name='buildtype')) in {'release', 'plain'}))
+    return (env.coredata.optstore.get_value_for_untyped(key) == 'true' or
+            (env.coredata.optstore.get_value_for_untyped(key) == 'if-release' and
+             env.coredata.optstore.get_value_for_untyped(key.evolve(name='buildtype')) in {'release', 'plain'}))
 
 
 def get_base_compile_args(target: 'BuildTarget', compiler: 'Compiler', env: 'Environment') -> T.List[str]:
     args: T.List[str] = []
     lto = False
     try:
-        if env.coredata.optstore.get_option_for_target(target, 'b_lto'):
+        if env.coredata.optstore.get_option_for_target_untyped(target, 'b_lto'):
             num_threads = get_option_value_for_target(env, target, OptionKey('b_lto_threads'), 0)
             ltomode = get_option_value_for_target(env, target, OptionKey('b_lto_mode'), 'default')
             args.extend(compiler.get_lto_compile_args(
@@ -301,13 +301,13 @@ def get_base_compile_args(target: 'BuildTarget', compiler: 'Compiler', env: 'Env
     except (KeyError, AttributeError):
         pass
     try:
-        clrout = env.coredata.optstore.get_option_for_target(target, 'b_colorout')
+        clrout = env.coredata.optstore.get_option_for_target_untyped(target, 'b_colorout')
         assert isinstance(clrout, str)
         args += compiler.get_colorout_args(clrout)
     except KeyError:
         pass
     try:
-        sanitize = env.coredata.optstore.get_option_for_target(target, 'b_sanitize')
+        sanitize = env.coredata.optstore.get_option_for_target_untyped(target, 'b_sanitize')
         assert isinstance(sanitize, list)
         if sanitize == ['none']:
             sanitize = []
@@ -321,7 +321,7 @@ def get_base_compile_args(target: 'BuildTarget', compiler: 'Compiler', env: 'Env
     except KeyError:
         pass
     try:
-        pgo_val = env.coredata.optstore.get_option_for_target(target, 'b_pgo')
+        pgo_val = env.coredata.optstore.get_option_for_target_untyped(target, 'b_pgo')
         if pgo_val == 'generate':
             args.extend(compiler.get_profile_generate_args())
         elif pgo_val == 'use':
@@ -329,7 +329,7 @@ def get_base_compile_args(target: 'BuildTarget', compiler: 'Compiler', env: 'Env
     except (KeyError, AttributeError):
         pass
     try:
-        if env.coredata.optstore.get_option_for_target(target, 'b_coverage'):
+        if env.coredata.optstore.get_option_for_target_untyped(target, 'b_coverage'):
             args += compiler.get_coverage_args()
     except (KeyError, AttributeError):
         pass
@@ -341,7 +341,7 @@ def get_base_compile_args(target: 'BuildTarget', compiler: 'Compiler', env: 'Env
     bitcode = option_enabled(compiler.base_options, target, env, 'b_bitcode')
     args.extend(compiler.get_embed_bitcode_args(bitcode, lto))
     try:
-        crt_val = env.coredata.optstore.get_option_for_target(target, 'b_vscrt')
+        crt_val = env.coredata.optstore.get_option_for_target_untyped(target, 'b_vscrt')
         assert isinstance(crt_val, str)
         try:
             args += compiler.get_crt_compile_args(crt_val)
@@ -356,11 +356,11 @@ def get_base_link_args(target: 'BuildTarget',
                        env: 'Environment') -> T.List[str]:
     args: T.List[str] = []
     build_dir = env.get_build_dir()
-    if env.coredata.optstore.get_option_for_target(target, 'werror'):
+    if env.coredata.optstore.get_option_for_target_untyped(target, 'werror'):
         args.extend(linker.get_linker_fatal_warnings())
     try:
-        if env.coredata.optstore.get_option_for_target(target, 'b_lto'):
-            if env.coredata.optstore.get_option_for_target(target, 'werror'):
+        if env.coredata.optstore.get_option_for_target_untyped(target, 'b_lto'):
+            if env.coredata.optstore.get_option_for_target_untyped(target, 'werror'):
                 args.extend(linker.get_werror_args())
 
             thinlto_cache_dir = None
@@ -382,7 +382,7 @@ def get_base_link_args(target: 'BuildTarget',
     except (KeyError, AttributeError):
         pass
     try:
-        sanitizer = env.coredata.optstore.get_option_for_target(target, 'b_sanitize')
+        sanitizer = env.coredata.optstore.get_option_for_target_untyped(target, 'b_sanitize')
         assert isinstance(sanitizer, list)
         if sanitizer == ['none']:
             sanitizer = []
@@ -396,7 +396,7 @@ def get_base_link_args(target: 'BuildTarget',
     except KeyError:
         pass
     try:
-        pgo_val = env.coredata.optstore.get_option_for_target(target, 'b_pgo')
+        pgo_val = env.coredata.optstore.get_option_for_target_untyped(target, 'b_pgo')
         if pgo_val == 'generate':
             args.extend(linker.get_profile_generate_args())
         elif pgo_val == 'use':
@@ -404,7 +404,7 @@ def get_base_link_args(target: 'BuildTarget',
     except (KeyError, AttributeError):
         pass
     try:
-        if env.coredata.optstore.get_option_for_target(target, 'b_coverage'):
+        if env.coredata.optstore.get_option_for_target_untyped(target, 'b_coverage'):
             args += linker.get_coverage_link_args()
     except (KeyError, AttributeError):
         pass
@@ -431,7 +431,7 @@ def get_base_link_args(target: 'BuildTarget',
             args.extend(linker.get_allow_undefined_link_args())
 
     try:
-        crt_val = env.coredata.optstore.get_option_for_target(target, 'b_vscrt')
+        crt_val = env.coredata.optstore.get_option_for_target_untyped(target, 'b_vscrt')
         assert isinstance(crt_val, str)
         try:
             crtargs = linker.get_crt_link_args(crt_val)
@@ -1246,7 +1246,7 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
             rel = 'mt'
 
         # Match what build type flags used to do.
-        buildtype = self.environment.coredata.optstore.get_value_for('buildtype')
+        buildtype = self.environment.coredata.optstore.get_value_for_untyped('buildtype')
         assert isinstance(buildtype, str), 'for mypy'
         if buildtype == 'plain':
             return 'none'
@@ -1685,9 +1685,9 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
         if isinstance(key, str):
             key = self.form_compileropt_key(key)
         if target:
-            return self.environment.coredata.optstore.get_option_for_target(target, key)
+            return self.environment.coredata.optstore.get_option_for_target_untyped(target, key)
         else:
-            return self.environment.coredata.optstore.get_value_for(key.evolve(subproject=subproject))
+            return self.environment.coredata.optstore.get_value_for_untyped(key.evolve(subproject=subproject))
 
     def _update_language_stds(self, opts: MutableKeyedOptionDictType, value: T.List[str]) -> None:
         key = self.form_compileropt_key('std')

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -281,9 +281,9 @@ def are_asserts_disabled(target: 'BuildTarget', env: 'Environment') -> bool:
 
 def are_asserts_disabled_for_subproject(subproject: str, env: 'Environment') -> bool:
     key = OptionKey('b_ndebug', subproject)
-    return (env.coredata.optstore.get_value_for_untyped(key) == 'true' or
-            (env.coredata.optstore.get_value_for_untyped(key) == 'if-release' and
-             env.coredata.optstore.get_value_for_untyped(key.evolve(name='buildtype')) in {'release', 'plain'}))
+    return (env.coredata.optstore.get_value_for(key, str) == 'true' or
+            (env.coredata.optstore.get_value_for(key, str) == 'if-release' and
+             env.coredata.optstore.get_value_for(key.evolve(name='buildtype'), str) in {'release', 'plain'}))
 
 
 def get_base_compile_args(target: 'BuildTarget', compiler: 'Compiler', env: 'Environment') -> T.List[str]:
@@ -1246,8 +1246,7 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
             rel = 'mt'
 
         # Match what build type flags used to do.
-        buildtype = self.environment.coredata.optstore.get_value_for_untyped('buildtype')
-        assert isinstance(buildtype, str), 'for mypy'
+        buildtype = self.environment.coredata.optstore.get_value_for(OptionKey('buildtype'), str)
         if buildtype == 'plain':
             return 'none'
         elif buildtype == 'debug':

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -105,9 +105,9 @@ SUFFIX_TO_LANG: T.Mapping[str, Language] = dict(itertools.chain(*(
     [(suffix, lang) for suffix in v] for lang, v in lang_suffixes.items())))
 
 # Languages that should use LDFLAGS arguments when linking.
-LANGUAGES_USING_LDFLAGS = {'objcpp', 'cpp', 'objc', 'c', 'fortran', 'd', 'cuda'}
+LANGUAGES_USING_LDFLAGS: set[Language] = {'objcpp', 'cpp', 'objc', 'c', 'fortran', 'd', 'cuda'}
 # Languages that should use CPPFLAGS arguments when linking.
-LANGUAGES_USING_CPPFLAGS = {'c', 'cpp', 'objc', 'objcpp'}
+LANGUAGES_USING_CPPFLAGS: set[Language] = {'c', 'cpp', 'objc', 'objcpp'}
 soregex = re.compile(r'.*\.so(\.[0-9]+)?(\.[0-9]+)?(\.[0-9]+)?$')
 
 # Environment variables that each lang uses.

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -248,7 +248,7 @@ def option_enabled(boptions: T.Set[OptionKey],
     try:
         if option not in boptions:
             return False
-        ret = env.coredata.get_option_for_target(target, option)
+        ret = env.coredata.optstore.get_option_for_target(target, option)
         assert isinstance(ret, bool), 'must return bool'  # could also be str
         return ret
     except KeyError:
@@ -258,7 +258,7 @@ def option_enabled(boptions: T.Set[OptionKey],
 def get_option_value_for_target(env: 'Environment', target: 'BuildTarget', opt: OptionKey, fallback: '_T') -> '_T':
     """Get the value of an option, or the fallback value."""
     try:
-        v = env.coredata.get_option_for_target(target, opt)
+        v = env.coredata.optstore.get_option_for_target(target, opt)
     except (KeyError, AttributeError):
         return fallback
 
@@ -274,9 +274,9 @@ def are_asserts_disabled(target: 'BuildTarget', env: 'Environment') -> bool:
     :param env: the environment
     :return: whether to disable assertions or not
     """
-    return (env.coredata.get_option_for_target(target, 'b_ndebug') == 'true' or
-            (env.coredata.get_option_for_target(target, 'b_ndebug') == 'if-release' and
-             env.coredata.get_option_for_target(target, 'buildtype') in {'release', 'plain'}))
+    return (env.coredata.optstore.get_option_for_target(target, 'b_ndebug') == 'true' or
+            (env.coredata.optstore.get_option_for_target(target, 'b_ndebug') == 'if-release' and
+             env.coredata.optstore.get_option_for_target(target, 'buildtype') in {'release', 'plain'}))
 
 
 def are_asserts_disabled_for_subproject(subproject: str, env: 'Environment') -> bool:
@@ -290,7 +290,7 @@ def get_base_compile_args(target: 'BuildTarget', compiler: 'Compiler', env: 'Env
     args: T.List[str] = []
     lto = False
     try:
-        if env.coredata.get_option_for_target(target, 'b_lto'):
+        if env.coredata.optstore.get_option_for_target(target, 'b_lto'):
             num_threads = get_option_value_for_target(env, target, OptionKey('b_lto_threads'), 0)
             ltomode = get_option_value_for_target(env, target, OptionKey('b_lto_mode'), 'default')
             args.extend(compiler.get_lto_compile_args(
@@ -301,13 +301,13 @@ def get_base_compile_args(target: 'BuildTarget', compiler: 'Compiler', env: 'Env
     except (KeyError, AttributeError):
         pass
     try:
-        clrout = env.coredata.get_option_for_target(target, 'b_colorout')
+        clrout = env.coredata.optstore.get_option_for_target(target, 'b_colorout')
         assert isinstance(clrout, str)
         args += compiler.get_colorout_args(clrout)
     except KeyError:
         pass
     try:
-        sanitize = env.coredata.get_option_for_target(target, 'b_sanitize')
+        sanitize = env.coredata.optstore.get_option_for_target(target, 'b_sanitize')
         assert isinstance(sanitize, list)
         if sanitize == ['none']:
             sanitize = []
@@ -321,7 +321,7 @@ def get_base_compile_args(target: 'BuildTarget', compiler: 'Compiler', env: 'Env
     except KeyError:
         pass
     try:
-        pgo_val = env.coredata.get_option_for_target(target, 'b_pgo')
+        pgo_val = env.coredata.optstore.get_option_for_target(target, 'b_pgo')
         if pgo_val == 'generate':
             args.extend(compiler.get_profile_generate_args())
         elif pgo_val == 'use':
@@ -329,7 +329,7 @@ def get_base_compile_args(target: 'BuildTarget', compiler: 'Compiler', env: 'Env
     except (KeyError, AttributeError):
         pass
     try:
-        if env.coredata.get_option_for_target(target, 'b_coverage'):
+        if env.coredata.optstore.get_option_for_target(target, 'b_coverage'):
             args += compiler.get_coverage_args()
     except (KeyError, AttributeError):
         pass
@@ -341,7 +341,7 @@ def get_base_compile_args(target: 'BuildTarget', compiler: 'Compiler', env: 'Env
     bitcode = option_enabled(compiler.base_options, target, env, 'b_bitcode')
     args.extend(compiler.get_embed_bitcode_args(bitcode, lto))
     try:
-        crt_val = env.coredata.get_option_for_target(target, 'b_vscrt')
+        crt_val = env.coredata.optstore.get_option_for_target(target, 'b_vscrt')
         assert isinstance(crt_val, str)
         try:
             args += compiler.get_crt_compile_args(crt_val)
@@ -356,11 +356,11 @@ def get_base_link_args(target: 'BuildTarget',
                        env: 'Environment') -> T.List[str]:
     args: T.List[str] = []
     build_dir = env.get_build_dir()
-    if env.coredata.get_option_for_target(target, 'werror'):
+    if env.coredata.optstore.get_option_for_target(target, 'werror'):
         args.extend(linker.get_linker_fatal_warnings())
     try:
-        if env.coredata.get_option_for_target(target, 'b_lto'):
-            if env.coredata.get_option_for_target(target, 'werror'):
+        if env.coredata.optstore.get_option_for_target(target, 'b_lto'):
+            if env.coredata.optstore.get_option_for_target(target, 'werror'):
                 args.extend(linker.get_werror_args())
 
             thinlto_cache_dir = None
@@ -382,7 +382,7 @@ def get_base_link_args(target: 'BuildTarget',
     except (KeyError, AttributeError):
         pass
     try:
-        sanitizer = env.coredata.get_option_for_target(target, 'b_sanitize')
+        sanitizer = env.coredata.optstore.get_option_for_target(target, 'b_sanitize')
         assert isinstance(sanitizer, list)
         if sanitizer == ['none']:
             sanitizer = []
@@ -396,7 +396,7 @@ def get_base_link_args(target: 'BuildTarget',
     except KeyError:
         pass
     try:
-        pgo_val = env.coredata.get_option_for_target(target, 'b_pgo')
+        pgo_val = env.coredata.optstore.get_option_for_target(target, 'b_pgo')
         if pgo_val == 'generate':
             args.extend(linker.get_profile_generate_args())
         elif pgo_val == 'use':
@@ -404,7 +404,7 @@ def get_base_link_args(target: 'BuildTarget',
     except (KeyError, AttributeError):
         pass
     try:
-        if env.coredata.get_option_for_target(target, 'b_coverage'):
+        if env.coredata.optstore.get_option_for_target(target, 'b_coverage'):
             args += linker.get_coverage_link_args()
     except (KeyError, AttributeError):
         pass
@@ -431,7 +431,7 @@ def get_base_link_args(target: 'BuildTarget',
             args.extend(linker.get_allow_undefined_link_args())
 
     try:
-        crt_val = env.coredata.get_option_for_target(target, 'b_vscrt')
+        crt_val = env.coredata.optstore.get_option_for_target(target, 'b_vscrt')
         assert isinstance(crt_val, str)
         try:
             crtargs = linker.get_crt_link_args(crt_val)
@@ -1685,7 +1685,7 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
         if isinstance(key, str):
             key = self.form_compileropt_key(key)
         if target:
-            return self.environment.coredata.get_option_for_target(target, key)
+            return self.environment.coredata.optstore.get_option_for_target(target, key)
         else:
             return self.environment.coredata.optstore.get_value_for(key.evolve(subproject=subproject))
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -247,40 +247,37 @@ def are_asserts_disabled(target: 'BuildTarget', env: 'Environment') -> bool:
     :return: whether to disable assertions or not
     """
     key = OptionKey('b_ndebug', target.subproject, target.for_machine)
-    return (env.coredata.optstore.get_option_for_target(target, key, str) == 'true' or
-            (env.coredata.optstore.get_option_for_target(target, key, str) == 'if-release' and
+    n_debug = env.coredata.optstore.get_option_for_target(target, key, str, default='false')
+    return (n_debug == 'true' or
+            (n_debug == 'if-release' and
              env.coredata.optstore.get_option_for_target(target, key.evolve(name='buildtype'), str) in {'release', 'plain'}))
 
 
 def are_asserts_disabled_for_subproject(subproject: str, env: 'Environment') -> bool:
     key = OptionKey('b_ndebug', subproject)
-    return (env.coredata.optstore.get_value_for(key, str) == 'true' or
-            (env.coredata.optstore.get_value_for(key, str) == 'if-release' and
+    n_debug = env.coredata.optstore.get_value_for(key, str, default='false')
+    return (n_debug == 'true' or
+            (n_debug == 'if-release' and
              env.coredata.optstore.get_value_for(key.evolve(name='buildtype'), str) in {'release', 'plain'}))
 
 
 # TODO: remove use of try/except, use default= instead
 def get_base_compile_args(target: 'BuildTarget', compiler: 'Compiler', env: 'Environment') -> T.List[str]:
     args: T.List[str] = []
-    lto = False
-    try:
-        if env.coredata.optstore.get_option_for_target(target, OptionKey('b_lto'), bool):
-            num_threads = env.coredata.optstore.get_option_for_target(target, OptionKey('b_lto_threads'), int, default=0)
-            ltomode = env.coredata.optstore.get_option_for_target(target, OptionKey('b_lto_mode'), str, default='default')
-            args.extend(compiler.get_lto_compile_args(
-                target=target,
-                threads=num_threads,
-                mode=ltomode))
-            lto = True
-    except (KeyError, AttributeError):
-        pass
-    try:
-        clrout = env.coredata.optstore.get_option_for_target(target, OptionKey('b_colorout'), str)
+    lto = env.coredata.optstore.get_option_for_target(target, OptionKey('b_lto'), bool, default=False)
+    if lto:
+        num_threads = env.coredata.optstore.get_option_for_target(target, OptionKey('b_lto_threads'), int, default=0)
+        ltomode = env.coredata.optstore.get_option_for_target(target, OptionKey('b_lto_mode'), str, default='default')
+        args.extend(compiler.get_lto_compile_args(
+            target=target,
+            threads=num_threads,
+            mode=ltomode))
+
+    if (clrout := env.coredata.optstore.get_option_for_target(target, OptionKey('b_colorout'), str, default='')) != '':
         args += compiler.get_colorout_args(clrout)
-    except KeyError:
-        pass
-    try:
-        sanitize = env.coredata.optstore.get_option_for_target(target, OptionKey('b_sanitize'), list)
+
+    sanitize = env.coredata.optstore.get_option_for_target(target, OptionKey('b_sanitize'), list, default=['sentinel'])
+    if sanitize != ['sentinel']:
         if sanitize == ['none']:
             sanitize = []
         sanitize_args = compiler.sanitizer_compile_args(target, sanitize)
@@ -290,37 +287,30 @@ def get_base_compile_args(target: 'BuildTarget', compiler: 'Compiler', env: 'Env
             if not compiler.has_multi_arguments(sanitize_args)[0]:
                 raise MesonException(f'Compiler {compiler.name_string()} does not support sanitizer arguments {sanitize_args}')
             args.extend(sanitize_args)
-    except KeyError:
-        pass
-    try:
-        pgo_val = env.coredata.optstore.get_option_for_target(target, OptionKey('b_pgo'), str)
-        if pgo_val == 'generate':
-            args.extend(compiler.get_profile_generate_args())
-        elif pgo_val == 'use':
-            args.extend(compiler.get_profile_use_args())
-    except (KeyError, AttributeError):
-        pass
-    try:
-        if env.coredata.optstore.get_option_for_target(target, OptionKey('b_coverage'), bool):
-            args += compiler.get_coverage_args()
-    except (KeyError, AttributeError):
-        pass
-    try:
-        args += compiler.get_assert_args(are_asserts_disabled(target, env))
-    except KeyError:
-        pass
+
+    pgo_val = env.coredata.optstore.get_option_for_target(target, OptionKey('b_pgo'), str, default='')
+    if pgo_val == 'generate':
+        args.extend(compiler.get_profile_generate_args())
+    elif pgo_val == 'use':
+        args.extend(compiler.get_profile_use_args())
+
+    if env.coredata.optstore.get_option_for_target(target, OptionKey('b_coverage'), bool, default=False):
+        args += compiler.get_coverage_args()
+
+    args += compiler.get_assert_args(are_asserts_disabled(target, env))
+
     # This does not need a try...except
     bitcode = env.coredata.optstore.get_option_for_target(target, OptionKey('b_bitcode'), bool, default=False)
     args.extend(compiler.get_embed_bitcode_args(bitcode, lto))
-    try:
-        crt_val = env.coredata.optstore.get_option_for_target(target, OptionKey('b_vscrt'), str)
-        # TODO: Is this attributeError posible?
+
+    if crt_val := env.coredata.optstore.get_option_for_target(target, OptionKey('b_vscrt'), str, default=''):
+        # We must try except here because `b_vscrt` is a global option, but
+        # while b_vscrt can be true a language my not support it.
         try:
             args += compiler.get_crt_compile_args(crt_val)
         except EnvironmentException:
             pass
-    except KeyError:
-        pass
+
     return args
 
 def get_base_link_args(target: 'BuildTarget',
@@ -330,28 +320,27 @@ def get_base_link_args(target: 'BuildTarget',
     build_dir = env.get_build_dir()
     if env.coredata.optstore.get_option_for_target(target, OptionKey('werror'), bool):
         args.extend(linker.get_linker_fatal_warnings())
-    try:
-        if env.coredata.optstore.get_option_for_target(target, OptionKey('b_lto'), bool, default=False):
-            thinlto_cache_dir = None
-            cachedir_key = OptionKey('b_thinlto_cache')
-            if env.coredata.optstore.get_option_for_target(target, cachedir_key, bool, default=False):
-                thinlto_cache_dir = env.coredata.optstore.get_option_for_target(target, OptionKey('b_thinlto_cache_dir'), str, default='')
-                if thinlto_cache_dir == '':
-                    thinlto_cache_dir = os.path.join(build_dir, 'meson-private', 'thinlto-cache')
-                    os.mkdir(thinlto_cache_dir)
-            num_threads = env.coredata.optstore.get_option_for_target(target, OptionKey('b_lto_threads'), int, default=0)
-            lto_mode = env.coredata.optstore.get_option_for_target(target, OptionKey('b_lto_mode'), str, default='default')
-            args.extend(linker.get_lto_link_args(
-                target=target,
-                threads=num_threads,
-                mode=lto_mode,
-                thinlto_cache_dir=thinlto_cache_dir))
-            obj_cache_path = os.path.join('@PRIVATE_DIR@', "lto.o")
-            args.extend(linker.get_lto_obj_cache_path(obj_cache_path))
-    except (KeyError, AttributeError):
-        pass
-    try:
-        sanitizer = env.coredata.optstore.get_option_for_target(target, OptionKey('b_sanitize'), list)
+
+    if env.coredata.optstore.get_option_for_target(target, OptionKey('b_lto'), bool, default=False):
+        thinlto_cache_dir = None
+        cachedir_key = OptionKey('b_thinlto_cache')
+        if env.coredata.optstore.get_option_for_target(target, cachedir_key, bool, default=False):
+            thinlto_cache_dir = env.coredata.optstore.get_option_for_target(target, OptionKey('b_thinlto_cache_dir'), str, default='')
+            if thinlto_cache_dir == '':
+                thinlto_cache_dir = os.path.join(build_dir, 'meson-private', 'thinlto-cache')
+                os.mkdir(thinlto_cache_dir)
+        num_threads = env.coredata.optstore.get_option_for_target(target, OptionKey('b_lto_threads'), int, default=0)
+        lto_mode = env.coredata.optstore.get_option_for_target(target, OptionKey('b_lto_mode'), str, default='default')
+        args.extend(linker.get_lto_link_args(
+            target=target,
+            threads=num_threads,
+            mode=lto_mode,
+            thinlto_cache_dir=thinlto_cache_dir))
+        obj_cache_path = os.path.join('@PRIVATE_DIR@', "lto.o")
+        args.extend(linker.get_lto_obj_cache_path(obj_cache_path))
+
+    sanitizer = env.coredata.optstore.get_option_for_target(target, OptionKey('b_sanitize'), list, default=['sentinel'])
+    if sanitizer != ['sentinel']:
         if sanitizer == ['none']:
             sanitizer = []
         sanitizer_args = linker.sanitizer_link_args(target, sanitizer)
@@ -361,21 +350,15 @@ def get_base_link_args(target: 'BuildTarget',
             if not linker.has_multi_link_arguments(sanitizer_args, False)[0]:
                 raise MesonException(f'Linker {linker.name_string()} does not support sanitizer arguments {sanitizer_args}')
             args.extend(sanitizer_args)
-    except KeyError:
-        pass
-    try:
-        pgo_val = env.coredata.optstore.get_option_for_target(target, OptionKey('b_pgo'), str)
-        if pgo_val == 'generate':
-            args.extend(linker.get_profile_generate_args())
-        elif pgo_val == 'use':
-            args.extend(linker.get_profile_use_args())
-    except (KeyError, AttributeError):
-        pass
-    try:
-        if env.coredata.optstore.get_option_for_target(target, OptionKey('b_coverage'), bool):
-            args += linker.get_coverage_link_args()
-    except (KeyError, AttributeError):
-        pass
+
+    pgo_val = env.coredata.optstore.get_option_for_target(target, OptionKey('b_pgo'), str, default='')
+    if pgo_val == 'generate':
+        args.extend(linker.get_profile_generate_args())
+    elif pgo_val == 'use':
+        args.extend(linker.get_profile_use_args())
+
+    if env.coredata.optstore.get_option_for_target(target, OptionKey('b_coverage'), bool, default=False):
+        args += linker.get_coverage_link_args()
 
     as_needed = env.coredata.optstore.get_option_for_target(target, OptionKey('b_asneeded'), bool, default=False)
     bitcode = env.coredata.optstore.get_option_for_target(target, OptionKey('b_bitcode'), bool, default=False)
@@ -398,14 +381,14 @@ def get_base_link_args(target: 'BuildTarget',
         else:
             args.extend(linker.get_allow_undefined_link_args())
 
-    try:
-        crt_val = env.coredata.optstore.get_option_for_target(target, OptionKey('b_vscrt'), str)
+    if crt_val := env.coredata.optstore.get_option_for_target(target, OptionKey('b_vscrt'), str, default=''):
+        # We must try except here because `b_vscrt` is a global option, but
+        # while b_vscrt can be true a language my not support it.
         try:
             args += linker.get_crt_link_args(crt_val)
         except EnvironmentException:
             pass
-    except KeyError:
-        pass
+
     return args
 
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -239,18 +239,6 @@ clike_debug_args: T.Dict[bool, T.List[str]] = {
 }
 
 
-# TODO: Can we delete this?
-def option_enabled(boptions: T.Set[OptionKey],
-                   target: 'BuildTarget',
-                   env: 'Environment',
-                   option: T.Union[str, OptionKey]) -> bool:
-    if isinstance(option, str):
-        option = OptionKey(option)
-    if option not in boptions:
-        return False
-    return env.coredata.optstore.get_option_for_target(target, option, bool, default=False)
-
-
 def are_asserts_disabled(target: 'BuildTarget', env: 'Environment') -> bool:
     """Should debug assertions be disabled
 
@@ -322,7 +310,7 @@ def get_base_compile_args(target: 'BuildTarget', compiler: 'Compiler', env: 'Env
     except KeyError:
         pass
     # This does not need a try...except
-    bitcode = option_enabled(compiler.base_options, target, env, 'b_bitcode')
+    bitcode = env.coredata.optstore.get_option_for_target(target, OptionKey('b_bitcode'), bool, default=False)
     args.extend(compiler.get_embed_bitcode_args(bitcode, lto))
     try:
         crt_val = env.coredata.optstore.get_option_for_target(target, OptionKey('b_vscrt'), str)
@@ -389,8 +377,8 @@ def get_base_link_args(target: 'BuildTarget',
     except (KeyError, AttributeError):
         pass
 
-    as_needed = option_enabled(linker.base_options, target, env, 'b_asneeded')
-    bitcode = option_enabled(linker.base_options, target, env, 'b_bitcode')
+    as_needed = env.coredata.optstore.get_option_for_target(target, OptionKey('b_asneeded'), bool, default=False)
+    bitcode = env.coredata.optstore.get_option_for_target(target, OptionKey('b_bitcode'), bool, default=False)
     # Shared modules cannot be built with bitcode_bundle because
     # -bitcode_bundle is incompatible with -undefined and -bundle
     if bitcode and not target.typename == 'shared module':
@@ -405,7 +393,7 @@ def get_base_link_args(target: 'BuildTarget',
         from ..build import SharedModule
         args.extend(linker.headerpad_args())
         if (not isinstance(target, SharedModule) and
-                option_enabled(linker.base_options, target, env, 'b_lundef')):
+                env.coredata.optstore.get_option_for_target(target, OptionKey('b_lundef'), bool, default=False)):
             args.extend(linker.no_undefined_link_args())
         else:
             args.extend(linker.get_allow_undefined_link_args())

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -804,7 +804,7 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
     def get_option_link_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         # need a typeddict for this
-        key = self.form_compileropt_key('winlibs').evolve(subproject=subproject)
+        key = self.form_compileropt_key('winlibs', subproject)
         if target:
             value = self.environment.coredata.optstore.get_option_for_target_untyped(target, key)
         else:
@@ -897,7 +897,7 @@ class CPP11AsCPP14Mixin(CompilerMixinBase):
         # which means setting the C++ standard version to C++14, in compilers that support it
         # (i.e., after VS2015U3)
         # if one is using anything before that point, one cannot set the standard.
-        stdkey = self.form_compileropt_key('std').evolve(subproject=subproject)
+        stdkey = self.form_compileropt_key('std', subproject)
         if target is not None:
             std = self.environment.coredata.optstore.get_option_for_target_untyped(target, stdkey)
         else:

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -791,7 +791,7 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
         # need a typeddict for this
         key = self.form_compileropt_key('winlibs').evolve(subproject=subproject)
         if target:
-            value = self.environment.coredata.get_option_for_target(target, key)
+            value = self.environment.coredata.optstore.get_option_for_target(target, key)
         else:
             value = self.environment.coredata.optstore.get_value_for(key)
         return T.cast('T.List[str]', value)[:]
@@ -881,7 +881,7 @@ class CPP11AsCPP14Mixin(CompilerMixinBase):
         # if one is using anything before that point, one cannot set the standard.
         stdkey = self.form_compileropt_key('std').evolve(subproject=subproject)
         if target is not None:
-            std = self.environment.coredata.get_option_for_target(target, stdkey)
+            std = self.environment.coredata.optstore.get_option_for_target(target, stdkey)
         else:
             std = self.environment.coredata.optstore.get_value_for(stdkey)
         if std in {'vc++11', 'c++11'}:

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -265,13 +265,12 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCPPStds, ClangCompiler, CPPCompiler
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
 
-        rtti = self.get_compileropt_value('rtti', target, subproject)
-        debugstl = self.get_compileropt_value('debugstl', target, subproject)
-        eh = self.get_compileropt_value('eh', target, subproject)
-
-        assert isinstance(rtti, bool)
-        assert isinstance(eh, str)
-        assert isinstance(debugstl, bool)
+        key = self.form_compileropt_key('rtti', subproject)
+        rtti = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, bool)
+        key = self.form_compileropt_key('debugstl', subproject)
+        debugstl = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, bool)
+        key = self.form_compileropt_key('eh', subproject)
+        eh = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
 
         non_msvc_eh_options(eh, args)
 
@@ -293,8 +292,8 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCPPStds, ClangCompiler, CPPCompiler
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append(self._find_best_cpp_std(std))
         return args
@@ -302,13 +301,8 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCPPStds, ClangCompiler, CPPCompiler
     def get_option_link_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         if self.info.is_windows() or self.info.is_cygwin():
             target, subproject = self._get_subproject_and_target(target)
-            # without a typedict mypy can't understand this.
-            retval = self.get_compileropt_value('winlibs', target, subproject)
-            assert isinstance(retval, list)
-            libs = retval[:]
-            for l in libs:
-                assert isinstance(l, str)
-            return libs
+            key = self.form_compileropt_key('winlibs', subproject)
+            return self.environment.coredata.optstore.get_option_for_maybe_target(target, key, list).copy()
         return []
 
     def get_assert_args(self, disable: bool) -> T.List[str]:
@@ -372,8 +366,8 @@ class EmscriptenCPPCompiler(EmscriptenMixin, ClangCPPCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append(self._find_best_cpp_std(std))
         return args
@@ -416,13 +410,13 @@ class ArmclangCPPCompiler(ArmclangCompiler, CPPCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append('-std=' + std)
 
-        eh = self.get_compileropt_value('eh', target, subproject)
-        assert isinstance(eh, str)
+        key = self.form_compileropt_key('eh', subproject)
+        eh = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         non_msvc_eh_options(eh, args)
 
         return args
@@ -490,13 +484,12 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCPPStds, GnuCompiler, CPPCompiler):
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
 
-        rtti = self.get_compileropt_value('rtti', target, subproject)
-        debugstl = self.get_compileropt_value('debugstl', target, subproject)
-        eh = self.get_compileropt_value('eh', target, subproject)
-
-        assert isinstance(rtti, bool)
-        assert isinstance(eh, str)
-        assert isinstance(debugstl, bool)
+        key = self.form_compileropt_key('rtti', subproject)
+        rtti = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, bool)
+        key = self.form_compileropt_key('debugstl', subproject)
+        debugstl = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, bool)
+        key = self.form_compileropt_key('eh', subproject)
+        eh = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
 
         non_msvc_eh_options(eh, args)
 
@@ -511,8 +504,8 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCPPStds, GnuCompiler, CPPCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append(self._find_best_cpp_std(std))
         return args
@@ -520,13 +513,8 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCPPStds, GnuCompiler, CPPCompiler):
     def get_option_link_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         if self.info.is_windows() or self.info.is_cygwin():
-            # without a typedict mypy can't understand this.
-            retval = self.get_compileropt_value('winlibs', target, subproject)
-            assert isinstance(retval, list)
-            libs: T.List[str] = retval[:]
-            for l in libs:
-                assert isinstance(l, str)
-            return libs
+            key = self.form_compileropt_key('winlibs', subproject)
+            return self.environment.coredata.optstore.get_option_for_maybe_target(target, key, list).copy()
         return []
 
     def get_assert_args(self, disable: bool) -> T.List[str]:
@@ -593,8 +581,8 @@ class NvidiaHPC_CPPCompiler(PGICompiler, CPPCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append(self._find_best_cpp_std(std))
         return args
@@ -663,13 +651,12 @@ class ElbrusCPPCompiler(ElbrusCompiler, CPPCompiler):
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
 
-        eh = self.get_compileropt_value('eh', target, subproject)
-        assert isinstance(eh, str)
-
+        key = self.form_compileropt_key('eh', subproject)
+        eh = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         non_msvc_eh_options(eh, args)
 
-        debugstl = self.get_compileropt_value('debugstl', target, subproject)
-        assert isinstance(debugstl, bool)
+        key = self.form_compileropt_key('debugstl', subproject)
+        debugstl = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, bool)
         if debugstl:
             args.append('-D_GLIBCXX_DEBUG=1')
         return args
@@ -677,8 +664,8 @@ class ElbrusCPPCompiler(ElbrusCompiler, CPPCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append(self._find_best_cpp_std(std))
         return args
@@ -744,9 +731,12 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
 
-        rtti = self.get_compileropt_value('rtti', target, subproject)
-        debugstl = self.get_compileropt_value('debugstl', target, subproject)
-        eh = self.get_compileropt_value('eh', target, subproject)
+        key = self.form_compileropt_key('rtti', subproject)
+        rtti = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, bool)
+        key = self.form_compileropt_key('debugstl', subproject)
+        debugstl = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, bool)
+        key = self.form_compileropt_key('eh', subproject)
+        eh = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
 
         assert isinstance(rtti, bool)
         assert isinstance(eh, str)
@@ -763,8 +753,8 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             remap_cpp03 = {
                 'c++03': 'c++98',
@@ -849,11 +839,10 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
 
-        eh = self.get_compileropt_value('eh', target, subproject)
-        rtti = self.get_compileropt_value('rtti', target, subproject)
-
-        assert isinstance(rtti, bool)
-        assert isinstance(eh, str)
+        key = self.form_compileropt_key('rtti', subproject)
+        rtti = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, bool)
+        key = self.form_compileropt_key('eh', subproject)
+        eh = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
 
         if eh == 'default':
             args.append('/EHsc')
@@ -870,8 +859,8 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
 
         permissive, ver = self.VC_VERSION_MAP[std]
         if ver is not None:
@@ -945,7 +934,8 @@ class VisualStudioCPPCompiler(CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixi
 
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
-        std = self.get_compileropt_value('std', target, subproject)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none' and version_compare(self.version, '<19.00.24210'):
             mlog.warning('This version of MSVC does not support cpp_std arguments', fatal=False)
 
@@ -980,8 +970,8 @@ class ClangClCPPCompiler(VisualStudioLikeCPPCompilerMixin, ClangClCompiler, CPPC
 
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std == 'none':
             return []
         # c++latest and vc++latest have no /clang:-std= equivalent
@@ -1049,8 +1039,8 @@ class ArmCPPCompiler(ArmCompiler, CPPCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std == 'c++11':
             args.append('--cpp11')
         elif std == 'c++03':
@@ -1107,8 +1097,8 @@ class TICPPCompiler(TICompiler, CPPCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append('--' + std)
         return args
@@ -1147,8 +1137,8 @@ class MetrowerksCPPCompilerARM(MetrowerksCompiler, CPPCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append('-lang')
             args.append(std)
@@ -1175,8 +1165,8 @@ class MetrowerksCPPCompilerEmbeddedPowerPC(MetrowerksCompiler, CPPCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append('-lang ' + std)
         return args

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -39,7 +39,7 @@ if T.TYPE_CHECKING:
     from ..dependencies import Dependency
     from ..environment import Environment
     from ..linkers.linkers import DynamicLinker
-    from ..mesonlib import MachineChoice
+    from ..mesonlib import MachineChoice, SubProject
     from ..build import BuildTarget
     CompilerMixinBase = CLikeCompiler
 else:
@@ -261,7 +261,8 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCPPStds, ClangCompiler, CPPCompiler
                 gnu_winlibs)
         return opts
 
-    def get_option_compile_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_compile_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
 
         rtti = self.get_compileropt_value('rtti', target, subproject)
@@ -289,7 +290,8 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCPPStds, ClangCompiler, CPPCompiler
 
         return args
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
@@ -297,8 +299,9 @@ class ClangCPPCompiler(_StdCPPLibMixin, ClangCPPStds, ClangCompiler, CPPCompiler
             args.append(self._find_best_cpp_std(std))
         return args
 
-    def get_option_link_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_link_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         if self.info.is_windows() or self.info.is_cygwin():
+            target, subproject = self._get_subproject_and_target(target)
             # without a typedict mypy can't understand this.
             retval = self.get_compileropt_value('winlibs', target, subproject)
             assert isinstance(retval, list)
@@ -366,7 +369,8 @@ class EmscriptenCPPCompiler(EmscriptenMixin, ClangCPPCompiler):
         ClangCPPCompiler.__init__(self, ccache, exelist, version, for_machine, env,
                                   linker=linker, defines=defines, full_version=full_version)
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
@@ -409,7 +413,8 @@ class ArmclangCPPCompiler(ArmclangCompiler, CPPCompiler):
         std_opt.set_versions(['c++98', 'c++03', 'c++11', 'c++14', 'c++17'], gnu=True)
         return opts
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
@@ -422,7 +427,7 @@ class ArmclangCPPCompiler(ArmclangCompiler, CPPCompiler):
 
         return args
 
-    def get_option_link_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_link_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         return []
 
 
@@ -481,7 +486,8 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCPPStds, GnuCompiler, CPPCompiler):
 
         return opts
 
-    def get_option_compile_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_compile_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
 
         rtti = self.get_compileropt_value('rtti', target, subproject)
@@ -502,7 +508,8 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCPPStds, GnuCompiler, CPPCompiler):
             args.append('-D_GLIBCXX_DEBUG=1')
         return args
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
@@ -510,7 +517,8 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCPPStds, GnuCompiler, CPPCompiler):
             args.append(self._find_best_cpp_std(std))
         return args
 
-    def get_option_link_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_link_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         if self.info.is_windows() or self.info.is_cygwin():
             # without a typedict mypy can't understand this.
             retval = self.get_compileropt_value('winlibs', target, subproject)
@@ -582,7 +590,8 @@ class NvidiaHPC_CPPCompiler(PGICompiler, CPPCompiler):
         std_opt.set_versions(cppstd_choices)
         return opts
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
@@ -650,8 +659,10 @@ class ElbrusCPPCompiler(ElbrusCompiler, CPPCompiler):
         return super().has_function(funcname, prefix, extra_args=extra_args, dependencies=dependencies)
 
     # Elbrus C++ compiler does not support RTTI, so don't check for it.
-    def get_option_compile_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_compile_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
+
         eh = self.get_compileropt_value('eh', target, subproject)
         assert isinstance(eh, str)
 
@@ -663,7 +674,8 @@ class ElbrusCPPCompiler(ElbrusCompiler, CPPCompiler):
             args.append('-D_GLIBCXX_DEBUG=1')
         return args
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
@@ -728,7 +740,8 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
         self._update_language_stds(opts, c_stds + g_stds)
         return opts
 
-    def get_option_compile_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_compile_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
 
         rtti = self.get_compileropt_value('rtti', target, subproject)
@@ -747,7 +760,8 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
             args.append('-D_GLIBCXX_DEBUG=1')
         return args
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
@@ -760,7 +774,7 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
 
         return args
 
-    def get_option_link_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_link_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         return []
 
 
@@ -787,7 +801,8 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
         'c++latest': (False, "latest"),
     }
 
-    def get_option_link_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_link_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         # need a typeddict for this
         key = self.form_compileropt_key('winlibs').evolve(subproject=subproject)
         if target:
@@ -830,7 +845,8 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
                                                 choices=['false', 'true'])
         return opts
 
-    def get_option_compile_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_compile_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
 
         eh = self.get_compileropt_value('eh', target, subproject)
@@ -851,7 +867,8 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
 
         return args
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
@@ -874,7 +891,8 @@ class CPP11AsCPP14Mixin(CompilerMixinBase):
     This is a limitation of Clang and MSVC that ICL doesn't share.
     """
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         # Note: there is no explicit flag for supporting C++11; we attempt to do the best we can
         # which means setting the C++ standard version to C++14, in compilers that support it
         # (i.e., after VS2015U3)
@@ -888,7 +906,8 @@ class CPP11AsCPP14Mixin(CompilerMixinBase):
             mlog.warning(self.id, 'does not support C++11;',
                          'attempting best effort; setting the standard to C++14',
                          once=True, fatal=False)
-        original_args = super().get_option_std_args(target, subproject)
+
+        original_args = super().get_option_std_args(target if target is not None else subproject)
         std_mapping = {'/std:c++11': '/std:c++14'}
         processed_args = [std_mapping.get(x, x) for x in original_args]
         return processed_args
@@ -924,12 +943,13 @@ class VisualStudioCPPCompiler(CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixi
             cpp_stds.extend(['c++20', 'vc++20'])
         return self._get_options_impl(super().get_options(), cpp_stds)
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         std = self.get_compileropt_value('std', target, subproject)
         if std != 'none' and version_compare(self.version, '<19.00.24210'):
             mlog.warning('This version of MSVC does not support cpp_std arguments', fatal=False)
 
-        args = super().get_option_std_args(target, subproject)
+        args = super().get_option_std_args(target if target is not None else subproject)
 
         if version_compare(self.version, '<19.11'):
             try:
@@ -958,7 +978,8 @@ class ClangClCPPCompiler(VisualStudioLikeCPPCompilerMixin, ClangClCompiler, CPPC
         cpp_stds = list(self.VC_VERSION_MAP) + ['c++23', 'vc++23']
         return self._get_options_impl(super().get_options(), cpp_stds)
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
         if std == 'none':
@@ -1025,7 +1046,8 @@ class ArmCPPCompiler(ArmCompiler, CPPCompiler):
         std_opt.set_versions(['c++03', 'c++11'])
         return opts
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
@@ -1035,7 +1057,7 @@ class ArmCPPCompiler(ArmCompiler, CPPCompiler):
             args.append('--cpp')
         return args
 
-    def get_option_link_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_link_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         return []
 
     def get_compiler_check_args(self, mode: CompileCheckMode) -> T.List[str]:
@@ -1060,7 +1082,7 @@ class CcrxCPPCompiler(CcrxCompiler, CPPCompiler):
     def get_output_args(self, outputname: str) -> T.List[str]:
         return [f'-output=obj={outputname}']
 
-    def get_option_link_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_link_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         return []
 
     def get_compiler_check_args(self, mode: CompileCheckMode) -> T.List[str]:
@@ -1082,7 +1104,8 @@ class TICPPCompiler(TICompiler, CPPCompiler):
         std_opt.set_versions(['c++03'])
         return opts
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
@@ -1093,7 +1116,7 @@ class TICPPCompiler(TICompiler, CPPCompiler):
     def get_always_args(self) -> T.List[str]:
         return []
 
-    def get_option_link_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_link_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         return []
 
 class C2000CPPCompiler(TICPPCompiler):
@@ -1121,7 +1144,8 @@ class MetrowerksCPPCompilerARM(MetrowerksCompiler, CPPCompiler):
         self._update_language_stds(opts, [])
         return opts
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
@@ -1148,7 +1172,8 @@ class MetrowerksCPPCompilerEmbeddedPowerPC(MetrowerksCompiler, CPPCompiler):
         self._update_language_stds(opts, [])
         return opts
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -795,11 +795,8 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
         target, subproject = self._get_subproject_and_target(target)
         # need a typeddict for this
         key = self.form_compileropt_key('winlibs', subproject)
-        if target:
-            value = self.environment.coredata.optstore.get_option_for_target_untyped(target, key)
-        else:
-            value = self.environment.coredata.optstore.get_value_for_untyped(key)
-        return T.cast('T.List[str]', value)[:]
+        value = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, list)
+        return value.copy()
 
     def _get_options_impl(self, opts: 'MutableKeyedOptionDictType', cpp_stds: T.List[str]) -> 'MutableKeyedOptionDictType':
         opts = super().get_options()
@@ -887,10 +884,7 @@ class CPP11AsCPP14Mixin(CompilerMixinBase):
         # (i.e., after VS2015U3)
         # if one is using anything before that point, one cannot set the standard.
         stdkey = self.form_compileropt_key('std', subproject)
-        if target is not None:
-            std = self.environment.coredata.optstore.get_option_for_target_untyped(target, stdkey)
-        else:
-            std = self.environment.coredata.optstore.get_value_for_untyped(stdkey)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, stdkey, str)
         if std in {'vc++11', 'c++11'}:
             mlog.warning(self.id, 'does not support C++11;',
                          'attempting best effort; setting the standard to C++14',

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -791,9 +791,9 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
         # need a typeddict for this
         key = self.form_compileropt_key('winlibs').evolve(subproject=subproject)
         if target:
-            value = self.environment.coredata.optstore.get_option_for_target(target, key)
+            value = self.environment.coredata.optstore.get_option_for_target_untyped(target, key)
         else:
-            value = self.environment.coredata.optstore.get_value_for(key)
+            value = self.environment.coredata.optstore.get_value_for_untyped(key)
         return T.cast('T.List[str]', value)[:]
 
     def _get_options_impl(self, opts: 'MutableKeyedOptionDictType', cpp_stds: T.List[str]) -> 'MutableKeyedOptionDictType':
@@ -881,9 +881,9 @@ class CPP11AsCPP14Mixin(CompilerMixinBase):
         # if one is using anything before that point, one cannot set the standard.
         stdkey = self.form_compileropt_key('std').evolve(subproject=subproject)
         if target is not None:
-            std = self.environment.coredata.optstore.get_option_for_target(target, stdkey)
+            std = self.environment.coredata.optstore.get_option_for_target_untyped(target, stdkey)
         else:
-            std = self.environment.coredata.optstore.get_value_for(stdkey)
+            std = self.environment.coredata.optstore.get_value_for_untyped(stdkey)
         if std in {'vc++11', 'c++11'}:
             mlog.warning(self.id, 'does not support C++11;',
                          'attempting best effort; setting the standard to C++14',

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -753,7 +753,7 @@ class CudaCompiler(Compiler):
                         subproject: T.Optional[str] = None) -> T.List[str]:
         key = self.form_compileropt_key('ccbindir').evolve(subproject=subproject)
         if target:
-            ccbindir = self.environment.coredata.get_option_for_target(target, key)
+            ccbindir = self.environment.coredata.optstore.get_option_for_target(target, key)
         else:
             ccbindir = self.environment.coredata.optstore.get_value_for(key)
         if isinstance(ccbindir, str) and ccbindir != '':

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -758,14 +758,11 @@ class CudaCompiler(Compiler):
                         subproject: T.Optional[SubProject] = None) -> T.List[str]:
         subproject = target.subproject if subproject is None else subproject
         key = self.form_compileropt_key('ccbindir', subproject)
-        if target:
-            ccbindir = self.environment.coredata.optstore.get_option_for_target_untyped(target, key)
-        else:
-            ccbindir = self.environment.coredata.optstore.get_value_for_untyped(key)
-        if isinstance(ccbindir, str) and ccbindir != '':
+        ccbindir = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
+
+        if ccbindir != '':
             return [self._shield_nvcc_list_arg('-ccbin='+ccbindir, False)]
-        else:
-            return []
+        return []
 
     def get_profile_generate_args(self) -> T.List[str]:
         return ['-Xcompiler=' + x for x in self.host_compiler.get_profile_generate_args()]

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -753,9 +753,9 @@ class CudaCompiler(Compiler):
                         subproject: T.Optional[str] = None) -> T.List[str]:
         key = self.form_compileropt_key('ccbindir').evolve(subproject=subproject)
         if target:
-            ccbindir = self.environment.coredata.optstore.get_option_for_target(target, key)
+            ccbindir = self.environment.coredata.optstore.get_option_for_target_untyped(target, key)
         else:
-            ccbindir = self.environment.coredata.optstore.get_value_for(key)
+            ccbindir = self.environment.coredata.optstore.get_value_for_untyped(key)
         if isinstance(ccbindir, str) and ccbindir != '':
             return [self._shield_nvcc_list_arg('-ccbin='+ccbindir, False)]
         else:

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -625,8 +625,8 @@ class CudaCompiler(Compiler):
         # the combination of CUDA version and MSVC version; the --std= is thus ignored
         # and attempting to use it will result in a warning: https://stackoverflow.com/a/51272091/741027
         if not is_windows():
-            std = self.get_compileropt_value('std', target, subproject)
-            assert isinstance(std, str)
+            key = self.form_compileropt_key('std', subproject)
+            std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
             if std != 'none':
                 return ['--std=' + std]
 

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -18,7 +18,7 @@ if T.TYPE_CHECKING:
     from ..dependencies import Dependency
     from ..environment import Environment  # noqa: F401
     from ..linkers.linkers import DynamicLinker
-    from ..mesonlib import MachineChoice
+    from ..mesonlib import MachineChoice, SubProject
 
 
 cuda_optimization_args: T.Dict[str, T.List[str]] = {
@@ -609,16 +609,18 @@ class CudaCompiler(Compiler):
 
         return opts
 
-    def get_option_compile_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_compile_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args = self._get_ccbin_args(target, subproject)
 
         try:
-            host_compiler_args = self.host_compiler.get_option_compile_args(target, subproject)
+            host_compiler_args = self.host_compiler.get_option_compile_args(target)
         except KeyError:
             host_compiler_args = []
         return args + self._to_host_flags(host_compiler_args)
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         # On Windows, the version of the C++ standard used by nvcc is dictated by
         # the combination of CUDA version and MSVC version; the --std= is thus ignored
         # and attempting to use it will result in a warning: https://stackoverflow.com/a/51272091/741027
@@ -629,14 +631,17 @@ class CudaCompiler(Compiler):
                 return ['--std=' + std]
 
         try:
-            host_compiler_args = self.host_compiler.get_option_std_args(target, subproject)
+            host_compiler_args = self.host_compiler.get_option_std_args(
+                target if target is not None else subproject)
         except KeyError:
             host_compiler_args = []
         return self._to_host_flags(host_compiler_args)
 
-    def get_option_link_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_link_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args = self._get_ccbin_args(target, subproject)
-        return args + self._to_host_flags(self.host_compiler.get_option_link_args(target, subproject), Phase.LINKER)
+        host_args = self.host_compiler.get_option_link_args(target if target is not None else subproject)
+        return args + self._to_host_flags(host_args, Phase.LINKER)
 
     def get_soname_args(self, prefix: str, shlib_name: str, suffix: str, soversion: str,
                         darwin_versions: T.Tuple[str, str]) -> T.List[str]:

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -9,7 +9,7 @@ import string
 import typing as T
 
 from .. import options
-from ..mesonlib import is_windows, LibType, version_compare
+from ..mesonlib import is_windows, LibType, version_compare, ROOT_SUBPROJECT
 from .compilers import Compiler, CompileCheckMode, CrossNoRunException, SimplePrefixLinkerOptionStyle
 
 if T.TYPE_CHECKING:
@@ -537,7 +537,7 @@ class CudaCompiler(Compiler):
         # Use the -ccbin option, if available, even during sanity checking.
         # Otherwise, on systems where CUDA does not support the default compiler,
         # NVCC becomes unusable.
-        flags += self._get_ccbin_args(None, '')
+        flags += self._get_ccbin_args(None, ROOT_SUBPROJECT)
 
         # If cross-compiling, we can't run the sanity check, only compile it.
         if self.is_cross and not self.environment.has_exe_wrapper():
@@ -755,8 +755,9 @@ class CudaCompiler(Compiler):
         return self._to_host_flags(super().get_dependency_link_args(dep), Phase.LINKER)
 
     def _get_ccbin_args(self, target: 'T.Optional[BuildTarget]',
-                        subproject: T.Optional[str] = None) -> T.List[str]:
-        key = self.form_compileropt_key('ccbindir').evolve(subproject=subproject)
+                        subproject: T.Optional[SubProject] = None) -> T.List[str]:
+        subproject = target.subproject if subproject is None else subproject
+        key = self.form_compileropt_key('ccbindir', subproject)
         if target:
             ccbindir = self.environment.coredata.optstore.get_option_for_target_untyped(target, key)
         else:

--- a/mesonbuild/compilers/cython.py
+++ b/mesonbuild/compilers/cython.py
@@ -15,6 +15,7 @@ from .compilers import Compiler
 if T.TYPE_CHECKING:
     from ..options import MutableKeyedOptionDictType
     from ..build import BuildTarget
+    from ..mesonlib import SubProject
 
 
 class CythonCompiler(Compiler):
@@ -131,8 +132,10 @@ class CythonCompiler(Compiler):
 
         return opts
 
-    def get_option_compile_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_compile_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
+
         version = self.get_compileropt_value('version', target, subproject)
         assert isinstance(version, str)
         args.append(f'-{version}')

--- a/mesonbuild/compilers/cython.py
+++ b/mesonbuild/compilers/cython.py
@@ -58,7 +58,8 @@ class CythonCompiler(Compiler):
     def _sanity_check_filenames(self) -> T.Tuple[str, T.Optional[str], str]:
         sourcename, _, binname = super()._sanity_check_filenames()
 
-        lang = self.get_compileropt_value('language', None)
+        key = self.form_compileropt_key('language', None)
+        lang = self.environment.coredata.optstore.get_value_for(key, str)
         assert isinstance(lang, str)
 
         # This is almost certainly not good enough
@@ -70,8 +71,8 @@ class CythonCompiler(Compiler):
     def _transpiled_sanity_check_compile_args(
             self, compiler: Compiler, sourcename: str, binname: str
             ) -> T.Tuple[T.List[str], T.List[str]]:
-        version = self.get_compileropt_value('version', None)
-        assert isinstance(version, str)
+        key = self.form_compileropt_key('version', None)
+        version = self.environment.coredata.optstore.get_value_for(key, str)
 
         from ..dependencies import find_external_dependency
         with mlog.no_logging():
@@ -136,12 +137,12 @@ class CythonCompiler(Compiler):
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
 
-        version = self.get_compileropt_value('version', target, subproject)
-        assert isinstance(version, str)
+        key = self.form_compileropt_key('version', None)
+        version = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         args.append(f'-{version}')
 
-        lang = self.get_compileropt_value('language', target, subproject)
-        assert isinstance(lang, str)
+        key = self.form_compileropt_key('language', None)
+        lang = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if lang == 'cpp':
             args.append('--cplus')
         return args

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -173,7 +173,7 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
             trials = [defaults['cuda_static_linker']] + default_linkers
         elif compiler.get_argument_syntax() == 'msvc':
             trials = [defaults['vs_static_linker'], defaults['clang_cl_static_linker']]
-        elif env.machines[compiler.for_machine].is_os2() and env.coredata.optstore.get_value_for_untyped(OptionKey('os2_emxomf')):
+        elif env.machines[compiler.for_machine].is_os2() and env.coredata.optstore.get_value_for(OptionKey('os2_emxomf'), bool):
             trials = [defaults['emxomf_static_linker']] + default_linkers
         elif compiler.id == 'gcc':
             # Use gcc-ar if available; needed for LTO

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -173,7 +173,7 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
             trials = [defaults['cuda_static_linker']] + default_linkers
         elif compiler.get_argument_syntax() == 'msvc':
             trials = [defaults['vs_static_linker'], defaults['clang_cl_static_linker']]
-        elif env.machines[compiler.for_machine].is_os2() and env.coredata.optstore.get_value_for(OptionKey('os2_emxomf')):
+        elif env.machines[compiler.for_machine].is_os2() and env.coredata.optstore.get_value_for_untyped(OptionKey('os2_emxomf')):
             trials = [defaults['emxomf_static_linker']] + default_linkers
         elif compiler.id == 'gcc':
             # Use gcc-ar if available; needed for LTO

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -288,8 +288,8 @@ class GnuFortranCompiler(GnuCompiler, FortranCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append('-std=' + std)
         return args
@@ -424,9 +424,10 @@ class IntelFortranCompiler(IntelGnuLikeCompiler, FortranCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
+
         stds = {'legacy': 'none', 'f95': 'f95', 'f2003': 'f03', 'f2008': 'f08', 'f2018': 'f18'}
-        assert isinstance(std, str)
         if std != 'none':
             args.append('-stand=' + stds[std])
         return args
@@ -483,9 +484,10 @@ class IntelClFortranCompiler(IntelVisualStudioLikeCompiler, FortranCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        std = self.get_compileropt_value('std', target, subproject)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
+
         stds = {'legacy': 'none', 'f95': 'f95', 'f2003': 'f03', 'f2008': 'f08', 'f2018': 'f18'}
-        assert isinstance(std, str)
         if std != 'none':
             args.append('/stand:' + stds[std])
         return args

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -33,7 +33,7 @@ if T.TYPE_CHECKING:
     from ..dependencies import Dependency
     from ..environment import Environment
     from ..linkers.linkers import DynamicLinker
-    from ..mesonlib import MachineChoice
+    from ..mesonlib import MachineChoice, SubProject
     from ..build import BuildTarget
 
 
@@ -285,7 +285,8 @@ class GnuFortranCompiler(GnuCompiler, FortranCompiler):
         self._update_language_stds(opts, fortran_stds)
         return opts
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
@@ -420,7 +421,8 @@ class IntelFortranCompiler(IntelGnuLikeCompiler, FortranCompiler):
         self._update_language_stds(opts, ['none', 'legacy', 'f95', 'f2003', 'f2008', 'f2018'])
         return opts
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         stds = {'legacy': 'none', 'f95': 'f95', 'f2003': 'f03', 'f2008': 'f08', 'f2018': 'f18'}
@@ -478,7 +480,8 @@ class IntelClFortranCompiler(IntelVisualStudioLikeCompiler, FortranCompiler):
         self._update_language_stds(opts, ['none', 'legacy', 'f95', 'f2003', 'f2008', 'f2018'])
         return opts
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
         std = self.get_compileropt_value('std', target, subproject)
         stds = {'legacy': 'none', 'f95': 'f95', 'f2003': 'f03', 'f2008': 'f08', 'f2018': 'f18'}

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -58,7 +58,7 @@ class FortranCompiler(CLikeCompiler, Compiler):
 
     def _get_basic_compiler_args(self, mode: CompileCheckMode) -> T.Tuple[T.List[str], T.List[str]]:
         cargs = self.environment.coredata.optstore.get_external_args(self.for_machine, self.language)
-        largs = self.environment.coredata.get_external_link_args(self.for_machine, self.language)
+        largs = self.environment.coredata.optstore.get_external_link_args(self.for_machine, self.language)
         return cargs, largs
 
     def _sanity_check_source_code(self) -> str:

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -57,7 +57,7 @@ class FortranCompiler(CLikeCompiler, Compiler):
                              'that example is to see if the compiler has Fortran 2008 Block element.')
 
     def _get_basic_compiler_args(self, mode: CompileCheckMode) -> T.Tuple[T.List[str], T.List[str]]:
-        cargs = self.environment.coredata.get_external_args(self.for_machine, self.language)
+        cargs = self.environment.coredata.optstore.get_external_args(self.for_machine, self.language)
         largs = self.environment.coredata.get_external_link_args(self.for_machine, self.language)
         return cargs, largs
 

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -355,7 +355,7 @@ class CLikeCompiler(Compiler):
                 cargs += self.use_linker_args(ld_value[0], self.version)
 
             # Add LDFLAGS from the env
-            sys_ld_args = self.environment.coredata.get_external_link_args(self.for_machine, self.language)
+            sys_ld_args = self.environment.coredata.optstore.get_external_link_args(self.for_machine, self.language)
             # CFLAGS and CXXFLAGS go to both linking and compiling, but we want them
             # to only appear on the command line once. Remove dupes.
             largs += [x for x in sys_ld_args if x not in cleaned_sys_args]

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -339,7 +339,7 @@ class CLikeCompiler(Compiler):
                 pass
 
         # Add CFLAGS/CXXFLAGS/OBJCFLAGS/OBJCXXFLAGS and CPPFLAGS from the env
-        sys_args = self.environment.coredata.get_external_args(self.for_machine, self.language)
+        sys_args = self.environment.coredata.optstore.get_external_args(self.for_machine, self.language)
         if isinstance(sys_args, str):
             sys_args = [sys_args]
         # Apparently it is a thing to inject linker flags both
@@ -1202,7 +1202,7 @@ class CLikeCompiler(Compiler):
         commands = self.get_exelist(ccache=False) + ['-v', '-E', '-']
         commands += self.get_always_args()
         # Add CFLAGS/CXXFLAGS/OBJCFLAGS/OBJCXXFLAGS from the env
-        commands += self.environment.coredata.get_external_args(self.for_machine, self.language)
+        commands += self.environment.coredata.optstore.get_external_args(self.for_machine, self.language)
         mlog.debug('Finding framework path by running: ', ' '.join(commands), '\n')
         os_env = os.environ.copy()
         os_env['LC_ALL'] = 'C'

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -331,7 +331,7 @@ class CLikeCompiler(Compiler):
             # linking with static libraries since MSVC won't select a CRT for
             # us in that case and will error out asking us to pick one.
             try:
-                crt_val = self.environment.coredata.optstore.get_value_for('b_vscrt')
+                crt_val = self.environment.coredata.optstore.get_value_for_untyped('b_vscrt')
                 assert isinstance(crt_val, str), 'for mypy'
                 cargs += self.get_crt_compile_args(crt_val)
                 largs += self.get_crt_link_args(crt_val)

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -27,6 +27,7 @@ from ... import mesonlib
 from ... import mlog
 from ...linkers.linkers import GnuLikeDynamicLinkerMixin, SolarisDynamicLinker, CompCertDynamicLinker
 from ...mesonlib import LibType
+from ...options import OptionKey
 from .. import compilers
 from ..compilers import CompileCheckMode
 from .visualstudio import VisualStudioLikeCompiler
@@ -331,8 +332,7 @@ class CLikeCompiler(Compiler):
             # linking with static libraries since MSVC won't select a CRT for
             # us in that case and will error out asking us to pick one.
             try:
-                crt_val = self.environment.coredata.optstore.get_value_for_untyped('b_vscrt')
-                assert isinstance(crt_val, str), 'for mypy'
+                crt_val = self.environment.coredata.optstore.get_value_for(OptionKey('b_vscrt'), str)
                 cargs += self.get_crt_compile_args(crt_val)
                 largs += self.get_crt_link_args(crt_val)
             except (KeyError, AttributeError):

--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -18,6 +18,7 @@ from ...options import OptionKey
 
 if T.TYPE_CHECKING:
     from ...build import BuildTarget
+    from ...mesonlib import SubProject
 
 
 class ElbrusCompiler(GnuLikeCompiler):
@@ -82,7 +83,8 @@ class ElbrusCompiler(GnuLikeCompiler):
         # Actually it's not supported for now, but probably will be supported in future
         return 'pch'
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
         key = OptionKey(f'{self.language}_std', subproject=subproject, machine=self.for_machine)
         if target:

--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -86,9 +86,9 @@ class ElbrusCompiler(GnuLikeCompiler):
         args: T.List[str] = []
         key = OptionKey(f'{self.language}_std', subproject=subproject, machine=self.for_machine)
         if target:
-            std = self.environment.coredata.optstore.get_option_for_target(target, key)
+            std = self.environment.coredata.optstore.get_option_for_target_untyped(target, key)
         else:
-            std = self.environment.coredata.optstore.get_value_for(key)
+            std = self.environment.coredata.optstore.get_value_for_untyped(key)
         assert isinstance(std, str)
         if std != 'none':
             args.append('-std=' + std)

--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -87,11 +87,7 @@ class ElbrusCompiler(GnuLikeCompiler):
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
         key = self.form_compileropt_key('std', subproject)
-        if target:
-            std = self.environment.coredata.optstore.get_option_for_target_untyped(target, key)
-        else:
-            std = self.environment.coredata.optstore.get_value_for_untyped(key)
-        assert isinstance(std, str)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append('-std=' + std)
         return args

--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -86,7 +86,7 @@ class ElbrusCompiler(GnuLikeCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
-        key = OptionKey(f'{self.language}_std', subproject=subproject, machine=self.for_machine)
+        key = self.form_compileropt_key('std', subproject)
         if target:
             std = self.environment.coredata.optstore.get_option_for_target_untyped(target, key)
         else:

--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -86,7 +86,7 @@ class ElbrusCompiler(GnuLikeCompiler):
         args: T.List[str] = []
         key = OptionKey(f'{self.language}_std', subproject=subproject, machine=self.for_machine)
         if target:
-            std = self.environment.coredata.get_option_for_target(target, key)
+            std = self.environment.coredata.optstore.get_option_for_target(target, key)
         else:
             std = self.environment.coredata.optstore.get_value_for(key)
         assert isinstance(std, str)

--- a/mesonbuild/compilers/mixins/emscripten.py
+++ b/mesonbuild/compilers/mixins/emscripten.py
@@ -49,8 +49,7 @@ class EmscriptenMixin(Compiler):
 
     def thread_link_flags(self) -> T.List[str]:
         args = ['-pthread']
-        count = self.environment.coredata.optstore.get_value_for_untyped(OptionKey(f'{self.language}_thread_count', machine=self.for_machine))
-        assert isinstance(count, int)
+        count = self.environment.coredata.optstore.get_value_for(OptionKey(f'{self.language}_thread_count', machine=self.for_machine), int)
         if count:
             args.append(f'-sPTHREAD_POOL_SIZE={count}')
         return args

--- a/mesonbuild/compilers/mixins/emscripten.py
+++ b/mesonbuild/compilers/mixins/emscripten.py
@@ -49,7 +49,7 @@ class EmscriptenMixin(Compiler):
 
     def thread_link_flags(self) -> T.List[str]:
         args = ['-pthread']
-        count = self.environment.coredata.optstore.get_value_for(OptionKey(f'{self.language}_thread_count', machine=self.for_machine))
+        count = self.environment.coredata.optstore.get_value_for_untyped(OptionKey(f'{self.language}_thread_count', machine=self.for_machine))
         assert isinstance(count, int)
         if count:
             args.append(f'-sPTHREAD_POOL_SIZE={count}')

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -659,7 +659,7 @@ class GnuCompiler(GnuLikeCompiler):
 
     def get_always_args(self) -> T.List[str]:
         args: T.List[str] = []
-        if self.info.is_os2() and self.environment.coredata.optstore.get_value_for_untyped(OptionKey('os2_emxomf')):
+        if self.info.is_os2() and self.environment.coredata.optstore.get_value_for(OptionKey('os2_emxomf'), bool):
             args += ['-Zomf']
         return super().get_always_args() + args
 

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -659,7 +659,7 @@ class GnuCompiler(GnuLikeCompiler):
 
     def get_always_args(self) -> T.List[str]:
         args: T.List[str] = []
-        if self.info.is_os2() and self.environment.coredata.optstore.get_value_for(OptionKey('os2_emxomf')):
+        if self.info.is_os2() and self.environment.coredata.optstore.get_value_for_untyped(OptionKey('os2_emxomf')):
             args += ['-Zomf']
         return super().get_always_args() + args
 

--- a/mesonbuild/compilers/mixins/islinker.py
+++ b/mesonbuild/compilers/mixins/islinker.py
@@ -20,6 +20,7 @@ if T.TYPE_CHECKING:
     from ...compilers.compilers import Compiler
     from ...build import BuildTarget
     from ...options import OptionStore
+    from ...mesonlib import SubProject
 else:
     # This is a bit clever, for mypy we pretend that these mixins descend from
     # Compiler, so we get all of the methods and attributes defined for us, but
@@ -59,7 +60,7 @@ class BasicLinkerIsCompilerMixin(Compiler):
     def get_linker_lib_prefix(self) -> str:
         return ''
 
-    def get_option_link_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_link_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         return []
 
     def has_multi_link_args(self, args: T.List[str]) -> T.Tuple[bool, bool]:

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -82,12 +82,7 @@ class GnuObjCCompiler(GnuCStds, GnuCompiler, ObjCCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
         key = self.form_compileropt_key('std', subproject)
-        if target:
-            std = self.environment.coredata.optstore.get_option_for_target_untyped(target, key)
-        else:
-            std = self.environment.coredata.optstore.get_value_for_untyped(key)
-        assert isinstance(std, str)
-
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         args: list[str] = []
         if std != 'none':
             args.append('-std=' + std)

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -55,6 +55,11 @@ class ObjCCompiler(CLikeCompiler, Compiler):
             return OptionKey('c_std', subproject=subproject, machine=self.for_machine)
         return super().form_compileropt_key(basename, subproject)
 
+    def make_option_name(self, key: OptionKey) -> str:
+        if key.name == 'std':
+            return 'c_std'
+        return super().make_option_name(key)
+
 
 class GnuObjCCompiler(GnuCStds, GnuCompiler, ObjCCompiler):
     def __init__(self, ccache: T.List[str], exelist: T.List[str], version: str, for_machine: MachineChoice,
@@ -76,7 +81,7 @@ class GnuObjCCompiler(GnuCStds, GnuCompiler, ObjCCompiler):
 
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         target, subproject = self._get_subproject_and_target(target)
-        key = OptionKey('c_std', subproject=subproject, machine=self.for_machine)
+        key = self.form_compileropt_key('std', subproject)
         if target:
             std = self.environment.coredata.optstore.get_option_for_target_untyped(target, key)
         else:
@@ -104,22 +109,11 @@ class ClangObjCCompiler(ClangCStds, ClangCompiler, ObjCCompiler):
                           '3': default_warn_args + ['-Wextra', '-Wpedantic'],
                           'everything': ['-Weverything']}
 
-    def form_compileropt_key(self, basename: str, subproject: T.Optional[SubProject] = None) -> OptionKey:
-        if basename == 'std':
-            return OptionKey('c_std', subproject=subproject, machine=self.for_machine)
-        return super().form_compileropt_key(basename, subproject)
-
-    def make_option_name(self, key: OptionKey) -> str:
-        if key.name == 'std':
-            return 'c_std'
-        return super().make_option_name(key)
-
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         args: T.List[str] = []
         target, subproject = self._get_subproject_and_target(target)
-        key = OptionKey('c_std', machine=self.for_machine)
-        std = self.get_compileropt_value(key, target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append('-std=' + std)
         return args

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -78,9 +78,9 @@ class GnuObjCCompiler(GnuCStds, GnuCompiler, ObjCCompiler):
         args: T.List[str] = []
         key = OptionKey('c_std', subproject=subproject, machine=self.for_machine)
         if target:
-            std = self.environment.coredata.optstore.get_option_for_target(target, key)
+            std = self.environment.coredata.optstore.get_option_for_target_untyped(target, key)
         else:
-            std = self.environment.coredata.optstore.get_value_for(key)
+            std = self.environment.coredata.optstore.get_value_for_untyped(key)
         assert isinstance(std, str)
         if std != 'none':
             args.append('-std=' + std)

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -78,7 +78,7 @@ class GnuObjCCompiler(GnuCStds, GnuCompiler, ObjCCompiler):
         args: T.List[str] = []
         key = OptionKey('c_std', subproject=subproject, machine=self.for_machine)
         if target:
-            std = self.environment.coredata.get_option_for_target(target, key)
+            std = self.environment.coredata.optstore.get_option_for_target(target, key)
         else:
             std = self.environment.coredata.optstore.get_value_for(key)
         assert isinstance(std, str)

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -17,7 +17,7 @@ from .mixins.gnu import GnuCompiler, GnuCStds, gnu_common_warning_args, gnu_objc
 if T.TYPE_CHECKING:
     from ..environment import Environment
     from ..linkers.linkers import DynamicLinker
-    from ..mesonlib import MachineChoice
+    from ..mesonlib import MachineChoice, SubProject
     from ..build import BuildTarget
     from ..options import MutableKeyedOptionDictType
 
@@ -74,14 +74,16 @@ class GnuObjCCompiler(GnuCStds, GnuCompiler, ObjCCompiler):
                                          self.supported_warn_args(gnu_common_warning_args) +
                                          self.supported_warn_args(gnu_objc_warning_args))}
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
-        args: T.List[str] = []
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         key = OptionKey('c_std', subproject=subproject, machine=self.for_machine)
         if target:
             std = self.environment.coredata.optstore.get_option_for_target_untyped(target, key)
         else:
             std = self.environment.coredata.optstore.get_value_for_untyped(key)
         assert isinstance(std, str)
+
+        args: list[str] = []
         if std != 'none':
             args.append('-std=' + std)
         return args
@@ -112,8 +114,9 @@ class ClangObjCCompiler(ClangCStds, ClangCompiler, ObjCCompiler):
             return 'c_std'
         return super().make_option_name(key)
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
-        args = []
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        args: T.List[str] = []
+        target, subproject = self._get_subproject_and_target(target)
         key = OptionKey('c_std', machine=self.for_machine)
         std = self.get_compileropt_value(key, target, subproject)
         assert isinstance(std, str)

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -50,10 +50,10 @@ class ObjCCompiler(CLikeCompiler, Compiler):
     def _sanity_check_source_code(self) -> str:
         return '#import<stddef.h>\nint main(void) { return 0; }\n'
 
-    def form_compileropt_key(self, basename: str) -> OptionKey:
+    def form_compileropt_key(self, basename: str, subproject: T.Optional[SubProject] = None) -> OptionKey:
         if basename == 'std':
-            return OptionKey(f'c_{basename}', machine=self.for_machine)
-        return super().form_compileropt_key(basename)
+            return OptionKey('c_std', subproject=subproject, machine=self.for_machine)
+        return super().form_compileropt_key(basename, subproject)
 
 
 class GnuObjCCompiler(GnuCStds, GnuCompiler, ObjCCompiler):
@@ -104,10 +104,10 @@ class ClangObjCCompiler(ClangCStds, ClangCompiler, ObjCCompiler):
                           '3': default_warn_args + ['-Wextra', '-Wpedantic'],
                           'everything': ['-Weverything']}
 
-    def form_compileropt_key(self, basename: str) -> OptionKey:
+    def form_compileropt_key(self, basename: str, subproject: T.Optional[SubProject] = None) -> OptionKey:
         if basename == 'std':
-            return OptionKey('c_std', machine=self.for_machine)
-        return super().form_compileropt_key(basename)
+            return OptionKey('c_std', subproject=subproject, machine=self.for_machine)
+        return super().form_compileropt_key(basename, subproject)
 
     def make_option_name(self, key: OptionKey) -> str:
         if key.name == 'std':

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -17,7 +17,7 @@ from .mixins.clike import CLikeCompiler
 if T.TYPE_CHECKING:
     from ..environment import Environment
     from ..linkers.linkers import DynamicLinker
-    from ..mesonlib import MachineChoice
+    from ..mesonlib import MachineChoice, SubProject
     from ..build import BuildTarget
     from ..options import MutableKeyedOptionDictType
 
@@ -84,8 +84,9 @@ class GnuObjCPPCompiler(GnuCPPStds, GnuCompiler, ObjCPPCompiler):
                                          self.supported_warn_args(gnu_common_warning_args) +
                                          self.supported_warn_args(gnu_objc_warning_args))}
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         args: T.List[str] = []
+        target, subproject = self._get_subproject_and_target(target)
         key = OptionKey('cpp_std', subproject=subproject, machine=self.for_machine)
         if target:
             std = self.environment.coredata.optstore.get_option_for_target_untyped(target, key)
@@ -113,8 +114,9 @@ class ClangObjCPPCompiler(ClangCPPStds, ClangCompiler, ObjCPPCompiler):
                           '3': default_warn_args + ['-Wextra', '-Wpedantic'],
                           'everything': ['-Weverything']}
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
-        args = []
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        args: T.List[str] = []
+        target, subproject = self._get_subproject_and_target(target)
         key = OptionKey('cpp_std', machine=self.for_machine)
         std = self.get_compileropt_value(key, target, subproject)
         assert isinstance(std, str)

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -40,10 +40,10 @@ class ObjCPPCompiler(CLikeCompiler, Compiler):
     def get_no_stdlib_link_args(self) -> T.List[str]:
         return ['-nostdlib++']
 
-    def form_compileropt_key(self, basename: str) -> OptionKey:
+    def form_compileropt_key(self, basename: str, subproject: T.Optional[SubProject] = None) -> OptionKey:
         if basename == 'std':
-            return OptionKey('cpp_std', machine=self.for_machine)
-        return super().form_compileropt_key(basename)
+            return OptionKey('cpp_std', subproject=subproject, machine=self.for_machine)
+        return super().form_compileropt_key(basename, subproject)
 
     def make_option_name(self, key: OptionKey) -> str:
         if key.name == 'std':

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -88,9 +88,9 @@ class GnuObjCPPCompiler(GnuCPPStds, GnuCompiler, ObjCPPCompiler):
         args: T.List[str] = []
         key = OptionKey('cpp_std', subproject=subproject, machine=self.for_machine)
         if target:
-            std = self.environment.coredata.optstore.get_option_for_target(target, key)
+            std = self.environment.coredata.optstore.get_option_for_target_untyped(target, key)
         else:
-            std = self.environment.coredata.optstore.get_value_for(key)
+            std = self.environment.coredata.optstore.get_value_for_untyped(key)
         assert isinstance(std, str)
         if std != 'none':
             args.append('-std=' + std)

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -88,7 +88,7 @@ class GnuObjCPPCompiler(GnuCPPStds, GnuCompiler, ObjCPPCompiler):
         args: T.List[str] = []
         key = OptionKey('cpp_std', subproject=subproject, machine=self.for_machine)
         if target:
-            std = self.environment.coredata.get_option_for_target(target, key)
+            std = self.environment.coredata.optstore.get_option_for_target(target, key)
         else:
             std = self.environment.coredata.optstore.get_value_for(key)
         assert isinstance(std, str)

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -117,9 +117,8 @@ class ClangObjCPPCompiler(ClangCPPStds, ClangCompiler, ObjCPPCompiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         args: T.List[str] = []
         target, subproject = self._get_subproject_and_target(target)
-        key = OptionKey('cpp_std', machine=self.for_machine)
-        std = self.get_compileropt_value(key, target, subproject)
-        assert isinstance(std, str)
+        key = OptionKey('cpp_std', subproject, self.for_machine)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append('-std=' + std)
         return args

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -88,11 +88,7 @@ class GnuObjCPPCompiler(GnuCPPStds, GnuCompiler, ObjCPPCompiler):
         args: T.List[str] = []
         target, subproject = self._get_subproject_and_target(target)
         key = OptionKey('cpp_std', subproject=subproject, machine=self.for_machine)
-        if target:
-            std = self.environment.coredata.optstore.get_option_for_target_untyped(target, key)
-        else:
-            std = self.environment.coredata.optstore.get_value_for_untyped(key)
-        assert isinstance(std, str)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append('-std=' + std)
         return args

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -155,7 +155,8 @@ class RustCompiler(Compiler):
         self.has_check_cfg = version_compare(version, '>=1.80.0')
 
     def init_from_options(self) -> None:
-        nightly_opt = self.get_compileropt_value('nightly', None)
+        key = self.form_compileropt_key('nightly', None)
+        nightly_opt = self.environment.coredata.optstore.get_value_for(key, str)
         if nightly_opt == 'enabled' and not self.is_nightly:
             raise EnvironmentException(f'Rust compiler {self.name_string()} is not a nightly compiler as required by the "nightly" option.')
         self.allow_nightly = nightly_opt != 'disabled' and self.is_nightly
@@ -388,8 +389,8 @@ class RustCompiler(Compiler):
     def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         args: T.List[str] = []
         target, subproject = self._get_subproject_and_target(target)
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
         if std != 'none':
             args.append('--edition=' + std)
         return args

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -268,7 +268,7 @@ class RustCompiler(Compiler):
         if not target:
             return self.allow_nightly
         key = self.form_compileropt_key('nightly')
-        nightly_opt = self.environment.coredata.optstore.get_option_for_target_untyped(target, key)
+        nightly_opt = self.environment.coredata.optstore.get_option_for_target(target, key, str)
         if nightly_opt == 'enabled' and not self.is_nightly:
             raise EnvironmentException(f'Rust compiler {self.name_string()} is not a nightly compiler as required by the "nightly" option.')
         return nightly_opt != 'disabled' and self.is_nightly

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -23,7 +23,7 @@ if T.TYPE_CHECKING:
     from ..options import MutableKeyedOptionDictType
     from ..environment import Environment  # noqa: F401
     from ..linkers.linkers import DynamicLinker
-    from ..mesonlib import MachineChoice
+    from ..mesonlib import MachineChoice, SubProject
     from ..dependencies import Dependency
     from ..build import BuildTarget
 
@@ -385,8 +385,9 @@ class RustCompiler(Compiler):
         # provided by the linker flags.
         return []
 
-    def get_option_std_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
-        args = []
+    def get_option_std_args(self, target: BuildTarget | SubProject | None) -> list[str]:
+        args: T.List[str] = []
+        target, subproject = self._get_subproject_and_target(target)
         std = self.get_compileropt_value('std', target, subproject)
         assert isinstance(std, str)
         if std != 'none':

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -268,7 +268,7 @@ class RustCompiler(Compiler):
         if not target:
             return self.allow_nightly
         key = self.form_compileropt_key('nightly')
-        nightly_opt = self.environment.coredata.get_option_for_target(target, key)
+        nightly_opt = self.environment.coredata.optstore.get_option_for_target(target, key)
         if nightly_opt == 'enabled' and not self.is_nightly:
             raise EnvironmentException(f'Rust compiler {self.name_string()} is not a nightly compiler as required by the "nightly" option.')
         return nightly_opt != 'disabled' and self.is_nightly

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -268,7 +268,7 @@ class RustCompiler(Compiler):
         if not target:
             return self.allow_nightly
         key = self.form_compileropt_key('nightly')
-        nightly_opt = self.environment.coredata.optstore.get_option_for_target(target, key)
+        nightly_opt = self.environment.coredata.optstore.get_option_for_target_untyped(target, key)
         if nightly_opt == 'enabled' and not self.is_nightly:
             raise EnvironmentException(f'Rust compiler {self.name_string()} is not a nightly compiler as required by the "nightly" option.')
         return nightly_opt != 'disabled' and self.is_nightly

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -18,7 +18,7 @@ if T.TYPE_CHECKING:
     from ..dependencies import Dependency
     from ..environment import Environment
     from ..linkers.linkers import DynamicLinker
-    from ..mesonlib import MachineChoice
+    from ..mesonlib import MachineChoice, SubProject
 
 swift_optimization_args: T.Dict[str, T.List[str]] = {
     'plain': [],
@@ -128,7 +128,8 @@ class SwiftCompiler(Compiler):
 
         return opts
 
-    def get_option_std_args(self, target: build.BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_std_args(self, target: build.BuildTarget | SubProject | None) -> list[str]:
+        target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
 
         std = self.get_compileropt_value('std', target, subproject)
@@ -145,7 +146,8 @@ class SwiftCompiler(Compiler):
         c_lang = first(c_langs, lambda x: x in target.compilers)
         if c_lang is not None:
             cc = target.compilers[c_lang]
-            args.extend(arg for c_arg in cc.get_option_std_args(target, subproject) for arg in ['-Xcc', c_arg])
+            cc_std_args = cc.get_option_std_args(target if target is not None else subproject)
+            args.extend(arg for c_arg in cc_std_args for arg in ['-Xcc', c_arg])
 
         return args
 

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -184,7 +184,7 @@ class SwiftCompiler(Compiler):
         if self.is_cross:
             args.extend(self.get_compile_only_args())
         else:
-            largs.extend(self.environment.coredata.get_external_link_args(self.for_machine, self.language))
+            largs.extend(self.environment.coredata.optstore.get_external_link_args(self.for_machine, self.language))
         args.extend(self.get_output_args(binname))
         args.append(sourcename)
 

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -132,8 +132,8 @@ class SwiftCompiler(Compiler):
         target, subproject = self._get_subproject_and_target(target)
         args: T.List[str] = []
 
-        std = self.get_compileropt_value('std', target, subproject)
-        assert isinstance(std, str)
+        key = self.form_compileropt_key('std', subproject)
+        std = self.environment.coredata.optstore.get_option_for_maybe_target(target, key, str)
 
         if std != 'none':
             args += ['-swift-version', std]

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -15,7 +15,7 @@ from .compilers import CompileCheckMode, Compiler
 if T.TYPE_CHECKING:
     from ..arglist import CompilerArgs
     from ..environment import Environment
-    from ..mesonlib import MachineChoice
+    from ..mesonlib import MachineChoice, SubProject
     from ..dependencies import Dependency
     from ..build import BuildTarget
 
@@ -173,7 +173,7 @@ class ValaCompiler(Compiler):
     def thread_link_flags(self) -> T.List[str]:
         return []
 
-    def get_option_link_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_link_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         return []
 
     def build_wrapper_args(self,

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -153,7 +153,7 @@ class ValaCompiler(Compiler):
         if not extra_dirs:
             code = 'class MesonFindLibrary : Object { }'
             args: T.List[str] = []
-            args += self.environment.coredata.get_external_args(self.for_machine, self.language)
+            args += self.environment.coredata.optstore.get_external_args(self.for_machine, self.language)
             vapi_args = ['--pkg', libname]
             args += vapi_args
             with self.cached_compile(code, extra_args=args, mode=CompileCheckMode.COMPILE) as p:
@@ -212,7 +212,7 @@ class ValaCompiler(Compiler):
 
         if mode is CompileCheckMode.COMPILE:
             # Add DFLAGS from the env
-            args += self.environment.coredata.get_external_args(self.for_machine, self.language)
+            args += self.environment.coredata.optstore.get_external_args(self.for_machine, self.language)
         elif mode is CompileCheckMode.LINK:
             # Add LDFLAGS from the env
             args += self.environment.coredata.get_external_link_args(self.for_machine, self.language)

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -215,7 +215,7 @@ class ValaCompiler(Compiler):
             args += self.environment.coredata.optstore.get_external_args(self.for_machine, self.language)
         elif mode is CompileCheckMode.LINK:
             # Add LDFLAGS from the env
-            args += self.environment.coredata.get_external_link_args(self.for_machine, self.language)
+            args += self.environment.coredata.optstore.get_external_link_args(self.for_machine, self.language)
         # extra_args must override all other arguments, so we add them last
         args += extra_args
         return args

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -121,8 +121,8 @@ class DependencyCache:
 
     def __calculate_subkey(self, type_: DependencyCacheType) -> T.Tuple[str, ...]:
         data: T.Dict[DependencyCacheType, T.List[str]] = {
-            DependencyCacheType.PKG_CONFIG: T.cast('T.List[str]', self.__builtins.get_value_for_untyped(self.__pkg_conf_key)),
-            DependencyCacheType.CMAKE: T.cast('T.List[str]', self.__builtins.get_value_for_untyped(self.__cmake_key)),
+            DependencyCacheType.PKG_CONFIG: self.__builtins.get_value_for(self.__pkg_conf_key, list),
+            DependencyCacheType.CMAKE: self.__builtins.get_value_for(self.__cmake_key, list),
             DependencyCacheType.OTHER: [],
         }
         assert type_ in data, 'Someone forgot to update subkey calculations for a new type'
@@ -348,7 +348,7 @@ class CoreData:
 
     def get_nondefault_buildtype_args(self) -> T.List[T.Union[T.Tuple[str, str, str], T.Tuple[str, bool, bool]]]:
         result: T.List[T.Union[T.Tuple[str, str, str], T.Tuple[str, bool, bool]]] = []
-        value = self.optstore.get_value_for_untyped('buildtype')
+        value = self.optstore.get_value_for(OptionKey('buildtype'), str)
         if value == 'plain':
             opt = 'plain'
             debug = False
@@ -367,10 +367,8 @@ class CoreData:
         else:
             assert value == 'custom'
             return []
-        actual_opt = self.optstore.get_value_for_untyped('optimization')
-        actual_debug = self.optstore.get_value_for_untyped('debug')
-        assert isinstance(actual_opt, str) # for mypy
-        assert isinstance(actual_debug, bool) # for mypy
+        actual_opt = self.optstore.get_value_for(OptionKey('optimization'), str)
+        actual_debug = self.optstore.get_value_for(OptionKey('debug'), bool)
         if actual_opt != opt:
             result.append(('optimization', actual_opt, opt))
         if actual_debug != debug:
@@ -423,7 +421,7 @@ class CoreData:
 
     def emit_base_options_warnings(self) -> None:
         bcodekey = OptionKey('b_bitcode')
-        if bcodekey in self.optstore and self.optstore.get_value_for_untyped(bcodekey):
+        if self.optstore.get_value_for(bcodekey, bool, default=False):
             msg = textwrap.dedent('''Base option 'b_bitcode' is enabled, which is incompatible with many linker options.
                                      Incompatible options such as \'b_asneeded\' have been disabled.'
                                      Please see https://mesonbuild.com/Builtin-options.html#Notes_about_Apple_Bitcode_support for more details.''')

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -121,8 +121,8 @@ class DependencyCache:
 
     def __calculate_subkey(self, type_: DependencyCacheType) -> T.Tuple[str, ...]:
         data: T.Dict[DependencyCacheType, T.List[str]] = {
-            DependencyCacheType.PKG_CONFIG: T.cast('T.List[str]', self.__builtins.get_value_for(self.__pkg_conf_key)),
-            DependencyCacheType.CMAKE: T.cast('T.List[str]', self.__builtins.get_value_for(self.__cmake_key)),
+            DependencyCacheType.PKG_CONFIG: T.cast('T.List[str]', self.__builtins.get_value_for_untyped(self.__pkg_conf_key)),
+            DependencyCacheType.CMAKE: T.cast('T.List[str]', self.__builtins.get_value_for_untyped(self.__cmake_key)),
             DependencyCacheType.OTHER: [],
         }
         assert type_ in data, 'Someone forgot to update subkey calculations for a new type'
@@ -348,7 +348,7 @@ class CoreData:
 
     def get_nondefault_buildtype_args(self) -> T.List[T.Union[T.Tuple[str, str, str], T.Tuple[str, bool, bool]]]:
         result: T.List[T.Union[T.Tuple[str, str, str], T.Tuple[str, bool, bool]]] = []
-        value = self.optstore.get_value_for('buildtype')
+        value = self.optstore.get_value_for_untyped('buildtype')
         if value == 'plain':
             opt = 'plain'
             debug = False
@@ -367,8 +367,8 @@ class CoreData:
         else:
             assert value == 'custom'
             return []
-        actual_opt = self.optstore.get_value_for('optimization')
-        actual_debug = self.optstore.get_value_for('debug')
+        actual_opt = self.optstore.get_value_for_untyped('optimization')
+        actual_debug = self.optstore.get_value_for_untyped('debug')
         assert isinstance(actual_opt, str) # for mypy
         assert isinstance(actual_debug, bool) # for mypy
         if actual_opt != opt:
@@ -423,7 +423,7 @@ class CoreData:
 
     def emit_base_options_warnings(self) -> None:
         bcodekey = OptionKey('b_bitcode')
-        if bcodekey in self.optstore and self.optstore.get_value_for(bcodekey):
+        if bcodekey in self.optstore and self.optstore.get_value_for_untyped(bcodekey):
             msg = textwrap.dedent('''Base option 'b_bitcode' is enabled, which is incompatible with many linker options.
                                      Incompatible options such as \'b_asneeded\' have been disabled.'
                                      Please see https://mesonbuild.com/Builtin-options.html#Notes_about_Apple_Bitcode_support for more details.''')

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -377,9 +377,6 @@ class CoreData:
             result.append(('debug', actual_debug, debug))
         return result
 
-    def get_external_link_args(self, for_machine: MachineChoice, lang: Language) -> T.List[str]:
-        return self.optstore.get_external_link_args(for_machine, lang)
-
     def is_cross_build(self, when_building_for: MachineChoice = MachineChoice.HOST) -> bool:
         if when_building_for == MachineChoice.BUILD:
             return False

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -377,9 +377,6 @@ class CoreData:
             result.append(('debug', actual_debug, debug))
         return result
 
-    def get_external_args(self, for_machine: MachineChoice, lang: Language) -> T.List[str]:
-        return self.optstore.get_external_args(for_machine, lang)
-
     def get_external_link_args(self, for_machine: MachineChoice, lang: Language) -> T.List[str]:
         return self.optstore.get_external_link_args(for_machine, lang)
 

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -9,7 +9,6 @@ import copy
 from . import mlog, options
 import pickle, os, uuid
 import sys
-from functools import lru_cache
 from collections import OrderedDict
 import textwrap
 
@@ -379,15 +378,10 @@ class CoreData:
         return result
 
     def get_external_args(self, for_machine: MachineChoice, lang: Language) -> T.List[str]:
-        # mypy cannot analyze type of OptionKey
-        key = OptionKey(f'{lang}_args', machine=for_machine)
-        return T.cast('T.List[str]', self.optstore.get_value_for(key))
+        return self.optstore.get_external_args(for_machine, lang)
 
-    @lru_cache(maxsize=None)
     def get_external_link_args(self, for_machine: MachineChoice, lang: Language) -> T.List[str]:
-        # mypy cannot analyze type of OptionKey
-        linkkey = OptionKey(f'{lang}_link_args', machine=for_machine)
-        return T.cast('T.List[str]', self.optstore.get_value_for(linkkey))
+        return self.optstore.get_external_link_args(for_machine, lang)
 
     def is_cross_build(self, when_building_for: MachineChoice = MachineChoice.HOST) -> bool:
         if when_building_for == MachineChoice.BUILD:

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -340,26 +340,7 @@ class CoreData:
                 ''))
 
     def get_option_for_target(self, target: 'BuildTarget', key: T.Union[str, OptionKey]) -> ElementaryOptionValues:
-        if isinstance(key, str):
-            assert ':' not in key
-            newkey = OptionKey(key, target.subproject)
-        else:
-            newkey = key
-        if newkey.subproject != target.subproject:
-            # FIXME: this should be an error. The caller needs to ensure that
-            # key and target have the same subproject for consistency.
-            # Now just do this to get things going.
-            newkey = newkey.evolve(subproject=target.subproject)
-        if self.is_cross_build():
-            newkey = newkey.evolve(machine=target.for_machine)
-        option_object, value = self.optstore.get_option_and_value_for(newkey)
-        override = target.get_override(newkey.name)
-        if override is not None:
-            try:
-                return option_object.validate_value(override)
-            except MesonException as e:
-                raise MesonException(f'In override_options for {target}: {e!s}')
-        return value
+        return self.optstore.get_option_for_target(target, key)
 
     def set_from_configure_command(self, options: SharedCMDOptions) -> bool:
         return self.optstore.set_from_configure_command(options.cmd_line_options)

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -30,8 +30,7 @@ if T.TYPE_CHECKING:
     from .dependencies.detect import TV_DepID
     from .mesonlib import FileOrString, SubProject
     from .cmake.traceparser import CMakeCacheEntry
-    from .options import ElementaryOptionValues, MutableKeyedOptionDictType
-    from .build import BuildTarget
+    from .options import MutableKeyedOptionDictType
     from .cmdline import SharedCMDOptions
 
     OptionDictType = T.Dict[str, options.AnyOptionType]
@@ -338,9 +337,6 @@ class CoreData:
                 'backend_startup_project',
                 'Default project to execute in Visual Studio',
                 ''))
-
-    def get_option_for_target(self, target: 'BuildTarget', key: T.Union[str, OptionKey]) -> ElementaryOptionValues:
-        return self.optstore.get_option_for_target(target, key)
 
     def set_from_configure_command(self, options: SharedCMDOptions) -> bool:
         return self.optstore.set_from_configure_command(options.cmd_line_options)

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -401,13 +401,13 @@ class CoreData:
             result.append(('debug', actual_debug, debug))
         return result
 
-    def get_external_args(self, for_machine: MachineChoice, lang: str) -> T.List[str]:
+    def get_external_args(self, for_machine: MachineChoice, lang: Language) -> T.List[str]:
         # mypy cannot analyze type of OptionKey
         key = OptionKey(f'{lang}_args', machine=for_machine)
         return T.cast('T.List[str]', self.optstore.get_value_for(key))
 
     @lru_cache(maxsize=None)
-    def get_external_link_args(self, for_machine: MachineChoice, lang: str) -> T.List[str]:
+    def get_external_link_args(self, for_machine: MachineChoice, lang: Language) -> T.List[str]:
         # mypy cannot analyze type of OptionKey
         linkkey = OptionKey(f'{lang}_link_args', machine=for_machine)
         return T.cast('T.List[str]', self.optstore.get_value_for(linkkey))

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -432,7 +432,7 @@ class ExternalDependency(Dependency):
         self.silent = kwargs.get('silent', False)
         static = kwargs.get('static')
         if static is None:
-            static = T.cast('bool', self.env.coredata.optstore.get_value_for(OptionKey('prefer_static')))
+            static = T.cast('bool', self.env.coredata.optstore.get_value_for_untyped(OptionKey('prefer_static')))
         self.static = static
         self.libtype = LibType.STATIC if self.static else LibType.PREFER_SHARED
         # Is this dependency to be run on the build platform?

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -432,7 +432,7 @@ class ExternalDependency(Dependency):
         self.silent = kwargs.get('silent', False)
         static = kwargs.get('static')
         if static is None:
-            static = T.cast('bool', self.env.coredata.optstore.get_value_for_untyped(OptionKey('prefer_static')))
+            static = self.env.coredata.optstore.get_value_for(OptionKey('prefer_static'), bool)
         self.static = static
         self.libtype = LibType.STATIC if self.static else LibType.PREFER_SHARED
         # Is this dependency to be run on the build platform?

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -343,8 +343,7 @@ class BoostDependency(SystemDependency):
     def __init__(self, name: str, environment: Environment, kwargs: DependencyObjectKWs) -> None:
         kwargs['language'] = 'cpp'
         super().__init__(name, environment, kwargs)
-        buildtype = environment.coredata.optstore.get_value_for_untyped(OptionKey('buildtype'))
-        assert isinstance(buildtype, str)
+        buildtype = environment.coredata.optstore.get_value_for(OptionKey('buildtype'), str)
         self.debug = buildtype.startswith('debug')
         self.multithreading = kwargs.get('threading', 'multi') == 'multi'
 
@@ -604,8 +603,7 @@ class BoostDependency(SystemDependency):
         # MSVC is very picky with the library tags
         vscrt = ''
         try:
-            crt_val = self.env.coredata.optstore.get_value_for_untyped('b_vscrt')
-            assert isinstance(crt_val, str)
+            crt_val = self.env.coredata.optstore.get_value_for(OptionKey('b_vscrt'), str)
             vscrt = self.clib_compiler.get_crt_compile_args(crt_val)[0]
         except (KeyError, IndexError, AttributeError):
             pass

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -343,7 +343,7 @@ class BoostDependency(SystemDependency):
     def __init__(self, name: str, environment: Environment, kwargs: DependencyObjectKWs) -> None:
         kwargs['language'] = 'cpp'
         super().__init__(name, environment, kwargs)
-        buildtype = environment.coredata.optstore.get_value_for(OptionKey('buildtype'))
+        buildtype = environment.coredata.optstore.get_value_for_untyped(OptionKey('buildtype'))
         assert isinstance(buildtype, str)
         self.debug = buildtype.startswith('debug')
         self.multithreading = kwargs.get('threading', 'multi') == 'multi'
@@ -604,7 +604,7 @@ class BoostDependency(SystemDependency):
         # MSVC is very picky with the library tags
         vscrt = ''
         try:
-            crt_val = self.env.coredata.optstore.get_value_for('b_vscrt')
+            crt_val = self.env.coredata.optstore.get_value_for_untyped('b_vscrt')
             assert isinstance(crt_val, str)
             vscrt = self.clib_compiler.get_crt_compile_args(crt_val)[0]
         except (KeyError, IndexError, AttributeError):

--- a/mesonbuild/dependencies/dub.py
+++ b/mesonbuild/dependencies/dub.py
@@ -124,7 +124,7 @@ class DubDependency(ExternalDependency):
         dub_arch = self.compiler.arch
 
         # we need to know the build type as well
-        dub_buildtype = str(environment.coredata.optstore.get_value_for_untyped(OptionKey('buildtype')))
+        dub_buildtype = environment.coredata.optstore.get_value_for(OptionKey('buildtype'), str)
         # MESON types: choices=['plain', 'debug', 'debugoptimized', 'release', 'minsize', 'custom'])),
         # DUB types: debug (default), plain, release, release-debug, release-nobounds, unittest, profile, profile-gc,
         # docs, ddox, cov, unittest-cov, syntax and custom

--- a/mesonbuild/dependencies/dub.py
+++ b/mesonbuild/dependencies/dub.py
@@ -124,7 +124,7 @@ class DubDependency(ExternalDependency):
         dub_arch = self.compiler.arch
 
         # we need to know the build type as well
-        dub_buildtype = str(environment.coredata.optstore.get_value_for(OptionKey('buildtype')))
+        dub_buildtype = str(environment.coredata.optstore.get_value_for_untyped(OptionKey('buildtype')))
         # MESON types: choices=['plain', 'debug', 'debugoptimized', 'release', 'minsize', 'custom'])),
         # DUB types: debug (default), plain, release, release-debug, release-nobounds, unittest, profile, profile-gc,
         # docs, ddox, cov, unittest-cov, syntax and custom

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -592,7 +592,7 @@ def shaderc_factory(env: 'Environment',
 
         static = kwargs.get('static')
         if static is None:
-            static = T.cast('bool', env.coredata.optstore.get_value_for(OptionKey('prefer_static')))
+            static = T.cast('bool', env.coredata.optstore.get_value_for_untyped(OptionKey('prefer_static')))
         if static:
             c = [DependencyCandidate.from_dependency(name, PkgConfigDependency, (env, kwargs))
                  for name in static_libs + shared_libs]

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -63,7 +63,7 @@ class AtomicBuiltinDependency(BuiltinDependency):
             self.is_found = True
         elif self.clib_compiler.get_id() == 'msvc':
             feature_flag = '/experimental:c11atomics'
-            std_args = self.clib_compiler.get_option_std_args(None, None)
+            std_args = self.clib_compiler.get_option_std_args(None)
             # atomic_flag_clear forwards to __c11_atomic_store in msvc,
             # which behaves like __builtin_* in gcc, and we're unable to detect it with .has_function().
             if self.clib_compiler.has_function("_Atomic_thread_fence",

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -592,7 +592,7 @@ def shaderc_factory(env: 'Environment',
 
         static = kwargs.get('static')
         if static is None:
-            static = T.cast('bool', env.coredata.optstore.get_value_for_untyped(OptionKey('prefer_static')))
+            static = env.coredata.optstore.get_value_for(OptionKey('prefer_static'), bool)
         if static:
             c = [DependencyCandidate.from_dependency(name, PkgConfigDependency, (env, kwargs))
                  for name in static_libs + shared_libs]

--- a/mesonbuild/dependencies/mpi.py
+++ b/mesonbuild/dependencies/mpi.py
@@ -9,6 +9,7 @@ import re
 
 from ..envconfig import detect_cpu_family
 from ..mesonlib import Popen_safe
+from ..options import OptionKey
 from .base import DependencyCandidate, DependencyException, DependencyMethods, detect_compiler, SystemDependency
 from .configtool import ConfigToolDependency
 from .detect import packages
@@ -283,8 +284,7 @@ class IMPIDependency(SystemDependency):
         incdir = os.path.join(rootdir, 'include')
         libdir = os.path.join(rootdir, 'lib')
 
-        debug = env.coredata.optstore.get_value_for_untyped('debug')
-        assert isinstance(debug, bool)
+        debug = env.coredata.optstore.get_value_for(OptionKey('debug'), bool)
         libdir_post = 'debug' if debug else 'release'
         for subdirs in (['mpi', libdir_post], [libdir_post]):
             libdir_buildtype = os.path.join(libdir, *subdirs)

--- a/mesonbuild/dependencies/mpi.py
+++ b/mesonbuild/dependencies/mpi.py
@@ -283,7 +283,7 @@ class IMPIDependency(SystemDependency):
         incdir = os.path.join(rootdir, 'include')
         libdir = os.path.join(rootdir, 'lib')
 
-        debug = env.coredata.optstore.get_value_for('debug')
+        debug = env.coredata.optstore.get_value_for_untyped('debug')
         assert isinstance(debug, bool)
         libdir_post = 'debug' if debug else 'release'
         for subdirs in (['mpi', libdir_post], [libdir_post]):

--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -266,9 +266,8 @@ class PkgConfigCLI(PkgConfigInterface):
     def _get_env(self, uninstalled: bool = False) -> EnvironmentVariables:
         env = EnvironmentVariables()
         key = OptionKey('pkg_config_path', machine=self.for_machine)
-        pathlist = self.env.coredata.optstore.get_value_for_untyped(key)
-        assert isinstance(pathlist, list)
-        extra_paths: T.List[str] = pathlist + self.extra_paths
+        pathlist = self.env.coredata.optstore.get_value_for(key, list)
+        extra_paths = pathlist + self.extra_paths
         if uninstalled:
             bpath = self.env.get_build_dir()
             if bpath is not None:
@@ -433,7 +432,7 @@ class PkgConfigDependency(ExternalDependency):
         #
         # Only prefix_libpaths are reordered here because there should not be
         # too many system_libpaths to cause library version issues.
-        pkg_config_path: T.List[str] = self.env.coredata.optstore.get_value_for_untyped(OptionKey('pkg_config_path', machine=self.for_machine)) # type: ignore[assignment]
+        pkg_config_path = self.env.coredata.optstore.get_value_for(OptionKey('pkg_config_path', machine=self.for_machine), list)
         pkg_config_path = self._convert_mingw_paths(pkg_config_path)
         prefix_libpaths = OrderedSet(sort_libpaths(list(prefix_libpaths), pkg_config_path))
         system_libpaths: OrderedSet[str] = OrderedSet()

--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -266,7 +266,7 @@ class PkgConfigCLI(PkgConfigInterface):
     def _get_env(self, uninstalled: bool = False) -> EnvironmentVariables:
         env = EnvironmentVariables()
         key = OptionKey('pkg_config_path', machine=self.for_machine)
-        pathlist = self.env.coredata.optstore.get_value_for(key)
+        pathlist = self.env.coredata.optstore.get_value_for_untyped(key)
         assert isinstance(pathlist, list)
         extra_paths: T.List[str] = pathlist + self.extra_paths
         if uninstalled:
@@ -433,7 +433,7 @@ class PkgConfigDependency(ExternalDependency):
         #
         # Only prefix_libpaths are reordered here because there should not be
         # too many system_libpaths to cause library version issues.
-        pkg_config_path: T.List[str] = self.env.coredata.optstore.get_value_for(OptionKey('pkg_config_path', machine=self.for_machine)) # type: ignore[assignment]
+        pkg_config_path: T.List[str] = self.env.coredata.optstore.get_value_for_untyped(OptionKey('pkg_config_path', machine=self.for_machine)) # type: ignore[assignment]
         pkg_config_path = self._convert_mingw_paths(pkg_config_path)
         prefix_libpaths = OrderedSet(sort_libpaths(list(prefix_libpaths), pkg_config_path))
         system_libpaths: OrderedSet[str] = OrderedSet()

--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -396,16 +396,13 @@ class _PythonDependencyBase(_Base):
                     # Python itself (except with pybind11, which has an ugly
                     # hack to work around this) - so emit a warning to explain
                     # the cause of the expected link error.
-                    buildtype = self.env.coredata.optstore.get_value_for_untyped(OptionKey('buildtype'))
-                    assert isinstance(buildtype, str)
-                    debug = self.env.coredata.optstore.get_value_for_untyped(OptionKey('debug'))
+                    buildtype = self.env.coredata.optstore.get_value_for(OptionKey('buildtype'), str)
+                    debug = self.env.coredata.optstore.get_value_for(OptionKey('debug'), bool)
                     # `debugoptimized` buildtype may not set debug=True currently, see gh-11645
                     is_debug_build = debug or buildtype == 'debug'
                     vscrt_debug = False
-                    if OptionKey('b_vscrt') in self.env.coredata.optstore:
-                        vscrt = self.env.coredata.optstore.get_value_for_untyped('b_vscrt')
-                        if vscrt in {'mdd', 'mtd', 'from_buildtype', 'static_from_buildtype'}:
-                            vscrt_debug = True
+                    if vscrt := self.env.coredata.optstore.get_value_for(OptionKey('b_vscrt'), str, default='sentinal'):
+                        vscrt_debug = vscrt in {'mdd', 'mtd', 'from_buildtype', 'static_from_buildtype'}
                     if is_debug_build and vscrt_debug and not self.variables.get('Py_DEBUG'):
                         mlog.warning(textwrap.dedent('''\
                             Using a debug build type with MSVC or an MSVC-compatible compiler

--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -396,14 +396,14 @@ class _PythonDependencyBase(_Base):
                     # Python itself (except with pybind11, which has an ugly
                     # hack to work around this) - so emit a warning to explain
                     # the cause of the expected link error.
-                    buildtype = self.env.coredata.optstore.get_value_for(OptionKey('buildtype'))
+                    buildtype = self.env.coredata.optstore.get_value_for_untyped(OptionKey('buildtype'))
                     assert isinstance(buildtype, str)
-                    debug = self.env.coredata.optstore.get_value_for(OptionKey('debug'))
+                    debug = self.env.coredata.optstore.get_value_for_untyped(OptionKey('debug'))
                     # `debugoptimized` buildtype may not set debug=True currently, see gh-11645
                     is_debug_build = debug or buildtype == 'debug'
                     vscrt_debug = False
                     if OptionKey('b_vscrt') in self.env.coredata.optstore:
-                        vscrt = self.env.coredata.optstore.get_value_for('b_vscrt')
+                        vscrt = self.env.coredata.optstore.get_value_for_untyped('b_vscrt')
                         if vscrt in {'mdd', 'mtd', 'from_buildtype', 'static_from_buildtype'}:
                             vscrt_debug = True
                     if is_debug_build and vscrt_debug and not self.variables.get('Py_DEBUG'):

--- a/mesonbuild/dependencies/qt.py
+++ b/mesonbuild/dependencies/qt.py
@@ -168,7 +168,7 @@ class _QtBase:
         return f'modules: {", ".join(sorted(self.requested_modules))}'
 
     def _get_common_defines(self) -> T.List[str]:
-        is_debug = self.env.coredata.optstore.get_value_for('debug')
+        is_debug = self.env.coredata.optstore.get_value_for_untyped('debug')
         return ['-DQT_DEBUG' if is_debug else '-DQT_NO_DEBUG']
 
 class QtPkgConfigDependency(_QtBase, PkgConfigDependency, metaclass=mesonlib.SimpleABC):
@@ -316,9 +316,9 @@ class QmakeQtDependency(_QtBase, ConfigToolDependency, metaclass=mesonlib.Simple
 
         # Use the buildtype by default, but look at the b_vscrt option if the
         # compiler supports it.
-        is_debug = self.env.coredata.optstore.get_value_for('buildtype') == 'debug'
+        is_debug = self.env.coredata.optstore.get_value_for_untyped('buildtype') == 'debug'
         if 'b_vscrt' in self.env.coredata.optstore:
-            if self.env.coredata.optstore.get_value_for('b_vscrt') in {'mdd', 'mtd'}:
+            if self.env.coredata.optstore.get_value_for_untyped('b_vscrt') in {'mdd', 'mtd'}:
                 is_debug = True
         modules_lib_suffix = _get_modules_lib_suffix(self.version, self.env.machines[self.for_machine], is_debug)
 

--- a/mesonbuild/dependencies/qt.py
+++ b/mesonbuild/dependencies/qt.py
@@ -18,6 +18,7 @@ from .detect import packages
 from .framework import ExtraFrameworkDependency
 from .pkgconfig import PkgConfigDependency
 from .factory import DependencyFactory
+from ..options import OptionKey
 from .. import mlog
 from .. import mesonlib
 
@@ -168,7 +169,7 @@ class _QtBase:
         return f'modules: {", ".join(sorted(self.requested_modules))}'
 
     def _get_common_defines(self) -> T.List[str]:
-        is_debug = self.env.coredata.optstore.get_value_for_untyped('debug')
+        is_debug = self.env.coredata.optstore.get_value_for(OptionKey('debug'), bool)
         return ['-DQT_DEBUG' if is_debug else '-DQT_NO_DEBUG']
 
 class QtPkgConfigDependency(_QtBase, PkgConfigDependency, metaclass=mesonlib.SimpleABC):
@@ -316,10 +317,8 @@ class QmakeQtDependency(_QtBase, ConfigToolDependency, metaclass=mesonlib.Simple
 
         # Use the buildtype by default, but look at the b_vscrt option if the
         # compiler supports it.
-        is_debug = self.env.coredata.optstore.get_value_for_untyped('buildtype') == 'debug'
-        if 'b_vscrt' in self.env.coredata.optstore:
-            if self.env.coredata.optstore.get_value_for_untyped('b_vscrt') in {'mdd', 'mtd'}:
-                is_debug = True
+        is_debug = self.env.coredata.optstore.get_value_for(OptionKey('buildtype'), str) == 'debug'
+        is_debug |= self.env.coredata.optstore.get_value_for(OptionKey('b_vscrt'), str, default='') in {'mdd', 'mtd'}
         modules_lib_suffix = _get_modules_lib_suffix(self.version, self.env.machines[self.for_machine], is_debug)
 
         for module in self.requested_modules:

--- a/mesonbuild/dependencies/scalapack.py
+++ b/mesonbuild/dependencies/scalapack.py
@@ -27,7 +27,7 @@ def scalapack_factory(env: 'Environment',
     candidates: T.List['DependencyGenerator'] = []
 
     if DependencyMethods.PKGCONFIG in methods:
-        static_opt = kwargs['static'] if kwargs.get('static') is not None else env.coredata.optstore.get_value_for_untyped(OptionKey('prefer_static'))
+        static_opt = s if (s := kwargs.get('static') is not None) else env.coredata.optstore.get_value_for(OptionKey('prefer_static'), bool)
         mkl = 'mkl-static-lp64-iomp' if static_opt else 'mkl-dynamic-lp64-iomp'
         candidates.append(DependencyCandidate.from_dependency(
             mkl, MKLPkgConfigDependency, (env, kwargs)))

--- a/mesonbuild/dependencies/scalapack.py
+++ b/mesonbuild/dependencies/scalapack.py
@@ -27,7 +27,7 @@ def scalapack_factory(env: 'Environment',
     candidates: T.List['DependencyGenerator'] = []
 
     if DependencyMethods.PKGCONFIG in methods:
-        static_opt = kwargs['static'] if kwargs.get('static') is not None else env.coredata.optstore.get_value_for(OptionKey('prefer_static'))
+        static_opt = kwargs['static'] if kwargs.get('static') is not None else env.coredata.optstore.get_value_for_untyped(OptionKey('prefer_static'))
         mkl = 'mkl-static-lp64-iomp' if static_opt else 'mkl-dynamic-lp64-iomp'
         candidates.append(DependencyCandidate.from_dependency(
             mkl, MKLPkgConfigDependency, (env, kwargs)))

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -51,11 +51,6 @@ NON_LANG_ENV_OPTIONS = [
 build_filename = 'meson.build'
 
 
-def _as_str(val: object) -> str:
-    assert isinstance(val, str), 'for mypy'
-    return val
-
-
 def _get_env_var(for_machine: MachineChoice, is_cross: bool, var_name: str) -> T.Optional[str]:
     """
     Returns the exact env var and the value.
@@ -521,28 +516,28 @@ class Environment:
         return self.get_libdir()
 
     def get_prefix(self) -> str:
-        return _as_str(self.coredata.optstore.get_value_for_untyped(OptionKey('prefix')))
+        return self.coredata.optstore.get_value_for(OptionKey('prefix'), str)
 
     def get_libdir(self) -> str:
-        return _as_str(self.coredata.optstore.get_value_for_untyped(OptionKey('libdir')))
+        return self.coredata.optstore.get_value_for(OptionKey('libdir'), str)
 
     def get_libexecdir(self) -> str:
-        return _as_str(self.coredata.optstore.get_value_for_untyped(OptionKey('libexecdir')))
+        return self.coredata.optstore.get_value_for(OptionKey('libexecdir'), str)
 
     def get_bindir(self) -> str:
-        return _as_str(self.coredata.optstore.get_value_for_untyped(OptionKey('bindir')))
+        return self.coredata.optstore.get_value_for(OptionKey('bindir'), str)
 
     def get_sbindir(self) -> str:
-        return _as_str(self.coredata.optstore.get_value_for_untyped(OptionKey('sbindir')))
+        return self.coredata.optstore.get_value_for(OptionKey('sbindir'), str)
 
     def get_includedir(self) -> str:
-        return _as_str(self.coredata.optstore.get_value_for_untyped(OptionKey('includedir')))
+        return self.coredata.optstore.get_value_for(OptionKey('includedir'), str)
 
     def get_mandir(self) -> str:
-        return _as_str(self.coredata.optstore.get_value_for_untyped(OptionKey('mandir')))
+        return self.coredata.optstore.get_value_for(OptionKey('mandir'), str)
 
     def get_datadir(self) -> str:
-        return _as_str(self.coredata.optstore.get_value_for_untyped(OptionKey('datadir')))
+        return self.coredata.optstore.get_value_for(OptionKey('datadir'), str)
 
     def get_compiler_system_lib_dirs(self, for_machine: MachineChoice) -> T.List[str]:
         for comp in self.coredata.compilers[for_machine].values():

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -521,28 +521,28 @@ class Environment:
         return self.get_libdir()
 
     def get_prefix(self) -> str:
-        return _as_str(self.coredata.optstore.get_value_for(OptionKey('prefix')))
+        return _as_str(self.coredata.optstore.get_value_for_untyped(OptionKey('prefix')))
 
     def get_libdir(self) -> str:
-        return _as_str(self.coredata.optstore.get_value_for(OptionKey('libdir')))
+        return _as_str(self.coredata.optstore.get_value_for_untyped(OptionKey('libdir')))
 
     def get_libexecdir(self) -> str:
-        return _as_str(self.coredata.optstore.get_value_for(OptionKey('libexecdir')))
+        return _as_str(self.coredata.optstore.get_value_for_untyped(OptionKey('libexecdir')))
 
     def get_bindir(self) -> str:
-        return _as_str(self.coredata.optstore.get_value_for(OptionKey('bindir')))
+        return _as_str(self.coredata.optstore.get_value_for_untyped(OptionKey('bindir')))
 
     def get_sbindir(self) -> str:
-        return _as_str(self.coredata.optstore.get_value_for(OptionKey('sbindir')))
+        return _as_str(self.coredata.optstore.get_value_for_untyped(OptionKey('sbindir')))
 
     def get_includedir(self) -> str:
-        return _as_str(self.coredata.optstore.get_value_for(OptionKey('includedir')))
+        return _as_str(self.coredata.optstore.get_value_for_untyped(OptionKey('includedir')))
 
     def get_mandir(self) -> str:
-        return _as_str(self.coredata.optstore.get_value_for(OptionKey('mandir')))
+        return _as_str(self.coredata.optstore.get_value_for_untyped(OptionKey('mandir')))
 
     def get_datadir(self) -> str:
-        return _as_str(self.coredata.optstore.get_value_for(OptionKey('datadir')))
+        return _as_str(self.coredata.optstore.get_value_for_untyped(OptionKey('datadir')))
 
     def get_compiler_system_lib_dirs(self, for_machine: MachineChoice) -> T.List[str]:
         for comp in self.coredata.compilers[for_machine].values():

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -698,7 +698,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
 
         search_dirs = extract_search_dirs(kwargs)
 
-        prefer_static = self.environment.coredata.optstore.get_value_for(OptionKey('prefer_static'))
+        prefer_static = self.environment.coredata.optstore.get_value_for_untyped(OptionKey('prefer_static'))
         if kwargs['static'] is True:
             libtype = mesonlib.LibType.STATIC
         elif kwargs['static'] is False:

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -238,10 +238,10 @@ class CompilerHolder(ObjectHolder['Compiler']):
             for idir in i.abs_string_list(self.environment.get_source_dir(), self.environment.get_build_dir()):
                 args.extend(self.compiler.get_include_args(idir, False))
         if not kwargs['no_builtin_args']:
-            args += self.compiler.get_option_compile_args(None, self.subproject)
-            args += self.compiler.get_option_std_args(None, self.subproject)
+            args += self.compiler.get_option_compile_args(self.subproject)
+            args += self.compiler.get_option_std_args(self.subproject)
             if mode is CompileCheckMode.LINK:
-                args.extend(self.compiler.get_option_link_args(None, self.subproject))
+                args.extend(self.compiler.get_option_link_args(self.subproject))
         if kwargs.get('werror', False):
             args.extend(self.compiler.get_werror_args())
         args.extend(kwargs['args'])

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -698,7 +698,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
 
         search_dirs = extract_search_dirs(kwargs)
 
-        prefer_static = self.environment.coredata.optstore.get_value_for_untyped(OptionKey('prefer_static'))
+        prefer_static = self.environment.coredata.optstore.get_value_for(OptionKey('prefer_static'), bool)
         if kwargs['static'] is True:
             libtype = mesonlib.LibType.STATIC
         elif kwargs['static'] is False:

--- a/mesonbuild/interpreter/dependencyfallbacks.py
+++ b/mesonbuild/interpreter/dependencyfallbacks.py
@@ -322,10 +322,10 @@ class DependencyFallbacksHolder(MesonInterpreterObject):
         required = kwargs.get('required', True)
 
         # Check if usage of the subproject fallback is forced
-        _wm = self.coredata.optstore.get_value_for(OptionKey('wrap_mode'))
+        _wm = self.coredata.optstore.get_value_for_untyped(OptionKey('wrap_mode'))
         assert isinstance(_wm, str), 'for mypy'
         wrap_mode = WrapMode.from_string(_wm)
-        force_fallback_for = self.coredata.optstore.get_value_for(OptionKey('force_fallback_for'))
+        force_fallback_for = self.coredata.optstore.get_value_for_untyped(OptionKey('force_fallback_for'))
         assert isinstance(force_fallback_for, list), 'for mypy'
         self.nofallback = wrap_mode == WrapMode.nofallback
         self.forcefallback = (force_fallback or

--- a/mesonbuild/interpreter/dependencyfallbacks.py
+++ b/mesonbuild/interpreter/dependencyfallbacks.py
@@ -322,11 +322,8 @@ class DependencyFallbacksHolder(MesonInterpreterObject):
         required = kwargs.get('required', True)
 
         # Check if usage of the subproject fallback is forced
-        _wm = self.coredata.optstore.get_value_for_untyped(OptionKey('wrap_mode'))
-        assert isinstance(_wm, str), 'for mypy'
-        wrap_mode = WrapMode.from_string(_wm)
-        force_fallback_for = self.coredata.optstore.get_value_for_untyped(OptionKey('force_fallback_for'))
-        assert isinstance(force_fallback_for, list), 'for mypy'
+        wrap_mode = WrapMode.from_string(self.coredata.optstore.get_value_for(OptionKey('wrap_mode'), str))
+        force_fallback_for = self.coredata.optstore.get_value_for(OptionKey('force_fallback_for'), list)
         self.nofallback = wrap_mode == WrapMode.nofallback
         self.forcefallback = (force_fallback or
                               wrap_mode == WrapMode.forcefallback or

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1171,7 +1171,7 @@ class Interpreter(InterpreterBase, HoldableObject):
 
         try:
             optkey = options.OptionKey.from_string(optname).evolve(subproject=self.subproject)
-            option_object, value = self.coredata.optstore.get_option_and_value_for(optkey)
+            option_object, value = self.coredata.optstore.get_option_and_value_for_untyped(optkey)
         except KeyError:
             if self.coredata.optstore.is_base_option(optkey):
                 # Due to backwards compatibility return the default
@@ -1220,11 +1220,11 @@ class Interpreter(InterpreterBase, HoldableObject):
         if OptionKey('genvslite') in self.user_defined_options.cmd_line_options:
             # Use of the '--genvslite vsxxxx' option ultimately overrides any '--backend xxx'
             # option the user may specify.
-            backend_name = self.coredata.optstore.get_value_for(OptionKey('genvslite'))
+            backend_name = self.coredata.optstore.get_value_for_untyped(OptionKey('genvslite'))
             assert isinstance(backend_name, str), 'for mypy'
             self.backend = backends.get_genvslite_backend(backend_name, self.build)
         else:
-            backend_name = self.coredata.optstore.get_value_for(OptionKey('backend'))
+            backend_name = self.coredata.optstore.get_value_for_untyped(OptionKey('backend'))
             assert isinstance(backend_name, str), 'for mypy'
             self.backend = backends.get_backend_from_name(backend_name, self.build)
 
@@ -1309,9 +1309,9 @@ class Interpreter(InterpreterBase, HoldableObject):
             # self.set_backend() otherwise it wouldn't be able to detect which
             # vs backend version we need. But after setting default_options in case
             # the project sets vs backend by default.
-            backend = self.coredata.optstore.get_value_for(OptionKey('backend'))
+            backend = self.coredata.optstore.get_value_for_untyped(OptionKey('backend'))
             assert backend is None or isinstance(backend, str), 'for mypy'
-            vsenv = self.coredata.optstore.get_value_for(OptionKey('vsenv'))
+            vsenv = self.coredata.optstore.get_value_for_untyped(OptionKey('vsenv'))
             assert isinstance(vsenv, bool), 'for mypy'
             force_vsenv = vsenv or backend.startswith('vs')
             mesonlib.setup_vsenv(force_vsenv)
@@ -1378,7 +1378,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         # Load wrap files from this (sub)project.
         subprojects_dir = os.path.join(self.subdir, spdirname)
         if not self.is_subproject():
-            wrap_mode_s = self.coredata.optstore.get_value_for(OptionKey('wrap_mode'))
+            wrap_mode_s = self.coredata.optstore.get_value_for_untyped(OptionKey('wrap_mode'))
             assert isinstance(wrap_mode_s, str), 'for mypy'
             wrap_mode = WrapMode.from_string(wrap_mode_s)
             self.environment.wrap_resolver = wrap.Resolver(self.environment.get_source_dir(), subprojects_dir, self.subproject, wrap_mode)
@@ -1817,8 +1817,8 @@ class Interpreter(InterpreterBase, HoldableObject):
             # Override find_program('meson') to return what we were invoked with
             return ExternalProgram('meson', self.environment.get_build_command(), silent=True)
 
-        wrap_mode_s = self.coredata.optstore.get_value_for(OptionKey('wrap_mode'))
-        force_fallback_for = self.coredata.optstore.get_value_for(OptionKey('force_fallback_for'))
+        wrap_mode_s = self.coredata.optstore.get_value_for_untyped(OptionKey('wrap_mode'))
+        force_fallback_for = self.coredata.optstore.get_value_for_untyped(OptionKey('force_fallback_for'))
         assert isinstance(wrap_mode_s, str), 'for mypy'
         assert isinstance(force_fallback_for, list), 'for mypy'
         wrap_mode = WrapMode.from_string(wrap_mode_s)
@@ -3254,9 +3254,9 @@ class Interpreter(InterpreterBase, HoldableObject):
             return
         if OptionKey('b_sanitize') not in self.coredata.optstore:
             return
-        if (self.coredata.optstore.get_value_for('b_lundef') and
-                self.coredata.optstore.get_value_for('b_sanitize')):
-            value = self.coredata.optstore.get_value_for('b_sanitize')
+        if (self.coredata.optstore.get_value_for_untyped('b_lundef') and
+                self.coredata.optstore.get_value_for_untyped('b_sanitize')):
+            value = self.coredata.optstore.get_value_for_untyped('b_sanitize')
             assert isinstance(value, list), 'for mypy'
             mlog.warning(textwrap.dedent(f'''\
                     Trying to use {value} sanitizer on Clang with b_lundef.
@@ -3505,10 +3505,10 @@ class Interpreter(InterpreterBase, HoldableObject):
     def build_both_libraries(self, node: mparser.BaseNode, args: T.Tuple[str, SourcesVarargsType], kwargs: kwtypes.Library) -> build.BothLibraries:
         shared_lib = self.build_target(node, args, kwargs, build.SharedLibrary, shared_library_only=False)
         static_lib = self.build_target(node, args, kwargs, build.StaticLibrary)
-        preferred_library = self.coredata.optstore.get_value_for(OptionKey('default_both_libraries', subproject=self.subproject))
+        preferred_library = self.coredata.optstore.get_value_for_untyped(OptionKey('default_both_libraries', subproject=self.subproject))
         assert isinstance(preferred_library, str), 'for mypy'
         if preferred_library == 'auto':
-            preferred_library = self.coredata.optstore.get_value_for(OptionKey('default_library', subproject=self.subproject))
+            preferred_library = self.coredata.optstore.get_value_for_untyped(OptionKey('default_library', subproject=self.subproject))
             assert isinstance(preferred_library, str), 'for mypy'
             if preferred_library == 'both':
                 preferred_library = 'shared'
@@ -3552,7 +3552,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         return build.BothLibraries(shared_lib, static_lib, preferred_library)
 
     def build_library(self, node: mparser.BaseNode, args: T.Tuple[str, SourcesVarargsType], kwargs: kwtypes.Library) -> build.SharedLibrary | build.BothLibraries | build.StaticLibrary:
-        default_library = self.coredata.optstore.get_value_for(OptionKey('default_library', subproject=self.subproject))
+        default_library = self.coredata.optstore.get_value_for_untyped(OptionKey('default_library', subproject=self.subproject))
         assert isinstance(default_library, str), 'for mypy'
         if default_library == 'shared':
             # Intentionally pass shared_library_only=False so that dependencies

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1220,12 +1220,10 @@ class Interpreter(InterpreterBase, HoldableObject):
         if OptionKey('genvslite') in self.user_defined_options.cmd_line_options:
             # Use of the '--genvslite vsxxxx' option ultimately overrides any '--backend xxx'
             # option the user may specify.
-            backend_name = self.coredata.optstore.get_value_for_untyped(OptionKey('genvslite'))
-            assert isinstance(backend_name, str), 'for mypy'
+            backend_name = self.coredata.optstore.get_value_for(OptionKey('genvslite'), str)
             self.backend = backends.get_genvslite_backend(backend_name, self.build)
         else:
-            backend_name = self.coredata.optstore.get_value_for_untyped(OptionKey('backend'))
-            assert isinstance(backend_name, str), 'for mypy'
+            backend_name = self.coredata.optstore.get_value_for(OptionKey('backend'), str)
             self.backend = backends.get_backend_from_name(backend_name, self.build)
 
         if backend_name != self.backend.name:
@@ -1309,10 +1307,8 @@ class Interpreter(InterpreterBase, HoldableObject):
             # self.set_backend() otherwise it wouldn't be able to detect which
             # vs backend version we need. But after setting default_options in case
             # the project sets vs backend by default.
-            backend = self.coredata.optstore.get_value_for_untyped(OptionKey('backend'))
-            assert backend is None or isinstance(backend, str), 'for mypy'
-            vsenv = self.coredata.optstore.get_value_for_untyped(OptionKey('vsenv'))
-            assert isinstance(vsenv, bool), 'for mypy'
+            backend = self.coredata.optstore.get_value_for(OptionKey('backend'), str)
+            vsenv = self.coredata.optstore.get_value_for(OptionKey('vsenv'), bool)
             force_vsenv = vsenv or backend.startswith('vs')
             mesonlib.setup_vsenv(force_vsenv)
         self.set_backend()
@@ -1378,9 +1374,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         # Load wrap files from this (sub)project.
         subprojects_dir = os.path.join(self.subdir, spdirname)
         if not self.is_subproject():
-            wrap_mode_s = self.coredata.optstore.get_value_for_untyped(OptionKey('wrap_mode'))
-            assert isinstance(wrap_mode_s, str), 'for mypy'
-            wrap_mode = WrapMode.from_string(wrap_mode_s)
+            wrap_mode = WrapMode.from_string(self.coredata.optstore.get_value_for(OptionKey('wrap_mode'), str))
             self.environment.wrap_resolver = wrap.Resolver(self.environment.get_source_dir(), subprojects_dir, self.subproject, wrap_mode)
         else:
             self.environment.wrap_resolver.load_and_merge(subprojects_dir, self.subproject)
@@ -1817,11 +1811,8 @@ class Interpreter(InterpreterBase, HoldableObject):
             # Override find_program('meson') to return what we were invoked with
             return ExternalProgram('meson', self.environment.get_build_command(), silent=True)
 
-        wrap_mode_s = self.coredata.optstore.get_value_for_untyped(OptionKey('wrap_mode'))
-        force_fallback_for = self.coredata.optstore.get_value_for_untyped(OptionKey('force_fallback_for'))
-        assert isinstance(wrap_mode_s, str), 'for mypy'
-        assert isinstance(force_fallback_for, list), 'for mypy'
-        wrap_mode = WrapMode.from_string(wrap_mode_s)
+        wrap_mode = WrapMode.from_string(self.coredata.optstore.get_value_for(OptionKey('wrap_mode'), str))
+        force_fallback_for = self.coredata.optstore.get_value_for(OptionKey('force_fallback_for'), list)
 
         fallback: SubProject | None = \
             self.environment.wrap_resolver.find_program_provider(args) \
@@ -3250,19 +3241,13 @@ class Interpreter(InterpreterBase, HoldableObject):
                 break
 
     def check_clang_asan_lundef(self) -> None:
-        if OptionKey('b_lundef') not in self.coredata.optstore:
-            return
-        if OptionKey('b_sanitize') not in self.coredata.optstore:
-            return
-        if (self.coredata.optstore.get_value_for_untyped('b_lundef') and
-                self.coredata.optstore.get_value_for_untyped('b_sanitize')):
-            value = self.coredata.optstore.get_value_for_untyped('b_sanitize')
-            assert isinstance(value, list), 'for mypy'
-            mlog.warning(textwrap.dedent(f'''\
-                    Trying to use {value} sanitizer on Clang with b_lundef.
-                    This will probably not work.
-                    Try setting b_lundef to false instead.'''),
-                location=self.current_node)  # noqa: E128
+        if self.coredata.optstore.get_value_for(OptionKey('b_lundef'), bool, default=False):
+            if value := self.coredata.optstore.get_value_for(OptionKey('b_sanitize'), list, default=[]):
+                mlog.warning(textwrap.dedent(f'''\
+                        Trying to use {', '.join(value)} sanitizer(s) on Clang with b_lundef.
+                        This will probably not work.
+                        Try setting b_lundef to false instead.'''),
+                    location=self.current_node)  # noqa: E128
 
     # Check that the indicated file is within the same subproject
     # as we currently are. This is to stop people doing
@@ -3505,11 +3490,9 @@ class Interpreter(InterpreterBase, HoldableObject):
     def build_both_libraries(self, node: mparser.BaseNode, args: T.Tuple[str, SourcesVarargsType], kwargs: kwtypes.Library) -> build.BothLibraries:
         shared_lib = self.build_target(node, args, kwargs, build.SharedLibrary, shared_library_only=False)
         static_lib = self.build_target(node, args, kwargs, build.StaticLibrary)
-        preferred_library = self.coredata.optstore.get_value_for_untyped(OptionKey('default_both_libraries', subproject=self.subproject))
-        assert isinstance(preferred_library, str), 'for mypy'
+        preferred_library = self.coredata.optstore.get_value_for(OptionKey('default_both_libraries', subproject=self.subproject), str)
         if preferred_library == 'auto':
-            preferred_library = self.coredata.optstore.get_value_for_untyped(OptionKey('default_library', subproject=self.subproject))
-            assert isinstance(preferred_library, str), 'for mypy'
+            preferred_library = self.coredata.optstore.get_value_for(OptionKey('default_library', subproject=self.subproject), str)
             if preferred_library == 'both':
                 preferred_library = 'shared'
         assert preferred_library in {'shared', 'static'}
@@ -3552,8 +3535,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         return build.BothLibraries(shared_lib, static_lib, preferred_library)
 
     def build_library(self, node: mparser.BaseNode, args: T.Tuple[str, SourcesVarargsType], kwargs: kwtypes.Library) -> build.SharedLibrary | build.BothLibraries | build.StaticLibrary:
-        default_library = self.coredata.optstore.get_value_for_untyped(OptionKey('default_library', subproject=self.subproject))
-        assert isinstance(default_library, str), 'for mypy'
+        default_library = self.coredata.optstore.get_value_for(OptionKey('default_library', subproject=self.subproject), str)
         if default_library == 'shared':
             # Intentionally pass shared_library_only=False so that dependencies
             # end up in Requires.private.  Many libraries that refer to their

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -1045,7 +1045,7 @@ class BuildTargetHolder(ObjectHolder[_BuildTarget]):
         if self.subproject != self.held_object.subproject:
             raise InterpreterException('Tried to extract objects from a different subproject.')
         tobj = self._target_object
-        unity_value = self.interpreter.coredata.optstore.get_option_for_target_untyped(tobj, "unity")
+        unity_value = self.interpreter.coredata.optstore.get_option_for_target(tobj, OptionKey("unity"), str)
         is_unity = (unity_value == 'on' or (unity_value == 'subprojects' and tobj.subproject != ''))
 
         obj_src: list[mesonlib.File | build.GeneratedTypes] = []

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -1044,7 +1044,7 @@ class BuildTargetHolder(ObjectHolder[_BuildTarget]):
         if self.subproject != self.held_object.subproject:
             raise InterpreterException('Tried to extract objects from a different subproject.')
         tobj = self._target_object
-        unity_value = self.interpreter.coredata.get_option_for_target(tobj, "unity")
+        unity_value = self.interpreter.coredata.optstore.get_option_for_target(tobj, "unity")
         is_unity = (unity_value == 'on' or (unity_value == 'subprojects' and tobj.subproject != ''))
 
         obj_src: list[mesonlib.File | build.GeneratedTypes] = []

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -25,6 +25,7 @@ from ..interpreterbase import (
                                InterpreterException, InvalidArguments, InvalidCode)
 from ..interpreter.type_checking import NoneType, ENV_KW, ENV_SEPARATOR_KW, PKGCONFIG_DEFINE_KW
 from ..dependencies import Dependency, ExternalLibrary, InternalDependency
+from ..options import OptionKey
 from ..programs import Program
 from ..mesonlib import File, HoldableObject, listify, MachineChoice, MesonException
 
@@ -115,7 +116,7 @@ def extract_search_dirs(kwargs: 'kwargs.ExtractSearchDirs') -> T.List[str]:
 class FeatureOptionHolder(ObjectHolder[Feature]):
     def __init__(self, option: Feature, interpreter: 'Interpreter'):
         if option.is_auto():
-            auto_value = T.cast('str', interpreter.environment.coredata.optstore.get_value_for_untyped('auto_features'))
+            auto_value = interpreter.environment.coredata.optstore.get_value_for(OptionKey('auto_features'), str)
             option = option.with_value(FeatureValue(auto_value))
         super().__init__(option, interpreter)
 

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -115,7 +115,7 @@ def extract_search_dirs(kwargs: 'kwargs.ExtractSearchDirs') -> T.List[str]:
 class FeatureOptionHolder(ObjectHolder[Feature]):
     def __init__(self, option: Feature, interpreter: 'Interpreter'):
         if option.is_auto():
-            auto_value = T.cast('str', interpreter.environment.coredata.optstore.get_value_for('auto_features'))
+            auto_value = T.cast('str', interpreter.environment.coredata.optstore.get_value_for_untyped('auto_features'))
             option = option.with_value(FeatureValue(auto_value))
         super().__init__(option, interpreter)
 
@@ -1044,7 +1044,7 @@ class BuildTargetHolder(ObjectHolder[_BuildTarget]):
         if self.subproject != self.held_object.subproject:
             raise InterpreterException('Tried to extract objects from a different subproject.')
         tobj = self._target_object
-        unity_value = self.interpreter.coredata.optstore.get_option_for_target(tobj, "unity")
+        unity_value = self.interpreter.coredata.optstore.get_option_for_target_untyped(tobj, "unity")
         is_unity = (unity_value == 'on' or (unity_value == 'subprojects' and tobj.subproject != ''))
 
         obj_src: list[mesonlib.File | build.GeneratedTypes] = []

--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -309,7 +309,7 @@ class MesonMain(MesonInterpreterObject):
     @noKwargs
     @InterpreterObject.method('is_unity')
     def is_unity_method(self, args: T.List['TYPE_var'], kwargs: 'TYPE_kwargs') -> bool:
-        optval = self.interpreter.environment.coredata.optstore.get_value_for(OptionKey('unity'))
+        optval = self.interpreter.environment.coredata.optstore.get_value_for_untyped(OptionKey('unity'))
         return optval == 'on' or (optval == 'subprojects' and self.interpreter.is_subproject())
 
     @noPosargs
@@ -368,7 +368,7 @@ class MesonMain(MesonInterpreterObject):
         dep.name = name
 
         optkey = OptionKey('default_library', subproject=self.interpreter.subproject)
-        default_library = self.interpreter.coredata.optstore.get_value_for(optkey)
+        default_library = self.interpreter.coredata.optstore.get_value_for_untyped(optkey)
         assert isinstance(default_library, str), 'for mypy'
         static = kwargs['static']
         if static is None:

--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -309,7 +309,7 @@ class MesonMain(MesonInterpreterObject):
     @noKwargs
     @InterpreterObject.method('is_unity')
     def is_unity_method(self, args: T.List['TYPE_var'], kwargs: 'TYPE_kwargs') -> bool:
-        optval = self.interpreter.environment.coredata.optstore.get_value_for_untyped(OptionKey('unity'))
+        optval = self.interpreter.environment.coredata.optstore.get_value_for(OptionKey('unity'), str)
         return optval == 'on' or (optval == 'subprojects' and self.interpreter.is_subproject())
 
     @noPosargs
@@ -368,8 +368,7 @@ class MesonMain(MesonInterpreterObject):
         dep.name = name
 
         optkey = OptionKey('default_library', subproject=self.interpreter.subproject)
-        default_library = self.interpreter.coredata.optstore.get_value_for_untyped(optkey)
-        assert isinstance(default_library, str), 'for mypy'
+        default_library = self.interpreter.coredata.optstore.get_value_for(optkey, str)
         static = kwargs['static']
         if static is None:
             # We don't know if dep represents a static or shared library, could

--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -138,7 +138,7 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
         override = comp_class.use_linker_args(value[0], comp_version)
         check_args += override
 
-    if env.machines[for_machine].is_os2() and env.coredata.optstore.get_value_for_untyped(OptionKey('os2_emxomf')):
+    if env.machines[for_machine].is_os2() and env.coredata.optstore.get_value_for(OptionKey('os2_emxomf'), bool):
         check_args += ['-Zomf']
 
     mlog.debug('-----')

--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -138,7 +138,7 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
         override = comp_class.use_linker_args(value[0], comp_version)
         check_args += override
 
-    if env.machines[for_machine].is_os2() and env.coredata.optstore.get_value_for(OptionKey('os2_emxomf')):
+    if env.machines[for_machine].is_os2() and env.coredata.optstore.get_value_for_untyped(OptionKey('os2_emxomf')):
         check_args += ['-Zomf']
 
     mlog.debug('-----')

--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -53,7 +53,7 @@ def guess_win_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
     else:
         check_args = comp_class.LINKER_OPTION_STYLE.wrap(['/logo', '--version'])
 
-    check_args += env.coredata.get_external_link_args(for_machine, comp_class.language)
+    check_args += env.coredata.optstore.get_external_link_args(for_machine, comp_class.language)
 
     override: T.List[str] = []
     value = env.lookup_binary_entry(for_machine, comp_class.language + '_ld')
@@ -128,7 +128,7 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
     extra_args = extra_args or []
 
     system = env.machines[for_machine].system
-    ldflags = env.coredata.get_external_link_args(for_machine, comp_class.language)
+    ldflags = env.coredata.optstore.get_external_link_args(for_machine, comp_class.language)
     extra_args += comp_class._unix_args_to_native(ldflags, env.machines[for_machine])
     check_args = comp_class.LINKER_OPTION_STYLE.wrap(['--version']) + extra_args
 

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -16,7 +16,7 @@ from ..arglist import CompilerArgs
 
 if T.TYPE_CHECKING:
     from ..environment import Environment
-    from ..mesonlib import MachineChoice
+    from ..mesonlib import MachineChoice, SubProject
     from ..build import BuildTarget
     from ..compilers.compilers import LinkerOptionStyle
 
@@ -88,7 +88,7 @@ class StaticLinker:
     def openmp_flags(self) -> T.List[str]:
         return []
 
-    def get_option_link_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_link_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         return []
 
     @classmethod
@@ -200,7 +200,7 @@ class DynamicLinker(metaclass=mesonlib.SimpleABC):
     def get_option_args(self, target: 'BuildTarget', env: 'Environment', subproject: T.Optional[str] = None) -> T.List[str]:
         return []
 
-    def get_option_link_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
+    def get_option_link_args(self, target: BuildTarget | SubProject | None) -> list[str]:
         return []
 
     def has_multi_arguments(self, args: T.List[str]) -> T.Tuple[bool, bool]:

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -355,14 +355,14 @@ def run(options: 'argparse.Namespace') -> int:
 
     b = build.load(options.wd)
     cdata = b.environment.coredata
-    need_vsenv = T.cast('bool', cdata.optstore.get_value_for(OptionKey('vsenv')))
+    need_vsenv = T.cast('bool', cdata.optstore.get_value_for_untyped(OptionKey('vsenv')))
     if setup_vsenv(need_vsenv):
         mlog.log(mlog.green('INFO:'), 'automatically activated MSVC compiler environment')
 
     cmd: T.List[str] = []
     env: T.Optional[T.Dict[str, str]] = None
 
-    backend = cdata.optstore.get_value_for(OptionKey('backend'))
+    backend = cdata.optstore.get_value_for_untyped(OptionKey('backend'))
     assert isinstance(backend, str)
     mlog.log(mlog.green('INFO:'), 'autodetecting backend as', backend)
     if backend == 'ninja':

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -355,15 +355,14 @@ def run(options: 'argparse.Namespace') -> int:
 
     b = build.load(options.wd)
     cdata = b.environment.coredata
-    need_vsenv = T.cast('bool', cdata.optstore.get_value_for_untyped(OptionKey('vsenv')))
+    need_vsenv = cdata.optstore.get_value_for(OptionKey('vsenv'), bool)
     if setup_vsenv(need_vsenv):
         mlog.log(mlog.green('INFO:'), 'automatically activated MSVC compiler environment')
 
     cmd: T.List[str] = []
     env: T.Optional[T.Dict[str, str]] = None
 
-    backend = cdata.optstore.get_value_for_untyped(OptionKey('backend'))
-    assert isinstance(backend, str)
+    backend = cdata.optstore.get_value_for(OptionKey('backend'), str)
     mlog.log(mlog.green('INFO:'), 'autodetecting backend as', backend)
     if backend == 'ninja':
         cmd, env = get_parsed_args_ninja(options, bdir)

--- a/mesonbuild/mdevenv.py
+++ b/mesonbuild/mdevenv.py
@@ -97,10 +97,8 @@ def bash_completion_files(b: build.Build, install_data: 'InstallData') -> T.List
     dep = PkgConfigDependency('bash-completion', b.environment,
                               {'required': False, 'silent': True, 'version': ['>=2.10'], 'native': MachineChoice.HOST})
     if dep.found():
-        prefix = b.environment.coredata.optstore.get_value_for_untyped(OptionKey('prefix'))
-        assert isinstance(prefix, str), 'for mypy'
-        datadir = b.environment.coredata.optstore.get_value_for_untyped(OptionKey('datadir'))
-        assert isinstance(datadir, str), 'for mypy'
+        prefix = b.environment.coredata.optstore.get_value_for(OptionKey('prefix'), str)
+        datadir = b.environment.coredata.optstore.get_value_for(OptionKey('datadir'), str)
         datadir_abs = os.path.join(prefix, datadir)
         completionsdir = dep.get_variable(pkgconfig='completionsdir', pkgconfig_define=(('datadir', datadir_abs),))
         assert isinstance(completionsdir, str), 'for mypy'
@@ -185,7 +183,7 @@ def run(options: argparse.Namespace) -> int:
     b = build.load(options.builddir)
     workdir = options.workdir or options.builddir
 
-    need_vsenv = T.cast('bool', b.environment.coredata.optstore.get_value_for_untyped(OptionKey('vsenv')))
+    need_vsenv = b.environment.coredata.optstore.get_value_for(OptionKey('vsenv'), bool)
     setup_vsenv(need_vsenv) # Call it before get_env to get vsenv vars as well
     dump_fmt = options.dump_format if options.dump else None
     devenv, varnames = get_env(b, dump_fmt)

--- a/mesonbuild/mdevenv.py
+++ b/mesonbuild/mdevenv.py
@@ -97,9 +97,9 @@ def bash_completion_files(b: build.Build, install_data: 'InstallData') -> T.List
     dep = PkgConfigDependency('bash-completion', b.environment,
                               {'required': False, 'silent': True, 'version': ['>=2.10'], 'native': MachineChoice.HOST})
     if dep.found():
-        prefix = b.environment.coredata.optstore.get_value_for(OptionKey('prefix'))
+        prefix = b.environment.coredata.optstore.get_value_for_untyped(OptionKey('prefix'))
         assert isinstance(prefix, str), 'for mypy'
-        datadir = b.environment.coredata.optstore.get_value_for(OptionKey('datadir'))
+        datadir = b.environment.coredata.optstore.get_value_for_untyped(OptionKey('datadir'))
         assert isinstance(datadir, str), 'for mypy'
         datadir_abs = os.path.join(prefix, datadir)
         completionsdir = dep.get_variable(pkgconfig='completionsdir', pkgconfig_define=(('datadir', datadir_abs),))
@@ -185,7 +185,7 @@ def run(options: argparse.Namespace) -> int:
     b = build.load(options.builddir)
     workdir = options.workdir or options.builddir
 
-    need_vsenv = T.cast('bool', b.environment.coredata.optstore.get_value_for(OptionKey('vsenv')))
+    need_vsenv = T.cast('bool', b.environment.coredata.optstore.get_value_for_untyped(OptionKey('vsenv')))
     setup_vsenv(need_vsenv) # Call it before get_env to get vsenv vars as well
     dump_fmt = options.dump_format if options.dump else None
     devenv, varnames = get_env(b, dump_fmt)

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -382,7 +382,7 @@ def run(options: argparse.Namespace) -> int:
     if not buildfile.is_file():
         raise MesonException(f'Directory {options.wd!r} does not seem to be a Meson build directory.')
     b = build.load(options.wd)
-    need_vsenv = T.cast('bool', b.environment.coredata.optstore.get_value_for(OptionKey('vsenv')))
+    need_vsenv = T.cast('bool', b.environment.coredata.optstore.get_value_for_untyped(OptionKey('vsenv')))
     setup_vsenv(need_vsenv)
     src_root = b.environment.source_dir
     bld_root = b.environment.build_dir

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -382,7 +382,7 @@ def run(options: argparse.Namespace) -> int:
     if not buildfile.is_file():
         raise MesonException(f'Directory {options.wd!r} does not seem to be a Meson build directory.')
     b = build.load(options.wd)
-    need_vsenv = T.cast('bool', b.environment.coredata.optstore.get_value_for_untyped(OptionKey('vsenv')))
+    need_vsenv = b.environment.coredata.optstore.get_value_for(OptionKey('vsenv'), bool)
     setup_vsenv(need_vsenv)
     src_root = b.environment.source_dir
     bld_root = b.environment.build_dir

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -193,7 +193,7 @@ def run(options: Arguments) -> int:
             raise SystemExit
 
         b = build.load(options.builddir)
-        need_vsenv = T.cast('bool', b.environment.coredata.optstore.get_value_for(OptionKey('vsenv')))
+        need_vsenv = T.cast('bool', b.environment.coredata.optstore.get_value_for_untyped(OptionKey('vsenv')))
         vsenv_active = mesonlib.setup_vsenv(need_vsenv)
         if vsenv_active:
             mlog.log(mlog.green('INFO:'), 'automatically activated MSVC compiler environment')

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -193,7 +193,7 @@ def run(options: Arguments) -> int:
             raise SystemExit
 
         b = build.load(options.builddir)
-        need_vsenv = T.cast('bool', b.environment.coredata.optstore.get_value_for_untyped(OptionKey('vsenv')))
+        need_vsenv = b.environment.coredata.optstore.get_value_for(OptionKey('vsenv'), bool)
         vsenv_active = mesonlib.setup_vsenv(need_vsenv)
         if vsenv_active:
             mlog.log(mlog.green('INFO:'), 'automatically activated MSVC compiler environment')

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -881,9 +881,9 @@ def run(opts: 'ArgumentType') -> int:
         sys.exit('Install data not found. Run this command in build directory root.')
     if not opts.no_rebuild:
         b = build.load(opts.wd)
-        need_vsenv = T.cast('bool', b.environment.coredata.optstore.get_value_for_untyped(OptionKey('vsenv')))
+        need_vsenv = b.environment.coredata.optstore.get_value_for(OptionKey('vsenv'), bool)
         setup_vsenv(need_vsenv)
-        backend = T.cast('str', b.environment.coredata.optstore.get_value_for_untyped(OptionKey('backend')))
+        backend = b.environment.coredata.optstore.get_value_for(OptionKey('backend'), str)
         if not rebuild_all(opts.wd, backend):
             sys.exit(-1)
     os.chdir(opts.wd)

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -881,9 +881,9 @@ def run(opts: 'ArgumentType') -> int:
         sys.exit('Install data not found. Run this command in build directory root.')
     if not opts.no_rebuild:
         b = build.load(opts.wd)
-        need_vsenv = T.cast('bool', b.environment.coredata.optstore.get_value_for(OptionKey('vsenv')))
+        need_vsenv = T.cast('bool', b.environment.coredata.optstore.get_value_for_untyped(OptionKey('vsenv')))
         setup_vsenv(need_vsenv)
-        backend = T.cast('str', b.environment.coredata.optstore.get_value_for(OptionKey('backend')))
+        backend = T.cast('str', b.environment.coredata.optstore.get_value_for_untyped(OptionKey('backend')))
         if not rebuild_all(opts.wd, backend):
             sys.exit(-1)
     os.chdir(opts.wd)

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -113,7 +113,7 @@ def list_install_plan(coredata: cdata.CoreData, builddata: build.Build, backend:
     return plan
 
 def get_target_dir(coredata: cdata.CoreData, subdir: str) -> str:
-    if coredata.optstore.get_value_for_untyped(OptionKey('layout')) == 'flat':
+    if coredata.optstore.get_value_for(OptionKey('layout'), str) == 'flat':
         return 'meson-out'
     else:
         return subdir

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -113,7 +113,7 @@ def list_install_plan(coredata: cdata.CoreData, builddata: build.Build, backend:
     return plan
 
 def get_target_dir(coredata: cdata.CoreData, subdir: str) -> str:
-    if coredata.optstore.get_value_for(OptionKey('layout')) == 'flat':
+    if coredata.optstore.get_value_for_untyped(OptionKey('layout')) == 'flat':
         return 'meson-out'
     else:
         return subdir

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -161,12 +161,6 @@ class ModuleState:
         # TODO: Use interpreter internal API, but we need to go through @typed_kwargs
         self._interpreter.func_test(self.current_node, real_args, kwargs)
 
-    def is_user_defined_option(self, name: str, subproject: str = '',
-                               machine: MachineChoice = MachineChoice.HOST,
-                               lang: T.Optional[str] = None) -> bool:
-        key = OptionKey(name, subproject, machine)
-        return key in self._interpreter.user_defined_options.cmd_line_options
-
     def process_include_dirs(self, dirs: T.Iterable[T.Union[str, IncludeDirs]]) -> T.Iterable[IncludeDirs]:
         """Convert raw include directory arguments to only IncludeDirs
 

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -23,7 +23,6 @@ if T.TYPE_CHECKING:
     from ..interpreterbase import TYPE_var, TYPE_kwargs
     from ..programs import Program
     from ..dependencies import Dependency
-    from ..options import ElementaryOptionValues
 
 class ModuleState:
     """Object passed to all module methods.
@@ -161,10 +160,6 @@ class ModuleState:
         real_args = list(args)
         # TODO: Use interpreter internal API, but we need to go through @typed_kwargs
         self._interpreter.func_test(self.current_node, real_args, kwargs)
-
-    def get_option(self, name: str, subproject: str = '',
-                   machine: MachineChoice = MachineChoice.HOST) -> ElementaryOptionValues:
-        return self.environment.coredata.optstore.get_value_for_untyped(OptionKey(name, subproject, machine))
 
     def is_user_defined_option(self, name: str, subproject: str = '',
                                machine: MachineChoice = MachineChoice.HOST,

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -164,7 +164,7 @@ class ModuleState:
 
     def get_option(self, name: str, subproject: str = '',
                    machine: MachineChoice = MachineChoice.HOST) -> ElementaryOptionValues:
-        return self.environment.coredata.optstore.get_value_for(OptionKey(name, subproject, machine))
+        return self.environment.coredata.optstore.get_value_for_untyped(OptionKey(name, subproject, machine))
 
     def is_user_defined_option(self, name: str, subproject: str = '',
                                machine: MachineChoice = MachineChoice.HOST,

--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -315,8 +315,7 @@ class CmakeModule(ExtensionModule):
 
         pkgroot = pkgroot_name = kwargs['install_dir']
         if pkgroot is None:
-            libdir = state.environment.coredata.optstore.get_value_for_untyped(OptionKey('libdir'))
-            assert isinstance(libdir, str), 'for mypy'
+            libdir = state.environment.coredata.optstore.get_value_for(OptionKey('libdir'), str)
             pkgroot = os.path.join(libdir, 'cmake', name)
             pkgroot_name = os.path.join('{libdir}', 'cmake', name)
 
@@ -388,8 +387,7 @@ class CmakeModule(ExtensionModule):
 
         install_dir = kwargs['install_dir']
         if install_dir is None:
-            libdir = state.environment.coredata.optstore.get_value_for_untyped(OptionKey('libdir'))
-            assert isinstance(libdir, str), 'for mypy'
+            libdir = state.environment.coredata.optstore.get_value_for(OptionKey('libdir'), str)
             install_dir = os.path.join(libdir, 'cmake', name)
 
         conf = kwargs['configuration']
@@ -397,8 +395,7 @@ class CmakeModule(ExtensionModule):
             FeatureNew.single_use('cmake.configure_package_config_file dict as configuration', '0.62.0', state.subproject, location=state.current_node)
             conf = build.ConfigurationData(conf)
 
-        prefix = state.environment.coredata.optstore.get_value_for_untyped(OptionKey('prefix'))
-        assert isinstance(prefix, str), 'for mypy'
+        prefix = state.environment.coredata.optstore.get_value_for(OptionKey('prefix'), str)
         abs_install_dir = install_dir
         if not os.path.isabs(abs_install_dir):
             abs_install_dir = os.path.join(prefix, install_dir)

--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -315,7 +315,7 @@ class CmakeModule(ExtensionModule):
 
         pkgroot = pkgroot_name = kwargs['install_dir']
         if pkgroot is None:
-            libdir = state.environment.coredata.optstore.get_value_for(OptionKey('libdir'))
+            libdir = state.environment.coredata.optstore.get_value_for_untyped(OptionKey('libdir'))
             assert isinstance(libdir, str), 'for mypy'
             pkgroot = os.path.join(libdir, 'cmake', name)
             pkgroot_name = os.path.join('{libdir}', 'cmake', name)
@@ -388,7 +388,7 @@ class CmakeModule(ExtensionModule):
 
         install_dir = kwargs['install_dir']
         if install_dir is None:
-            libdir = state.environment.coredata.optstore.get_value_for(OptionKey('libdir'))
+            libdir = state.environment.coredata.optstore.get_value_for_untyped(OptionKey('libdir'))
             assert isinstance(libdir, str), 'for mypy'
             install_dir = os.path.join(libdir, 'cmake', name)
 
@@ -397,7 +397,7 @@ class CmakeModule(ExtensionModule):
             FeatureNew.single_use('cmake.configure_package_config_file dict as configuration', '0.62.0', state.subproject, location=state.current_node)
             conf = build.ConfigurationData(conf)
 
-        prefix = state.environment.coredata.optstore.get_value_for(OptionKey('prefix'))
+        prefix = state.environment.coredata.optstore.get_value_for_untyped(OptionKey('prefix'))
         assert isinstance(prefix, str), 'for mypy'
         abs_install_dir = install_dir
         if not os.path.isabs(abs_install_dir):

--- a/mesonbuild/modules/external_project.py
+++ b/mesonbuild/modules/external_project.py
@@ -156,7 +156,7 @@ class ExternalProject(NewExtensionModule):
         for lang, compiler in self.env.coredata.compilers[MachineChoice.HOST].items():
             if any(lang not in i for i in (ENV_VAR_PROG_MAP, CFLAGS_MAPPING)):
                 continue
-            cargs = self.env.coredata.get_external_args(MachineChoice.HOST, lang)
+            cargs = self.env.coredata.optstore.get_external_args(MachineChoice.HOST, lang)
             assert isinstance(cargs, list), 'for mypy'
             self.run_env[ENV_VAR_PROG_MAP[lang][0]] = self._quote_and_join(compiler.get_exelist())
             self.run_env[CFLAGS_MAPPING[lang]] = self._quote_and_join(cargs)

--- a/mesonbuild/modules/external_project.py
+++ b/mesonbuild/modules/external_project.py
@@ -76,16 +76,16 @@ class ExternalProject(NewExtensionModule):
         self.src_dir = Path(self.env.get_source_dir(), self.subdir)
         self.build_dir = Path(self.env.get_build_dir(), self.subdir, 'build')
         self.install_dir = Path(self.env.get_build_dir(), self.subdir, 'dist')
-        _p = self.env.coredata.optstore.get_value_for(OptionKey('prefix'))
+        _p = self.env.coredata.optstore.get_value_for_untyped(OptionKey('prefix'))
         assert isinstance(_p, str), 'for mypy'
         self.prefix = Path(_p)
-        _l = self.env.coredata.optstore.get_value_for(OptionKey('libdir'))
+        _l = self.env.coredata.optstore.get_value_for_untyped(OptionKey('libdir'))
         assert isinstance(_l, str), 'for mypy'
         self.libdir = Path(_l)
-        _l = self.env.coredata.optstore.get_value_for(OptionKey('bindir'))
+        _l = self.env.coredata.optstore.get_value_for_untyped(OptionKey('bindir'))
         assert isinstance(_l, str), 'for mypy'
         self.bindir = Path(_l)
-        _i = self.env.coredata.optstore.get_value_for(OptionKey('includedir'))
+        _i = self.env.coredata.optstore.get_value_for_untyped(OptionKey('includedir'))
         assert isinstance(_i, str), 'for mypy'
         self.includedir = Path(_i)
         self.name = self.src_dir.name

--- a/mesonbuild/modules/external_project.py
+++ b/mesonbuild/modules/external_project.py
@@ -76,18 +76,10 @@ class ExternalProject(NewExtensionModule):
         self.src_dir = Path(self.env.get_source_dir(), self.subdir)
         self.build_dir = Path(self.env.get_build_dir(), self.subdir, 'build')
         self.install_dir = Path(self.env.get_build_dir(), self.subdir, 'dist')
-        _p = self.env.coredata.optstore.get_value_for_untyped(OptionKey('prefix'))
-        assert isinstance(_p, str), 'for mypy'
-        self.prefix = Path(_p)
-        _l = self.env.coredata.optstore.get_value_for_untyped(OptionKey('libdir'))
-        assert isinstance(_l, str), 'for mypy'
-        self.libdir = Path(_l)
-        _l = self.env.coredata.optstore.get_value_for_untyped(OptionKey('bindir'))
-        assert isinstance(_l, str), 'for mypy'
-        self.bindir = Path(_l)
-        _i = self.env.coredata.optstore.get_value_for_untyped(OptionKey('includedir'))
-        assert isinstance(_i, str), 'for mypy'
-        self.includedir = Path(_i)
+        self.prefix = Path(self.env.coredata.optstore.get_value_for(OptionKey('prefix'), str))
+        self.libdir = Path(self.env.coredata.optstore.get_value_for(OptionKey('libdir'), str))
+        self.bindir = Path(self.env.coredata.optstore.get_value_for(OptionKey('bindir'), str))
+        self.includedir = Path(self.env.coredata.optstore.get_value_for(OptionKey('includedir'), str))
         self.name = self.src_dir.name
 
         self.prefix = self._cygpath_convert(self.prefix)

--- a/mesonbuild/modules/external_project.py
+++ b/mesonbuild/modules/external_project.py
@@ -162,7 +162,7 @@ class ExternalProject(NewExtensionModule):
             self.run_env[CFLAGS_MAPPING[lang]] = self._quote_and_join(cargs)
             if not link_exelist:
                 link_exelist = compiler.get_linker_exelist()
-                _l = self.env.coredata.get_external_link_args(MachineChoice.HOST, lang)
+                _l = self.env.coredata.optstore.get_external_link_args(MachineChoice.HOST, lang)
                 assert isinstance(_l, list), 'for mypy'
                 link_args = _l
         if link_exelist:

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2015-2016 The Meson development team
-# Copyright © 2023-2025 Intel Corporation
+# Copyright © 2023-2026 Intel Corporation
 
 '''This module provides helper functions for Gnome/GLib related
 functionality such as gobject-introspection, gresources and gtk-doc'''
@@ -44,7 +44,7 @@ if T.TYPE_CHECKING:
     from ..compilers import Compiler
     from ..interpreter import Interpreter
     from ..interpreterbase import TYPE_var, TYPE_kwargs
-    from ..mesonlib import FileOrString
+    from ..mesonlib import EnvironmentVariables, FileOrString
     from ..programs import Program, CommandList, CommandListEntry
 
     class PostInstall(TypedDict):
@@ -84,6 +84,7 @@ if T.TYPE_CHECKING:
         build_by_default: bool
         dependencies: T.List[Dependency]
         doc_format: T.Optional[str]
+        env: EnvironmentVariables
         export_packages: T.List[str]
         extra_args: T.List[str]
         fatal_warnings: bool
@@ -92,8 +93,10 @@ if T.TYPE_CHECKING:
         include_directories: T.List[T.Union[build.IncludeDirs, str]]
         includes: T.List[T.Union[str, GirTarget]]
         install: bool
-        install_dir_gir: T.Optional[str]
-        install_dir_typelib: T.Optional[str]
+        install_gir: T.Optional[bool]
+        install_dir_gir: T.Union[str, None, Literal[False]]
+        install_typelib: T.Optional[bool]
+        install_dir_typelib: T.Union[str, None, Literal[False]]
         link_with: T.List[T.Union[build.SharedLibrary, build.StaticLibrary]]
         namespace: str
         nsversion: str
@@ -972,7 +975,7 @@ class GnomeModule(ExtensionModule):
             generated_files: T.Sequence[T.Union[str, mesonlib.File, build.GeneratedTypes]],
             depends: T.Sequence[T.Union['FileOrString', build.BuildTarget, 'build.GeneratedTypes', build.StructuredSources]],
             env_flags: T.Sequence[str],
-            kwargs: T.Dict[str, T.Any]) -> GirTarget:
+            kwargs: GenerateGir) -> GirTarget:
         install = kwargs['install_gir']
         if install is None:
             install = kwargs['install']
@@ -1023,7 +1026,7 @@ class GnomeModule(ExtensionModule):
     def _make_typelib_target(state: 'ModuleState', typelib_output: str,
                              typelib_cmd: T.Sequence[T.Union[str, CustomTarget, Program]],
                              generated_files: T.Sequence[T.Union[str, mesonlib.File, build.GeneratedTypes]],
-                             kwargs: T.Dict[str, T.Any]) -> TypelibTarget:
+                             kwargs: GenerateGir) -> TypelibTarget:
         install = kwargs['install_typelib']
         if install is None:
             install = kwargs['install']
@@ -1244,9 +1247,8 @@ class GnomeModule(ExtensionModule):
         generated_files = [f for f in libsources if isinstance(f, (GeneratedList, CustomTarget, CustomTargetIndex))]
 
         scan_target = self._make_gir_target(
-            state, girfile, scan_command, generated_files, depends, scan_env_ldflags,
-            # We have to cast here because mypy can't figure this out
-            T.cast('T.Dict[str, T.Any]', kwargs))
+            state, girfile, scan_command, generated_files, depends,
+            scan_env_ldflags, kwargs)
 
         typelib_output = f'{ns}-{nsversion}.typelib'
         typelib_cmd: T.List[T.Union[str, Program, CustomTarget]]
@@ -1256,7 +1258,8 @@ class GnomeModule(ExtensionModule):
         for incdir in typelib_includes:
             typelib_cmd += ["--includedir=" + incdir]
 
-        typelib_target = self._make_typelib_target(state, typelib_output, typelib_cmd, generated_files, T.cast('T.Dict[str, T.Any]', kwargs))
+        typelib_target = self._make_typelib_target(
+            state, typelib_output, typelib_cmd, generated_files, kwargs)
 
         self._devenv_prepend('GI_TYPELIB_PATH', os.path.join(state.environment.get_build_dir(), state.subdir))
 

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -41,8 +41,7 @@ if T.TYPE_CHECKING:
 
     from . import ModuleState
     from ..build import BuildTarget
-    from ..compilers import Compiler
-    from ..compilers.compilers import Language
+    from ..compilers.compilers import Compiler, Language
     from ..interpreter import Interpreter
     from ..interpreter.interpreter import CustomTargetSources
     from ..interpreter.kwargs import CustomTargetInputs, TargetDepends
@@ -844,7 +843,7 @@ class GnomeModule(ExtensionModule):
         return ret, gir_inc_dirs, depends
 
     @staticmethod
-    def _scan_langs(state: 'ModuleState', langs: T.Iterable[str]) -> T.List[str]:
+    def _scan_langs(state: 'ModuleState', langs: T.Iterable[Language]) -> T.List[str]:
         ret: T.List[str] = []
 
         for lang in langs:
@@ -1102,7 +1101,7 @@ class GnomeModule(ExtensionModule):
         return typelib_includes, new_depends
 
     @staticmethod
-    def _get_external_args_for_langs(state: 'ModuleState', langs: T.List[str]) -> T.List[str]:
+    def _get_external_args_for_langs(state: 'ModuleState', langs: T.List[Language]) -> T.List[str]:
         ret: T.List[str] = []
         for lang in langs:
             ret += mesonlib.listify(state.environment.coredata.get_external_args(MachineChoice.HOST, lang))

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -532,8 +532,7 @@ class GnomeModule(ExtensionModule):
         if gresource: # Only one target for .gresource files
             return ModuleReturnValue(target_c, [target_c])
 
-        install_dir = kwargs['install_dir'] or state.environment.coredata.optstore.get_value_for_untyped(OptionKey('includedir'))
-        assert isinstance(install_dir, str), 'for mypy'
+        install_dir = kwargs['install_dir'] or state.environment.coredata.optstore.get_value_for(OptionKey('includedir'), str)
         target_h = GResourceHeaderTarget(
             f'{target_name}_h',
             state.subdir,
@@ -929,8 +928,7 @@ class GnomeModule(ExtensionModule):
             if state.project_args.get(lang):
                 cflags += state.project_args[lang]
             if OptionKey('b_sanitize') in compiler.base_options:
-                sanitize = state.environment.coredata.optstore.get_value_for_untyped('b_sanitize')
-                assert isinstance(sanitize, list)
+                sanitize = state.environment.coredata.optstore.get_value_for(OptionKey('b_sanitize'), list)
                 cflags += compiler.sanitizer_compile_args(None, sanitize)
                 # These must be first in ldflags
                 if 'address' in sanitize:
@@ -1694,8 +1692,7 @@ class GnomeModule(ExtensionModule):
 
         targets = []
         install_header = kwargs['install_header']
-        install_dir = kwargs['install_dir'] or state.environment.coredata.optstore.get_value_for_untyped(OptionKey('includedir'))
-        assert isinstance(install_dir, str), 'for mypy'
+        install_dir = kwargs['install_dir'] or state.environment.coredata.optstore.get_value_for(OptionKey('includedir'), str)
 
         output = namebase + '.c'
         # Added in https://gitlab.gnome.org/GNOME/glib/commit/e4d68c7b3e8b01ab1a4231bf6da21d045cb5a816 (2.55.2)
@@ -2063,13 +2060,12 @@ class GnomeModule(ExtensionModule):
             cmd: T.List[str],
             *,
             install: bool = False,
-            install_dir: T.Optional[T.Sequence[T.Union[str, bool]]] = None,
+            install_dir: T.Optional[str] = None,
             depends: T.Optional[T.Sequence[build.BuildTargetTypes]] = None
             ) -> build.CustomTarget:
         real_cmd: CommandList = [self._find_tool(state, 'glib-mkenums')]
         real_cmd.extend(cmd)
-        _install_dir = install_dir or state.environment.coredata.optstore.get_value_for_untyped(OptionKey('includedir'))
-        assert isinstance(_install_dir, str), 'for mypy'
+        _install_dir = install_dir or state.environment.coredata.optstore.get_value_for(OptionKey('includedir'), str)
 
         return CustomTarget(
             output,
@@ -2286,8 +2282,7 @@ class GnomeModule(ExtensionModule):
             inputs.append(i)
 
         vapi_output = library + '.vapi'
-        datadir = state.environment.coredata.optstore.get_value_for_untyped(OptionKey('datadir'))
-        assert isinstance(datadir, str), 'for mypy'
+        datadir = state.environment.coredata.optstore.get_value_for(OptionKey('datadir'), str)
         install_dir = kwargs['install_dir'] or os.path.join(datadir, 'vala', 'vapi')
 
         if kwargs['install']:

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -532,7 +532,7 @@ class GnomeModule(ExtensionModule):
         if gresource: # Only one target for .gresource files
             return ModuleReturnValue(target_c, [target_c])
 
-        install_dir = kwargs['install_dir'] or state.environment.coredata.optstore.get_value_for(OptionKey('includedir'))
+        install_dir = kwargs['install_dir'] or state.environment.coredata.optstore.get_value_for_untyped(OptionKey('includedir'))
         assert isinstance(install_dir, str), 'for mypy'
         target_h = GResourceHeaderTarget(
             f'{target_name}_h',
@@ -929,7 +929,7 @@ class GnomeModule(ExtensionModule):
             if state.project_args.get(lang):
                 cflags += state.project_args[lang]
             if OptionKey('b_sanitize') in compiler.base_options:
-                sanitize = state.environment.coredata.optstore.get_value_for('b_sanitize')
+                sanitize = state.environment.coredata.optstore.get_value_for_untyped('b_sanitize')
                 assert isinstance(sanitize, list)
                 cflags += compiler.sanitizer_compile_args(None, sanitize)
                 # These must be first in ldflags
@@ -1694,7 +1694,7 @@ class GnomeModule(ExtensionModule):
 
         targets = []
         install_header = kwargs['install_header']
-        install_dir = kwargs['install_dir'] or state.environment.coredata.optstore.get_value_for(OptionKey('includedir'))
+        install_dir = kwargs['install_dir'] or state.environment.coredata.optstore.get_value_for_untyped(OptionKey('includedir'))
         assert isinstance(install_dir, str), 'for mypy'
 
         output = namebase + '.c'
@@ -2068,7 +2068,7 @@ class GnomeModule(ExtensionModule):
             ) -> build.CustomTarget:
         real_cmd: CommandList = [self._find_tool(state, 'glib-mkenums')]
         real_cmd.extend(cmd)
-        _install_dir = install_dir or state.environment.coredata.optstore.get_value_for(OptionKey('includedir'))
+        _install_dir = install_dir or state.environment.coredata.optstore.get_value_for_untyped(OptionKey('includedir'))
         assert isinstance(_install_dir, str), 'for mypy'
 
         return CustomTarget(
@@ -2286,7 +2286,7 @@ class GnomeModule(ExtensionModule):
             inputs.append(i)
 
         vapi_output = library + '.vapi'
-        datadir = state.environment.coredata.optstore.get_value_for(OptionKey('datadir'))
+        datadir = state.environment.coredata.optstore.get_value_for_untyped(OptionKey('datadir'))
         assert isinstance(datadir, str), 'for mypy'
         install_dir = kwargs['install_dir'] or os.path.join(datadir, 'vala', 'vapi')
 

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -847,7 +847,7 @@ class GnomeModule(ExtensionModule):
         ret: T.List[str] = []
 
         for lang in langs:
-            link_args = state.environment.coredata.get_external_link_args(MachineChoice.HOST, lang)
+            link_args = state.environment.coredata.optstore.get_external_link_args(MachineChoice.HOST, lang)
             for link_arg in link_args:
                 if link_arg.startswith('-L'):
                     ret.append(link_arg)
@@ -1195,7 +1195,7 @@ class GnomeModule(ExtensionModule):
         scan_cflags += list(self._get_scanner_cflags(self._get_external_args_for_langs(state, [lc[0] for lc in langs_compilers])))
         scan_internal_ldflags = []
         scan_external_ldflags = []
-        scan_env_ldflags = state.environment.coredata.get_external_link_args(MachineChoice.HOST, 'c')
+        scan_env_ldflags = state.environment.coredata.optstore.get_external_link_args(MachineChoice.HOST, 'c')
         for cli_flags, env_flags in (self._get_scanner_ldflags(internal_ldflags), self._get_scanner_ldflags(dep_internal_ldflags)):
             scan_internal_ldflags += cli_flags
             scan_env_ldflags += env_flags
@@ -1610,7 +1610,7 @@ class GnomeModule(ExtensionModule):
         ldflags.extend(external_ldflags)
 
         cflags.extend(state.environment.coredata.optstore.get_external_args(MachineChoice.HOST, 'c'))
-        ldflags.extend(state.environment.coredata.get_external_link_args(MachineChoice.HOST, 'c'))
+        ldflags.extend(state.environment.coredata.optstore.get_external_link_args(MachineChoice.HOST, 'c'))
         compiler = state.environment.coredata.compilers[MachineChoice.HOST]['c']
 
         compiler_flags = self._get_langs_compilers_flags(state, [('c', compiler)])

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1104,7 +1104,7 @@ class GnomeModule(ExtensionModule):
     def _get_external_args_for_langs(state: 'ModuleState', langs: T.List[Language]) -> T.List[str]:
         ret: T.List[str] = []
         for lang in langs:
-            ret += mesonlib.listify(state.environment.coredata.get_external_args(MachineChoice.HOST, lang))
+            ret += mesonlib.listify(state.environment.coredata.optstore.get_external_args(MachineChoice.HOST, lang))
         return ret
 
     @staticmethod
@@ -1609,7 +1609,7 @@ class GnomeModule(ExtensionModule):
         ldflags.extend(internal_ldflags)
         ldflags.extend(external_ldflags)
 
-        cflags.extend(state.environment.coredata.get_external_args(MachineChoice.HOST, 'c'))
+        cflags.extend(state.environment.coredata.optstore.get_external_args(MachineChoice.HOST, 'c'))
         ldflags.extend(state.environment.coredata.get_external_link_args(MachineChoice.HOST, 'c'))
         compiler = state.environment.coredata.compilers[MachineChoice.HOST]['c']
 

--- a/mesonbuild/modules/hotdoc.py
+++ b/mesonbuild/modules/hotdoc.py
@@ -317,7 +317,7 @@ class HotdocTargetBuilder:
         for path in self.include_paths:
             self.cmd.extend(['--include-path', path])
 
-        if self.state.environment.coredata.optstore.get_value_for_untyped(OptionKey('werror', subproject=self.state.subproject)):
+        if self.state.environment.coredata.optstore.get_value_for(OptionKey('werror', subproject=self.state.subproject), bool):
             self.cmd.append('--fatal-warnings')
         self.generate_hotdoc_config()
 

--- a/mesonbuild/modules/hotdoc.py
+++ b/mesonbuild/modules/hotdoc.py
@@ -317,7 +317,7 @@ class HotdocTargetBuilder:
         for path in self.include_paths:
             self.cmd.extend(['--include-path', path])
 
-        if self.state.environment.coredata.optstore.get_value_for(OptionKey('werror', subproject=self.state.subproject)):
+        if self.state.environment.coredata.optstore.get_value_for_untyped(OptionKey('werror', subproject=self.state.subproject)):
             self.cmd.append('--fatal-warnings')
         self.generate_hotdoc_config()
 

--- a/mesonbuild/modules/hotdoc.py
+++ b/mesonbuild/modules/hotdoc.py
@@ -343,11 +343,9 @@ class HotdocTargetBuilder:
 
         install_script = None
         if install:
-            prefix = self.state.get_option('prefix')
-            assert isinstance(prefix, str), 'for mypy'
-            datadir = self.state.get_option('datadir')
-            assert isinstance(datadir, str), 'for mypy'
-            datadir = os.path.join(prefix, datadir)
+            datadir = os.path.join(
+                self.state.environment.coredata.optstore.get_value_for(OptionKey('prefix'), str),
+                self.state.environment.coredata.optstore.get_value_for(OptionKey('datadir'), str))
             devhelp = self.kwargs.get('devhelp_activate', False)
             if not isinstance(devhelp, bool):
                 FeatureDeprecated.single_use('hotdoc.generate_doc() devhelp_activate must be boolean', '1.1.0', self.state.subproject)

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -423,7 +423,7 @@ class I18nModule(ExtensionModule):
         targets.append(pottarget)
 
         install = kwargs['install']
-        install_dir = kwargs['install_dir'] or state.environment.coredata.optstore.get_value_for(OptionKey('localedir'))
+        install_dir = kwargs['install_dir'] or state.environment.coredata.optstore.get_value_for_untyped(OptionKey('localedir'))
         assert isinstance(install_dir, str), 'for mypy'
         if not languages:
             languages = read_linguas(path.join(state.environment.source_dir, state.subdir))

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -423,8 +423,7 @@ class I18nModule(ExtensionModule):
         targets.append(pottarget)
 
         install = kwargs['install']
-        install_dir = kwargs['install_dir'] or state.environment.coredata.optstore.get_value_for_untyped(OptionKey('localedir'))
-        assert isinstance(install_dir, str), 'for mypy'
+        install_dir = kwargs['install_dir'] or state.environment.coredata.optstore.get_value_for(OptionKey('localedir'), str)
         if not languages:
             languages = read_linguas(path.join(state.environment.source_dir, state.subdir))
         for l in languages:

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -784,7 +784,7 @@ class PkgConfigModule(NewExtensionModule):
             else:
                 pkgroot = os.path.join(state.environment.coredata.optstore.get_value_for(OptionKey('libdir'), str), 'pkgconfig')
                 pkgroot_name = os.path.join('{libdir}', 'pkgconfig')
-        relocatable = state.get_option('pkgconfig.relocatable')
+        relocatable = state.environment.coredata.optstore.get_value_for(OptionKey('pkgconfig.relocatable'), bool)
         self._generate_pkgconfig_file(state, deps, subdirs, name, description, url,
                                       version, license, pcfile, conflicts, variables,
                                       unescaped_variables, False, dataonly,

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -547,7 +547,7 @@ class PkgConfigModule(NewExtensionModule):
         else:
             pure_path_class = state.environment.machines.host.pure_path_class
             outdir = state.environment.scratch_dir
-            prefix = pure_path_class(_as_str(coredata.optstore.get_value_for(OptionKey('prefix'))))
+            prefix = pure_path_class(_as_str(coredata.optstore.get_value_for_untyped(OptionKey('prefix'))))
             if pkgroot:
                 prefix = self._get_relocatable_prefix(pkgroot, prefix, pure_path_class)
                 # relocatable paths will never have a drive letter
@@ -560,7 +560,7 @@ class PkgConfigModule(NewExtensionModule):
                     if optname == 'prefix':
                         ofile.write('prefix={}\n'.format(self._escape(prefix)))
                     else:
-                        dirpath = PurePath(_as_str(coredata.optstore.get_value_for(OptionKey(optname))))
+                        dirpath = PurePath(_as_str(coredata.optstore.get_value_for_untyped(OptionKey(optname))))
                         ofile.write('{}={}\n'.format(optname, self._escape('${prefix}' / dirpath)))
             if uninstalled and not dataonly:
                 ofile.write('srcdir={}\n'.format(self._escape(srcdir)))
@@ -781,13 +781,13 @@ class PkgConfigModule(NewExtensionModule):
         if pkgroot is None:
             m = state.environment.machines.host
             if m.is_freebsd():
-                pkgroot = os.path.join(_as_str(state.environment.coredata.optstore.get_value_for(OptionKey('prefix'))), 'libdata', 'pkgconfig')
+                pkgroot = os.path.join(_as_str(state.environment.coredata.optstore.get_value_for_untyped(OptionKey('prefix'))), 'libdata', 'pkgconfig')
                 pkgroot_name = os.path.join('{prefix}', 'libdata', 'pkgconfig')
             elif m.is_haiku():
-                pkgroot = os.path.join(_as_str(state.environment.coredata.optstore.get_value_for(OptionKey('prefix'))), 'develop', 'lib', 'pkgconfig')
+                pkgroot = os.path.join(_as_str(state.environment.coredata.optstore.get_value_for_untyped(OptionKey('prefix'))), 'develop', 'lib', 'pkgconfig')
                 pkgroot_name = os.path.join('{prefix}', 'develop', 'lib', 'pkgconfig')
             else:
-                pkgroot = os.path.join(_as_str(state.environment.coredata.optstore.get_value_for(OptionKey('libdir'))), 'pkgconfig')
+                pkgroot = os.path.join(_as_str(state.environment.coredata.optstore.get_value_for_untyped(OptionKey('libdir'))), 'pkgconfig')
                 pkgroot_name = os.path.join('{libdir}', 'pkgconfig')
         relocatable = state.get_option('pkgconfig.relocatable')
         self._generate_pkgconfig_file(state, deps, subdirs, name, description, url,

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -78,11 +78,6 @@ _PKG_REQUIRES: KwargInfo[T.List[REQS]] = KwargInfo(
 )
 
 
-def _as_str(obj: object) -> str:
-    assert isinstance(obj, str)
-    return obj
-
-
 @dataclass
 class MetaData:
 
@@ -547,7 +542,7 @@ class PkgConfigModule(NewExtensionModule):
         else:
             pure_path_class = state.environment.machines.host.pure_path_class
             outdir = state.environment.scratch_dir
-            prefix = pure_path_class(_as_str(coredata.optstore.get_value_for_untyped(OptionKey('prefix'))))
+            prefix = pure_path_class(coredata.optstore.get_value_for(OptionKey('prefix'), str))
             if pkgroot:
                 prefix = self._get_relocatable_prefix(pkgroot, prefix, pure_path_class)
                 # relocatable paths will never have a drive letter
@@ -560,7 +555,7 @@ class PkgConfigModule(NewExtensionModule):
                     if optname == 'prefix':
                         ofile.write('prefix={}\n'.format(self._escape(prefix)))
                     else:
-                        dirpath = PurePath(_as_str(coredata.optstore.get_value_for_untyped(OptionKey(optname))))
+                        dirpath = PurePath(coredata.optstore.get_value_for(OptionKey(optname), str))
                         ofile.write('{}={}\n'.format(optname, self._escape('${prefix}' / dirpath)))
             if uninstalled and not dataonly:
                 ofile.write('srcdir={}\n'.format(self._escape(srcdir)))
@@ -781,13 +776,13 @@ class PkgConfigModule(NewExtensionModule):
         if pkgroot is None:
             m = state.environment.machines.host
             if m.is_freebsd():
-                pkgroot = os.path.join(_as_str(state.environment.coredata.optstore.get_value_for_untyped(OptionKey('prefix'))), 'libdata', 'pkgconfig')
+                pkgroot = os.path.join(state.environment.coredata.optstore.get_value_for(OptionKey('prefix'), str), 'libdata', 'pkgconfig')
                 pkgroot_name = os.path.join('{prefix}', 'libdata', 'pkgconfig')
             elif m.is_haiku():
-                pkgroot = os.path.join(_as_str(state.environment.coredata.optstore.get_value_for_untyped(OptionKey('prefix'))), 'develop', 'lib', 'pkgconfig')
+                pkgroot = os.path.join(state.environment.coredata.optstore.get_value_for(OptionKey('prefix'), str), 'develop', 'lib', 'pkgconfig')
                 pkgroot_name = os.path.join('{prefix}', 'develop', 'lib', 'pkgconfig')
             else:
-                pkgroot = os.path.join(_as_str(state.environment.coredata.optstore.get_value_for_untyped(OptionKey('libdir'))), 'pkgconfig')
+                pkgroot = os.path.join(state.environment.coredata.optstore.get_value_for(OptionKey('libdir'), str), 'pkgconfig')
                 pkgroot_name = os.path.join('{libdir}', 'pkgconfig')
         relocatable = state.get_option('pkgconfig.relocatable')
         self._generate_pkgconfig_file(state, deps, subdirs, name, description, url,

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -117,7 +117,7 @@ class PythonInstallation(ProgramHolder['PythonExternalProgram']):
     def __init__(self, python: 'PythonExternalProgram', interpreter: 'Interpreter'):
         ProgramHolder.__init__(self, python, interpreter)
         info = python.info
-        prefix = self.interpreter.environment.coredata.optstore.get_value_for(OptionKey('prefix'))
+        prefix = self.interpreter.environment.coredata.optstore.get_value_for_untyped(OptionKey('prefix'))
         assert isinstance(prefix, str), 'for mypy'
 
         if python.build_config:
@@ -185,7 +185,7 @@ class PythonInstallation(ProgramHolder['PythonExternalProgram']):
                                   self.current_node)
 
         limited_api_version = kwargs.get('limited_api')
-        allow_limited_api = self.interpreter.environment.coredata.optstore.get_value_for(OptionKey('python.allow_limited_api'))
+        allow_limited_api = self.interpreter.environment.coredata.optstore.get_value_for_untyped(OptionKey('python.allow_limited_api'))
         if limited_api_version != '' and allow_limited_api:
 
             target_suffix = self.limited_api_suffix
@@ -225,7 +225,7 @@ class PythonInstallation(ProgramHolder['PythonExternalProgram']):
 
                 new_link_args = kwargs['link_args'].copy()
 
-                is_debug = self.interpreter.environment.coredata.optstore.get_value_for('debug')
+                is_debug = self.interpreter.environment.coredata.optstore.get_value_for_untyped('debug')
                 if is_debug:
                     new_link_args.append(python_windows_debug_link_exception)
                 else:
@@ -276,7 +276,7 @@ class PythonInstallation(ProgramHolder['PythonExternalProgram']):
         if dep is not None:
             return dep
 
-        build_config = self.interpreter.environment.coredata.optstore.get_value_for(OptionKey('python.build_config'))
+        build_config = self.interpreter.environment.coredata.optstore.get_value_for_untyped(OptionKey('python.build_config'))
         assert isinstance(build_config, str), 'for mypy'
 
         new_kwargs = kwargs.copy()
@@ -413,7 +413,7 @@ class PythonModule(ExtensionModule):
     def _get_install_scripts(self) -> T.List[mesonlib.ExecutableSerialisation]:
         backend = self.interpreter.backend
         ret: T.List[mesonlib.ExecutableSerialisation] = []
-        optlevel = self.interpreter.environment.coredata.optstore.get_value_for(OptionKey('python.bytecompile'))
+        optlevel = self.interpreter.environment.coredata.optstore.get_value_for_untyped(OptionKey('python.bytecompile'))
         if optlevel == -1:
             return ret
         if not any(PythonExternalProgram.run_bytecompile.values()):
@@ -479,7 +479,7 @@ class PythonModule(ExtensionModule):
             return None
 
     def _find_installation_impl(self, state: 'ModuleState', display_name: str, name_or_path: str, required: bool) -> MaybePythonProg:
-        build_config = self.interpreter.environment.coredata.optstore.get_value_for(OptionKey('python.build_config'))
+        build_config = self.interpreter.environment.coredata.optstore.get_value_for_untyped(OptionKey('python.build_config'))
         assert isinstance(build_config, str), 'for mypy'
 
         if not name_or_path:

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -89,7 +89,7 @@ class PythonExternalProgram(BasicPythonExternalProgram):
             return rel_path
         value = state.environment.coredata.optstore.get_value_for(OptionKey(f'python.{key}dir'), str)
         if value:
-            if state.is_user_defined_option('python.install_env'):
+            if not state.environment.coredata.optstore.get_value_object(OptionKey('python.install_env')).has_default_value():
                 raise mesonlib.MesonException(f'python.{key}dir and python.install_env are mutually exclusive')
             return value
 

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -117,8 +117,7 @@ class PythonInstallation(ProgramHolder['PythonExternalProgram']):
     def __init__(self, python: 'PythonExternalProgram', interpreter: 'Interpreter'):
         ProgramHolder.__init__(self, python, interpreter)
         info = python.info
-        prefix = self.interpreter.environment.coredata.optstore.get_value_for_untyped(OptionKey('prefix'))
-        assert isinstance(prefix, str), 'for mypy'
+        prefix = self.interpreter.environment.coredata.optstore.get_value_for(OptionKey('prefix'), str)
 
         if python.build_config:
             def as_(obj: object, type_: T.Type[_T]) -> _T:
@@ -185,7 +184,7 @@ class PythonInstallation(ProgramHolder['PythonExternalProgram']):
                                   self.current_node)
 
         limited_api_version = kwargs.get('limited_api')
-        allow_limited_api = self.interpreter.environment.coredata.optstore.get_value_for_untyped(OptionKey('python.allow_limited_api'))
+        allow_limited_api = self.interpreter.environment.coredata.optstore.get_value_for(OptionKey('python.allow_limited_api'), bool)
         if limited_api_version != '' and allow_limited_api:
 
             target_suffix = self.limited_api_suffix
@@ -225,7 +224,7 @@ class PythonInstallation(ProgramHolder['PythonExternalProgram']):
 
                 new_link_args = kwargs['link_args'].copy()
 
-                is_debug = self.interpreter.environment.coredata.optstore.get_value_for_untyped('debug')
+                is_debug = self.interpreter.environment.coredata.optstore.get_value_for(OptionKey('debug'), bool)
                 if is_debug:
                     new_link_args.append(python_windows_debug_link_exception)
                 else:
@@ -276,8 +275,7 @@ class PythonInstallation(ProgramHolder['PythonExternalProgram']):
         if dep is not None:
             return dep
 
-        build_config = self.interpreter.environment.coredata.optstore.get_value_for_untyped(OptionKey('python.build_config'))
-        assert isinstance(build_config, str), 'for mypy'
+        build_config = self.interpreter.environment.coredata.optstore.get_value_for(OptionKey('python.build_config'), str)
 
         new_kwargs = kwargs.copy()
         new_kwargs['required'] = False
@@ -413,7 +411,7 @@ class PythonModule(ExtensionModule):
     def _get_install_scripts(self) -> T.List[mesonlib.ExecutableSerialisation]:
         backend = self.interpreter.backend
         ret: T.List[mesonlib.ExecutableSerialisation] = []
-        optlevel = self.interpreter.environment.coredata.optstore.get_value_for_untyped(OptionKey('python.bytecompile'))
+        optlevel = self.interpreter.environment.coredata.optstore.get_value_for(OptionKey('python.bytecompile'), int)
         if optlevel == -1:
             return ret
         if not any(PythonExternalProgram.run_bytecompile.values()):
@@ -479,8 +477,7 @@ class PythonModule(ExtensionModule):
             return None
 
     def _find_installation_impl(self, state: 'ModuleState', display_name: str, name_or_path: str, required: bool) -> MaybePythonProg:
-        build_config = self.interpreter.environment.coredata.optstore.get_value_for_untyped(OptionKey('python.build_config'))
-        assert isinstance(build_config, str), 'for mypy'
+        build_config = self.interpreter.environment.coredata.optstore.get_value_for(OptionKey('python.build_config'), str)
 
         if not name_or_path:
             python = PythonExternalProgram('python3', mesonlib.python_command, build_config_path=build_config)

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -87,13 +87,13 @@ class PythonExternalProgram(BasicPythonExternalProgram):
         if not state:
             # This happens only from run_project_tests.py
             return rel_path
-        value = T.cast('str', state.get_option(f'python.{key}dir'))
+        value = state.environment.coredata.optstore.get_value_for(OptionKey(f'python.{key}dir'), str)
         if value:
             if state.is_user_defined_option('python.install_env'):
                 raise mesonlib.MesonException(f'python.{key}dir and python.install_env are mutually exclusive')
             return value
 
-        install_env = state.get_option('python.install_env')
+        install_env = state.environment.coredata.optstore.get_value_for(OptionKey('python.install_env'), str)
         if install_env == 'auto':
             install_env = 'venv' if self.info['is_venv'] else 'system'
 

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -979,7 +979,7 @@ class RustModule(ExtensionModule):
             cmd.extend(['--rust-target', self._bindgen_rust_target])
         if self._bindgen_set_std and '--rust-edition' not in cmd:
             try:
-                rust_std = state.environment.coredata.optstore.get_value_for('rust_std')
+                rust_std = state.environment.coredata.optstore.get_value_for_untyped('rust_std')
             except KeyError:
                 rust_std = 'none'
             assert isinstance(rust_std, str), 'for mypy'

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -930,8 +930,7 @@ class RustModule(ExtensionModule):
         language = T.cast('Language', language)
 
         # We only want include directories and defines, other things may not be valid
-        cargs = state.get_option(f'{language}_args', state.subproject)
-        assert isinstance(cargs, list), 'for mypy'
+        cargs = state.environment.coredata.optstore.get_value_for(OptionKey(f'{language}_args', state.subproject), list)
         for a in itertools.chain(state.global_args.get(language, []), state.project_args.get(language, []), cargs):
             if a.startswith(('-I', '/I', '-D', '/D', '-U', '/U')):
                 clang_args.append(a)
@@ -941,8 +940,7 @@ class RustModule(ExtensionModule):
 
         # Add the C++ standard to the clang arguments. Attempt to translate VS
         # extension versions into the nearest standard version
-        std = state.get_option(f'{language}_std')
-        assert isinstance(std, str), 'for mypy'
+        std = state.environment.coredata.optstore.get_value_for(OptionKey(f'{language}_std'), str)
         if std.startswith('vc++'):
             if std.endswith('latest'):
                 mlog.warning('Attempting to translate vc++latest into a clang compatible version.',

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -27,6 +27,7 @@ from ..interpreter.type_checking import (
 from ..interpreterbase import ContainerTypeInfo, InterpreterException, KwargInfo, typed_kwargs, typed_pos_args, noKwargs, noPosargs
 from ..interpreter.interpreterobjects import Doctest
 from ..mesonlib import (is_parent_path, File, MachineChoice, MesonException, PerMachine)
+from ..options import OptionKey
 from ..programs import ExternalProgram, NonExistingExternalProgram
 
 if T.TYPE_CHECKING:
@@ -978,11 +979,7 @@ class RustModule(ExtensionModule):
         if self._bindgen_rust_target and '--rust-target' not in cmd:
             cmd.extend(['--rust-target', self._bindgen_rust_target])
         if self._bindgen_set_std and '--rust-edition' not in cmd:
-            try:
-                rust_std = state.environment.coredata.optstore.get_value_for_untyped('rust_std')
-            except KeyError:
-                rust_std = 'none'
-            assert isinstance(rust_std, str), 'for mypy'
+            rust_std = state.environment.coredata.optstore.get_value_for(OptionKey('rust_std'), str, default='none')
             if rust_std != 'none':
                 cmd.extend(['--rust-edition', rust_std])
         cmd.append('--')

--- a/mesonbuild/modules/snippets.py
+++ b/mesonbuild/modules/snippets.py
@@ -22,6 +22,7 @@ from . import NewExtensionModule, ModuleInfo
 from ..interpreterbase import KwargInfo, typed_kwargs, typed_pos_args
 from ..interpreter.type_checking import NoneType
 from .. import mesonlib
+from ..options import OptionKey
 
 if T.TYPE_CHECKING:
     from typing_extensions import TypedDict
@@ -63,7 +64,7 @@ class SnippetsModule(NewExtensionModule):
         static_compilation = kwargs['static_compilation'] or f'{namespace}_STATIC_COMPILATION'
         static_only = kwargs['static_only']
         if static_only is None:
-            default_library = state.get_option('default_library')
+            default_library = state.environment.coredata.optstore.get_value_for(OptionKey('default_library'), str)
             static_only = default_library == 'static'
         content = textwrap.dedent('''\
             // SPDX-license-identifier: 0BSD OR CC0-1.0 OR WTFPL OR Apache-2.0 OR LGPL-2.0-or-later

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -310,9 +310,9 @@ class MesonApp:
 
             # collect warnings about unsupported build configurations; must be done after full arg processing
             # by Interpreter() init, but this is most visible at the end
-            if env.coredata.optstore.get_value_for_untyped('backend') == 'xcode':
+            if env.coredata.optstore.get_value_for(OptionKey('backend'), str) == 'xcode':
                 mlog.warning('xcode backend is currently unmaintained, patches welcome')
-            if env.coredata.optstore.get_value_for_untyped('layout') == 'flat':
+            if env.coredata.optstore.get_value_for(OptionKey('layout'), str) == 'flat':
                 mlog.warning('-Dlayout=flat is unsupported and probably broken. It was a failed experiment at '
                              'making Windows build artifacts runnable while uninstalled, due to PATH considerations, '
                              'but was untested by CI and anyways breaks reasonable use of conflicting targets in different subdirs. '

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -310,9 +310,9 @@ class MesonApp:
 
             # collect warnings about unsupported build configurations; must be done after full arg processing
             # by Interpreter() init, but this is most visible at the end
-            if env.coredata.optstore.get_value_for('backend') == 'xcode':
+            if env.coredata.optstore.get_value_for_untyped('backend') == 'xcode':
                 mlog.warning('xcode backend is currently unmaintained, patches welcome')
-            if env.coredata.optstore.get_value_for('layout') == 'flat':
+            if env.coredata.optstore.get_value_for_untyped('layout') == 'flat':
                 mlog.warning('-Dlayout=flat is unsupported and probably broken. It was a failed experiment at '
                              'making Windows build artifacts runnable while uninstalled, due to PATH considerations, '
                              'but was untested by CI and anyways breaks reasonable use of conflicting targets in different subdirs. '

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -2321,11 +2321,11 @@ def run(options: argparse.Namespace) -> int:
             return 1
 
     b = build.load(options.wd)
-    need_vsenv = T.cast('bool', b.environment.coredata.optstore.get_value_for_untyped(OptionKey('vsenv')))
+    need_vsenv = b.environment.coredata.optstore.get_value_for(OptionKey('vsenv'), bool)
     setup_vsenv(need_vsenv)
 
     if not options.no_rebuild:
-        backend = b.environment.coredata.optstore.get_value_for_untyped(OptionKey('backend'))
+        backend = b.environment.coredata.optstore.get_value_for(OptionKey('backend'), str)
         if backend == 'none':
             # nothing to build...
             options.no_rebuild = True

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -2321,11 +2321,11 @@ def run(options: argparse.Namespace) -> int:
             return 1
 
     b = build.load(options.wd)
-    need_vsenv = T.cast('bool', b.environment.coredata.optstore.get_value_for(OptionKey('vsenv')))
+    need_vsenv = T.cast('bool', b.environment.coredata.optstore.get_value_for_untyped(OptionKey('vsenv')))
     setup_vsenv(need_vsenv)
 
     if not options.no_rebuild:
-        backend = b.environment.coredata.optstore.get_value_for(OptionKey('backend'))
+        backend = b.environment.coredata.optstore.get_value_for_untyped(OptionKey('backend'))
         if backend == 'none':
             # nothing to build...
             options.no_rebuild = True

--- a/mesonbuild/munstable_coredata.py
+++ b/mesonbuild/munstable_coredata.py
@@ -65,7 +65,7 @@ def run(options: Arguments) -> int:
     print('')
 
     coredata = cdata.load(options.builddir)
-    backend = coredata.optstore.get_value_for(OptionKey('backend'))
+    backend = coredata.optstore.get_value_for_untyped(OptionKey('backend'))
     assert isinstance(backend, str), 'for mypy'
     for k, v in sorted(coredata.__dict__.items()):
         if k in {'backend_options', 'base_options', 'builtins', 'compiler_options', 'user_options'}:

--- a/mesonbuild/munstable_coredata.py
+++ b/mesonbuild/munstable_coredata.py
@@ -65,8 +65,7 @@ def run(options: Arguments) -> int:
     print('')
 
     coredata = cdata.load(options.builddir)
-    backend = coredata.optstore.get_value_for_untyped(OptionKey('backend'))
-    assert isinstance(backend, str), 'for mypy'
+    backend = coredata.optstore.get_value_for(OptionKey('backend'), str)
     for k, v in sorted(coredata.__dict__.items()):
         if k in {'backend_options', 'base_options', 'builtins', 'compiler_options', 'user_options'}:
             # use `meson configure` to view these

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -47,6 +47,7 @@ if T.TYPE_CHECKING:
         'UserIntegerOption', 'UserStdOption', 'UserStringArrayOption',
         'UserStringOption', 'UserUmaskOption']
     ElementaryOptionValues: TypeAlias = T.Union[str, int, bool, T.List[str]]
+    ElementaryOptionType = T.TypeVar('ElementaryOptionType', str, int, bool, T.List[str])
     MutableKeyedOptionDictType: TypeAlias = T.Dict['OptionKey', AnyOptionType]
 
     _OptionKeyTuple: TypeAlias = T.Tuple[T.Optional[str], MachineChoice, str]
@@ -875,6 +876,12 @@ class OptionStore:
         _, resolved_value = self.get_option_and_value_for_untyped(key)
         return resolved_value
 
+    def get_value_for(self, key: OptionKey, type_: T.Type[ElementaryOptionType]) -> ElementaryOptionType:
+        val = self.get_value_for_untyped(key)
+        if not isinstance(val, type_):
+            raise MesonBugException(f'Expected {key!s} to have type {type_!s}, but had type {type(val)!s}')
+        return val
+
     def get_option_for_target_untyped(self, target: 'BuildTarget', key: T.Union[str, OptionKey]) -> ElementaryOptionValues:
         if isinstance(key, str):
             assert ':' not in key
@@ -897,16 +904,20 @@ class OptionStore:
                 raise MesonException(f'In override_options for {target}: {e!s}')
         return value
 
+    def get_option_for_target(self, target: 'BuildTarget', key: OptionKey, type_: T.Type[ElementaryOptionType]) -> ElementaryOptionType:
+        val = self.get_option_for_target_untyped(target, key)
+        if not isinstance(val, type_):
+            raise MesonBugException(f'Expected {key!s} to have type {type_!s}, but had type {type(val)!s}')
+        return val
+
     def get_external_args(self, for_machine: MachineChoice, lang: Language) -> T.List[str]:
-        # mypy cannot analyze type of OptionKey
         key = OptionKey(f'{lang}_args', machine=for_machine)
-        return T.cast('T.List[str]', self.get_value_for_untyped(key))
+        return self.get_value_for(key, list)
 
     @lru_cache(maxsize=None)
     def get_external_link_args(self, for_machine: MachineChoice, lang: Language) -> T.List[str]:
-        # mypy cannot analyze type of OptionKey
         linkkey = OptionKey(f'{lang}_link_args', machine=for_machine)
-        return T.cast('T.List[str]', self.get_value_for_untyped(linkkey))
+        return self.get_value_for(linkkey, list)
 
     def add_system_option(self, key: T.Union[OptionKey, str], valobj: AnyOptionType) -> None:
         key = self.ensure_and_validate_key(key)

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -1072,8 +1072,7 @@ class OptionStore:
             assert isinstance(new_value, str), 'for mypy'
             new_value = self.sanitize_prefix(new_value)
         elif self.is_builtin_option(key):
-            prefix = self.get_value_for_untyped('prefix')
-            assert isinstance(prefix, str), 'for mypy'
+            prefix = self.get_value_for(OptionKey('prefix'), str)
             new_value = self.sanitize_dir_option_value(prefix, key, new_value)
 
         try:

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -359,6 +359,9 @@ class UserOption(T.Generic[_T], HoldableObject):
         self.value = self.validate_value(newvalue)
         return self.value != oldvalue
 
+    def has_default_value(self) -> bool:
+        return self.value == self.default
+
 @dataclasses.dataclass
 class EnumeratedUserOption(UserOption[_T]):
 

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -851,7 +851,7 @@ class OptionStore:
                 return self.options[parent_key]
         return potential
 
-    def get_option_and_value_for(self, key: OptionKey) -> T.Tuple[AnyOptionType, ElementaryOptionValues]:
+    def get_option_and_value_for_untyped(self, key: OptionKey) -> T.Tuple[AnyOptionType, ElementaryOptionValues]:
         key = self.ensure_and_validate_key(key)
         option_object = self.resolve_option(key)
         computed_value = option_object.value
@@ -863,19 +863,19 @@ class OptionStore:
         return (option_object, computed_value)
 
     def option_has_value(self, key: OptionKey, value: ElementaryOptionValues) -> bool:
-        option_object, current_value = self.get_option_and_value_for(key)
+        option_object, current_value = self.get_option_and_value_for_untyped(key)
         return option_object.validate_value(value) == current_value
 
-    def get_value_for(self, name: 'T.Union[OptionKey, str]', subproject: T.Optional[str] = None) -> ElementaryOptionValues:
+    def get_value_for_untyped(self, name: 'T.Union[OptionKey, str]', subproject: T.Optional[str] = None) -> ElementaryOptionValues:
         if isinstance(name, str):
             key = OptionKey(name, subproject)
         else:
             assert subproject is None
             key = name
-        _, resolved_value = self.get_option_and_value_for(key)
+        _, resolved_value = self.get_option_and_value_for_untyped(key)
         return resolved_value
 
-    def get_option_for_target(self, target: 'BuildTarget', key: T.Union[str, OptionKey]) -> ElementaryOptionValues:
+    def get_option_for_target_untyped(self, target: 'BuildTarget', key: T.Union[str, OptionKey]) -> ElementaryOptionValues:
         if isinstance(key, str):
             assert ':' not in key
             newkey = OptionKey(key, target.subproject)
@@ -888,7 +888,7 @@ class OptionStore:
             newkey = newkey.evolve(subproject=target.subproject)
         if self.is_cross:
             newkey = newkey.evolve(machine=target.for_machine)
-        option_object, value = self.get_option_and_value_for(newkey)
+        option_object, value = self.get_option_and_value_for_untyped(newkey)
         override = target.get_override(newkey.name)
         if override is not None:
             try:
@@ -900,13 +900,13 @@ class OptionStore:
     def get_external_args(self, for_machine: MachineChoice, lang: Language) -> T.List[str]:
         # mypy cannot analyze type of OptionKey
         key = OptionKey(f'{lang}_args', machine=for_machine)
-        return T.cast('T.List[str]', self.get_value_for(key))
+        return T.cast('T.List[str]', self.get_value_for_untyped(key))
 
     @lru_cache(maxsize=None)
     def get_external_link_args(self, for_machine: MachineChoice, lang: Language) -> T.List[str]:
         # mypy cannot analyze type of OptionKey
         linkkey = OptionKey(f'{lang}_link_args', machine=for_machine)
-        return T.cast('T.List[str]', self.get_value_for(linkkey))
+        return T.cast('T.List[str]', self.get_value_for_untyped(linkkey))
 
     def add_system_option(self, key: T.Union[OptionKey, str], valobj: AnyOptionType) -> None:
         key = self.ensure_and_validate_key(key)
@@ -1048,7 +1048,7 @@ class OptionStore:
             assert isinstance(new_value, str), 'for mypy'
             new_value = self.sanitize_prefix(new_value)
         elif self.is_builtin_option(key):
-            prefix = self.get_value_for('prefix')
+            prefix = self.get_value_for_untyped('prefix')
             assert isinstance(prefix, str), 'for mypy'
             new_value = self.sanitize_dir_option_value(prefix, key, new_value)
 

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 from collections import OrderedDict
+from functools import lru_cache
 from itertools import chain
 import copy
 import dataclasses
@@ -895,6 +896,17 @@ class OptionStore:
             except MesonException as e:
                 raise MesonException(f'In override_options for {target}: {e!s}')
         return value
+
+    def get_external_args(self, for_machine: MachineChoice, lang: Language) -> T.List[str]:
+        # mypy cannot analyze type of OptionKey
+        key = OptionKey(f'{lang}_args', machine=for_machine)
+        return T.cast('T.List[str]', self.get_value_for(key))
+
+    @lru_cache(maxsize=None)
+    def get_external_link_args(self, for_machine: MachineChoice, lang: Language) -> T.List[str]:
+        # mypy cannot analyze type of OptionKey
+        linkkey = OptionKey(f'{lang}_link_args', machine=for_machine)
+        return T.cast('T.List[str]', self.get_value_for(linkkey))
 
     def add_system_option(self, key: T.Union[OptionKey, str], valobj: AnyOptionType) -> None:
         key = self.ensure_and_validate_key(key)

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -923,6 +923,13 @@ class OptionStore:
             raise MesonBugException(f'Expected {key!s} to have type {type_!s}, but had type {type(val)!s}')
         return val
 
+    def get_option_for_maybe_target(self, target: T.Optional[BuildTarget], key: OptionKey,
+                                    type_: T.Type[ElementaryOptionType],
+                                    *, default: T.Optional[ElementaryOptionType] = None) -> ElementaryOptionType:
+        if target is not None:
+            return self.get_option_for_target(target, key, type_, default=default)
+        return self.get_value_for(key, type_, default=default)
+
     def get_external_args(self, for_machine: MachineChoice, lang: Language) -> T.List[str]:
         key = OptionKey(f'{lang}_args', machine=for_machine)
         return self.get_value_for(key, list)

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -876,8 +876,14 @@ class OptionStore:
         _, resolved_value = self.get_option_and_value_for_untyped(key)
         return resolved_value
 
-    def get_value_for(self, key: OptionKey, type_: T.Type[ElementaryOptionType]) -> ElementaryOptionType:
-        val = self.get_value_for_untyped(key)
+    def get_value_for(self, key: OptionKey, type_: T.Type[ElementaryOptionType],
+                      *, default: T.Optional[ElementaryOptionType] = None) -> ElementaryOptionType:
+        try:
+            val = self.get_value_for_untyped(key)
+        except KeyError:
+            if default is not None:
+                return default
+            raise
         if not isinstance(val, type_):
             raise MesonBugException(f'Expected {key!s} to have type {type_!s}, but had type {type(val)!s}')
         return val
@@ -904,8 +910,15 @@ class OptionStore:
                 raise MesonException(f'In override_options for {target}: {e!s}')
         return value
 
-    def get_option_for_target(self, target: 'BuildTarget', key: OptionKey, type_: T.Type[ElementaryOptionType]) -> ElementaryOptionType:
-        val = self.get_option_for_target_untyped(target, key)
+    def get_option_for_target(self, target: 'BuildTarget', key: OptionKey,
+                              type_: T.Type[ElementaryOptionType],
+                              *, default: T.Optional[ElementaryOptionType] = None) -> ElementaryOptionType:
+        try:
+            val = self.get_option_for_target_untyped(target, key)
+        except KeyError:
+            if default is not None:
+                return default
+            raise
         if not isinstance(val, type_):
             raise MesonBugException(f'Expected {key!s} to have type {type_!s}, but had type {type(val)!s}')
         return val

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -35,6 +35,7 @@ from . import mlog
 if T.TYPE_CHECKING:
     from typing_extensions import Literal, Final, TypeAlias
 
+    from .build import BuildTarget
     from .envconfig import MachineInfo
     from .mesonlib import SubProject
     from .compilers.compilers import Language
@@ -872,6 +873,28 @@ class OptionStore:
             key = name
         _, resolved_value = self.get_option_and_value_for(key)
         return resolved_value
+
+    def get_option_for_target(self, target: 'BuildTarget', key: T.Union[str, OptionKey]) -> ElementaryOptionValues:
+        if isinstance(key, str):
+            assert ':' not in key
+            newkey = OptionKey(key, target.subproject)
+        else:
+            newkey = key
+        if newkey.subproject != target.subproject:
+            # FIXME: this should be an error. The caller needs to ensure that
+            # key and target have the same subproject for consistency.
+            # Now just do this to get things going.
+            newkey = newkey.evolve(subproject=target.subproject)
+        if self.is_cross:
+            newkey = newkey.evolve(machine=target.for_machine)
+        option_object, value = self.get_option_and_value_for(newkey)
+        override = target.get_override(newkey.name)
+        if override is not None:
+            try:
+                return option_object.validate_value(override)
+            except MesonException as e:
+                raise MesonException(f'In override_options for {target}: {e!s}')
+        return value
 
     def add_system_option(self, key: T.Union[OptionKey, str], valobj: AnyOptionType) -> None:
         key = self.ensure_and_validate_key(key)

--- a/mesonbuild/scripts/regen_checker.py
+++ b/mesonbuild/scripts/regen_checker.py
@@ -44,8 +44,7 @@ def run(args: T.List[str]) -> int:
     with open(coredata_file, 'rb') as f:
         coredata = pickle.load(f)
         assert isinstance(coredata, CoreData)
-    backend = coredata.optstore.get_value_for_untyped(OptionKey('backend'))
-    assert isinstance(backend, str)
+    backend = coredata.optstore.get_value_for(OptionKey('backend'), str)
     regen_timestamp = os.stat(dumpfile).st_mtime
     if need_regen(regeninfo, regen_timestamp):
         regen(regeninfo, coredata.meson_command, backend)

--- a/mesonbuild/scripts/regen_checker.py
+++ b/mesonbuild/scripts/regen_checker.py
@@ -44,7 +44,7 @@ def run(args: T.List[str]) -> int:
     with open(coredata_file, 'rb') as f:
         coredata = pickle.load(f)
         assert isinstance(coredata, CoreData)
-    backend = coredata.optstore.get_value_for(OptionKey('backend'))
+    backend = coredata.optstore.get_value_for_untyped(OptionKey('backend'))
     assert isinstance(backend, str)
     regen_timestamp = os.stat(dumpfile).st_mtime
     if need_regen(regeninfo, regen_timestamp):

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -2880,35 +2880,35 @@ class AllPlatformTests(BasePlatformTests):
         out = self.init(testdir, extra_args=['--profile-self', '--fatal-meson-warnings'])
         self.assertNotIn('[default: true]', out)
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value_for('default_library'), 'static')
-        self.assertEqual(obj.optstore.get_value_for('warning_level'), '1')
-        self.assertEqual(obj.optstore.get_value_for(OptionKey('set_sub_opt', '')), True)
-        self.assertEqual(obj.optstore.get_value_for(OptionKey('subp_opt', 'subp')), 'default3')
+        self.assertEqual(obj.optstore.get_value_for_untyped('default_library'), 'static')
+        self.assertEqual(obj.optstore.get_value_for_untyped('warning_level'), '1')
+        self.assertEqual(obj.optstore.get_value_for_untyped(OptionKey('set_sub_opt', '')), True)
+        self.assertEqual(obj.optstore.get_value_for_untyped(OptionKey('subp_opt', 'subp')), 'default3')
         self.wipe()
 
         # warning_level is special, it's --warnlevel instead of --warning-level
         # for historical reasons
         self.init(testdir, extra_args=['--warnlevel=2', '--fatal-meson-warnings'])
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value_for('warning_level'), '2')
+        self.assertEqual(obj.optstore.get_value_for_untyped('warning_level'), '2')
         self.setconf('--warnlevel=3')
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value_for('warning_level'), '3')
+        self.assertEqual(obj.optstore.get_value_for_untyped('warning_level'), '3')
         self.setconf('--warnlevel=everything')
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value_for('warning_level'), 'everything')
+        self.assertEqual(obj.optstore.get_value_for_untyped('warning_level'), 'everything')
         self.wipe()
 
         # But when using -D syntax, it should be 'warning_level'
         self.init(testdir, extra_args=['-Dwarning_level=2', '--fatal-meson-warnings'])
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value_for('warning_level'), '2')
+        self.assertEqual(obj.optstore.get_value_for_untyped('warning_level'), '2')
         self.setconf('-Dwarning_level=3')
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value_for('warning_level'), '3')
+        self.assertEqual(obj.optstore.get_value_for_untyped('warning_level'), '3')
         self.setconf('-Dwarning_level=everything')
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value_for('warning_level'), 'everything')
+        self.assertEqual(obj.optstore.get_value_for_untyped('warning_level'), 'everything')
         self.wipe()
 
         # Mixing --option and -Doption is forbidden
@@ -2932,15 +2932,15 @@ class AllPlatformTests(BasePlatformTests):
         # --default-library should override default value from project()
         self.init(testdir, extra_args=['--default-library=both', '--fatal-meson-warnings'])
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value_for('default_library'), 'both')
+        self.assertEqual(obj.optstore.get_value_for_untyped('default_library'), 'both')
         self.setconf('--default-library=shared')
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value_for('default_library'), 'shared')
+        self.assertEqual(obj.optstore.get_value_for_untyped('default_library'), 'shared')
         if self.backend is Backend.ninja:
             # reconfigure target works only with ninja backend
             self.build('reconfigure')
             obj = mesonbuild.coredata.load(self.builddir)
-            self.assertEqual(obj.optstore.get_value_for('default_library'), 'shared')
+            self.assertEqual(obj.optstore.get_value_for_untyped('default_library'), 'shared')
         self.wipe()
 
         # Should fail on unknown options
@@ -2977,22 +2977,22 @@ class AllPlatformTests(BasePlatformTests):
         # Test we can set subproject option
         self.init(testdir, extra_args=['-Dsubp:subp_opt=foo', '--fatal-meson-warnings'])
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value_for(OptionKey('subp_opt', 'subp')), 'foo')
+        self.assertEqual(obj.optstore.get_value_for_untyped(OptionKey('subp_opt', 'subp')), 'foo')
         self.wipe()
 
         # c_args value should be parsed with split_args
         self.init(testdir, extra_args=['-Dc_args=-Dfoo -Dbar "-Dthird=one two"', '--fatal-meson-warnings'])
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value_for(OptionKey('c_args')), ['-Dfoo', '-Dbar', '-Dthird=one two'])
+        self.assertEqual(obj.optstore.get_value_for_untyped(OptionKey('c_args')), ['-Dfoo', '-Dbar', '-Dthird=one two'])
 
         self.setconf('-Dc_args="foo bar" one two')
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value_for(OptionKey('c_args')), ['foo bar', 'one', 'two'])
+        self.assertEqual(obj.optstore.get_value_for_untyped(OptionKey('c_args')), ['foo bar', 'one', 'two'])
         self.wipe()
 
         self.init(testdir, extra_args=['-Dset_percent_opt=myoption%', '--fatal-meson-warnings'])
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value_for(OptionKey('set_percent_opt', '')), 'myoption%')
+        self.assertEqual(obj.optstore.get_value_for_untyped(OptionKey('set_percent_opt', '')), 'myoption%')
         self.wipe()
 
         # Setting a 2nd time the same option should override the first value
@@ -3003,19 +3003,19 @@ class AllPlatformTests(BasePlatformTests):
                                            '-Dc_args=-Dfoo', '-Dc_args=-Dbar',
                                            '-Db_lundef=false', '--fatal-meson-warnings'])
             obj = mesonbuild.coredata.load(self.builddir)
-            self.assertEqual(obj.optstore.get_value_for('bindir'), 'bar')
-            self.assertEqual(obj.optstore.get_value_for('buildtype'), 'release')
-            self.assertEqual(obj.optstore.get_value_for('b_sanitize'), ['thread'])
-            self.assertEqual(obj.optstore.get_value_for(OptionKey('c_args')), ['-Dbar'])
+            self.assertEqual(obj.optstore.get_value_for_untyped('bindir'), 'bar')
+            self.assertEqual(obj.optstore.get_value_for_untyped('buildtype'), 'release')
+            self.assertEqual(obj.optstore.get_value_for_untyped('b_sanitize'), ['thread'])
+            self.assertEqual(obj.optstore.get_value_for_untyped(OptionKey('c_args')), ['-Dbar'])
             self.setconf(['--bindir=bar', '--bindir=foo',
                           '-Dbuildtype=release', '-Dbuildtype=plain',
                           '-Db_sanitize=thread', '-Db_sanitize=address',
                           '-Dc_args=-Dbar', '-Dc_args=-Dfoo'])
             obj = mesonbuild.coredata.load(self.builddir)
-            self.assertEqual(obj.optstore.get_value_for('bindir'), 'foo')
-            self.assertEqual(obj.optstore.get_value_for('buildtype'), 'plain')
-            self.assertEqual(obj.optstore.get_value_for('b_sanitize'), ['address'])
-            self.assertEqual(obj.optstore.get_value_for(OptionKey('c_args')), ['-Dfoo'])
+            self.assertEqual(obj.optstore.get_value_for_untyped('bindir'), 'foo')
+            self.assertEqual(obj.optstore.get_value_for_untyped('buildtype'), 'plain')
+            self.assertEqual(obj.optstore.get_value_for_untyped('b_sanitize'), ['address'])
+            self.assertEqual(obj.optstore.get_value_for_untyped(OptionKey('c_args')), ['-Dfoo'])
             self.wipe()
         except KeyError:
             # Ignore KeyError, it happens on CI for compilers that does not
@@ -3029,25 +3029,25 @@ class AllPlatformTests(BasePlatformTests):
         # Verify default values when passing no args
         self.init(testdir)
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value_for('warning_level'), '0')
+        self.assertEqual(obj.optstore.get_value_for_untyped('warning_level'), '0')
         self.wipe()
 
         # verify we can override w/ --warnlevel
         self.init(testdir, extra_args=['--warnlevel=1'])
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value_for('warning_level'), '1')
+        self.assertEqual(obj.optstore.get_value_for_untyped('warning_level'), '1')
         self.setconf('--warnlevel=0')
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value_for('warning_level'), '0')
+        self.assertEqual(obj.optstore.get_value_for_untyped('warning_level'), '0')
         self.wipe()
 
         # verify we can override w/ -Dwarning_level
         self.init(testdir, extra_args=['-Dwarning_level=1'])
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value_for('warning_level'), '1')
+        self.assertEqual(obj.optstore.get_value_for_untyped('warning_level'), '1')
         self.setconf('-Dwarning_level=0')
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.optstore.get_value_for('warning_level'), '0')
+        self.assertEqual(obj.optstore.get_value_for_untyped('warning_level'), '0')
         self.wipe()
 
     def test_feature_check_usage_subprojects(self):

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016-2021 The Meson development team
-# Copyright © 2023-2025 Intel Corporation
+# Copyright © 2023-2026 Intel Corporation
 
+from __future__ import annotations
 import itertools
 import subprocess
 import re
@@ -31,6 +32,7 @@ import mesonbuild.environment
 import mesonbuild.coredata
 import mesonbuild.machinefile
 import mesonbuild.modules.gnome
+import mesonbuild.tooldetect
 from mesonbuild.mesonlib import (
     DirectoryLock, DirectoryLockAction, MachineChoice, is_windows, is_osx, is_cygwin, is_dragonflybsd,
     is_sunos, windows_proof_rmtree, python_command, version_compare, split_args, quote_arg,
@@ -49,7 +51,7 @@ from mesonbuild.compilers.c import VisualStudioCCompiler, ClangClCCompiler
 from mesonbuild.compilers.cpp import VisualStudioCPPCompiler, ClangClCPPCompiler
 from mesonbuild.compilers import (
     detect_static_linker, detect_c_compiler, compiler_from_language,
-    detect_compiler_for, lang_suffixes
+    detect_compiler_for
 )
 from mesonbuild.linkers import linkers
 
@@ -67,6 +69,10 @@ from run_tests import (
 
 from .baseplatformtests import BasePlatformTests
 from .helpers import *
+
+if T.TYPE_CHECKING:
+    from mesonbuild.compilers.compilers import Language
+    from mesonbuild.environment import Environment
 
 UNIT_MACHINEFILE_DIR = Path(__file__).parent / 'machinefiles'
 
@@ -2536,86 +2542,137 @@ class AllPlatformTests(BasePlatformTests):
             self.init(tdir)
         self.assertIn('ERROR: compiler.has_header_symbol got unknown keyword arguments "prefixxx"', cm.exception.output)
 
-    def test_templates(self):
-        ninja = mesonbuild.tooldetect.detect_ninja()
-        if ninja is None:
-            raise SkipTest('This test currently requires ninja. Fix this once "meson build" works.')
+    def _template_test_fresh(self, lang: Language, target_type: str, env: Environment, ninja: list[str]) -> None:
+        if is_windows() and lang == 'fortran' and target_type == 'library':
+            # non-Gfortran Windows Fortran compilers do not do shared libraries in a Fortran standard way
+            # see "test cases/fortran/6 dynamic"
+            fc = detect_compiler_for(env, 'fortran', MachineChoice.HOST, True, '')
+            if fc.get_id() in {'intel-cl', 'pgi'}:
+                raise SkipTest('The Intel (classic) and PGI fortran compilers do not support standard shared libraries')
 
-        langs = []
-        env = get_fake_env()
-        for l in ['c', 'cpp', 'cs', 'cuda', 'd', 'fortran', 'java', 'objc', 'objcpp', 'rust', 'vala']:
-            try:
-                comp = detect_compiler_for(env, l, MachineChoice.HOST, True, '')
-                with tempfile.TemporaryDirectory() as d:
-                    comp.sanity_check(d)
-                langs.append(l)
-            except EnvironmentException:
-                pass
+        # test empty directory
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._run(self.meson_command + ['init', '--language', lang, '--type', target_type],
+                      workdir=tmpdir)
+            self._run(self.setup_command + ['--backend=ninja', 'builddir'], workdir=tmpdir)
+            self._run(ninja, workdir=os.path.join(tmpdir, 'builddir'))
 
-        # The D template fails under mac CI and we don't know why.
-        # Patches welcome
-        if is_osx():
-            langs = [l for l in langs if l != 'd']
-
-        def _template_test_fresh(lang, target_type):
-            if is_windows() and lang == 'fortran' and target_type == 'library':
-                # non-Gfortran Windows Fortran compilers do not do shared libraries in a Fortran standard way
-                # see "test cases/fortran/6 dynamic"
-                fc = detect_compiler_for(env, 'fortran', MachineChoice.HOST, True, '')
-                if fc.get_id() in {'intel-cl', 'pgi'}:
-                    return
-
-            # test empty directory
+        # custom executable name
+        if target_type == 'executable':
             with tempfile.TemporaryDirectory() as tmpdir:
-                self._run(self.meson_command + ['init', '--language', lang, '--type', target_type],
-                            workdir=tmpdir)
-                self._run(self.setup_command + ['--backend=ninja', 'builddir'], workdir=tmpdir)
-                self._run(ninja, workdir=os.path.join(tmpdir, 'builddir'))
-
-            # custom executable name
-            if target_type == 'executable':
-                with tempfile.TemporaryDirectory() as tmpdir:
-                    self._run(self.meson_command + ['init', '--language', lang, '--type', target_type,
-                                                    '--executable', 'foobar'],
-                                                    workdir=tmpdir)
-                    self._run(self.setup_command + ['--backend=ninja', 'builddir'], workdir=tmpdir)
-                    self._run(ninja, workdir=os.path.join(tmpdir, 'builddir'))
-
-                    if lang not in {'cs', 'java'}:
-                        exe = os.path.join(tmpdir, 'builddir', 'foobar' + exe_suffix)
-                        self.assertTrue(os.path.exists(exe))
-
-        def _template_test_dirty(lang, target_type):
-            if is_windows() and lang == 'fortran' and target_type == 'library':
-                # non-Gfortran Windows Fortran compilers do not do shared libraries in a Fortran standard way
-                # see "test cases/fortran/6 dynamic"
-                fc = detect_compiler_for(env, 'fortran', MachineChoice.HOST, True, '')
-                if fc.get_id() in {'intel-cl', 'pgi'}:
-                    return
-
-            # test empty directory
-            with tempfile.TemporaryDirectory() as tmpdir:
-                self._run(self.meson_command + ['init', '--language', lang, '--type', target_type],
+                self._run(self.meson_command + ['init', '--language', lang, '--type', target_type,
+                                                '--executable', 'foobar'],
                           workdir=tmpdir)
                 self._run(self.setup_command + ['--backend=ninja', 'builddir'], workdir=tmpdir)
                 self._run(ninja, workdir=os.path.join(tmpdir, 'builddir'))
 
-            # test directory with existing code file
-            if lang in {'c', 'cpp', 'd'}:
-                with tempfile.TemporaryDirectory() as tmpdir:
-                    with open(os.path.join(tmpdir, 'foo.' + lang), 'w', encoding='utf-8') as f:
-                        f.write('int main(void) {}')
-                    self._run(self.meson_command + ['init', '-b'], workdir=tmpdir)
+                if lang not in {'cs', 'java'}:
+                    exe = os.path.join(tmpdir, 'builddir', 'foobar' + exe_suffix)
+                    self.assertTrue(os.path.exists(exe))
 
-            elif lang in {'java'}:
-                with tempfile.TemporaryDirectory() as tmpdir:
-                    with open(os.path.join(tmpdir, 'Foo.' + lang), 'w', encoding='utf-8') as f:
-                        f.write('public class Foo { public static void main() {} }')
-                    self._run(self.meson_command + ['init', '-b'], workdir=tmpdir)
+    def _template_test_dirty(self, lang: Language, target_type: str, env: Environment, ninja: list[str]) -> None:
+        if is_windows() and lang == 'fortran' and target_type == 'library':
+            # non-Gfortran Windows Fortran compilers do not do shared libraries in a Fortran standard way
+            # see "test cases/fortran/6 dynamic"
+            fc = detect_compiler_for(env, 'fortran', MachineChoice.HOST, True, '')
+            if fc.get_id() in {'intel-cl', 'pgi'}:
+                raise SkipTest('The Intel (classic) and PGI fortran compilers do not support standard shared libraries')
 
-        for lang, target_type, fresh in itertools.product(langs, ('executable', 'library'), (True, False)):
-            with self.subTest(f'Language: {lang}; type: {target_type}; fresh: {fresh}'):
-                _template_test_fresh(lang, target_type) if fresh else _template_test_dirty(lang, target_type)
+        # test empty directory
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._run(self.meson_command + ['init', '--language', lang, '--type', target_type],
+                      workdir=tmpdir)
+            self._run(self.setup_command + ['--backend=ninja', 'builddir'], workdir=tmpdir)
+            self._run(ninja, workdir=os.path.join(tmpdir, 'builddir'))
+
+        # test directory with existing code file
+        if lang in {'c', 'cpp', 'd'}:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                with open(os.path.join(tmpdir, 'foo.' + lang), 'w', encoding='utf-8') as f:
+                    f.write('int main(void) {}')
+                self._run(self.meson_command + ['init', '-b'], workdir=tmpdir)
+
+        elif lang in {'java'}:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                with open(os.path.join(tmpdir, 'Foo.' + lang), 'w', encoding='utf-8') as f:
+                    f.write('public class Foo { public static void main() {} }')
+                self._run(self.meson_command + ['init', '-b'], workdir=tmpdir)
+
+    def _test_template(self, lang: Language) -> None:
+        ninja = mesonbuild.tooldetect.detect_ninja()
+        if ninja is None:
+            raise SkipTest('This test currently requires ninja. Fix this once "meson build" works.')
+
+        env = get_fake_env(bdir=self.builddir)
+
+        extra_lang: Language | None
+        match lang:
+            case 'cuda':
+                extra_lang = 'cpp'
+            case 'vala':
+                extra_lang = 'c'
+            case _:
+                extra_lang = None
+
+        if extra_lang is not None:
+            try:
+                comp = detect_compiler_for(env, extra_lang, MachineChoice.HOST, True, '')
+            except EnvironmentException:
+                comp = None
+            if comp is None:
+                raise SkipTest(f'Could not find compiler for {extra_lang}, which is required for {lang}')
+
+        with tempfile.TemporaryDirectory() as d:
+            try:
+                comp = detect_compiler_for(env, lang, MachineChoice.HOST, True, '')
+                if comp is None:
+                    raise SkipTest(f'Could not find compiler for language: {lang}')
+                comp.sanity_check(d)
+            except EnvironmentException:
+                raise SkipTest(f'Compiler for language {lang} failed to sanity check')
+
+        for target_type, fresh in itertools.product(('executable', 'library'), (True, False)):
+            with self.subTest(type=target_type, fresh=fresh):
+                func = self._template_test_fresh if fresh else self._template_test_dirty
+                try:
+                    func(lang, target_type, env, ninja)
+                except subprocess.CalledProcessError as e:
+                    self.fail(e.stdout)
+
+    def test_template_c(self) -> None:
+        self._test_template('c')
+
+    def test_template_cpp(self) -> None:
+        self._test_template('cpp')
+
+    def test_template_cs(self) -> None:
+        self._test_template('cs')
+
+    def test_template_cuda(self) -> None:
+        self._test_template('cuda')
+
+    def test_template_d(self) -> None:
+        if is_osx():
+            raise SkipTest('The D template fails under MacOS CI, we are unsure why. Patches welcome.')
+        self._test_template('d')
+
+    def test_template_fortran(self) -> None:
+        self._test_template('fortran')
+
+    def test_template_java(self) -> None:
+        self._test_template('java')
+
+    def test_template_objc(self) -> None:
+        self._test_template('objc')
+
+    def test_template_objcpp(self) -> None:
+        self._test_template('objcpp')
+
+    def test_template_rust(self) -> None:
+        self._test_template('rust')
+
+    def test_template_vala(self) -> None:
+        self._test_template('vala')
 
     def test_compiler_run_command(self):
         '''

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -4928,10 +4928,10 @@ class AllPlatformTests(BasePlatformTests):
             # C does have a separate linking step. It can be done through the compiler
             # driver or not; act accordingly.
             if cc.USED_FOR_SEPARATE_LINKING_STEP:
-                link_args = env.coredata.get_external_link_args(cc.for_machine, cc.language)
+                link_args = env.coredata.optstore.get_external_link_args(cc.for_machine, cc.language)
                 self.assertEqual(sorted(link_args), sorted(['-DCFLAG', '-flto']))
             else:
-                link_args = env.coredata.get_external_link_args(cc.for_machine, cc.language)
+                link_args = env.coredata.optstore.get_external_link_args(cc.for_machine, cc.language)
                 self.assertEqual(sorted(link_args), sorted(['-flto']))
 
     def test_install_tag(self) -> None:

--- a/unittests/datatests.py
+++ b/unittests/datatests.py
@@ -168,9 +168,9 @@ class DataTests(unittest.TestCase):
             else:
                 raise RuntimeError(f'Invalid debug value {debug!r} in row:\n{m.group()}')
             env.coredata.optstore.set_option(OptionKey('buildtype'), buildtype)
-            self.assertEqual(env.coredata.optstore.get_value_for('buildtype'), buildtype)
-            self.assertEqual(env.coredata.optstore.get_value_for('optimization'), opt)
-            self.assertEqual(env.coredata.optstore.get_value_for('debug'), debug)
+            self.assertEqual(env.coredata.optstore.get_value_for_untyped('buildtype'), buildtype)
+            self.assertEqual(env.coredata.optstore.get_value_for_untyped('optimization'), opt)
+            self.assertEqual(env.coredata.optstore.get_value_for_untyped('debug'), debug)
 
     def test_cpu_families_documented(self):
         with open("docs/markdown/Reference-tables.md", encoding='utf-8') as f:

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -1183,7 +1183,7 @@ class LinuxlikeTests(BasePlatformTests):
         # option, adding the meson-uninstalled directory to it.
         PkgConfigInterface.setup_env({}, env, MachineChoice.HOST, uninstalled=True)
 
-        pkg_config_path = env.coredata.optstore.get_value_for('pkg_config_path')
+        pkg_config_path = env.coredata.optstore.get_value_for_untyped('pkg_config_path')
         self.assertEqual(pkg_config_path, [pkg_dir])
 
     def test_pkgconfig_uninstalled_env_added(self):

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -3,7 +3,9 @@
 
 from mesonbuild.options import *
 from mesonbuild.envconfig import MachineInfo
+from mesonbuild.build import BuildTarget
 
+from unittest import mock
 import os
 import unittest
 
@@ -639,3 +641,9 @@ class OptionTests(unittest.TestCase):
         optstore = OptionStore(False)
         self.assertTrue(optstore._is_host_absolute(os.sep + 'myprog'))
         self.assertTrue(optstore._is_host_absolute('/myprog'))
+
+    def test_get_value_default(self) -> None:
+        optstore = OptionStore(False)
+        self.assertTrue(optstore.get_value_for(OptionKey('nonexistent'), bool, default=True))
+        target = mock.Mock(spec=BuildTarget, subproject='')
+        self.assertTrue(optstore.get_option_for_target(target, OptionKey('nonexistent'), bool, default=True))

--- a/unittests/optiontests.py
+++ b/unittests/optiontests.py
@@ -25,9 +25,9 @@ class OptionTests(unittest.TestCase):
         new_value = 'new_value'
         vo = UserStringOption(name, 'An option of some sort', default_value)
         optstore.add_system_option(name, vo)
-        self.assertEqual(optstore.get_value_for(name), default_value)
+        self.assertEqual(optstore.get_value_for_untyped(name), default_value)
         optstore.set_option(OptionKey.from_string(name), new_value)
-        self.assertEqual(optstore.get_value_for(name), new_value)
+        self.assertEqual(optstore.get_value_for_untyped(name), new_value)
 
     def test_toplevel_project(self):
         optstore = OptionStore(False)
@@ -37,9 +37,9 @@ class OptionTests(unittest.TestCase):
         k = OptionKey(name)
         vo = UserStringOption(k.name, 'An option of some sort', default_value)
         optstore.add_system_option(k.name, vo)
-        self.assertEqual(optstore.get_value_for(k), default_value)
+        self.assertEqual(optstore.get_value_for_untyped(k), default_value)
         optstore.initialize_from_top_level_project_call({OptionKey('someoption'): new_value}, {}, {})
-        self.assertEqual(optstore.get_value_for(k), new_value)
+        self.assertEqual(optstore.get_value_for_untyped(k), new_value)
 
     def test_machine_vs_project(self):
         optstore = OptionStore(False)
@@ -52,10 +52,10 @@ class OptionTests(unittest.TestCase):
         optstore.add_system_option('prefix', prefix)
         vo = UserStringOption(k.name, 'You know what this is', default_value)
         optstore.add_system_option(k.name, vo)
-        self.assertEqual(optstore.get_value_for(k), default_value)
+        self.assertEqual(optstore.get_value_for_untyped(k), default_value)
         optstore.initialize_from_top_level_project_call({OptionKey(name): proj_value}, {},
                                                         {OptionKey(name): mfile_value})
-        self.assertEqual(optstore.get_value_for(k), mfile_value)
+        self.assertEqual(optstore.get_value_for_untyped(k), mfile_value)
 
     def test_subproject_system_option(self):
         """Test that subproject system options get their default value from the global
@@ -69,7 +69,7 @@ class OptionTests(unittest.TestCase):
         optstore.initialize_from_top_level_project_call({}, {}, {OptionKey(name): new_value})
         vo = UserStringOption(k.name, 'An option of some sort', default_value)
         optstore.add_system_option(subk, vo)
-        self.assertEqual(optstore.get_value_for(subk), new_value)
+        self.assertEqual(optstore.get_value_for_untyped(subk), new_value)
 
     def test_parsing(self):
         with self.subTest('subproject'):
@@ -96,7 +96,7 @@ class OptionTests(unittest.TestCase):
         default_value = 'somevalue'
         vo = UserStringOption(name, 'An option of some sort', default_value)
         optstore.add_system_option(name, vo)
-        self.assertEqual(optstore.get_value_for(name, 'somesubproject'), default_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, 'somesubproject'), default_value)
 
     def test_reset(self):
         optstore = OptionStore(False)
@@ -105,11 +105,11 @@ class OptionTests(unittest.TestCase):
         reset_value = 'reset'
         vo = UserStringOption(name, 'An option set twice', original_value)
         optstore.add_system_option(name, vo)
-        self.assertEqual(optstore.get_value_for(name), original_value)
+        self.assertEqual(optstore.get_value_for_untyped(name), original_value)
         self.assertEqual(num_options(optstore), 1)
         vo2 = UserStringOption(name, 'An option set twice', reset_value)
         optstore.add_system_option(name, vo2)
-        self.assertEqual(optstore.get_value_for(name), original_value)
+        self.assertEqual(optstore.get_value_for_untyped(name), original_value)
         self.assertEqual(num_options(optstore), 1)
 
     def test_project_nonyielding(self):
@@ -119,12 +119,12 @@ class OptionTests(unittest.TestCase):
         sub_value = 'sub'
         vo = UserStringOption(name, 'A top level option', top_value, False)
         optstore.add_project_option(OptionKey(name, ''), vo)
-        self.assertEqual(optstore.get_value_for(name, ''), top_value, False)
+        self.assertEqual(optstore.get_value_for_untyped(name, ''), top_value, False)
         self.assertEqual(num_options(optstore), 1)
         vo2 = UserStringOption(name, 'A subproject option', sub_value)
         optstore.add_project_option(OptionKey(name, 'sub'), vo2)
-        self.assertEqual(optstore.get_value_for(name, ''), top_value)
-        self.assertEqual(optstore.get_value_for(name, 'sub'), sub_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, ''), top_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, 'sub'), sub_value)
         self.assertEqual(num_options(optstore), 2)
 
     def test_toplevel_project_yielding(self):
@@ -133,7 +133,7 @@ class OptionTests(unittest.TestCase):
         top_value = 'top'
         vo = UserStringOption(name, 'A top level option', top_value, True)
         optstore.add_project_option(OptionKey(name, ''), vo)
-        self.assertEqual(optstore.get_value_for(name, ''), top_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, ''), top_value)
 
     def test_project_yielding(self):
         optstore = OptionStore(False)
@@ -142,12 +142,12 @@ class OptionTests(unittest.TestCase):
         sub_value = 'sub'
         vo = UserStringOption(name, 'A top level option', top_value)
         optstore.add_project_option(OptionKey(name, ''), vo)
-        self.assertEqual(optstore.get_value_for(name, ''), top_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, ''), top_value)
         self.assertEqual(num_options(optstore), 1)
         vo2 = UserStringOption(name, 'A subproject option', sub_value, True)
         optstore.add_project_option(OptionKey(name, 'sub'), vo2)
-        self.assertEqual(optstore.get_value_for(name, ''), top_value)
-        self.assertEqual(optstore.get_value_for(name, 'sub'), top_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, ''), top_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, 'sub'), top_value)
         self.assertEqual(num_options(optstore), 2)
 
     def test_project_yielding_not_defined_in_top_project(self):
@@ -158,12 +158,12 @@ class OptionTests(unittest.TestCase):
         sub_value = 'sub'
         vo = UserStringOption(top_name, 'A top level option', top_value)
         optstore.add_project_option(OptionKey(top_name, ''), vo)
-        self.assertEqual(optstore.get_value_for(top_name, ''), top_value)
+        self.assertEqual(optstore.get_value_for_untyped(top_name, ''), top_value)
         self.assertEqual(num_options(optstore), 1)
         vo2 = UserStringOption(sub_name, 'A subproject option', sub_value, True)
         optstore.add_project_option(OptionKey(sub_name, 'sub'), vo2)
-        self.assertEqual(optstore.get_value_for(top_name, ''), top_value)
-        self.assertEqual(optstore.get_value_for(sub_name, 'sub'), sub_value)
+        self.assertEqual(optstore.get_value_for_untyped(top_name, ''), top_value)
+        self.assertEqual(optstore.get_value_for_untyped(sub_name, 'sub'), sub_value)
         self.assertEqual(num_options(optstore), 2)
 
     def test_project_yielding_initialize(self):
@@ -177,18 +177,18 @@ class OptionTests(unittest.TestCase):
         vo = UserStringOption(name, 'A top level option', 'default1')
         optstore.add_project_option(OptionKey(name, ''), vo)
         optstore.initialize_from_top_level_project_call({}, cmd_line, {})
-        self.assertEqual(optstore.get_value_for(name, ''), top_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, ''), top_value)
         self.assertEqual(num_options(optstore), 1)
 
         vo2 = UserStringOption(name, 'A subproject option', 'default2', True)
         optstore.add_project_option(OptionKey(name, 'subp'), vo2)
-        self.assertEqual(optstore.get_value_for(name, ''), top_value)
-        self.assertEqual(optstore.get_value_for(name, subp), top_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, ''), top_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, subp), top_value)
         self.assertEqual(num_options(optstore), 2)
 
         optstore.initialize_from_subproject_call(subp, {}, {}, cmd_line, {})
-        self.assertEqual(optstore.get_value_for(name, ''), top_value)
-        self.assertEqual(optstore.get_value_for(name, subp), sub_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, ''), top_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, subp), sub_value)
 
     def test_augments(self):
         optstore = OptionStore(False)
@@ -203,34 +203,34 @@ class OptionTests(unittest.TestCase):
                              top_value,
                              choices=['c++98', 'c++11', 'c++14', 'c++17', 'c++20', 'c++23'])
         optstore.add_system_option(name, co)
-        self.assertEqual(optstore.get_value_for(name), top_value)
-        self.assertEqual(optstore.get_value_for(name, sub_name), top_value)
-        self.assertEqual(optstore.get_value_for(name, sub2_name), top_value)
+        self.assertEqual(optstore.get_value_for_untyped(name), top_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, sub_name), top_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, sub2_name), top_value)
 
         # First augment a subproject
         with self.subTest('set subproject override'):
             optstore.set_from_configure_command({OptionKey.from_string(f'{sub_name}:{name}'): aug_value})
-            self.assertEqual(optstore.get_value_for(name), top_value)
-            self.assertEqual(optstore.get_value_for(name, sub_name), aug_value)
-            self.assertEqual(optstore.get_value_for(name, sub2_name), top_value)
+            self.assertEqual(optstore.get_value_for_untyped(name), top_value)
+            self.assertEqual(optstore.get_value_for_untyped(name, sub_name), aug_value)
+            self.assertEqual(optstore.get_value_for_untyped(name, sub2_name), top_value)
 
         with self.subTest('unset subproject override'):
             optstore.set_from_configure_command({OptionKey.from_string(f'{sub_name}:{name}'): None})
-            self.assertEqual(optstore.get_value_for(name), top_value)
-            self.assertEqual(optstore.get_value_for(name, sub_name), top_value)
-            self.assertEqual(optstore.get_value_for(name, sub2_name), top_value)
+            self.assertEqual(optstore.get_value_for_untyped(name), top_value)
+            self.assertEqual(optstore.get_value_for_untyped(name, sub_name), top_value)
+            self.assertEqual(optstore.get_value_for_untyped(name, sub2_name), top_value)
 
         # And now augment the top level option
         optstore.set_from_configure_command({OptionKey.from_string(f':{name}'): aug_value})
-        self.assertEqual(optstore.get_value_for(name, None), top_value)
-        self.assertEqual(optstore.get_value_for(name, ''), aug_value)
-        self.assertEqual(optstore.get_value_for(name, sub_name), top_value)
-        self.assertEqual(optstore.get_value_for(name, sub2_name), top_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, None), top_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, ''), aug_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, sub_name), top_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, sub2_name), top_value)
 
         optstore.set_from_configure_command({OptionKey.from_string(f':{name}'): None})
-        self.assertEqual(optstore.get_value_for(name), top_value)
-        self.assertEqual(optstore.get_value_for(name, sub_name), top_value)
-        self.assertEqual(optstore.get_value_for(name, sub2_name), top_value)
+        self.assertEqual(optstore.get_value_for_untyped(name), top_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, sub_name), top_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, sub2_name), top_value)
 
     def test_augment_set_sub(self):
         optstore = OptionStore(False)
@@ -249,8 +249,8 @@ class OptionTests(unittest.TestCase):
         optstore.add_system_option(name, co)
         optstore.set_from_configure_command({OptionKey.from_string(f'{sub_name}:{name}'): aug_value})
         optstore.set_from_configure_command({OptionKey.from_string(f'{sub_name}:{name}'): set_value})
-        self.assertEqual(optstore.get_value_for(name), top_value)
-        self.assertEqual(optstore.get_value_for(name, sub_name), set_value)
+        self.assertEqual(optstore.get_value_for_untyped(name), top_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, sub_name), set_value)
 
     def test_build_to_host(self):
         key = OptionKey('cpp_std')
@@ -266,8 +266,8 @@ class OptionTests(unittest.TestCase):
 
         cmd_line = {key: opt_value}
         optstore.initialize_from_top_level_project_call({}, cmd_line, {})
-        self.assertEqual(optstore.get_option_and_value_for(key.as_build())[1], opt_value)
-        self.assertEqual(optstore.get_value_for(key.as_build()), opt_value)
+        self.assertEqual(optstore.get_option_and_value_for_untyped(key.as_build())[1], opt_value)
+        self.assertEqual(optstore.get_value_for_untyped(key.as_build()), opt_value)
 
     def test_build_to_host_subproject(self):
         key = OptionKey('cpp_std')
@@ -285,9 +285,9 @@ class OptionTests(unittest.TestCase):
         spcall = {key: opt_value}
         optstore.initialize_from_top_level_project_call({}, {}, {})
         optstore.initialize_from_subproject_call(subp, spcall, {}, {}, {})
-        self.assertEqual(optstore.get_option_and_value_for(key.evolve(subproject=subp,
+        self.assertEqual(optstore.get_option_and_value_for_untyped(key.evolve(subproject=subp,
                                                                             machine=MachineChoice.BUILD))[1], opt_value)
-        self.assertEqual(optstore.get_value_for(key.evolve(subproject=subp,
+        self.assertEqual(optstore.get_value_for_untyped(key.evolve(subproject=subp,
                                                            machine=MachineChoice.BUILD)), opt_value)
 
     def test_build_to_host_cross(self):
@@ -307,10 +307,10 @@ class OptionTests(unittest.TestCase):
         optstore.initialize_from_top_level_project_call({}, cmd_line, {})
         print(optstore.options)
 
-        self.assertEqual(optstore.get_option_and_value_for(key)[1], opt_value)
-        self.assertEqual(optstore.get_option_and_value_for(key.as_build())[1], def_value)
-        self.assertEqual(optstore.get_value_for(key), opt_value)
-        self.assertEqual(optstore.get_value_for(key.as_build()), def_value)
+        self.assertEqual(optstore.get_option_and_value_for_untyped(key)[1], opt_value)
+        self.assertEqual(optstore.get_option_and_value_for_untyped(key.as_build())[1], def_value)
+        self.assertEqual(optstore.get_value_for_untyped(key), opt_value)
+        self.assertEqual(optstore.get_value_for_untyped(key.as_build()), def_value)
 
     def test_b_nonexistent(self):
         optstore = OptionStore(False)
@@ -349,8 +349,8 @@ class OptionTests(unittest.TestCase):
 
         optstore.initialize_from_top_level_project_call({}, cmd_line, {})
         optstore.initialize_from_subproject_call(subp, spcall, {}, cmd_line, {})
-        self.assertEqual(optstore.get_value_for(name, ''), True)
-        self.assertEqual(optstore.get_value_for(name, subp), False)
+        self.assertEqual(optstore.get_value_for_untyped(name, ''), True)
+        self.assertEqual(optstore.get_value_for_untyped(name, subp), False)
 
     def test_subproject_cmdline_override_global(self):
         name = 'optimization'
@@ -369,8 +369,8 @@ class OptionTests(unittest.TestCase):
 
         optstore.initialize_from_top_level_project_call(toplevel_proj_default, cmd_line, {})
         optstore.initialize_from_subproject_call(subp, {}, subp_proj_default, cmd_line, {})
-        self.assertEqual(optstore.get_value_for(name, subp), new_value)
-        self.assertEqual(optstore.get_value_for(name), new_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, subp), new_value)
+        self.assertEqual(optstore.get_value_for_untyped(name), new_value)
 
     def test_subproject_parent_override_subp(self):
         name = 'optimization'
@@ -389,8 +389,8 @@ class OptionTests(unittest.TestCase):
 
         optstore.initialize_from_top_level_project_call(toplevel_proj_default, {}, {})
         optstore.initialize_from_subproject_call(subp, {}, subp_proj_default, {}, {})
-        self.assertEqual(optstore.get_value_for(name, subp), subp_value)
-        self.assertEqual(optstore.get_value_for(name), default_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, subp), subp_value)
+        self.assertEqual(optstore.get_value_for_untyped(name), default_value)
 
     def test_subproject_cmdline_override_global_and_augment(self):
         name = 'optimization'
@@ -410,8 +410,8 @@ class OptionTests(unittest.TestCase):
 
         optstore.initialize_from_top_level_project_call(toplevel_proj_default, cmd_line, {})
         optstore.initialize_from_subproject_call(subp, {}, subp_proj_default, cmd_line, {})
-        self.assertEqual(optstore.get_value_for(name, subp), new_value)
-        self.assertEqual(optstore.get_value_for(name), global_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, subp), new_value)
+        self.assertEqual(optstore.get_value_for_untyped(name), global_value)
 
     def test_subproject_cmdline_override_toplevel(self):
         name = 'default_library'
@@ -431,8 +431,8 @@ class OptionTests(unittest.TestCase):
 
         optstore.initialize_from_top_level_project_call(toplevel_proj_default, cmd_line, {})
         optstore.initialize_from_subproject_call(subp, {}, subp_proj_default, cmd_line, {})
-        self.assertEqual(optstore.get_value_for(name, subp), subp_value)
-        self.assertEqual(optstore.get_value_for(name, ''), toplevel_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, subp), subp_value)
+        self.assertEqual(optstore.get_value_for_untyped(name, ''), toplevel_value)
 
     def test_subproject_buildtype(self):
         subp = 'subp'
@@ -456,9 +456,9 @@ class OptionTests(unittest.TestCase):
 
             optstore.initialize_from_top_level_project_call(mainopt, {}, {})
             optstore.initialize_from_subproject_call(subp, {}, subopt, {}, {})
-            self.assertEqual(optstore.get_value_for('buildtype', subp), 'debug')
-            self.assertEqual(optstore.get_value_for('optimization', subp), '0')
-            self.assertEqual(optstore.get_value_for('debug', subp), True)
+            self.assertEqual(optstore.get_value_for_untyped('buildtype', subp), 'debug')
+            self.assertEqual(optstore.get_value_for_untyped('optimization', subp), '0')
+            self.assertEqual(optstore.get_value_for_untyped('debug', subp), True)
 
     def test_deprecated_nonstring_value(self):
         # TODO: add a lot more deprecated option tests
@@ -468,7 +468,7 @@ class OptionTests(unittest.TestCase):
                               deprecated={'true': '1'})
         optstore.add_system_option(name, do)
         optstore.set_option(OptionKey(name), True)
-        value = optstore.get_value_for(name)
+        value = optstore.get_value_for_untyped(name)
         self.assertEqual(value, '1')
 
     def test_pending_augment_validation(self):
@@ -485,7 +485,7 @@ class OptionTests(unittest.TestCase):
         bo = UserBooleanOption(name, 'LTO', False)
         key = OptionKey(name, subproject=subproject)
         optstore.add_system_option(key, bo)
-        stored_value = optstore.get_value_for(key)
+        stored_value = optstore.get_value_for_untyped(key)
         self.assertIsInstance(stored_value, bool)
         self.assertTrue(stored_value)
 
@@ -513,7 +513,7 @@ class OptionTests(unittest.TestCase):
         build_option_obj = UserStringArrayOption('pkg_config_path', 'Build pkg-config paths', ['/usr/lib64/pkgconfig'])
         optstore.add_system_option(host_pkg_config, host_option_obj)
         optstore.add_system_option(build_pkg_config, build_option_obj)
-        option, value = optstore.get_option_and_value_for(build_pkg_config)
+        option, value = optstore.get_option_and_value_for_untyped(build_pkg_config)
         self.assertEqual(value, ['/usr/lib64/pkgconfig'])
 
         # Test that non-per-machine BUILD option IS canonicalized to HOST
@@ -522,7 +522,7 @@ class OptionTests(unittest.TestCase):
         common_option_obj = UserComboOption('optimization', 'Optimization level', '0',
                                             choices=['plain', '0', 'g', '1', '2', '3', 's'])
         optstore.add_system_option(host_opt, common_option_obj)
-        self.assertEqual(optstore.get_value_for(build_opt), '0')
+        self.assertEqual(optstore.get_value_for_untyped(build_opt), '0')
 
     def test_machine_canonicalization_native(self):
         """Test that BUILD machine options are canonicalized to HOST when not cross compiling."""
@@ -535,12 +535,12 @@ class OptionTests(unittest.TestCase):
 
         # Add per-machine option for HOST only (BUILD will be canonicalized)
         optstore.add_system_option(host_pkg_config, host_option_obj)
-        option, value = optstore.get_option_and_value_for(build_pkg_config)
+        option, value = optstore.get_option_and_value_for_untyped(build_pkg_config)
         self.assertEqual(value, ['/mingw/lib64/pkgconfig'])
 
         # Try again adding build option too, for completeness
         optstore.add_system_option(build_pkg_config, build_option_obj)
-        option, value = optstore.get_option_and_value_for(build_pkg_config)
+        option, value = optstore.get_option_and_value_for_untyped(build_pkg_config)
         self.assertEqual(value, ['/mingw/lib64/pkgconfig'])
 
     def test_sanitize_prefix_windows_host(self):
@@ -593,7 +593,7 @@ class OptionTests(unittest.TestCase):
         # Set libdir to absolute path inside prefix, should be relativized
         optstore.set_option(OptionKey('prefix'), 'C:\\Program Files\\MyProg')
         optstore.set_option(OptionKey('libdir'), 'C:\\Program Files\\MyProg\\lib')
-        self.assertEqual(optstore.get_value_for('libdir'), 'lib')
+        self.assertEqual(optstore.get_value_for_untyped('libdir'), 'lib')
 
     def test_sanitize_dir_option_cross_to_linux(self):
         """Test directory option sanitization when cross-compiling to Linux."""
@@ -603,7 +603,7 @@ class OptionTests(unittest.TestCase):
         # Set libdir to absolute path inside prefix, should be relativized
         optstore.set_option(OptionKey('prefix'), '/opt/myapp')
         optstore.set_option(OptionKey('libdir'), '/opt/myapp/lib64')
-        self.assertEqual(optstore.get_value_for('libdir'), 'lib64')
+        self.assertEqual(optstore.get_value_for_untyped('libdir'), 'lib64')
 
     def test_sanitize_prefix_native_path(self):
         """Test that native paths are accepted without set_host_machine()."""


### PR DESCRIPTION
This adds a couple of methods to the OptionStore to work with options value in a type safe manner. This works by putting the type in the getter itself, this avoids the need for the pattern of:
```python
opt = optstore.get_value_for('b_foo')
assert isinstance(opt, str), 'for mypy'
```
While also giving better error messages. Additionally, I've added a `default=` parameter, to allow not erroring when an options isn't available (a per-platform or per-compiler option). The end result is the following:
- `get_value_for` a type safe getter for a system value
- `get_value_for_untyped` a type unsafe getter for system values, works like `get_value_for` in current main
- `get_value_for_target` a type safe getter for an option that could be overwritten by a target
- `get_value_for_target_untyped` a type unsafe getter for an option that could be overwritten by a target, same as `get_value_for_target` in current main branch
- `get_value_for_maybe_target` a type safe getter that allows a target to be optional. This is a bit ugly, but I don't see a better way to handle this without duplicating code in a way that would lead to bugs.

this allows the following patterns to be eliminated:
```python
opt = optstore.get_value_for_untyped(OptionKey('b_foo'))
assert isinstance(opt, str), 'for mypy'
```
with
```python
opt = opstore.get_value_for(OptionKey('b_foo'), str)
```
(and the same for targets)

and
```python
key = OptionKey('b_foo')
if target is not None:
    opt = opstore.get_value_for_target(target, key, str)
else:
    opt = opstore.get_value_for(key, str)
```
with
```python
opt = optstore.get_value_for_maybe_target(target, OptionKey('b_foo'), str)
```

and
```python
try:
    opt = opstore.get_value_for(OptionKey('b_foo'), bool)
except KeyError:
    opt = False
```
with
```python
opt = optstore.get_value_for(OptionKey('b_foo'), bool, default=False)
```

This has been set to draft as I'm sure there will be some issues with Windows and the VS backend that need to be resolved.