### PR TITLE
introduce a faster, meson-specific variant of ABCMeta

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -20,7 +20,7 @@ from . import dependencies
 from . import mlog
 from . import programs
 from .mesonlib import (
-    HoldableObject, SecondLevelHolder,
+    HoldableObject, SecondLevelHolder, SimpleABC,
     File, MesonException, MachineChoice, PerMachine, OrderedSet, listify,
     classify_unity_sources,
     get_filenames_templates_dict, substitute_values, has_path_sep,
@@ -667,7 +667,7 @@ class StructuredSources(HoldableObject):
 
 
 @dataclass(eq=False)
-class Target(HoldableObject, metaclass=abc.ABCMeta):
+class Target(HoldableObject, metaclass=SimpleABC):
 
     name: str
     subdir: str

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -16,7 +16,7 @@ from .. import mlog
 from .. import mesonlib
 from .. import options
 from ..mesonlib import (
-    HoldableObject,
+    HoldableObject, SimpleABC,
     EnvironmentException, MesonBugException, MesonException,
     Popen_safe_logged, LibType, TemporaryDirectoryWinProof,
 )
@@ -467,7 +467,7 @@ class CompileResult(HoldableObject):
     output_name: T.Optional[str] = field(default=None, init=False)
     cached: bool = field(default=False, init=False)
 
-class Compiler(HoldableObject, metaclass=abc.ABCMeta):
+class Compiler(HoldableObject, metaclass=SimpleABC):
 
     # Libraries to ignore in find_library() since they are provided by the
     # compiler or the C library. Currently only used for MSVC.

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -348,7 +348,7 @@ def gnulike_default_include_dirs(compiler: T.Tuple[str, ...], lang: str) -> 'Imm
     return paths
 
 
-class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
+class GnuLikeCompiler(Compiler, metaclass=mesonlib.SimpleABC):
     """
     GnuLikeCompiler is a common interface to all compilers implementing
     the GNU-style commandline interface. This includes GCC, Clang

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 interface.
 """
 
-import abc
 import os
 import typing as T
 
@@ -65,7 +64,7 @@ msvc_optimization_args: T.Dict[str, T.List[str]] = {
 }
 
 
-class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
+class VisualStudioLikeCompiler(Compiler, metaclass=mesonlib.SimpleABC):
 
     """A common interface for all compilers implementing an MSVC-style
     interface.

--- a/mesonbuild/dependencies/qt.py
+++ b/mesonbuild/dependencies/qt.py
@@ -171,7 +171,7 @@ class _QtBase:
         is_debug = self.env.coredata.optstore.get_value_for('debug')
         return ['-DQT_DEBUG' if is_debug else '-DQT_NO_DEBUG']
 
-class QtPkgConfigDependency(_QtBase, PkgConfigDependency, metaclass=abc.ABCMeta):
+class QtPkgConfigDependency(_QtBase, PkgConfigDependency, metaclass=mesonlib.SimpleABC):
 
     """Specialization of the PkgConfigDependency for Qt."""
 
@@ -249,7 +249,7 @@ class QtPkgConfigDependency(_QtBase, PkgConfigDependency, metaclass=abc.ABCMeta)
         return 'pkg-config'
 
 
-class QmakeQtDependency(_QtBase, ConfigToolDependency, metaclass=abc.ABCMeta):
+class QmakeQtDependency(_QtBase, ConfigToolDependency, metaclass=mesonlib.SimpleABC):
 
     """Find Qt using Qmake as a config-tool."""
 

--- a/mesonbuild/interpreterbase/baseobjects.py
+++ b/mesonbuild/interpreterbase/baseobjects.py
@@ -7,11 +7,10 @@ from .. import mparser
 from .exceptions import InvalidCode, InvalidArguments
 from .helpers import flatten, resolve_second_level_holders
 from .operator import MesonOperator
-from ..mesonlib import HoldableObject, MesonBugException
+from ..mesonlib import HoldableObject, MesonBugException, SimpleABC
 import textwrap
 
 import typing as T
-from abc import ABCMeta
 from contextlib import AbstractContextManager
 
 if T.TYPE_CHECKING:
@@ -215,7 +214,7 @@ class ObjectHolder(InterpreterObject, T.Generic[InterpreterObjectTypeVar]):
     def __repr__(self) -> str:
         return f'<[{type(self).__name__}] holds [{type(self.held_object).__name__}]: {self.held_object!r}>'
 
-class IterableObject(metaclass=ABCMeta):
+class IterableObject(metaclass=SimpleABC):
     '''Base class for all objects that can be iterated over in a foreach loop'''
 
     def iter_tuple_size(self) -> T.Optional[int]:

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -641,7 +641,7 @@ def typed_kwargs(name: str, *types: KwargInfo, allow_unknown: bool = False) -> T
 
 
 # This cannot be a dataclass due to https://github.com/python/mypy/issues/5374
-class FeatureCheckBase(metaclass=abc.ABCMeta):
+class FeatureCheckBase(metaclass=mesonlib.SimpleABC):
     "Base class for feature version checks"
 
     feature_registry: T.ClassVar[T.Dict[str, T.Dict[str, T.Set[T.Tuple[str, T.Optional['mparser.BaseNode']]]]]]
@@ -859,7 +859,7 @@ class FeatureBroken(FeatureCheckBase):
 
 
 # This cannot be a dataclass due to https://github.com/python/mypy/issues/5374
-class FeatureCheckKwargsBase(metaclass=abc.ABCMeta):
+class FeatureCheckKwargsBase(metaclass=mesonlib.SimpleABC):
 
     @property
     @abc.abstractmethod

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -114,7 +114,7 @@ class StaticLinker:
         raise EnvironmentException(f'{self.id} does not implement rsp format, this shouldn\'t be called')
 
 
-class DynamicLinker(metaclass=abc.ABCMeta):
+class DynamicLinker(metaclass=mesonlib.SimpleABC):
 
     """Base class for dynamic linkers."""
 

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -22,7 +22,7 @@ from glob import glob
 from pathlib import Path
 from mesonbuild.environment import Environment
 from mesonbuild.tooldetect import detect_ninja
-from mesonbuild.mesonlib import (GIT, MesonException, RealPathAction, get_meson_command, quiet_git,
+from mesonbuild.mesonlib import (GIT, MesonException, RealPathAction, SimpleABC, get_meson_command, quiet_git,
                                  windows_proof_rmtree, setup_vsenv, determine_worker_count)
 from .options import OptionKey
 from mesonbuild.msetup import add_arguments as msetup_argparse
@@ -122,7 +122,7 @@ def is_hg(src_root: str) -> bool:
 
 
 @dataclass
-class Dist(metaclass=abc.ABCMeta):
+class Dist(metaclass=SimpleABC):
     dist_name: str
     src_root: str
     bld_root: str

--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -13,11 +13,11 @@ import sys
 import re
 import typing as T
 from pathlib import Path
-from abc import ABCMeta, abstractmethod
+from abc import abstractmethod
 
 from . import mesonlib
 from . import mlog
-from .mesonlib import MachineChoice, OrderedSet
+from .mesonlib import MachineChoice, OrderedSet, SimpleABC
 
 if T.TYPE_CHECKING:
     from typing_extensions import TypeAlias
@@ -28,7 +28,7 @@ if T.TYPE_CHECKING:
     CommandList: TypeAlias = T.List[CommandListEntry]
 
 
-class Program(mesonlib.HoldableObject, metaclass=ABCMeta):
+class Program(mesonlib.HoldableObject, metaclass=SimpleABC):
     '''A base class for LocalProgram and ExternalProgram.'''
 
     name: str

--- a/mesonbuild/templates/sampleimpl.py
+++ b/mesonbuild/templates/sampleimpl.py
@@ -10,11 +10,13 @@ import os
 import re
 import typing as T
 
+from ..mesonlib import SimpleABC
+
 if T.TYPE_CHECKING:
     from ..minit import Arguments
 
 
-class SampleImpl(metaclass=abc.ABCMeta):
+class SampleImpl(metaclass=SimpleABC):
 
     def __init__(self, args: Arguments):
         self.name = args.name

--- a/mesonbuild/utils/core.py
+++ b/mesonbuild/utils/core.py
@@ -12,7 +12,6 @@ as possible for performance reasons.
 from __future__ import annotations
 from dataclasses import dataclass
 import os
-import abc
 import typing as T
 
 if T.TYPE_CHECKING:
@@ -54,9 +53,13 @@ class MesonBugException(MesonException):
         super().__init__(msg + '\n\n    This is a Meson bug and should be reported!',
                          file=file, lineno=lineno, colno=colno)
 
-class HoldableObject(metaclass=abc.ABCMeta):
+class HoldableObject:
     ''' Dummy base class for all objects that can be
         held by an interpreter.baseobjects.ObjectHolder '''
+    def __new__(cls, *args: T.Any, **kwargs: T.Any) -> HoldableObject:
+        if cls is HoldableObject:
+            raise TypeError(f"Can't instantiate abstract class {cls.__name__}")
+        return super().__new__(cls)
 
 class EnvironmentVariables(HoldableObject):
     def __init__(self, values: T.Optional[EnvInitValueType] = None,

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -59,6 +59,7 @@ _U = T.TypeVar('_U')
 
 __all__ = [
     'GIT',
+    'SimpleABC',
     'python_command',
     'NoProjectVersion',
     'project_meson_versions',
@@ -281,6 +282,37 @@ def check_direntry_issues(direntry_array: T.Union[T.Iterable[T.Union[str, bytes]
                 locale but you are trying to access a file system entry called {de!r} which is
                 not pure ASCII. This may cause problems.
                 '''))
+
+class SimpleABC(type):
+    '''Lightweight replacement for ``abc.ABCMeta``.
+
+    Supports ``@abc.abstractmethod`` but omits virtual subclass
+    registration and ``__subclasshook__``. This way, ``isinstance()``
+    goes through the C fast path. '''
+
+    __abstractmethods__: T.FrozenSet[str]
+
+    def __new__(mcs, name: str, bases: T.Tuple[type, ...],
+                namespace: T.Dict[str, T.Any], **kwargs: T.Any) -> SimpleABC:
+        cls = super().__new__(mcs, name, bases, namespace, **kwargs)
+        abstracts = {n for n, v in namespace.items()
+                     if getattr(v, '__isabstractmethod__', False)}
+        for base in bases:
+            for n in getattr(base, '__abstractmethods__', ()):
+                if getattr(getattr(cls, n, None), '__isabstractmethod__', False):
+                    abstracts.add(n)
+        cls.__abstractmethods__ = frozenset(abstracts)
+        return cls
+
+    def __call__(cls, *args: T.Any, **kwargs: T.Any) -> T.Any:
+        if cls.__abstractmethods__:
+            raise TypeError(
+                f"Can't instantiate abstract class {cls.__name__} without an "
+                f"implementation for abstract method"
+                f"{'s' if len(cls.__abstractmethods__) > 1 else ''} "
+                f"{', '.join(repr(m) for m in sorted(cls.__abstractmethods__))}")
+        return super().__call__(*args, **kwargs)
+
 
 class SecondLevelHolder(HoldableObject, metaclass=abc.ABCMeta):
     ''' A second level object holder. The primary purpose

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -314,7 +314,7 @@ class SimpleABC(type):
         return super().__call__(*args, **kwargs)
 
 
-class SecondLevelHolder(HoldableObject, metaclass=abc.ABCMeta):
+class SecondLevelHolder(HoldableObject, metaclass=SimpleABC):
     ''' A second level object holder. The primary purpose
         of such objects is to hold multiple objects with one
         default option. '''

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -36,7 +36,7 @@ from mesonbuild.linkers import linkers
 from mesonbuild.interpreterbase import typed_pos_args, InvalidArguments, ObjectHolder
 from mesonbuild.interpreterbase import typed_pos_args, InvalidArguments, typed_kwargs, ContainerTypeInfo, KwargInfo
 from mesonbuild.mesonlib import (
-    LibType, MachineChoice, PerMachine, Version, is_windows, is_osx,
+    LibType, MachineChoice, PerMachine, SimpleABC, Version, is_windows, is_osx,
     is_cygwin, is_openbsd, search_version, MesonException, python_command,
 )
 from mesonbuild.options import OptionKey
@@ -74,6 +74,56 @@ class InternalTests(unittest.TestCase):
             Default locale: en_US, platform encoding: UTF-8
             OS name: "linux", version: "5.12.17", arch: "amd64", family: "unix"'''),
             '3.8.1')
+
+    def test_simple_abc(self):
+        from abc import abstractmethod
+
+        # The whole point is for isinstance() to stay on the C fast path
+        self.assertNotIn('__instancecheck__', vars(SimpleABC))
+        self.assertNotIn('__subclasscheck__', vars(SimpleABC))
+
+        class A(metaclass=SimpleABC):
+            @abstractmethod
+            def foo(self): ...
+
+        class B(A, metaclass=SimpleABC):
+            def foo(self):
+                return 1
+
+            @abstractmethod
+            def bar(self): ...
+
+        class C(B):
+            def foo(self):
+                return 2
+
+        class D(B):
+            def bar(self):
+                return 3
+
+        self.assertEqual(A.__abstractmethods__, frozenset({'foo'}))
+        with self.assertRaises(TypeError):
+            A()
+
+        self.assertEqual(B.__abstractmethods__, frozenset({'bar'}))
+        self.assertTrue(issubclass(B, A))
+        with self.assertRaises(TypeError):
+            B()
+
+        self.assertEqual(C.__abstractmethods__, frozenset({'bar'}))
+        self.assertTrue(issubclass(C, A))
+        self.assertTrue(issubclass(C, B))
+        with self.assertRaises(TypeError):
+            # subclass inheriting SimpleABC
+            C()
+
+        self.assertEqual(D.__abstractmethods__, frozenset())
+        self.assertTrue(issubclass(D, A))
+        self.assertTrue(issubclass(D, B))
+        self.assertTrue(issubclass(D, D))
+        self.assertIsInstance(D(), A)
+        self.assertIsInstance(D(), B)
+        self.assertIsInstance(D(), D)
 
     def test_mode_symbolic_to_bits(self):
         modefunc = mesonbuild.mesonlib.FileMode.perms_s_to_bits


### PR DESCRIPTION
The virtual superclass feature of ABCMeta is never used by Meson.  Replace
with a simpler version that only checks for abstract methods, so that
isinstance() against any of Meson's concrete subclasses now goes
through the CPython C fast path.
    
This introduces a 3-4% speedup on QEMU.