### PR TITLE
i18n: add support for passing --no-fuzzy-matching to msgmerge

### DIFF
--- a/docs/markdown/i18n-module.md
+++ b/docs/markdown/i18n-module.md
@@ -30,6 +30,10 @@ argument which is the name of the gettext module.
   for their value
 * `install`: (*Added 0.43.0*) if false, do not install the built translations.
 * `install_dir`: (*Added 0.50.0*) override default install location, default is `localedir`
+* `no_fuzzy_matching`: (*Added 1.12.0*) if `true`, pass
+  `--no-fuzzy-matching` to `msgmerge` when updating the `.po` files,
+  preventing the auto-generation of fuzzy translations for new
+  strings. Defaults to `false`.
 
 This function also defines targets for maintainers to use:
 **Note**: These output to the source directory

--- a/docs/markdown/snippets/i18n-gettext-no-fuzzy-matching.md
+++ b/docs/markdown/snippets/i18n-gettext-no-fuzzy-matching.md
@@ -1,0 +1,12 @@
+## New `no_fuzzy_matching` keyword argument for `i18n.gettext()`
+
+`i18n.gettext()` now accepts a `no_fuzzy_matching` boolean keyword argument
+that, when set to `true`, passes `--no-fuzzy-matching` to `msgmerge`. This
+prevents `msgmerge` from auto-generating fuzzy translations for new strings,
+which are almost always incorrect.
+
+```meson
+i18n.gettext('myproject',
+             preset : 'glib',
+             no_fuzzy_matching : true)
+```

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -52,6 +52,7 @@ if T.TYPE_CHECKING:
         install: bool
         install_dir: T.Optional[str]
         languages: T.List[str]
+        no_fuzzy_matching: bool
         preset: T.Optional[str]
 
     class ItsJoinFile(TypedDict):
@@ -358,6 +359,7 @@ class I18nModule(ExtensionModule):
             validator=in_set_validator(set(PRESET_ARGS)),
             since='0.37.0',
         ),
+        KwargInfo('no_fuzzy_matching', bool, default=False, since='1.12.0'),
     )
     def gettext(self, state: 'ModuleState', args: T.Tuple[str], kwargs: 'Gettext') -> ModuleReturnValue:
         for tool, strict in [('msgfmt', True), ('msginit', False), ('msgmerge', False), ('xgettext', False)]:
@@ -454,6 +456,8 @@ class I18nModule(ExtensionModule):
             updatepoargs.append(datadirs)
         if extra_arg:
             updatepoargs.append(extra_arg)
+        if kwargs['no_fuzzy_matching']:
+            updatepoargs.append('--no-fuzzy-matching')
         for tool in ['msginit', 'msgmerge']:
             if self.tools[tool].found():
                 updatepoargs.append(f'--{tool}=' + self.tools[tool].get_path())

--- a/mesonbuild/scripts/gettext.py
+++ b/mesonbuild/scripts/gettext.py
@@ -23,6 +23,7 @@ parser.add_argument('--xgettext', default='xgettext')
 parser.add_argument('--msgmerge', default='msgmerge')
 parser.add_argument('--msginit', default='msginit')
 parser.add_argument('--extra-args', default='')
+parser.add_argument('--no-fuzzy-matching', action='store_true')
 
 def read_linguas(src_sub: str) -> T.List[str]:
     # Syntax of this file is documented here:
@@ -57,12 +58,14 @@ def run_potgen(src_sub: str, xgettext: str, pkgname: str, datadirs: str, args: T
                             '-D', source_root, '-k_', '-o', ofile] + args,
                            env=child_env)
 
-def update_po(src_sub: str, msgmerge: str, msginit: str, pkgname: str, langs: T.List[str]) -> int:
+def update_po(src_sub: str, msgmerge: str, msginit: str, pkgname: str, langs: T.List[str],
+              no_fuzzy_matching: bool) -> int:
     potfile = os.path.join(src_sub, pkgname + '.pot')
+    extra_args = ['--no-fuzzy-matching'] if no_fuzzy_matching else []
     for l in langs:
         pofile = os.path.join(src_sub, l + '.po')
         if os.path.exists(pofile):
-            exe = ExecutableSerialisation([msgmerge, '-q', pofile, potfile], capture=pofile)
+            exe = ExecutableSerialisation([msgmerge, '-q', *extra_args, pofile, potfile], capture=pofile)
             if run_exe(exe) != 0:
                 return 1
         else:
@@ -85,7 +88,7 @@ def run(args: T.List[str]) -> int:
     elif subcmd == 'update_po':
         if run_potgen(src_sub, options.xgettext, options.pkgname, options.datadirs, extra_args, options.source_root) != 0:
             return 1
-        return update_po(src_sub, options.msgmerge, options.msginit, options.pkgname, langs)
+        return update_po(src_sub, options.msgmerge, options.msginit, options.pkgname, langs, options.no_fuzzy_matching)
     else:
         print('Unknown subcommand.')
         return 1


### PR DESCRIPTION
By default msgmerge will try to add 'fuzzy' translations, which are almost always wrong. Add a new parameter to i18n.gettext(), disabled by default, that configures msgmerge to avoid this.