### PR TITLE
fixes for cargo_ws.packages()

### DIFF
--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -271,7 +271,8 @@ say "require this specific configuration," which may conflict with the parent pr
 packages = ws.packages()
 ```
 
-Returns a list of package names in the workspace.
+Returns a list of configured package names in the workspace.  Non-default
+workspace members are not included.
 
 ### workspace.package()
 

--- a/mesonbuild/cargo/manifest.py
+++ b/mesonbuild/cargo/manifest.py
@@ -9,6 +9,7 @@ import collections
 import dataclasses
 import os
 import typing as T
+from pathlib import PurePath
 
 
 from . import version
@@ -617,8 +618,12 @@ class Workspace:
         ws = _raw_to_dataclass(raw['workspace'], cls, 'Workspace')
         if 'package' in raw:
             ws.root_package = Manifest.from_raw(raw, path, ws, '.')
-        if not ws.default_members:
-            ws.default_members = ['.'] if ws.root_package else ws.members
+        ws.members = list(PurePath(m).as_posix() for m in ws.members)
+        if ws.default_members:
+            ws.default_members = list(PurePath(m).as_posix() for m in ws.default_members)
+        else:
+            ws.default_members = ['.'] if ws.root_package else list(ws.members)
+
         return ws
 
 

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -152,7 +152,9 @@ class RustWorkspace(ModuleObject):
     @noKwargs
     def packages_method(self, state: ModuleState, args: T.List, kwargs: TYPE_kwargs) -> T.List[str]:
         """Returns list of package names in workspace."""
-        package_names = [pkg.manifest.package.name for pkg in self.ws.packages.values()]
+        package_names = [pkg.manifest.package.name
+                         for pkg in self.ws.packages.values()
+                         if pkg.cfg]
         return sorted(package_names)
 
     @typed_pos_args('workspace.package', optargs=[str])
@@ -260,6 +262,8 @@ class RustPackage(RustCrate):
 
     def __init__(self, rust_ws: RustWorkspace, package: cargo.PackageState) -> None:
         super().__init__(rust_ws, package)
+        if not package.cfg:
+            raise MesonException(f"package {self.package.manifest.package.name}-{self.package.manifest.package.version} not configured")
         self.methods.update({
             'dependencies': self.dependencies_method,
             'library': self.library_method,

--- a/test cases/rust/34 rust.workspace workspace/Cargo.toml
+++ b/test cases/rust/34 rust.workspace workspace/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
-members = [".", "more"]
+members = [".", "more", "another"]
+default_members = [".", "more"]
 
 [package]
 name = "workspace_test"

--- a/test cases/rust/34 rust.workspace workspace/another/Cargo.toml
+++ b/test cases/rust/34 rust.workspace workspace/another/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "another"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["rlib"]

--- a/test cases/rust/34 rust.workspace workspace/another/src/lib.rs
+++ b/test cases/rust/34 rust.workspace workspace/another/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn do_something() {
+    MIGHT_AS_WELL_FAIL_COMPILATION!();
+}

--- a/test cases/rust/34 rust.workspace workspace/meson.build
+++ b/test cases/rust/34 rust.workspace workspace/meson.build
@@ -37,6 +37,9 @@ endtestcase
 testcase expect_error('workspace member "nonexistent" not found')
   cargo_ws.package('nonexistent')
 endtestcase
+testcase expect_error('package another-0.1.0 not configured')
+  cargo_ws.package('another')
+endtestcase
 
 # failure test cases for dependency()
 testcase expect_error('package.dependency.*must be one of c, proc-macro, rust.*', how: 're')


### PR DESCRIPTION
Two fixes extracted from #15814 and useful for backporting to 1.11.2:
* Instead of raising an exception for accessing a field of a NoneType, report a Meson error and omit the entry from packages().
* canonicalize all workspace members to POSIX paths