### PR TITLE
test cases: skip test_python_build_config_extensions with pkg-config installed

### DIFF
--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -3184,7 +3184,7 @@ class AllPlatformTests(BasePlatformTests):
                     for sys_root in (None, sys.base_prefix):
                         with self.subTest(build_config_via_cross=build_config_via_cross, sys_root=sys_root):
                             # fd.o pkg-config does not handle sys_root correctly
-                            if sys_root is not None and with_pkgconfig and shutil.which('pkgconf') is None:
+                            if sys_root is not None and with_pkgconfig and shutil.which('pkg-config') is not None:
                                 raise SkipTest('sys_root subtest skipped because of fd.o pkg-config')
 
                             with tempfile.NamedTemporaryFile(mode='w', delete=False, encoding='utf-8') as cross_file:


### PR DESCRIPTION
fixes #15796