### PR TITLE
CI & test fixes: split libwmf and Qt, update dependencies and skip lists

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python3 -m pip install pytest pytest-xdist pytest-subtests fastjsonschema
-    - run: brew install pkg-config ninja llvm qt@5
+    - run: brew install pkg-config ninja llvm qt@6
     - env:
         CPPFLAGS: "-I/opt/homebrew/include"
         LDFLAGS: "-L/opt/homebrew/lib"
@@ -56,8 +56,8 @@ jobs:
         # These cannot evaluate anything, so we cannot set PATH or SDKROOT here
       run: |
         export SDKROOT="$(xcodebuild -version -sdk macosx Path)"
-        export PATH="$HOME/tools:/opt/homebrew/opt/qt@5/bin:/opt/homebrew/opt/llvm/bin:$PATH"
-        export PKG_CONFIG_PATH="/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/Current/lib/pkgconfig:/opt/homebrew/opt/qt@5/lib/pkgconfig:$PKG_CONFIG_PATH"
+        export PATH="$HOME/tools:/opt/homebrew/opt/qt@6/bin:/opt/homebrew/opt/llvm/bin:$PATH"
+        export PKG_CONFIG_PATH="/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/Current/lib/pkgconfig:/opt/homebrew/opt/qt@6/lib/pkgconfig:$PKG_CONFIG_PATH"
         python3 ./run_unittests.py
 
 
@@ -93,7 +93,7 @@ jobs:
         find /opt/homebrew/Cellar/python* -name EXTERNALLY-MANAGED -print0 | xargs -0 rm -vf
     # use python3 from homebrew because it is a valid framework, unlike the actions one:
     # https://github.com/actions/setup-python/issues/58
-    - run: brew install pkg-config ninja llvm qt@5 boost ldc hdf5 openmpi lapack scalapack sdl2 boost-python3 gtk-doc zstd ncurses objfw libomp
+    - run: brew install pkg-config ninja llvm qt@6 boost ldc hdf5 openmpi lapack scalapack sdl2 boost-python3 gtk-doc zstd ncurses objfw libomp
     - run: |
         python3 -m pip install cython
     - env:
@@ -107,6 +107,6 @@ jobs:
         export SDKROOT="$(xcodebuild -version -sdk macosx Path)"
         # Append LLVM's bin directory to PATH to prioritise Apple Clang over Homebrew Clang.
         # We need this to avoid objfw test failures.
-        export PATH="$HOME/tools:/opt/homebrew/opt/qt@5/bin:/opt/homebrew/opt/ncurses/bin:$PATH:/opt/homebrew/opt/llvm/bin"
-        export PKG_CONFIG_PATH="/opt/homebrew/opt/qt@5/lib/pkgconfig:/opt/homebrew/opt/lapack/lib/pkgconfig:/opt/homebrew/opt/ncurses/lib/pkgconfig:$PKG_CONFIG_PATH"
+        export PATH="$HOME/tools:/opt/homebrew/opt/qt@6/bin:/opt/homebrew/opt/ncurses/bin:$PATH:/opt/homebrew/opt/llvm/bin"
+        export PKG_CONFIG_PATH="/opt/homebrew/opt/qt@6/lib/pkgconfig:/opt/homebrew/opt/lapack/lib/pkgconfig:/opt/homebrew/opt/ncurses/lib/pkgconfig:$PKG_CONFIG_PATH"
         ./run_project_tests.py --backend=ninja -- $MESON_ARGS

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python3 -m pip install pytest pytest-xdist pytest-subtests fastjsonschema
-    - run: brew install pkg-config ninja llvm qt@6
+    - run: brew install pkg-config ninja llvm qt@5
     - env:
         CPPFLAGS: "-I/opt/homebrew/include"
         LDFLAGS: "-L/opt/homebrew/lib"
@@ -56,8 +56,8 @@ jobs:
         # These cannot evaluate anything, so we cannot set PATH or SDKROOT here
       run: |
         export SDKROOT="$(xcodebuild -version -sdk macosx Path)"
