### PR TITLE
modules: qt: probe libexec before bin for Qt6

### DIFF
--- a/mesonbuild/modules/_qt.py
+++ b/mesonbuild/modules/_qt.py
@@ -229,10 +229,13 @@ class QtBaseModule(ExtensionModule):
 
         def gen_bins() -> T.Generator[T.Tuple[str, str], None, None]:
             for b in self.tools:
-                if qt_dep.bindir:
-                    yield os.path.join(qt_dep.bindir, b), b
-                if qt_dep.libexecdir:
-                    yield os.path.join(qt_dep.libexecdir, b), b
+                if self.qt_version >= 6 and b != 'lrelease':
+                    dirs = [qt_dep.libexecdir, qt_dep.bindir]
+                else:
+                    dirs = [qt_dep.bindir, qt_dep.libexecdir]
+                for d in dirs:
+                    if d:
+                        yield os.path.join(d, b), b
                 # prefer the (official) <tool><version> or (unofficial) <tool>-qt<version>
                 # of the tool to the plain one, as we
                 # don't know what the unsuffixed one points to without calling it.


### PR DESCRIPTION
Qt6 moved all tools (at least those Meson cares about by default) except `lrelease` from `bin` to `libexec`. Update order of probing in `QtBaseModule.compilers_detect` accordingly to avoid some _"... found: NO"_ messages in Meson's output.

Before:

```
Run-time dependency qt6 (modules: Core) found: YES 6.8.3 (pkg-config)
Program /usr/lib64/qt6/bin/uic found: NO
Program /usr/lib64/qt6/libexec/uic found: YES 6.8.3 6.8.3 (/usr/lib64/qt6/libexec/uic)
Program /usr/lib64/qt6/bin/moc found: NO
Program /usr/lib64/qt6/libexec/moc found: YES 6.8.3 6.8.3 (/usr/lib64/qt6/libexec/moc)
Program /usr/lib64/qt6/bin/rcc found: NO
Program /usr/lib64/qt6/libexec/rcc found: YES 6.8.3 6.8.3 (/usr/lib64/qt6/libexec/rcc)
Program /usr/lib64/qt6/bin/qmlcachegen found: NO
Program /usr/lib64/qt6/libexec/qmlcachegen found: YES 6.8.3 6.8.3 (/usr/lib64/qt6/libexec/qmlcachegen)
Program /usr/lib64/qt6/bin/qmltyperegistrar found: NO
Program /usr/lib64/qt6/libexec/qmltyperegistrar found: YES 6.8.3 6.8.3 (/usr/lib64/qt6/libexec/qmltyperegistrar)
Program /usr/lib64/qt6/bin/lrelease found: YES 6.8.3 6.8.3 (/usr/lib64/qt6/bin/lrelease)
```

After:

```
Run-time dependency qt6 (modules: Core) found: YES 6.8.3 (pkg-config)
Program /usr/lib64/qt6/bin/lrelease found: YES 6.8.3 6.8.3 (/usr/lib64/qt6/bin/lrelease)
Program /usr/lib64/qt6/libexec/moc found: YES 6.8.3 6.8.3 (/usr/lib64/qt6/libexec/moc)
Program /usr/lib64/qt6/libexec/qmlcachegen found: YES 6.8.3 6.8.3 (/usr/lib64/qt6/libexec/qmlcachegen)
Program /usr/lib64/qt6/libexec/qmltyperegistrar found: YES 6.8.3 6.8.3 (/usr/lib64/qt6/libexec/qmltyperegistrar)
Program /usr/lib64/qt6/libexec/rcc found: YES 6.8.3 6.8.3 (/usr/lib64/qt6/libexec/rcc)
Program /usr/lib64/qt6/libexec/uic found: YES 6.8.3 6.8.3 (/usr/lib64/qt6/libexec/uic)
```