### PR TITLE
Re-evaluate host machine arch on Xcode backend generate

### DIFF
--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -254,9 +254,7 @@ class XCodeBackend(backends.Backend):
         self.regen_dependency_id = self.gen_id()
         self.top_level_dict = PbxDict()
         self.generator_outputs = {}
-        self.arch = self.build.environment.machines.host.cpu
-        if self.arch == 'aarch64':
-            self.arch = 'arm64'
+        self.set_arch()
         self.xcodeversion, self.objversion = autodetect_xcode_version()
         # In Xcode files are not accessed via their file names, but rather every one of them
         # gets an unique id. More precisely they get one unique id per target they are used
@@ -310,7 +308,14 @@ class XCodeBackend(backends.Backend):
             result.append(os.path.join(self.environment.get_build_dir(), self.get_target_dir(l)))
         return result
 
+    def set_arch(self):
+        self.arch = self.build.environment.machines.host.cpu
+        if self.arch == 'aarch64':
+            self.arch = 'arm64'
+
     def generate(self, capture: bool = False, vslite_ctx: T.Optional[T.Dict] = None) -> None:
+        if self.arch is None: # The host machine arch may not be set when backend is created
+            self.set_arch()
         # Check for (currently) unexpected capture arg use cases -
         if capture:
             raise MesonBugException('We do not expect the xcode backend to generate with \'capture = True\'')


### PR DESCRIPTION
Fixes: #14650

If not set explicitly via a host machine file, Meson's Interpreter will _redetect_machines() at the end of initialization. However, the backend is created before this and therefore the host machine arch may be set to None when the Xcode backend is initialized.

---

I am willing to make any revisions this needs to be applied.