### PR TITLE
tests: skip importstd with gcc on Windows

### DIFF
--- a/test cases/common/288 importstd/meson.build
+++ b/test cases/common/288 importstd/meson.build
@@ -5,8 +5,11 @@ cpp = meson.get_compiler('cpp')
 
 cpp_id = cpp.get_id()
 cpp_version = cpp.version()
+is_windows = host_machine.system() == 'windows'
 
-if cpp_id == 'gcc' and cpp_version.version_compare('>=15.3')
+# gcc 16 on Windows fails with "undefined reference to 'std::__open_terminal(_iobuf*)'"
+# clang 22 + mingw-w64 on Windows fails with "fatal error: module 'std' not found"
+if not is_windows and cpp_id == 'gcc' and cpp_version.version_compare('>=15.3')
   # Versions between 15.0 and 15.2 are too unreliable to test.
   # The same version number of GCC works in some distros
   # but fails in others.


### PR DESCRIPTION
It's failing since we updated from gcc 15.2 to 16.1 in MSYS2.

The test was checking for an unreleased 15.3 so the test was never run on Windows to begin with. Just skip it with gcc on Windows.

fyi, it fails with:
undefined reference to 'std::__open_terminal(_iobuf*)'
undefined reference to 'std::__write_to_terminal(void*, std::span<char, 4294967295u>)'