### PR TITLE
gnome: use LDFLAGS for g-ir-scanner

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1006,7 +1006,7 @@ class GnomeModule(ExtensionModule):
         # backslashes, so best avoid them entirely.
         cc_exelist = [pathlib.Path(exe).as_posix() for exe in cc_exelist]
         run_env.set('CC', [quote_arg(x) for x in cc_exelist], ' ')
-        run_env.set('CFLAGS', [quote_arg(x) for x in env_flags], ' ')
+        run_env.set('LDFLAGS', [quote_arg(x) for x in env_flags], ' ')
         run_env.merge(kwargs['env'])
 
         # response file supported?


### PR DESCRIPTION
The flags are for the linker and g-ir-scanner places LDFLAGS at the end of the invocation, unlike CFLAGS. This avoids possible conflicts with build-specific options.