### PR TITLE
interpreter: do not apply CARGO_SUBDIR if subproject has a meson.build

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1068,7 +1068,7 @@ class Interpreter(InterpreterBase, HoldableObject):
 
             return self._do_subproject_meson(
                 subp_name, subdir, default_options, kwargs, ast,
-                relaxations={InterpreterRuleRelaxation.CARGO_SUBDIR},
+                relaxations={InterpreterRuleRelaxation.CARGO_SUBDIR} if ast is not None else None,
                 cargo=cargo_int)
 
     @typed_pos_args('get_option', str)


### PR DESCRIPTION
Commit 57bf0c857 ("cargo: allow overriding Meson's Cargo interpreter") allow using Cargo subprojects to share the parent's Cargo.lock file, even for subprojects that have their own meson.build file.

However, in that case subdir() does not represent delayed generation of the meson.build rules for a workspace member---that would not even work if the subdir() is not for a crate but, say, for documentation. Drop CARGO_SUBDIR from the interpreter relaxations if _do_subproject_cargo() did not generate the subproject's AST.

Fixes: 57bf0c857 ("cargo: allow overriding Meson's Cargo interpreter")