### PR TITLE
python: Add test cases for PEP 803/820 ft-compatible limited API

### DIFF
--- a/test cases/python/12 extmodule limited api ft/limited.c
+++ b/test cases/python/12 extmodule limited api ft/limited.c
@@ -1,0 +1,36 @@
+#include <Python.h>
+
+#ifndef Py_LIMITED_API
+#error Py_LIMITED_API must be defined.
+#elif Py_LIMITED_API != 0x030f0000
+#error Wrong value for Py_LIMITED_API
+#endif
+
+static PyObject *
+hello(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args)) {
+    return PyUnicode_FromString("hello world");
+}
+
+static struct PyMethodDef methods[] = {
+    { "hello", hello, METH_NOARGS, NULL },
+    { NULL, NULL, 0, NULL },
+};
+
+PyABIInfo_VAR(abi_info);
+
+static PySlot limited_module_slots[] = {
+    PySlot_STATIC_DATA(Py_mod_name, "limited"),
+    PySlot_STATIC_DATA(Py_mod_methods, methods),
+    PySlot_STATIC_DATA(Py_mod_gil, Py_MOD_GIL_NOT_USED),
+    PySlot_STATIC_DATA(Py_mod_abi, &abi_info),
+    PySlot_END,
+};
+
+PyMODEXPORT_FUNC PyModExport_limited(void) {
+    return limited_module_slots;
+}
+
+PyMODINIT_FUNC PyInit_limited(void) {
+    PyErr_SetString(PyExc_NotImplementedError, "legacy init not supported");
+    return NULL;
+}

--- a/test cases/python/12 extmodule limited api ft/meson.build
+++ b/test cases/python/12 extmodule limited api ft/meson.build
@@ -1,21 +1,16 @@
-project('Python limited api', 'c',
+project('Python limited api ft', 'c',
   default_options : ['buildtype=release', 'werror=true'])
 
 py_mod = import('python')
 py = py_mod.find_installation()
 
-if py.get_variable('Py_GIL_DISABLED', 0) == 1
-  error('MESON_SKIP_TEST: Freethreading Python does not support (old) limited API')
+if py.language_version().version_compare('<3.15')
+  error('MESON_SKIP_TEST: Py_TARGET_ABI3T is supported since 3.15.0a8')
 endif
 
 ext_mod_limited = py.extension_module('limited',
   'limited.c',
-  limited_api: '3.7',
-  install: true,
-)
-
-ext_mod = py.extension_module('not_limited',
-  'not_limited.c',
+  limited_api: '3.15',
   install: true,
 )
 

--- a/test cases/python/12 extmodule limited api ft/test.json
+++ b/test cases/python/12 extmodule limited api ft/test.json
@@ -1,0 +1,6 @@
+{
+  "installed": [
+    {"type": "python_limited_lib", "file": "usr/@PYTHON_PLATLIB@/limited"},
+    {"type": "py_limited_implib", "file": "usr/@PYTHON_PLATLIB@/limited"}
+  ]
+}

--- a/test cases/python/12 extmodule limited api ft/test_limited.py
+++ b/test cases/python/12 extmodule limited api ft/test_limited.py
@@ -1,0 +1,6 @@
+from limited import hello
+
+def test_hello():
+    assert hello() == "hello world"
+
+test_hello()

--- a/unittests/pythontests.py
+++ b/unittests/pythontests.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2016-2021 The Meson development team
 
-import glob, os, pathlib, shutil, subprocess, sys, unittest
+import glob, os, pathlib, shutil, subprocess, sys, sysconfig, unittest
 
 from run_tests import (
     Backend
@@ -109,6 +109,37 @@ python = pymod.find_installation('python3', required: true)
         self.assertPathExists(limited_library_path)
 
         limited_dep_name = 'python3.dll'
+        if shutil.which('dumpbin'):
+            # MSVC
+            output = subprocess.check_output(['dumpbin', '/DEPENDENTS', limited_library_path],
+                                            stderr=subprocess.STDOUT)
+            self.assertIn(limited_dep_name, output.decode())
+        elif shutil.which('objdump'):
+            # mingw
+            output = subprocess.check_output(['objdump', '-p', limited_library_path],
+                                             stderr=subprocess.STDOUT)
+            self.assertIn(limited_dep_name, output.decode())
+        else:
+            raise self.skipTest('Test needs either dumpbin(MSVC) or objdump(mingw).')
+
+    def test_abi3t_linked_correct_lib(self):
+        if sysconfig.get_config_var('Py_GIL_DISABLED') != 1:
+            return self.skipTest('Test only run with freethreading Python')
+        if not is_windows():
+            return self.skipTest('Test only run on Windows.')
+
+        testdir = os.path.join(self.src_root, 'test cases', 'python', '12 extmodule limited api ft')
+
+        self.init(testdir)
+        self.build()
+
+        from importlib.machinery import EXTENSION_SUFFIXES
+        limited_suffix = EXTENSION_SUFFIXES[1]
+
+        limited_library_path = os.path.join(self.builddir, f'limited{limited_suffix}')
+        self.assertPathExists(limited_library_path)
+
+        limited_dep_name = 'python3t.dll'
         if shutil.which('dumpbin'):
             # MSVC
             output = subprocess.check_output(['dumpbin', '/DEPENDENTS', limited_library_path],


### PR DESCRIPTION
Add a new test case that exercises the limited API code in Python 3.15.0b1.  It is run with Python 3.15+, both GIL-enabled (where `.abi3.so` extension is built) and freethreading (`.abi3t.so`).  The "old" limited API test case is now restricted to GIL-enabled builds only, as the code is not compatible with the new API, and it is cleaner to have separate test cases rather than add conditions to that code.