-        export PATH="$HOME/tools:/opt/homebrew/opt/qt@6/bin:/opt/homebrew/opt/llvm/bin:$PATH"
-        export PKG_CONFIG_PATH="/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/Current/lib/pkgconfig:/opt/homebrew/opt/qt@6/lib/pkgconfig:$PKG_CONFIG_PATH"
+        export PATH="$HOME/tools:/opt/homebrew/opt/qt@5/bin:/opt/homebrew/opt/llvm/bin:$PATH"
+        export PKG_CONFIG_PATH="/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/Current/lib/pkgconfig:/opt/homebrew/opt/qt@5/lib/pkgconfig:$PKG_CONFIG_PATH"
         python3 ./run_unittests.py
 
 
@@ -93,7 +93,7 @@ jobs:
         find /opt/homebrew/Cellar/python* -name EXTERNALLY-MANAGED -print0 | xargs -0 rm -vf
     # use python3 from homebrew because it is a valid framework, unlike the actions one:
     # https://github.com/actions/setup-python/issues/58
-    - run: brew install pkg-config ninja llvm qt@6 boost ldc hdf5 openmpi lapack scalapack sdl2 boost-python3 gtk-doc zstd ncurses objfw libomp
+    - run: brew install pkg-config ninja llvm qt@5 boost ldc hdf5 openmpi lapack scalapack sdl2 boost-python3 gtk-doc zstd ncurses objfw libomp
     - run: |
         python3 -m pip install cython
     - env:
@@ -107,6 +107,6 @@ jobs:
         export SDKROOT="$(xcodebuild -version -sdk macosx Path)"
         # Append LLVM's bin directory to PATH to prioritise Apple Clang over Homebrew Clang.
         # We need this to avoid objfw test failures.
-        export PATH="$HOME/tools:/opt/homebrew/opt/qt@6/bin:/opt/homebrew/opt/ncurses/bin:$PATH:/opt/homebrew/opt/llvm/bin"
-        export PKG_CONFIG_PATH="/opt/homebrew/opt/qt@6/lib/pkgconfig:/opt/homebrew/opt/lapack/lib/pkgconfig:/opt/homebrew/opt/ncurses/lib/pkgconfig:$PKG_CONFIG_PATH"
+        export PATH="$HOME/tools:/opt/homebrew/opt/qt@5/bin:/opt/homebrew/opt/ncurses/bin:$PATH:/opt/homebrew/opt/llvm/bin"
+        export PKG_CONFIG_PATH="/opt/homebrew/opt/qt@5/lib/pkgconfig:/opt/homebrew/opt/lapack/lib/pkgconfig:/opt/homebrew/opt/ncurses/lib/pkgconfig:$PKG_CONFIG_PATH"
         ./run_project_tests.py --backend=ninja -- $MESON_ARGS

--- a/ci/ciimage/ubuntu-rolling/install.sh
+++ b/ci/ciimage/ubuntu-rolling/install.sh
@@ -47,7 +47,7 @@ eatmydata apt-get -y build-dep meson
 
 # packages
 eatmydata apt-get -y install "${pkgs[@]}" "${transitivepkgs[@]}"
-eatmydata apt-get -y install --no-install-recommends wine-stable  # Wine is special
+eatmydata apt-get -y install --no-install-recommends wine  # Wine is special
 
 # HACK: build hotdoc from git repo since current sdist is broken on modern compilers
 # change back to 'hotdoc' once it's fixed

--- a/test cases/frameworks/21 libwmf/meson.build
+++ b/test cases/frameworks/21 libwmf/meson.build
@@ -1,11 +1,13 @@
 project('libwmf test', 'c')
 
-wm = find_program('libwmf-config', required : false)
-if not wm.found() or meson.is_cross_build()
-  error('MESON_SKIP_TEST: libwmf-config not installed')
+method = get_option('method')
+
+libwmf_dep = dependency('libwmf', method : method, required : false, version : '>= 0.2.8')
+
+if not libwmf_dep.found()
+  error(f'MESON_SKIP_TEST libwmf not found for method {method}.')
 endif
 
