### PR TITLE
Add `encoding` to Path().write_text() calls

### DIFF
--- a/test cases/common/182 find override/subdir/converter.py
+++ b/test cases/common/182 find override/subdir/converter.py
@@ -12,4 +12,4 @@ ftempl = '''int %s(void) {
 
 d = pathlib.Path(ifilename).read_text().split('\n')[0].strip()
 
-pathlib.Path(ofilename).write_text(ftempl % d)
+pathlib.Path(ofilename).write_text(ftempl % d, encoding='utf-8')

--- a/test cases/common/182 find override/subdir/gencodegen.py.in
+++ b/test cases/common/182 find override/subdir/gencodegen.py.in
@@ -12,4 +12,4 @@ ftempl = '''int %s(void) {
 
 d = pathlib.Path(ifilename).read_text().split('\n')[0].strip()
 
-pathlib.Path(ofilename).write_text(ftempl % d)
+pathlib.Path(ofilename).write_text(ftempl % d, encoding='utf-8')

--- a/test cases/common/208 link custom/custom_stlib.py
+++ b/test cases/common/208 link custom/custom_stlib.py
@@ -70,7 +70,7 @@ def generate_lib(outfile, private_dir, compiler_array):
     if not private_dir.exists():
         private_dir.mkdir()
     c_file = private_dir / 'flob.c'
-    c_file.write_text(contents)
+    c_file.write_text(contents, encoding='utf-8')
     for i in compiler_array:
         if (i.endswith('cl') or i.endswith('cl.exe')) and 'clang-cl' not in i:
             return generate_lib_msvc(outfile, c_file, private_dir, compiler_array)

--- a/test cases/common/209 link custom_i single from multiple/generate_conflicting_stlibs.py
+++ b/test cases/common/209 link custom_i single from multiple/generate_conflicting_stlibs.py
@@ -67,7 +67,7 @@ def generate_lib(outfiles, private_dir, compiler_array):
 
     for i, content in enumerate(contents):
         c_file = private_dir / ('flob_' + str(i + 1) + '.c')
-        c_file.write_text(content)
+        c_file.write_text(content, encoding='utf-8')
         outfile = outfiles[i]
 
         cl_found = False

--- a/test cases/common/210 link custom_i multiple from multiple/generate_stlibs.py
+++ b/test cases/common/210 link custom_i multiple from multiple/generate_stlibs.py
@@ -69,7 +69,7 @@ def generate_lib(outfiles, private_dir, compiler_array):
 
     for i, content in enumerate(contents):
         c_file = private_dir / ('flob_' + str(i + 1) + '.c')
-        c_file.write_text(content)
+        c_file.write_text(content, encoding='utf-8')
         outfile = outfiles[i]
 
         cl_found = False

--- a/test cases/common/227 very long command line/codegen.py
+++ b/test cases/common/227 very long command line/codegen.py
@@ -4,4 +4,4 @@ import sys
 from pathlib import Path
 
 Path(sys.argv[2]).write_text(
-    'int func{n}(void) {{ return {n}; }}'.format(n=sys.argv[1]))
+    'int func{n}(void) {{ return {n}; }}'.format(n=sys.argv[1]), encoding='utf-8')

--- a/test cases/common/262 generator chain/stage1.py
+++ b/test cases/common/262 generator chain/stage1.py
@@ -3,4 +3,4 @@ import sys
 from pathlib import Path
 
 assert(Path(sys.argv[1]).read_text() == 'stage1\n')
-Path(sys.argv[2]).write_text('stage2\n')
+Path(sys.argv[2]).write_text('stage2\n', encoding='utf-8')

--- a/test cases/common/262 generator chain/stage2.py
+++ b/test cases/common/262 generator chain/stage2.py
@@ -3,4 +3,4 @@ import sys
 from pathlib import Path
 
 assert(Path(sys.argv[1]).read_text() == 'stage2\n')
-Path(sys.argv[2]).write_text('int main(void){}\n')
+Path(sys.argv[2]).write_text('int main(void){}\n', encoding='utf-8')

--- a/test cases/unit/132 custom target index test/meson.build
+++ b/test cases/unit/132 custom target index test/meson.build
@@ -4,8 +4,8 @@ python3 = find_program('python3')
 
 gen_code = '''
 import sys, pathlib
-pathlib.Path(sys.argv[1]).write_text("foo")
-pathlib.Path(sys.argv[2]).write_text("bar")'''
+pathlib.Path(sys.argv[1]).write_text("foo", encoding='utf-8')
+pathlib.Path(sys.argv[2]).write_text("bar", encoding='utf-8')'''
 foobar_txt = custom_target(command: [python3, '-c', gen_code, '@OUTPUT@'], output: ['foo.txt', 'bar.txt'])
 
 test_code = '''

--- a/test cases/unit/35 dist script/replacer.py
+++ b/test cases/unit/35 dist script/replacer.py
@@ -13,4 +13,4 @@ modfile = source_root / 'prog.c'
 
 contents = modfile.read_text()
 contents = contents.replace(sys.argv[1], sys.argv[2])
-modfile.write_text(contents)
+modfile.write_text(contents, encoding='utf-8')


### PR DESCRIPTION
To help with more Visual Studio backend failures.