### PR TITLE
tests/d: fix compat w/ >=dub-1.41.0

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -868,7 +868,7 @@ $ wx-config --libs std stc
 ## Zlib
 
 Zlib ships with pkg-config and cmake support, but on some operating
-systems (windows, macOs, FreeBSD, dragonflybsd, android), it is provided as
+systems (windows, macOs, FreeBSD, DragonFly BSD, android), it is provided as
 part of the base operating system without pkg-config support. The new
 System finder can be used on these OSes to link with the bundled
 version.

--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -868,7 +868,7 @@ $ wx-config --libs std stc
 ## Zlib
 
 Zlib ships with pkg-config and cmake support, but on some operating
-systems (windows, macOs, FreeBSD, DragonFly BSD, android), it is provided as
+systems (Windows, macOS, FreeBSD, DragonFly BSD, Android), it is provided as
 part of the base operating system without pkg-config support. The new
 System finder can be used on these OSes to link with the bundled
 version.

--- a/docs/markdown/Release-notes-for-0.64.0.md
+++ b/docs/markdown/Release-notes-for-0.64.0.md
@@ -94,7 +94,7 @@ method.
 ## BSD support for the `jni` dependency
 
 This system dependency now supports all BSD systems that Meson currently
-supports, including FreeBSD, NetBSD, OpenBSD, and DragonflyBSD.
+supports, including FreeBSD, NetBSD, OpenBSD, and DragonFly BSD.
 
 ## Credentials from `~/.netrc` for `https` URLs
 

--- a/mesonbuild/dependencies/dub.py
+++ b/mesonbuild/dependencies/dub.py
@@ -351,6 +351,8 @@ class DubDependency(ExternalDependency):
         ret, res, err = self._call_dubbin(describe_cmd)
         if ret == 0:
             return (json.loads(res), helper_build, source)
+        else:
+            mlog.debug('DUB describe (raw) failed: ' + err)
 
         pack_spec = self.name
         if self.version_reqs is not None:

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -363,7 +363,7 @@ class MachineInfo(HoldableObject):
         return self.system == 'openbsd'
 
     def is_dragonflybsd(self) -> bool:
-        """Machine is DragonflyBSD?"""
+        """Machine is DragonFly BSD?"""
         return self.system == 'dragonfly'
 
     def is_freebsd(self) -> bool:

--- a/test cases/common/221 zlib/meson.build
+++ b/test cases/common/221 zlib/meson.build
@@ -1,7 +1,7 @@
 project('zlib system dependency', 'c')
 
 if not ['darwin', 'freebsd', 'dragonfly', 'windows', 'android'].contains(host_machine.system())
-  error('MESON_SKIP_TEST only applicable on macOS, FreeBSD, DragonflyBSD, Windows, and Android.')
+  error('MESON_SKIP_TEST only applicable on macOS, FreeBSD, DragonFly BSD, Windows, and Android.')
 endif
 
 cc = meson.get_compiler('c')

--- a/test cases/d/17 dub and meson project/multi-configuration/dub.json
+++ b/test cases/d/17 dub and meson project/multi-configuration/dub.json
@@ -1,14 +1,16 @@
 {
   "name": "multi-configuration",
-  "configurations": {
-    "app": {
+  "configurations": [
+    {
+      "name": "app",
       "targetType": "executable"
     },
-    "lib": {
+    {
+      "name": "lib",
       "targetType": "library",
       "excludedSourceFiles": [
         "source/app.d"
       ]
     }
-  }
+  ]
 }

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1752,7 +1752,7 @@ class AllPlatformTests(BasePlatformTests):
             rpath = get_rpath(os.path.join(self.builddir, each))
             self.assertTrue(rpath, f'Rpath could not be determined for {each}.')
             if is_dragonflybsd():
-                # DragonflyBSD will prepend /usr/lib/gccVERSION to the rpath,
+                # DragonFly BSD will prepend /usr/lib/gccVERSION to the rpath,
                 # so ignore that.
                 self.assertTrue(rpath.startswith('/usr/lib/gcc'))
                 rpaths = rpath.split(':')[1:]


### PR DESCRIPTION
dub-1.41.0 starts to reject invalid dub.json (5cf450f5fd2f62a3d60207ba4bdeb9599783cd0f) which hits us in multi-configuration:
```
(dmd-2.112.0)[root multi-configuration]# dub
Error /tmp/meson/test cases/d/17 dub and meson project/multi-configuration/dub.json(3:21): configurations: Expected to be sequence (array), but is a mapping
```

Correct it based on the docs at https://dub.pm/dub-guide/recipe/#configurations

Closes: https://github.com/mesonbuild/meson/issues/15719