### PR TITLE
ninja: Respect preserve_path_from for depfiles

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2839,6 +2839,9 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             else:
                 rulename = 'CUSTOM_COMMAND_DEP'
                 depfilename = generator.get_dep_outname(infilename)
+                if genlist.preserve_path_from:
+                    path_segment = genlist.get_preserved_path_segment(curfile)
+                    depfilename = os.path.join(path_segment, depfilename)
                 depfile = os.path.join(self.get_target_private_dir(target), depfilename)
                 args = [x.replace('@DEPFILE@', depfile) for x in base_args]
             args = [x.replace("@INPUT@", infilename).replace('@OUTPUT@', sole_output)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2088,7 +2088,7 @@ class Generator(HoldableObject):
         bases = [x.replace('@BASENAME@', basename).replace('@PLAINNAME@', plainname) for x in self.outputs]
         return bases
 
-    def get_dep_outname(self, inname: str) -> T.List[str]:
+    def get_dep_outname(self, inname: str) -> str:
         if self.depfile is None:
             raise InvalidArguments('Tried to get dep name for rule that does not have dependency file defined.')
         plainname = os.path.basename(inname)
@@ -2134,7 +2134,7 @@ class Generator(HoldableObject):
                     if not is_parent_path(preserve_path_from, abs_f):
                         raise InvalidArguments('generator.process: When using preserve_path_from, all input files must be in a subdirectory of the given dir.')
                 f = FileMaybeInTargetPrivateDir(f)
-                output.add_file(f, self.environment)
+                output.add_file(f)
         return output
 
 
@@ -2179,21 +2179,18 @@ class GeneratedList(HoldableObject):
                 # know the absolute path of
                 self.depend_files.append(File.from_absolute_file(path))
 
-    def add_preserved_path_segment(self, infile: FileMaybeInTargetPrivateDir, outfiles: T.List[str], environment: Environment) -> T.List[str]:
-        result: T.List[str] = []
-        in_abs = infile.absolute_path(environment.source_dir, environment.build_dir)
+    def get_preserved_path_segment(self, infile: FileMaybeInTargetPrivateDir) -> str:
+        in_abs = infile.absolute_path(self.generator.environment.source_dir, self.generator.environment.build_dir)
         assert os.path.isabs(self.preserve_path_from)
         rel = os.path.relpath(in_abs, self.preserve_path_from)
-        path_segment = os.path.dirname(rel)
-        for of in outfiles:
-            result.append(os.path.join(path_segment, of))
-        return result
+        return os.path.dirname(rel)
 
-    def add_file(self, newfile: FileMaybeInTargetPrivateDir, environment: Environment) -> None:
+    def add_file(self, newfile: FileMaybeInTargetPrivateDir) -> None:
         self.infilelist.append(newfile)
         outfiles = self.generator.get_base_outnames(newfile.fname)
         if self.preserve_path_from:
-            outfiles = self.add_preserved_path_segment(newfile, outfiles, environment)
+            path_segment = self.get_preserved_path_segment(newfile)
+            outfiles = [os.path.join(path_segment, of) for of in outfiles]
         self.outfilelist += outfiles
         self.outmap[newfile] = outfiles
 

--- a/test cases/common/168 preserve gendir/meson.build
+++ b/test cases/common/168 preserve gendir/meson.build
@@ -4,7 +4,8 @@ gprog = find_program('genprog.py')
 
 gen = generator(gprog, \
   output    : ['@BASENAME@.c', '@BASENAME@.h'],
-  arguments : ['--searchdir=@CURRENT_SOURCE_DIR@', '--outdir=@BUILD_DIR@', '@INPUT@'])
+  arguments : ['--searchdir=@CURRENT_SOURCE_DIR@', '--outdir=@BUILD_DIR@', '@INPUT@'],
+  depfile   : '@BASENAME@.d')
 
 generated = gen.process('base.inp', 'com/mesonbuild/subbie.inp',
   preserve_path_from : meson.current_source_dir())


### PR DESCRIPTION
## Description

The path for `DEPFILE` does not respect `preserve_path_from` when it is specified by `generator.process`. Using `test cases/common/168 preserve gendir` as an example, this results in the following generated Ninja rules:

```ninja
build testprog.p/base.c testprog.p/base.h: CUSTOM_COMMAND_DEP ../base.inp | /home/rachel/code/git/meson/test$ cases/common/168$ preserve$ gendir/genprog.py
 DEPFILE = testprog.p/base.d
 DEPFILE_UNQUOTED = testprog.p/base.d
 DESC = Generating$ from$ 'base.inp'
 COMMAND = '/home/rachel/code/git/meson/test$ cases/common/168$ preserve$ gendir/genprog.py' --searchdir=.. --outdir=testprog.p ../base.inp

build testprog.p/com/mesonbuild/subbie.c testprog.p/com/mesonbuild/subbie.h: CUSTOM_COMMAND_DEP ../com/mesonbuild/subbie.inp | /home/rachel/code/git/meson/test$ cases/common/168$ preserve$ gendir/genprog.py
 DEPFILE = testprog.p/subbie.d
 DEPFILE_UNQUOTED = testprog.p/subbie.d
 DESC = Generating$ from$ 'com/mesonbuild/subbie.inp'
 COMMAND = '/home/rachel/code/git/meson/test$ cases/common/168$ preserve$ gendir/genprog.py' --searchdir=.. --outdir=testprog.p ../com/mesonbuild/subbie.inp
```

While this works for *this* set of outputs, it is inconsistent with the behavior of `@BASENAME@` substitutions, which are already updated for Ninja's explicit outputs to include the preserved subpath in the private directory. Further, it breaks a potential use-case for using `preserve_path_from` where many input files share a base filename and use a component of the subpath for deduping. e.g., in one of my projects, we have the following:

```
.
├── absorb/anim.s
├── acid/anim.s
├── acid_armor/anim.s
└── ...etc...
```

Without preserving the subpath in `DEPFILE`, all of these generated targets wind up with the same `DEPFILE` value of `example.p/anim.d`, which creates a race condition in Ninja's depfile ingestion.

## Testing

With the fix, the observed output in `test cases/common/168 preserve gendir` is:

```ninja
build testprog.p/base.c testprog.p/base.h: CUSTOM_COMMAND_DEP ../base.inp | /home/rachel/code/git/meson/test$ cases/common/168$ preserve$ gendir/genprog.py
 DEPFILE = testprog.p/base.d
 DEPFILE_UNQUOTED = testprog.p/base.d
 DESC = Generating$ from$ 'base.inp'
 COMMAND = '/home/rachel/code/git/meson/test$ cases/common/168$ preserve$ gendir/genprog.py' --searchdir=.. --outdir=testprog.p ../base.inp

build testprog.p/com/mesonbuild/subbie.c testprog.p/com/mesonbuild/subbie.h: CUSTOM_COMMAND_DEP ../com/mesonbuild/subbie.inp | /home/rachel/code/git/meson/test$ cases/common/168$ preserve$ gendir/genprog.py
 DEPFILE = testprog.p/com/mesonbuild/subbie.d
 DEPFILE_UNQUOTED = testprog.p/com/mesonbuild/subbie.d
 DESC = Generating$ from$ 'com/mesonbuild/subbie.inp'
 COMMAND = '/home/rachel/code/git/meson/test$ cases/common/168$ preserve$ gendir/genprog.py' --searchdir=.. --outdir=testprog.p ../com/mesonbuild/subbie.inp
```

> [!IMPORTANT]
> Are there any tests that analyze the Ninja output programmatically? A short `grep` for `'ninja'` in the `test cases/common` directory did not turn up any matches.