### PR TITLE
compilers: fix arguments to Intel openmp_flags

### DIFF
--- a/mesonbuild/compilers/mixins/intel.py
+++ b/mesonbuild/compilers/mixins/intel.py
@@ -113,7 +113,7 @@ class IntelGnuLikeCompiler(GnuLikeCompiler):
 
 
 class IntelLLVMLikeCompiler:
-    def openmp_flags(self, env: Environment) -> T.List[str]:
+    def openmp_flags(self) -> T.List[str]:
         return ['-qopenmp']
 
 


### PR DESCRIPTION
Which do not take an `Environment` parameter.

Fixes: aceb4d82c ("Pass -qopenmp to Intel LLVM based compilers")