### PR TITLE
options: fix typo 'nonexistant' -> 'nonexistent' in error messages

### DIFF
--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -838,12 +838,12 @@ class OptionStore:
         if self.is_project_option(key):
             assert key.subproject is not None
             if potential is None:
-                raise KeyError(f'Tried to access nonexistant project option {key}.')
+                raise KeyError(f'Tried to access nonexistent project option {key}.')
         else:
             if potential is None:
                 parent_key = OptionKey(key.name, subproject=None, machine=key.machine)
                 if parent_key not in self.options:
-                    raise KeyError(f'Tried to access nonexistant project parent option {parent_key}.')
+                    raise KeyError(f'Tried to access nonexistent project parent option {parent_key}.')
                 # This is a global option but it can still have per-project
                 # augment, so return the subproject key.
                 return self.options[parent_key]


### PR DESCRIPTION

**Repo:** mesonbuild/meson (⭐ 6471)
**Type:** docs
**Files changed:** 1
**Lines:** +2/-2

## What
Corrects the misspelling "nonexistant" to the correct "nonexistent" in two user-facing `KeyError` messages in `mesonbuild/options.py` (`resolve_option`).

## Why
These strings appear in exceptions surfaced to Meson users when accessing an unknown project option. Using the correct spelling improves the polish of error output and is easier to search/grep for when users report issues. No other occurrences of this misspelling remain in the tree.

## Testing
- `grep -rn nonexistant` across the repo returns no results post-patch.
- The change is a string-literal fix with no logic impact; the surrounding behavior (raising `KeyError`) is unchanged.

## Risk
Low — user-visible string only, no API or control-flow change.
