### PR TITLE
docs: Update docs on `include_directories` and `d_import_dirs`

### DIFF
--- a/docs/yaml/functions/_build_target_base.yaml
+++ b/docs/yaml/functions/_build_target_base.yaml
@@ -169,8 +169,9 @@ kwargs:
   include_directories:
     type: array[inc | str]
     description: |
-      one or more objects created with the [[include_directories]] function,
-      or *(since 0.50.0)* strings, which will be transparently expanded to include directory objects
+      one or more objects created with the [[include_directories]] function, or
+      *(since 0.50.0)* strings, which will be implicitly convert to [[@inc]]
+      objects
 
   install:
     type: bool
@@ -282,7 +283,8 @@ kwargs:
     since: 0.62.0
     description: |
       the directories to add to the string search path (i.e. `-J` switch for DMD).
-      Must be [[@inc]] objects or plain strings.
+      Must be objects created with the [[include_directories]] function or plain
+      strings, which will be implicitly converted into [[@inc]] objects.
 
   d_unittest:
     type: bool

--- a/docs/yaml/functions/include_directories.yaml
+++ b/docs/yaml/functions/include_directories.yaml
@@ -1,12 +1,11 @@
 name: include_directories
 returns: inc
 description: |
-  Returns an opaque object which contains the directories (relative to
-  the current directory) given in the positional arguments. The result
-  can then be passed to the `include_directories:` keyword argument when
-  building executables or libraries. You can use the returned object in
-  any subdirectory you want, Meson will make the paths work
-  automatically.
+  Returns an opaque object which contains the directories (relative to the
+  current directory) given in the positional arguments. The result can then be
+  passed to the `include_directories:` and `d_import_dirs:` keyword arguments
+  when building executables or libraries. You can use the returned object in any
+  subdirectory you want, Meson will make the paths work automatically.
 
   Note that this function call itself does not add the directories into
   the search path, since there is no global search path. For something


### PR DESCRIPTION
Hopefully this will help make it clearer for D that an import_dir is just another use of include_directories