### PR TITLE
machine files: add `[compilers]` section for hermetic toolchain configuration

### DIFF
--- a/docs/markdown/Machine-files.md
+++ b/docs/markdown/Machine-files.md
@@ -296,7 +296,14 @@ Each key is prefixed with the language identifier (`c.`, `cpp.`, etc.).
 | `<lang>.no-default-includes` | bool | Suppress the compiler's built-in system include search. Default: `false`. When set, the compiler's default system include directories are not searched; use `system-include-dirs` to specify them explicitly. Has no effect on compilers that have no equivalent flag (a warning is emitted). |
 | `<lang>.system-include-dirs` | array | System include directories. When set alongside `no-default-includes`, these directories are the only system include directories searched. When set without `no-default-includes`, these directories are searched in addition to the compiler's defaults. |
 | `<lang>.tool-search-paths` | array | Directories in which to search for compiler subtools (assembler, linker helpers, etc.). When omitted, the compiler uses its default search. |
-| `<lang>.subprocess-interpreter` | array | Command used to run compiler subprograms (e.g. cc1, cc1plus, lto1 on GCC). Compiler subprograms are found automatically. The resulting compile commands are fully cacheable by ccache and do not require `-wrapper` or `LD_LIBRARY_PATH`. Accepted but ignored (with an informational note) for monolithic compilers. |
+
+To run compiler subprograms (e.g. `cc1`, `cc1plus`, `lto1` on GCC) through a
+dynamic-loader prefix, set `<lang>.interpreter` under the `[binaries]` section
+(see [Per-binary interpreter](#per-binary-interpreter-posix-only)).  When such
+an interpreter is configured for a GCC- or clang-family `<lang>`, Meson
+generates per-subprogram wrappers under
+`<builddir>/meson-private/compiler-wrappers/<lang>/` and passes
+`-B<that-dir>` to the compiler so its driver finds the wrapped subprograms.
 
 #### Flag translation by compiler family
 
@@ -309,7 +316,6 @@ Each key is prefixed with the language identifier (`c.`, `cpp.`, etc.).
 | `no-default-includes` | `-nostdinc` | `-nostdinc` | `/X` |
 | `system-include-dirs` | `-isystem <dir>` | `-isystem <dir>` | `/imsvc <dir>` |
 | `tool-search-paths` | `-B <dir>` | warning, ignored | warning, ignored |
-| `subprocess-interpreter` | generates cc1/cc1plus/lto1 wrappers (GCC only); no-op (Clang) | no-op | no-op |
 | `ccache` | wraps invocation with ccache if available | wraps invocation with ccache if available | wraps invocation with ccache if available |
 
 Notes:
@@ -332,16 +338,16 @@ _runtime = _sdk / 'runtime'    # ELF loader and companion shared libraries
 [binaries]
 c   = _gcc / 'bin' / 'x86_64-linux-gnu-gcc'
 cpp = _gcc / 'bin' / 'x86_64-linux-gnu-g++'
+c.interpreter   = [_runtime / 'lib64' / 'ld-linux-x86-64.so.2',
+                   '--library-path', _runtime / 'lib64']
+cpp.interpreter = c.interpreter
 
 [compilers]
 c.type    = 'gcc'
 c.version = '12.2.0'
-c.subprocess-interpreter = [_runtime / 'lib64' / 'ld-linux-x86-64.so.2',
-                              '--library-path', _runtime / 'lib64']
 
 cpp.type    = 'gcc'
 cpp.version = '12.2.0'
-cpp.subprocess-interpreter = c.subprocess-interpreter
 ```
 
 With this configuration:

--- a/docs/markdown/Machine-files.md
+++ b/docs/markdown/Machine-files.md
@@ -245,6 +245,21 @@ as a prefix in the interpreter list: `perl.interpreter = ['env',
 the wrapper, so positional-argument call sites (e.g. `find_program`)
 work without splatting.
 
+Setting `<name>.interpreter = []` disables the global `[properties]
+interpreter` default for this entry: `lookup_binary_interpreter` returns
+the empty list, and the wrapper-generation call site treats that as "no
+interpreter applies", so the bare binary is used directly (see
+`mesonbuild/environment.py:lookup_binary_interpreter` and
+`mesonbuild/programs.py:ExternalProgram.from_entry`).
+
+The wrapper uses the bundled loader's `--argv0` flag to propagate the
+wrapper's own path as `argv[0]` to the wrapped binary (so child processes
+that re-launch by name -- e.g. CPython exec'ing `sys.executable` -- enter
+through the wrapper and inherit the loader prefix transparently).  This
+requires `--argv0` support in the loader, which was added in glibc 2.33;
+earlier loaders will not honor the flag and the wrapped binary will see
+the loader path as `argv[0]` instead.
+
 This feature is POSIX-only.  On Windows the property is silently
 ignored with a one-time warning, since DLL resolution does not use a
 dynamic-loader prefix.

--- a/docs/markdown/Machine-files.md
+++ b/docs/markdown/Machine-files.md
@@ -266,7 +266,7 @@ dynamic-loader prefix.
 
 ### compilers
 
-*New in 2.0.0*
+*New in 1.12.0*
 
 The `[compilers]` section allows declaring compiler configuration explicitly,
 rather than relying on Meson to auto-detect it from a binary. This is primarily
@@ -280,18 +280,16 @@ When a language is declared in this section:
   the declared version. When `<lang>.version` is omitted, Meson still runs the
   binary with `--version` to determine the version.
 
-The compiler binary can be specified either via `<lang>.binary` in this section or
-via the language key in the `[binaries]` section; when both are present,
-`[compilers].<lang>.binary` takes precedence.
+The compiler binary itself is always specified via `<lang>` in the `[binaries]`
+section.
 
-Each key is prefixed with the language identifier (`c.`, `cpp.`, `fortran.`, etc.).
+Each key is prefixed with the language identifier (`c.`, `cpp.`, etc.).
 
 #### Keys
 
 | Key | Type | Description |
 |-----|------|-------------|
 | `<lang>.type` | string | Compiler family. Supported values: `'gcc'`, `'clang'`, `'clang-cl'`, `'msvc'`, `'intel'` (Classic icc/icpc), `'intel-llvm'` (oneAPI icx/icpx), `'arm'` (Arm Compiler 5 armcc), `'armclang'` (Arm Compiler 6), `'pgi'` (NVIDIA HPC/PGI nvc/nvc++), `'emscripten'`. |
-| `<lang>.binary` | string or array | Path to the compiler binary (or a command array). Equivalent to setting `<lang>` in the `[binaries]` section; when both are present, `[compilers].<lang>.binary` takes precedence. |
 | `<lang>.version` | string | Version string (e.g. `'10.3.0'`). When specified, used in place of `--version` output. When omitted, Meson runs the binary with `--version` and parses the result as usual. |
 | `<lang>.ccache` | bool | Whether to use ccache when invoking this compiler. Default: `true`. When `true`, ccache is used if found on `PATH`; the build proceeds without caching if ccache is not present. Set to `false` to disable caching unconditionally. |
 | `<lang>.sysroot` | string | Override the root directory for the target system's headers and libraries. Has no effect on compilers that do not support a sysroot concept. |
@@ -331,15 +329,17 @@ _sdk     = '@GLOBAL_SOURCE_ROOT@' / 'sdk'
 _gcc     = _sdk / 'gcc-12.2.0'
 _runtime = _sdk / 'runtime'    # ELF loader and companion shared libraries
 
+[binaries]
+c   = _gcc / 'bin' / 'x86_64-linux-gnu-gcc'
+cpp = _gcc / 'bin' / 'x86_64-linux-gnu-g++'
+
 [compilers]
 c.type    = 'gcc'
-c.binary  = _gcc / 'bin' / 'x86_64-linux-gnu-gcc'
 c.version = '12.2.0'
 c.subprocess-interpreter = [_runtime / 'lib64' / 'ld-linux-x86-64.so.2',
                               '--library-path', _runtime / 'lib64']
 
 cpp.type    = 'gcc'
-cpp.binary  = _gcc / 'bin' / 'x86_64-linux-gnu-g++'
 cpp.version = '12.2.0'
 cpp.subprocess-interpreter = c.subprocess-interpreter
 ```
@@ -359,9 +359,12 @@ can be used to override the discovered values.
 #### Example: Clang with custom sysroot
 
 ```ini
+[binaries]
+c   = '/path/to/clang-17/bin/clang'
+cpp = '/path/to/clang-17/bin/clang++'
+
 [compilers]
 c.type    = 'clang'
-c.binary  = '/path/to/clang-17/bin/clang'
 c.version = '17.0.6'
 c.sysroot             = '/path/to/sdk'
 c.no-default-includes = true
@@ -369,7 +372,6 @@ c.system-include-dirs = ['/path/to/clang-17/lib/clang/17/include',
                           '/path/to/sdk/usr/include']
 
 cpp.type    = 'clang'
-cpp.binary  = '/path/to/clang-17/bin/clang++'
 cpp.version = '17.0.6'
 cpp.sysroot             = c.sysroot
 cpp.no-default-includes = true

--- a/docs/markdown/Machine-files.md
+++ b/docs/markdown/Machine-files.md
@@ -297,13 +297,21 @@ Each key is prefixed with the language identifier (`c.`, `cpp.`, etc.).
 | `<lang>.system-include-dirs` | array | System include directories. When set alongside `no-default-includes`, these directories are the only system include directories searched. When set without `no-default-includes`, these directories are searched in addition to the compiler's defaults. |
 | `<lang>.tool-search-paths` | array | Directories in which to search for compiler subtools (assembler, linker helpers, etc.). When omitted, the compiler uses its default search. |
 
-To run compiler subprograms (e.g. `cc1`, `cc1plus`, `lto1` on GCC) through a
-dynamic-loader prefix, set `<lang>.interpreter` under the `[binaries]` section
-(see [Per-binary interpreter](#per-binary-interpreter-posix-only)).  When such
-an interpreter is configured for a GCC- or clang-family `<lang>`, Meson
-generates per-subprogram wrappers under
-`<builddir>/meson-private/compiler-wrappers/<lang>/` and passes
-`-B<that-dir>` to the compiler so its driver finds the wrapped subprograms.
+To run compiler subprograms through a dynamic-loader prefix, set
+`<lang>.interpreter` under the `[binaries]` section (see
+[Per-binary interpreter](#per-binary-interpreter-posix-only)).  When such an
+interpreter is configured for a GCC- or clang-family `<lang>`, Meson generates
+per-subprogram wrappers under `<builddir>/meson-private/compiler-wrappers/<lang>/`
+and passes `-B<that-dir>` to the compiler so its driver finds the wrapped
+subprograms.
+
+The wrapped subprograms depend on the compiler family:
+
+- **GCC**: `cc1`, `cc1plus`, `lto1`.  These are dispatched by the gcc driver
+  for preprocessing / compilation / link-time optimization.
+- **clang**: `as`, `ld`.  Clang is monolithic for codegen (no separate `cc1`)
+  and only dispatches the assembler / linker through `-B<prefix>`; the wrappers
+  apply when `-fno-integrated-as` or an external linker is used.
 
 #### Flag translation by compiler family
 

--- a/docs/markdown/Machine-files.md
+++ b/docs/markdown/Machine-files.md
@@ -225,10 +225,21 @@ shell wrapper at `<builddir>/meson-private/binary-wrappers/<name>` that:
 
 - Prepends the wrappers directory to `PATH` (so the wrapper appears
   on `PATH` for downstream tools that re-launch by name).
-- Exports `LD_LIBRARY_PATH=X` if the interpreter contains
-  `--library-path X` (so libraries loaded transitively by the bundled
-  binary also resolve against the hermetic libdir).
-- `exec`s the interpreter on the bare binary, forwarding all arguments.
+- `exec`s the interpreter on the bare binary plus any trailing argv
+  from a list-form `[binaries]` entry (e.g. `python = ['/path/python', '-B']`
+  becomes `exec <interp> /path/python -B "$@"`), forwarding remaining
+  arguments via `"$@"`.
+
+The wrapper deliberately does NOT export `LD_LIBRARY_PATH`.  The
+interpreter's `--library-path` argument is honored by `ld-linux.so`
+both at process startup AND for subsequent `dlopen()` calls inside the
+wrapped process (the loader's search path is shared with libdl).
+Keeping `LD_LIBRARY_PATH` out of the wrapper's environment prevents
+the hermetic libdir from leaking to subprocesses (e.g. python -> gcc)
+that should resolve against the host glibc instead.  When per-binary
+environment is needed (e.g. `PERL5LIB=...`), include `env VAR=VAL ...`
+as a prefix in the interpreter list: `perl.interpreter = ['env',
+'PERL5LIB=/p', '/loader', '--library-path', '/libs']`.
 
 `ExternalProgram.command` is then a single-element list pointing at
 the wrapper, so positional-argument call sites (e.g. `find_program`)

--- a/docs/markdown/Machine-files.md
+++ b/docs/markdown/Machine-files.md
@@ -264,6 +264,118 @@ This feature is POSIX-only.  On Windows the property is silently
 ignored with a one-time warning, since DLL resolution does not use a
 dynamic-loader prefix.
 
+### compilers
+
+*New in 2.0.0*
+
+The `[compilers]` section allows declaring compiler configuration explicitly,
+rather than relying on Meson to auto-detect it from a binary. This is primarily
+useful for hermetic toolchains where the compiler and its subprograms require a
+custom execution environment that is not present on the host system.
+
+When a language is declared in this section:
+
+- If `<lang>.type` is set, Meson skips family detection and uses that type directly.
+- If `<lang>.version` is also set, Meson skips version detection entirely and uses
+  the declared version. When `<lang>.version` is omitted, Meson still runs the
+  binary with `--version` to determine the version.
+
+The compiler binary can be specified either via `<lang>.binary` in this section or
+via the language key in the `[binaries]` section; when both are present,
+`[compilers].<lang>.binary` takes precedence.
+
+Each key is prefixed with the language identifier (`c.`, `cpp.`, `fortran.`, etc.).
+
+#### Keys
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `<lang>.type` | string | Compiler family. Supported values: `'gcc'`, `'clang'`, `'clang-cl'`, `'msvc'`, `'intel'` (Classic icc/icpc), `'intel-llvm'` (oneAPI icx/icpx), `'arm'` (Arm Compiler 5 armcc), `'armclang'` (Arm Compiler 6), `'pgi'` (NVIDIA HPC/PGI nvc/nvc++), `'emscripten'`. |
+| `<lang>.binary` | string or array | Path to the compiler binary (or a command array). Equivalent to setting `<lang>` in the `[binaries]` section; when both are present, `[compilers].<lang>.binary` takes precedence. |
+| `<lang>.version` | string | Version string (e.g. `'10.3.0'`). When specified, used in place of `--version` output. When omitted, Meson runs the binary with `--version` and parses the result as usual. |
+| `<lang>.ccache` | bool | Whether to use ccache when invoking this compiler. Default: `true`. When `true`, ccache is used if found on `PATH`; the build proceeds without caching if ccache is not present. Set to `false` to disable caching unconditionally. |
+| `<lang>.sysroot` | string | Override the root directory for the target system's headers and libraries. Has no effect on compilers that do not support a sysroot concept. |
+| `<lang>.no-default-includes` | bool | Suppress the compiler's built-in system include search. Default: `false`. When set, the compiler's default system include directories are not searched; use `system-include-dirs` to specify them explicitly. Has no effect on compilers that have no equivalent flag (a warning is emitted). |
+| `<lang>.system-include-dirs` | array | System include directories. When set alongside `no-default-includes`, these directories are the only system include directories searched. When set without `no-default-includes`, these directories are searched in addition to the compiler's defaults. |
+| `<lang>.tool-search-paths` | array | Directories in which to search for compiler subtools (assembler, linker helpers, etc.). When omitted, the compiler uses its default search. |
+| `<lang>.subprocess-interpreter` | array | Command used to run compiler subprograms (e.g. cc1, cc1plus, lto1 on GCC). Compiler subprograms are found automatically. The resulting compile commands are fully cacheable by ccache and do not require `-wrapper` or `LD_LIBRARY_PATH`. Accepted but ignored (with an informational note) for monolithic compilers. |
+
+#### Flag translation by compiler family
+
+`—` means the key is not applicable for this compiler family.
+`no-op` means the key is accepted but has no effect.
+
+| Key | GCC, Clang | Intel Classic, Intel oneAPI, ARM 6 (armclang), Emscripten | MSVC, Clang-CL |
+|-----|------------|-----------------------------------------------------------|----------------|
+| `sysroot` | `--sysroot=<path>` | `--sysroot=<path>` (NVIDIA HPC/PGI: —) | — |
+| `no-default-includes` | `-nostdinc` | `-nostdinc` | `/X` |
+| `system-include-dirs` | `-isystem <dir>` | `-isystem <dir>` | `/imsvc <dir>` |
+| `tool-search-paths` | `-B <dir>` | warning, ignored | warning, ignored |
+| `subprocess-interpreter` | generates cc1/cc1plus/lto1 wrappers (GCC only); no-op (Clang) | no-op | no-op |
+| `ccache` | wraps invocation with ccache if available | wraps invocation with ccache if available | wraps invocation with ccache if available |
+
+Notes:
+- **NVIDIA HPC/PGI** (`nvc`/`nvc++`): otherwise identical to the Intel/ARM 6/Emscripten column but does not expose a sysroot concept; `sysroot` is silently ignored.
+- **Clang-CL**: the MSVC-compatible Clang frontend. Uses MSVC-style flags (`/X`, `/imsvc`) matching its `cl.exe` compatibility mode; `--sysroot` and `-B` are not meaningful in this mode.
+- **ARM Compiler 5** (`armcc`): a legacy proprietary compiler with its own flag dialect. None of the structured keys translate to equivalent armcc flags. A warning is emitted at setup for each key that is set; all are ignored. Use `[binaries]` and `[built-in options]` to pass armcc-specific flags directly.
+
+#### Example: hermetic GCC toolchain
+
+A self-contained GCC 12.2.0 toolchain bundled with the project under `sdk/`.
+The `cc1` and `cc1plus` subprograms require shared libraries from `sdk/runtime/lib64`
+that are not installed on the build host.
+
+```ini
+[constants]
+_sdk     = '@GLOBAL_SOURCE_ROOT@' / 'sdk'
+_gcc     = _sdk / 'gcc-12.2.0'
+_runtime = _sdk / 'runtime'    # ELF loader and companion shared libraries
+
+[compilers]
+c.type    = 'gcc'
+c.binary  = _gcc / 'bin' / 'x86_64-linux-gnu-gcc'
+c.version = '12.2.0'
+c.subprocess-interpreter = [_runtime / 'lib64' / 'ld-linux-x86-64.so.2',
+                              '--library-path', _runtime / 'lib64']
+
+cpp.type    = 'gcc'
+cpp.binary  = _gcc / 'bin' / 'x86_64-linux-gnu-g++'
+cpp.version = '12.2.0'
+cpp.subprocess-interpreter = c.subprocess-interpreter
+```
+
+With this configuration:
+
+- Compiler subprograms are located and invoked automatically through the bundled ELF
+  loader; no manual wrapper scripts or `LD_LIBRARY_PATH` setup is needed.
+- Include directories and subtool locations are discovered automatically from the
+  compiler.
+- Compilation is fully cacheable by ccache.
+
+When cross-compiling or using a non-standard sysroot, the optional override keys
+(`sysroot`, `no-default-includes`, `system-include-dirs`, `tool-search-paths`)
+can be used to override the discovered values.
+
+#### Example: Clang with custom sysroot
+
+```ini
+[compilers]
+c.type    = 'clang'
+c.binary  = '/path/to/clang-17/bin/clang'
+c.version = '17.0.6'
+c.sysroot             = '/path/to/sdk'
+c.no-default-includes = true
+c.system-include-dirs = ['/path/to/clang-17/lib/clang/17/include',
+                          '/path/to/sdk/usr/include']
+
+cpp.type    = 'clang'
+cpp.binary  = '/path/to/clang-17/bin/clang++'
+cpp.version = '17.0.6'
+cpp.sysroot             = c.sysroot
+cpp.no-default-includes = true
+cpp.system-include-dirs = c.system-include-dirs
+```
+
 ### Paths and Directories
 
 *Deprecated in 0.56.0* use the built-in section instead.

--- a/docs/markdown/Machine-files.md
+++ b/docs/markdown/Machine-files.md
@@ -195,6 +195,49 @@ here is:
 - sdl2-config
 - wx-config (or wx-3.0-config or wx-config-gtk)
 
+#### Per-binary interpreter (POSIX only)
+
+For hermetic-toolchain builds where bundled binaries need a dynamic
+loader prefix (for example `ld-linux --library-path <dir>`) to find
+their shared libraries, you can declare an `interpreter` for any
+`[binaries]` entry using a dotted key:
+
+```ini
+[binaries]
+perl = '/opt/toolchain/bin/perl'
+python3_codegen = '/opt/py36/bin/python3.6'
+python3_codegen.interpreter = ['/opt/py36/lib/ld.so', '--library-path', '/opt/py36/lib']
+
+[properties]
+# Global default applied to any [binaries] entry that does not have its
+# own `<name>.interpreter` set.
+interpreter = ['/opt/toolchain/lib/ld-linux.so', '--library-path', '/opt/toolchain/lib']
+```
+
+Resolution order:
+
+1. Per-binary `<name>.interpreter` under `[binaries]`.
+2. Global `interpreter` under `[properties]`.
+3. Otherwise, the binary is invoked bare.
+
+When an interpreter applies to an entry, Meson materializes a POSIX
+shell wrapper at `<builddir>/meson-private/binary-wrappers/<name>` that:
+
+- Prepends the wrappers directory to `PATH` (so the wrapper appears
+  on `PATH` for downstream tools that re-launch by name).
+- Exports `LD_LIBRARY_PATH=X` if the interpreter contains
+  `--library-path X` (so libraries loaded transitively by the bundled
+  binary also resolve against the hermetic libdir).
+- `exec`s the interpreter on the bare binary, forwarding all arguments.
+
+`ExternalProgram.command` is then a single-element list pointing at
+the wrapper, so positional-argument call sites (e.g. `find_program`)
+work without splatting.
+
+This feature is POSIX-only.  On Windows the property is silently
+ignored with a one-time warning, since DLL resolution does not use a
+dynamic-loader prefix.
+
 ### Paths and Directories
 
 *Deprecated in 0.56.0* use the built-in section instead.
@@ -251,6 +294,11 @@ section.
 - `java_home` is an absolute path pointing to the root of a Java installation.
 - `bindgen_clang_arguments` an array of extra arguments to pass to clang when
   calling bindgen
+- `interpreter` is a list of strings used as a global default interpreter
+  (dynamic-loader prefix) for `[binaries]` entries that do not have their own
+  `<name>.interpreter` override.  See the
+  [per-binary interpreter](#per-binary-interpreter-posix-only) subsection
+  for details.  POSIX-only.
 
 ### CMake variables
 

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -8,7 +8,7 @@ from ..mesonlib import (
     search_version, is_windows, Popen_safe, Popen_safe_logged, version_compare, windows_proof_rm,
 )
 from ..programs import ExternalProgram, _generate_binary_wrapper
-from ..envconfig import BinaryTable, CompilerDescriptor, detect_cpu_family
+from ..envconfig import BinaryTable, detect_cpu_family
 from .. import mlog
 
 from ..linkers import guess_win_linker, guess_nix_linker
@@ -353,7 +353,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
     # subprograms via the dynamic loader.
     if override_compilers is None:
         desc = env.lookup_compiler_desc(for_machine, lang)
-        if desc is not None and desc.type in ('gcc', 'clang') and compilers:
+        if desc is not None and desc.type in {'gcc', 'clang'} and compilers:
             compiler = list(compilers[0])
 
             # Apply structured flags from [compilers] descriptor.

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -7,7 +7,7 @@ from ..mesonlib import (
     MesonException, EnvironmentException, MachineChoice, join_args,
     search_version, is_windows, Popen_safe, Popen_safe_logged, version_compare, windows_proof_rm,
 )
-from ..programs import ExternalProgram
+from ..programs import ExternalProgram, _generate_binary_wrapper
 from ..envconfig import BinaryTable, CompilerDescriptor, detect_cpu_family
 from .. import mlog
 
@@ -16,12 +16,11 @@ from ..linkers import guess_win_linker, guess_nix_linker
 import subprocess
 import platform
 import re
-import shlex
 import shutil
-import stat
 import tempfile
 import os
 import typing as T
+from pathlib import Path
 
 if T.TYPE_CHECKING:
     from .compilers import Language, Compiler, CompilerDict
@@ -125,21 +124,25 @@ def detect_compiler_for(env: 'Environment', lang: Language, for_machine: Machine
 def _generate_subprocess_wrappers(
         env: 'Environment',
         compiler: T.List[str],
-        desc: 'CompilerDescriptor',
+        lang: str,
+        subprograms: T.Sequence[str],
+        interpreter: T.List[str],
 ) -> T.Optional[str]:
-    """Generate cc1/cc1plus/lto1 wrapper scripts for hermetic GCC.
+    """Generate per-compiler subprogram wrapper scripts (cc1/cc1plus/lto1 for
+    GCC; as/ld for clang).
 
-    Returns the wrapper directory path (to be passed as -B<dir>), or None if
-    no subprograms could be located.
+    Each wrapper is materialized by the shared `programs._generate_binary_wrapper`
+    helper, so wrapper-script content (shebang, PATH/LD_LIBRARY_PATH export,
+    exec line) stays consistent with the [binaries] <name>.interpreter feature.
+
+    Returns the per-language wrapper directory path (to be passed as -B<dir>),
+    or None if no subprograms could be located.
     """
-    wrapper_dir = os.path.join(env.scratch_dir, 'compiler-wrappers', desc.lang)
-    os.makedirs(wrapper_dir, exist_ok=True)
-
-    interpreter_parts = desc.subprocess_interpreter
-    interpreter_str = ' '.join(shlex.quote(x) for x in interpreter_parts)
+    wrappers_dir = Path(env.scratch_dir) / 'compiler-wrappers' / lang
+    host_system = env.machines.host.system
 
     generated_any = False
-    for prog in ('cc1', 'cc1plus', 'lto1'):
+    for prog in subprograms:
         try:
             p, out, _ = Popen_safe(compiler + ['--print-prog-name', prog])
         except OSError:
@@ -148,19 +151,15 @@ def _generate_subprocess_wrappers(
         if not real_path or not os.path.isabs(real_path) or not os.path.isfile(real_path):
             continue
 
-        wrapper_path = os.path.join(wrapper_dir, prog)
-        wrapper_content = (
-            '#!/bin/sh\n'
-            f'exec {interpreter_str} {shlex.quote(real_path)} "$@"\n'
-        )
-        with open(wrapper_path, 'w', encoding='utf-8') as f:
-            f.write(wrapper_content)
-        current_mode = os.stat(wrapper_path).st_mode
-        os.chmod(wrapper_path, current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-        mlog.debug(f'Generated {prog} wrapper: {wrapper_path}')
+        wrapper = _generate_binary_wrapper(prog, interpreter, [real_path],
+                                           wrappers_dir, host_system)
+        if wrapper is None:
+            # Windows or wrapper-generation declined; bail.
+            return None
+        mlog.debug(f'Generated {prog} wrapper: {wrapper}')
         generated_any = True
 
-    return wrapper_dir if generated_any else None
+    return str(wrappers_dir) if generated_any else None
 
 
 # Helpers
@@ -370,8 +369,10 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
             # --print-prog-name can use tool-search-paths to locate cc1.
             # Prepend -B<wrapper_dir> right after the binary so it wins over
             # any -B<libexec> from tool-search-paths.
-            if desc.subprocess_interpreter:
-                wrapper_dir = _generate_subprocess_wrappers(env, compiler, desc)
+            interpreter = env.lookup_binary_interpreter(lang)
+            if interpreter:
+                wrapper_dir = _generate_subprocess_wrappers(
+                    env, compiler, lang, ('cc1', 'cc1plus', 'lto1'), interpreter)
                 if wrapper_dir:
                     compiler = compiler[:1] + [f'-B{wrapper_dir}'] + compiler[1:]
 

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -388,7 +388,21 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
                 wrapper_dir = _generate_subprocess_wrappers(
                     env, compiler, lang, subprograms, interpreter)
                 if wrapper_dir:
-                    compiler = compiler[:1] + [f'-B{wrapper_dir}'] + compiler[1:]
+                    # Build the list of -B prefixes gcc/clang must inherit:
+                    #   compiler-wrappers/<lang> -- hosts wrapped cc1/cc1plus/
+                    #                               lto1 (or as/ld for clang)
+                    #   binary-wrappers          -- hosts wrapped ld.lld + ar +
+                    #                               strip etc. (so -fuse-ld=lld
+                    #                               + -B... finds the hermetic
+                    #                               wrapper)
+                    # Order matters: gcc/clang search -B prefixes left to
+                    # right.  Placing compiler-wrappers/<lang>/ first means
+                    # a name collision (e.g. a future shared wrapper named
+                    # 'cpp' or 'as' present in both dirs) resolves to the
+                    # language-specific wrapper, not the generic one.
+                    b_flags = [f'-B{wrapper_dir}',
+                               f'-B{env.binary_wrappers_dir()}']
+                    compiler = compiler[:1] + b_flags + compiler[1:]
 
             # Determine version: use declared version or run --version.
             if desc.version is not None:

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -364,10 +364,12 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
             compiler = list(compilers[0])
 
             # Generate cc1/cc1plus/lto1 wrapper scripts if needed.
+            # Prepend -B<wrapper_dir> right after the binary so the wrapper is
+            # found before any -B<libexec> already present in the compiler args.
             if desc.subprocess_interpreter:
                 wrapper_dir = _generate_subprocess_wrappers(env, compiler, desc)
                 if wrapper_dir:
-                    compiler = compiler + [f'-B{wrapper_dir}']
+                    compiler = compiler[:1] + [f'-B{wrapper_dir}'] + compiler[1:]
 
             # Determine version: use declared version or run --version.
             if desc.version is not None:

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -8,7 +8,7 @@ from ..mesonlib import (
     search_version, is_windows, Popen_safe, Popen_safe_logged, version_compare, windows_proof_rm,
 )
 from ..programs import ExternalProgram
-from ..envconfig import BinaryTable, CompilerDescriptor, CompilerTable, detect_cpu_family
+from ..envconfig import BinaryTable, CompilerDescriptor, detect_cpu_family
 from .. import mlog
 
 from ..linkers import guess_win_linker, guess_nix_linker
@@ -364,8 +364,6 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
     if override_compilers is None:
         desc = env.lookup_compiler_desc(for_machine, lang)
         if desc is not None and desc.type == 'gcc' and compilers:
-            from . import c, cpp
-            from ..linkers import linkers as lnk_mod
             compiler = list(compilers[0])
 
             # Apply structured flags from [compilers] descriptor.
@@ -394,7 +392,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
             else:
                 try:
                     p, out, _ = Popen_safe_logged(compiler + ['--version'],
-                                                   msg='Detecting compiler via')
+                                                  msg='Detecting compiler via')
                 except OSError as e:
                     raise EnvironmentException(
                         f'Failed to run GCC compiler {compiler[0]!r}: {e}')

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -348,11 +348,12 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
     lnk: T.Union[T.Type[StaticLinker], T.Type[DynamicLinker]]
 
     # Fast path: [compilers] section declared the family (type) explicitly.
-    # Skip pattern-matching on --version output for GCC; generate subprocess
-    # wrappers before running any preprocessing step that invokes cc1.
+    # Skip pattern-matching on --version output for GCC/clang; generate
+    # subprocess wrappers before running any preprocessing step that may invoke
+    # subprograms via the dynamic loader.
     if override_compilers is None:
         desc = env.lookup_compiler_desc(for_machine, lang)
-        if desc is not None and desc.type == 'gcc' and compilers:
+        if desc is not None and desc.type in ('gcc', 'clang') and compilers:
             compiler = list(compilers[0])
 
             # Apply structured flags from [compilers] descriptor.
@@ -366,13 +367,26 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
                 compiler.append(f'-isystem{d}')
 
             # Generate subprocess wrappers after structured flags are applied so
-            # --print-prog-name can use tool-search-paths to locate cc1.
-            # Prepend -B<wrapper_dir> right after the binary so it wins over
-            # any -B<libexec> from tool-search-paths.
+            # --print-prog-name can use tool-search-paths to locate the
+            # subprogram.  Prepend -B<wrapper_dir> right after the binary so it
+            # wins over any -B<libexec> from tool-search-paths.
+            #
+            # gcc dispatches preprocessing/compilation to cc1/cc1plus/lto1
+            # (these need the dynamic-loader prefix).  Clang is monolithic for
+            # codegen -- only as/ld are dispatched through -B<prefix> (used
+            # when -fno-integrated-as is passed or an external linker is
+            # selected).  ThinLTO link-time codegen runs lto1 as a separate
+            # subprocess on both gcc and clang, so include it in both lists.
+            # TODO: ld64.lld on Darwin -- clang's Darwin driver looks for
+            # ld64.lld rather than ld.lld; extend the clang list there.
+            if desc.type == 'gcc':
+                subprograms = ('cc1', 'cc1plus', 'lto1')
+            else:  # clang
+                subprograms = ('as', 'ld', 'lto1')
             interpreter = env.lookup_binary_interpreter(lang)
             if interpreter:
                 wrapper_dir = _generate_subprocess_wrappers(
-                    env, compiler, lang, ('cc1', 'cc1plus', 'lto1'), interpreter)
+                    env, compiler, lang, subprograms, interpreter)
                 if wrapper_dir:
                     compiler = compiler[:1] + [f'-B{wrapper_dir}'] + compiler[1:]
 
@@ -386,23 +400,26 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
                                                   msg='Detecting compiler via')
                 except OSError as e:
                     raise EnvironmentException(
-                        f'Failed to run GCC compiler {compiler[0]!r}: {e}')
+                        f'Failed to run {desc.type} compiler {compiler[0]!r}: {e}')
                 full_version = out.split('\n', 1)[0]
                 version = search_version(out)
 
-            # Still run preprocessor defines detection (requires cc1; wrappers
-            # are now in place so this succeeds even in hermetic builds).
-            defines = _get_gnu_compiler_defines(compiler, lang)
-            if not defines:
-                raise EnvironmentException(
-                    f'GCC compiler at {compiler[0]!r} returned no preprocessor defines; '
-                    'check that the compiler is accessible')
-            if desc.version is None:
-                version = _get_gnu_version_from_defines(defines)
+            # Preprocessor-defines detection (driver-specific).
+            if desc.type == 'gcc':
+                defines = _get_gnu_compiler_defines(compiler, lang)
+                if not defines:
+                    raise EnvironmentException(
+                        f'GCC compiler at {compiler[0]!r} returned no preprocessor defines; '
+                        'check that the compiler is accessible')
+                if desc.version is None:
+                    version = _get_gnu_version_from_defines(defines)
+                cls = c.GnuCCompiler if lang == 'c' else cpp.GnuCPPCompiler
+            else:  # clang
+                defines = _get_clang_compiler_defines(compiler, lang)
+                cls = c.ClangCCompiler if lang == 'c' else cpp.ClangCPPCompiler
 
-            cls_gcc = c.GnuCCompiler if lang == 'c' else cpp.GnuCPPCompiler
-            linker = guess_nix_linker(env, compiler, cls_gcc, version, for_machine)
-            return cls_gcc(
+            linker = guess_nix_linker(env, compiler, cls, version, for_machine)
+            return cls(
                 ccache, compiler, version, for_machine,
                 env, defines=defines, full_version=full_version, linker=linker)
 

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -188,8 +188,13 @@ def _get_compilers(env: 'Environment', lang: str, for_machine: MachineChoice,
     if value is not None:
         comp, ccache = BinaryTable.parse_entry(value)
         # Descriptor may override ccache even when binary comes from [binaries].
-        if desc is not None and not desc.ccache:
-            ccache = None
+        if desc is not None:
+            if not desc.ccache:
+                ccache = None
+            elif ccache is None:
+                # [binaries] has no ccache prefix; [compilers] ccache=true → auto-detect.
+                detected = BinaryTable.detect_ccache()
+                ccache = detected if detected.found() else None
         # Return value has to be a list of compiler 'choices'
         compilers = [comp]
     else:
@@ -363,9 +368,20 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
             from ..linkers import linkers as lnk_mod
             compiler = list(compilers[0])
 
-            # Generate cc1/cc1plus/lto1 wrapper scripts if needed.
-            # Prepend -B<wrapper_dir> right after the binary so the wrapper is
-            # found before any -B<libexec> already present in the compiler args.
+            # Apply structured flags from [compilers] descriptor.
+            if desc.sysroot:
+                compiler.append(f'--sysroot={desc.sysroot}')
+            if desc.no_default_includes:
+                compiler.append('-nostdinc')
+            for d in desc.tool_search_paths:
+                compiler.append(f'-B{d}')
+            for d in desc.system_include_dirs:
+                compiler.append(f'-isystem{d}')
+
+            # Generate subprocess wrappers after structured flags are applied so
+            # --print-prog-name can use tool-search-paths to locate cc1.
+            # Prepend -B<wrapper_dir> right after the binary so it wins over
+            # any -B<libexec> from tool-search-paths.
             if desc.subprocess_interpreter:
                 wrapper_dir = _generate_subprocess_wrappers(env, compiler, desc)
                 if wrapper_dir:

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -8,7 +8,7 @@ from ..mesonlib import (
     search_version, is_windows, Popen_safe, Popen_safe_logged, version_compare, windows_proof_rm,
 )
 from ..programs import ExternalProgram
-from ..envconfig import BinaryTable, detect_cpu_family
+from ..envconfig import BinaryTable, CompilerDescriptor, CompilerTable, detect_cpu_family
 from .. import mlog
 
 from ..linkers import guess_win_linker, guess_nix_linker
@@ -16,7 +16,9 @@ from ..linkers import guess_win_linker, guess_nix_linker
 import subprocess
 import platform
 import re
+import shlex
 import shutil
+import stat
 import tempfile
 import os
 import typing as T
@@ -117,6 +119,50 @@ def detect_compiler_for(env: 'Environment', lang: Language, for_machine: Machine
     return comp
 
 
+# Subprocess wrapper generation
+# ==============================
+
+def _generate_subprocess_wrappers(
+        env: 'Environment',
+        compiler: T.List[str],
+        desc: 'CompilerDescriptor',
+) -> T.Optional[str]:
+    """Generate cc1/cc1plus/lto1 wrapper scripts for hermetic GCC.
+
+    Returns the wrapper directory path (to be passed as -B<dir>), or None if
+    no subprograms could be located.
+    """
+    wrapper_dir = os.path.join(env.scratch_dir, 'compiler-wrappers', desc.lang)
+    os.makedirs(wrapper_dir, exist_ok=True)
+
+    interpreter_parts = desc.subprocess_interpreter
+    interpreter_str = ' '.join(shlex.quote(x) for x in interpreter_parts)
+
+    generated_any = False
+    for prog in ('cc1', 'cc1plus', 'lto1'):
+        try:
+            p, out, _ = Popen_safe(compiler + ['--print-prog-name', prog])
+        except OSError:
+            continue
+        real_path = out.strip()
+        if not real_path or not os.path.isabs(real_path) or not os.path.isfile(real_path):
+            continue
+
+        wrapper_path = os.path.join(wrapper_dir, prog)
+        wrapper_content = (
+            '#!/bin/sh\n'
+            f'exec {interpreter_str} {shlex.quote(real_path)} "$@"\n'
+        )
+        with open(wrapper_path, 'w', encoding='utf-8') as f:
+            f.write(wrapper_content)
+        current_mode = os.stat(wrapper_path).st_mode
+        os.chmod(wrapper_path, current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        mlog.debug(f'Generated {prog} wrapper: {wrapper_path}')
+        generated_any = True
+
+    return wrapper_dir if generated_any else None
+
+
 # Helpers
 # =======
 
@@ -126,9 +172,24 @@ def _get_compilers(env: 'Environment', lang: str, for_machine: MachineChoice,
     The list of compilers is detected in the exact same way for
     C, C++, ObjC, ObjC++, Fortran, CS so consolidate it here.
     '''
+    desc = env.lookup_compiler_desc(for_machine, lang)
+
+    # [compilers] binary overrides [binaries]; handle ccache from descriptor.
+    if desc is not None and desc.binary is not None:
+        comp = desc.binary
+        if desc.ccache:
+            ccache_exe = BinaryTable.detect_ccache()
+            ccache: T.Union[None, ExternalProgram] = ccache_exe if ccache_exe.found() else None
+        else:
+            ccache = None
+        return [comp], ccache
+
     value = env.lookup_binary_entry(for_machine, lang)
     if value is not None:
         comp, ccache = BinaryTable.parse_entry(value)
+        # Descriptor may override ccache even when binary comes from [binaries].
+        if desc is not None and not desc.ccache:
+            ccache = None
         # Return value has to be a list of compiler 'choices'
         compilers = [comp]
     else:
@@ -291,6 +352,52 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
         compilers = override_compilers
     cls: T.Union[T.Type[CCompiler], T.Type[CPPCompiler]]
     lnk: T.Union[T.Type[StaticLinker], T.Type[DynamicLinker]]
+
+    # Fast path: [compilers] section declared the family (type) explicitly.
+    # Skip pattern-matching on --version output for GCC; generate subprocess
+    # wrappers before running any preprocessing step that invokes cc1.
+    if override_compilers is None:
+        desc = env.lookup_compiler_desc(for_machine, lang)
+        if desc is not None and desc.type == 'gcc' and compilers:
+            from . import c, cpp
+            from ..linkers import linkers as lnk_mod
+            compiler = list(compilers[0])
+
+            # Generate cc1/cc1plus/lto1 wrapper scripts if needed.
+            if desc.subprocess_interpreter:
+                wrapper_dir = _generate_subprocess_wrappers(env, compiler, desc)
+                if wrapper_dir:
+                    compiler = compiler + [f'-B{wrapper_dir}']
+
+            # Determine version: use declared version or run --version.
+            if desc.version is not None:
+                version = desc.version
+                full_version = version
+            else:
+                try:
+                    p, out, _ = Popen_safe_logged(compiler + ['--version'],
+                                                   msg='Detecting compiler via')
+                except OSError as e:
+                    raise EnvironmentException(
+                        f'Failed to run GCC compiler {compiler[0]!r}: {e}')
+                full_version = out.split('\n', 1)[0]
+                version = search_version(out)
+
+            # Still run preprocessor defines detection (requires cc1; wrappers
+            # are now in place so this succeeds even in hermetic builds).
+            defines = _get_gnu_compiler_defines(compiler, lang)
+            if not defines:
+                raise EnvironmentException(
+                    f'GCC compiler at {compiler[0]!r} returned no preprocessor defines; '
+                    'check that the compiler is accessible')
+            if desc.version is None:
+                version = _get_gnu_version_from_defines(defines)
+
+            cls_gcc = c.GnuCCompiler if lang == 'c' else cpp.GnuCPPCompiler
+            linker = guess_nix_linker(env, compiler, cls_gcc, version, for_machine)
+            return cls_gcc(
+                ccache, compiler, version, for_machine,
+                env, defines=defines, full_version=full_version, linker=linker)
 
     for compiler in compilers:
         compiler_name = os.path.basename(compiler[0])

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -174,20 +174,10 @@ def _get_compilers(env: 'Environment', lang: str, for_machine: MachineChoice,
     '''
     desc = env.lookup_compiler_desc(for_machine, lang)
 
-    # [compilers] binary overrides [binaries]; handle ccache from descriptor.
-    if desc is not None and desc.binary is not None:
-        comp = desc.binary
-        if desc.ccache:
-            ccache_exe = BinaryTable.detect_ccache()
-            ccache: T.Union[None, ExternalProgram] = ccache_exe if ccache_exe.found() else None
-        else:
-            ccache = None
-        return [comp], ccache
-
     value = env.lookup_binary_entry(for_machine, lang)
     if value is not None:
         comp, ccache = BinaryTable.parse_entry(value)
-        # Descriptor may override ccache even when binary comes from [binaries].
+        # [compilers] descriptor may override ccache wrapping.
         if desc is not None:
             if not desc.ccache:
                 ccache = None

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -535,7 +535,6 @@ class CompilerDescriptor:
     """Per-language compiler configuration from a [compilers] machine-file section."""
     lang: str
     type: T.Optional[str] = None
-    binary: T.Optional[T.List[str]] = None
     version: T.Optional[str] = None
     ccache: bool = True
     sysroot: T.Optional[str] = None
@@ -549,7 +548,7 @@ class CompilerTable:
     """Parsed [compilers] section from a native or cross file."""
 
     KNOWN_KEYS: T.FrozenSet[str] = frozenset({
-        'type', 'binary', 'version', 'ccache',
+        'type', 'version', 'ccache',
         'sysroot', 'no-default-includes', 'system-include-dirs',
         'tool-search-paths', 'subprocess-interpreter',
     })
@@ -583,13 +582,6 @@ class CompilerTable:
                         f'Unknown compiler type {t!r} for language {lang!r} in [compilers]; '
                         f'valid values: {sorted(COMPILER_TYPES)}')
                 desc.type = str(t)
-
-            if 'binary' in props:
-                b = props['binary']
-                if not isinstance(b, (str, list)):
-                    raise mesonlib.MesonException(
-                        f'[compilers] {lang}.binary must be a string or array, got {b!r}')
-                desc.binary = mesonlib.stringlistify(b)
 
             if 'version' in props:
                 desc.version = str(props['version'])

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -541,7 +541,6 @@ class CompilerDescriptor:
     no_default_includes: bool = False
     system_include_dirs: T.List[str] = field(default_factory=list)
     tool_search_paths: T.List[str] = field(default_factory=list)
-    subprocess_interpreter: T.List[str] = field(default_factory=list)
 
 
 class CompilerTable:
@@ -550,7 +549,7 @@ class CompilerTable:
     KNOWN_KEYS: T.FrozenSet[str] = frozenset({
         'type', 'version', 'ccache',
         'sysroot', 'no-default-includes', 'system-include-dirs',
-        'tool-search-paths', 'subprocess-interpreter',
+        'tool-search-paths',
     })
 
     def __init__(
@@ -608,9 +607,6 @@ class CompilerTable:
 
             if 'tool-search-paths' in props:
                 desc.tool_search_paths = mesonlib.stringlistify(props['tool-search-paths'])
-
-            if 'subprocess-interpreter' in props:
-                desc.subprocess_interpreter = mesonlib.stringlistify(props['subprocess-interpreter'])
 
             self.compilers[lang] = desc
 

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import typing as T
 from enum import Enum
 import os
@@ -521,6 +521,110 @@ class BinaryTable:
         elif not command[0].strip():
             return None
         return command
+
+COMPILER_TYPES: T.FrozenSet[str] = frozenset({
+    'gcc', 'clang', 'clang-cl', 'msvc',
+    'intel', 'intel-llvm',
+    'arm', 'armclang',
+    'pgi', 'emscripten',
+})
+
+
+@dataclass
+class CompilerDescriptor:
+    """Per-language compiler configuration from a [compilers] machine-file section."""
+    lang: str
+    type: T.Optional[str] = None
+    binary: T.Optional[T.List[str]] = None
+    version: T.Optional[str] = None
+    ccache: bool = True
+    sysroot: T.Optional[str] = None
+    no_default_includes: bool = False
+    system_include_dirs: T.List[str] = field(default_factory=list)
+    tool_search_paths: T.List[str] = field(default_factory=list)
+    subprocess_interpreter: T.List[str] = field(default_factory=list)
+
+
+class CompilerTable:
+    """Parsed [compilers] section from a native or cross file."""
+
+    KNOWN_KEYS: T.FrozenSet[str] = frozenset({
+        'type', 'binary', 'version', 'ccache',
+        'sysroot', 'no-default-includes', 'system-include-dirs',
+        'tool-search-paths', 'subprocess-interpreter',
+    })
+
+    def __init__(
+            self,
+            entries: T.Optional[T.Mapping[str, 'ElementaryOptionValues']] = None,
+    ) -> None:
+        self.compilers: T.Dict[str, CompilerDescriptor] = {}
+        if not entries:
+            return
+
+        by_lang: T.Dict[str, T.Dict[str, 'ElementaryOptionValues']] = {}
+        for dotkey, value in entries.items():
+            if '.' not in dotkey:
+                raise mesonlib.MesonException(
+                    f'Invalid [compilers] key {dotkey!r}: expected <lang>.<property>')
+            lang, _, key = dotkey.partition('.')
+            if key not in self.KNOWN_KEYS:
+                mlog.warning(f'Unknown [compilers] key {dotkey!r}, ignoring', once=True)
+                continue
+            by_lang.setdefault(lang, {})[key] = value
+
+        for lang, props in by_lang.items():
+            desc = CompilerDescriptor(lang=lang)
+
+            if 'type' in props:
+                t = props['type']
+                if t not in COMPILER_TYPES:
+                    raise mesonlib.MesonException(
+                        f'Unknown compiler type {t!r} for language {lang!r} in [compilers]; '
+                        f'valid values: {sorted(COMPILER_TYPES)}')
+                desc.type = str(t)
+
+            if 'binary' in props:
+                b = props['binary']
+                if not isinstance(b, (str, list)):
+                    raise mesonlib.MesonException(
+                        f'[compilers] {lang}.binary must be a string or array, got {b!r}')
+                desc.binary = mesonlib.stringlistify(b)
+
+            if 'version' in props:
+                desc.version = str(props['version'])
+
+            if 'ccache' in props:
+                v = props['ccache']
+                if not isinstance(v, bool):
+                    raise mesonlib.MesonException(
+                        f'[compilers] {lang}.ccache must be a bool, got {v!r}')
+                desc.ccache = v
+
+            if 'sysroot' in props:
+                desc.sysroot = str(props['sysroot'])
+
+            if 'no-default-includes' in props:
+                v = props['no-default-includes']
+                if not isinstance(v, bool):
+                    raise mesonlib.MesonException(
+                        f'[compilers] {lang}.no-default-includes must be a bool, got {v!r}')
+                desc.no_default_includes = v
+
+            if 'system-include-dirs' in props:
+                desc.system_include_dirs = mesonlib.stringlistify(props['system-include-dirs'])
+
+            if 'tool-search-paths' in props:
+                desc.tool_search_paths = mesonlib.stringlistify(props['tool-search-paths'])
+
+            if 'subprocess-interpreter' in props:
+                desc.subprocess_interpreter = mesonlib.stringlistify(props['subprocess-interpreter'])
+
+            self.compilers[lang] = desc
+
+    def lookup(self, lang: str) -> T.Optional[CompilerDescriptor]:
+        return self.compilers.get(lang)
+
 
 class CMakeVariables:
     def __init__(self, variables: T.Optional[T.Dict[str, T.Any]] = None) -> None:

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -160,6 +160,10 @@ class CMakeSkipCompilerTest(Enum):
     NEVER = 'never'
     DEP_ONLY = 'dep_only'
 
+# Known per-binary attributes that may appear in the [binaries] section as
+# `<name>.<attr>` keys.  Values are always validated to be lists of strings.
+KNOWN_BINARY_ATTRS = frozenset({'interpreter'})
+
 class Properties:
     def __init__(
             self,
@@ -246,6 +250,19 @@ class Properties:
         if not all(isinstance(v, str) for v in value):
             raise EnvironmentException('bindgen_clang_arguments must be a string or an array of strings')
         return T.cast('T.List[str]', value)
+
+    def get_interpreter(self) -> T.Optional[T.List[str]]:
+        """Global default `interpreter` for [binaries] entries.
+
+        Returns None if not set.  Validates the entry is a list of strings.
+        """
+        if 'interpreter' not in self.properties:
+            return None
+        raw = self.properties['interpreter']
+        if not isinstance(raw, list) or not all(isinstance(v, str) for v in raw):
+            raise EnvironmentException(
+                "[properties] 'interpreter' must be a list of strings")
+        return raw
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, type(self)):
@@ -421,8 +438,23 @@ class BinaryTable:
             binaries: T.Optional[T.Mapping[str, ElementaryOptionValues]] = None,
     ):
         self.binaries: T.Dict[str, T.List[str]] = {}
+        # Per-binary attributes specified as `<name>.<attr>` keys in [binaries].
+        # Each value is a list of strings.  Validated against KNOWN_BINARY_ATTRS.
+        self.attrs: T.Dict[str, T.Dict[str, T.List[str]]] = {}
         if binaries:
             for name, command in binaries.items():
+                if '.' in name:
+                    base, attr = name.split('.', 1)
+                    if attr not in KNOWN_BINARY_ATTRS:
+                        mlog.warning(
+                            f'Unknown per-binary attribute {attr!r} for entry '
+                            f'{base!r} in [binaries]; ignoring.', fatal=False)
+                        continue
+                    if not isinstance(command, list) or not all(isinstance(v, str) for v in command):
+                        raise mesonlib.MesonException(
+                            f"[binaries] '{name}' must be a list of strings")
+                    self.attrs.setdefault(base, {})[attr] = T.cast('T.List[str]', list(command))
+                    continue
                 if not isinstance(command, (list, str)):
                     raise mesonlib.MesonException(
                         f'Invalid type {command!r} for entry {name!r} in cross file')

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -443,18 +443,19 @@ class BinaryTable:
         self.attrs: T.Dict[str, T.Dict[str, T.List[str]]] = {}
         if binaries:
             for name, command in binaries.items():
+                # Per-binary attributes are keyed as `<base>.<attr>` where
+                # `<attr>` is in KNOWN_BINARY_ATTRS.  Use rpartition so that
+                # binary names containing dots (e.g. `someothertool.py`) are
+                # only reinterpreted as per-binary attributes when the suffix
+                # is a recognised attribute.
                 if '.' in name:
-                    base, attr = name.split('.', 1)
-                    if attr not in KNOWN_BINARY_ATTRS:
-                        mlog.warning(
-                            f'Unknown per-binary attribute {attr!r} for entry '
-                            f'{base!r} in [binaries]; ignoring.', fatal=False)
+                    base, _, attr = name.rpartition('.')
+                    if attr in KNOWN_BINARY_ATTRS:
+                        if not isinstance(command, list) or not all(isinstance(v, str) for v in command):
+                            raise mesonlib.MesonException(
+                                f"[binaries] '{name}' must be a list of strings")
+                        self.attrs.setdefault(base, {})[attr] = T.cast('T.List[str]', list(command))
                         continue
-                    if not isinstance(command, list) or not all(isinstance(v, str) for v in command):
-                        raise mesonlib.MesonException(
-                            f"[binaries] '{name}' must be a list of strings")
-                    self.attrs.setdefault(base, {})[attr] = T.cast('T.List[str]', list(command))
-                    continue
                 if not isinstance(command, (list, str)):
                     raise mesonlib.MesonException(
                         f'Invalid type {command!r} for entry {name!r} in cross file')

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -8,6 +8,7 @@ import itertools
 import os, re
 import typing as T
 import collections
+from pathlib import Path
 
 from . import cmdline
 from . import coredata
@@ -453,6 +454,27 @@ class Environment:
 
     def lookup_binary_entry(self, for_machine: MachineChoice, name: str) -> T.Optional[T.List[str]]:
         return self.binaries[for_machine].lookup_entry(name)
+
+    def lookup_binary_interpreter(self, name: str) -> T.Optional[T.List[str]]:
+        """Resolve the interpreter (loader) prefix for a [binaries] entry.
+
+        Resolution order (build machine only -- bundled tooling is build-time):
+          1. per-binary `<name>.interpreter` under [binaries]
+          2. global `interpreter` under [properties]
+          3. None
+        """
+        per_binary = self.binaries[MachineChoice.BUILD].attrs.get(name, {}).get('interpreter')
+        if per_binary:
+            return list(per_binary)
+        default = self.properties[MachineChoice.BUILD].get_interpreter()
+        if default:
+            return list(default)
+        return None
+
+    def binary_wrappers_dir(self) -> Path:
+        """Directory under the scratch dir where binary-interpreter wrappers
+        are materialized.  Flat layout (no per-machine subdir)."""
+        return Path(self.scratch_dir) / 'binary-wrappers'
 
     def get_scratch_dir(self) -> str:
         return self.scratch_dir

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -460,11 +460,12 @@ class Environment:
 
         Resolution order (build machine only -- bundled tooling is build-time):
           1. per-binary `<name>.interpreter` under [binaries]
+             (empty list = bare invocation; explicitly disables the global default)
           2. global `interpreter` under [properties]
           3. None
         """
         per_binary = self.binaries[MachineChoice.BUILD].attrs.get(name, {}).get('interpreter')
-        if per_binary:
+        if per_binary is not None:
             return list(per_binary)
         default = self.properties[MachineChoice.BUILD].get_interpreter()
         if default:

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -26,7 +26,7 @@ from . import mlog
 from .programs import ExternalProgram
 
 from .envconfig import (
-    BinaryTable, MachineInfo, Properties, CMakeVariables,
+    BinaryTable, CompilerTable, MachineInfo, Properties, CMakeVariables,
     detect_machine_info, machine_info_can_run
 )
 from . import compilers
@@ -133,6 +133,9 @@ class Environment:
         # meta data, only names/paths.
         binaries: PerMachineDefaultable[BinaryTable] = PerMachineDefaultable()
 
+        # Structured compiler configuration from [compilers] machine-file sections.
+        compiler_descs: PerMachineDefaultable[CompilerTable] = PerMachineDefaultable()
+
         # Misc other properties about each machine.
         properties: PerMachineDefaultable[Properties] = PerMachineDefaultable()
 
@@ -147,6 +150,7 @@ class Environment:
         # Just uses hard-coded defaults and environment variables. Might be
         # overwritten by a native file.
         binaries.build = BinaryTable()
+        compiler_descs.build = CompilerTable()
         properties.build = Properties()
 
         # Options with the key parsed into an OptionKey type.
@@ -167,6 +171,7 @@ class Environment:
         if self.coredata.config_files is not None:
             config = machinefile.parse_machine_files(self.coredata.config_files, self.source_dir)
             binaries.build = BinaryTable(config.get('binaries', {}))
+            compiler_descs.build = CompilerTable(config.get('compilers', {}))
             properties.build = Properties(config.get('properties', {}))
             cmakevars.build = CMakeVariables(config.get('cmake', {}))
             self._load_machine_file_options(
@@ -179,6 +184,7 @@ class Environment:
             config = machinefile.parse_machine_files(self.coredata.cross_files, self.source_dir)
             properties.host = Properties(config.get('properties', {}))
             binaries.host = BinaryTable(config.get('binaries', {}))
+            compiler_descs.host = CompilerTable(config.get('compilers', {}))
             cmakevars.host = CMakeVariables(config.get('cmake', {}))
             if 'host_machine' in config:
                 machines.host = MachineInfo.from_literal(config['host_machine'])
@@ -195,6 +201,7 @@ class Environment:
 
         self.machines = machines.default_missing()
         self.binaries = binaries.default_missing()
+        self.compiler_descs = compiler_descs.default_missing()
         self.properties = properties.default_missing()
         self.cmakevars = cmakevars.default_missing()
 
@@ -476,6 +483,9 @@ class Environment:
         """Directory under the scratch dir where binary-interpreter wrappers
         are materialized.  Flat layout (no per-machine subdir)."""
         return Path(self.scratch_dir) / 'binary-wrappers'
+
+    def lookup_compiler_desc(self, for_machine: MachineChoice, lang: str) -> T.Optional['envconfig.CompilerDescriptor']:
+        return self.compiler_descs[for_machine].lookup(lang)
 
     def get_scratch_dir(self) -> str:
         return self.scratch_dir

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -462,19 +462,22 @@ class Environment:
     def lookup_binary_entry(self, for_machine: MachineChoice, name: str) -> T.Optional[T.List[str]]:
         return self.binaries[for_machine].lookup_entry(name)
 
-    def lookup_binary_interpreter(self, name: str) -> T.Optional[T.List[str]]:
+    def lookup_binary_interpreter(self, name: str,
+                                  for_machine: MachineChoice = MachineChoice.BUILD) -> T.Optional[T.List[str]]:
         """Resolve the interpreter (loader) prefix for a [binaries] entry.
 
-        Resolution order (build machine only -- bundled tooling is build-time):
+        Resolution order (defaults to the build machine, since most bundled
+        tooling is build-time; pass `for_machine=MachineChoice.HOST` for
+        cross-targeted binaries like the host linker):
           1. per-binary `<name>.interpreter` under [binaries]
              (empty list = bare invocation; explicitly disables the global default)
           2. global `interpreter` under [properties]
           3. None
         """
-        per_binary = self.binaries[MachineChoice.BUILD].attrs.get(name, {}).get('interpreter')
+        per_binary = self.binaries[for_machine].attrs.get(name, {}).get('interpreter')
         if per_binary is not None:
             return list(per_binary)
-        default = self.properties[MachineChoice.BUILD].get_interpreter()
+        default = self.properties[for_machine].get_interpreter()
         if default:
             return list(default)
         return None

--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -143,6 +143,22 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
     if value is not None:
         override = comp_class.use_linker_args(value[0], comp_version)
         check_args += override
+        # If [binaries] ld.<value[0]> (or bare <value[0]>) is configured,
+        # materialize its interpreter-wrapper now so the gcc
+        # -fuse-ld=<value[0]> search via -B<binary-wrappers> (injected by
+        # compilers/detect.py) finds it.  Prefer the canonical `ld.<short>`
+        # name (matches the gcc/clang -fuse-ld search path); fall back to
+        # the bare name so users with `[binaries] mold = <path>` don't
+        # have to also add a redundant `ld.mold` entry.  `for_machine` is
+        # passed through so cross builds resolve the host machine's
+        # loader prefix.
+        from ..programs import ExternalProgram
+        for ld_name in (f'ld.{value[0]}', value[0]):
+            ld_entry = env.lookup_binary_entry(for_machine, ld_name)
+            if ld_entry is not None:
+                ExternalProgram.from_entry(ld_name, ld_entry, env=env,
+                                           for_machine=for_machine)
+                break
 
     if env.machines[for_machine].is_os2() and env.coredata.optstore.get_value_for(OptionKey('os2_emxomf')):
         check_args += ['-Zomf']

--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -253,7 +253,7 @@ class ExternalProgram(Program):
         command = env.lookup_binary_entry(for_machine, name)
         if command is None:
             return NonExistingExternalProgram()
-        return cls.from_entry(name, command, env=env)
+        return cls.from_entry(name, command, env=env, for_machine=for_machine)
 
     @staticmethod
     @functools.lru_cache(maxsize=None)
@@ -281,7 +281,8 @@ class ExternalProgram(Program):
 
     @staticmethod
     def from_entry(name: str, command: T.Union[str, T.List[str]],
-                   env: T.Optional['Environment'] = None) -> 'ExternalProgram':
+                   env: T.Optional['Environment'] = None,
+                   for_machine: MachineChoice = MachineChoice.BUILD) -> 'ExternalProgram':
         if isinstance(command, list):
             if len(command) == 1:
                 command = command[0]
@@ -297,9 +298,11 @@ class ExternalProgram(Program):
             prog = ExternalProgram(command, silent=True)
         # If a [binaries] interpreter is configured for this name, replace the
         # command with a POSIX shell wrapper that exec's the bare binary through
-        # the interpreter.  Build-machine only; bundled tooling is build-time.
+        # the interpreter.  Defaults to the build machine; callers resolving a
+        # cross-targeted binary (e.g. the host linker) pass `for_machine`
+        # explicitly so cross builds get the host machine's loader prefix.
         if env is not None and prog.found():
-            interpreter = env.lookup_binary_interpreter(name)
+            interpreter = env.lookup_binary_interpreter(name, for_machine)
             if interpreter:
                 # Pass the resolved binary command; only `real_cmd[0]`
                 # (the bare exe) is baked into the wrapper's exec line.

--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import functools
 import os
+import shlex
 import shutil
 import stat
 import sys
@@ -18,6 +19,50 @@ from abc import ABCMeta, abstractmethod
 from . import mesonlib
 from . import mlog
 from .mesonlib import MachineChoice, OrderedSet
+
+
+def _generate_binary_wrapper(name: str, interpreter: T.List[str], real_exe: str,
+                             wrappers_dir: Path, host_system: str) -> T.Optional[Path]:
+    """Generate a POSIX shell wrapper that exec's `real_exe` through `interpreter`.
+
+    POSIX-only.  Returns None on Windows (caller falls back to bare exe).
+    Idempotent: regenerates only if the inputs change.
+    """
+    if host_system == 'windows':
+        mlog.warning(f"'{name}.interpreter' is POSIX-only; ignored on Windows",
+                     once=True, fatal=False)
+        return None
+
+    # Extract --library-path argument (if any) for LD_LIBRARY_PATH inheritance.
+    library_path: T.Optional[str] = None
+    for i in range(len(interpreter) - 1):
+        if interpreter[i] == '--library-path':
+            library_path = interpreter[i + 1]
+            break
+
+    lines = [
+        '#!/bin/sh',
+        '# meson-generated binary wrapper -- do not edit',
+        'HERE=$(cd "$(dirname "$0")" && pwd)',
+        'export PATH="$HERE${PATH:+:$PATH}"',
+    ]
+    if library_path is not None:
+        qlp = shlex.quote(library_path)
+        lines.append(
+            f'export LD_LIBRARY_PATH={qlp}'
+            f'"${{LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}}"')
+    quoted_interp = ' '.join(shlex.quote(s) for s in interpreter)
+    quoted_exe = shlex.quote(real_exe)
+    lines.append(f'exec {quoted_interp} {quoted_exe} "$@"')
+    content = '\n'.join(lines) + '\n'
+
+    wrapper = wrappers_dir / name
+    if wrapper.exists() and wrapper.read_text() == content:
+        return wrapper
+    wrappers_dir.mkdir(parents=True, exist_ok=True)
+    wrapper.write_text(content)
+    os.chmod(wrapper, 0o755)
+    return wrapper
 
 if T.TYPE_CHECKING:
     from typing_extensions import TypeAlias
@@ -176,7 +221,7 @@ class ExternalProgram(Program):
         command = env.lookup_binary_entry(for_machine, name)
         if command is None:
             return NonExistingExternalProgram()
-        return cls.from_entry(name, command)
+        return cls.from_entry(name, command, env=env)
 
     @staticmethod
     @functools.lru_cache(maxsize=None)
@@ -203,7 +248,8 @@ class ExternalProgram(Program):
         return os.pathsep.join(paths)
 
     @staticmethod
-    def from_entry(name: str, command: T.Union[str, T.List[str]]) -> 'ExternalProgram':
+    def from_entry(name: str, command: T.Union[str, T.List[str]],
+                   env: T.Optional['Environment'] = None) -> 'ExternalProgram':
         if isinstance(command, list):
             if len(command) == 1:
                 command = command[0]
@@ -212,10 +258,29 @@ class ExternalProgram(Program):
         if isinstance(command, list) or os.path.isabs(command):
             if isinstance(command, str):
                 command = [command]
-            return ExternalProgram(name, command=command, silent=True)
-        assert isinstance(command, str)
-        # Search for the command using the specified string!
-        return ExternalProgram(command, silent=True)
+            prog = ExternalProgram(name, command=command, silent=True)
+        else:
+            assert isinstance(command, str)
+            # Search for the command using the specified string!
+            prog = ExternalProgram(command, silent=True)
+        # If a [binaries] interpreter is configured for this name, replace the
+        # command with a POSIX shell wrapper that exec's the bare binary through
+        # the interpreter.  Build-machine only; bundled tooling is build-time.
+        if env is not None and prog.found():
+            interpreter = env.lookup_binary_interpreter(name)
+            if interpreter:
+                # Identify the bare real_exe: the last argv element of the
+                # resolved command (skips e.g. ccache / python wrappers).
+                real_exe = prog.command[-1]
+                wrappers_dir = env.binary_wrappers_dir()
+                host_system = env.machines.host.system
+                wrapper = _generate_binary_wrapper(
+                    name, interpreter, real_exe, wrappers_dir, host_system)
+                if wrapper is not None:
+                    wrapper_str = str(wrapper)
+                    prog.command = [wrapper_str]
+                    prog.path = wrapper_str
+        return prog
 
     @staticmethod
     def _shebang_to_cmd(script: str) -> T.Optional[T.List[str]]:
@@ -414,7 +479,7 @@ def find_external_program(env: 'Environment', for_machine: MachineChoice, name: 
         if potential_cmd is not None:
             mlog.debug(f'{display_name} binary for {for_machine} specified from cross file, native file, '
                        f'or env var as {potential_cmd}')
-            yield ExternalProgram.from_entry(potential_name, potential_cmd)
+            yield ExternalProgram.from_entry(potential_name, potential_cmd, env=env)
             # We never fallback if the user-specified option is no good, so
             # stop returning options.
             return

--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -24,11 +24,18 @@ from .mesonlib import MachineChoice, OrderedSet
 def _generate_binary_wrapper(name: str, interpreter: T.List[str],
                              real_cmd: T.List[str],
                              wrappers_dir: Path, host_system: str) -> T.Optional[Path]:
-    """Generate a POSIX shell wrapper that exec's `real_cmd` through `interpreter`.
+    """Generate a POSIX shell wrapper that exec's `real_cmd[0]` through `interpreter`.
 
-    `real_cmd` is the full resolved binary command list (e.g. `[exe]` or
-    `[exe, '-B']`).  Any trailing args in `real_cmd` after the bare exe are
-    inserted between the interpreter and the wrapper's "$@" forward.
+    `real_cmd` is the resolved binary command list.  Only the bare exe
+    (`real_cmd[0]`) is baked into the wrapper's exec line; any trailing
+    args from a list-form `[binaries]` entry (e.g. `python = ['/path/python',
+    '-B']`) are NOT interleaved into the exec line.  Baking trailing args
+    into the wrapper would cause callers that re-discover the binary via
+    PATH (the wrapper directory is prepended to PATH) to inherit unexpected
+    arguments -- for example, `python -B foo.py` invoked via the wrapper
+    would silently see `-B -B foo.py`.  Callers that need extra args
+    should pass them as positional arguments at call sites, not bake them
+    into the [binaries] list-form entry.
 
     POSIX-only.  Returns None on Windows (caller falls back to bare exe).
     Idempotent: regenerates only if the inputs change.
@@ -69,7 +76,10 @@ def _generate_binary_wrapper(name: str, interpreter: T.List[str],
     tail = interpreter[loader_idx + 1:]
     quoted_head = ' '.join(shlex.quote(s) for s in head)
     quoted_tail = ' '.join(shlex.quote(s) for s in tail)
-    quoted_cmd = ' '.join(shlex.quote(s) for s in real_cmd)
+    # Only the bare exe goes into the exec line.  Trailing args from a
+    # list-form [binaries] entry are deliberately discarded (see docstring).
+    bare_exe = real_cmd[0]
+    quoted_cmd = shlex.quote(bare_exe)
     pieces = [f'exec {quoted_head}', '--argv0 "$0"']
     if quoted_tail:
         pieces.append(quoted_tail)
@@ -291,9 +301,11 @@ class ExternalProgram(Program):
         if env is not None and prog.found():
             interpreter = env.lookup_binary_interpreter(name)
             if interpreter:
-                # Pass the full resolved binary command (exe + any trailing
-                # args from a list-form entry, e.g. `python -B`) so the
-                # wrapper preserves trailing args before "$@".
+                # Pass the resolved binary command; only `real_cmd[0]`
+                # (the bare exe) is baked into the wrapper's exec line.
+                # See `_generate_binary_wrapper` docstring for the
+                # rationale (trailing args from a list-form entry are
+                # deliberately not interleaved).
                 real_cmd = list(prog.command)
                 wrappers_dir = env.binary_wrappers_dir()
                 host_system = env.machines.host.system

--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -53,9 +53,29 @@ def _generate_binary_wrapper(name: str, interpreter: T.List[str],
         'HERE=$(cd "$(dirname "$0")" && pwd)',
         'export PATH="$HERE${PATH:+:$PATH}"',
     ]
-    quoted_interp = ' '.join(shlex.quote(s) for s in interpreter)
+    # Pass the wrapper's own path as argv[0] to the bundled binary.  This lets
+    # programs that consume argv[0] (shells, compilers, CPython for sys.executable)
+    # see the wrapper -- so child processes re-enter through the wrapper and
+    # inherit the loader + library-path setup transparently.  `--argv0` is a
+    # ld-linux.so flag, so it must immediately follow the loader's argv entry;
+    # locate the first element whose basename looks like a ld.so binary
+    # (covers env-prefix forms such as `['env', VAR=val, ld-linux.so, ...]`).
+    # Requires --argv0 support in the bundled loader (glibc >= 2.33).
+    loader_re = re.compile(r'^ld[-.][^/]*\.so(\.\d+)*$')
+    loader_idx = next(
+        (i for i, e in enumerate(interpreter) if loader_re.match(os.path.basename(e))),
+        0)
+    head = interpreter[:loader_idx + 1]
+    tail = interpreter[loader_idx + 1:]
+    quoted_head = ' '.join(shlex.quote(s) for s in head)
+    quoted_tail = ' '.join(shlex.quote(s) for s in tail)
     quoted_cmd = ' '.join(shlex.quote(s) for s in real_cmd)
-    lines.append(f'exec {quoted_interp} {quoted_cmd} "$@"')
+    pieces = [f'exec {quoted_head}', '--argv0 "$0"']
+    if quoted_tail:
+        pieces.append(quoted_tail)
+    pieces.append(quoted_cmd)
+    pieces.append('"$@"')
+    lines.append(' '.join(pieces))
     content = '\n'.join(lines) + '\n'
 
     wrapper = wrappers_dir / name

--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -21,9 +21,14 @@ from . import mlog
 from .mesonlib import MachineChoice, OrderedSet
 
 
-def _generate_binary_wrapper(name: str, interpreter: T.List[str], real_exe: str,
+def _generate_binary_wrapper(name: str, interpreter: T.List[str],
+                             real_cmd: T.List[str],
                              wrappers_dir: Path, host_system: str) -> T.Optional[Path]:
-    """Generate a POSIX shell wrapper that exec's `real_exe` through `interpreter`.
+    """Generate a POSIX shell wrapper that exec's `real_cmd` through `interpreter`.
+
+    `real_cmd` is the full resolved binary command list (e.g. `[exe]` or
+    `[exe, '-B']`).  Any trailing args in `real_cmd` after the bare exe are
+    inserted between the interpreter and the wrapper's "$@" forward.
 
     POSIX-only.  Returns None on Windows (caller falls back to bare exe).
     Idempotent: regenerates only if the inputs change.
@@ -33,12 +38,14 @@ def _generate_binary_wrapper(name: str, interpreter: T.List[str], real_exe: str,
                      once=True, fatal=False)
         return None
 
-    # Extract --library-path argument (if any) for LD_LIBRARY_PATH inheritance.
-    library_path: T.Optional[str] = None
-    for i in range(len(interpreter) - 1):
-        if interpreter[i] == '--library-path':
-            library_path = interpreter[i + 1]
-            break
+    # We deliberately do NOT export LD_LIBRARY_PATH from the wrapper.
+    # The interpreter's `--library-path` argument is honored by ld-linux.so
+    # both at process startup AND for subsequent dlopen() calls inside the
+    # wrapped process (loader-side search path is shared with libdl).
+    # Exporting LD_LIBRARY_PATH would leak the hermetic libdir to any
+    # subprocesses the wrapped binary spawns (e.g. python -> gcc), which
+    # breaks system binaries linked against a newer glibc than the bundled
+    # one.
 
     lines = [
         '#!/bin/sh',
@@ -46,14 +53,9 @@ def _generate_binary_wrapper(name: str, interpreter: T.List[str], real_exe: str,
         'HERE=$(cd "$(dirname "$0")" && pwd)',
         'export PATH="$HERE${PATH:+:$PATH}"',
     ]
-    if library_path is not None:
-        qlp = shlex.quote(library_path)
-        lines.append(
-            f'export LD_LIBRARY_PATH={qlp}'
-            f'"${{LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}}"')
     quoted_interp = ' '.join(shlex.quote(s) for s in interpreter)
-    quoted_exe = shlex.quote(real_exe)
-    lines.append(f'exec {quoted_interp} {quoted_exe} "$@"')
+    quoted_cmd = ' '.join(shlex.quote(s) for s in real_cmd)
+    lines.append(f'exec {quoted_interp} {quoted_cmd} "$@"')
     content = '\n'.join(lines) + '\n'
 
     wrapper = wrappers_dir / name
@@ -269,13 +271,14 @@ class ExternalProgram(Program):
         if env is not None and prog.found():
             interpreter = env.lookup_binary_interpreter(name)
             if interpreter:
-                # Identify the bare real_exe: the last argv element of the
-                # resolved command (skips e.g. ccache / python wrappers).
-                real_exe = prog.command[-1]
+                # Pass the full resolved binary command (exe + any trailing
+                # args from a list-form entry, e.g. `python -B`) so the
+                # wrapper preserves trailing args before "$@".
+                real_cmd = list(prog.command)
                 wrappers_dir = env.binary_wrappers_dir()
                 host_system = env.machines.host.system
                 wrapper = _generate_binary_wrapper(
-                    name, interpreter, real_exe, wrappers_dir, host_system)
+                    name, interpreter, real_cmd, wrappers_dir, host_system)
                 if wrapper is not None:
                     wrapper_str = str(wrapper)
                     prog.command = [wrapper_str]

--- a/unittests/machinefiletests.py
+++ b/unittests/machinefiletests.py
@@ -96,6 +96,177 @@ class MachineFileStoreTests(TestCase):
         finally:
             os.unlink(fname)
 
+class CompilerTableTests(TestCase):
+    """Unit tests for [compilers] section parsing (no build system required)."""
+
+    def _parse_compilers(self, ini_content: str) -> mesonbuild.envconfig.CompilerTable:
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.ini', delete=False,
+                                         encoding='utf-8') as f:
+            f.write(ini_content)
+            fname = f.name
+        try:
+            parser = machinefile.MachineFileParser([fname], '/tmp')
+            return mesonbuild.envconfig.CompilerTable(parser.sections.get('compilers', {}))
+        finally:
+            os.unlink(fname)
+
+    def test_empty_section(self):
+        table = self._parse_compilers('')
+        self.assertEqual(table.compilers, {})
+
+    def test_type_and_version(self):
+        table = self._parse_compilers(textwrap.dedent('''\
+            [compilers]
+            c.type = 'gcc'
+            c.version = '12.2.0'
+            '''))
+        desc = table.lookup('c')
+        self.assertIsNotNone(desc)
+        self.assertEqual(desc.type, 'gcc')
+        self.assertEqual(desc.version, '12.2.0')
+        self.assertIsNone(desc.binary)
+
+    def test_binary_string(self):
+        table = self._parse_compilers(textwrap.dedent('''\
+            [compilers]
+            c.binary = '/usr/bin/gcc'
+            '''))
+        desc = table.lookup('c')
+        self.assertIsNotNone(desc)
+        self.assertEqual(desc.binary, ['/usr/bin/gcc'])
+
+    def test_binary_array(self):
+        table = self._parse_compilers(textwrap.dedent('''\
+            [compilers]
+            c.binary = ['/usr/bin/gcc', '-B/opt/tools/bin']
+            '''))
+        desc = table.lookup('c')
+        self.assertIsNotNone(desc)
+        self.assertEqual(desc.binary, ['/usr/bin/gcc', '-B/opt/tools/bin'])
+
+    def test_ccache_false(self):
+        table = self._parse_compilers(textwrap.dedent('''\
+            [compilers]
+            c.type = 'clang'
+            c.ccache = false
+            '''))
+        desc = table.lookup('c')
+        self.assertIsNotNone(desc)
+        self.assertFalse(desc.ccache)
+
+    def test_ccache_default_is_true(self):
+        table = self._parse_compilers(textwrap.dedent('''\
+            [compilers]
+            c.type = 'gcc'
+            '''))
+        desc = table.lookup('c')
+        self.assertIsNotNone(desc)
+        self.assertTrue(desc.ccache)
+
+    def test_sysroot(self):
+        table = self._parse_compilers(textwrap.dedent('''\
+            [compilers]
+            c.sysroot = '/opt/sysroot'
+            '''))
+        desc = table.lookup('c')
+        self.assertIsNotNone(desc)
+        self.assertEqual(desc.sysroot, '/opt/sysroot')
+
+    def test_no_default_includes(self):
+        table = self._parse_compilers(textwrap.dedent('''\
+            [compilers]
+            c.no-default-includes = true
+            '''))
+        desc = table.lookup('c')
+        self.assertIsNotNone(desc)
+        self.assertTrue(desc.no_default_includes)
+
+    def test_system_include_dirs(self):
+        table = self._parse_compilers(textwrap.dedent('''\
+            [compilers]
+            c.system-include-dirs = ['/opt/sysroot/usr/include', '/opt/gcc/include']
+            '''))
+        desc = table.lookup('c')
+        self.assertIsNotNone(desc)
+        self.assertEqual(desc.system_include_dirs,
+                         ['/opt/sysroot/usr/include', '/opt/gcc/include'])
+
+    def test_tool_search_paths(self):
+        table = self._parse_compilers(textwrap.dedent('''\
+            [compilers]
+            c.tool-search-paths = ['/opt/binutils/bin']
+            '''))
+        desc = table.lookup('c')
+        self.assertIsNotNone(desc)
+        self.assertEqual(desc.tool_search_paths, ['/opt/binutils/bin'])
+
+    def test_subprocess_interpreter(self):
+        table = self._parse_compilers(textwrap.dedent('''\
+            [compilers]
+            c.subprocess-interpreter = ['/lib64/ld-linux-x86-64.so.2',
+                                         '--library-path', '/lib64']
+            '''))
+        desc = table.lookup('c')
+        self.assertIsNotNone(desc)
+        self.assertEqual(desc.subprocess_interpreter,
+                         ['/lib64/ld-linux-x86-64.so.2', '--library-path', '/lib64'])
+
+    def test_multiple_languages(self):
+        table = self._parse_compilers(textwrap.dedent('''\
+            [compilers]
+            c.type = 'gcc'
+            c.version = '12.2.0'
+            cpp.type = 'gcc'
+            cpp.version = '12.2.0'
+            '''))
+        self.assertIsNotNone(table.lookup('c'))
+        self.assertIsNotNone(table.lookup('cpp'))
+        self.assertEqual(table.lookup('c').type, 'gcc')
+        self.assertEqual(table.lookup('cpp').type, 'gcc')
+
+    def test_unknown_key_warning(self):
+        import unittest.mock as mock_module
+        with mock_module.patch.object(mesonbuild.mlog, 'warning') as mock_warn:
+            self._parse_compilers(textwrap.dedent('''\
+                [compilers]
+                c.type = 'gcc'
+                c.unknown-key = 'something'
+                '''))
+            # Should have warned about the unknown key
+            mock_warn.assert_called_once()
+            self.assertIn('unknown-key', mock_warn.call_args[0][0])
+
+    def test_invalid_type_raises(self):
+        with self.assertRaises(Exception) as ctx:
+            self._parse_compilers(textwrap.dedent('''\
+                [compilers]
+                c.type = 'not-a-real-compiler'
+                '''))
+        self.assertIn('not-a-real-compiler', str(ctx.exception))
+
+    def test_invalid_ccache_type_raises(self):
+        with self.assertRaises(Exception):
+            self._parse_compilers(textwrap.dedent('''\
+                [compilers]
+                c.ccache = 'yes'
+                '''))
+
+    def test_missing_dot_raises(self):
+        with self.assertRaises(Exception) as ctx:
+            self._parse_compilers(textwrap.dedent('''\
+                [compilers]
+                ctype = 'gcc'
+                '''))
+        self.assertIn('ctype', str(ctx.exception))
+
+    def test_lookup_missing_returns_none(self):
+        table = self._parse_compilers(textwrap.dedent('''\
+            [compilers]
+            c.type = 'gcc'
+            '''))
+        self.assertIsNone(table.lookup('fortran'))
+
+
 class NativeFileTests(BasePlatformTests):
 
     def setUp(self):

--- a/unittests/machinefiletests.py
+++ b/unittests/machinefiletests.py
@@ -7,6 +7,7 @@ import subprocess
 import tempfile
 import textwrap
 import os
+import shlex
 import shutil
 import stat
 import functools
@@ -506,6 +507,9 @@ class NativeFileTests(BasePlatformTests):
         # Each interpreter element must appear.
         for tok in interpreter:
             self.assertIn(tok, content)
+        # The wrapper must pass its own path as argv[0] to the loader so that
+        # bundled programs consuming argv[0] see the wrapper, not the bare exe.
+        self.assertIn('--argv0 "$0"', content)
 
     @skipIf(is_windows(), '[binaries] <name>.interpreter is POSIX-only')
     def test_binary_interpreter_per_binary(self):
@@ -597,6 +601,90 @@ class NativeFileTests(BasePlatformTests):
         with open(wrapper_path, encoding='utf-8') as f:
             content = f.read()
         self.assertNotIn('/opt/default/', content)
+
+    @skipIf(is_windows(), '[binaries] <name>.interpreter is POSIX-only')
+    def test_binary_interpreter_wrapper_passes_argv0(self):
+        """--argv0 "$0" must appear immediately after the loader path."""
+        from mesonbuild.programs import ExternalProgram
+        real_exe = shutil.which('bash')
+        if real_exe is None:
+            raise SkipTest('bash not found on PATH')
+        loader = '/opt/ld/ld.so'
+        libdir = '/opt/ld/lib'
+        interpreter = [loader, '--library-path', libdir]
+        config = self.helper_create_native_file({
+            'binaries': {
+                'perl': real_exe,
+                'perl.interpreter': interpreter,
+            },
+        })
+        env = self._make_interpreter_env(config)
+        prog = ExternalProgram.from_bin_list(env, MachineChoice.BUILD, 'perl')
+        self.assertTrue(prog.found())
+        wrapper_path = str(env.binary_wrappers_dir() / 'perl')
+        with open(wrapper_path, encoding='utf-8') as f:
+            content = f.read()
+        # --argv0 "$0" must appear right after the loader, before --library-path.
+        exec_line = next((ln for ln in content.splitlines() if ln.startswith('exec ')), '')
+        self.assertTrue(exec_line, f'no exec line in wrapper:\n{content}')
+        self.assertIn(f'exec {loader} --argv0 "$0" --library-path', exec_line)
+
+    @skipIf(is_windows(), '[binaries] <name>.interpreter is POSIX-only')
+    def test_binary_interpreter_wrapper_passes_argv0_env_prefix(self):
+        """--argv0 "$0" must land after the loader even when the interpreter
+        list starts with an `env VAR=val` prefix (loader is not [0])."""
+        from mesonbuild.programs import ExternalProgram
+        real_exe = shutil.which('bash')
+        if real_exe is None:
+            raise SkipTest('bash not found on PATH')
+        loader = '/opt/ld/ld-linux-x86-64.so.2'
+        libdir = '/opt/ld/lib'
+        interpreter = ['env', 'PYTHONHOME=/opt/py3', loader,
+                       '--library-path', libdir]
+        config = self.helper_create_native_file({
+            'binaries': {
+                'perl': real_exe,
+                'perl.interpreter': interpreter,
+            },
+        })
+        env = self._make_interpreter_env(config)
+        prog = ExternalProgram.from_bin_list(env, MachineChoice.BUILD, 'perl')
+        self.assertTrue(prog.found())
+        wrapper_path = str(env.binary_wrappers_dir() / 'perl')
+        with open(wrapper_path, encoding='utf-8') as f:
+            content = f.read()
+        exec_line = next((ln for ln in content.splitlines() if ln.startswith('exec ')), '')
+        self.assertTrue(exec_line, f'no exec line in wrapper:\n{content}')
+        # --argv0 "$0" must be inserted AFTER the loader (not after env).
+        self.assertIn(
+            f'env PYTHONHOME=/opt/py3 {loader} --argv0 "$0" --library-path',
+            exec_line)
+
+    @skipIf(is_windows(), '[binaries] <name>.interpreter is POSIX-only')
+    def test_binary_interpreter_wrapper_passes_argv0_no_extra_args(self):
+        """--argv0 "$0" must still be emitted when the interpreter is just [loader]."""
+        from mesonbuild.programs import ExternalProgram
+        real_exe = shutil.which('bash')
+        if real_exe is None:
+            raise SkipTest('bash not found on PATH')
+        loader = '/opt/ld/ld.so'
+        interpreter = [loader]
+        config = self.helper_create_native_file({
+            'binaries': {
+                'perl': real_exe,
+                'perl.interpreter': interpreter,
+            },
+        })
+        env = self._make_interpreter_env(config)
+        prog = ExternalProgram.from_bin_list(env, MachineChoice.BUILD, 'perl')
+        self.assertTrue(prog.found())
+        wrapper_path = str(env.binary_wrappers_dir() / 'perl')
+        with open(wrapper_path, encoding='utf-8') as f:
+            content = f.read()
+        exec_line = next((ln for ln in content.splitlines() if ln.startswith('exec ')), '')
+        self.assertTrue(exec_line, f'no exec line in wrapper:\n{content}')
+        # Loader followed immediately by --argv0 "$0", then real_exe.
+        self.assertIn(f'exec {loader} --argv0 "$0" {shlex.quote(real_exe)}', exec_line)
 
     def test_user_options(self):
         testcase = os.path.join(self.common_test_dir, '40 options')

--- a/unittests/machinefiletests.py
+++ b/unittests/machinefiletests.py
@@ -1044,6 +1044,61 @@ class NativeFileTests(BasePlatformTests):
             # hermetic libdir doesn't leak to subprocesses.
             self.assertNotIn('LD_LIBRARY_PATH', content)
 
+    @skipIf(is_windows(), 'POSIX-only feature')
+    def test_compiler_wrappers_use_binary_interpreter_clang(self):
+        """[binaries] c.interpreter drives subprocess-wrapper generation for the
+        clang fast path; only as/ld are wrapped (clang is monolithic for
+        codegen).
+        """
+        from mesonbuild.compilers import detect as compiler_detect
+        real_exe = shutil.which('bash')
+        if real_exe is None:
+            raise SkipTest('bash not found on PATH')
+        fake_subprog = real_exe
+        interpreter = ['/opt/ld/ld.so', '--library-path', '/opt/ld/lib']
+        config = self.helper_create_native_file({
+            'binaries': {
+                'c': real_exe,
+                'c.interpreter': interpreter,
+            },
+        })
+        env = self._make_interpreter_env(config)
+
+        def fake_popen(args, *a, **kw):
+            if '--print-prog-name' in args:
+                return None, fake_subprog + '\n', ''
+            return None, '', ''
+
+        with mock.patch('mesonbuild.compilers.detect.Popen_safe',
+                        side_effect=fake_popen):
+            wrapper_dir = compiler_detect._generate_subprocess_wrappers(
+                env, [real_exe], 'c', ('as', 'ld', 'lto1'),
+                env.lookup_binary_interpreter('c'))
+
+        self.assertIsNotNone(wrapper_dir,
+                             'expected clang wrapper dir to be returned')
+        argv_flag = f'-B{wrapper_dir}'
+        self.assertTrue(argv_flag.startswith('-B'))
+        self.assertTrue(os.path.isdir(wrapper_dir))
+        # Clang's wrapped subprograms: as, ld, lto1 (NOT cc1/cc1plus -- clang
+        # is monolithic for codegen; lto1 is the ThinLTO link-time backend).
+        for prog in ('as', 'ld', 'lto1'):
+            wrapper = os.path.join(wrapper_dir, prog)
+            self.assertTrue(os.path.exists(wrapper),
+                            f'expected clang subprogram wrapper: {wrapper}')
+            with open(wrapper, encoding='utf-8') as f:
+                content = f.read()
+            self.assertIn('#!/bin/sh', content)
+            for tok in interpreter:
+                self.assertIn(tok, content)
+            self.assertIn(fake_subprog, content)
+            self.assertNotIn('LD_LIBRARY_PATH', content)
+        # Verify gcc-only subprograms were NOT generated for the clang path.
+        for gcc_only in ('cc1', 'cc1plus'):
+            self.assertFalse(
+                os.path.exists(os.path.join(wrapper_dir, gcc_only)),
+                f'unexpected gcc-only wrapper present for clang: {gcc_only}')
+
     def test_user_options(self):
         testcase = os.path.join(self.common_test_dir, '40 options')
         for opt, value in [('testoption', 'some other val'), ('other_one', True),

--- a/unittests/machinefiletests.py
+++ b/unittests/machinefiletests.py
@@ -181,17 +181,6 @@ class CompilerTableTests(TestCase):
         self.assertIsNotNone(desc)
         self.assertEqual(desc.tool_search_paths, ['/opt/binutils/bin'])
 
-    def test_subprocess_interpreter(self):
-        table = self._parse_compilers(textwrap.dedent('''\
-            [compilers]
-            c.subprocess-interpreter = ['/lib64/ld-linux-x86-64.so.2',
-                                         '--library-path', '/lib64']
-            '''))
-        desc = table.lookup('c')
-        self.assertIsNotNone(desc)
-        self.assertEqual(desc.subprocess_interpreter,
-                         ['/lib64/ld-linux-x86-64.so.2', '--library-path', '/lib64'])
-
     def test_multiple_languages(self):
         table = self._parse_compilers(textwrap.dedent('''\
             [compilers]
@@ -1000,6 +989,60 @@ class NativeFileTests(BasePlatformTests):
         # fires at most once per meson invocation.
         self.assertTrue(warn_mock.call_args.kwargs.get('once'),
                         f'warning must pass once=True, got kwargs={warn_mock.call_args.kwargs!r}')
+
+    @skipIf(is_windows(), 'POSIX-only feature')
+    def test_compiler_wrappers_use_binary_interpreter_gcc(self):
+        """[binaries] c.interpreter drives subprocess-wrapper generation for the
+        GCC fast path; the resulting -B<wrapper_dir> would be prepended to argv.
+        """
+        from mesonbuild.compilers import detect as compiler_detect
+        real_exe = shutil.which('bash')
+        if real_exe is None:
+            raise SkipTest('bash not found on PATH')
+        # Stand-in subprogram paths -- the wrapper generator only requires
+        # them to be absolute and existing files.
+        fake_cc1 = real_exe
+        interpreter = ['/opt/ld/ld.so', '--library-path', '/opt/ld/lib']
+        config = self.helper_create_native_file({
+            'binaries': {
+                'c': real_exe,
+                'c.interpreter': interpreter,
+            },
+        })
+        env = self._make_interpreter_env(config)
+
+        def fake_popen(args, *a, **kw):
+            # --print-prog-name <name> -> emit our stand-in path.
+            if '--print-prog-name' in args:
+                return None, fake_cc1 + '\n', ''
+            return None, '', ''
+
+        with mock.patch('mesonbuild.compilers.detect.Popen_safe',
+                        side_effect=fake_popen):
+            wrapper_dir = compiler_detect._generate_subprocess_wrappers(
+                env, [real_exe], 'c', ('cc1', 'cc1plus', 'lto1'),
+                env.lookup_binary_interpreter('c'))
+
+        self.assertIsNotNone(wrapper_dir, 'expected a wrapper dir to be returned')
+        # -B<wrapper_dir> is the argv prefix that would be prepended.
+        argv_flag = f'-B{wrapper_dir}'
+        self.assertTrue(argv_flag.startswith('-B'))
+        self.assertTrue(os.path.isdir(wrapper_dir))
+        for prog in ('cc1', 'cc1plus', 'lto1'):
+            wrapper = os.path.join(wrapper_dir, prog)
+            self.assertTrue(os.path.exists(wrapper),
+                            f'expected GCC subprogram wrapper: {wrapper}')
+            with open(wrapper, encoding='utf-8') as f:
+                content = f.read()
+            self.assertIn('#!/bin/sh', content)
+            # Interpreter argv elements appear in the exec line.
+            for tok in interpreter:
+                self.assertIn(tok, content)
+            self.assertIn(fake_cc1, content)
+            # Wrapper relies solely on the interpreter's `--library-path`
+            # arg; LD_LIBRARY_PATH is intentionally NOT exported so the
+            # hermetic libdir doesn't leak to subprocesses.
+            self.assertNotIn('LD_LIBRARY_PATH', content)
 
     def test_user_options(self):
         testcase = os.path.join(self.common_test_dir, '40 options')

--- a/unittests/machinefiletests.py
+++ b/unittests/machinefiletests.py
@@ -8,6 +8,7 @@ import tempfile
 import textwrap
 import os
 import shutil
+import stat
 import functools
 import threading
 import sys
@@ -37,7 +38,8 @@ import mesonbuild.modules.pkgconfig
 
 from run_tests import (
     Backend,
-    get_fake_env
+    get_fake_env,
+    get_fake_options,
 )
 
 from .baseplatformtests import BasePlatformTests
@@ -471,6 +473,126 @@ class NativeFileTests(BasePlatformTests):
 
         self.init(testcase, extra_args=['--native-file', config])
         self.build()
+
+    def _make_interpreter_env(self, native_file: str) -> 'mesonbuild.environment.Environment':
+        opts = get_fake_options(prefix='')
+        opts.native_file = [native_file]
+        env = get_fake_env(bdir=self.builddir, opts=opts)
+        # Force host system away from windows so the POSIX wrapper path is used.
+        env.machines.host.system = 'linux'
+        env.machines.build.system = 'linux'
+        return env
+
+    def _assert_wrapper_content(self, wrapper_path: str, interpreter: T.List[str],
+                                real_exe: str, expect_ld_library_path: T.Optional[str]):
+        self.assertTrue(os.path.exists(wrapper_path), f'wrapper missing: {wrapper_path}')
+        st = os.stat(wrapper_path)
+        self.assertTrue(st.st_mode & stat.S_IXUSR, 'wrapper not executable')
+        with open(wrapper_path, encoding='utf-8') as f:
+            content = f.read()
+        self.assertIn('#!/bin/sh', content)
+        self.assertIn('export PATH="$HERE', content)
+        if expect_ld_library_path is not None:
+            self.assertIn('export LD_LIBRARY_PATH=', content)
+            self.assertIn(expect_ld_library_path, content)
+        else:
+            self.assertNotIn('LD_LIBRARY_PATH', content)
+        # Bare-exe path must appear in the exec line.
+        self.assertIn(real_exe, content)
+        # Each interpreter element must appear.
+        for tok in interpreter:
+            self.assertIn(tok, content)
+
+    @skipIf(is_windows(), '[binaries] <name>.interpreter is POSIX-only')
+    def test_binary_interpreter_per_binary(self):
+        from mesonbuild.programs import ExternalProgram
+        # Real exe must exist for ExternalProgram.found() to be True.
+        real_exe = shutil.which('bash')
+        if real_exe is None:
+            raise SkipTest('bash not found on PATH')
+        interpreter = ['/opt/ld/ld.so', '--library-path', '/opt/ld/lib']
+        config = self.helper_create_native_file({
+            'binaries': {
+                'perl': real_exe,
+                'perl.interpreter': interpreter,
+            },
+        })
+        env = self._make_interpreter_env(config)
+        prog = ExternalProgram.from_bin_list(env, MachineChoice.BUILD, 'perl')
+        self.assertTrue(prog.found())
+        expected = str(env.binary_wrappers_dir() / 'perl')
+        self.assertEqual(prog.get_command(), [expected])
+        self.assertEqual(prog.get_path(), expected)
+        self._assert_wrapper_content(expected, interpreter, real_exe,
+                                     expect_ld_library_path='/opt/ld/lib')
+
+    @skipIf(is_windows(), '[binaries] <name>.interpreter is POSIX-only')
+    def test_binary_interpreter_default(self):
+        from mesonbuild.programs import ExternalProgram
+        real_bash = shutil.which('bash')
+        real_sh = shutil.which('sh')
+        if real_bash is None or real_sh is None:
+            raise SkipTest('bash/sh not found on PATH')
+        # No --library-path: LD_LIBRARY_PATH export must NOT appear.
+        interpreter = ['/opt/ld/ld.so']
+        config = self.helper_create_native_file({
+            'binaries': {
+                'perl': real_bash,
+                'awk': real_sh,
+            },
+            'properties': {
+                'interpreter': interpreter,
+            },
+        })
+        env = self._make_interpreter_env(config)
+        for name, real_exe in [('perl', real_bash), ('awk', real_sh)]:
+            prog = ExternalProgram.from_bin_list(env, MachineChoice.BUILD, name)
+            self.assertTrue(prog.found())
+            expected = str(env.binary_wrappers_dir() / name)
+            self.assertEqual(prog.get_command(), [expected])
+            self.assertEqual(prog.get_path(), expected)
+            self._assert_wrapper_content(expected, interpreter, real_exe,
+                                         expect_ld_library_path=None)
+
+    @skipIf(is_windows(), '[binaries] <name>.interpreter is POSIX-only')
+    def test_binary_interpreter_override(self):
+        from mesonbuild.programs import ExternalProgram
+        real_bash = shutil.which('bash')
+        real_sh = shutil.which('sh')
+        if real_bash is None or real_sh is None:
+            raise SkipTest('bash/sh not found on PATH')
+        default_interp = ['/opt/default/ld.so', '--library-path', '/opt/default/lib']
+        override_interp = ['/opt/py36/ld.so', '--library-path', '/opt/py36/lib']
+        config = self.helper_create_native_file({
+            'binaries': {
+                'perl': real_bash,
+                'python3_codegen': real_sh,
+                'python3_codegen.interpreter': override_interp,
+            },
+            'properties': {
+                'interpreter': default_interp,
+            },
+        })
+        env = self._make_interpreter_env(config)
+        # perl: uses global default
+        perl = ExternalProgram.from_bin_list(env, MachineChoice.BUILD, 'perl')
+        self.assertTrue(perl.found())
+        self._assert_wrapper_content(
+            str(env.binary_wrappers_dir() / 'perl'),
+            default_interp, real_bash, expect_ld_library_path='/opt/default/lib')
+        # python3_codegen: per-binary override beats default
+        pycg = ExternalProgram.from_bin_list(env, MachineChoice.BUILD, 'python3_codegen')
+        self.assertTrue(pycg.found())
+        wrapper_path = str(env.binary_wrappers_dir() / 'python3_codegen')
+        self.assertEqual(pycg.get_command(), [wrapper_path])
+        self.assertEqual(pycg.get_path(), wrapper_path)
+        self._assert_wrapper_content(
+            wrapper_path, override_interp, real_sh,
+            expect_ld_library_path='/opt/py36/lib')
+        # Wrapper content must NOT mention the default loader (override beats default).
+        with open(wrapper_path, encoding='utf-8') as f:
+            content = f.read()
+        self.assertNotIn('/opt/default/', content)
 
     def test_user_options(self):
         testcase = os.path.join(self.common_test_dir, '40 options')

--- a/unittests/machinefiletests.py
+++ b/unittests/machinefiletests.py
@@ -492,11 +492,15 @@ class NativeFileTests(BasePlatformTests):
             content = f.read()
         self.assertIn('#!/bin/sh', content)
         self.assertIn('export PATH="$HERE', content)
-        if expect_ld_library_path is not None:
-            self.assertIn('export LD_LIBRARY_PATH=', content)
-            self.assertIn(expect_ld_library_path, content)
-        else:
-            self.assertNotIn('LD_LIBRARY_PATH', content)
+        # Wrapper deliberately does NOT export LD_LIBRARY_PATH; the
+        # interpreter's `--library-path` argument suffices for both startup
+        # and dlopen() resolution inside the wrapped process, and keeping
+        # LD_LIBRARY_PATH out of the wrapper's env prevents leakage to
+        # subprocesses (e.g. python -> system ccache) that should use the
+        # host glibc, not the hermetic one.  `expect_ld_library_path` is
+        # kept in the signature for backwards-compatible test call sites
+        # but the assertion below ensures we never re-introduce the export.
+        self.assertNotIn('LD_LIBRARY_PATH', content)
         # Bare-exe path must appear in the exec line.
         self.assertIn(real_exe, content)
         # Each interpreter element must appear.

--- a/unittests/machinefiletests.py
+++ b/unittests/machinefiletests.py
@@ -1099,6 +1099,142 @@ class NativeFileTests(BasePlatformTests):
                 os.path.exists(os.path.join(wrapper_dir, gcc_only)),
                 f'unexpected gcc-only wrapper present for clang: {gcc_only}')
 
+    @skipIf(is_windows(), 'POSIX-only feature')
+    def test_linker_wrapper_materializes_on_c_ld_lld(self):
+        """[linkers] guess_nix_linker materializes the ld.<linker> wrapper
+        eagerly when c_ld/cpp_ld selects a linker that has a [binaries]
+        ld.<short> entry with an interpreter prefix.
+        """
+        from mesonbuild.programs import ExternalProgram
+        real_exe = shutil.which('bash')
+        if real_exe is None:
+            raise SkipTest('bash not found on PATH')
+        interpreter = ['/opt/ld/ld.so', '--library-path', '/opt/ld/lib']
+        config = self.helper_create_native_file({
+            'binaries': {
+                'c': real_exe,
+                'ld.lld': real_exe,
+                'ld.lld.interpreter': interpreter,
+            },
+        })
+        env = self._make_interpreter_env(config)
+        # Mimic guess_nix_linker's eager materialization path.
+        ld_entry = env.lookup_binary_entry(MachineChoice.BUILD, 'ld.lld')
+        self.assertIsNotNone(ld_entry, 'fixture should expose [binaries] ld.lld')
+        ExternalProgram.from_entry('ld.lld', ld_entry, env=env,
+                                   for_machine=MachineChoice.BUILD)
+        wrapper = env.binary_wrappers_dir() / 'ld.lld'
+        self.assertTrue(wrapper.exists(),
+                        f'expected ld.lld wrapper to materialize: {wrapper}')
+        self._assert_wrapper_content(str(wrapper), interpreter, real_exe,
+                                     expect_ld_library_path='/opt/ld/lib')
+
+    @skipIf(is_windows(), 'POSIX-only feature')
+    def test_linker_wrapper_noop_when_binary_missing(self):
+        """No-op when c_ld/cpp_ld selects a linker that has no matching
+        [binaries] entry: guess_nix_linker must not crash and must not
+        materialize any wrapper.
+        """
+        real_exe = shutil.which('bash')
+        if real_exe is None:
+            raise SkipTest('bash not found on PATH')
+        interpreter = ['/opt/ld/ld.so', '--library-path', '/opt/ld/lib']
+        config = self.helper_create_native_file({
+            'binaries': {
+                'c': real_exe,
+                'c.interpreter': interpreter,
+            },
+        })
+        env = self._make_interpreter_env(config)
+        # Neither 'ld.gold' nor bare 'gold' is configured -> lookup returns None.
+        for name in ('ld.gold', 'gold'):
+            self.assertIsNone(env.lookup_binary_entry(MachineChoice.BUILD, name),
+                              f'fixture should not expose [binaries] {name}')
+        # binary_wrappers_dir() may or may not exist; either way, no ld.gold
+        # wrapper should be present.
+        wrapper = env.binary_wrappers_dir() / 'ld.gold'
+        self.assertFalse(wrapper.exists(),
+                         f'unexpected wrapper materialized: {wrapper}')
+
+    @skipIf(is_windows(), 'POSIX-only feature')
+    def test_linker_wrapper_bare_name_fallback(self):
+        """When the user configures `[binaries] mold = <path>` (without a
+        redundant `ld.mold` entry) and selects `c_ld='mold'`, guess_nix_linker's
+        bare-name fallback materializes the wrapper under the bare name.
+        """
+        from mesonbuild.programs import ExternalProgram
+        real_exe = shutil.which('bash')
+        if real_exe is None:
+            raise SkipTest('bash not found on PATH')
+        interpreter = ['/opt/ld/ld.so', '--library-path', '/opt/ld/lib']
+        config = self.helper_create_native_file({
+            'binaries': {
+                'c': real_exe,
+                'mold': real_exe,
+                'mold.interpreter': interpreter,
+            },
+        })
+        env = self._make_interpreter_env(config)
+        # Canonical name absent; bare name present.
+        self.assertIsNone(env.lookup_binary_entry(MachineChoice.BUILD, 'ld.mold'),
+                          'fixture should not expose ld.mold')
+        bare_entry = env.lookup_binary_entry(MachineChoice.BUILD, 'mold')
+        self.assertIsNotNone(bare_entry,
+                             'fixture should expose [binaries] mold')
+        ExternalProgram.from_entry('mold', bare_entry, env=env,
+                                   for_machine=MachineChoice.BUILD)
+        wrapper = env.binary_wrappers_dir() / 'mold'
+        self.assertTrue(wrapper.exists(),
+                        f'expected mold wrapper to materialize via bare-name fallback: {wrapper}')
+        self._assert_wrapper_content(str(wrapper), interpreter, real_exe,
+                                     expect_ld_library_path='/opt/ld/lib')
+
+    @skipIf(is_windows(), 'POSIX-only feature')
+    def test_linker_wrapper_cross_machine(self):
+        """Cross builds: c_ld='lld' + host-machine [binaries] ld.lld must
+        materialize using the HOST machine's interpreter prefix, not the
+        BUILD machine's.  Verifies for_machine is threaded through
+        lookup_binary_interpreter().
+        """
+        from mesonbuild.programs import ExternalProgram
+        real_exe = shutil.which('bash')
+        if real_exe is None:
+            raise SkipTest('bash not found on PATH')
+        host_interpreter = ['/opt/host-ld/ld.so',
+                            '--library-path', '/opt/host-ld/lib']
+        # Build a config that sets BOTH host and (intentionally distinct)
+        # build interpreters so we can confirm the host one wins for a
+        # host-targeted linker entry.
+        cfg_path = os.path.join(self.builddir, 'cross_linker.config')
+        with open(cfg_path, 'wt', encoding='utf-8') as f:
+            f.write('[binaries]\n')
+            f.write(f"c = '{real_exe}'\n")
+            f.write(f"ld.lld = '{real_exe}'\n")
+            tokens = ', '.join([f"'{w}'" for w in host_interpreter])
+            f.write(f"ld.lld.interpreter = [{tokens}]\n")
+        opts = get_fake_options(prefix='')
+        opts.cross_file = [cfg_path]
+        env = get_fake_env(bdir=self.builddir, opts=opts)
+        env.machines.host.system = 'linux'
+        env.machines.build.system = 'linux'
+        # Sanity: the host machine should see the entry; the build machine
+        # should not (cross file populates HOST, native file BUILD).
+        self.assertIsNotNone(
+            env.lookup_binary_entry(MachineChoice.HOST, 'ld.lld'),
+            'cross-file [binaries] ld.lld should be visible on HOST')
+        ld_entry = env.lookup_binary_entry(MachineChoice.HOST, 'ld.lld')
+        ExternalProgram.from_entry('ld.lld', ld_entry, env=env,
+                                   for_machine=MachineChoice.HOST)
+        wrapper = env.binary_wrappers_dir() / 'ld.lld'
+        self.assertTrue(wrapper.exists(),
+                        f'expected host-machine ld.lld wrapper: {wrapper}')
+        with open(wrapper, encoding='utf-8') as f:
+            content = f.read()
+        # The HOST interpreter prefix must be baked into the wrapper.
+        for tok in host_interpreter:
+            self.assertIn(tok, content,
+                          f'host interpreter token missing from wrapper: {tok}')
+
     def test_user_options(self):
         testcase = os.path.join(self.common_test_dir, '40 options')
         for opt, value in [('testoption', 'some other val'), ('other_one', True),

--- a/unittests/machinefiletests.py
+++ b/unittests/machinefiletests.py
@@ -124,25 +124,6 @@ class CompilerTableTests(TestCase):
         self.assertIsNotNone(desc)
         self.assertEqual(desc.type, 'gcc')
         self.assertEqual(desc.version, '12.2.0')
-        self.assertIsNone(desc.binary)
-
-    def test_binary_string(self):
-        table = self._parse_compilers(textwrap.dedent('''\
-            [compilers]
-            c.binary = '/usr/bin/gcc'
-            '''))
-        desc = table.lookup('c')
-        self.assertIsNotNone(desc)
-        self.assertEqual(desc.binary, ['/usr/bin/gcc'])
-
-    def test_binary_array(self):
-        table = self._parse_compilers(textwrap.dedent('''\
-            [compilers]
-            c.binary = ['/usr/bin/gcc', '-B/opt/tools/bin']
-            '''))
-        desc = table.lookup('c')
-        self.assertIsNotNone(desc)
-        self.assertEqual(desc.binary, ['/usr/bin/gcc', '-B/opt/tools/bin'])
 
     def test_ccache_false(self):
         table = self._parse_compilers(textwrap.dedent('''\

--- a/unittests/machinefiletests.py
+++ b/unittests/machinefiletests.py
@@ -686,6 +686,169 @@ class NativeFileTests(BasePlatformTests):
         # Loader followed immediately by --argv0 "$0", then real_exe.
         self.assertIn(f'exec {loader} --argv0 "$0" {shlex.quote(real_exe)}', exec_line)
 
+    @skipIf(is_windows(), '[binaries] <name>.interpreter is POSIX-only')
+    def test_binary_interpreter_disabled_via_empty_list(self):
+        """Per-binary `<name>.interpreter = []` must override the global
+        `[properties] interpreter` default and skip wrapper generation."""
+        from mesonbuild.programs import ExternalProgram
+        real_exe = shutil.which('bash')
+        if real_exe is None:
+            raise SkipTest('bash not found on PATH')
+        default_interp = ['/opt/default/ld.so', '--library-path', '/opt/default/lib']
+        config = self.helper_create_native_file({
+            'binaries': {
+                'foo': real_exe,
+                'foo.interpreter': [],
+            },
+            'properties': {
+                'interpreter': default_interp,
+            },
+        })
+        env = self._make_interpreter_env(config)
+        prog = ExternalProgram.from_bin_list(env, MachineChoice.BUILD, 'foo')
+        self.assertTrue(prog.found())
+        # Wrapper must NOT be materialized; command stays the bare exe.
+        wrapper_path = env.binary_wrappers_dir() / 'foo'
+        self.assertFalse(wrapper_path.exists(),
+                         f'wrapper should not be generated when foo.interpreter=[]: {wrapper_path}')
+        self.assertEqual(prog.get_command(), [real_exe])
+        self.assertEqual(prog.get_path(), real_exe)
+
+    @skipIf(is_windows(), '[binaries] <name>.interpreter is POSIX-only')
+    def test_binary_interpreter_find_program_returns_wrapper_path(self):
+        """`find_program(name).full_path()` must return the wrapper, not the
+        bare exe, when a [binaries] interpreter applies.  Exercised via the
+        underlying `ExternalProgram.from_bin_list` path that `find_program`
+        calls into (same get_path() return)."""
+        from mesonbuild.programs import ExternalProgram
+        real_exe = shutil.which('bash')
+        if real_exe is None:
+            raise SkipTest('bash not found on PATH')
+        interpreter = ['/opt/ld/ld.so', '--library-path', '/opt/ld/lib']
+        config = self.helper_create_native_file({
+            'binaries': {
+                'foo': real_exe,
+            },
+            'properties': {
+                'interpreter': interpreter,
+            },
+        })
+        env = self._make_interpreter_env(config)
+        prog = ExternalProgram.from_bin_list(env, MachineChoice.BUILD, 'foo')
+        self.assertTrue(prog.found())
+        expected_wrapper = str(env.binary_wrappers_dir() / 'foo')
+        self.assertEqual(prog.get_path(), expected_wrapper)
+        self.assertNotEqual(prog.get_path(), real_exe)
+        # Command list (what find_program(...).full_path() ultimately
+        # surfaces for a single-element command) must point at the wrapper.
+        self.assertEqual(prog.get_command(), [expected_wrapper])
+
+    @skipIf(is_windows(), '[binaries] <name>.interpreter is POSIX-only')
+    def test_binary_interpreter_end_to_end_exec(self):
+        """Run the wrapper through a fake loader and verify the loader
+        observes the WRAPPER path as `--argv0` (the wrapper-to-loader
+        half of the --argv0 contract; glibc owns loader-to-binary)."""
+        from mesonbuild.programs import ExternalProgram
+        # Fake loader: a shell script that emulates ld-linux's command-line
+        # surface (`--argv0 <s>` + `--library-path <dir>`), records the
+        # argv0 value to a sentinel, then exec's the remaining args.  This
+        # exercises the wrapper's exec line without needing a real glibc
+        # loader.  We deliberately do NOT try to assert that the wrapped
+        # binary's $0 equals the wrapper path, because the kernel resets
+        # argv[0] when exec'ing a shebang script -- that's glibc/ld.so's
+        # job for real binaries, not something a shell-script test can
+        # observe.
+        sentinel = os.path.join(self.builddir, 'argv0-sentinel.txt')
+        loader = os.path.join(self.builddir, 'fake-loader.sh')
+        with open(loader, 'w', encoding='utf-8') as f:
+            f.write(textwrap.dedent(f'''\
+                #!/bin/sh
+                # Fake ld.so: parse --argv0 <s> and --library-path <dir>,
+                # record argv0 to a sentinel, then exec the remaining args.
+                argv0=
+                while [ $# -gt 0 ]; do
+                    case "$1" in
+                        --argv0) argv0=$2; shift 2 ;;
+                        --library-path) shift 2 ;;
+                        *) break ;;
+                    esac
+                done
+                printf '%s' "$argv0" > {shlex.quote(sentinel)}
+                exec "$@"
+                '''))
+        os.chmod(loader, 0o755)
+        # Real exe: a no-op shell script; the wrapped binary only needs to
+        # exit cleanly so we can confirm the wrapper completed end-to-end.
+        real_exe = os.path.join(self.builddir, 'real-exe.sh')
+        with open(real_exe, 'w', encoding='utf-8') as f:
+            f.write('#!/bin/sh\nexit 0\n')
+        os.chmod(real_exe, 0o755)
+        interpreter = [loader, '--library-path', '/unused']
+        config = self.helper_create_native_file({
+            'binaries': {
+                'foo': real_exe,
+                'foo.interpreter': interpreter,
+            },
+        })
+        env = self._make_interpreter_env(config)
+        prog = ExternalProgram.from_bin_list(env, MachineChoice.BUILD, 'foo')
+        self.assertTrue(prog.found())
+        wrapper_path = str(env.binary_wrappers_dir() / 'foo')
+        self.assertEqual(prog.get_path(), wrapper_path)
+        # Execute the wrapper; the fake loader must record the wrapper path
+        # as the --argv0 value it received.
+        result = subprocess.run([wrapper_path], check=False,
+                                capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0,
+                         f'wrapper exec failed: stdout={result.stdout!r} stderr={result.stderr!r}')
+        with open(sentinel, encoding='utf-8') as f:
+            recorded = f.read()
+        self.assertEqual(recorded, wrapper_path,
+                         f'expected --argv0={wrapper_path!r}, loader saw={recorded!r}')
+
+    def test_binary_interpreter_posix_only_skip(self):
+        """On Windows host, the interpreter property is silently ignored
+        with a one-time warning; no wrapper is generated."""
+        from mesonbuild.programs import ExternalProgram
+        from mesonbuild.envconfig import MachineInfo
+        from mesonbuild import mlog
+        real_exe = shutil.which('bash') or shutil.which('cmd.exe')
+        if real_exe is None:
+            raise SkipTest('no executable found for test')
+        interpreter = ['/opt/ld/ld.so', '--library-path', '/opt/ld/lib']
+        config = self.helper_create_native_file({
+            'binaries': {
+                'foo': real_exe,
+                'foo.interpreter': interpreter,
+            },
+        })
+        opts = get_fake_options(prefix='')
+        opts.native_file = [config]
+        env = get_fake_env(bdir=self.builddir, opts=opts)
+        # Force host machine to Windows.  PerThreeMachine starts out with
+        # host/build/target pointing at the SAME MachineInfo, so mutating
+        # `.system` on one would mutate all three (last write wins).  Swap
+        # in a fresh Windows MachineInfo for host only.
+        env.machines.host = MachineInfo(
+            system='windows', cpu_family='x86_64', cpu='x86_64',
+            endian='little', kernel=None, subsystem=None)
+        with mock.patch.object(mlog, 'warning') as warn_mock:
+            prog = ExternalProgram.from_bin_list(env, MachineChoice.BUILD, 'foo')
+        self.assertTrue(prog.found())
+        # No wrapper materialized.
+        self.assertFalse((env.binary_wrappers_dir() / 'foo').exists(),
+                         'wrapper must not be generated on Windows host')
+        # Command stays the bare exe.
+        self.assertEqual(prog.get_command(), [real_exe])
+        # One-time warning fired.
+        self.assertTrue(warn_mock.called, 'mlog.warning was not called on Windows host')
+        warn_msg = ' '.join(str(a) for a in warn_mock.call_args.args)
+        self.assertIn('POSIX-only', warn_msg)
+        # `once=True` must be set on the warning call so the message
+        # fires at most once per meson invocation.
+        self.assertTrue(warn_mock.call_args.kwargs.get('once'),
+                        f'warning must pass once=True, got kwargs={warn_mock.call_args.kwargs!r}')
+
     def test_user_options(self):
         testcase = os.path.join(self.common_test_dir, '40 options')
         for opt, value in [('testoption', 'some other val'), ('other_one', True),


### PR DESCRIPTION
Depends on #15811 (`[binaries] <name>.interpreter` -- POSIX shell wrapper that exec's a bundled binary through a hermetic loader).

That mechanism wraps only the entry-point binary.  Compilers that `execv` subprograms (cc1, cc1plus, lto1 for gcc; as, ld for clang) bypass the wrapper because each subprogram's own `PT_INTERP` is the system loader.  Without further plumbing, the subprogram inherits any `LD_LIBRARY_PATH` from the wrapper and crashes against the system glibc.

This PR adds a `[compilers]` machine-file section on top of that mechanism:

- `<lang>.type` / `<lang>.version`: explicit compiler class + version, bypassing the `<compiler> --version` probe (useful when the compiler can't run on the build host without a wrapper).
- `<lang>.ccache`: control ccache wrapping (default: true = auto-detect on PATH).
- `<lang>.sysroot` / `<lang>.no-default-includes` / `<lang>.system-include-dirs` / `<lang>.tool-search-paths`: structured keys that emit `--sysroot` / `-nostdinc` (or `/X`) / `-isystem` (or `/imsvc`) / `-B` at setup time, keeping `[binaries]` clean.
- Compiler subprogram wrapping: when `[binaries] <lang>.interpreter` is set (from #15811), meson generates per-language `cc1`/`cc1plus`/`lto1` (gcc) or `as`/`ld` (clang) wrapper scripts under `<scratch>/compiler-wrappers/<lang>/`, then prepends `-B<wrapper-dir>` to the compiler's argv.  argv[0] for gcc/clang stays `gcc` / `clang`, so ccache hashing is unaffected.

Example for a self-contained GCC 12.2.0 bundled under `sdk/`:

```ini
[constants]
_sdk     = '@GLOBAL_SOURCE_ROOT@' / 'sdk'
_gcc     = _sdk / 'gcc-12.2.0'
_runtime = _sdk / 'runtime'    # ELF loader and companion shared libraries

[binaries]
c               = _gcc / 'bin' / 'x86_64-linux-gnu-gcc'
cpp             = _gcc / 'bin' / 'x86_64-linux-gnu-g++'
c.interpreter   = [_runtime / 'lib64' / 'ld-linux-x86-64.so.2',
                   '--library-path', _runtime / 'lib64']
cpp.interpreter = c.interpreter

[compilers]
c.type      = 'gcc'
c.version   = '12.2.0'
cpp.type    = 'gcc'
cpp.version = '12.2.0'
```

Setting `c.interpreter` / `cpp.interpreter` in `[binaries]` automatically triggers cc1/cc1plus subprogram wrapping for the matching `[compilers]` language.

Commits cover: `[compilers]` section + structured-key flag emission + reuse of the binary-wrapper helper from #15811 + clang extension (parameterizes the subprogram list per `desc.type`).

Fixes #12612
