### PR TITLE
Set the encoding parameter for all open() calls that write in text mode

### DIFF
--- a/packaging/createmsi.py
+++ b/packaging/createmsi.py
@@ -231,13 +231,13 @@ class PackageGenerator:
         # ElementTree cannot do pretty-printing, so do it manually
         import xml.dom.minidom
         doc = xml.dom.minidom.parse(self.main_xml)
-        with open(self.main_xml, 'w') as open_file:
+        with open(self.main_xml, 'w', encoding='utf-8') as open_file:
             open_file.write(doc.toprettyxml())
         # One last fix, add CDATA.
         with open(self.main_xml) as open_file:
             data = open_file.read()
         data = data.replace('X'*len(WINVER_CHECK), WINVER_CHECK)
-        with open(self.main_xml, 'w') as open_file:
+        with open(self.main_xml, 'w', encoding='utf-8') as open_file:
             open_file.write(data)
 
     def build_features(self, top_feature, staging_dir):

--- a/packaging/createpkg.py
+++ b/packaging/createpkg.py
@@ -91,7 +91,7 @@ class PkgGenerator:
         # ElementTree cannot do pretty-printing, so do it manually
         import xml.dom.minidom
         doc = xml.dom.minidom.parse(self.distribution_file)
-        with open(self.distribution_file, 'w') as open_file:
+        with open(self.distribution_file, 'w', encoding='utf-8') as open_file:
             open_file.write(doc.toprettyxml())
 
     def remove_tempfiles(self):

--- a/run_meson_command_tests.py
+++ b/run_meson_command_tests.py
@@ -218,7 +218,7 @@ class CommandTests(unittest.TestCase):
         test_command = 'import sys; print(sys.argv[1])'
         env = os.environ.copy()
         del env['MESON_COMMAND_TESTS']
-        with open(script_file, 'w') as f:
+        with open(script_file, 'w', encoding='utf-8') as f:
             f.write('#!/usr/bin/env python3\n\n')
             f.write(f'{test_command}\n')
         self.addCleanup(os.remove, script_file)

