### PR TITLE
build: fix install name when using link_whole

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1331,7 +1331,7 @@ class BuildTarget(Target):
     @lru_cache(maxsize=None)
     def get_transitive_link_deps_mapping(self, prefix: str) -> T.Mapping[str, str]:
         result: T.Dict[str, str] = {}
-        for i in self.link_targets:
+        for i in itertools.chain(self.link_targets, self.link_whole_targets):
             mapping = i.get_link_deps_mapping(prefix)
             #we are merging two dictionaries, while keeping the earlier one dominant
             result_tmp = mapping.copy()

--- a/test cases/darwin/1 rpath removal on install/meson.build
+++ b/test cases/darwin/1 rpath removal on install/meson.build
@@ -15,3 +15,8 @@ main = executable('main', 'main.c',
   link_with: bar_internal,
   install: true,
 )
+
+main_whole = executable('main-whole', 'main.c',
+  link_whole: bar_internal,
+  install: true,
+)

--- a/unittests/darwintests.py
+++ b/unittests/darwintests.py
@@ -182,6 +182,8 @@ class DarwinTests(BasePlatformTests):
         self.assertListEqual(rpaths, [])
         libs = self._get_darwin_rpath_libraries(os.path.join(self.installdir, 'usr/bin/main'))
         self.assertListEqual(libs, [])
+        libs = self._get_darwin_rpath_libraries(os.path.join(self.installdir, 'usr/bin/main-whole'))
+        self.assertListEqual(libs, [])
 
     @skip_if_not_language('rust')
     def test_rust_apple_framework_rlib(self):


### PR DESCRIPTION
This is done by [mesa](https://gitlab.freedesktop.org/mesa/mesa/-/blob/642bed9eba724132c5e0802fac99af11b9ef7841/src/glx/meson.build#L123).