### PR TITLE
rust: Prefer cl over clang-cl when linking

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -1128,7 +1128,7 @@ def detect_rust_compiler(env: 'Environment', for_machine: MachineChoice) -> Rust
             if rust_target and rust_target.endswith('-msvc'):
                 try:
                     cc = _detect_c_or_cpp_compiler(env, 'c', for_machine,
-                                                   override_compiler=['clang-cl', 'cl'])
+                                                   override_compiler=['cl', 'clang-cl'])
                 except EnvironmentException:
                     popen_exceptions[join_args(compiler)] = \
                         EnvironmentException('No MSVC-compatible C compiler found for MSVC Rust target')


### PR DESCRIPTION
clang-cl is not necessarily available, and we should be preferring cl anyway since that is what almost everyone uses (which will use link.exe underneath). CI didn't catch it because the GitHub windows images ship with clang-cl.