### PR TITLE
modules: qt: fix typing issue in _detect_tools()

### DIFF
--- a/mesonbuild/modules/_qt.py
+++ b/mesonbuild/modules/_qt.py
@@ -265,11 +265,12 @@ class QtBaseModule(ExtensionModule):
             if p.found():
                 self.tools[name] = p
 
-    def _detect_tools(self, state: ModuleState, method: DependencyMethods, required: bool = True, version: T.List[str] = None) -> None:
+    def _detect_tools(self, state: ModuleState, method: DependencyMethods, required: bool = True, version: T.Optional[T.List[str]] = None) -> None:
         if self._tools_detected:
             return
         self._tools_detected = True
         mlog.log(f'Detecting Qt{self.qt_version} tools')
+        version = version or []
         kwargs: DependencyObjectKWs = {'required': required, 'modules': ['Core'], 'method': method, 'native': MachineChoice.HOST, 'version': version}
         # Just pick one to make mypy happy
         qt = T.cast('QtPkgConfigDependency', find_external_dependency(f'qt{self.qt_version}', state.environment, kwargs))

--- a/test cases/frameworks/41 qt module no dep/meson.build
+++ b/test cases/frameworks/41 qt module no dep/meson.build
@@ -1,0 +1,18 @@
+project('qt5 module method test', 'cpp', meson_version: '>=1.4.0')
+
+qtmodule = import('qt5')
+
+# because methods like .compile_ui() request the Qt dependency
+# with required: true, it is not possible to skip the test when
+# Qt is absent.
+#
+# always ending the test with an error checks at least that there
+# were no internal errors.  The actual functionality of the
+# methods is checked in the "4 qt" test.
+testcase expect_error('.*not found.*', how: 're')
+  prep = qtmodule.compile_ui(
+    sources : 'ui/mainWindow.ui',
+    method: get_option('method'),
+    preserve_paths: true)
+  error('dummy not found error')
+endtestcase

--- a/test cases/frameworks/41 qt module no dep/meson_options.txt
+++ b/test cases/frameworks/41 qt module no dep/meson_options.txt
@@ -1,0 +1,1 @@
+option('method', type : 'string', value : 'auto', description : 'The method to use to find Qt')

--- a/test cases/frameworks/41 qt module no dep/test.json
+++ b/test cases/frameworks/41 qt module no dep/test.json
@@ -1,0 +1,11 @@
+{
+  "matrix": {
+    "options": {
+      "method": [
+        { "val": "config-tool" },
+        { "val": "qmake" },
+        { "val": "pkg-config" }
+      ]
+    }
+  }
+}

--- a/test cases/frameworks/41 qt module no dep/ui/mainWindow.ui
+++ b/test cases/frameworks/41 qt module no dep/ui/mainWindow.ui
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MainWindow</class>
+ <widget class="QMainWindow" name="MainWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>260</width>
+    <height>313</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>MainWindow</string>
+  </property>
+  <widget class="QWidget" name="centralwidget">
+   <widget class="QPushButton" name="pushButton">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>10</y>
+      <width>241</width>
+      <height>91</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>I am a button</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_stuff">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>112</y>
+      <width>241</width>
+      <height>91</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_stuff2">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>212</y>
+      <width>241</width>
+      <height>91</height>
+     </rect>
+    </property>
+   </widget>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
The version argument was incorrectly passed as None when looking for the qt dependency from e.g. the preprocess() method.

Fixes: ab9cffbc05c149bfad1b158ce41ac765147fc139
Fixes: #15705