### PR TITLE
cmake: convert drive-letter paths to POSIX form for MSYS2/Cygwin cmake to fix #14636 

### DIFF
--- a/mesonbuild/cmake/toolchain.py
+++ b/mesonbuild/cmake/toolchain.py
@@ -81,24 +81,29 @@ class CMakeToolchain:
         return res
 
     @staticmethod
-    def _cmake_needs_unix_paths() -> bool:
+    def _cmake_needs_unix_paths(cmakebin: 'CMakeExecutor') -> bool:
         """Detect whether cmake expects POSIX-style paths without drive letters.
 
         MSYS2/Cygwin cmake treats ':' in set() values as a list separator,
         so paths like C:/foo break. Convert to /c/foo form instead.
         See https://github.com/mesonbuild/meson/issues/14636
+
+        MSYSTEM being set does not imply MSYS2 cmake is in use (native Windows
+        cmake may appear earlier on PATH). Check the cmake binary path instead.
         """
-        # Cygwin cmake always uses POSIX paths
         if is_cygwin():
             return True
         if not is_windows():
             return False
-        # Under MSYS2, MSYSTEM is always set (MINGW64, UCRT64, etc.)
-        if not os.environ.get('MSYSTEM'):
-            return False
-        # cygpath is only available in MSYS2/Cygwin environments — its
-        # presence confirms the cmake in PATH is the MSYS2 build.
-        return shutil.which('cygpath') is not None
+        path = cmakebin.executable_path().replace('\\', '/').lower()
+        # MSYSTEM_PREFIX is a unix-style path like /ucrt64; check whether
+        # it appears as a component in the cmake binary's resolved path.
+        prefix = os.environ.get('MSYSTEM_PREFIX', '').replace('\\', '/').lower().rstrip('/')
+        if prefix and f'{prefix}/' in path:
+            return True
+        return any(x in path for x in (
+            '/msys64/', '/ucrt64/', '/clang64/', '/clangarm64/',
+            '/mingw64/', '/mingw32/'))
 
     @staticmethod
     def _to_cmake_unix_path(path: str, cygpath_bin: T.Optional[str]) -> str:
@@ -107,12 +112,13 @@ class CMakeToolchain:
         if len(path) >= 2 and path[1] == ':':
             if cygpath_bin:
                 _p, o, _e = Popen_safe([cygpath_bin, '-u', path])
-                return o.strip()
+                if _p.returncode == 0:
+                    return o.strip()
             return '/' + path[0].lower() + path[2:]
         return path
 
     def _normalize_cmake_paths(self, vars: T.Dict[str, T.List[str]]) -> None:
-        if not self._cmake_needs_unix_paths():
+        if not self._cmake_needs_unix_paths(self.cmakebin):
             return
         cygpath_bin = shutil.which('cygpath')
         for key, value in vars.items():

--- a/mesonbuild/cmake/toolchain.py
+++ b/mesonbuild/cmake/toolchain.py
@@ -8,6 +8,7 @@ from .traceparser import CMakeTraceParser
 from ..envconfig import CMakeSkipCompilerTest
 from .common import language_map, cmake_get_generator_args
 from .. import mlog
+from ..mesonlib import Popen_safe, is_cygwin, is_windows
 
 import os.path
 import shutil
@@ -79,6 +80,44 @@ class CMakeToolchain:
             res += ')\n'
         return res
 
