### PR TITLE
linkers: apple: do not pass -object_path_lto to dyld

### DIFF
--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -228,15 +228,17 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
         cmd = compiler + comp_class.LINKER_OPTION_STYLE.wrap(['-v']) + extra_args
         _, newo, newerr = Popen_safe_logged(cmd, msg='Detecting Apple linker via')
 
+        is_dyld: bool
         for line in newerr.split('\n'):
             if 'PROJECT:ld' in line or 'PROJECT:dyld' in line:
                 v = line.split('-')[1]
+                is_dyld = 'PROJECT:dyld' in line
                 break
         else:
             __failed_to_detect_linker(compiler, check_args, o, e)
         linker = linkers.AppleDynamicLinker(
             compiler, env, for_machine, comp_class.LINKER_OPTION_STYLE, override,
-            system=system, version=v
+            system=system, version=v, is_dyld=is_dyld
         )
     elif 'ld.exe: unrecognized option' in e or 'ld: unrecognized option' in e:
         linker = linkers.OS2AoutDynamicLinker(

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -853,6 +853,13 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
 
     id = 'ld64'
 
+    def __init__(self, exelist: T.List[str], env: Environment,
+                 for_machine: mesonlib.MachineChoice, prefix_arg: T.Optional[LinkerOptionStyle],
+                 always_args: T.List[str], *, system: str,
+                 version: str, is_dyld: bool = False):
+        super().__init__(exelist, env, for_machine, prefix_arg, always_args, system=system, version=version)
+        self.is_dyld = is_dyld
+
     def get_asneeded_args(self) -> T.List[str]:
         return self._apply_prefix('-dead_strip_dylibs')
 
@@ -959,6 +966,8 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
 
     def get_lto_obj_cache_path(self, path: str) -> T.List[str]:
         # https://clang.llvm.org/docs/CommandGuide/clang.html#cmdoption-flto
+        if self.is_dyld:
+            return []
         return ["-Wl,-object_path_lto," + path]
 
     def export_dynamic_args(self) -> T.List[str]:


### PR DESCRIPTION
Until now, Meson did not really need to check specifically whether the linker was Apple ld64 or dyld, because the version numbers are more or less compatible.

However, -object_path_lto is not supported by dyld at all.  To account for that, save whether ld64 or dyld are in use, and use it to remove the option for dyld.

Fixes: #15808 