### PR TITLE
More easy typing fixes for ninjabackend

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1470,7 +1470,7 @@ class Backend:
             srcs += fname
         return srcs
 
-    def get_target_depend_files(self, target: T.Union[build.CustomTarget, build.BuildTarget, build.GeneratedList], absolute_paths: bool = False) -> T.List[str]:
+    def get_target_depend_files(self, target: T.Union[build.CustomTarget, build.BuildTarget, build.GeneratedList, build.RunTarget], absolute_paths: bool = False) -> T.List[str]:
         deps: T.List[str] = []
         for i in target.depend_files:
             if isinstance(i, mesonlib.File):

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1501,7 +1501,7 @@ class Backend:
     def get_normpath_target(self, source: str) -> str:
         return os.path.normpath(source)
 
-    def get_custom_target_dirs(self, target: build.CustomTarget, compiler: 'Compiler', *,
+    def get_custom_target_dirs(self, target: build.BuildTarget | build.CustomTarget, compiler: 'Compiler', *,
                                absolute_path: bool = False) -> T.List[str]:
         custom_target_include_dirs: T.List[str] = []
         for i in target.get_generated_sources():
@@ -1520,7 +1520,7 @@ class Backend:
         return custom_target_include_dirs
 
     def get_custom_target_dir_include_args(
-            self, target: build.CustomTarget, compiler: 'Compiler', *,
+            self, target: build.BuildTarget | build.CustomTarget, compiler: 'Compiler', *,
             absolute_path: bool = False) -> T.List[str]:
         incs: T.List[str] = []
         for i in self.get_custom_target_dirs(target, compiler, absolute_path=absolute_path):

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1439,7 +1439,7 @@ class Backend:
             libs.extend(self.get_custom_target_provided_by_generated_source(t))
         return libs
 
-    def get_custom_target_sources(self, target: build.CustomTarget) -> T.List[str]:
+    def get_custom_target_sources(self, target: build.RunTarget | build.CustomTarget) -> T.List[str]:
         '''
         Custom target sources can be of various object types; strings, File,
         BuildTarget, even other CustomTargets.
@@ -1456,6 +1456,7 @@ class Backend:
             elif isinstance(i, (build.CustomTarget, build.CustomTargetIndex)):
                 fname = [os.path.join(self.get_custom_target_output_dir(i), p) for p in i.get_outputs()]
             elif isinstance(i, build.GeneratedList):
+                assert not isinstance(target, build.RunTarget)
                 fname = [os.path.join(self.get_target_private_dir(target), p) for p in i.get_outputs()]
             elif isinstance(i, build.ExtractedObjects):
                 fname = self.determine_ext_objs(i)
@@ -1527,7 +1528,7 @@ class Backend:
         return incs
 
     def eval_custom_target_command(
-            self, target: build.CustomTarget, absolute_outputs: bool = False) -> \
+            self, target: build.RunTarget | build.CustomTarget, absolute_outputs: bool = False) -> \
             T.Tuple[T.List[str], T.List[str], T.List[str | programs.Program]]:
         # We want the outputs to be absolute only when using the VS backend
         # XXX: Maybe allow the vs backend to use relative paths too?
@@ -1565,6 +1566,7 @@ class Backend:
                 if '@CURRENT_SOURCE_DIR@' in i:
                     i = i.replace('@CURRENT_SOURCE_DIR@', os.path.join(source_root, target.get_subdir()))
                 if '@DEPFILE@' in i:
+                    assert not isinstance(target, build.RunTarget)
                     if target.depfile is None:
                         msg = f'Custom target {target.name!r} has @DEPFILE@ but no depfile ' \
                               'keyword argument.'
@@ -1572,6 +1574,7 @@ class Backend:
                     dfilename = os.path.join(outdir, target.depfile)
                     i = i.replace('@DEPFILE@', dfilename)
                 if '@PRIVATE_DIR@' in i:
+                    assert not isinstance(target, build.RunTarget)
                     pdir = self.get_target_private_dir_abs(target)
                     os.makedirs(pdir, exist_ok=True)
                     if not target.absolute_paths:

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1037,7 +1037,7 @@ class Backend:
                 commands += compiler.get_include_args(priv_dir, False)
         return commands
 
-    def build_target_link_arguments(self, compiler: 'Compiler', deps: T.List[build.Target]) -> T.List[str]:
+    def build_target_link_arguments(self, compiler: Compiler, deps: T.Iterable[build.BuildTargetTypes]) -> T.List[str]:
         args: T.List[str] = []
         for d in deps:
             if not d.is_linkable_target():

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -544,7 +544,7 @@ class Backend:
     def get_executable_serialisation(
             self, cmd: T.Sequence[T.Union[programs.Program, build.BuildTargetTypes, File, str]],
             workdir: T.Optional[str] = None,
-            extra_bdeps: T.Optional[T.Sequence[build.BuildTargetTypes]] = None,
+            extra_bdeps: T.Optional[T.Iterable[build.BuildTargetTypes]] = None,
             capture: T.Optional[str] = None,
             feed: T.Optional[str] = None,
             env: T.Optional[mesonlib.EnvironmentVariables] = None,
@@ -634,7 +634,7 @@ class Backend:
     def as_meson_exe_cmdline(self, exe: T.Union[str, mesonlib.File, build.BuildTargetTypes, programs.Program],
                              cmd_args: T.Sequence[T.Union[str, mesonlib.File, build.BuildTargetTypes, programs.Program]],
                              workdir: T.Optional[str] = None,
-                             extra_bdeps: T.Optional[T.Sequence[build.BuildTargetTypes]] = None,
+                             extra_bdeps: T.Optional[T.Iterable[build.BuildTargetTypes]] = None,
                              capture: T.Optional[str] = None,
                              feed: T.Optional[str] = None,
                              force_serialize: bool = False,
@@ -1138,7 +1138,7 @@ class Backend:
 
     def determine_windows_extra_paths(
             self, target: T.Union[build.BuildTargetTypes, programs.Program, mesonlib.File, str],
-            extra_bdeps: T.Sequence[build.BuildTargetTypes]) -> T.List[str]:
+            extra_bdeps: T.Iterable[build.BuildTargetTypes]) -> T.List[str]:
         """On Windows there is no such thing as an rpath.
 
         We must determine all locations of DLLs that this exe

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -527,8 +527,10 @@ class Backend:
         return obj_list, deps
 
     @staticmethod
-    def is_swift_target(target: build.BuildTarget) -> bool:
-        for s in target.sources:
+    def is_swift_target(target: build.BuildTargetTypes) -> bool:
+        if not isinstance(target, build.BuildTarget):
+            return False
+        for s in target.get_sources():
             if s.endswith('swift'):
                 return True
         return False

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -483,7 +483,7 @@ class Backend:
                                os.path.join('dummyprefixdir', fromdir))
 
     def flatten_object_list(self, target: build.BuildTarget, proj_dir_to_build_root: str = ''
-                            ) -> T.Tuple[T.List[str], T.List[build.BuildTargetTypes]]:
+                            ) -> T.Tuple[T.List[str], T.List[build.BuildTarget]]:
         obj_list, deps = self._flatten_object_list(target, target.get_objects(), proj_dir_to_build_root)
         return unique_list(obj_list), deps
 
@@ -493,9 +493,9 @@ class Backend:
 
     def _flatten_object_list(self, target: build.BuildTarget,
                              objects: T.Sequence[build.ObjectTypes],
-                             proj_dir_to_build_root: str) -> T.Tuple[T.List[str], T.List[build.BuildTargetTypes]]:
+                             proj_dir_to_build_root: str) -> T.Tuple[T.List[str], T.List[build.BuildTarget]]:
         obj_list: T.List[str] = []
-        deps: T.List[build.BuildTargetTypes] = []
+        deps: T.List[build.BuildTarget] = []
         for obj in objects:
             if isinstance(obj, str):
                 o = os.path.join(proj_dir_to_build_root,

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2821,7 +2821,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 continue
             self.generate_genlist_for_target(genlist, target)
 
-    def replace_paths(self, target: build.BuildTarget, args: T.List[str], override_subdir: T.Optional[str] = None) -> T.List[str]:
+    def replace_paths(self, target: build.BuildTarget | build.CustomTarget, args: T.List[str], override_subdir: T.Optional[str] = None) -> T.List[str]:
         if override_subdir:
             source_target_dir = os.path.join(self.build_to_src, override_subdir)
         else:
@@ -2835,7 +2835,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         args = [x.replace('\\', '/') for x in args]
         return args
 
-    def generate_genlist_for_target(self, genlist: build.GeneratedList, target: build.BuildTarget) -> None:
+    def generate_genlist_for_target(self, genlist: build.GeneratedList, target: build.BuildTarget | build.CustomTarget) -> None:
         for x in genlist.depends:
             if isinstance(x, build.GeneratedList):
                 self.generate_genlist_for_target(x, target)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -52,6 +52,7 @@ if T.TYPE_CHECKING:
 
     CommandArgTypes = T.TypeVar('CommandArgTypes', 'NinjaCommandArg', str, 'NinjaCommandArg | str')
     CommandArgs = T.List[CommandArgTypes]
+    FileList = T.List[File] | T.List[str] | T.List[File | str]
     ListifiedStr = str | T.List[str]
     RUST_EDITIONS = Literal['2015', '2018', '2021', '2024']
 
@@ -834,9 +835,9 @@ class NinjaBackend(backends.Backend):
 
     def create_target_source_introspection(self, target: build.Target, comp: compilers.Compiler,
                                            parameters: CompilerArgs | T.List[str],
-                                           sources: T.List[FileOrString],
-                                           generated_sources: T.List[FileOrString],
-                                           unity_sources: T.Optional[T.List[FileOrString]] = None) -> None:
+                                           sources: FileList,
+                                           generated_sources: FileList,
+                                           unity_sources: T.Optional[T.List[str]] = None) -> None:
         '''
         Adds the source file introspection information for a language of a target
 
@@ -1172,7 +1173,7 @@ class NinjaBackend(backends.Backend):
     def generate_dependency_scan_target(self, target: build.BuildTarget,
                                         compiled_sources: T.List[str],
                                         source2object: T.Dict[str, str],
-                                        object_deps: T.List[FileOrString]) -> None:
+                                        object_deps: T.List[File]) -> None:
         if not self.should_use_dyndeps_for_target(target):
             return
         self._uses_dyndeps = True
