### PR TITLE
cargo: allow git dependencies with slash in branch name

### DIFF
--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -884,7 +884,8 @@ def _parse_git_url(url: str, branch: T.Optional[str] = None) -> T.Tuple[str, str
     if directory.endswith('.git'):
         directory = directory[:-4]
     if branch:
-        directory += f'-{branch}'
+        branch_encoded = branch.replace('/', '-')
+        directory += f'-{branch_encoded}'
     url = urllib.parse.urlunparse(parts._replace(params='', query='', fragment=''))
     return url, revision, directory
 


### PR DESCRIPTION
If you have something like this in Cargo.toml:

    [dependencies]
    gtk = { git = "https://github.com/valpackett/gtk4-rs", branch = "val/xsqkvtwpkqkz", features = ["gnome_49"], package = "gtk4" }

you can get errors like

    ../meson.build:12:23: ERROR: Neither a subproject directory nor a gtk4-rs-val/xsqkvtwpkqkz.wrap file was found.

or

    ../meson.build:1:0: ERROR: Directory key must be a name and not a path

The first case shows clearly what's going on, the branch contains a slash but subprojects must be directly under subprojects/ with no intermediate directories.

Fixes: #15780