### PR TITLE
mtest: add -k as alias to --maxfail

### DIFF
--- a/data/shell-completions/bash/meson
+++ b/data/shell-completions/bash/meson
@@ -561,6 +561,7 @@ _meson-test() {
   shortopts=(
     h
     j
+    k
     q
     v
     t
@@ -595,7 +596,7 @@ _meson-test() {
   local cur prev
   if _get_comp_words_by_ref -n ':' cur prev &>/dev/null; then
     case $prev in
-      --maxfail | --repeat)
+      -k | --maxfail | --repeat)
         # number, can't be completed
         return
         ;;

--- a/data/shell-completions/zsh/_meson
+++ b/data/shell-completions/zsh/_meson
@@ -182,6 +182,7 @@ local -a meson_commands=(
 
   # TODO: complete test suites
   local -a specs=(
+  '(--maxfail -k)'{'--maxfail','-k'}'=[number of failing tests before aborting]:number of failing tests: '
   '--repeat[number of times to run the tests]:number of times to repeat: '
   '--no-rebuild[do not rebuild before running tests]'
   '--gdb[run tests under gdb]'

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -127,7 +127,7 @@ def test_slice(arg: str) -> T.Tuple[int, int]:
 # Note: when adding arguments, please also add them to the completion
 # scripts in $MESONSRC/data/shell-completions/
 def add_arguments(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument('--maxfail', default=0, type=int,
+    parser.add_argument('-k', '--maxfail', default=0, type=int,
                         help='Number of failing tests before aborting the '
                         'test run. (default: 0, to disable aborting on failure)')
     parser.add_argument('--repeat', default=1, dest='repeat', type=int,


### PR DESCRIPTION
An equivalent option is available on ninja as -k, so let's alias that.