### PR TITLE
init: respect explicitly provided source files

### DIFF
--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -30,6 +30,7 @@ if T.TYPE_CHECKING:
     class Arguments(Protocol):
 
         srcfiles: T.List[Path]
+        provided_srcfiles: bool
         wd: str
         name: str
         executable: str
@@ -170,6 +171,7 @@ def run(options: Arguments) -> int:
     if not Path(options.wd).exists():
         sys.exit('Project source root directory not found. Run this command in source directory root.')
     os.chdir(options.wd)
+    options.provided_srcfiles = bool(options.srcfiles)
 
     if not glob('*'):
         autodetect_options(options, sample=True)

--- a/mesonbuild/templates/sampleimpl.py
+++ b/mesonbuild/templates/sampleimpl.py
@@ -19,6 +19,7 @@ class SampleImpl(metaclass=abc.ABCMeta):
     def __init__(self, args: Arguments):
         self.name = args.name
         self.executable_name = args.executable if args.executable else None
+        self.provided_srcfiles = args.provided_srcfiles
         self.version = args.version
         self.lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         self.uppercase_token = self.lowercase_token.upper()
@@ -73,6 +74,8 @@ class SampleImpl(metaclass=abc.ABCMeta):
         return ''.join(f"\n  '{x}'," for x in self.sources)
 
     def _detect_sources(self, srcfiles: T.List[Path], transform: T.Callable[[str], str]) -> T.Tuple[str, T.List[Path]]:
+        if self.provided_srcfiles:
+            return str(srcfiles[0]), srcfiles
         # Try a source based on the executable name, fallback to one based
         # on the project name if none is found.
         expected_name = f'{transform(self.executable_name)}.{self.source_ext}'

--- a/unittests/platformagnostictests.py
+++ b/unittests/platformagnostictests.py
@@ -618,6 +618,28 @@ class PlatformAgnosticTests(BasePlatformTests):
             self.assertIn("'foo.c'", meson_build, 'existing foo.c not listed in meson.build')
             self.assertIn("'bar.c'", meson_build, 'existing bar.c not listed in meson.build')
 
+    def test_minit_explicit_srcfile_keeps_existing_source(self) -> None:
+        """meson init main.cpp must use the explicitly provided source file"""
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, 'main.cpp').write_text('int main() {}', encoding='utf-8')
+            self._run(self.meson_command + ['init', 'main.cpp'], workdir=d)
+            files = {p.name for p in Path(d).iterdir()}
+            self.assertEqual(files, {'main.cpp', 'meson.build'})
+            meson_build = Path(d, 'meson.build').read_text(encoding='utf-8')
+            self.assertIn("'main.cpp'", meson_build, 'explicit main.cpp not listed in meson.build')
+
+    def test_minit_explicit_srcfiles_keep_existing_sources(self) -> None:
+        """meson init main.cpp helper.cpp must use both explicitly provided source files"""
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, 'main.cpp').write_text('int main() {}', encoding='utf-8')
+            Path(d, 'helper.cpp').write_text('int helper() {}', encoding='utf-8')
+            self._run(self.meson_command + ['init', 'main.cpp', 'helper.cpp'], workdir=d)
+            files = {p.name for p in Path(d).iterdir()}
+            self.assertEqual(files, {'main.cpp', 'helper.cpp', 'meson.build'})
+            meson_build = Path(d, 'meson.build').read_text(encoding='utf-8')
+            self.assertIn("'main.cpp'", meson_build, 'explicit main.cpp not listed in meson.build')
+            self.assertIn("'helper.cpp'", meson_build, 'explicit helper.cpp not listed in meson.build')
+
     def test_minit_wrong_name_creates_sample(self) -> None:
         """meson init in an empty directory must create a sample source file"""
         with tempfile.TemporaryDirectory() as d:


### PR DESCRIPTION
Closes #15700.

Before this change, `meson init main.cpp` in a directory that already contained `main.cpp` still generated a starter source file named after the project directory, and `meson.build` referenced that generated file instead of the explicitly provided source.

This tracks whether source files were passed explicitly on the command line and keeps those sources when generating `meson.build`, while leaving the existing autodetected-directory fallback unchanged.

Validation:
- manual repro: `python3 /tmp/codex-pr-meson/meson.py init main.cpp` in a temp directory with an existing `main.cpp`
- `. /tmp/codex-meson-venv/bin/activate && python -m pytest -q unittests/platformagnostictests.py -k 'test_minit_'`
