### PR TITLE
mdist: skip transitive subprojects not present at top level

### DIFF
--- a/docs/markdown/snippets/mdist-skip-transitive-subprojects.md
+++ b/docs/markdown/snippets/mdist-skip-transitive-subprojects.md
@@ -1,0 +1,8 @@
+## `meson dist --include-subprojects` no longer fails on transitive subprojects
+
+`meson dist --include-subprojects` previously failed with a
+`FileNotFoundError` when a subproject itself had a subproject (i.e. a
+transitive subproject) that was not present as a directory in the
+top-level `subprojects/` folder. Such transitive subprojects are
+already included as part of their parent subproject's source tree, so
+they are now silently skipped rather than causing an error.

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -398,6 +398,13 @@ def run(options: argparse.Namespace) -> int:
         for sub in b.projects:
             if sub:
                 directory = wrap.get_directory(subproject_dir, sub)
+                sub_path = os.path.join(subproject_dir, directory)
+                if not os.path.exists(sub_path):
+                    # Subproject directory not found at the top level. It is likely a
+                    # transitive subproject nested inside another subproject's source
+                    # tree and will be included when that parent subproject is bundled.
+                    mlog.debug(f'Skipping subproject {sub!r} for dist: directory {sub_path!r} not found at top level')
+                    continue
                 subprojects[sub] = os.path.join(b.subproject_dir, directory)
         extra_meson_args.append('-Dwrap_mode=nodownload')
 

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1607,6 +1607,44 @@ class AllPlatformTests(BasePlatformTests):
             # fails sometimes.
             pass
 
+    @skipIfNoExecutable('git')
+    def test_dist_git_include_subprojects_transitive(self):
+        if self.backend is not Backend.ninja:
+            raise SkipTest('Dist is only supported with Ninja')
+
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                project_dir = os.path.join(tmpdir, 'mainproj')
+                os.makedirs(project_dir)
+
+                with open(os.path.join(project_dir, 'meson.build'), 'w', encoding='utf-8') as f:
+                    f.write(textwrap.dedent('''\
+                        project('mainproj', version: '1.0')
+                        subproject('parentsub')
+                        '''))
+
+                parentsub_dir = os.path.join(project_dir, 'subprojects', 'parentsub')
+                os.makedirs(parentsub_dir)
+                with open(os.path.join(parentsub_dir, 'meson.build'), 'w', encoding='utf-8') as f:
+                    f.write(textwrap.dedent('''\
+                        project('parentsub', version: '1.0')
+                        subproject('transitivesub')
+                        '''))
+
+                # transitivesub lives only inside parentsub's source tree, not at the top level
+                transitivesub_dir = os.path.join(parentsub_dir, 'subprojects', 'transitivesub')
+                os.makedirs(transitivesub_dir)
+                with open(os.path.join(transitivesub_dir, 'meson.build'), 'w', encoding='utf-8') as f:
+                    f.write("project('transitivesub', version: '1.0')\n")
+
+                git_init(project_dir)
+                self.init(project_dir)
+                # Should succeed without FileNotFoundError for the transitive subproject
+                self._run(self.meson_command + ['dist', '--include-subprojects', '--no-tests'],
+                          workdir=self.builddir)
+        except PermissionError:
+            pass
+
     def create_dummy_subproject(self, project_dir, name):
         path = os.path.join(project_dir, 'subprojects', name)
         os.makedirs(path)


### PR DESCRIPTION
b.subprojects includes all subprojects registered during configure, including those propagated up from nested subproject interpreters. When --include-subprojects is used, iterating this set and computing paths relative to the top-level subprojects directory produces a nonexistent path for any subproject that lives only inside another subproject's source tree, causing a FileNotFoundError.

Skip subprojects whose resolved directory does not exist at the top level. They are transitive dependencies that will be included when their parent subproject's source tree is bundled.

Fixes #12489