### PR TITLE
refman: spelling: FetureCheck -> FeatureCheck

### DIFF
--- a/docs/refman/loaderbase.py
+++ b/docs/refman/loaderbase.py
@@ -8,7 +8,7 @@ import typing as T
 
 from .model import (
     NamedObject,
-    FetureCheck,
+    FeatureCheck,
     ArgBase,
     PosArg,
     DataTypeInfo,
@@ -36,7 +36,7 @@ class _Resolver:
         assert obj.name.islower(), f'Object names must be lower case ({obj.name})'
         assert name_regex.match(obj.name) or obj.name == '[index]', f'Invalid name {obj.name}'
 
-    def _validate_feature_check(self, obj: FetureCheck) -> None:
+    def _validate_feature_check(self, obj: FeatureCheck) -> None:
         meson_version_reg = re.compile(r'[0-9]+\.[0-9]+\.[0-9]+')
         obj.since = obj.since.strip()
         obj.deprecated = obj.deprecated.strip()

--- a/docs/refman/loaderyaml.py
+++ b/docs/refman/loaderyaml.py
@@ -37,27 +37,27 @@ class StrictTemplate(Template):
             'description': Str(),
         }
 
-        d_feture_check = {
+        d_feature_check = {
             Optional('since', default=''): Str(),
             Optional('deprecated', default=''): Str(),
         }
 
         self.s_posarg = Map({
-            **d_feture_check,
+            **d_feature_check,
             'description': Str(),
             'type': Str(),
             Optional('default', default=''): Str(),
         })
 
         self.s_varargs = Map({
-            **d_named_object, **d_feture_check,
+            **d_named_object, **d_feature_check,
             'type': Str(),
             Optional('min_varargs', default=-1): Int(),
             Optional('max_varargs', default=-1): Int(),
         })
 
         self.s_kwarg = Map({
-            **d_feture_check,
+            **d_feature_check,
             'type': Str(),
             'description': Str(),
             Optional('required', default=False): Bool(),
@@ -65,7 +65,7 @@ class StrictTemplate(Template):
         })
 
         self.s_function = Map({
-            **d_named_object, **d_feture_check,
+            **d_named_object, **d_feature_check,
             'returns': Str(),
             Optional('notes', default=[]): OrValidator(Seq(Str()), EmptyList()),
             Optional('warnings', default=[]): OrValidator(Seq(Str()), EmptyList()),
@@ -82,7 +82,7 @@ class StrictTemplate(Template):
         })
 
         self.s_object = Map({
-            **d_named_object, **d_feture_check,
+            **d_named_object, **d_feature_check,
             'long_name': Str(),
             Optional('extends', default=''): Str(),
             Optional('notes', default=[]): OrValidator(Seq(Str()), EmptyList()),

--- a/docs/refman/model.py
+++ b/docs/refman/model.py
@@ -16,7 +16,7 @@ class NamedObject:
         return self.name.startswith('_')
 
 @dataclass
-class FetureCheck:
+class FeatureCheck:
     since: str
     deprecated: str
 
@@ -33,7 +33,7 @@ class Type:
 
 # Arguments
 @dataclass
-class ArgBase(NamedObject, FetureCheck):
+class ArgBase(NamedObject, FeatureCheck):
     type: Type
 
 @dataclass
@@ -53,7 +53,7 @@ class Kwarg(ArgBase):
 
 # Function
 @dataclass
-class Function(NamedObject, FetureCheck):
+class Function(NamedObject, FeatureCheck):
     notes: T.List[str]
     warnings: T.List[str]
     returns: Type
@@ -82,7 +82,7 @@ class ObjectType(Enum):
     RETURNED = 4
 
 @dataclass
-class Object(NamedObject, FetureCheck):
+class Object(NamedObject, FeatureCheck):
     notes: T.List[str]
     warnings: T.List[str]
     long_name: str


### PR DESCRIPTION
This is a minor spelling fix for the `refman` **_code_**. (The `docs/refman/` Python modules involved in **generating** the reference manual. Not the content of the reference manual. It will have no visible effect on the documentation.)

A class named `FetureCheck` should, of course, be `FeatureCheck`.
