### PR TITLE
compilers: force clang to error on unknown warning options

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1449,7 +1449,12 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
             OptionKey(f'{self.language}_args', machine=self.for_machine))))
         largs = list(T.cast('T.List[str]', optstore.get_value_for(
             OptionKey(f'{self.language}_link_args', machine=self.for_machine))))
-        return self.exelist_no_ccache + self.get_always_args() + self.get_output_args(binname) + [sourcename] + cargs, largs
+        return self.exelist_no_ccache \
+            + self.get_always_args() \
+            + self.get_compiler_check_args(CompileCheckMode.COMPILE) \
+            + self.get_output_args(binname) \
+            + [sourcename] \
+            + cargs, largs
 
     @abc.abstractmethod
     def _sanity_check_source_code(self) -> str:

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -975,6 +975,10 @@ class ClangClCPPCompiler(VisualStudioLikeCPPCompilerMixin, ClangClCompiler, CPPC
         # clang-cl does not support /interface.
         return ['-fmodules', '-fmodules-ts']
 
+    def get_compiler_check_args(self, mode: CompileCheckMode) -> T.List[str]:
+        # XXX: this is a hack because so much GnuLike stuff is in the base CPPCompiler class.
+        return ClangClCompiler.get_compiler_check_args(self, mode)
+
 
 class IntelClCPPCompiler(VisualStudioLikeCPPCompilerMixin, IntelVisualStudioLikeCompiler, CPPCompiler):
 

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -90,6 +90,12 @@ class ClangCompiler(GnuLikeCompiler):
         # All Clang backends can also do LLVM IR
         self.can_compile_suffixes.add('ll')
 
+    def get_always_args(self) -> T.List[str]:
+        # Force clang to fail in sanity checks if an unknwon warning option is
+        # user
+        myargs: T.List[str] = ['-Werror=unknown-warning-option']
+        return super().get_always_args() + myargs
+
     def get_crt_compile_args(self, crt_val: str) -> T.List[str]:
         if not isinstance(self.linker, VisualStudioLikeLinkerMixin):
             return []

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -469,14 +469,16 @@ class ClangClCompiler(VisualStudioLikeCompiler):
             args.append('/clang:-fno-omit-frame-pointer')
         return args
 
-    def has_arguments(self, args: T.List[str], code: str, mode: CompileCheckMode) -> T.Tuple[bool, bool]:
+    def get_compiler_check_args(self, mode: CompileCheckMode) -> T.List[str]:
+        myargs: T.List[str] = []
         if mode != CompileCheckMode.LINK:
-            args = args + [
+            myargs.extend((
                 '-Werror=unknown-argument',
                 '-Werror=unknown-warning-option',
                 '-Werror=unused-command-line-argument',
-            ]
-        return super().has_arguments(args, code, mode)
+            ))
+
+        return super().get_compiler_check_args(mode) + myargs
 
     def get_pch_base_name(self, header: str) -> str:
         return header

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -238,6 +238,15 @@ class InternalTests(unittest.TestCase):
         self.assertEqual(a.to_native(copy=True), ['/nologo', '/showIncludes', '/Zc:__cplusplus', '/validate-charset-'])
 
 
+    def test_clang_always_args_contain_werror_unknown_warning(self):
+        env = get_fake_env()
+        linker = linkers.MoldDynamicLinker([], env, MachineChoice.HOST, '-Wl,', [])
+        cc = ClangCCompiler([], [], '14.0.0', MachineChoice.HOST, env, linker=linker)
+
+        always_args = cc.get_always_args()
+        self.assertIn('-Werror=unknown-warning-option', always_args)
+
+
     def test_msvc_unix_args_to_native(self):
         # joined
         self.assertEqual(MSVCCompiler.unix_args_to_native(['-isystemfoo']), ['/Ifoo'])

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -29,8 +29,9 @@ import mesonbuild.modules.gnome
 import mesonbuild.scripts.depfixer
 import mesonbuild.scripts.env2mfile
 from mesonbuild import coredata
-from mesonbuild.compilers.c import ClangCCompiler, GnuCCompiler
-from mesonbuild.compilers.compilers import Compiler, ManyInOneLinkerOptionStyle
+from mesonbuild.compilers import Compiler
+from mesonbuild.compilers.c import ClangCCompiler, ClangClCCompiler, GnuCCompiler
+from mesonbuild.compilers.compilers import CompileCheckMode, ManyInOneLinkerOptionStyle
 from mesonbuild.compilers.cpp import VisualStudioCPPCompiler
 from mesonbuild.compilers.d import DmdDCompiler
 from mesonbuild.compilers.detect import detect_c_compiler
@@ -433,6 +434,27 @@ Thread model: posix'''), '21.9.0')
             _, largs = cc._sanity_check_compile_args('foo.c', 'foo.exe')
 
         self.assertEqual(largs, [])
+
+
+    def test_clang_family_compiler_check_args_contain_werror_unknown_warning(self):
+        env = get_fake_env()
+        mold = linkers.MoldDynamicLinker([], env, MachineChoice.HOST, '-Wl,', [])
+        lld_link = linkers.ClangClDynamicLinker(env, MachineChoice.HOST, [])
+
+        compilers = {
+            'clang': ClangCCompiler([], [], '14.0.0', MachineChoice.HOST, env, linker=mold),
+            'clang-cl': ClangClCCompiler([], '14.0.0', MachineChoice.HOST, env, 'x64', linker=lld_link),
+        }
+
+        for name, cc in compilers.items():
+            with self.subTest(compiler=name):
+                self.assertIn('-Werror=unknown-warning-option',
+                              cc.get_compiler_check_args(CompileCheckMode.COMPILE))
+                # Both clang and clang-cl only apply this diagnostic when
+                # actually compiling; it's intentionally omitted for LINK to
+                # avoid failing on flags that are unused during linking.
+                self.assertNotIn('-Werror=unknown-warning-option',
+                                 cc.get_compiler_check_args(CompileCheckMode.LINK))
 
 
     def test_msvc_unix_args_to_native(self):

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -797,8 +797,8 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertNotIn('-std=c++98', plain_comp)
         self.assertNotIn('-std=c++11', plain_comp)
         # Now werror
-        self.assertIn('-Werror', plain_comp)
-        self.assertNotIn('-Werror', c98_comp)
+        self.assertIn('-Werror', plain_comp.split())
+        self.assertNotIn('-Werror', c98_comp.split())
 
     def test_run_installed(self):
         if is_cygwin() or is_osx():

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -845,8 +845,13 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertNotIn('-std=c++98', plain_comp)
         self.assertNotIn('-std=c++11', plain_comp)
         # Now werror
-        self.assertIn('-Werror', plain_comp)
-        self.assertNotIn('-Werror', c98_comp)
+        self.assertIn('-Werror', plain_comp.split())
+        self.assertNotIn('-Werror', c98_comp.split())
+
+    def test_sanity_check_fails_on_bad_c_args(self):
+        testdir = os.path.join(self.common_test_dir, '1 trivial')
+        with self.assertRaises((subprocess.CalledProcessError, RuntimeError)):
+            self.init(testdir, extra_args=['-Dc_args=-Wbad-flag-does-not-exist'])
 
     def test_run_installed(self):
         if is_cygwin() or is_osx():


### PR DESCRIPTION
gcc seems to error by default if an unknown warning option is passed to it:

    CC=gcc meson setup build -Dc_args=-Wbad

gcc will fail in the project() call during the sanity check. clang does not currently doing that:

    CC=clang meson setup build -Dc_args=-Wbad
    ...will continue until an actual compilation like cc.compiles()

    from meson-log.txt...
    Sanity check compile stderr:
    warning: unknown warning option '-Wbad' [-Wunknown-warning-option]

We should error in the sanity check to notify the user as soon as possible that they have errors in their environment.