### PR TITLE
meson: include rust_abi in strongly-typed BuildTargetKeywordArguments…

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -109,6 +109,7 @@ if T.TYPE_CHECKING:
         resources: T.List[str]
         swift_interoperability_mode: Literal['c', 'cpp']
         swift_module_name: str
+        rust_abi: T.Optional[Literal['rust', 'c']]
         rust_crate_type: RustCrateType
         rust_dependency_map: T.Dict[str, str]
         vala_gir: T.Optional[str]

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3606,7 +3606,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         final: build.StaticLibraryKeywordArguments = {}
         self.__convert_build_target_base_kwargs(kwargs, final)
 
-        for arg in ('pic', 'prelink'):
+        for arg in ('pic', 'prelink', 'rust_abi'):
             final[arg] = kwargs[arg]
 
         for lang in compilers.all_languages - {'java'}:
@@ -3629,7 +3629,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         final: build.SharedLibraryKeywordArguments = {}
         self.__convert_build_target_base_kwargs(kwargs, final)
 
-        for arg in ('version', 'soversion', 'darwin_versions', 'shortname', 'vs_module_defs'):
+        for arg in ('version', 'soversion', 'darwin_versions', 'rust_abi', 'shortname', 'vs_module_defs'):
             final[arg] = kwargs[arg]
 
         for lang in compilers.all_languages - {'java'}:
@@ -3652,7 +3652,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         final: build.SharedModuleKeywordArguments = {}
         self.__convert_build_target_base_kwargs(kwargs, final)
 
-        for arg in ('vs_module_defs', ):
+        for arg in ('vs_module_defs', 'rust_abi'):
             final[arg] = kwargs[arg]
 
         for lang in compilers.all_languages - {'java'}:


### PR DESCRIPTION
A recent commit modified how kwargs is passed to internal build objects.

The interpreter now uses rust_abi to decide the rust_crate_type, but doesn't copy the rust_abi key itself into the final dictionary.

Consequently, meson2hermetic looks for build_target.original_kwargs, it's Rust conversion is slightly off.

Fixes: 34d127d26731 ("Convert BuildTarget kwargs explicitly from DSL
                      to build format")