@@ -2249,7 +2250,7 @@ class NinjaBackend(backends.Backend):
         return deps, project_deps, args
 
     def generate_rust_target(self, target: build.BuildTarget, target_name: str, obj_list: T.List[str],
-                             fortran_order_deps: T.List[str]) -> None:
+                             fortran_order_deps: T.List[File]) -> None:
         orderdeps, main_rust_file = self.generate_rust_sources(target)
         if main_rust_file is None:
             raise RuntimeError('A Rust target has no Rust sources. This is weird. Also a bug. Please report')
@@ -3203,9 +3204,9 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
     def generate_single_compile(self, target: build.BuildTarget, src: FileOrString,
                                 is_generated: bool = False,
                                 header_deps: T.Optional[T.List[FileOrString]] = None,
-                                order_deps: T.Optional[T.List[FileOrString]] = None,
+                                order_deps: T.Optional[T.List[File] | T.List[FileOrString]] = None,
                                 extra_args: T.Optional[T.List[str]] = None,
-                                unity_sources: T.Optional[T.List[FileOrString]] = None,
+                                unity_sources: T.Optional[T.List[str]] = None,
                                 ) -> T.Tuple[str, str]:
         """
         Compiles C/C++, ObjC/ObjC++, Fortran, and D sources

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3714,14 +3714,14 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         try:
             static_patterns = linker.get_library_naming(LibType.STATIC, strict=True)
             shared_patterns = linker.get_library_naming(LibType.SHARED, strict=True)
-            search_dirs = tuple(search_dirs) + tuple(linker.get_library_dirs())
+            search_dirs_tuple = tuple(search_dirs) + tuple(linker.get_library_dirs())
             for libname in libs:
                 # be conservative and record most likely shared and static resolution, because we don't know exactly
                 # which one the linker will prefer
                 staticlibs = self.guess_library_absolute_path(linker, libname,
-                                                              search_dirs, static_patterns)
+                                                              search_dirs_tuple, static_patterns)
                 sharedlibs = self.guess_library_absolute_path(linker, libname,
-                                                              search_dirs, shared_patterns)
+                                                              search_dirs_tuple, shared_patterns)
                 if staticlibs:
                     guessed_dependencies.append(staticlibs.resolve().as_posix())
                 if sharedlibs:
@@ -3841,7 +3841,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         # Add link args to link to all internal libraries (link_with:) and
         # internal dependencies needed by this target.
         dep_targets: T.List[str] = []
-        dependencies: T.List[build.BuildTargetTypes]
+        dependencies: T.Iterable[build.BuildTargetTypes]
         if isinstance(target, build.StaticLibrary):
             # Link arguments of static libraries are not put in the command
             # line of the library. They are instead appended to the command

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3473,6 +3473,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         ]
 
     def generate_msvc_pch_command(self, target: build.BuildTarget, compiler: Compiler, pch: T.Tuple[str, T.Optional[str]]) -> T.Tuple[T.List[str], str, str, T.List[str], str]:
+        from ..compilers.mixins.visualstudio import VisualStudioLikeCompiler
+        assert isinstance(compiler, VisualStudioLikeCompiler) # for mypy
         header = pch[0]
         pchname = compiler.get_pch_name(header)
         dst = os.path.join(self.get_target_private_dir(target), pchname)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3574,7 +3574,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             elem.add_item('CROSS', '--cross-host=' + self.environment.machines[target.for_machine].system)
         self.add_build(elem)
 
-    def get_import_filename(self, target: build.BuildTarget) -> str:
+    def get_import_filename(self, target: build.Executable | build.SharedLibrary) -> str:
         return os.path.join(self.get_target_dir(target), target.import_filename)
 
     def get_target_type_link_args(self, target: build.BuildTarget, linker: T.Union[StaticLinker, Compiler]) -> T.List[str]:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1203,7 +1203,7 @@ class NinjaBackend(backends.Backend):
         # they use or export.
         for s in scan_sources:
             elem.deps.add(s[0])
-        elem.orderdeps.update(object_deps)
+        elem.add_orderdep(self.order_deps_to_strings(target, object_deps))
         elem.add_item('name', target.name)
         self.add_build(elem)
 
@@ -2279,8 +2279,7 @@ class NinjaBackend(backends.Backend):
         element = NinjaBuildElement(self.all_outputs, target_name, compiler_name, main_rust_file)
         if orderdeps:
             element.add_orderdep(orderdeps)
-        if fortran_order_deps:
-            element.add_orderdep(fortran_order_deps)
+        element.add_orderdep(self.order_deps_to_strings(target, fortran_order_deps))
         if deps:
             # dependencies need to cause a relink, they're not just for ordering
             element.add_dep(deps)
@@ -3201,6 +3200,16 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             src_type_to_args[src_type_str] = commands.to_native()
         return src_type_to_args
 
+    def order_deps_to_strings(self, target: build.BuildTarget, order_deps: T.List[File] | T.List[FileOrString]) -> T.List[str]:
+        result: T.List[str] = []
+        for d in order_deps:
+            if isinstance(d, File):
+                d = d.rel_to_builddir(self.build_to_src)
+            elif not self.has_dir_part(d):
+                d = os.path.join(self.get_target_private_dir(target), d)
+            result.append(d)
+        return result
+
     def generate_single_compile(self, target: build.BuildTarget, src: FileOrString,
                                 is_generated: bool = False,
                                 header_deps: T.Optional[T.List[FileOrString]] = None,
@@ -3323,12 +3332,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         self.add_header_deps(target, element, header_deps)
         for d in extra_deps:
             element.add_dep(d)
-        for d in order_deps:
-            if isinstance(d, File):
-                d = d.rel_to_builddir(self.build_to_src)
-            elif not self.has_dir_part(d):
-                d = os.path.join(self.get_target_private_dir(target), d)
-            element.add_orderdep(d)
+        element.add_orderdep(self.order_deps_to_strings(target, order_deps))
         element.add_dep(pch_dep)
         if not self.use_dyndeps_for_fortran():
             for i in self.get_fortran_module_deps(target, compiler):

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2145,7 +2145,7 @@ class NinjaBackend(backends.Backend):
             if isinstance(d, build.StaticLibrary):
                 external_deps.extend(d.external_deps)
             if d.uses_rust_abi():
-                if d not in itertools.chain(target.link_targets, target.link_whole_targets):
+                if d not in target.link_targets and d not in target.link_whole_targets:
                     # Indirect Rust ABI dependency, we only need its path in linkdirs.
                     continue
                 assert isinstance(d, build.BuildTarget)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1142,8 +1142,10 @@ class NinjaBackend(backends.Backend):
                 elem = NinjaBuildElement(self.all_outputs, linker.get_archive_name(outname), 'AIX_LINKER', [outname])
                 self.add_build(elem)
 
-    def should_use_dyndeps_for_target(self, target: 'build.BuildTarget') -> bool:
+    def should_use_dyndeps_for_target(self, target: build.BuildTargetTypes) -> bool:
         if not self.ninja_has_dyndeps:
+            return False
+        if not isinstance(target, build.BuildTarget):
             return False
         if 'fortran' in target.compilers:
             return True
@@ -1207,6 +1209,7 @@ class NinjaBackend(backends.Backend):
         infiles: T.Set[str] = set()
         for t in target.get_all_linked_targets():
             if self.should_use_dyndeps_for_target(t):
+                assert isinstance(t, build.BuildTarget)
                 infiles.add(self.get_dep_scan_file_for(t)[0])
         _, od = self.flatten_object_list(target)
         infiles.update({self.get_dep_scan_file_for(t)[0] for t in od if t.uses_fortran()})
@@ -2322,6 +2325,7 @@ class NinjaBackend(backends.Backend):
         result = []
         for l in target.link_targets:
             if self.is_swift_target(l):
+                assert isinstance(l, build.BuildTarget) # for mypy
                 result.append(self.swift_module_file_name(l))
         return result
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1768,7 +1768,7 @@ class NinjaBackend(backends.Backend):
             # If the Vala file is outside the build directory, the paths from
             # the --basedir till the subdir will be duplicated inside the
             # private builddir.
-            if isinstance(gensrc, (build.CustomTarget, build.GeneratedList)) or gensrc.is_built:
+            if isinstance(gensrc, (build.CustomTarget, build.CustomTargetIndex, build.GeneratedList)) or gensrc.is_built:
                 vala_c_file = os.path.splitext(os.path.basename(vala_file))[0] + '.c'
                 # Check if the vala file is in a subdir of --basedir
                 abs_srcbasedir = os.path.join(self.environment.get_source_dir(), target.get_subdir())


### PR DESCRIPTION
Down to 19, but they mostly seem nasty.

```
mesonbuild/backend/ninjabackend.py:514:9: error: Need type annotation for "introspection_data" (hint: "introspection_data: dict[<type>, <type>] = ...")  [var-annotated]
mesonbuild/backend/ninjabackend.py:618:93: error: If x = b'abc' then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes  [str-bytes-safe]
mesonbuild/backend/ninjabackend.py:886:9: error: Item "Sequence[str]" of "Any | Sequence[str]" has no attribute "extend"  [union-attr]
mesonbuild/backend/ninjabackend.py:887:9: error: Item "Sequence[str]" of "Any | Sequence[str]" has no attribute "extend"  [union-attr]
mesonbuild/backend/ninjabackend.py:889:13: error: Item "Sequence[str]" of "Any | Sequence[str]" has no attribute "extend"  [union-attr]
mesonbuild/backend/ninjabackend.py:1237:18: error: "Target" has no attribute "get_dependencies"  [attr-defined]
mesonbuild/backend/ninjabackend.py:1253:27: error: Item "Program" of "RunTarget | CustomTarget | CustomTargetIndex | BuildTarget | GeneratedList | Program" has no attribute "get_outputs"  [union-attr]
mesonbuild/backend/ninjabackend.py:1826:33: error: "BuildTarget" has no attribute "get"  [attr-defined]
mesonbuild/backend/ninjabackend.py:1857:16: error: Incompatible return value type (got "tuple[MutableMapping[str, File | CustomTarget | CustomTargetIndex | GeneratedList], MutableMapping[str, File | CustomTarget | CustomTargetIndex | GeneratedList], list[str]]", expected "tuple[MutableMapping[str, File], MutableMapping[str, File], list[str]]")  [return-value]
mesonbuild/backend/ninjabackend.py:1921:77: error: Item "GeneratedList" of "CustomTarget | CustomTargetIndex | GeneratedList" has no attribute "get_builddir"  [union-attr]
mesonbuild/backend/ninjabackend.py:2849:27: error: Item "Program" of "CustomTarget | CustomTargetIndex | BuildTarget | GeneratedList | Program" has no attribute "get_outputs"  [union-attr]
mesonbuild/backend/ninjabackend.py:2885:52: error: Argument 1 to "get_target_filename" of "Backend" has incompatible type "CustomTarget | CustomTargetIndex | BuildTarget | GeneratedList | Program"; expected "Target | CustomTargetIndex"  [arg-type]
mesonbuild/backend/ninjabackend.py:3650:21: error: Too many arguments for "extract_all_objects" of "CustomTarget"  [call-arg]
mesonbuild/backend/ninjabackend.py:3650:21: error: Too many arguments for "extract_all_objects" of "CustomTargetIndex"  [call-arg]
mesonbuild/backend/ninjabackend.py:3651:45: error: Argument 1 to "__iadd__" of "list" has incompatible type "list[str]"; expected "Iterable[ExtractedObjects]"  [arg-type]
mesonbuild/backend/ninjabackend.py:3651:69: error: Argument 1 to "determine_ext_objs" of "Backend" has incompatible type "ExtractedObjects | list[str | ExtractedObjects] | str"; expected "ExtractedObjects"  [arg-type]
mesonbuild/backend/ninjabackend.py:3652:49: error: Argument 1 to "extend" of "list" has incompatible type "list[str]"; expected "Iterable[ExtractedObjects]"  [arg-type]
mesonbuild/backend/ninjabackend.py:3652:74: error: Argument 1 to "flatten_object_list" of "Backend" has incompatible type "StaticLibrary | CustomTarget | CustomTargetIndex"; expected "BuildTarget"  [arg-type]
mesonbuild/backend/ninjabackend.py:3654:20: error: Incompatible return value type (got "list[ExtractedObjects]", expected "list[str]")  [return-value]
```