### PR TITLE
interpreter: allow Program for "depends" or custom target "input"

### DIFF
--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -131,8 +131,8 @@ typelib_target]`
 Generates a marshal file using the `glib-genmarshal` tool. The first
 argument is the basename of the output files.
 
-* `depends` [](BuildTarget | CustomTarget | CustomTargetIndex):
-  passed directly to CustomTarget (*since 0.61.0*)
+* `depends` [](BuildTarget | CustomTarget | CustomTargetIndex | Program):
+  passed directly to CustomTarget (*since 0.61.0*; `program` *since 1.11.2*)
 * `depend_files` [](str | File): Passed directly to CustomTarget (*since 0.61.0*)
 * `extra_args`: (*Added 0.42.0*) additional command line arguments to pass
 * `install_dir`: directory to install header to

--- a/docs/markdown/Release-notes-for-1.11.0.md
+++ b/docs/markdown/Release-notes-for-1.11.0.md
@@ -204,3 +204,14 @@ now has an `implicit_include_directories` keyword argument to automatically
 add current build and source directories to the included paths when compiling
 a resource.
 
+## External programs as inputs and dependencies to custom targets
+
+Custom targets now allow specifying an external program in
+the `input` and `depends` keyword arguments.  This also applies
+to several methods provided by modules, as they are lowered to
+custom targets internally. (*Added in 1.11.2*).
+
+## External programs as dependencies to tests
+
+Tests now allow specifying an external program in
+the `depends` keyword argument. (*Added in 1.11.2*).

--- a/docs/yaml/functions/benchmark.yaml
+++ b/docs/yaml/functions/benchmark.yaml
@@ -88,7 +88,7 @@ kwargs:
       for the test
 
   depends:
-    type: array[build_tgt | custom_tgt]
+    type: array[build_tgt | custom_tgt | custom_idx | program]
     since: 0.46.0
     description: |
       specifies that this test depends on the specified
@@ -96,6 +96,7 @@ kwargs:
       line argument. This is meant for cases where test finds those
       targets internally, e.g. plugins or globbing. Those targets are built
       before test is executed even if they have `build_by_default : false`.
+      `program` is supported *since 1.11.2*.
 
   protocol:
     type: str

--- a/docs/yaml/functions/custom_target.yaml
+++ b/docs/yaml/functions/custom_target.yaml
@@ -167,7 +167,7 @@ kwargs:
       argument. Useful for adding regen dependencies.
 
   depends:
-    type: array[build_tgt | custom_tgt | custom_idx]
+    type: array[build_tgt | custom_tgt | custom_idx | program]
     description: |
       Specifies that this target depends on the specified
       target(s), even though it does not take any of them as a command
@@ -175,7 +175,7 @@ kwargs:
       e.g. does globbing internally. Usually you should just put the
       generated sources as inputs and Meson will set up all dependencies
       automatically (custom_idx was unavailable as a type between 0.60
-      and 1.4.0).
+      and 1.4.0).  `program` is supported *since 1.11.2*.
 
   depfile:
     type: str

--- a/docs/yaml/functions/custom_target.yaml
+++ b/docs/yaml/functions/custom_target.yaml
@@ -189,8 +189,10 @@ kwargs:
       are also accepted.
 
   input:
-    type: array[str | file]
-    description: Array of source files. *(since 0.41.0)* the array is flattened.
+    type: array[str | file | program]
+    description: |
+      Array of source files. *(since 0.41.0)* the array is flattened.
+      `program` is supported *since 1.11.2*.
 
   install:
     type: bool

--- a/docs/yaml/functions/generator.yaml
+++ b/docs/yaml/functions/generator.yaml
@@ -50,13 +50,13 @@ kwargs:
 
   depends:
     # Not sure why this is not just `target`
-    type: array[build_tgt | custom_tgt | custom_idx]
+    type: array[build_tgt | custom_tgt | custom_idx | program]
     since: 0.51.0
     description: |
       An array of build targets that must be built before
       this generator can be run. This is used if you have a generator that calls
       a second executable that is built in this project (custom_idx was not
-      available between 0.60 and 1.4.0).
+      available between 0.60 and 1.4.0).  `program` is supported *since 1.11.2*.
 
   depfile:
     type: str

--- a/docs/yaml/functions/run_target.yaml
+++ b/docs/yaml/functions/run_target.yaml
@@ -40,12 +40,13 @@ kwargs:
       the first item will find that command in `PATH` and run it.
 
   depends:
-    type: array[build_tgt | custom_tgt | custom_idx]
+    type: array[build_tgt | custom_tgt | custom_idx | program]
     description: |
       An array of targets that this target depends on but which
       are not listed in the command array (because, for example, the
       script does file globbing internally, custom_idx was not possible
-      as a type between 0.60 and 1.4.0).
+      as a type between 0.60 and 1.4.0). `program` is supported *since
+      1.11.2*.
 
   env:
     since: 0.57.0

--- a/docs/yaml/objects/generator.yaml
+++ b/docs/yaml/objects/generator.yaml
@@ -45,7 +45,7 @@ methods:
           sophisticated environment juggling.
 
       depends:
-        type: array[build_tgt | custom_tgt | custom_idx]
+        type: array[build_tgt | custom_tgt | custom_idx | program]
         since: 1.12.0
         description: |
           An array of build targets that must be built before attempting to run this

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1469,7 +1469,7 @@ class Backend:
             srcs += fname
         return srcs
 
-    def get_target_depend_files(self, target: T.Union[build.CustomTarget, build.BuildTarget], absolute_paths: bool = False) -> T.List[str]:
+    def get_target_depend_files(self, target: T.Union[build.CustomTarget, build.BuildTarget, build.GeneratedList], absolute_paths: bool = False) -> T.List[str]:
         deps: T.List[str] = []
         for i in target.depend_files:
             if isinstance(i, mesonlib.File):

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1181,11 +1181,12 @@ class Backend:
             exe = t.get_exe()
             if isinstance(exe, build.LocalProgram):
                 exe = exe.program
-            if isinstance(exe, programs.Program):
-                cmd = exe.get_command()
-            else:
+            if isinstance(exe, (build.BuildTarget, build.CustomTarget, build.CustomTargetIndex)):
                 cmd = [os.path.join(self.environment.get_build_dir(), self.get_target_filename(exe))]
-            if isinstance(exe, (build.BuildTarget, programs.Program)):
+            else:
+                cmd = exe.get_command()
+
+            if isinstance(exe, (build.BuildTarget, programs.ExternalProgram)):
                 test_for_machine = exe.for_machine
             else:
                 # E.g. an external verifier or simulator program run on a generated executable.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1218,16 +1218,14 @@ class Backend:
                 extra_paths = []
 
             cmd_args: T.List[str] = []
-            depends: T.Set[build.Target] = set(t.depends)
-            if isinstance(exe, build.Target):
+            depends: T.Set[build.BuildTargetTypes] = set(t.depends)
+            if isinstance(exe, (build.BuildTarget, build.CustomTarget, build.CustomTargetIndex)):
                 depends.add(exe)
             for a in t.cmd_args:
                 if isinstance(a, build.LocalProgram):
                     a = a.program
-                if isinstance(a, build.Target):
+                if isinstance(a, (build.BuildTarget, build.CustomTarget, build.CustomTargetIndex)):
                     depends.add(a)
-                elif isinstance(a, build.CustomTargetIndex):
-                    depends.add(a.target)
 
                 if isinstance(a, mesonlib.File):
                     a = os.path.join(self.environment.get_build_dir(), a.rel_to_builddir(self.build_to_src))

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -3029,7 +3029,6 @@ class CustomTarget(Target, CustomTargetBase, CommandBase):
         self.depfile = depfile
         self.depfile_type = 'gcc' if depfile else depfile_type
         self.env = env or EnvironmentVariables()
-        self.extra_depends = list(extra_depends or [])
         self.feed = feed
         self.install_dir = list(install_dir or [])
         self.has_custom_install_dir = bool(self.install_dir)
@@ -3043,6 +3042,23 @@ class CustomTarget(Target, CustomTargetBase, CommandBase):
 
         # Whether to enable using response files for the underlying tool
         self.rspable = rspable
+
+        self.extra_depends: T.List[T.Union[GeneratedTypes, BuildTarget]] = []
+        if extra_depends:
+            for d in extra_depends:
+                if isinstance(d, LocalProgram):
+                    d = d.get_target()
+                elif isinstance(d, programs.Program):
+                    path = d.get_path()
+                    # Can only add a dependency on an external program which we
+                    # know the absolute path of
+                    if not os.path.isabs(path):
+                        continue
+                    d = File.from_absolute_file(path)
+                if isinstance(d, File):
+                    self.depend_files.append(d)
+                else:
+                    self.extra_depends.append(d)
 
     def install_dir_names(self) -> T.List[T.Optional[str]]:
         install_dir_names: T.List[T.Optional[str]] = []

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2982,7 +2982,7 @@ class CustomTarget(Target, CustomTargetBase, CommandBase):
                  subproject: str,
                  environment: Environment,
                  command: T.Sequence[T.Union[
-                     str, BuildTargetTypes, GeneratedList,
+                     str, BuildTargetTypes,
                      programs.Program, File]],
                  sources: T.Sequence[CustomTargetSources],
                  outputs: T.List[str],

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -46,6 +46,7 @@ if T.TYPE_CHECKING:
     from .compilers.compilers import Compiler, CompilerDict, Language
     from .interpreter.interpreter import CustomTargetSources, SourceOutputs, Interpreter
     from .interpreter.interpreterobjects import Test, Doctest
+    from .interpreter.kwargs import TargetDepends
     from .linkers.linkers import StaticLinker
     from .mesonlib import ExecutableSerialisation, FileMode, FileOrString
     from .mparser import BaseNode
@@ -2055,13 +2056,13 @@ class Generator(HoldableObject):
                  *,
                  depfile: T.Optional[str] = None,
                  capture: bool = False,
-                 depends: T.Optional[T.List[BuildTargetTypes]] = None,
+                 depends: T.Optional[T.Sequence[TargetDepends]] = None,
                  name: str = 'Generator'):
         self.environment = env
         self.exe = exe
         self.depfile = depfile
         self.capture = capture
-        self.depends: T.List[BuildTargetTypes] = depends or []
+        self.depends: T.List[TargetDepends] = list(depends or [])
         self.arglist = arguments
         self.outputs = output
         self.name = name
@@ -2096,7 +2097,7 @@ class Generator(HoldableObject):
                       preserve_path_from: T.Optional[str] = None,
                       extra_args: T.Optional[T.List[str]] = None,
                       env: T.Optional[EnvironmentVariables] = None,
-                      extra_depends: T.Optional[T.List[GeneratedTypes]] = None) -> 'GeneratedList':
+                      extra_depends: T.Optional[T.Sequence[TargetDepends]] = None) -> 'GeneratedList':
         output = GeneratedList(
             self,
             subdir,
@@ -2139,7 +2140,7 @@ class GeneratedList(HoldableObject):
     preserve_path_from: T.Optional[str]
     extra_args: T.List[str]
     env: T.Optional[EnvironmentVariables]
-    extra_depends: T.List[GeneratedTypes]
+    extra_depends: T.List[TargetDepends]
 
     def __post_init__(self) -> None:
         self.name = self.generator.exe
@@ -2156,7 +2157,7 @@ class GeneratedList(HoldableObject):
             self.env: EnvironmentVariables = EnvironmentVariables()
 
         if self.extra_depends is None:
-            self.extra_depends: T.List[GeneratedTypes] = []
+            self.extra_depends: T.List[TargetDepends] = []
 
         if isinstance(self.generator.exe, programs.Program):
             if not self.generator.exe.found():
@@ -2991,7 +2992,7 @@ class CustomTarget(Target, CustomTargetBase, CommandBase):
                  capture: bool = False,
                  console: bool = False,
                  depend_files: T.Optional[T.Sequence[FileOrString]] = None,
-                 extra_depends: T.Optional[T.Sequence[T.Union[str, SourceOutputs]]] = None,
+                 extra_depends: T.Optional[T.Sequence[TargetDepends]] = None,
                  depfile: T.Optional[str] = None,
                  depfile_type: T.Optional[Literal['gcc', 'msvc']] = None,
                  env: T.Optional[EnvironmentVariables] = None,
@@ -3050,8 +3051,8 @@ class CustomTarget(Target, CustomTargetBase, CommandBase):
         repr_str = "<{0} {1}: {2}>"
         return repr_str.format(self.__class__.__name__, self.get_id(), self.command)
 
-    def get_target_dependencies(self) -> T.List[T.Union[SourceOutputs, str]]:
-        deps: T.List[T.Union[SourceOutputs, str]] = []
+    def get_target_dependencies(self) -> T.List[TargetDepends]:
+        deps: T.List[TargetDepends] = []
         deps.extend(self.dependencies)
         deps.extend(self.extra_depends)
         for c in self.sources:
@@ -3249,7 +3250,8 @@ class RunTarget(Target, CommandBase):
 
     def __init__(self, name: str,
                  command: T.Sequence[T.Union[str, File, BuildTargetTypes, programs.Program]],
-                 dependencies: T.Sequence[AnyTargetType],
+                 # the RunTarget case is used by gnome.yelp()
+                 dependencies: T.Sequence[T.Union[RunTarget, TargetDepends]],
                  subdir: str,
                  subproject: str,
                  environment: Environment,
@@ -3257,7 +3259,7 @@ class RunTarget(Target, CommandBase):
                  default_env: bool = True):
         # These don't produce output artifacts
         super().__init__(name, subdir, subproject, False, MachineChoice.BUILD, environment)
-        self.dependencies = dependencies
+        self.dependencies = list(dependencies)
         self.depend_files = []
         self.command = self.flatten_command(command)
         self.absolute_paths = False
@@ -3268,7 +3270,7 @@ class RunTarget(Target, CommandBase):
         repr_str = "<{0} {1}: {2}>"
         return repr_str.format(self.__class__.__name__, self.get_id(), self.command[0])
 
-    def get_dependencies(self) -> T.List[BuildTargetTypes]:
+    def get_dependencies(self) -> T.List[T.Union[RunTarget, TargetDepends]]:
         return self.dependencies
 
     def get_generated_sources(self) -> T.List[GeneratedTypes]:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2163,7 +2163,11 @@ class GeneratedList(HoldableObject):
             if not self.generator.exe.found():
                 raise InvalidArguments('Tried to use not-found external program as generator')
         if isinstance(self.generator.exe, LocalProgram):
-            self.extra_depends.append(self.generator.exe.program)
+            t = self.generator.exe.get_target()
+            if isinstance(t, File):
+                self.depend_files.append(t)
+            else:
+                self.extra_depends.append(t)
         else:
             path = self.generator.exe.get_path()
             if os.path.isabs(path):
@@ -3499,12 +3503,17 @@ class ConfigurationData(HoldableObject):
         return self.values.keys()
 
 class LocalProgram(programs.Program):
-    def __init__(self, program: T.Union[programs.ExternalProgram, Executable, CustomTarget, CustomTargetIndex], version: str) -> None:
+    def __init__(self, program: T.Union[programs.ExternalProgram, Executable, CustomTarget, CustomTargetIndex], version: str,
+                 file: T.Optional[File] = None) -> None:
         super().__init__()
         if isinstance(program, CustomTarget):
             if len(program.outputs) != 1:
                 raise InvalidArguments('CustomTarget used as LocalProgram must have exactly one output.')
+        if isinstance(program, programs.ExternalProgram):
+            if not file:
+                raise MesonBugException('ExternalProgram used as LocalProgram must be a file from the project')
         self.name = program.name
+        self.file = file
         self.for_machine = program.for_machine
         self.program = program
         self.version = version
@@ -3526,6 +3535,12 @@ class LocalProgram(programs.Program):
             return self.program.get_path()
         # Only the backend knows the actual path to the build program.
         raise MesonBugException('Cannot call get_path() on program that is a build target.')
+
+    def get_target(self) -> T.Union[File, Executable, CustomTarget, CustomTargetIndex]:
+        if self.file:
+            return self.file
+        assert not isinstance(self.program, programs.ExternalProgram)
+        return self.program
 
     def description(self) -> str:
         if isinstance(self.program, programs.ExternalProgram):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -3576,10 +3576,11 @@ class TestSetup:
     env: EnvironmentVariables
     exclude_suites: T.List[str]
 
-def get_sources_string_names(sources, backend):
+
+def get_sources_string_names(sources: T.Sequence[CustomTargetSources], backend: Backend) -> list[str]:
     '''
-    For the specified list of @sources which can be strings, Files, or targets,
-    get all the output basenames.
+    For the specified list of @sources which can be strings, Files,
+    ExternalPrograms, or targets, get all the output basenames.
     '''
     names = []
     for s in sources:
@@ -3589,8 +3590,10 @@ def get_sources_string_names(sources, backend):
             names += backend.determine_ext_objs(s)
         elif isinstance(s, File):
             names.append(s.fname)
+        elif isinstance(s, programs.ExternalProgram):
+            names.append(s.get_path())
         else:
-            raise AssertionError(f'Unknown source type: {s!r}')
+            raise MesonBugException(f'Unknown source type: {s!r}')
     return names
 
 def load(build_dir: str) -> Build:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3228,6 +3228,10 @@ class Interpreter(InterpreterBase, HoldableObject):
     def source_strings_to_files(self, sources: T.List[kwtypes.CustomTargetInputs]) -> T.List['CustomTargetSources']: ... # noqa: F811
 
     @T.overload
+    def source_strings_to_files(self, sources: T.List[T.Union[mesonlib.FileOrString, build.BuildTargetTypes, build.BothLibraries, build.ExtractedObjects, build.GeneratedTypes]]
+                                ) -> T.List[T.Union[mesonlib.File, build.BuildTargetTypes, build.BothLibraries, build.ExtractedObjects, build.GeneratedTypes]]: ... # noqa: F811
+
+    @T.overload
     def source_strings_to_files(self, sources: T.List[T.Union[mesonlib.FileOrString, build.GeneratedTypes, build.StructuredSources]]
                                 ) -> T.List[T.Union[mesonlib.File, build.GeneratedTypes, build.StructuredSources]]: ... # noqa: F811
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3264,9 +3264,8 @@ class Interpreter(InterpreterBase, HoldableObject):
                 else:
                     self.validate_within_subproject(self.subdir, s)
                     results.append(mesonlib.File.from_source_file(self.environment.source_dir, self.subdir, s))
-            elif isinstance(s, mesonlib.File):
-                results.append(s)
-            elif isinstance(s, (build.GeneratedList, build.BuildTarget,
+            elif isinstance(s, (mesonlib.File, ExternalProgram,
+                                build.GeneratedList, build.BuildTarget,
                                 build.CustomTargetIndex, build.CustomTarget,
                                 build.ExtractedObjects, build.StructuredSources)):
                 results.append(s)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2252,7 +2252,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     @typed_pos_args('benchmark', str, (build.Executable, build.Jar, Program, mesonlib.File, build.CustomTarget, build.CustomTargetIndex))
     @typed_kwargs('benchmark', *TEST_KWS)
     def func_benchmark(self, node: mparser.BaseNode,
-                       args: T.Tuple[str, T.Union[build.Executable, build.Jar, Program, mesonlib.File]],
+                       args: T.Tuple[str, T.Union[build.Executable, build.Jar, Program, mesonlib.File, build.CustomTarget, build.CustomTargetIndex]],
                        kwargs: 'kwtypes.FuncBenchmark') -> None:
         self.add_test(node, args, kwargs, False)
 
@@ -2282,12 +2282,8 @@ class Interpreter(InterpreterBase, HoldableObject):
                              location=node)
             name = name.replace(':', '_')
         exe = args[1]
-        if isinstance(exe, Program):
-            if not exe.found():
-                raise InvalidArguments('Tried to use not-found external program as test exe')
-            if isinstance(exe, build.LocalProgram):
-                # This will add exe to 'depends' below
-                exe = exe.program
+        if isinstance(exe, Program) and not exe.found():
+            raise InvalidArguments('Tried to use not-found external program as test exe')
         elif isinstance(exe, mesonlib.File):
             exe = self.find_program_impl([exe])
         if isinstance(exe, (build.Executable, build.CustomTarget)):

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -26,7 +26,7 @@ from ..interpreterbase import (
 from ..interpreter.type_checking import NoneType, ENV_KW, ENV_SEPARATOR_KW, PKGCONFIG_DEFINE_KW
 from ..dependencies import Dependency, ExternalLibrary, InternalDependency
 from ..programs import ExternalProgram, Program
-from ..mesonlib import HoldableObject, listify
+from ..mesonlib import HoldableObject, listify, MesonException
 
 import typing as T
 
@@ -839,7 +839,7 @@ class GeneratedObjectsHolder(ObjectHolder[build.ExtractedObjects]):
 class Test(MesonInterpreterObject):
     def __init__(self, name: str, project: str, suite: T.List[str],
                  exe: T.Union[Program, build.Executable, build.Jar, build.CustomTarget, build.CustomTargetIndex],
-                 depends: T.List[T.Union[build.CustomTarget, build.BuildTarget]],
+                 depends: T.Sequence[kwargs.TargetDepends],
                  is_parallel: bool,
                  cmd_args: T.List[T.Union[str, mesonlib.File, build.Target, Program]],
                  env: mesonlib.EnvironmentVariables,
@@ -850,7 +850,6 @@ class Test(MesonInterpreterObject):
         self.suite = listify(suite)
         self.project_name = project
         self.exe = exe
-        self.depends = depends
         self.is_parallel = is_parallel
         self.cmd_args = cmd_args
         self.env = env
@@ -861,6 +860,12 @@ class Test(MesonInterpreterObject):
         self.protocol = TestProtocol.from_str(protocol)
         self.priority = priority
         self.verbose = verbose
+
+        self.depends: T.List[build.BuildTargetTypes] = []
+        for d in depends:
+            if isinstance(d, build.GeneratedList):
+                raise MesonException('generated_list not allowed as a dependency for test')
+            self.depends.append(d)
 
     def get_exe(self) -> T.Union[Program, build.Executable, build.Jar, build.CustomTarget, build.CustomTargetIndex]:
         return self.exe

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -25,8 +25,8 @@ from ..interpreterbase import (
                                InterpreterException, InvalidArguments, InvalidCode)
 from ..interpreter.type_checking import NoneType, ENV_KW, ENV_SEPARATOR_KW, PKGCONFIG_DEFINE_KW
 from ..dependencies import Dependency, ExternalLibrary, InternalDependency
-from ..programs import ExternalProgram, Program
-from ..mesonlib import HoldableObject, listify, MesonException
+from ..programs import Program
+from ..mesonlib import File, HoldableObject, listify, MesonException
 
 import typing as T
 
@@ -838,7 +838,7 @@ class GeneratedObjectsHolder(ObjectHolder[build.ExtractedObjects]):
 
 class Test(MesonInterpreterObject):
     def __init__(self, name: str, project: str, suite: T.List[str],
-                 exe: T.Union[Program, build.Executable, build.Jar, build.CustomTarget, build.CustomTargetIndex],
+                 exe: T.Union[Program, build.Executable, build.CustomTarget, build.CustomTargetIndex],
                  depends: T.Sequence[kwargs.TargetDepends],
                  is_parallel: bool,
                  cmd_args: T.List[T.Union[str, mesonlib.File, build.Target, Program]],
@@ -865,6 +865,12 @@ class Test(MesonInterpreterObject):
         for d in depends:
             if isinstance(d, build.GeneratedList):
                 raise MesonException('generated_list not allowed as a dependency for test')
+            if isinstance(d, Program):
+                if not isinstance(d, build.LocalProgram):
+                    continue
+                d = d.get_target()
+                if isinstance(d, File):
+                    continue
             self.depends.append(d)
 
     def get_exe(self) -> T.Union[Program, build.Executable, build.Jar, build.CustomTarget, build.CustomTargetIndex]:

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -838,10 +838,10 @@ class GeneratedObjectsHolder(ObjectHolder[build.ExtractedObjects]):
 
 class Test(MesonInterpreterObject):
     def __init__(self, name: str, project: str, suite: T.List[str],
-                 exe: T.Union[ExternalProgram, build.Executable, build.CustomTarget, build.CustomTargetIndex],
+                 exe: T.Union[Program, build.Executable, build.Jar, build.CustomTarget, build.CustomTargetIndex],
                  depends: T.List[T.Union[build.CustomTarget, build.BuildTarget]],
                  is_parallel: bool,
-                 cmd_args: T.List[T.Union[str, mesonlib.File, build.Target, ExternalProgram]],
+                 cmd_args: T.List[T.Union[str, mesonlib.File, build.Target, Program]],
                  env: mesonlib.EnvironmentVariables,
                  expected_fail: bool, expected_exitcode: int, timeout: int, workdir: T.Optional[str], protocol: str,
                  priority: int, verbose: bool):
@@ -862,7 +862,7 @@ class Test(MesonInterpreterObject):
         self.priority = priority
         self.verbose = verbose
 
-    def get_exe(self) -> T.Union[ExternalProgram, build.Executable, build.CustomTarget, build.CustomTargetIndex]:
+    def get_exe(self) -> T.Union[Program, build.Executable, build.Jar, build.CustomTarget, build.CustomTargetIndex]:
         return self.exe
 
     def get_name(self) -> str:

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -21,7 +21,7 @@ from ..modules.cmake import CMakeSubprojectOptions
 from ..programs import Program, ExternalProgram
 from .type_checking import PkgConfigDefineType, SourcesVarargsType
 
-TestArgs = T.Union[str, File, build.Target, ExternalProgram]
+TestArgs = T.Union[str, File, build.Target, Program]
 TargetDepends = T.Union[build.CustomTarget, build.CustomTargetIndex, build.BuildTarget, build.GeneratedList]
 CustomTargetInputs = T.Union[str, build.BuildTarget, build.GeneratedTypes,
                              build.ExtractedObjects, ExternalProgram, File]

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -22,7 +22,7 @@ from ..programs import Program, ExternalProgram
 from .type_checking import PkgConfigDefineType, SourcesVarargsType
 
 TestArgs = T.Union[str, File, build.Target, Program]
-TargetDepends = T.Union[build.CustomTarget, build.CustomTargetIndex, build.BuildTarget, build.GeneratedList]
+TargetDepends = T.Union[build.CustomTarget, build.CustomTargetIndex, build.BuildTarget, build.GeneratedList, Program]
 CustomTargetInputs = T.Union[str, build.BuildTarget, build.GeneratedTypes,
                              build.ExtractedObjects, ExternalProgram, File]
 RustAbi = Literal['rust', 'c']

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -22,6 +22,7 @@ from ..programs import Program, ExternalProgram
 from .type_checking import PkgConfigDefineType, SourcesVarargsType
 
 TestArgs = T.Union[str, File, build.Target, ExternalProgram]
+TargetDepends = T.Union[build.CustomTarget, build.CustomTargetIndex, build.BuildTarget, build.GeneratedList]
 CustomTargetInputs = T.Union[str, build.BuildTarget, build.GeneratedTypes,
                              build.ExtractedObjects, ExternalProgram, File]
 RustAbi = Literal['rust', 'c']
@@ -55,7 +56,7 @@ class BaseTest(TypedDict):
     expected_exitcode: T.Optional[int]
     timeout: int
     workdir: T.Optional[str]
-    depends: T.List[T.Union[build.CustomTarget, build.BuildTarget]]
+    depends: T.List[TargetDepends]
     priority: int
     env: EnvironmentVariables
     suite: T.List[str]
@@ -109,7 +110,7 @@ class FuncGenerator(TypedDict):
     output: T.List[str]
     depfile: T.Optional[str]
     capture:  bool
-    depends: T.List[T.Union[build.BuildTarget, build.CustomTarget]]
+    depends: T.List[TargetDepends]
 
 
 class GeneratorProcess(TypedDict):
@@ -185,7 +186,7 @@ class FuncAddLanguages(ExtractRequired):
 class RunTarget(TypedDict):
 
     command: T.List[T.Union[str, build.BuildTargetTypes, ExternalProgram, File]]
-    depends: T.List[T.Union[build.BuildTargetTypes]]
+    depends: T.List[TargetDepends]
     env: EnvironmentVariables
 
 
@@ -199,7 +200,7 @@ class CustomTarget(TypedDict):
     command: T.List[T.Union[str, build.BuildTargetTypes, Program, File]]
     console: bool
     depend_files: T.List[FileOrString]
-    depends: T.List[T.Union[build.BuildTarget, build.CustomTarget]]
+    depends: T.List[TargetDepends]
     depfile: T.Optional[str]
     env: EnvironmentVariables
     feed: bool

--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -334,7 +334,7 @@ class MesonMain(MesonInterpreterObject):
             if not os.path.exists(abspath):
                 raise InterpreterException(f'Tried to override {name} with a file that does not exist.')
             prog = ExternalProgram(name, command=[abspath], silent=True)
-            exe = build.LocalProgram(prog, self.interpreter.project_version)
+            exe = build.LocalProgram(prog, self.interpreter.project_version, file=exe)
         elif isinstance(exe, build.Executable):
             exe = build.LocalProgram(exe, self.interpreter.project_version)
         self.interpreter.add_find_program_override(name, exe)

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -9,7 +9,7 @@ import typing as T
 
 from .. import compilers
 from ..build import (CustomTarget, BuildTarget,
-                     CustomTargetIndex, ExtractedObjects, GeneratedList, IncludeDirs,
+                     CustomTargetIndex, ExtractedObjects, GeneratedList, IncludeDirs, LocalProgram,
                      BothLibraries, SharedLibrary, StaticLibrary, Jar, Executable, StructuredSources)
 from ..options import OptionKey
 from ..dependencies import Dependency, DependencyMethods, InternalDependency
@@ -25,6 +25,7 @@ NoneType: T.Type[None] = type(None)
 if T.TYPE_CHECKING:
     from typing_extensions import Literal
 
+    from .kwargs import CustomTargetInputs
     from ..build import ObjectTypes, GeneratedTypes, BuildTargetTypes
     from ..interpreterbase import TYPE_var
     from ..options import ElementaryOptionValues
@@ -351,11 +352,22 @@ OUTPUT_KW: KwargInfo[str] = KwargInfo(
     validator=lambda x: _output_validator([x])
 )
 
-CT_INPUT_KW: KwargInfo[T.List[T.Union[str, File, ExternalProgram, BuildTarget, GeneratedTypes, ExtractedObjects]]] = KwargInfo(
+def _local_program_convertor(raw: T.List[T.Union[str, File, BuildTarget, GeneratedTypes, ExtractedObjects, LocalProgram]]) -> T.List[CustomTargetInputs]:
+    result: T.List[CustomTargetInputs] = []
+    for i in raw:
+        if isinstance(i, LocalProgram):
+            result.append(i.get_target())
+        else:
+            result.append(i)
+    return result
+
+CT_INPUT_KW: KwargInfo[T.List[T.Union[str, File, BuildTarget, GeneratedTypes, ExtractedObjects, LocalProgram]]] = KwargInfo(
     'input',
-    ContainerTypeInfo(list, (str, File, ExternalProgram, BuildTarget, CustomTarget, CustomTargetIndex, ExtractedObjects, GeneratedList)),
+    ContainerTypeInfo(list, (str, File, BuildTarget, CustomTarget, CustomTargetIndex, ExtractedObjects, GeneratedList, Program)),
     listify=True,
     default=[],
+    convertor=_local_program_convertor,
+    since_values={ExternalProgram: '1.11.2'},
 )
 
 CT_INSTALL_TAG_KW: KwargInfo[T.List[T.Union[str, bool]]] = KwargInfo(

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -272,12 +272,12 @@ DEPFILE_KW: KwargInfo[T.Optional[str]] = KwargInfo(
     validator=lambda x: 'Depfile must be a plain filename with a subdirectory' if has_path_sep(x) else None
 )
 
-DEPENDS_KW: KwargInfo[T.List[BuildTargetTypes]] = KwargInfo(
+DEPENDS_KW: KwargInfo[T.List[T.Union[BuildTarget, CustomTarget, CustomTargetIndex, Program]]] = KwargInfo(
     'depends',
-    ContainerTypeInfo(list, (BuildTarget, CustomTarget, CustomTargetIndex)),
+    ContainerTypeInfo(list, (BuildTarget, CustomTarget, CustomTargetIndex, Program)),
     listify=True,
     default=[],
-    since_values={CustomTargetIndex: '1.5.0'},
+    since_values={CustomTargetIndex: '1.5.0', ExternalProgram: '1.11.2'},
 )
 
 DEPEND_FILES_KW: KwargInfo[T.List[T.Union[str, File]]] = KwargInfo(

--- a/mesonbuild/modules/external_project.py
+++ b/mesonbuild/modules/external_project.py
@@ -28,8 +28,8 @@ if T.TYPE_CHECKING:
 
     from . import ModuleState
     from .._typing import ImmutableListProtocol
-    from ..build import BuildTarget, CustomTarget
     from ..interpreter import Interpreter
+    from ..interpreter.kwargs import TargetDepends
     from ..interpreterbase import TYPE_var
     from ..mesonlib import EnvironmentVariables
     from ..utils.core import EnvironOrDict
@@ -44,7 +44,7 @@ if T.TYPE_CHECKING:
         cross_configure_options: T.List[str]
         verbose: bool
         env: EnvironmentVariables
-        depends: T.List[T.Union[BuildTarget, CustomTarget]]
+        depends: T.List[TargetDepends]
 
 
 class ExternalProject(NewExtensionModule):
@@ -58,7 +58,7 @@ class ExternalProject(NewExtensionModule):
                  cross_configure_options: T.List[str],
                  env: EnvironmentVariables,
                  verbose: bool,
-                 extra_depends: T.List[T.Union['BuildTarget', 'CustomTarget']]):
+                 extra_depends: T.List[TargetDepends]):
         super().__init__()
         self.methods.update({'dependency': self.dependency_method,
                              })
@@ -234,7 +234,7 @@ class ExternalProject(NewExtensionModule):
                 print(contents)
             raise MesonException(m)
 
-    def _create_targets(self, extra_depends: T.List[T.Union['BuildTarget', 'CustomTarget']]) -> T.List['TYPE_var']:
+    def _create_targets(self, extra_depends: T.List[TargetDepends]) -> T.List['TYPE_var']:
         cmd = self.env.get_build_command()
         cmd += ['--internal', 'externalproject',
                 '--name', self.name,

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1173,7 +1173,9 @@ class GnomeModule(ExtensionModule):
         builddir = os.path.join(state.environment.get_build_dir(), state.subdir)
 
         depends: T.List[T.Union['FileOrString', 'build.GeneratedTypes', build.BuildTarget, build.StructuredSources]] = []
-        depends.extend(gir_dep.sources)
+        # hack - this cast represents how sources are defined for the
+        # dependency in gobject-introspection's gir/meson.build
+        depends.extend(T.cast('T.List[CustomTarget]', gir_dep.sources))
         depends.extend(girtargets)
 
         langs_compilers = self._get_girtargets_langs_compilers(girtargets)

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -44,7 +44,7 @@ if T.TYPE_CHECKING:
     from ..compilers import Compiler
     from ..interpreter import Interpreter
     from ..interpreter.interpreter import CustomTargetSources
-    from ..interpreter.kwargs import CustomTargetInputs
+    from ..interpreter.kwargs import CustomTargetInputs, TargetDepends
     from ..interpreterbase import TYPE_var, TYPE_kwargs
     from ..mesonlib import EnvironmentVariables, FileOrString
     from ..programs import Program, CommandList, CommandListEntry
@@ -627,10 +627,10 @@ class GnomeModule(ExtensionModule):
 
     def _get_link_args(self, state: 'ModuleState',
                        lib: T.Union[build.SharedLibrary, build.StaticLibrary],
-                       depends: T.Sequence[T.Union[build.BuildTarget, 'build.GeneratedTypes', 'FileOrString', build.StructuredSources]],
+                       depends: T.Sequence[TargetDepends],
                        include_rpath: bool = False,
                        use_gir_args: bool = False
-                       ) -> T.Tuple[T.List[str], T.List[T.Union[build.BuildTarget, 'build.GeneratedTypes', 'FileOrString', build.StructuredSources]]]:
+                       ) -> T.Tuple[T.List[str], T.List[TargetDepends]]:
         link_command: T.List[str] = []
         new_depends = list(depends)
         # Construct link args
@@ -658,11 +658,11 @@ class GnomeModule(ExtensionModule):
     def _get_dependencies_flags_raw(
             self, deps: T.Sequence[T.Union['Dependency', build.BuildTargetTypes]],
             state: 'ModuleState',
-            depends: T.Sequence[T.Union[build.BuildTarget, 'build.GeneratedTypes', 'FileOrString', build.StructuredSources]],
+            depends: T.Sequence[TargetDepends],
             include_rpath: bool,
             use_gir_args: bool,
             ) -> T.Tuple[OrderedSet[str], OrderedSet[T.Union[str, T.Tuple[str, str]]], OrderedSet[T.Union[str, T.Tuple[str, str]]], OrderedSet[str],
-                         T.List[T.Union[build.BuildTarget, 'build.GeneratedTypes', 'FileOrString', build.StructuredSources]]]:
+                         T.List[TargetDepends]]:
         cflags: OrderedSet[str] = OrderedSet()
         # External linker flags that can't be de-duped reliably because they
         # require two args in order, such as -framework AVFoundation will be stored as a tuple.
@@ -751,13 +751,13 @@ class GnomeModule(ExtensionModule):
     def _get_dependencies_flags(
             self, deps: T.Sequence[T.Union['Dependency', build.BuildTargetTypes]],
             state: 'ModuleState',
-            depends: T.Sequence[T.Union[build.BuildTarget, 'build.GeneratedTypes', 'FileOrString', build.StructuredSources]],
+            depends: T.Sequence[TargetDepends],
             include_rpath: bool = False,
             use_gir_args: bool = False,
             ) -> T.Tuple[OrderedSet[str], T.List[str], T.List[str], OrderedSet[str],
-                         T.List[T.Union[build.BuildTarget, 'build.GeneratedTypes', 'FileOrString', build.StructuredSources]]]:
+                         T.List[TargetDepends]]:
 
-        cflags, internal_ldflags_raw, external_ldflags_raw, gi_includes, depends = self._get_dependencies_flags_raw(deps, state, depends, include_rpath, use_gir_args)
+        cflags, internal_ldflags_raw, external_ldflags_raw, gi_includes, new_depends = self._get_dependencies_flags_raw(deps, state, depends, include_rpath, use_gir_args)
         internal_ldflags: T.List[str] = []
         external_ldflags: T.List[str] = []
 
@@ -773,7 +773,7 @@ class GnomeModule(ExtensionModule):
             else:
                 external_ldflags.extend(ldflag)
 
-        return cflags, internal_ldflags, external_ldflags, gi_includes, depends
+        return cflags, internal_ldflags, external_ldflags, gi_includes, new_depends
 
     def _unwrap_gir_target(self, girtarget: T.Union[Executable, build.StaticLibrary, build.SharedLibrary], state: 'ModuleState'
                            ) -> T.Union[Executable, build.StaticLibrary, build.SharedLibrary]:
@@ -980,7 +980,7 @@ class GnomeModule(ExtensionModule):
             girfile: str,
             scan_command: T.Sequence[T.Union['FileOrString', Executable, Program]],
             generated_files: T.Sequence[build.GeneratedTypes],
-            depends: T.Sequence[T.Union['FileOrString', build.BuildTarget, 'build.GeneratedTypes', build.StructuredSources]],
+            depends: T.Sequence[TargetDepends],
             env_flags: T.Sequence[str],
             kwargs: GenerateGir) -> GirTarget:
         install = kwargs['install_gir']
@@ -1063,8 +1063,8 @@ class GnomeModule(ExtensionModule):
     def _gather_typelib_includes_and_update_depends(
             state: 'ModuleState',
             deps: T.Sequence[T.Union[Dependency, build.BuildTargetTypes]],
-            depends: T.Sequence[T.Union[build.BuildTarget, 'build.GeneratedTypes', 'FileOrString', build.StructuredSources]]
-            ) -> T.Tuple[T.List[str], T.List[T.Union[build.BuildTarget, 'build.GeneratedTypes', 'FileOrString', build.StructuredSources]]]:
+            depends: T.Sequence[TargetDepends]
+            ) -> T.Tuple[T.List[str], T.List[TargetDepends]]:
         # Need to recursively add deps on GirTarget sources from our
         # dependencies and also find the include directories needed for the
         # typelib generation custom target below.
@@ -1172,7 +1172,7 @@ class GnomeModule(ExtensionModule):
         srcdir = os.path.join(state.environment.get_source_dir(), state.subdir)
         builddir = os.path.join(state.environment.get_build_dir(), state.subdir)
 
-        depends: T.List[T.Union['FileOrString', 'build.GeneratedTypes', build.BuildTarget, build.StructuredSources]] = []
+        depends: T.List[TargetDepends] = []
         # hack - this cast represents how sources are defined for the
         # dependency in gobject-introspection's gir/meson.build
         depends.extend(T.cast('T.List[CustomTarget]', gir_dep.sources))
@@ -1597,7 +1597,7 @@ class GnomeModule(ExtensionModule):
                         deps: T.List[T.Union[Dependency, build.SharedLibrary, build.StaticLibrary]],
                         state: 'ModuleState',
                         depends: T.Sequence[T.Union[build.BuildTarget, 'build.GeneratedTypes']]) -> T.Tuple[
-                                T.List[str], T.List[T.Union[build.BuildTarget, 'build.GeneratedTypes', 'FileOrString', build.StructuredSources]]]:
+                                T.List[str], T.List[TargetDepends]]:
         args: T.List[str] = []
         cflags = c_args.copy()
         deps_cflags, internal_ldflags, external_ldflags, _gi_includes, new_depends = \

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -38,7 +38,8 @@ if T.TYPE_CHECKING:
     from ..dependencies import ExternalLibrary
     from ..interpreter import Interpreter
     from ..interpreter import kwargs as _kwargs
-    from ..interpreter.interpreter import SourceInputs, SourceOutputs
+    from ..interpreter.kwargs import TargetDepends
+    from ..interpreter.interpreter import SourceOutputs
     from ..interpreter.interpreterobjects import Test
     from ..interpreterbase import TYPE_kwargs
     from ..programs import Program
@@ -785,7 +786,7 @@ class RustModule(ExtensionModule):
         header = self.interpreter.source_strings_to_files([_header])[0]
 
         # Split File and Target dependencies to add pass to CustomTarget
-        depends: T.List[SourceOutputs] = []
+        depends: T.List[TargetDepends] = []
         depend_files: T.List[File] = []
         for d in self.interpreter.source_strings_to_files(_deps):
             if isinstance(d, File):

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -31,7 +31,7 @@ from ..programs import ExternalProgram, NonExistingExternalProgram
 if T.TYPE_CHECKING:
     from . import ModuleState
     from .. import cargo
-    from ..build import BuildTargetTypes, ExecutableKeywordArguments, IncludeDirs, LibTypes
+    from ..build import BuildTargetTypes, ExecutableKeywordArguments, GeneratedTypes, IncludeDirs, LibTypes
     from ..cargo.interpreter import RUST_ABI
     from ..compilers.compilers import Language
     from ..compilers.rust import RustCompiler
@@ -64,7 +64,7 @@ if T.TYPE_CHECKING:
         args: T.List[str]
         c_args: T.List[str]
         include_directories: T.List[IncludeDirs]
-        input: T.List[SourceInputs]
+        input: T.List[T.Union[File, str, GeneratedTypes, BuildTarget, BothLibraries, ExtractedObjects]]
         output: str
         output_inline_wrapper: str
         dependencies: T.List[T.Union[Dependency, ExternalLibrary]]
@@ -778,14 +778,23 @@ class RustModule(ExtensionModule):
         The main thing this simplifies is the use of `include_directory`
         objects, instead of having to pass a plethora of `-I` arguments.
         """
-        header, *_deps = self.interpreter.source_strings_to_files(kwargs['input'])
+        _header, *_deps = kwargs['input']
+
+        if isinstance(_header, (BuildTarget, BothLibraries, ExtractedObjects)):
+            raise InterpreterException('bindgen source file must be a C header, not an object or build target')
+        header = self.interpreter.source_strings_to_files([_header])[0]
 
         # Split File and Target dependencies to add pass to CustomTarget
         depends: T.List[SourceOutputs] = []
         depend_files: T.List[File] = []
-        for d in _deps:
+        for d in self.interpreter.source_strings_to_files(_deps):
             if isinstance(d, File):
                 depend_files.append(d)
+            elif isinstance(d, BothLibraries):
+                depends.append(d.shared)
+                depends.append(d.static)
+            elif isinstance(d, ExtractedObjects):
+                depends.append(d.target)
             else:
                 depends.append(d)
 
@@ -855,8 +864,6 @@ class RustModule(ExtensionModule):
         name: str
         if isinstance(header, File):
             name = header.fname
-        elif isinstance(header, (BuildTarget, BothLibraries, ExtractedObjects, StructuredSources)):
-            raise InterpreterException('bindgen source file must be a C header, not an object or build target')
         else:
             name = header.get_outputs()[0]
 

--- a/test cases/common/296 program in kwargs/customtarget.py
+++ b/test cases/common/296 program in kwargs/customtarget.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('sometool')
+    parser.add_argument('output')
+    args = parser.parse_args()
+
+    with open(args.output, 'w', encoding='utf-8') as f:
+        f.write('')
+
+
+if __name__ == "__main__":
+    main()

--- a/test cases/common/296 program in kwargs/foo.py
+++ b/test cases/common/296 program in kwargs/foo.py
@@ -1,0 +1,1 @@
+#! /usr/bin/env python3

--- a/test cases/common/296 program in kwargs/meson.build
+++ b/test cases/common/296 program in kwargs/meson.build
@@ -1,0 +1,46 @@
+project('test')
+
+subproject('sub')
+sometool = find_program('sometool')
+
+custom_target('something1',
+  output: 'something1',
+  input: [sometool],
+  command: [find_program('customtarget.py'), '@INPUT@', '@OUTPUT@'],
+  build_by_default: true)
+
+custom_target('something2',
+  output: 'something2',
+  input: files('foo.py'),
+  command: [find_program('customtarget.py'), '@INPUT@', '@OUTPUT@'],
+  depends: sometool,
+  build_by_default: true)
+
+testcase expect_error('.*ExternalProgram.*', how: 're')
+  custom_target('something3',
+    output: 'something3',
+    input: files('foo.py'),
+    command: [find_program('customtarget.py'), '@INPUT@', '@OUTPUT@'],
+    depends: find_program('foo.py'),
+    build_by_default: true)
+endtestcase
+
+testcase expect_error('.*ExternalProgram.*', how: 're')
+  custom_target('something4',
+    output: 'something4',
+    input: [find_program('foo.py')],
+    command: [find_program('customtarget.py'), '@INPUT@', '@OUTPUT@'],
+    build_by_default: true)
+endtestcase
+
+test('mytest1',
+  find_program('test.py'),
+  args: [find_program('foo.py')],
+  depends: [sometool])
+
+testcase expect_error('.*ExternalProgram.*', how: 're')
+  test('mytest2',
+    find_program('test.py'),
+    args: [sometool],
+    depends: [find_program('foo.py')])
+endtestcase

--- a/test cases/common/296 program in kwargs/meson.build
+++ b/test cases/common/296 program in kwargs/meson.build
@@ -16,14 +16,12 @@ custom_target('something2',
   depends: sometool,
   build_by_default: true)
 
-testcase expect_error('.*ExternalProgram.*', how: 're')
-  custom_target('something3',
-    output: 'something3',
-    input: files('foo.py'),
-    command: [find_program('customtarget.py'), '@INPUT@', '@OUTPUT@'],
-    depends: find_program('foo.py'),
-    build_by_default: true)
-endtestcase
+custom_target('something3',
+  output: 'something3',
+  input: files('foo.py'),
+  command: [find_program('customtarget.py'), '@INPUT@', '@OUTPUT@'],
+  depends: find_program('foo.py'),
+  build_by_default: true)
 
 custom_target('something4',
   output: 'something4',
@@ -36,9 +34,7 @@ test('mytest1',
   args: [find_program('foo.py')],
   depends: [sometool])
 
-testcase expect_error('.*ExternalProgram.*', how: 're')
-  test('mytest2',
-    find_program('test.py'),
-    args: [sometool],
-    depends: [find_program('foo.py')])
-endtestcase
+test('mytest2',
+  find_program('test.py'),
+  args: [sometool],
+  depends: [find_program('foo.py')])

--- a/test cases/common/296 program in kwargs/meson.build
+++ b/test cases/common/296 program in kwargs/meson.build
@@ -25,13 +25,11 @@ testcase expect_error('.*ExternalProgram.*', how: 're')
     build_by_default: true)
 endtestcase
 
-testcase expect_error('.*ExternalProgram.*', how: 're')
-  custom_target('something4',
-    output: 'something4',
-    input: [find_program('foo.py')],
-    command: [find_program('customtarget.py'), '@INPUT@', '@OUTPUT@'],
-    build_by_default: true)
-endtestcase
+custom_target('something4',
+  output: 'something4',
+  input: [find_program('foo.py')],
+  command: [find_program('customtarget.py'), '@INPUT@', '@OUTPUT@'],
+  build_by_default: true)
 
 test('mytest1',
   find_program('test.py'),

--- a/test cases/common/296 program in kwargs/subprojects/sub/meson.build
+++ b/test cases/common/296 program in kwargs/subprojects/sub/meson.build
@@ -1,0 +1,4 @@
+project('tools', 'c')
+
+exe = executable('sometool', 'trivial.c')
+meson.override_find_program('sometool', exe)

--- a/test cases/common/296 program in kwargs/subprojects/sub/trivial.c
+++ b/test cases/common/296 program in kwargs/subprojects/sub/trivial.c
@@ -1,0 +1,6 @@
+#include<stdio.h>
+
+int main(void) {
+    printf("Trivial test is working.\n");
+    return 0;
+}

--- a/test cases/common/296 program in kwargs/test.py
+++ b/test cases/common/296 program in kwargs/test.py
@@ -5,7 +5,7 @@ import argparse
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument('sometool')
+    parser.add_argument('sometool', nargs='+')
     parser.parse_args()
 
 

--- a/test cases/common/296 program in kwargs/test.py
+++ b/test cases/common/296 program in kwargs/test.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import argparse
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('sometool')
+    parser.parse_args()
+
+
+if __name__ == "__main__":
+    main()

--- a/test cases/rust/12 bindgen/meson.build
+++ b/test cases/rust/12 bindgen/meson.build
@@ -132,16 +132,30 @@ gp_exe = executable(
 
 test('global and project arguments', gp_exe)
 
-cpp_lib = static_library('cpplib', 'src/impl.cpp')
+cpp_lib_sources = files('src/impl.cpp')
+cpp_lib = both_libraries('cpplib', cpp_lib_sources)
+cpp_lib_static = static_library('cpplib-static', cpp_lib_sources)
 
 cpp_bind = rust.bindgen(
   input : 'src/header.hpp',
   output : 'generated-cpp.rs',
 )
 
+# test passing various kinds of objects as dependencies
+
+rust.bindgen(
+  input : ['src/header2.hpp', cpp_lib.get_static_lib()],
+  output : 'generated-cpp-static.rs')
+rust.bindgen(
+  input : ['src/header3.hpp', cpp_lib_static.extract_objects(cpp_lib_sources)],
+  output : 'generated-cpp-objs.rs')
+rust.bindgen(
+  input : ['src/header4.hpp', cpp_lib],
+  output : 'generated-cpp-both.rs')
+
 cpp_exe = executable(
   'cpp_exe',
   structured_sources(['src/cpp.rs', cpp_bind]),
-  link_with : cpp_lib,
+  link_with : cpp_lib_static,
 )
 test('cpp', cpp_exe)

--- a/test cases/rust/12 bindgen/src/header2.hpp
+++ b/test cases/rust/12 bindgen/src/header2.hpp
@@ -1,0 +1,1 @@
+#include "header.hpp"

--- a/test cases/rust/12 bindgen/src/header3.hpp
+++ b/test cases/rust/12 bindgen/src/header3.hpp
@@ -1,0 +1,1 @@
+#include "header.hpp"

--- a/test cases/rust/12 bindgen/src/header4.hpp
+++ b/test cases/rust/12 bindgen/src/header4.hpp
@@ -1,0 +1,1 @@
+#include "header.hpp"


### PR DESCRIPTION
This could be a whack-a-mole game, but for now these are the ones that are reported for nix.

While at it, clean up and unify how "depends" is represented in the TypedDict.

Fixes: #15774 