-libwmf_dep = dependency('libwmf', version : '>= 0.2.8')
 libwmf_ver = libwmf_dep.version()
 assert(libwmf_ver.split('.').length() > 1, 'libwmf version is "@0@"'.format(libwmf_ver))
 message('libwmf version is "@0@"'.format(libwmf_ver))
@@ -17,11 +19,5 @@ e = executable('libwmf_prog', 'libwmf_prog.c', dependencies : [libwmf_dep, ft_de
 
 test('libwmftest', e)
 
-# Test using the method keyword:
-
-dependency('libwmf', method : 'config-tool')
-dependency('libwmf', method : 'libwmf-config')
-
 # Check we can apply a version constraint
-dependency('libwmf', version: '>=@0@'.format(libwmf_dep.version()), method: 'pkg-config', required: false)
-dependency('libwmf', version: '>=@0@'.format(libwmf_dep.version()), method: 'config-tool')
+dependency('libwmf', version: '>=@0@'.format(libwmf_dep.version()), method : method)

--- a/test cases/frameworks/21 libwmf/meson_options.txt
+++ b/test cases/frameworks/21 libwmf/meson_options.txt
@@ -1,0 +1,6 @@
+option(
+    'method',
+    type : 'combo',
+    choices : ['auto', 'pkg-config', 'config-tool'],
+    value : 'auto',
+)

--- a/test cases/frameworks/21 libwmf/test.json
+++ b/test cases/frameworks/21 libwmf/test.json
@@ -1,3 +1,12 @@
 {
+  "matrix": {
+    "options": {
+      "method": [
+        { "val": "auto" },
+        { "val": "pkg-config" },
+        { "val": "config-tool", "expect_skip_on_jobname": ["ubuntu-rolling"] }
+      ]
+    }
+  },
   "expect_skip_on_jobname": ["azure", "cygwin", "macos", "msys2", "windows"]
 }

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -7,183 +7,174 @@ subdir('mocdep')
 
 qt5_modules = ['Widgets']
 qt6_modules = ['Widgets']
-foreach qt : ['qt4', 'qt5', 'qt6']
-  qt_modules = ['Core', 'Gui']
+qt = get_option('version').to_lower()
+
+qt_modules = ['Core', 'Gui']
+if qt == 'qt5'
+  qt_modules += qt5_modules
+elif qt == 'qt6'
+  qt_modules += qt6_modules
+endif
+
+# Test that invalid modules are indeed not found
+fakeqtdep = dependency(qt, modules : ['DefinitelyNotFound'], required : false, method : get_option('method'))
+if fakeqtdep.found()
+  error('Invalid qt dep incorrectly found!')
+endif
+
+# Test that partially-invalid modules are indeed not found
+fakeqtdep = dependency(qt, modules : ['Core', 'DefinitelyNotFound'], required : false, method : get_option('method'))
+if fakeqtdep.found()
+  error('Invalid qt dep incorrectly found!')
+endif
+
+dep = dependency(qt, modules : ['Core'], required : false, method : get_option('method'))
+if not dep.found()
+  error('MESON_SKIP_TEST @0@ not found.'.format(qt))
+endif
+
+# Ensure that the "no-Core-module-specified" code branch is hit
+nocoredep = dependency(qt, modules : ['Gui'], required : true, method : get_option('method'))
+
+# If 'qt' modules are found, test that.
+qtdep = dependency(qt, modules : qt_modules, main : true, private_headers: true, required : true, method : get_option('method'))
+if qtdep.found()
+  qtmodule = import(qt)
+  assert(qtmodule.has_tools(tools: ['moc'], method: get_option('method'), version: '>=4'))
+  if get_option('expect_lrelease')
+    assert(qtmodule.has_tools(), 'You may be missing a devel package. (qttools5-dev-tools on Debian based systems)')
+  else
+    assert(not qtmodule.has_tools(), 'Unexpectedly found lrelease')
+    assert(not qtmodule.has_tools(tools: ['lrelease']), 'Unexpectedly found lrelease')
+    assert(qtmodule.has_tools(tools: ['moc', 'uic', 'rcc']), 'You may be missing a devel package. (qttools5-dev-tools on Debian based systems)')
+  endif
+
+  # Test that fetching a variable works and yields a non-empty value
+  assert(qtdep.get_variable('prefix', configtool: 'QT_INSTALL_PREFIX') != '')
+
+  # The following has two resource files because having two in one target
+  # requires you to do it properly or you get linker symbol clashes.
+
+  prep = qtmodule.preprocess(
+    moc_headers : ['mainWindow.h'],           # These need to be fed through the moc tool before use.
+    method : get_option('method')
+  )
+  # XML files that need to be compiled with the uic tol.
+  prep += qtmodule.compile_ui(
+    sources : 'ui/mainWindow.ui',
+    method: get_option('method'),
+    preserve_paths: true)
+
+  qtmodule.preprocess(
+    ui_files : 'ui/mainWindow.ui',
+    method: get_option('method'),
+    preserve_paths: true)
+
+  # Resource file(s) for rcc compiler
+  extra_cpp_args = []
+  if meson.is_unity()
+    extra_cpp_args += '-DUNITY_BUILD'
+    prep_rcc = qtmodule.preprocess(qt + '_unity_resource', qresources : ['stuff.qrc', 'stuff2.qrc'], method : get_option('method'))
+  else
+    prep_rcc = qtmodule.preprocess(qresources : ['stuff.qrc', 'stuff2.qrc'], method : get_option('method'))
+  endif
+
+  # Test that setting a unique name with a positional argument works
+  qtmodule.compile_resources(
+    name : qt + 'teststuff',
+    sources : files(['stuff.qrc', 'stuff2.qrc']),
+    method : get_option('method')
+  )
+
+  # Test that passing extra arguments to rcc works
+  # qt4-rcc and qt5-rcc take different arguments, for example qt4: ['-compress', '3']; qt5: '--compress=3'
+  qtmodule.preprocess(qt + 'testrccarg', qresources : files(['stuff.qrc', 'stuff2.qrc']), rcc_extra_arguments : '--compress=3', method : get_option('method'))
+
+  if get_option('expect_lrelease')
+    translations_cpp = qtmodule.compile_translations(qresource: qt+'_lang.qrc')
+    # unity builds suck and definitely cannot handle two qrc embeds in one compilation unit
+    unityproof_translations = static_library(qt+'unityproof_translations', translations_cpp, dependencies: qtdep)
+
+    extra_cpp_args += '-DQT="@0@"'.format(qt)
+    qexe = executable(qt + 'app',
+      sources : ['main.cpp', 'mainWindow.cpp', # Sources that don't need preprocessing.
+      prep, prep_rcc],
+      dependencies : qtdep,
+      link_with: unityproof_translations,
+      cpp_args: extra_cpp_args,
+      gui_app : true)
+
+    # We need a console test application because some test environments
+    # do not have an X server.
+
+    translations = qtmodule.compile_translations(ts_files : qt+'core_fr.ts', build_by_default : true)
+  endif
+
+  qtcore = dependency(qt, modules : 'Core', method : get_option('method'))
+
+  qtcoreapp = executable(qt + 'core', 'q5core.cpp',
+    cpp_args: '-DQT="@0@"'.format(qt),
+    dependencies : qtcore)
+
+  test(qt + 'test', qtcoreapp)
+
+  # The build system needs to include the cpp files from
+  # headers but the user must manually include moc
+  # files from sources.
+  qtmodule.preprocess(
+    moc_extra_arguments : ['-DMOC_EXTRA_FLAG'], # This is just a random macro to test `extra_arguments`
+    moc_sources : 'manualinclude.cpp',
+    moc_headers : 'manualinclude.h',
+    method : get_option('method'),
+    dependencies: mocdep,
+  )
+
+  manpreprocessed = qtmodule.compile_moc(
+    extra_args : ['-DMOC_EXTRA_FLAG'], # This is just a random macro to test `extra_arguments`
+    sources : 'manualinclude.cpp',
+    headers : 'manualinclude.h',
+    method : get_option('method'),
+    dependencies: mocdep,
+  )
+
+  qtmaninclude = executable(qt + 'maninclude',
+    sources : ['manualinclude.cpp', manpreprocessed],
+    dependencies : [qtcore, mocdep])
+
+  test(qt + 'maninclude', qtmaninclude)
+
+  # building Qt plugins implies to give include path to moc
+  plugin_includes = include_directories('pluginInterface', 'plugin')
+  pluginpreprocess = qtmodule.preprocess(
+    moc_headers : 'plugin/plugin.h',
+    include_directories : plugin_includes
+  )
+  plugin = library(qt + 'plugin', 'plugin/plugin.cpp', pluginpreprocess,
+        include_directories : plugin_includes,
+        dependencies : qtcore)
+
+  # implementing Qt interfaces requires passing Qt include paths to moc
+  qtinterfacepreprocess = qtmodule.preprocess(
+    moc_sources : 'qtinterface.cpp',
+    dependencies : qtdep
+  )
+  qtinterface = library(qt + 'qtinterface',
+                        sources : ['qtinterface.cpp', qtinterfacepreprocess],
+                        dependencies : qtdep)
+
   if qt == 'qt5'
-    qt_modules += qt5_modules
-  elif qt == 'qt6'
-    qt_modules += qt6_modules
+    subdir('subfolder')
   endif
 
-  # Test that invalid modules are indeed not found
-  fakeqtdep = dependency(qt, modules : ['DefinitelyNotFound'], required : false, method : get_option('method'))
-  if fakeqtdep.found()
-    error('Invalid qt dep incorrectly found!')
+  # Check we can apply a version constraint
+  accept_versions = ['>=@0@'.format(qtdep.version()), '<@0@'.format(qtdep.version()[0].to_int() + 1)]
+  dependency(qt, modules: qt_modules, version: accept_versions, method : get_option('method'))
+
+  # check that QT_DEBUG is correctly defined depending on whether this is a debug build
+  if get_option('debug')
+    assert_source = 'assert_qt_debug.cpp'
+  else
+    assert_source = 'assert_qt_no_debug.cpp'
   endif
-
-  # Test that partially-invalid modules are indeed not found
-  fakeqtdep = dependency(qt, modules : ['Core', 'DefinitelyNotFound'], required : false, method : get_option('method'))
-  if fakeqtdep.found()
-    error('Invalid qt dep incorrectly found!')
-  endif
-
-  # This test should be skipped if the required version of Qt isn't found
-  #
-  # (In the CI environment, the specified version of Qt is definitely present.
-  # An unexpected skip here is treated as a failure, so we are testing that the
-  # detection mechanism is able to find Qt.)
-  needed_qt = get_option('required').to_lower()
-  required = (qt == needed_qt)
-  if required
-    dep = dependency(qt, modules : ['Core'], required : false, method : get_option('method'))
-    if not dep.found()
-      error('MESON_SKIP_TEST @0@ not found.'.format(needed_qt))
-    endif
-  endif
-
-  # Ensure that the "no-Core-module-specified" code branch is hit
-  nocoredep = dependency(qt, modules : ['Gui'], required : required, method : get_option('method'))
-
-  # If 'qt' modules are found, test that.
-  qtdep = dependency(qt, modules : qt_modules, main : true, private_headers: true, required : required, method : get_option('method'))
-  if qtdep.found()
-    qtmodule = import(qt)
-    assert(qtmodule.has_tools(tools: ['moc'], method: get_option('method'), version: '>=4'))
-    if get_option('expect_lrelease')
-      assert(qtmodule.has_tools(), 'You may be missing a devel package. (qttools5-dev-tools on Debian based systems)')
-    else
-      assert(not qtmodule.has_tools(), 'Unexpectedly found lrelease')
-      assert(not qtmodule.has_tools(tools: ['lrelease']), 'Unexpectedly found lrelease')
-      assert(qtmodule.has_tools(tools: ['moc', 'uic', 'rcc']), 'You may be missing a devel package. (qttools5-dev-tools on Debian based systems)')
-    endif
-
-    # Test that fetching a variable works and yields a non-empty value
-    assert(qtdep.get_variable('prefix', configtool: 'QT_INSTALL_PREFIX') != '')
-
-    # The following has two resource files because having two in one target
-    # requires you to do it properly or you get linker symbol clashes.
-
-    prep = qtmodule.preprocess(
-      moc_headers : ['mainWindow.h'],           # These need to be fed through the moc tool before use.
-      method : get_option('method')
-    )
-    # XML files that need to be compiled with the uic tol.
-    prep += qtmodule.compile_ui(
-      sources : 'ui/mainWindow.ui',
-      method: get_option('method'),
-      preserve_paths: true)
-
-    qtmodule.preprocess(
-      ui_files : 'ui/mainWindow.ui',
-      method: get_option('method'),
-      preserve_paths: true)
-
-    # Resource file(s) for rcc compiler
-    extra_cpp_args = []
-    if meson.is_unity()
-      extra_cpp_args += '-DUNITY_BUILD'
-      prep_rcc = qtmodule.preprocess(qt + '_unity_resource', qresources : ['stuff.qrc', 'stuff2.qrc'], method : get_option('method'))
-    else
-      prep_rcc = qtmodule.preprocess(qresources : ['stuff.qrc', 'stuff2.qrc'], method : get_option('method'))
-    endif
-
-    # Test that setting a unique name with a positional argument works
-    qtmodule.compile_resources(
-      name : qt + 'teststuff',
-      sources : files(['stuff.qrc', 'stuff2.qrc']),
-      method : get_option('method')
-    )
-
-    # Test that passing extra arguments to rcc works
-    # qt4-rcc and qt5-rcc take different arguments, for example qt4: ['-compress', '3']; qt5: '--compress=3'
-    qtmodule.preprocess(qt + 'testrccarg', qresources : files(['stuff.qrc', 'stuff2.qrc']), rcc_extra_arguments : '--compress=3', method : get_option('method'))
-
-    if get_option('expect_lrelease')
-      translations_cpp = qtmodule.compile_translations(qresource: qt+'_lang.qrc')
-      # unity builds suck and definitely cannot handle two qrc embeds in one compilation unit
-      unityproof_translations = static_library(qt+'unityproof_translations', translations_cpp, dependencies: qtdep)
-
-      extra_cpp_args += '-DQT="@0@"'.format(qt)
-      qexe = executable(qt + 'app',
-        sources : ['main.cpp', 'mainWindow.cpp', # Sources that don't need preprocessing.
-        prep, prep_rcc],
-        dependencies : qtdep,
-        link_with: unityproof_translations,
-        cpp_args: extra_cpp_args,
-        gui_app : true)
-
-      # We need a console test application because some test environments
-      # do not have an X server.
-
-      translations = qtmodule.compile_translations(ts_files : qt+'core_fr.ts', build_by_default : true)
-    endif
-
-    qtcore = dependency(qt, modules : 'Core', method : get_option('method'))
-
-    qtcoreapp = executable(qt + 'core', 'q5core.cpp',
-      cpp_args: '-DQT="@0@"'.format(qt),
-      dependencies : qtcore)
-
-    test(qt + 'test', qtcoreapp)
-
-    # The build system needs to include the cpp files from
-    # headers but the user must manually include moc
-    # files from sources.
-    qtmodule.preprocess(
-      moc_extra_arguments : ['-DMOC_EXTRA_FLAG'], # This is just a random macro to test `extra_arguments`
-      moc_sources : 'manualinclude.cpp',
-      moc_headers : 'manualinclude.h',
-      method : get_option('method'),
-      dependencies: mocdep,
-    )
-
-    manpreprocessed = qtmodule.compile_moc(
-      extra_args : ['-DMOC_EXTRA_FLAG'], # This is just a random macro to test `extra_arguments`
-      sources : 'manualinclude.cpp',
-      headers : 'manualinclude.h',
-      method : get_option('method'),
-      dependencies: mocdep,
-    )
-
-    qtmaninclude = executable(qt + 'maninclude',
-      sources : ['manualinclude.cpp', manpreprocessed],
-      dependencies : [qtcore, mocdep])
-
-    test(qt + 'maninclude', qtmaninclude)
-
-    # building Qt plugins implies to give include path to moc
-    plugin_includes = include_directories('pluginInterface', 'plugin')
-    pluginpreprocess = qtmodule.preprocess(
-      moc_headers : 'plugin/plugin.h',
-      include_directories : plugin_includes
-    )
-    plugin = library(qt + 'plugin', 'plugin/plugin.cpp', pluginpreprocess,
-          include_directories : plugin_includes,
-          dependencies : qtcore)
-
-    # implementing Qt interfaces requires passing Qt include paths to moc
-    qtinterfacepreprocess = qtmodule.preprocess(
-      moc_sources : 'qtinterface.cpp',
-      dependencies : qtdep
-    )
-    qtinterface = library(qt + 'qtinterface',
-                          sources : ['qtinterface.cpp', qtinterfacepreprocess],
-                          dependencies : qtdep)
-
-    if qt == 'qt5'
-      subdir('subfolder')
-    endif
-
-    # Check we can apply a version constraint
-    accept_versions = ['>=@0@'.format(qtdep.version()), '<@0@'.format(qtdep.version()[0].to_int() + 1)]
-    dependency(qt, modules: qt_modules, version: accept_versions, method : get_option('method'))
-
-    # check that QT_DEBUG is correctly defined depending on whether this is a debug build
-    if get_option('debug')
-      assert_source = 'assert_qt_debug.cpp'
-    else
-      assert_source = 'assert_qt_no_debug.cpp'
-    endif
-    executable(qt + 'assert_debug', sources: [ assert_source ], dependencies: [ qtdep ])
-  endif
-endforeach
+  executable(qt + 'assert_debug', sources: [ assert_source ], dependencies: [ qtdep ])
+endif

--- a/test cases/frameworks/4 qt/meson_options.txt
+++ b/test cases/frameworks/4 qt/meson_options.txt
@@ -1,3 +1,3 @@
 option('method', type : 'string', value : 'auto', description : 'The method to use to find Qt')
-option('required', type : 'string', value : 'qt5', description : 'The version of Qt which is required to be present')
+option('required', type : 'string', value : 'qt6', description : 'The version of Qt which is required to be present')
 option('expect_lrelease', type: 'boolean', value: true)

--- a/test cases/frameworks/4 qt/meson_options.txt
+++ b/test cases/frameworks/4 qt/meson_options.txt
@@ -1,3 +1,3 @@
 option('method', type : 'string', value : 'auto', description : 'The method to use to find Qt')
-option('required', type : 'string', value : 'qt6', description : 'The version of Qt which is required to be present')
+option('version', type : 'string', value : 'qt6', description : 'The version of Qt to test')
 option('expect_lrelease', type: 'boolean', value: true)

--- a/test cases/frameworks/4 qt/test.json
+++ b/test cases/frameworks/4 qt/test.json
@@ -2,9 +2,9 @@
   "matrix": {
     "options": {
       "version": [
-        { "val": "qt4" },
-        { "val": "qt5" },
-        { "val": "qt6" }
+        { "val": "qt4", "expect_skip_on_jobname": ["arch", "fedora", "gentoo", "opensuse", "ubuntu-rolling"] },
+        { "val": "qt5", "expect_skip_on_jobname": ["gentoo"] },
+        { "val": "qt6", "expect_skip_on_jobname": ["macos"] }
       ],
       "method": [
         { "val": "config-tool" },

--- a/test cases/frameworks/4 qt/test.json
+++ b/test cases/frameworks/4 qt/test.json
@@ -2,7 +2,7 @@
   "matrix": {
     "options": {
       "version": [
-        { "val": "qt4", "expect_skip_on_jobname": ["arch", "fedora", "gentoo", "opensuse", "ubuntu-rolling"] },
+        { "val": "qt4", "expect_skip_on_jobname": ["arch", "fedora", "gentoo", "macos", "opensuse", "ubuntu-rolling"] },
         { "val": "qt5", "expect_skip_on_jobname": ["gentoo"] },
         { "val": "qt6", "expect_skip_on_jobname": ["macos"] }
       ],

--- a/test cases/frameworks/4 qt/test.json
+++ b/test cases/frameworks/4 qt/test.json
@@ -1,6 +1,11 @@
 {
   "matrix": {
     "options": {
+      "version": [
+        { "val": "qt4" },
+        { "val": "qt5" },
+        { "val": "qt6" }
+      ],
       "method": [
         { "val": "config-tool" },
         { "val": "qmake" },

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -325,7 +325,7 @@ class LinuxlikeTests(BasePlatformTests):
                 return NonExistingExternalProgram(prog)
             return self._interpreter.find_program_impl(prog, *args, **kwargs)
         with mock.patch.object(mesonbuild.modules.ModuleState, 'find_program', _no_lrelease):
-            self.init(testdir, inprocess=True, extra_args=['-Dmethod=qmake', '-Dexpect_lrelease=false'])
+            self.init(testdir, inprocess=True, extra_args=['-Dmethod=qmake', '-Dexpect_lrelease=false', '-Dversion=qt5'])
 
     def test_qt5dependency_qmake_detection(self):
         '''
@@ -341,7 +341,7 @@ class LinuxlikeTests(BasePlatformTests):
                 raise SkipTest('Qmake found, but it is not for Qt 5.')
         # Disable pkg-config codepath and force searching with qmake/qmake-qt5
         testdir = os.path.join(self.framework_test_dir, '4 qt')
-        self.init(testdir, extra_args=['-Dmethod=qmake'])
+        self.init(testdir, extra_args=['-Dmethod=qmake', '-Dversion=qt5'])
         # Confirm that the dependency was found with qmake
         mesonlog = self.get_meson_log_raw()
         self.assertRegex(mesonlog,
@@ -361,7 +361,7 @@ class LinuxlikeTests(BasePlatformTests):
                 raise SkipTest('Qmake found, but it is not for Qt 6.')
         # Disable pkg-config codepath and force searching with qmake/qmake-qt6
         testdir = os.path.join(self.framework_test_dir, '4 qt')
-        self.init(testdir, extra_args=['-Dmethod=qmake'])
+        self.init(testdir, extra_args=['-Dmethod=qmake', '-Dversion=qt6'])
         # Confirm that the dependency was found with qmake
         mesonlog = self.get_meson_log_raw()
         self.assertRegex(mesonlog,

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -303,25 +303,6 @@ class LinuxlikeTests(BasePlatformTests):
         self.build()
         self._run(self.mtest_command)
 
-    @skipIfNoPkgconfig
-    def test_qtdependency_pkgconfig_detection(self):
-        '''
-        Test that qt4 and qt5 detection with pkgconfig works.
-        '''
-        # Verify Qt4 or Qt5 can be found with pkg-config
-        qt4 = subprocess.call([PKG_CONFIG, '--exists', 'QtCore'])
-        qt5 = subprocess.call([PKG_CONFIG, '--exists', 'Qt5Core'])
-        testdir = os.path.join(self.framework_test_dir, '4 qt')
-        self.init(testdir, extra_args=['-Dmethod=pkg-config'])
-        # Confirm that the dependency was found with pkg-config
-        mesonlog = self.get_meson_log_raw()
-        if qt4 == 0:
-            self.assertRegex(mesonlog,
-                             r'Run-time dependency qt4 \(modules: Core\) found: YES 4.* \(pkg-config\)')
-        if qt5 == 0:
-            self.assertRegex(mesonlog,
-                             r'Run-time dependency qt5 \(modules: Core\) found: YES 5.* \(pkg-config\)')
-
     @skip_if_not_base_option('b_sanitize')
     def test_generate_gir_with_address_sanitizer(self):
         if is_cygwin():


### PR DESCRIPTION
- [x] switch the Ubuntu image to use `wine` which replaced `wine-stable` package
- [x] split the `libwmf` test over `method`, and expect-skip `config-tool` method on Ubuntu per #15833 
- [x] split the `qt` test over Qt versions, and update skip-lists per Qt availability