### PR TITLE
Merge C++, ObjC language arguments

### DIFF
--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -1756,8 +1756,8 @@ class XCodeBackend(backends.Backend):
                         lang = 'cpp'
                     langs.add(lang)
                     langname = LANGNAMEMAP[lang]
-                    langargs.setdefault(langname, [])
-                    langargs[langname] = cargs + cti_args + args
+                    langargs.setdefault(langname, set())
+                    langargs[langname] |= set(cargs + cti_args + args)
             symroot = os.path.join(self.environment.get_build_dir(), target.subdir).rstrip('/')
             bt_dict = PbxDict()
             objects_dict.add_item(valid, bt_dict, buildtype)


### PR DESCRIPTION
...in Xcode build targets.

From the original author:

    I ran into an issue trying to compile lc0 (Leela Chess Zero
    engine) with Meson where a compiler option -DNO_PEXT was not
    being passed to clang. This was because the lc0@exe target
    had both cpp, objc languages and the latter language's project
    arguments were overriding the cpp language options. I'm assuming
    that since objc options are set as cpp options, the options for
    both languages need to be merged. After doing this, the Xcode
    build for lc0 succeeds.

---

Again, following up after the original submitter apparently rage-quit.