### PR TITLE
Speed up introspection interpreter

### DIFF
--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -26,7 +26,7 @@ from ..interpreterbase import (
     default_resolve_key,
     is_disabled,
     UnknownValue,
-    UndefinedVariable,
+    UNDEFINED_VARIABLE,
     InterpreterObject,
 )
 
@@ -60,7 +60,7 @@ from ..mparser import (
 if T.TYPE_CHECKING:
     from .visitor import AstVisitor
     from ..interpreter import Interpreter
-    from ..interpreterbase import SubProject, TYPE_var, TYPE_nvar
+    from ..interpreterbase import SubProject, TYPE_var, TYPE_nvar, UndefinedVariable
     from ..mparser import (
         AndNode,
         ComparisonNode,
@@ -468,13 +468,13 @@ class AstInterpreter(InterpreterBase):
         for var_name in self.cur_assignments:
             potential_values = []
             oldval = self.get_cur_value_if_defined(var_name)
-            if not isinstance(oldval, UndefinedVariable):
+            if oldval is not UNDEFINED_VARIABLE:
                 potential_values.append(oldval)
             for nesting, value in self.cur_assignments[var_name]:
                 if len(nesting) > len(self.nesting):
                     potential_values.append(value)
             self.cur_assignments[var_name] = [(nesting, v) for (nesting, v) in self.cur_assignments[var_name] if len(nesting) <= len(self.nesting)]
-            if len(potential_values) > 1 or (len(potential_values) > 0 and isinstance(oldval, UndefinedVariable)):
+            if len(potential_values) > 1 or (len(potential_values) > 0 and oldval is UNDEFINED_VARIABLE):
                 uv = UnknownValue()
                 for pv in potential_values:
                     self.dataflow_dag.add_edge(pv, uv)
@@ -494,18 +494,18 @@ class AstInterpreter(InterpreterBase):
     def get_cur_value_if_defined(self, var_name: str) -> T.Union[BaseNode, UnknownValue, UndefinedVariable]:
         if var_name in self.predefined_vars:
             return self.predefined_vars[var_name]
-        ret: T.Union[BaseNode, UnknownValue, UndefinedVariable] = UndefinedVariable()
+        ret: T.Union[BaseNode, UnknownValue, UndefinedVariable] = UNDEFINED_VARIABLE
         for nesting, value in reversed(self.cur_assignments[var_name]):
             if len(self.nesting) >= len(nesting) and self.nesting[:len(nesting)] == nesting:
                 ret = value
                 break
-        if isinstance(ret, UndefinedVariable) and self.tainted:
+        if ret is UNDEFINED_VARIABLE and self.tainted:
             return UnknownValue()
         return ret
 
     def get_cur_value(self, var_name: str) -> T.Union[BaseNode, UnknownValue]:
         ret = self.get_cur_value_if_defined(var_name)
-        if isinstance(ret, UndefinedVariable):
+        if ret is UNDEFINED_VARIABLE:
             path = mlog.get_relative_path(Path(self.current_node.filename), Path(os.getcwd()))
             mlog.warning(f"{path}:{self.current_node.lineno}:{self.current_node.colno} will always crash if executed, since a variable named `{var_name}` is not defined")
             # We could add more advanced analysis of code referencing undefined

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -26,6 +26,7 @@ from ..interpreterbase import (
     default_resolve_key,
     is_disabled,
     UnknownValue,
+    UNKNOWN_VALUE,
     UNDEFINED_VARIABLE,
     InterpreterObject,
 )
@@ -189,10 +190,10 @@ class AstInterpreter(InterpreterBase):
         self.funcvals: T.Dict[BaseNode, T.Any] = {}
         self.tainted = False
         self.predefined_vars = {
-            'meson': UnknownValue(),
-            'host_machine': UnknownValue(),
-            'build_machine': UnknownValue(),
-            'target_machine': UnknownValue()
+            'meson': UNKNOWN_VALUE,
+            'host_machine': UNKNOWN_VALUE,
+            'build_machine': UNKNOWN_VALUE,
+            'target_machine': UNKNOWN_VALUE
         }
         self.funcs.update({'project': self.func_do_nothing,
                            'test': self.func_do_nothing,
@@ -262,7 +263,7 @@ class AstInterpreter(InterpreterBase):
         return res
 
     def func_do_nothing(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> UnknownValue:
-        return UnknownValue()
+        return UNKNOWN_VALUE
 
     def load_root_meson_file(self) -> None:
         super().load_root_meson_file()
@@ -286,8 +287,8 @@ class AstInterpreter(InterpreterBase):
 
     def inner_method_call(self, obj: BaseNode, method_name: str, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> T.Any:
         for arg in itertools.chain(args, kwargs.values()):
-            if isinstance(arg, UnknownValue):
-                return UnknownValue()
+            if arg is UNKNOWN_VALUE:
+                return UNKNOWN_VALUE
 
         if isinstance(obj, str):
             result = StringHolder(obj, T.cast('Interpreter', self)).method_call(method_name, args, kwargs)
@@ -300,7 +301,7 @@ class AstInterpreter(InterpreterBase):
         elif isinstance(obj, dict):
             result = DictHolder(obj, T.cast('Interpreter', self)).method_call(method_name, args, kwargs)
         else:
-            return UnknownValue()
+            return UNKNOWN_VALUE
         return result
 
     def method_call(self, node: mparser.MethodNode) -> None:
@@ -447,7 +448,7 @@ class AstInterpreter(InterpreterBase):
     def evaluate_foreach(self, node: ForeachClauseNode) -> None:
         asses = self.find_potential_writes(node)
         for ass in asses:
-            self.cur_assignments[ass].append((self.nesting.copy(), UnknownValue()))
+            self.cur_assignments[ass].append((self.nesting.copy(), UNKNOWN_VALUE))
         try:
             self.evaluate_codeblock(node.block)
         except ContinueRequest:
@@ -455,7 +456,7 @@ class AstInterpreter(InterpreterBase):
         except BreakRequest:
             pass
         for ass in asses:
-            self.cur_assignments[ass].append((self.nesting.copy(), UnknownValue())) # In case the foreach loops 0 times.
+            self.cur_assignments[ass].append((self.nesting.copy(), UNKNOWN_VALUE)) # In case the foreach loops 0 times.
 
     def evaluate_if(self, node: IfClauseNode) -> None:
         self.nesting.append(0)
@@ -475,7 +476,7 @@ class AstInterpreter(InterpreterBase):
                     potential_values.append(value)
             self.cur_assignments[var_name] = [(nesting, v) for (nesting, v) in self.cur_assignments[var_name] if len(nesting) <= len(self.nesting)]
             if len(potential_values) > 1 or (len(potential_values) > 0 and oldval is UNDEFINED_VARIABLE):
-                uv = UnknownValue()
+                uv = UNKNOWN_VALUE
                 for pv in potential_values:
                     self.dataflow_dag.add_edge(pv, uv)
                 self.cur_assignments[var_name].append((self.nesting.copy(), uv))
@@ -485,8 +486,8 @@ class AstInterpreter(InterpreterBase):
         for arg in args:
             if isinstance(arg, str):
                 ret.append(IntrospectionFile(self.subdir, arg))
-            elif isinstance(arg, UnknownValue):
-                ret.append(UnknownValue())
+            elif arg is UNKNOWN_VALUE:
+                ret.append(UNKNOWN_VALUE)
             else:
                 raise TypeError
         return ret
@@ -500,7 +501,7 @@ class AstInterpreter(InterpreterBase):
                 ret = value
                 break
         if ret is UNDEFINED_VARIABLE and self.tainted:
-            return UnknownValue()
+            return UNKNOWN_VALUE
         return ret
 
     def get_cur_value(self, var_name: str) -> T.Union[BaseNode, UnknownValue]:
@@ -512,13 +513,13 @@ class AstInterpreter(InterpreterBase):
             # variables, but it is probably not worth the effort and the
             # complexity. So we do the simplest thing, returning an
             # UnknownValue.
-            return UnknownValue()
+            return UNKNOWN_VALUE
         return ret
 
     # The function `node_to_runtime_value` takes a node of the ast as an
     # argument and tries to return the same thing that would be passed to e.g.
     # `func_message` if you put `message(node)` in your `meson.build` file and
-    # run `meson setup`. If this is not possible, `UnknownValue()` is returned.
+    # run `meson setup`. If this is not possible, `UNKNOWN_VALUE` is returned.
     # There are 3 Reasons why this is sometimes impossible:
     #     1. Because the meson rewriter is imperfect and has not implemented everything yet
     #     2. Because the value is different on different machines, example:
@@ -528,7 +529,7 @@ class AstInterpreter(InterpreterBase):
     #     ```
     #     will print `true` on some machines and `false` on others, so
     #     `node_to_runtime_value` does not know whether to return `true` or
-    #     `false` and will return `UnknownValue()`.
+    #     `false` and will return `UNKNOWN_VALUE`.
     #     3. Here:
     #     ```meson
     #     foreach x : [1, 2]
@@ -537,19 +538,19 @@ class AstInterpreter(InterpreterBase):
     #     endforeach
     #     ```
     #     `node_to_runtime_value` does not know whether to return `1` or `2` and
-    #     will return `UnknownValue()`.
+    #     will return `UNKNOWN_VALUE`.
     #
     # If you have something like
     # ```
     # node = [123, somedep.found()]
     # ```
-    # `node_to_runtime_value` will return `[123, UnknownValue()]`.
+    # `node_to_runtime_value` will return `[123, UNKNOWN_VALUE]`.
     def node_to_runtime_value(self, node: T.Union[UnknownValue, BaseNode, TYPE_var]) -> T.Any:
         if isinstance(node, (mparser.StringNode, mparser.BooleanNode, mparser.NumberNode)):
             return node.value
         elif isinstance(node, mparser.StringNode):
             if node.is_fstring:
-                return UnknownValue()
+                return UNKNOWN_VALUE
             else:
                 return node.value
         elif isinstance(node, list):
@@ -571,12 +572,12 @@ class AstInterpreter(InterpreterBase):
         elif isinstance(node, ArithmeticNode):
             left = self.node_to_runtime_value(node.left)
             right = self.node_to_runtime_value(node.right)
-            if isinstance(left, list) and isinstance(right, UnknownValue):
+            if isinstance(left, list) and right is UNKNOWN_VALUE:
                 return left + [right]
-            if isinstance(right, list) and isinstance(left, UnknownValue):
+            if isinstance(right, list) and left is UNKNOWN_VALUE:
                 return [left] + right
-            if isinstance(left, UnknownValue) or isinstance(right, UnknownValue):
-                return UnknownValue()
+            if left is UNKNOWN_VALUE or right is UNKNOWN_VALUE:
+                return UNKNOWN_VALUE
             if node.operation == '+':
                 if isinstance(left, dict) and isinstance(right, dict):
                     ret = left.copy()
@@ -605,14 +606,14 @@ class AstInterpreter(InterpreterBase):
         elif isinstance(node, mparser.IndexNode):
             iobject = self.node_to_runtime_value(node.iobject)
             index = self.node_to_runtime_value(node.index)
-            if isinstance(iobject, UnknownValue) or isinstance(index, UnknownValue):
-                return UnknownValue()
+            if iobject is UNKNOWN_VALUE or index is UNKNOWN_VALUE:
+                return UNKNOWN_VALUE
             return iobject[index]
         elif isinstance(node, mparser.ComparisonNode):
             left = self.node_to_runtime_value(node.left)
             right = self.node_to_runtime_value(node.right)
-            if isinstance(left, UnknownValue) or isinstance(right, UnknownValue):
-                return UnknownValue()
+            if left is UNKNOWN_VALUE or right is UNKNOWN_VALUE:
+                return UNKNOWN_VALUE
             if node.ctype == '==':
                 return left == right
             elif node.ctype == '!=':
@@ -623,8 +624,8 @@ class AstInterpreter(InterpreterBase):
                 return left not in right
         elif isinstance(node, mparser.TernaryNode):
             cond = self.node_to_runtime_value(node.condition)
-            if isinstance(cond, UnknownValue):
-                return UnknownValue()
+            if cond is UNKNOWN_VALUE:
+                return UNKNOWN_VALUE
             if cond is True:
                 return self.node_to_runtime_value(node.trueblock)
             if cond is False:
@@ -632,24 +633,24 @@ class AstInterpreter(InterpreterBase):
         elif isinstance(node, mparser.OrNode):
             left = self.node_to_runtime_value(node.left)
             right = self.node_to_runtime_value(node.right)
-            if isinstance(left, UnknownValue) or isinstance(right, UnknownValue):
-                return UnknownValue()
+            if left is UNKNOWN_VALUE or right is UNKNOWN_VALUE:
+                return UNKNOWN_VALUE
             return left or right
         elif isinstance(node, mparser.AndNode):
             left = self.node_to_runtime_value(node.left)
             right = self.node_to_runtime_value(node.right)
-            if isinstance(left, UnknownValue) or isinstance(right, UnknownValue):
-                return UnknownValue()
+            if left is UNKNOWN_VALUE or right is UNKNOWN_VALUE:
+                return UNKNOWN_VALUE
             return left and right
         elif isinstance(node, mparser.UMinusNode):
             val = self.node_to_runtime_value(node.value)
-            if isinstance(val, UnknownValue):
+            if val is UNKNOWN_VALUE:
                 return val
             if isinstance(val, (int, float)):
                 return -val
         elif isinstance(node, mparser.NotNode):
             val = self.node_to_runtime_value(node.value)
-            if isinstance(val, UnknownValue):
+            if val is UNKNOWN_VALUE:
                 return val
             if isinstance(val, bool):
                 return not val
@@ -668,8 +669,8 @@ class AstInterpreter(InterpreterBase):
         self.evaluate_statement(node.value)
         lhs = self.get_cur_value(node.var_name.value)
         newval: T.Union[UnknownValue, ArithmeticNode]
-        if isinstance(lhs, UnknownValue):
-            newval = UnknownValue()
+        if lhs is UNKNOWN_VALUE:
+            newval = UNKNOWN_VALUE
         else:
             newval = mparser.ArithmeticNode(operation='+', left=lhs, operator=_symbol('+'), right=node.value)
         self.cur_assignments[node.var_name.value].append((self.nesting.copy(), newval))
@@ -686,7 +687,7 @@ class AstInterpreter(InterpreterBase):
             raise InvalidArguments('set_variable requires exactly two positional arguments')
         var_name = args[0]
         value = node.args.arguments[1]
-        if isinstance(var_name, UnknownValue):
+        if var_name is UNKNOWN_VALUE:
             self.evaluate_statement(value)
             self.tainted = True
             return
@@ -698,8 +699,8 @@ class AstInterpreter(InterpreterBase):
     def func_get_variable(self, node: BaseNode, args: T.List[TYPE_var], kwargs: T.Dict[str, TYPE_var]) -> T.Any:
         assert isinstance(node, FunctionNode)
         var_name = args[0]
-        if isinstance(var_name, UnknownValue):
-            val: T.Union[UnknownValue, BaseNode] = UnknownValue()
+        if var_name is UNKNOWN_VALUE:
+            val: T.Union[UnknownValue, BaseNode] = UNKNOWN_VALUE
         else:
             assert isinstance(var_name, str)
             val = self.get_cur_value(var_name)
@@ -722,7 +723,7 @@ class AstInterpreter(InterpreterBase):
                 return os.path.normpath(os.path.join(root_path, subdir, src))
             elif isinstance(src, IntrospectionFile):
                 return str(src.to_abs_path(root_path))
-            elif isinstance(src, UnknownValue):
+            elif src is UNKNOWN_VALUE:
                 return src
             else:
                 raise TypeError

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -12,7 +12,7 @@ import typing as T
 from .. import compilers, environment, mesonlib
 from ..build import Executable, Jar, SharedLibrary, SharedModule, StaticLibrary
 from ..compilers import detect_compiler_for
-from ..interpreterbase import InvalidArguments, SubProject, UnknownValue, Feature
+from ..interpreterbase import InvalidArguments, SubProject, UnknownValue, UNKNOWN_VALUE, Feature
 from ..mesonlib import MachineChoice
 from ..options import OptionKey
 from ..mparser import BaseNode, ArrayNode, ElementaryNode, IdNode, FunctionNode, StringNode
@@ -158,7 +158,7 @@ class IntrospectionInterpreter(AstInterpreter):
         else:
             for for_machine in [MachineChoice.BUILD, MachineChoice.HOST]:
                 self._add_languages(args, required, for_machine)
-        return UnknownValue()
+        return UNKNOWN_VALUE
 
     def _add_languages(self, raw_langs: T.List[TYPE_var], required: T.Union[bool, UnknownValue], for_machine: MachineChoice) -> None:
         langs: T.List[Language] = []
@@ -193,8 +193,8 @@ class IntrospectionInterpreter(AstInterpreter):
         version = kwargs.get('version', [])
         if not isinstance(version, list):
             version = [version]
-        if any(isinstance(el, UnknownValue) for el in version):
-            version = UnknownValue()
+        if any(el is UNKNOWN_VALUE for el in version):
+            version = UNKNOWN_VALUE
         else:
             assert all(isinstance(el, str) for el in version)
             version = T.cast(T.List[str], version)
@@ -213,7 +213,7 @@ class IntrospectionInterpreter(AstInterpreter):
         assert isinstance(node, FunctionNode)
         args = self.flatten_args(args)
         if not args or not isinstance(args[0], str):
-            return UnknownValue()
+            return UNKNOWN_VALUE
         name = args[0]
         srcqueue: T.List[BaseNode] = [node]
         extra_queue = []
@@ -257,12 +257,12 @@ class IntrospectionInterpreter(AstInterpreter):
         target.process_compilers_late()
 
         build_by_default: T.Union[UnknownValue, bool] = target.build_by_default
-        if 'build_by_default' in kwargs and isinstance(kwargs['build_by_default'], UnknownValue):
-            build_by_default = kwargs['build_by_default']
+        if kwargs.get('build_by_default', None) is UNKNOWN_VALUE:
+            build_by_default = UNKNOWN_VALUE
 
         install: T.Union[UnknownValue, bool] = target.should_install()
-        if 'install' in kwargs and isinstance(kwargs['install'], UnknownValue):
-            install = kwargs['install']
+        if kwargs.get('install', None) is UNKNOWN_VALUE:
+            install = UNKNOWN_VALUE
 
         new_target = IntrospectionBuildTarget(
             name=target.get_basename(),

--- a/mesonbuild/interpreterbase/__init__.py
+++ b/mesonbuild/interpreterbase/__init__.py
@@ -64,6 +64,7 @@ __all__ = [
 
     'UnknownValue',
     'UndefinedVariable',
+    'UNDEFINED_VARIABLE',
 ]
 
 from .baseobjects import (
@@ -89,6 +90,7 @@ from .baseobjects import (
 
     UnknownValue,
     UndefinedVariable,
+    UNDEFINED_VARIABLE,
 )
 
 from .decorators import (

--- a/mesonbuild/interpreterbase/__init__.py
+++ b/mesonbuild/interpreterbase/__init__.py
@@ -63,6 +63,7 @@ __all__ = [
     'HoldableTypes',
 
     'UnknownValue',
+    'UNKNOWN_VALUE',
     'UndefinedVariable',
     'UNDEFINED_VARIABLE',
 ]
@@ -89,6 +90,7 @@ from .baseobjects import (
     HoldableTypes,
 
     UnknownValue,
+    UNKNOWN_VALUE,
     UndefinedVariable,
     UNDEFINED_VARIABLE,
 )

--- a/mesonbuild/interpreterbase/baseobjects.py
+++ b/mesonbuild/interpreterbase/baseobjects.py
@@ -8,6 +8,7 @@ from .exceptions import InvalidCode, InvalidArguments
 from .helpers import flatten, resolve_second_level_holders
 from .operator import MesonOperator
 from ..mesonlib import HoldableObject, MesonBugException
+import enum
 import textwrap
 
 import typing as T
@@ -174,9 +175,18 @@ class UnknownValue(MesonInterpreterObject):
     limitations in our code or because the value differs from machine to
     machine.'''
 
-class UndefinedVariable(MesonInterpreterObject):
+class UndefinedVariable(MesonInterpreterObject, enum.Enum):
     '''This class is only used for the rewriter/static introspection tool and
     represents the `value` a meson-variable has if it was never written to.'''
+
+    _ = 0
+
+    def __init__(self, zero: int) -> None:
+        pass
+
+# Stateless singletons: callers should compare with "is", not isinstance()
+# mypy knows that "is" and "isinstance" is the same for one-item enums
+UNDEFINED_VARIABLE: UndefinedVariable = UndefinedVariable._
 
 HoldableTypes = (HoldableObject, int, bool, str, list, dict)
 TYPE_HoldableTypes = T.Union[TYPE_var, HoldableObject]

--- a/mesonbuild/interpreterbase/baseobjects.py
+++ b/mesonbuild/interpreterbase/baseobjects.py
@@ -169,11 +169,16 @@ class MesonInterpreterObject(InterpreterObject):
 class MutableInterpreterObject:
     ''' Dummy class to mark the object type as mutable '''
 
-class UnknownValue(MesonInterpreterObject):
+class UnknownValue(MesonInterpreterObject, enum.Enum):
     '''This class is only used for the rewriter/static introspection tool and
     indicates that a value cannot be determined statically, either because of
     limitations in our code or because the value differs from machine to
     machine.'''
+
+    _ = 0
+
+    def __init__(self, zero: int) -> None:
+        pass
 
 class UndefinedVariable(MesonInterpreterObject, enum.Enum):
     '''This class is only used for the rewriter/static introspection tool and
@@ -187,6 +192,7 @@ class UndefinedVariable(MesonInterpreterObject, enum.Enum):
 # Stateless singletons: callers should compare with "is", not isinstance()
 # mypy knows that "is" and "isinstance" is the same for one-item enums
 UNDEFINED_VARIABLE: UndefinedVariable = UndefinedVariable._
+UNKNOWN_VALUE: UnknownValue = UnknownValue._
 
 HoldableTypes = (HoldableObject, int, bool, str, list, dict)
 TYPE_HoldableTypes = T.Union[TYPE_var, HoldableObject]

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -21,17 +21,18 @@ import typing as T
 from . import build, environment, mesonlib, options, coredata as cdata
 from .ast import IntrospectionInterpreter, AstConditionLevel, AstIDGenerator, AstIndentationGenerator, AstJSONPrinter
 from .backend import backends
-from .interpreterbase import UnknownValue
+from .interpreterbase import UNKNOWN_VALUE
 from .options import OptionKey
 
 if T.TYPE_CHECKING:
     import argparse
 
     from .dependencies import Dependency
+    from .interpreterbase import UnknownValue
 
 class IntrospectionEncoder(json.JSONEncoder):
     def default(self, obj: T.Any) -> T.Any:
-        if isinstance(obj, UnknownValue):
+        if obj is UNKNOWN_VALUE:
             return 'unknown'
         return json.JSONEncoder.default(self, obj)
 

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from .ast import IntrospectionInterpreter, BUILD_TARGET_FUNCTIONS, AstConditionLevel, AstIDGenerator, AstIndentationGenerator, AstPrinter
 from .ast.interpreter import IntrospectionBuildTarget, IntrospectionDependency, _symbol
-from .interpreterbase import UnknownValue, TV_func
+from .interpreterbase import UNKNOWN_VALUE, TV_func
 from .interpreterbase.helpers import flatten
 from mesonbuild.mesonlib import MesonException, pathname_sort_key, relpath, setup_vsenv
 from . import mlog, environment
@@ -25,6 +25,7 @@ from pathlib import Path
 if T.TYPE_CHECKING:
     import argparse
     from argparse import ArgumentParser, _FormatterClass
+    from .interpreterbase import UnknownValue
     from .mlog import AnsiDecorator
 
 class RewriterException(MesonException):
@@ -719,7 +720,7 @@ class Rewriter:
             all_paths = self.interpreter.dataflow_dag.find_all_paths(candidate, target.node)
             for path in all_paths:
                 for el in path:
-                    if isinstance(el, UnknownValue):
+                    if el is UNKNOWN_VALUE:
                         return True
             return False
 
@@ -771,7 +772,7 @@ class Rewriter:
         to_append = []
         added = []
 
-        old_src_list = [(target_dir_abs / x).resolve() if isinstance(x, str) else x.to_abs_path(source_root_abs) for x in old_src_list if not isinstance(x, UnknownValue)]
+        old_src_list = [(target_dir_abs / x).resolve() if isinstance(x, str) else x.to_abs_path(source_root_abs) for x in old_src_list if x is not UNKNOWN_VALUE]
         for _newf in sorted(set(newfiles)):
             newf = Path(_newf)
             if os.path.isabs(newf):
@@ -833,7 +834,7 @@ class Rewriter:
             elif op == 'extra_files_rm':
                 nodes = self.interpreter.dataflow_dag.reachable({target.extra_files}, True)
             for i in nodes:
-                if isinstance(i, UnknownValue):
+                if i is UNKNOWN_VALUE:
                     continue
                 relto = self.get_relto(target.node, i)
                 if relto is not None:
@@ -951,8 +952,8 @@ class Rewriter:
             src_list = self.interpreter.nodes_to_pretty_filelist(source_root_abs, target.subdir, target.source_nodes)
             extra_files_list = self.interpreter.nodes_to_pretty_filelist(source_root_abs, target.subdir, [target.extra_files] if target.extra_files else [])
 
-            src_list = ['unknown' if isinstance(x, UnknownValue) else relpath(x, source_root_abs) for x in src_list]
-            extra_files_list = ['unknown' if isinstance(x, UnknownValue) else relpath(x, source_root_abs) for x in extra_files_list]
+            src_list = ['unknown' if x is UNKNOWN_VALUE else relpath(x, source_root_abs) for x in src_list]
+            extra_files_list = ['unknown' if x is UNKNOWN_VALUE else relpath(x, source_root_abs) for x in extra_files_list]
 
             test_data = {
                 'name': target.name,


### PR DESCRIPTION
@anarazel reports 1.06s for Postgres `meson configure` in 1.8, whereas >= 1.9 take 1.80s.

While most of the regression is due to the improved dataflow computations, and the cost of creating new objects was already reduced heavily by #14091, try making things a little better by making `UnknownValue()` and `UndefinedVariable` singletons.

```
   master: Time (mean ± σ):      1.741 s ±  0.003 s
 pr/15743: Time (mean ± σ):      1.638 s ±  0.002 s
```

The hack that makes it possible to tell `mypy` that `x is not OBJ` implies `not isinstance(x, Type)` is horrible, but... it works.