### PR TITLE
build: fix install name when linking with static library

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2446,9 +2446,6 @@ class StaticLibrary(BuildTarget):
                         suffix = 'ma'
         return (prefix, suffix)
 
-    def get_link_deps_mapping(self, prefix: str) -> T.Mapping[str, str]:
-        return {}
-
     def get_default_install_dir(self) -> T.Tuple[str, str]:
         return self.environment.get_static_lib_dir(), '{libdir_static}'
 

--- a/test cases/darwin/1 rpath removal on install/main.c
+++ b/test cases/darwin/1 rpath removal on install/main.c
@@ -1,0 +1,5 @@
+#include "foo/foo.h"
+
+int main() {
+  foo();
+}

--- a/test cases/darwin/1 rpath removal on install/meson.build
+++ b/test cases/darwin/1 rpath removal on install/meson.build
@@ -6,3 +6,12 @@ bar = library('bar', 'bar.c',
   link_with: foo,
   install: true,
 )
+
+bar_internal = static_library('bar-internal', 'bar.c',
+  link_with: foo,
+)
+
+main = executable('main', 'main.c',
+  link_with: bar_internal,
+  install: true,
+)

--- a/unittests/darwintests.py
+++ b/unittests/darwintests.py
@@ -108,6 +108,12 @@ class DarwinTests(BasePlatformTests):
         rpaths = pattern.findall(out)
         return rpaths
 
+    def _get_darwin_rpath_libraries(self, fname: str) -> T.List[str]:
+        out = subprocess.check_output(['otool', '-L', fname], universal_newlines=True)
+        pattern = re.compile(r'@rpath/\S+')
+        libs = pattern.findall(out)
+        return libs
+
     @skipIfNoPkgconfig
     def test_library_versioning(self):
         '''
@@ -174,6 +180,8 @@ class DarwinTests(BasePlatformTests):
         # Those RPATHs are no longer valid and should not be present after installation
         rpaths = self._get_darwin_rpaths(os.path.join(self.installdir, 'usr/lib/libbar.dylib'))
         self.assertListEqual(rpaths, [])
+        libs = self._get_darwin_rpath_libraries(os.path.join(self.installdir, 'usr/bin/main'))
+        self.assertListEqual(libs, [])
 
     @skip_if_not_language('rust')
     def test_rust_apple_framework_rlib(self):


### PR DESCRIPTION
A static library can specify a dynamic library in `link_with`.

DBus [does this](https://gitlab.freedesktop.org/dbus/dbus/-/blob/4f5796a37dd303b6030127d20cba52c72523df79/bus/meson.build#L138) and the build succeeds but the `@rpath` is left in the binary causing a failure at runtime.