### PR TITLE
compilers: Don't use -I=path in TI toolchains

### DIFF
--- a/mesonbuild/compilers/mixins/ti.py
+++ b/mesonbuild/compilers/mixins/ti.py
@@ -103,14 +103,12 @@ class TICompiler(Compiler):
     def get_include_args(self, path: str, is_system: bool) -> T.List[str]:
         if path == '':
             path = '.'
-        return ['-I=' + path]
+        return ['-I' + path]
 
     @classmethod
     def _unix_args_to_native(cls, args: T.List[str], info: MachineInfo) -> T.List[str]:
         result: T.List[str] = []
         for i in args:
-            if i.startswith('-D'):
-                i = '--define=' + i[2:]
             if i.startswith('-Wl,-rpath='):
                 continue
             elif i == '--print-search-dirs':


### PR DESCRIPTION
Meson currently uses the syntax `-I=path` instead of `-Ipath` when using Texas Instruments compilers.

This is problematic because it generates a `compile_commands.json` using this syntax and tools such as `clangd` will fail to use the `compile_commands.json`.

Now, I tried checking if there was TI compilers that only supported `-I=path` syntax and I couldn't find any. I checked TI CGT, TI MSP430 and TI C2000 compilers, which [were the compilers that were initially supported by Meson](https://github.com/mesonbuild/meson/commit/b4d9b2551c32288754a3008d14895c6fe53f48e2). I also did a deep research with Gemini and it couldn't find a TI compiler that required `-I=path` and even discouraged it (not perfect tools, to take with a grain of salt).

### Additional Changes

I've found out that the same can be said of `--define=foo`. It should be `-Dfoo`.

### Related Documentation

* [ARM Optimizing C/C++ Compiler v20.2.0.LTS](https://www.ti.com/lit/ug/spnu151w/spnu151w.pdf)
* [MSP430 Optimizing C/C++ Compiler v21.6.0.LTS](https://www.ti.com/lit/ug/slau132y/slau132y.pdf)
* [TMS320C28x Optimizing C/C++ Compiler v22.6.0.LTS](https://www.ti.com/lit/ug/spru514z/spru514z.pdf)
* [C7000 Optimizing C/C++ Compiler v5.0.0.LTS](https://www.ti.com/lit/ug/spruig8k/spruig8k.pdf)
* [PRU Optimizing C/C++ Compiler v2.3](https://www.ti.com/lit/ug/spruhv7c/spruhv7c.pdf)
* [TMS320C6000 Optimizing C/C++ Compiler v8.5.x](https://www.ti.com/lit/ug/sprui04g/sprui04g.pdf)