--- a/test cases/cmake/11 cmake_module_path/subprojects/cmMod/gen.py
+++ b/test cases/cmake/11 cmake_module_path/subprojects/cmMod/gen.py
@@ -1,4 +1,4 @@
-with open('main.c', 'w') as fp:
+with open('main.c', 'w', encoding='utf-8') as fp:
   print('''
 #include <stdio.h>
 

--- a/test cases/common/105 generatorcustom/catter.py
+++ b/test cases/common/105 generatorcustom/catter.py
@@ -5,7 +5,7 @@ import sys
 output = sys.argv[-1]
 inputs = sys.argv[1:-1]
 
-with open(output, 'w') as ofile:
+with open(output, 'w', encoding='utf-8') as ofile:
     ofile.write('#pragma once\n')
     for i in inputs:
         with open(i) as ifile:

--- a/test cases/common/105 generatorcustom/gen-resx.py
+++ b/test cases/common/105 generatorcustom/gen-resx.py
@@ -5,5 +5,5 @@ import sys
 ofile = sys.argv[1]
 num = sys.argv[2]
 
-with open(ofile, 'w') as f:
+with open(ofile, 'w', encoding='utf-8') as f:
     f.write(f'res{num}\n')

--- a/test cases/common/105 generatorcustom/gen.py
+++ b/test cases/common/105 generatorcustom/gen.py
@@ -9,5 +9,5 @@ with open(ifile) as f:
     resname = f.readline().strip()
 
 templ = 'const char %s[] = "%s";\n'
-with open(ofile, 'w') as f:
+with open(ofile, 'w', encoding='utf-8') as f:
     f.write(templ % (resname, resname))

--- a/test cases/common/110 allgenerate/converter.py
+++ b/test cases/common/110 allgenerate/converter.py
@@ -5,4 +5,4 @@ import sys
 ifile = sys.argv[1]
 ofile = sys.argv[2]
 
-open(ofile, 'w').write(open(ifile).read())
+open(ofile, 'w', encoding='utf-8').write(open(ifile).read())

--- a/test cases/common/123 custom target directory install/docgen.py
+++ b/test cases/common/123 custom target directory install/docgen.py
@@ -11,5 +11,5 @@ except FileExistsError:
     pass
 
 for name in ('a', 'b', 'c'):
-    with open(os.path.join(out, name + '.html'), 'w') as f:
+    with open(os.path.join(out, name + '.html'), 'w', encoding='utf-8') as f:
         f.write(name)

--- a/test cases/common/125 configure file in generator/src/gen.py
+++ b/test cases/common/125 configure file in generator/src/gen.py
@@ -9,5 +9,5 @@ with open(ifile) as f:
     resval = f.readline().strip()
 
 templ = '#define RESULT (%s)\n'
-with open(ofile, 'w') as f:
+with open(ofile, 'w', encoding='utf-8') as f:
     f.write(templ % (resval, ))

--- a/test cases/common/128 build by default targets in tests/write_file.py
+++ b/test cases/common/128 build by default targets in tests/write_file.py
@@ -2,5 +2,5 @@
 
 import sys
 
-with open(sys.argv[1], 'w') as f:
+with open(sys.argv[1], 'w', encoding='utf-8') as f:
     f.write('Test')

--- a/test cases/common/129 build by default/mygen.py
+++ b/test cases/common/129 build by default/mygen.py
@@ -3,6 +3,6 @@
 import sys
 
 ifile = open(sys.argv[1])
-ofile = open(sys.argv[2], 'w')
+ofile = open(sys.argv[2], 'w', encoding='utf-8')
 
 ofile.write(ifile.read())

--- a/test cases/common/13 pch/generated/gen_custom.py
+++ b/test cases/common/13 pch/generated/gen_custom.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
 import sys
 
-with open(sys.argv[1], 'w') as f:
+with open(sys.argv[1], 'w', encoding='utf-8') as f:
     f.write("#define FOO 0")

--- a/test cases/common/13 pch/generated/gen_generator.py
+++ b/test cases/common/13 pch/generated/gen_generator.py
@@ -3,5 +3,5 @@ import sys
 
 with open(sys.argv[1]) as f:
     content = f.read()
-with open(sys.argv[2], 'w') as f:
+with open(sys.argv[2], 'w', encoding='utf-8') as f:
     f.write(content)

--- a/test cases/common/140 custom target multiple outputs/generator.py
+++ b/test cases/common/140 custom target multiple outputs/generator.py
@@ -8,7 +8,7 @@ if len(sys.argv) != 3:
 name = sys.argv[1]
 odir = sys.argv[2]
 
-with open(os.path.join(odir, name + '.h'), 'w') as f:
+with open(os.path.join(odir, name + '.h'), 'w', encoding='utf-8') as f:
     f.write('int func();\n')
-with open(os.path.join(odir, name + '.sh'), 'w') as f:
+with open(os.path.join(odir, name + '.sh'), 'w', encoding='utf-8') as f:
     f.write('#!/bin/bash')

--- a/test cases/common/141 special characters/check_quoting.py
+++ b/test cases/common/141 special characters/check_quoting.py
@@ -24,5 +24,5 @@ for arg in sys.argv[1:]:
         raise RuntimeError('{!r} is {!r} but should be {!r}'.format(name, value, expected[name]))
 
 if output is not None:
-    with open(output, 'w') as f:
+    with open(output, 'w', encoding='utf-8') as f:
         f.write('Success!')

--- a/test cases/common/144 link depends custom target/make_file.py
+++ b/test cases/common/144 link depends custom target/make_file.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
 import sys
 
-with open(sys.argv[1], 'w') as f:
+with open(sys.argv[1], 'w', encoding='utf-8') as f:
     print('# this file does nothing', file=f)

--- a/test cases/common/152 index customtarget/gen_sources.py
+++ b/test cases/common/152 index customtarget/gen_sources.py
@@ -27,10 +27,10 @@ def main():
     parser.add_argument('--code')
     args = parser.parse_args()
 
-    with open(args.header, 'w') as f:
+    with open(args.header, 'w', encoding='utf-8') as f:
         f.write(HEADER)
 
-    with open(args.code, 'w') as f:
+    with open(args.code, 'w', encoding='utf-8') as f:
         f.write(CODE)
 
 

--- a/test cases/common/168 preserve gendir/genprog.py
+++ b/test cases/common/168 preserve gendir/genprog.py
@@ -42,5 +42,5 @@ for i, ifile_name in enumerate(ifiles):
     h_out = ofile_bases[i] + '.h'
     c_out = ofile_bases[i] + '.c'
     os.makedirs(os.path.split(ofile_bases[i])[0], exist_ok=True)
-    open(h_out, 'w').write(h_templ % (proto_name))
-    open(c_out, 'w').write(c_templ % (proto_name, proto_name))
+    open(h_out, 'w', encoding='utf-8').write(h_templ % (proto_name))
+    open(c_out, 'w', encoding='utf-8').write(c_templ % (proto_name, proto_name))

--- a/test cases/common/169 source in dep/generated/genheader.py
+++ b/test cases/common/169 source in dep/generated/genheader.py
@@ -14,4 +14,4 @@ int %s(void) {
 
 funname = open(ifile).readline().strip()
 
-open(ofile, 'w').write(templ % funname)
+open(ofile, 'w', encoding='utf-8').write(templ % funname)

--- a/test cases/common/170 generator link whole/generator.py
+++ b/test cases/common/170 generator link whole/generator.py
@@ -11,13 +11,13 @@ def main():
     hname = os.path.join(out, name + '.h')
     cname = os.path.join(out, name + '.c')
     print(os.getcwd(), hname)
-    with open(hname, 'w') as hfile:
+    with open(hname, 'w', encoding='utf-8') as hfile:
         hfile.write('''
 #pragma once
 #include "export.h"
 int DLL_PUBLIC {name}(void);
 '''.format(name=name))
-    with open(cname, 'w') as cfile:
+    with open(cname, 'w', encoding='utf-8') as cfile:
         cfile.write('''
 #include "{name}.h"
 int {name}(void) {{

--- a/test cases/common/186 test depends/gen.py
+++ b/test cases/common/186 test depends/gen.py
@@ -4,7 +4,7 @@ import sys
 
 
 def main():
-    with open(sys.argv[1], 'w') as out:
+    with open(sys.argv[1], 'w', encoding='utf-8') as out:
         out.write(sys.argv[2])
         out.write('\n')
 

--- a/test cases/common/195 generator in subdir/com/mesonbuild/tooldir/genprog.py
+++ b/test cases/common/195 generator in subdir/com/mesonbuild/tooldir/genprog.py
@@ -42,5 +42,5 @@ for i, ifile_name in enumerate(ifiles):
     h_out = ofile_bases[i] + '.h'
     c_out = ofile_bases[i] + '.c'
     os.makedirs(os.path.split(ofile_bases[i])[0], exist_ok=True)
-    open(h_out, 'w').write(h_templ % (proto_name))
-    open(c_out, 'w').write(c_templ % (proto_name, proto_name))
+    open(h_out, 'w', encoding='utf-8').write(h_templ % (proto_name))
+    open(c_out, 'w', encoding='utf-8').write(c_templ % (proto_name, proto_name))

--- a/test cases/common/202 custom target build by default/docgen.py
+++ b/test cases/common/202 custom target build by default/docgen.py
@@ -8,5 +8,5 @@ out = sys.argv[1]
 os.mkdir(out)
 
 for name in ('a', 'b', 'c'):
-    with open(os.path.join(out, name + '.txt'), 'w') as f:
+    with open(os.path.join(out, name + '.txt'), 'w', encoding='utf-8') as f:
         f.write(name)

--- a/test cases/common/226 link depends indexed custom target/check_arch.py
+++ b/test cases/common/226 link depends indexed custom target/check_arch.py
@@ -9,7 +9,7 @@ exepath = sys.argv[1]
 want_arch = sys.argv[2]
 dummy_output = sys.argv[3]
 
-with open(dummy_output, 'w') as f:
+with open(dummy_output, 'w', encoding='utf-8') as f:
     f.write('')
 
 if not shutil.which('dumpbin'):

--- a/test cases/common/226 link depends indexed custom target/make_file.py
+++ b/test cases/common/226 link depends indexed custom target/make_file.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 import sys
 
-with open(sys.argv[1], 'w') as f:
+with open(sys.argv[1], 'w', encoding='utf-8') as f:
     print('# this file does nothing', file=f)
 
-with open(sys.argv[2], 'w') as f:
+with open(sys.argv[2], 'w', encoding='utf-8') as f:
     print('# this file does nothing', file=f)

--- a/test cases/common/228 custom_target source/x.py
+++ b/test cases/common/228 custom_target source/x.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python3
-with open('x.c', 'w') as f:
+with open('x.c', 'w', encoding='utf-8') as f:
     print('int main(void) { return 0; }', file=f)
-with open('y', 'w'):
+with open('y', 'w', encoding='utf-8'):
     pass

--- a/test cases/common/242 custom target feed/my_compiler.py
+++ b/test cases/common/242 custom target feed/my_compiler.py
@@ -10,5 +10,5 @@ if __name__ == '__main__':
     if ifile != 'This is a text only input file.\n':
         print('Malformed input')
         sys.exit(1)
-    with open(sys.argv[1], 'w+') as f:
+    with open(sys.argv[1], 'w+', encoding='utf-8') as f:
         f.write('This is a binary output file.')

--- a/test cases/common/271 env in generator.process/generate_main.py
+++ b/test cases/common/271 env in generator.process/generate_main.py
@@ -6,6 +6,6 @@ ENV_VAR_VALUE = os.environ.get('ENV_VAR_VALUE')
 assert ENV_VAR_VALUE is not None
 
 with open(sys.argv[1], 'r') as infile, \
-     open(sys.argv[2], 'w') as outfile:
-    
+     open(sys.argv[2], 'w', encoding='utf-8') as outfile:
+
     outfile.write(infile.read().replace('ENV_VAR_VALUE', ENV_VAR_VALUE))

--- a/test cases/common/274 customtarget exe for test/generate.py
+++ b/test cases/common/274 customtarget exe for test/generate.py
@@ -9,6 +9,6 @@ raise SystemExit({})
 '''
 
 for i, a in enumerate(sys.argv[1:]):
-    with open(a, 'w') as f:
+    with open(a, 'w', encoding='utf-8') as f:
         print(program.format(i), file=f)
     os.chmod(a, 0o755)

--- a/test cases/common/295 depends in generator.process/generate_config.py
+++ b/test cases/common/295 depends in generator.process/generate_config.py
@@ -3,7 +3,7 @@
 import configparser
 import sys
 
-with open(sys.argv[2], 'w') as outfile:
+with open(sys.argv[2], 'w', encoding='utf-8') as outfile:
     config = configparser.ConfigParser()
     config.read(sys.argv[1])
 

--- a/test cases/common/295 depends in generator.process/generate_main.py
+++ b/test cases/common/295 depends in generator.process/generate_main.py
@@ -2,6 +2,6 @@
 import sys
 
 with open(sys.argv[1], 'r') as infile, \
-     open(sys.argv[2], 'w') as outfile:
+     open(sys.argv[2], 'w', encoding='utf-8') as outfile:
 
     outfile.write(infile.read())

--- a/test cases/common/49 custom target/depfile/dep.py
+++ b/test cases/common/49 custom target/depfile/dep.py
@@ -9,7 +9,7 @@ depfiles = glob(os.path.join(srcdir, '*'))
 
 quoted_depfiles = [x.replace(' ', r'\ ') for x in depfiles]
 
-with open(output, 'w') as f:
+with open(output, 'w', encoding='utf-8') as f:
     f.write('I am the result of globbing.')
-with open(depfile, 'w') as f:
+with open(depfile, 'w', encoding='utf-8') as f:
     f.write('{}: {}\n'.format(output, ' '.join(quoted_depfiles)))

--- a/test cases/common/49 custom target/my_compiler.py
+++ b/test cases/common/49 custom target/my_compiler.py
@@ -18,5 +18,5 @@ if __name__ == '__main__':
     if ifile != 'This is a text only input file.\n':
         print('Malformed input')
         sys.exit(1)
-    with open(args[2].split('=', 1)[1], 'w') as ofile:
+    with open(args[2].split('=', 1)[1], 'w', encoding='utf-8') as ofile:
         ofile.write('This is a binary output file.\n')

--- a/test cases/common/50 custom target chain/my_compiler.py
+++ b/test cases/common/50 custom target chain/my_compiler.py
@@ -11,5 +11,5 @@ if __name__ == '__main__':
     if ifile != 'This is a text only input file.\n':
         print('Malformed input')
         sys.exit(1)
-    with open(sys.argv[2], 'w') as ofile:
+    with open(sys.argv[2], 'w', encoding='utf-8') as ofile:
         ofile.write('This is a binary output file.\n')

--- a/test cases/common/50 custom target chain/my_compiler2.py
+++ b/test cases/common/50 custom target chain/my_compiler2.py
@@ -11,5 +11,5 @@ if __name__ == '__main__':
     if ifile != 'This is a binary output file.\n':
         print('Malformed input')
         sys.exit(1)
-    with open(sys.argv[2], 'w') as ofile:
+    with open(sys.argv[2], 'w', encoding='utf-8') as ofile:
         ofile.write('This is a different binary output file.\n')

--- a/test cases/common/50 custom target chain/usetarget/subcomp.py
+++ b/test cases/common/50 custom target chain/usetarget/subcomp.py
@@ -3,5 +3,5 @@
 import sys
 
 with open(sys.argv[1], 'rb') as ifile:
-    with open(sys.argv[2], 'w') as ofile:
+    with open(sys.argv[2], 'w', encoding='utf-8') as ofile:
         ofile.write('Everything ok.\n')

--- a/test cases/common/53 install script/customtarget.py
+++ b/test cases/common/53 install script/customtarget.py
@@ -9,9 +9,9 @@ def main() -> None:
     parser.add_argument('dirname')
     args = parser.parse_args()
 
-    with open(os.path.join(args.dirname, '1.txt'), 'w') as f:
+    with open(os.path.join(args.dirname, '1.txt'), 'w', encoding='utf-8') as f:
         f.write('')
-    with open(os.path.join(args.dirname, '2.txt'), 'w') as f:
+    with open(os.path.join(args.dirname, '2.txt'), 'w', encoding='utf-8') as f:
         f.write('')
 
 

--- a/test cases/common/53 install script/myinstall.py
+++ b/test cases/common/53 install script/myinstall.py
@@ -27,7 +27,7 @@ def main() -> None:
             if dry_run:
                 print(f'DRYRUN: Writing file {name}')
             else:
-                with open(os.path.join(dirname, name), 'w') as f:
+                with open(os.path.join(dirname, name), 'w', encoding='utf-8') as f:
                     f.write('')
     else:
         for name in args.files:

--- a/test cases/common/53 install script/src/myinstall.py
+++ b/test cases/common/53 install script/src/myinstall.py
@@ -10,5 +10,5 @@ dirname = os.path.join(prefix, sys.argv[1])
 if not os.path.exists(dirname):
     os.makedirs(dirname)
 
-with open(os.path.join(dirname, sys.argv[2] + '.in'), 'w') as f:
+with open(os.path.join(dirname, sys.argv[2] + '.in'), 'w', encoding='utf-8') as f:
     f.write('')

--- a/test cases/common/54 custom target source output/generator.py
+++ b/test cases/common/54 custom target source output/generator.py
@@ -7,9 +7,9 @@ if len(sys.argv) != 2:
 
 odir = sys.argv[1]
 
-with open(os.path.join(odir, 'mylib.h'), 'w') as f:
+with open(os.path.join(odir, 'mylib.h'), 'w', encoding='utf-8') as f:
     f.write('int func(void);\n')
-with open(os.path.join(odir, 'mylib.c'), 'w') as f:
+with open(os.path.join(odir, 'mylib.c'), 'w', encoding='utf-8') as f:
     f.write('''int func(void) {
     return 0;
 }

--- a/test cases/common/57 custom header generator/makeheader.py
+++ b/test cases/common/57 custom header generator/makeheader.py
@@ -8,5 +8,5 @@ import sys
 template = '#define RET_VAL %s\n'
 with open(sys.argv[1]) as f:
     output = template % (f.readline().strip(), )
-with open(sys.argv[2], 'w') as f:
+with open(sys.argv[2], 'w', encoding='utf-8') as f:
     f.write(output)

--- a/test cases/common/58 multiple generators/mygen.py
+++ b/test cases/common/58 multiple generators/mygen.py
@@ -13,9 +13,9 @@ outdir = sys.argv[2]
 outhdr = os.path.join(outdir, 'source%s.h' % val)
 outsrc = os.path.join(outdir, 'source%s.cpp' % val)
 
-with open(outhdr, 'w') as f:
+with open(outhdr, 'w', encoding='utf-8') as f:
     f.write('int func%s();\n' % val)
-with open(outsrc, 'w') as f:
+with open(outsrc, 'w', encoding='utf-8') as f:
     f.write('''int func%s() {
     return 0;
 }

--- a/test cases/common/65 build always/version_gen.py
+++ b/test cases/common/65 build always/version_gen.py
@@ -19,7 +19,7 @@ def generate(infile, outfile, fallback):
             return
     except OSError:
         pass
-    with open(outfile, 'w') as f:
+    with open(outfile, 'w', encoding='utf-8') as f:
         f.write(newdata)
 
 if __name__ == '__main__':

--- a/test cases/common/69 configure file in custom target/src/mycompiler.py
+++ b/test cases/common/69 configure file in custom target/src/mycompiler.py
@@ -5,5 +5,5 @@ import sys
 with open(sys.argv[1]) as ifile:
     if ifile.readline().strip() != '42':
         print('Incorrect input')
-with open(sys.argv[2], 'w') as ofile:
+with open(sys.argv[2], 'w', encoding='utf-8') as ofile:
     ofile.write('Success\n')

--- a/test cases/common/71 ctarget dependency/gen1.py
+++ b/test cases/common/71 ctarget dependency/gen1.py
@@ -8,5 +8,5 @@ time.sleep(0.5)
 
 with open(sys.argv[1]) as f:
     contents = f.read()
-with open(sys.argv[2], 'w') as f:
+with open(sys.argv[2], 'w', encoding='utf-8') as f:
     f.write(contents)

--- a/test cases/common/71 ctarget dependency/gen2.py
+++ b/test cases/common/71 ctarget dependency/gen2.py
@@ -6,5 +6,5 @@ from glob import glob
 files = glob(os.path.join(sys.argv[1], '*.tmp'))
 assert len(files) == 1
 
-with open(files[0]) as ifile, open(sys.argv[2], 'w') as ofile:
+with open(files[0]) as ifile, open(sys.argv[2], 'w', encoding='utf-8') as ofile:
     ofile.write(ifile.read())

--- a/test cases/common/8 install/gendir.py
+++ b/test cases/common/8 install/gendir.py
@@ -5,4 +5,4 @@ import sys, os
 dirname = sys.argv[1]
 fname = os.path.join(dirname, 'file.txt')
 os.makedirs(dirname, exist_ok=True)
-open(fname, 'w').close()
+open(fname, 'w', encoding='utf-8').close()

--- a/test cases/common/86 private include/stlib/compiler.py
+++ b/test cases/common/86 private include/stlib/compiler.py
@@ -26,7 +26,7 @@ hfile = os.path.join(outdir, base + '.h')
 c_code = c_templ % (base, base)
 h_code = h_templ % base
 
-with open(cfile, 'w') as f:
+with open(cfile, 'w', encoding='utf-8') as f:
     f.write(c_code)
-with open(hfile, 'w') as f:
+with open(hfile, 'w', encoding='utf-8') as f:
     f.write(h_code)

--- a/test cases/common/88 dep fallback/subprojects/boblib/genbob.py
+++ b/test cases/common/88 dep fallback/subprojects/boblib/genbob.py
@@ -2,5 +2,5 @@
 
 import sys
 
-with open(sys.argv[1], 'w') as f:
+with open(sys.argv[1], 'w', encoding='utf-8') as f:
     f.write('')

--- a/test cases/common/90 gen extra/srcgen.py
+++ b/test cases/common/90 gen extra/srcgen.py
@@ -23,5 +23,5 @@ with open(options.input) as f:
 if options.upper:
     funcname = funcname.upper()
 
-with open(options.output, 'w') as f:
+with open(options.output, 'w', encoding='utf-8') as f:
     f.write(c_templ % funcname)

--- a/test cases/common/90 gen extra/srcgen2.py
+++ b/test cases/common/90 gen extra/srcgen2.py
@@ -19,7 +19,7 @@ with open(options.input) as f:
 
 
 output_c = os.path.join(options.target_dir, options.stem + ".tab.c")
-with open(output_c, 'w') as f:
+with open(output_c, 'w', encoding='utf-8') as f:
     f.write(content)
 
 
@@ -28,5 +28,5 @@ h_content = '''#pragma once
 
 int myfun(void);
 '''
-with open(output_h, 'w') as f:
+with open(output_h, 'w', encoding='utf-8') as f:
     f.write(h_content)

--- a/test cases/common/95 manygen/subdir/manygen.py
+++ b/test cases/common/95 manygen/subdir/manygen.py
@@ -40,21 +40,21 @@ outc = os.path.join(outdir, funcname + '.c')
 tmpc = 'diibadaaba.c'
 tmpo = 'diibadaaba' + objsuffix
 
-with open(outc, 'w') as f:
+with open(outc, 'w', encoding='utf-8') as f:
     f.write('''#include"{}.h"
 int {}_in_src(void) {{
   return 0;
 }}
 '''.format(funcname, funcname))
 
-with open(outh, 'w') as f:
+with open(outh, 'w', encoding='utf-8') as f:
     f.write('''#pragma once
 int {}_in_lib(void);
 int {}_in_obj(void);
 int {}_in_src(void);
 '''.format(funcname, funcname, funcname))
 
-with open(tmpc, 'w') as f:
+with open(tmpc, 'w', encoding='utf-8') as f:
     f.write('''int %s_in_obj(void) {
   return 0;
 }
@@ -65,7 +65,7 @@ if is_vs:
 else:
     subprocess.check_call(compiler + ['-c', '-o', outo, tmpc])
 
-with open(tmpc, 'w') as f:
+with open(tmpc, 'w', encoding='utf-8') as f:
     f.write('''int %s_in_lib() {
   return 0;
 }

--- a/test cases/cython/2 generated sources/gen.py
+++ b/test cases/cython/2 generated sources/gen.py
@@ -7,7 +7,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument('output')
 args = parser.parse_args()
 
-with open(args.output, 'w') as f:
+with open(args.output, 'w', encoding='utf-8') as f:
     f.write(textwrap.dedent('''\
         cpdef func():
             return "Hello, World!"

--- a/test cases/cython/2 generated sources/generator.py
+++ b/test cases/cython/2 generated sources/generator.py
@@ -8,5 +8,5 @@ parser.add_argument('input')
 parser.add_argument('output')
 args = parser.parse_args()
 
-with open(args.input) as i, open(args.output, 'w') as o:
+with open(args.input) as i, open(args.output, 'w', encoding='utf-8') as o:
     o.write(i.read())

--- a/test cases/cython/2 generated sources/libdir/gen.py
+++ b/test cases/cython/2 generated sources/libdir/gen.py
@@ -7,7 +7,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument('output')
 args = parser.parse_args()
 
-with open(args.output, 'w') as f:
+with open(args.output, 'w', encoding='utf-8') as f:
     f.write(textwrap.dedent('''\
         cpdef func():
             return "Hello, World!"

--- a/test cases/failing/40 custom target outputs not matching install_dirs/generator.py
+++ b/test cases/failing/40 custom target outputs not matching install_dirs/generator.py
@@ -8,9 +8,9 @@ if len(sys.argv) != 3:
 name = sys.argv[1]
 odir = sys.argv[2]
 
-with open(os.path.join(odir, name + '.h'), 'w') as f:
+with open(os.path.join(odir, name + '.h'), 'w', encoding='utf-8') as f:
     f.write('int func();\n')
-with open(os.path.join(odir, name + '.c'), 'w') as f:
+with open(os.path.join(odir, name + '.c'), 'w', encoding='utf-8') as f:
     f.write('int main(int argc, char *argv[]) { return 0; }')
-with open(os.path.join(odir, name + '.sh'), 'w') as f:
+with open(os.path.join(odir, name + '.sh'), 'w', encoding='utf-8') as f:
     f.write('#!/bin/bash')

--- a/test cases/frameworks/10 gtk-doc/include/generate-enums-docbook.py
+++ b/test cases/frameworks/10 gtk-doc/include/generate-enums-docbook.py
@@ -49,7 +49,7 @@ DOC_FOOTER = '''
 
 if __name__ == '__main__':
     if len(sys.argv) >= 4:
-        with open(sys.argv[1], 'w') as doc_out:
+        with open(sys.argv[1], 'w', encoding='utf-8') as doc_out:
             enum_name = sys.argv[2]
             enum_type = sys.argv[3]
 

--- a/test cases/python/4 custom target depends extmodule/blaster.py
+++ b/test cases/python/4 custom target depends extmodule/blaster.py
@@ -22,7 +22,7 @@ options = parser.parse_args(sys.argv[1:])
 result = tachyon.phaserize('shoot')
 
 if options.output:
-    with open(options.output, 'w') as f:
+    with open(options.output, 'w', encoding='utf-8') as f:
         f.write('success')
 
 if not isinstance(result, int):

--- a/test cases/python3/4 custom target depends extmodule/blaster.py
+++ b/test cases/python3/4 custom target depends extmodule/blaster.py
@@ -23,7 +23,7 @@ options = parser.parse_args(sys.argv[1:])
 result = tachyon.phaserize('shoot')
 
 if options.output:
-    with open(options.output, 'w') as f:
+    with open(options.output, 'w', encoding='utf-8') as f:
         f.write('success')
 
 if not isinstance(result, int):

--- a/test cases/rust/11 generated main/gen.py
+++ b/test cases/rust/11 generated main/gen.py
@@ -9,7 +9,7 @@ def main() -> None:
     parser.add_argument('--mode', choices=['main', 'lib'], default='main')
     args = parser.parse_args()
 
-    with open(args.out, 'w') as f:
+    with open(args.out, 'w', encoding='utf-8') as f:
         if args.mode == 'main':
             f.write('fn main() { println!("I prefer tarnish, actually.") }')
         elif args.mode == 'lib':

--- a/test cases/rust/19 structured sources/gen.py
+++ b/test cases/rust/19 structured sources/gen.py
@@ -9,7 +9,7 @@ def main() -> None:
     parser.add_argument('output')
     args = parser.parse_args()
 
-    with open(args.output, 'w') as f:
+    with open(args.output, 'w', encoding='utf-8') as f:
         f.write(textwrap.dedent('''\
             pub fn bar() -> () {
                 println!("Hello, World!");

--- a/test cases/unit/26 install umask/myinstall.py
+++ b/test cases/unit/26 install umask/myinstall.py
@@ -13,5 +13,5 @@ except FileExistsError:
     if not os.path.isdir(dirname):
         raise
 
-with open(os.path.join(dirname, sys.argv[2]), 'w') as f:
+with open(os.path.join(dirname, sys.argv[2]), 'w', encoding='utf-8') as f:
     f.write('')

--- a/test cases/unit/94 custominc/easytogrepfor/genh.py
+++ b/test cases/unit/94 custominc/easytogrepfor/genh.py
@@ -2,6 +2,6 @@
 
 import sys
 
-f = open(sys.argv[1], 'w')
+f = open(sys.argv[1], 'w', encoding='utf-8')
 f.write('#define RETURN_VALUE 0')
 f.close()

--- a/test cases/unit/98 install all targets/script.py
+++ b/test cases/unit/98 install all targets/script.py
@@ -3,5 +3,5 @@
 import sys
 
 for f in sys.argv[1:]:
-  with open(f, 'w') as f:
+  with open(f, 'w', encoding='utf-8') as f:
       pass

--- a/test cases/unit/98 install all targets/subdir/script.py
+++ b/test cases/unit/98 install all targets/subdir/script.py
@@ -3,5 +3,5 @@
 import sys
 
 for f in sys.argv[1:]:
-  with open(f, 'w') as f:
+  with open(f, 'w', encoding='utf-8') as f:
       pass

--- a/test cases/vala/10 mixed sources/c/writec.py
+++ b/test cases/vala/10 mixed sources/c/writec.py
@@ -8,5 +8,5 @@ retval(void) {
 }
 '''
 
-with open(sys.argv[1], 'w') as f:
+with open(sys.argv[1], 'w', encoding='utf-8') as f:
     f.write(c)

--- a/test cases/vala/8 generated sources/src/write_wrapper.py
+++ b/test cases/vala/8 generated sources/src/write_wrapper.py
@@ -8,5 +8,5 @@ void print_wrapper(string arg) {
 }
 '''
 
-with open(sys.argv[1], 'w') as f:
+with open(sys.argv[1], 'w', encoding='utf-8') as f:
     f.write(contents)

--- a/test cases/windows/10 vs module defs generated custom target/subdir/make_def.py
+++ b/test cases/windows/10 vs module defs generated custom target/subdir/make_def.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import sys
 
-with open(sys.argv[1], 'w') as f:
+with open(sys.argv[1], 'w', encoding='utf-8') as f:
     print('EXPORTS', file=f)
     print('        somedllfunc', file=f)

--- a/test cases/windows/12 resources with custom targets/res/gen-res.py
+++ b/test cases/windows/12 resources with custom targets/res/gen-res.py
@@ -2,5 +2,5 @@
 
 import sys
 
-with open(sys.argv[1]) as infile, open(sys.argv[2], 'w') as outfile:
+with open(sys.argv[1]) as infile, open(sys.argv[2], 'w', encoding='utf-8') as outfile:
     outfile.write(infile.read().format(icon=sys.argv[3]))


### PR DESCRIPTION
This was generated with a regex search/replace in vscode using: `(open\(.*, 'w\+?')` -> `$1, encoding='utf-8')`

This should silence a bunch of warnings.