### PR TITLE
meson_exe: Always emit stderr when it has content

### DIFF
--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -77,6 +77,9 @@ def run_exe(exe: ExecutableSerialisation, extra_env: T.Optional[T.Dict[str, str]
         print('--- stderr ---')
         print(stderr.decode(encoding=encoding, errors='replace'))
         return p.returncode
+    elif stderr: # Allow a wrapped subprocess to gracefully communicate warnings
+        encoding = locale.getpreferredencoding()
+        print(stderr.decode(encoding=encoding, errors='replace'))
 
     if exe.capture:
         skip_write = False


### PR DESCRIPTION
A wrapped-subprocess may write warnings or notes to `stderr` which communicate important information to an end-user that is not necessarily erroneous, similar to a compiler. We do this in a project that I help maintain, where `meson --internal exe` is used for a target that uses a custom environment. Without this change, those warnings are swallowed unless the command for that target has a non-zero exit code.

As a leading question, should this change be behind a feature-flag of some sort? Should it be controllable with a new interpreter argument?