+    @staticmethod
+    def _cmake_needs_unix_paths() -> bool:
+        """Detect whether cmake expects POSIX-style paths without drive letters.
+
+        MSYS2/Cygwin cmake treats ':' in set() values as a list separator,
+        so paths like C:/foo break. Convert to /c/foo form instead.
+        See https://github.com/mesonbuild/meson/issues/14636
+        """
+        # Cygwin cmake always uses POSIX paths
+        if is_cygwin():
+            return True
+        if not is_windows():
+            return False
+        # Under MSYS2, MSYSTEM is always set (MINGW64, UCRT64, etc.)
+        if not os.environ.get('MSYSTEM'):
+            return False
+        # cygpath is only available in MSYS2/Cygwin environments — its
+        # presence confirms the cmake in PATH is the MSYS2 build.
+        return shutil.which('cygpath') is not None
+
+    @staticmethod
+    def _to_cmake_unix_path(path: str, cygpath_bin: T.Optional[str]) -> str:
+        """Convert a Windows drive-letter path to POSIX form for MSYS2/Cygwin cmake."""
+        path = path.replace('\\', '/')
+        if len(path) >= 2 and path[1] == ':':
+            if cygpath_bin:
+                _p, o, _e = Popen_safe([cygpath_bin, '-u', path])
+                return o.strip()
+            return '/' + path[0].lower() + path[2:]
+        return path
+
+    def _normalize_cmake_paths(self, vars: T.Dict[str, T.List[str]]) -> None:
+        if not self._cmake_needs_unix_paths():
+            return
+        cygpath_bin = shutil.which('cygpath')
+        for key, value in vars.items():
+            vars[key] = [self._to_cmake_unix_path(x, cygpath_bin) for x in value]
+
     def generate(self) -> str:
         res = dedent('''\
             ######################################
@@ -98,6 +137,7 @@ class CMakeToolchain:
         # Escape all \ in the values
         for key, value in self.variables.items():
             self.variables[key] = [x.replace('\\', '/') for x in value]
+        self._normalize_cmake_paths(self.variables)
 
         # Set compiler
         if self.skip_check:

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -46,6 +46,7 @@ from mesonbuild.dependencies.pkgconfig import PkgConfigDependency, PkgConfigInte
 from mesonbuild.programs import ExternalProgram
 import mesonbuild.modules.pkgconfig
 from mesonbuild import utils
+from mesonbuild.cmake.toolchain import CMakeToolchain
 
 from run_tests import get_fake_env, get_fake_options
 
@@ -2208,3 +2209,39 @@ class InternalTests(unittest.TestCase):
                 self.assertEqual(actual.compile_args, expected.compile_args)
                 self.assertEqual(actual.link_args, expected.link_args)
                 self.assertEqual(actual.cmake, expected.cmake)
+
+    def test_cmake_toolchain_to_unix_path(self) -> None:
+        # Same convention as test cases/unit/18 pkgconfig static: C:/foo/bar -> /c/foo/bar
+        cases = [
+            (r'C:\foo\bar', '/c/foo/bar'),
+            ('C:/foo/bar', '/c/foo/bar'),
+            ('D:/Some/Path', '/d/Some/Path'),
+            ('/usr/bin/gcc', '/usr/bin/gcc'),
+            ('relative/path', 'relative/path'),
+        ]
+        for inp, expected in cases:
+            with self.subTest(inp):
+                self.assertEqual(CMakeToolchain._to_cmake_unix_path(inp, None), expected)
+
+    @mock.patch('mesonbuild.cmake.toolchain.is_windows', return_value=True)
+    @mock.patch('mesonbuild.cmake.toolchain.is_cygwin', return_value=False)
+    @mock.patch.dict(os.environ, {'MSYSTEM': 'UCRT64'})
+    @mock.patch('mesonbuild.cmake.toolchain.shutil.which', return_value='/usr/bin/cygpath')
+    def test_cmake_toolchain_needs_unix_paths_msys2(self, *_: mock.Mock) -> None:
+        self.assertTrue(CMakeToolchain._cmake_needs_unix_paths())
+
+    @mock.patch('mesonbuild.cmake.toolchain.is_windows', return_value=True)
+    @mock.patch('mesonbuild.cmake.toolchain.is_cygwin', return_value=False)
+    @mock.patch.dict(os.environ, {}, clear=True)
+    def test_cmake_toolchain_needs_unix_paths_native_win(self, *_: mock.Mock) -> None:
+        self.assertFalse(CMakeToolchain._cmake_needs_unix_paths())
+
+    @mock.patch('mesonbuild.cmake.toolchain.is_windows', return_value=False)
+    @mock.patch('mesonbuild.cmake.toolchain.is_cygwin', return_value=True)
+    def test_cmake_toolchain_needs_unix_paths_cygwin(self, *_: mock.Mock) -> None:
+        self.assertTrue(CMakeToolchain._cmake_needs_unix_paths())
+
+    @mock.patch('mesonbuild.cmake.toolchain.is_windows', return_value=False)
+    @mock.patch('mesonbuild.cmake.toolchain.is_cygwin', return_value=False)
+    def test_cmake_toolchain_needs_unix_paths_linux(self, *_: mock.Mock) -> None:
+        self.assertFalse(CMakeToolchain._cmake_needs_unix_paths())

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -2225,23 +2225,38 @@ class InternalTests(unittest.TestCase):
 
     @mock.patch('mesonbuild.cmake.toolchain.is_windows', return_value=True)
     @mock.patch('mesonbuild.cmake.toolchain.is_cygwin', return_value=False)
-    @mock.patch.dict(os.environ, {'MSYSTEM': 'UCRT64'})
-    @mock.patch('mesonbuild.cmake.toolchain.shutil.which', return_value='/usr/bin/cygpath')
     def test_cmake_toolchain_needs_unix_paths_msys2(self, *_: mock.Mock) -> None:
-        self.assertTrue(CMakeToolchain._cmake_needs_unix_paths())
+        cmakebin = mock.Mock()
+        for path in (
+            'C:/msys64/ucrt64/bin/cmake.exe',
+            'C:/prefix/mingw64/bin/cmake.exe',
+        ):
+            with self.subTest(path):
+                cmakebin.executable_path.return_value = path
+                self.assertTrue(CMakeToolchain._cmake_needs_unix_paths(cmakebin))
+        # Non-standard MSYS2 install detected via MSYSTEM_PREFIX
+        with self.subTest('MSYSTEM_PREFIX fallback'):
+            cmakebin.executable_path.return_value = 'D:/tools/msys/custom64/bin/cmake.exe'
+            with mock.patch.dict(os.environ, {'MSYSTEM_PREFIX': '/custom64'}):
+                self.assertTrue(CMakeToolchain._cmake_needs_unix_paths(cmakebin))
 
     @mock.patch('mesonbuild.cmake.toolchain.is_windows', return_value=True)
     @mock.patch('mesonbuild.cmake.toolchain.is_cygwin', return_value=False)
-    @mock.patch.dict(os.environ, {}, clear=True)
     def test_cmake_toolchain_needs_unix_paths_native_win(self, *_: mock.Mock) -> None:
-        self.assertFalse(CMakeToolchain._cmake_needs_unix_paths())
+        cmakebin = mock.Mock()
+        cmakebin.executable_path.return_value = 'C:/Program Files/CMake/bin/cmake.exe'
+        with mock.patch.dict(os.environ, {'MSYSTEM': 'UCRT64', 'MSYSTEM_PREFIX': '/ucrt64'}):
+            self.assertFalse(CMakeToolchain._cmake_needs_unix_paths(cmakebin))
 
     @mock.patch('mesonbuild.cmake.toolchain.is_windows', return_value=False)
     @mock.patch('mesonbuild.cmake.toolchain.is_cygwin', return_value=True)
     def test_cmake_toolchain_needs_unix_paths_cygwin(self, *_: mock.Mock) -> None:
-        self.assertTrue(CMakeToolchain._cmake_needs_unix_paths())
+        cmakebin = mock.Mock()
+        self.assertTrue(CMakeToolchain._cmake_needs_unix_paths(cmakebin))
 
     @mock.patch('mesonbuild.cmake.toolchain.is_windows', return_value=False)
     @mock.patch('mesonbuild.cmake.toolchain.is_cygwin', return_value=False)
     def test_cmake_toolchain_needs_unix_paths_linux(self, *_: mock.Mock) -> None:
-        self.assertFalse(CMakeToolchain._cmake_needs_unix_paths())
+        cmakebin = mock.Mock()
+        cmakebin.executable_path.return_value = '/usr/bin/cmake'
+        self.assertFalse(CMakeToolchain._cmake_needs_unix_paths(cmakebin))


### PR DESCRIPTION
MSYS2/Cygwin cmake interprets `:` in `set()` values as a list separator, so a
toolchain file containing `set(CMAKE_C_COMPILER "C:/msys64/ucrt64/bin/cc.EXE")`
is parsed as two list elements (`C` and `/msys64/ucrt64/bin/cc.EXE`), causing:
The CMAKE_C_COMPILER: C is not a full path and was not found in the PATH.


This patch detects when meson is running under MSYS2/Cygwin (via `MSYSTEM` env
var + `cygpath` availability) and converts Windows drive-letter paths in the
generated `CMakeMesonToolchainFile.cmake` to POSIX form (`/c/msys64/...`).
Uses `cygpath -u` when available (handles MSYS2 mount points), falls back to
manual `C:/foo` → `/c/foo` conversion otherwise.
Follows the same pattern as `modules/external_project.py`'s `_cygpath_convert`.
Fixes #14636
## Changes
- `mesonbuild/cmake/toolchain.py`: Add `_cmake_needs_unix_paths()`,
  `_to_cmake_unix_path()`, and `_normalize_cmake_paths()` to
  `CMakeToolchain`. Called during `generate()` after backslash normalization.
- `unittests/internaltests.py`: Unit tests for path conversion and environment
  detection (MSYS2, native Windows, Cygwin, Linux).