### PR TITLE
cargo: just require tomllib

### DIFF
--- a/mesonbuild/cargo/toml.py
+++ b/mesonbuild/cargo/toml.py
@@ -1,34 +1,9 @@
 from __future__ import annotations
 
-import importlib
-import shutil
-import json
 import typing as T
+import tomllib
 
-from ..mesonlib import MesonException, Popen_safe
-if T.TYPE_CHECKING:
-    from types import ModuleType
-
-
-# tomllib is present in python 3.11, before that it is a pypi module called tomli,
-# we try to import tomllib, then tomli,
-tomllib: T.Optional[ModuleType] = None
-toml2json: T.Optional[str] = None
-for t in ['tomllib', 'tomli']:
-    try:
-        tomllib = importlib.import_module(t)
-        break
-    except ImportError:
-        pass
-else:
-    # TODO: it would be better to use an Executable here, which could be looked
-    # up in the cross file or provided by a wrap. However, that will have to be
-    # passed in externally, since we don't have (and I don't think we should),
-    # have access to the `Environment` for that in this module.
-    toml2json = shutil.which('toml2json')
-
-class TomlImplementationMissing(MesonException):
-    pass
+from ..mesonlib import MesonException
 
 
 class CargoTomlError(MesonException):
@@ -36,25 +11,11 @@ class CargoTomlError(MesonException):
 
 
 def load_toml(filename: str) -> T.Dict[str, object]:
-    if tomllib:
-        try:
-            with open(filename, 'rb') as f:
-                raw = tomllib.load(f)
-        except tomllib.TOMLDecodeError as e:
-            if hasattr(e, 'msg'):
-                raise CargoTomlError(e.msg, file=filename, lineno=e.lineno, colno=e.colno) from e
-            else:
-                raise CargoTomlError(str(e), file=filename) from e
-    else:
-        if toml2json is None:
-            raise TomlImplementationMissing('Could not find an implementation of tomllib, nor toml2json')
-
-        p, out, err = Popen_safe([toml2json, filename])
-        if p.returncode != 0:
-            error_msg = err.strip() or 'toml2json failed to decode TOML'
-            raise CargoTomlError(error_msg, file=filename)
-
-        raw = json.loads(out)
-
-    # tomllib.load() returns T.Dict[str, T.Any] but not other implementations.
-    return T.cast('T.Dict[str, object]', raw)
+    try:
+        with open(filename, 'rb') as f:
+            return tomllib.load(f)
+    except tomllib.TOMLDecodeError as e:
+        if hasattr(e, 'msg'):
+            raise CargoTomlError(e.msg, file=filename, lineno=e.lineno, colno=e.colno) from e
+        else:
+            raise CargoTomlError(str(e), file=filename) from e

--- a/test cases/failing/135 cargo toml error/meson.build
+++ b/test cases/failing/135 cargo toml error/meson.build
@@ -4,16 +4,5 @@ if not add_languages('rust', required: false)
   error('MESON_SKIP_TEST Rust not present, required for Cargo subprojets')
 endif
 
-# Check if we have tomllib/tomli (not toml2json)
-python = find_program('python3', 'python')
-result = run_command(python, '-c', 'import tomllib', check: false)
-if result.returncode() != 0
-  result = run_command(python, '-c', 'import tomli', check: false)
-  if result.returncode() != 0
-    # Skip test if using toml2json - error format will be different
-    error('MESON_SKIP_TEST toml2json in use, skipping test')
-  endif
-endif
-
 # This should trigger a CargoTomlError with proper location info
 foo_dep = dependency('foo-0')


### PR DESCRIPTION
Python 3.11 has tomllib, so there is no need to fall back to tomli or toml2json.

Simplify the code accordingly, but keep the wrapper to be able to pass location info in the usual Meson way.