### PR TITLE
fs: add build_subdir to copyfile()

### DIFF
--- a/docs/markdown/FAQ.md
+++ b/docs/markdown/FAQ.md
@@ -729,3 +729,8 @@ Even though [MSVC documentation](https://learn.microsoft.com/en-us/cpp/build/ref
 uses `/D` for preprocessor defines, its [command-line syntax](https://learn.microsoft.com/en-us/cpp/build/reference/compiler-command-line-syntax)
 accepts `-` instead of `/`.
 It's not necessary to treat preprocessor defines specially in Meson ([GH-6269](https://github.com/mesonbuild/meson/issues/6269#issuecomment-560003922)).
+
+## Why do all outputs go to the build directory that corresponds to the source directory in which they are declared?
+
+This simplifies debugging build problems, since you always know that files in
+build directory X must come from the corresponding source directory X.

--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -186,7 +186,7 @@ new = fs.replace_suffix(original, '')  # /opt/foo.dll
 
 ### parent
 
-Returns the parent directory (i.e. dirname).
+Returns the parent directory (i.e., dirname).
 
 ```meson
 new = fs.parent('foo/bar')  # foo
@@ -195,7 +195,7 @@ new = fs.parent('foo/bar/baz.dll')  # foo/bar
 
 ### name
 
-Returns the last component of the path (i.e. basename).
+Returns the last component of the path (i.e., basename).
 
 ```meson
 fs.name('foo/bar/baz.dll.a')  # baz.dll.a
@@ -256,20 +256,23 @@ returns:
 
 *Since 0.64.0*
 
-Copy a file from the source directory to the build directory at build time
+Copy a file from the source directory to the build directory at build time.
 
 Has the following positional arguments:
    - src `File | str`: the file to copy
 
 Has the following optional arguments:
    - dest `str`: the name of the output file. If unset will be the basename of
-     the src argument
+     the src argument (i.e., the last component of its path).
 
 Has the following keyword arguments:
    - install `bool`: Whether to install the copied file, defaults to false
    - install_dir `str`: Where to install the file to
    - install_tag: `str`: the install tag to assign to this target
    - install_mode `array[str | int]`: the mode to install the file with
+   - build_subdir `str`: *since 1.12.0*.  Places the build results in a subdirectory
+     of the given name rather than directly into the build directory.
+     For more information, see [[custom_target]].
 
 returns:
    - a [[custom_target]] object

--- a/docs/markdown/snippets/fs-copyfile-build-subdir.md
+++ b/docs/markdown/snippets/fs-copyfile-build-subdir.md
@@ -1,0 +1,4 @@
+## `fs.copyfile()` now has a `build_subdir` argument
+
+`fs.copyfile()`'s new `build_subdir` argument allows creating a file
+inside a subdirectory of the current build directory.

--- a/docs/yaml/functions/configure_file.yaml
+++ b/docs/yaml/functions/configure_file.yaml
@@ -20,7 +20,11 @@ description: |
 
   *(since 0.47.0)* When the `copy:` keyword argument is set to `true`,
   this function will copy the file provided in `input:` to a file in the
-  build directory with the name `output:` in the current directory.
+  current build directory with the name provided in `output:`.
+  The copy happens at configuration.  If the input file is subsequently
+  modified, Meson will regenerate the build files.
+  To perform the copy at build time (with the usual dependency on the source
+  file) use `copyfile()` from the FS (filesystem) module.
 
 warnings:
   - the `install_mode` kwarg ignored integer values between 0.62 -- 1.1.0.

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -580,6 +580,13 @@ _JAVA_LANG_KW: KwargInfo[T.List[str]] = _BASE_LANG_KW.evolve(
     deprecated_message='This does not, and never has, done anything. It should be removed'
 )
 
+BUILD_SUBDIR_KW: KwargInfo[str] = KwargInfo(
+    'build_subdir',
+    str,
+    default='',
+    since='1.10.0'
+)
+
 def _objects_validator(vals: T.List[ObjectTypes]) -> T.Optional[str]:
     non_objects: T.List[str] = []
 
@@ -665,7 +672,7 @@ _ALL_TARGET_KWS: T.List[KwargInfo] = [
                 ('1.1.0', 'generated sources as positional "objects" arguments')
         },
     ),
-    KwargInfo('build_subdir', str, default='', since='1.10.0')
+    BUILD_SUBDIR_KW,
 ]
 
 

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -12,7 +12,8 @@ import typing as T
 from . import ExtensionModule, ModuleReturnValue, ModuleInfo
 from .. import mlog
 from ..build import BuildTarget, CustomTarget, CustomTargetIndex, InvalidArguments
-from ..interpreter.type_checking import INSTALL_KW, INSTALL_MODE_KW, INSTALL_TAG_KW, NoneType
+from ..interpreter.type_checking import INSTALL_KW, INSTALL_MODE_KW, INSTALL_TAG_KW, \
+    BUILD_SUBDIR_KW, NoneType
 from ..interpreterbase import FeatureNew, KwargInfo, typed_kwargs, typed_pos_args, noKwargs
 from ..mesonlib import File, MesonException, has_path_sep, is_windows, path_is_in_root, relpath
 
@@ -34,6 +35,7 @@ if T.TYPE_CHECKING:
 
         """Kwargs for fs.copy"""
 
+        build_subdir: str
         install: bool
         install_dir: T.Optional[str]
         install_mode: FileMode
@@ -285,6 +287,7 @@ class FSModule(ExtensionModule):
         INSTALL_MODE_KW,
         INSTALL_TAG_KW,
         KwargInfo('install_dir', (str, NoneType)),
+        BUILD_SUBDIR_KW.evolve(since='1.12.0'),
     )
     def copyfile(self, state: ModuleState, args: T.Tuple[FileOrString, T.Optional[str]],
                  kwargs: CopyKw) -> ModuleReturnValue:
@@ -315,6 +318,7 @@ class FSModule(ExtensionModule):
             install_tag=[kwargs['install_tag']],
             backend=state.backend,
             description='Copying file {}',
+            build_subdir=kwargs['build_subdir'],
         )
 
         return ModuleReturnValue(ct, [ct])


### PR DESCRIPTION
`fs.copyfile()` is just a custom target wrapper, but it does not have the flexibility of the `build_subdir` keyword. This removes an unexpected restriction which #14734 wanted to document.

The remaining documentation added by #14734 are preserved in this PR.