### PR TITLE
cargo: add docsrs to unconditionally added --check-cfg cfg's

### DIFF
--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -155,8 +155,8 @@ class PackageState:
             args.extend(lint.to_arguments(has_check_cfg))
 
         if has_check_cfg:
-            args.append('--check-cfg')
-            args.append('cfg(test)')
+            args.extend(['--check-cfg', 'cfg(docsrs)',
+                         '--check-cfg', 'cfg(test)'])
             for feature in self.manifest.features:
                 if feature != 'default':
                     args.append('--check-cfg')


### PR DESCRIPTION
In order to suppress compiler warnings that'll occur otherwise if the crate in question is relying on it:

```
[195/209] Compiling Rust source ../libglycin-rebind/libglycin-rebind/sys/src/lib.rs
warning: unexpected `cfg` condition name: `docsrs`
  --> ../libglycin-rebind/libglycin-rebind/sys/src/lib.rs:13:13
   |
13 | #![cfg_attr(docsrs, feature(doc_cfg))]
   |             ^^^^^^
   |
   = help: expected names are: `system_deps_have_glycin_2` and `test` and 31 more
   = help: to expect this configuration use `--check-cfg=cfg(docsrs)`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
   = note: `#[warn(unexpected_cfgs)]` on by default

warning: 1 warning emitted
```

Cargo [does the same](https://github.com/rust-lang/cargo/blob/a4090d8a9861649b782c6cea5a4e9de71943ad07/src/cargo/core/compiler/mod.rs#L1678).