### PR TITLE
type_checking: allow empty string in dependencies

### DIFF
--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -430,6 +430,7 @@ DEPENDENCIES_KW: KwargInfo[T.List[Dependency]] = KwargInfo(
     extra_types={
         BuildTarget: lambda arg: f'Tried to use a build_target "{T.cast("BuildTarget", arg).name}" as a dependency. This should be in `link_with` or `link_whole` instead.',
     },
+    as_default=[('', ('1.11.1', "Replace an empty string with an empty array: `dependencies : ''` -> `dependencies : []`"))],
 )
 
 D_MODULE_VERSIONS_KW: KwargInfo[T.List[T.Union[str, int]]] = KwargInfo(

--- a/test cases/common/1 trivial/meson.build
+++ b/test cases/common/1 trivial/meson.build
@@ -14,7 +14,9 @@ elif cc.get_id() == 'intel-cl'
   add_project_arguments('/Qdiag-error:10159', language : 'c')
 endif
 
-exe = executable('trivialprog', sources : sources, link_args : '')
+exe = executable('trivialprog', sources : sources,
+  link_args : '',
+  dependencies: '')
 assert(exe.name() == 'trivialprog')
 test('runtest', exe) # This is a comment
 

--- a/test cases/common/1 trivial/test.json
+++ b/test cases/common/1 trivial/test.json
@@ -1,6 +1,9 @@
 {
   "stdout": [
     {
+      "line": "test cases/common/1 trivial/meson.build:17: DEPRECATION: Project uses feature that was always broken, and is now deprecated since '1.11.1': Using '' as an empty value in dependencies. Replace an empty string with an empty array: `dependencies : ''` -> `dependencies : []`"
+    },
+    {
       "line": "test cases/common/1 trivial/meson.build:17: DEPRECATION: Project uses feature that was always broken, and is now deprecated since '1.10.1': Using '' as an empty value in link_args. Replace an empty string with an empty array: `link_args : ''` -> `link_args : []`"
     }
   ]


### PR DESCRIPTION
This was used by Pandas, and generates an error starting from Meson 1.11.0.

Related: pandas-dev/pandas#65252