### PR TITLE
Qt docs update

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -761,50 +761,36 @@ but dependency tries `pkg-config` first.
 
 ## Qt
 
-Meson has native Qt support. Its usage is best demonstrated with an
-example.
+Meson has native support for Qt
 
 ```meson
-qt5_mod = import('qt5')
-qt5widgets = dependency('qt5', modules : 'Widgets')
-
-processed = qt5_mod.preprocess(
-  moc_headers : 'mainWindow.h',   # Only headers that need moc should be put here
-  moc_sources : 'helperFile.cpp', # must have #include"moc_helperFile.cpp"
-  ui_files    : 'mainWindow.ui',
-  qresources  : 'resources.qrc',
-)
-
-q5exe = executable('qt5test',
-  sources     : ['main.cpp',
-                 'mainWindow.cpp',
-                 processed],
-  dependencies: qt5widgets)
+qt6_dep = dependency('qt6', modules : ['Core', 'Gui', 'Widgets'])
 ```
 
-Here we have an UI file created with Qt Designer and one source and
-header file each that require preprocessing with the `moc` tool. We
-also define a resource file to be compiled with `rcc`. We just have to
-tell Meson which files are which and it will take care of invoking all
-the necessary tools in the correct order, which is done with the
-`preprocess` method of the `qt5` module. Its output is simply put in
-the list of sources for the target. The `modules` keyword of
-`dependency` works just like it does with Boost. It tells which
-subparts of Qt the program uses.
-
-You can set the `main` keyword argument to `true` to use the
-`WinMain()` function provided by qtmain static library (this argument
-does nothing on platforms other than Windows).
-
-Setting the optional `private_headers` keyword to true adds the
-private header include path of the given module(s) to the compiler
-flags. (since v0.47.0)
-
-**Note** using private headers in your project is a bad idea, do so at
-your own risk.
-
-`method` may be `auto`, `pkg-config`, `config-tool` or `qmake` (*deprecated
+An optional `method` keyword argument can be set: `auto` (default), `pkg-config`, `config-tool` or `qmake` (*deprecated
 since 0.58.0*; use `config-tool` instead).
+
+The `modules` keyword receives an array of Qt module names that will be required
+and linked against.
+
+Obtaining the list of possible is not straightforward, here is a
+non exhaustive list of possible Qt6 modules:
+
+* `Core`
+* `Gui`
+* `Widgets`
+* `Network`
+* `Svg`
+* `Quick`
+* `Qml`
+* `QuickWidgets`
+* `QmlIntegration`
+
+**Notes:**
+
+* In Qt's documentation, the module names are referenced with and extra `Qt` prefix,
+e.g. `QtCore` or `QtQmlIntegration`.
+* For more information on how to build a Qt application with meson, see the [Qt6 module](Qt6-module.md)
 
 ## SDL2
 

--- a/docs/markdown/Qt6-module.md
+++ b/docs/markdown/Qt6-module.md
@@ -16,8 +16,11 @@ and tool names being suffixed with only the Qt major version number e.g. qmake6.
 Qt is a framework with many sub-modules, meson can selectively look for and link with any combination,
 see [Qt dependencies](Dependencies.md#qt).
 
-## Example
-A simple example would look like this:
+## Examples
+
+We provide examples to showcase how meson can be used to build Qt applications.
+
+### Simple example
 
 ```meson
 qt6 = import('qt6')
@@ -44,6 +47,103 @@ qt6_dep = dependency('qt6', modules: ['Core', 'Gui'])
 lang_cpp = qt6.compile_translations(qresource: 'lang.qrc')
 executable('myprog', 'main.cpp', lang_cpp,
            dependencies: qt6_dep)
+```
+
+### QML-C++ integration
+
+A complex Qt app that uses
+
+- A Qt resource collection file
+  ([documentation here](https://doc.qt.io/qt-6/resources.html))
+- `QObject` (C++ only) derived C++ classes
+- `QML_ELEMENT` and `Q_GADGET` annotated classes that are exposed to QML
+  ([documentation here](https://doc.qt.io/qt-6/qtqml-cppintegration-definetypes.html))
+
+can also be build with meson using the following methods of the qt module object:
+
+- [compile_resources](#compile_resources)
+- [compile_moc](#compile_moc)
+- [qml_module](#qml_module)
+
+**Note:** when using [qml_module](#qml_module) with C++ `QML_ELEMENT` or `Q_GADGET` annotated headers in sub-folders,
+their direct parent folder needs to be added to "include directories". This will cause problems is the header names are not unique.
+
+Here's an example meson code
+
+```meson
+
+# these sources do not contain any QObject derived classes
+source_files = [
+  'main.cpp',
+  'non-qt-sources/foo.cpp',
+  'non-qt-sources/foo.h',
+]
+
+# these sources contain QObject derived classes but are not exposed to QML
+moc_header_files = [
+  'qt-cpp-only-sources/bar.cpp',
+  'qt-cpp-only-sources/bar.h',
+]
+
+# classes that are Q_GADGET or QML_ELEMENT + QObject "tainted"
+# that are exposed to QML and can be used in QML code
+qmlcpp_files = [
+  'qt-cpp-qml-integration/quux.cpp',
+  'qt-cpp-qml-integration/quux.h',
+]
+
+# actual QML files that will be able to use
+# C++ classes defined in 'qmlcpp_files'
+qml_files = [
+  'QML/Baz.qml',
+]
+
+fs = import('fs')
+
+# workaround a Qt bug / design limitation:
+#   we add the parent folder of every C++ header involved with QML to the include dirs
+# see https://bugreports.qt.io/browse/QTBUG-93443
+# see https://bugreports.qt.io/browse/QTBUG-87221
+# Note: qmlcpp_file needs to be a list of str and not files() otherwise the logic bellow gets tripped
+qmlcpp_inc_dirs = []
+foreach qmlcpp_file: qmlcpp_files
+  qmlcpp_inc_dirs += [include_directories(fs.parent(qmlcpp_file))]
+endforeach
+
+inc = include_directories('.')
+
+qt6 = import('qt6')
+
+# Qml and QmlIntegration are needed here
+qt6_dep = dependency('qt6', modules: ['Core', 'Gui', 'Network', 'Svg', 'Quick', 'Qml', 'QuickWidgets', 'QmlIntegration'])
+
+compiled_resources = qt6.compile_resources(sources: files('resources.qrc'))
+
+# compile 'moc_header_files' list with moc
+moc_files = qt6.compile_moc(
+  headers : moc_header_files,
+  include_directories: inc,
+  dependencies: qt6_dep
+)
+
+# everything involved in C++-QML interaction goes in here
+# the can be split into many modules, but works with a single one too
+qml_mods = qt6.qml_module(
+  'MyModule',
+  qml_sources: qml_files,
+  moc_headers: qmlcpp_files,
+  include_directories: qmlcpp_inc_dirs,
+  dependencies: [qt6_dep],
+)
+
+# Build the final executable and give it all the resources built above
+executable('MyExecutable',
+  sources: [source_files, compiled_ressources, moc_files, qml_mods],
+  include_directories: [inc] + qmlcpp_inc_dirs,
+  dependencies: [qt6_dep],
+  win_subsystem: 'windows', # useful for Windows: displays the app without spawning
+                            # a console alongside it, no-op on other platforms.
+  install: true)
 ```
 
 ## Functions

--- a/docs/markdown/Qt6-module.md
+++ b/docs/markdown/Qt6-module.md
@@ -11,7 +11,50 @@ Qt 6.1 or later due to the Qt tools having moved to the libexec subdirectory,
 and tool names being suffixed with only the Qt major version number e.g. qmake6.
 </div>
 
-## compile_resources
+## Dependencies
+
+See [Qt dependencies](Dependencies.md#qt)
+
+The 'modules' argument is used to include Qt modules in the project.
+See the Qt documentation for the [list of
+modules](https://doc.qt.io/qt-6/qtmodules.html).
+
+The 'private_headers' argument allows usage of Qt's modules private
+headers.
+
+## Example
+A simple example would look like this:
+
+```meson
+qt6 = import('qt6')
+qt6_dep = dependency('qt6', modules: ['Core', 'Gui'])
+inc = include_directories('includes')
+moc_files = qt6.compile_moc(headers : 'myclass.h',
+                            extra_arguments: ['-DMAKES_MY_MOC_HEADER_COMPILE'],
+                            include_directories: inc,
+                            dependencies: qt6_dep)
+translations = qt6.compile_translations(ts_files : 'myTranslation_fr.ts', build_by_default : true)
+executable('myprog', 'main.cpp', 'myclass.cpp', moc_files,
+           include_directories: inc,
+           dependencies : qt6_dep)
+```
+
+Sometimes, translations are embedded inside the binary using qresource
+files. In this case the ts files do not need to be explicitly listed,
+but will be inferred from the built qm files listed in the qresource
+file. For example:
+
+```meson
+qt6 = import('qt6')
+qt6_dep = dependency('qt6', modules: ['Core', 'Gui'])
+lang_cpp = qt6.compile_translations(qresource: 'lang.qrc')
+executable('myprog', 'main.cpp', lang_cpp,
+           dependencies: qt6_dep)
+```
+
+## Functions
+
+### compile_resources
 
 *New in 0.59.0*
 
@@ -27,7 +70,7 @@ It takes no positional arguments, and the following keyword arguments:
   - `extra_args` string[]: Extra arguments to pass directly to `qt-rcc`
   - `method` string: The method to use to detect Qt, see [[dependency]]
 
-## compile_ui
+### compile_ui
 
 *New in 0.59.0*
 
@@ -45,7 +88,7 @@ It takes no positional arguments, and the following keyword arguments:
     it generates a file `{target private directory}/subdir/one.out` when `true`,
     and `{target private directory}/one.out` when `false` (default).
 
-## compile_moc
+### compile_moc
 
 *New in 0.59.0*
 
@@ -72,7 +115,7 @@ It takes no positional arguments, and the following keyword arguments:
   - `output_json` bool: *New in 1.7.0*. If `true`, generates additionally a
     JSON representation which may be used by external tools such as qmltyperegistrar
 
-## preprocess
+### preprocess
 
 Consider using `compile_resources`, `compile_ui`, and `compile_moc` instead.
 
@@ -118,7 +161,7 @@ This method takes the following keyword arguments:
 
 It returns an array of targets and sources to pass to a compilation target.
 
-## compile_translations
+### compile_translations
 
 This method generates the necessary targets to build translation files with
 lrelease, it takes no positional arguments, and the following keyword arguments:
@@ -141,7 +184,7 @@ translations, or, if using a `qresource` file, a single custom target
 containing the processed source file, which should be passed to a main
 build target.
 
-## has_tools
+### has_tools
 
 This method returns `true` if all tools used by this module are found,
 `false` otherwise.
@@ -166,7 +209,7 @@ This method takes the following keyword arguments:
 - `version` str | array[str]: *Since 1.11.0*. Specifies the required version,
   a string containing a comparison operator followed by the version string.
 
-## qml_module
+### qml_module
 
 *New in 1.7.0*
 
@@ -239,45 +282,3 @@ replaced with `_`. Type registration may be invoked explicitly using
 
 See [Qt documentation](https://doc.qt.io/qt-6/resources.html#explicit-loading-and-unloading-of-embedded-resources)
 for more information
-
-
-## Dependencies
-
-See [Qt dependencies](Dependencies.md#qt)
-
-The 'modules' argument is used to include Qt modules in the project.
-See the Qt documentation for the [list of
-modules](https://doc.qt.io/qt-6/qtmodules.html).
-
-The 'private_headers' argument allows usage of Qt's modules private
-headers.
-
-## Example
-A simple example would look like this:
-
-```meson
-qt6 = import('qt6')
-qt6_dep = dependency('qt6', modules: ['Core', 'Gui'])
-inc = include_directories('includes')
-moc_files = qt6.compile_moc(headers : 'myclass.h',
-                            extra_arguments: ['-DMAKES_MY_MOC_HEADER_COMPILE'],
-                            include_directories: inc,
-                            dependencies: qt6_dep)
-translations = qt6.compile_translations(ts_files : 'myTranslation_fr.ts', build_by_default : true)
-executable('myprog', 'main.cpp', 'myclass.cpp', moc_files,
-           include_directories: inc,
-           dependencies : qt6_dep)
-```
-
-Sometimes, translations are embedded inside the binary using qresource
-files. In this case the ts files do not need to be explicitly listed,
-but will be inferred from the built qm files listed in the qresource
-file. For example:
-
-```meson
-qt6 = import('qt6')
-qt6_dep = dependency('qt6', modules: ['Core', 'Gui'])
-lang_cpp = qt6.compile_translations(qresource: 'lang.qrc')
-executable('myprog', 'main.cpp', lang_cpp,
-           dependencies: qt6_dep)
-```

--- a/docs/markdown/Qt6-module.md
+++ b/docs/markdown/Qt6-module.md
@@ -13,14 +13,8 @@ and tool names being suffixed with only the Qt major version number e.g. qmake6.
 
 ## Dependencies
 
-See [Qt dependencies](Dependencies.md#qt)
-
-The 'modules' argument is used to include Qt modules in the project.
-See the Qt documentation for the [list of
-modules](https://doc.qt.io/qt-6/qtmodules.html).
-
-The 'private_headers' argument allows usage of Qt's modules private
-headers.
+Qt is a framework with many sub-modules, meson can selectively look for and link with any combination,
+see [Qt dependencies](Dependencies.md#qt).
 
 ## Example
 A simple example would look like this:

--- a/docs/yaml/functions/dependency.yaml
+++ b/docs/yaml/functions/dependency.yaml
@@ -57,7 +57,7 @@ description: |
 notes:
   - This function supports additional [library-specific](Dependencies.md#dependencies-with-custom-lookup-functionality)
     keyword arguments that may also be accepted (e.g. `modules` specifies submodules to use for
-    dependencies such as Qt5 or Boost. `components` allows the user to manually
+    dependencies such as Qt or Boost. `components` allows the user to manually
     add CMake `COMPONENTS` for the `find_package` lookup)
 
 varargs:


### PR DESCRIPTION
Hey,

Thought that the documentation around Qt could be improved, so here we go.

The main drive is that I could only really use the `qt6.qml_module()` function after being actively involved in the PR that introduced it #13304, so I wanted to add a full example on how one could use it to the docs.

I tried to make small incremental edits through each commit so review goes more smoothly.

Cheers!