### PR TITLE
mtest: fix handling of empty lines in TAP YAML block

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -398,7 +398,6 @@ class TAPParser:
     def parse_line(self, line: T.Optional[str]) -> T.Iterator[TYPE_TAPResult]:
         if line is not None:
             self.lineno += 1
-            line = line.rstrip()
 
             # YAML blocks are only accepted after a test
             if self.state == self._AFTER_TEST:
@@ -419,6 +418,8 @@ class TAPParser:
                     return
                 yield self.Error(f'YAML block not terminated (started on line {self.yaml_lineno})')
                 self.state = self._MAIN
+
+            line = line.rstrip()
 
             assert self.state == self._MAIN
             if not line or line.startswith('#'):

--- a/unittests/taptests.py
+++ b/unittests/taptests.py
@@ -331,3 +331,10 @@ class TAPParserTests(unittest.TestCase):
         self.assert_error(events)
         self.assert_test(events, number=2, name='', result=TestResult.FAIL)
         self.assert_last(events)
+
+        # Whitespace-only line in YAML block
+        events = self.parse_tap_v13('ok 1\n ---\n foo: abc\n \n bar: def\nnot ok 2')
+        self.assert_test(events, number=1, name='', result=TestResult.OK)
+        self.assert_error(events)
+        self.assert_test(events, number=2, name='', result=TestResult.FAIL)
+        self.assert_last(events)


### PR DESCRIPTION
YAML blocks can contain lines that consist of whitespace only. `.rstrip()` makes such lines empty. Move `.rstrip()` past YAML block handling.

```
project('tap-yaml-empty-line')

echo = find_program('echo')
tap = '''TAP version 13
1..2
ok
  ---
  data:
  
  ...
ok
'''

test('yaml block', echo, args : [tap], protocol: 'tap')
```

Before:

```
stderr:
TAP parsing error: YAML block not terminated (started on line 4)
―――――――――――――――――――――――――――――――――――――――――――――――――――――――――

stdout: 7: UNKNOWN:   ...
ERROR: Unknown TAP output lines for a supported TAP version.
This is probably a bug in the test; if they are not TAP syntax, prefix them with a #



Summary of Failures:

1/1 tap-yaml-empty-line:yaml block ERROR           0.00s   2 subtests passed

Ok:                0   
Fail:              1

```

After:

```
1/1 tap-yaml-empty-line:yaml block        OK              0.00s   2 subtests passed

Ok:                1   
Fail:              0
```