### PR TITLE
vs2010backend: allow missing b_lto or b_pgo options

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1234,6 +1234,22 @@ class Vs2010Backend(backends.Backend):
 
         return (nmake_base_meson_command, exe_search_paths)
 
+    def get_target_whole_program_opt(self, target: build.BuildTarget) -> str:
+        lto = False
+        pgo = 'off'
+        try:
+            lto = self.get_target_option(target, 'b_lto')
+            pgo = self.get_target_option(target, 'b_pgo')
+        except KeyError:
+            pass
+
+        if pgo == 'off':
+            return 'true' if lto else 'false'
+
+        if not lto:
+            raise MesonException("b_pgo requires b_lto on MSVC.")
+        return 'PGInstrument' if pgo == 'generate' else 'PGOptimize'
+
     def add_gen_lite_makefile_vcxproj_elements(self,
                                                root: ET.Element,
                                                platform: str,
@@ -1322,19 +1338,7 @@ class Vs2010Backend(backends.Backend):
         # FIXME: Should the following just be set in create_basic_project(), even if
         # irrelevant for current target?
 
-        lto = self.get_target_option(target, 'b_lto')
-        pgo = self.get_target_option(target, 'b_pgo')
-
-        if lto:
-            if pgo == 'off':
-                ET.SubElement(type_config, 'WholeProgramOptimization').text = 'true'
-            elif pgo == 'generate':
-                ET.SubElement(type_config, 'WholeProgramOptimization').text = 'PGInstrument'
-            elif pgo == 'use':
-                ET.SubElement(type_config, 'WholeProgramOptimization').text = 'PGOptimize'
-        else:
-            if pgo != 'off':
-                raise MesonException("b_pgo requires b_lto on MSVC.")
+        ET.SubElement(type_config, 'WholeProgramOptimization').text = self.get_target_whole_program_opt(target)
 
         # Let VS auto-set the RTC level
         ET.SubElement(type_config, 'BasicRuntimeChecks').text = 'Default'


### PR DESCRIPTION
If the options are missing, do not enable LTO or PGO.

As a side effect of cleaning up the code, the WholeProgramOptimization element is always emitted as was the case before commit 6835b6ed6 ("vs2010backend: integrate b_lto/b_pgo with vcxproj backends", 2026-02-06).

Fixes: 6835b6ed6 ("vs2010backend: integrate b_lto/b_pgo with vcxproj backends", 2026-02-06)
Fixes: #15702