### PR TITLE
cargo: Pass env vars in the env when --env-set is not available

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -15,6 +15,7 @@ import json
 import os
 import pickle
 import re
+import shlex
 import subprocess
 import typing as T
 
@@ -106,7 +107,7 @@ rsp_threshold = mesonlib.get_rsp_threshold()
 # variables (or variables we use them in) is interpreted directly by ninja
 # (e.g. the value of the depfile variable is a pathname that ninja will read
 # from, etc.), so it must not be shell quoted.
-raw_names = {'DEPFILE_UNQUOTED', 'DESC', 'pool', 'description', 'targetdep', 'dyndep'}
+raw_names = {'DEPFILE_UNQUOTED', 'DESC', 'pool', 'description', 'targetdep', 'dyndep', 'RUSTENV'}
 
 NINJA_QUOTE_BUILD_PAT = re.compile(r"[$ :\n]")
 NINJA_QUOTE_VAR_PAT = re.compile(r"[$ \n]")
@@ -2282,6 +2283,8 @@ class NinjaBackend(backends.Backend):
             element.add_dep(deps)
         element.add_item('ARGS', args)
         element.add_item('targetdep', depfile)
+        if target.rust_compile_env:
+            element.add_item('RUSTENV', self._rust_env_tokens(target.rust_compile_env))
         self.add_build(element)
         self.create_target_source_introspection(target, rustc, args, [main_rust_file], [])
 
@@ -2605,9 +2608,27 @@ class NinjaBackend(backends.Backend):
                                 depfile=depfile,
                                 restat=True))
 
+    def _rust_env_tokens(self, env: T.Dict[str, str]) -> T.List[str]:
+        '''
+        Build the tokens that expand into the $RUSTENV ninja variable. They
+        are pre-quoted for the target shell so they survive ninja
+        substitution without further escaping
+        '''
+        if mesonlib.is_windows():
+            wrapper = self.environment.meson_env_exe
+            assert wrapper is not None, \
+                'meson_env.exe path not set; setup-time build is missing'
+            tokens = [mesonlib.quote_arg(wrapper)]
+            tokens += [mesonlib.quote_arg(f'{k}={v}') for k, v in env.items()]
+            return tokens
+        return [f'{k}={shlex.quote(v)}' for k, v in env.items()]
+
     def generate_rust_compile_rules(self, compiler: RustCompiler) -> None:
         rule = self.compiler_to_rule_name(compiler)
-        command = compiler.get_exelist() + ['$ARGS', '$in']
+        command: T.List[T.Union[str, NinjaCommandArg]] = [
+            NinjaCommandArg('$RUSTENV', Quoting.none),
+        ]
+        command += compiler.get_exelist() + ['$ARGS', '$in']
         description = 'Compiling Rust source $in'
         depfile = '$targetdep'
         depstyle = 'gcc'

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -904,6 +904,8 @@ class BuildTarget(Target):
         self.implicit_include_directories = kwargs.get('implicit_include_directories', True)
         self.gnu_symbol_visibility = kwargs.get('gnu_symbol_visibility', '')
         self.rust_dependency_map = kwargs.get('rust_dependency_map', {})
+        # Env vars to set for rustc
+        self.rust_compile_env: T.Dict[str, str] = {}
 
         self.swift_interoperability_mode = kwargs.get('swift_interoperability_mode', 'c')
         self.swift_module_name = kwargs.get('swift_module_name') or self.name

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -16,6 +16,7 @@ import itertools
 import os
 import pathlib
 import collections
+import subprocess
 import urllib.parse
 import typing as T
 from pathlib import PurePath
@@ -45,6 +46,41 @@ if T.TYPE_CHECKING:
 def _dependency_name(package_name: str, api: str, suffix: str = '-rs') -> str:
     basename = package_name[:-len(suffix)] if suffix and package_name.endswith(suffix) else package_name
     return f'{basename}-{api}{suffix}'
+
+
+def ensure_meson_env_exe(environment: Environment) -> None:
+    """
+    Build the meson_env wrapper on windows when using stable Rust that lacks
+    --env-set, since that's the only way to set a process's environment in
+    ninja. Requires a build-machine Rust toolchain.
+    """
+    if environment.meson_env_exe is not None:
+        return
+    from ..mesonlib import is_windows
+    if not is_windows():
+        return
+    host_rust = environment.coredata.compilers[MachineChoice.HOST].get('rust')
+    if host_rust is None:
+        return
+    if T.cast('RustCompiler', host_rust).enable_env_set_args() is not None:
+        # rustc supports --env-set; no wrapper needed.
+        return
+
+    build_rust = environment.coredata.compilers[MachineChoice.BUILD].get('rust')
+    if build_rust is None:
+        raise MesonException('Cargo subproject on Windows requires a build-machine Rust toolchain')
+
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    source = os.path.join(here, 'scripts', 'meson_env.rs')
+    out = os.path.join(environment.get_scratch_dir(), 'meson_env.exe')
+    if not os.path.exists(out) or os.path.getmtime(out) < os.path.getmtime(source):
+        mlog.log('Building meson_env wrapper for Cargo subprojects...')
+        cmd = build_rust.get_exelist() + ['-O', '-o', out, source]
+        try:
+            subprocess.run(cmd, check=True)
+        except subprocess.CalledProcessError as e:
+            raise MesonException(f'Failed to build meson_env wrapper: {e}')
+    environment.meson_env_exe = out
 
 
 def _extra_args_varname() -> str:
@@ -167,7 +203,7 @@ class PackageState:
 
         return args
 
-    def get_env_args(self, rustc: RustCompiler, environment: Environment, subdir: str) -> T.List[str]:
+    def get_env_set_args(self, rustc: RustCompiler, environment: Environment, subdir: str) -> T.List[str]:
         """Get environment variable arguments for rustc."""
         enable_env_set_args = rustc.enable_env_set_args()
         if enable_env_set_args is None:
@@ -178,6 +214,15 @@ class PackageState:
         for k, v in env_dict.items():
             env_args.extend(['--env-set', f'{k}={v}'])
         return env_args
+
+    def get_rustc_env(self, environment: Environment, subdir: str, machine: MachineChoice) -> T.Dict[str, str]:
+        """Get environment variables as a dict for rustc."""
+        if not environment.is_cross_build():
+            machine = MachineChoice.HOST
+        rustc = T.cast('RustCompiler', environment.coredata.compilers[machine]['rust'])
+        if rustc.enable_env_set_args() is not None:
+            return {}
+        return self.get_env_dict(environment, subdir)
 
     def get_rustc_args(self, environment: Environment, subdir: str, machine: MachineChoice) -> T.List[str]:
         """Get rustc arguments for this package."""
@@ -191,7 +236,7 @@ class PackageState:
         args: T.List[str] = []
         args.extend(self.get_lint_args(rustc))
         args.extend(cfg.get_features_args())
-        args.extend(self.get_env_args(rustc, environment, subdir))
+        args.extend(self.get_env_set_args(rustc, environment, subdir))
         return args
 
     def supported_abis(self) -> T.Set[RUST_ABI]:

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -85,6 +85,10 @@ class Environment:
 
     def __init__(self, source_dir: str, build_dir: T.Optional[str], cmd_options: cmdline.SharedCMDOptions) -> None:
         self.source_dir = source_dir
+        # Path to the meson_env wrapper executable built at setup time.
+        # Currently only used when a Cargo workspace is being interpreted on
+        # Windows with stable Rust.
+        self.meson_env_exe: T.Optional[str] = None
         # Do not try to create build directories when build_dir is none.
         # This reduced mode is used by the --buildoptions introspector
         if build_dir is not None:

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -342,6 +342,22 @@ class RustPackage(RustCrate):
 
         kwargs['override_options'].setdefault('rust_std', self.package.manifest.package.edition)
 
+    def _apply_rustc_env(self, state: ModuleState,
+                         native: MachineChoice,
+                         result: T.Union[BothLibraries, BuildTarget]) -> None:
+        env = self.package.get_rustc_env(state.environment, state.subdir, native)
+        if not env:
+            return
+        # On Windows we need a tiny native wrapper to set the env before
+        # running rustc
+        from .. import cargo as _cargo
+        _cargo.interpreter.ensure_meson_env_exe(state.environment)
+        if isinstance(result, BothLibraries):
+            result.shared.rust_compile_env = dict(env)
+            result.static.rust_compile_env = dict(env)
+        else:
+            result.rust_compile_env = dict(env)
+
     def _library_method(self, state: ModuleState, args: T.Tuple[
             T.Optional[T.Union[str, StructuredSources]],
             T.Optional[StructuredSources]], kwargs: RustPackageLibrary,
@@ -366,22 +382,25 @@ class RustPackage(RustCrate):
 
         lib_args: T.Tuple[str, SourcesVarargsType] = (tgt_name, [sources])
         self.merge_kw_args(state, kwargs)
+        native = kwargs['native']
 
+        result: T.Union[BothLibraries, SharedLibrary, StaticLibrary, SharedModule]
         if shared_mod:
-            return state._interpreter.build_target(state.current_node, lib_args,
-                                                   T.cast('_kwargs.SharedModule', kwargs),
-                                                   SharedModule)
-
-        if static and shared:
-            return state._interpreter.build_both_libraries(state.current_node, lib_args, kwargs)
+            result = state._interpreter.build_target(state.current_node, lib_args,
+                                                     T.cast('_kwargs.SharedModule', kwargs),
+                                                     SharedModule)
+        elif static and shared:
+            result = state._interpreter.build_both_libraries(state.current_node, lib_args, kwargs)
         elif shared:
-            return state._interpreter.build_target(state.current_node, lib_args,
-                                                   T.cast('_kwargs.SharedLibrary', kwargs),
-                                                   SharedLibrary)
+            result = state._interpreter.build_target(state.current_node, lib_args,
+                                                     T.cast('_kwargs.SharedLibrary', kwargs),
+                                                     SharedLibrary)
         else:
-            return state._interpreter.build_target(state.current_node, lib_args,
-                                                   T.cast('_kwargs.StaticLibrary', kwargs),
-                                                   StaticLibrary)
+            result = state._interpreter.build_target(state.current_node, lib_args,
+                                                     T.cast('_kwargs.StaticLibrary', kwargs),
+                                                     StaticLibrary)
+        self._apply_rustc_env(state, native, result)
+        return result
 
     def _proc_macro_method(self, state: 'ModuleState', args: T.Tuple[
             T.Optional[T.Union[str, StructuredSources]],
@@ -519,7 +538,10 @@ class RustPackage(RustCrate):
 
         exe_args: T.Tuple[str, SourcesVarargsType] = (tgt_name, [sources])
         self.merge_kw_args(state, kwargs)
-        return state._interpreter.build_target(state.current_node, exe_args, kwargs, Executable)
+        native = kwargs['native']
+        result = state._interpreter.build_target(state.current_node, exe_args, kwargs, Executable)
+        self._apply_rustc_env(state, native, result)
+        return result
 
 
 class RustSubproject(RustCrate):

--- a/mesonbuild/scripts/meson_env.rs
+++ b/mesonbuild/scripts/meson_env.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright The Meson development team
+
+// Tiny helper used by Meson on Windows to set environment variables before
+// executing a command, equivalent to `env(1)` on POSIX systems.
+//
+// Usage: meson_env KEY1=VAL1 [KEY2=VAL2 ...] COMMAND [ARG ...]
+//
+// All leading arguments that look like `K=V` (and where K is a valid env-var
+// name) are consumed as assignments; the first non-assignment argument and
+// everything after it becomes the command to execute. The child process'
+// exit code is propagated.
+
+use std::env;
+use std::process::{exit, Command};
+
+fn is_assignment(arg: &str) -> Option<(&str, &str)> {
+    let (k, v) = arg.split_once('=')?;
+    if k.is_empty() {
+        return None;
+    }
+    let first = k.as_bytes()[0];
+    if !(first.is_ascii_alphabetic() || first == b'_') {
+        return None;
+    }
+    if !k.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_') {
+        return None;
+    }
+    Some((k, v))
+}
+
+fn main() {
+    let mut args = env::args().skip(1);
+    let mut cmd: Option<String> = None;
+    while let Some(arg) = args.next() {
+        match is_assignment(&arg) {
+            Some((k, v)) => env::set_var(k, v),
+            None => {
+                cmd = Some(arg);
+                break;
+            }
+        }
+    }
+    let cmd = match cmd {
+        Some(c) => c,
+        None => {
+            eprintln!("meson_env: no command given");
+            exit(2);
+        }
+    };
+    let rest: Vec<String> = args.collect();
+    let status = match Command::new(&cmd).args(&rest).status() {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("meson_env: failed to execute {cmd}: {e}");
+            exit(127);
+        }
+    };
+    exit(status.code().unwrap_or(1));
+}

--- a/test cases/rust/43 cargo env vars/main.c
+++ b/test cases/rust/43 cargo env vars/main.c
@@ -1,0 +1,5 @@
+int check_envs(void);
+
+int main(int argc, char *argv[]) {
+    return check_envs();
+}

--- a/test cases/rust/43 cargo env vars/meson.build
+++ b/test cases/rust/43 cargo env vars/meson.build
@@ -1,0 +1,5 @@
+project('cargo env vars', 'c')
+
+envcheck_dep = dependency('envcheck-1')
+exe = executable('app', 'main.c', dependencies: envcheck_dep)
+test('cargo env vars', exe)

--- a/test cases/rust/43 cargo env vars/subprojects/envcheck-1-rs.wrap
+++ b/test cases/rust/43 cargo env vars/subprojects/envcheck-1-rs.wrap
@@ -1,0 +1,5 @@
+[wrap-file]
+method = cargo
+
+[provide]
+dependency_names = envcheck-1

--- a/test cases/rust/43 cargo env vars/subprojects/envcheck-1-rs/Cargo.toml
+++ b/test cases/rust/43 cargo env vars/subprojects/envcheck-1-rs/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "envcheck"
+version = "1.2.3"
+edition = "2021"
+
+[lib]
+crate-type = ["staticlib"]
+path = "lib.rs"

--- a/test cases/rust/43 cargo env vars/subprojects/envcheck-1-rs/lib.rs
+++ b/test cases/rust/43 cargo env vars/subprojects/envcheck-1-rs/lib.rs
@@ -1,0 +1,17 @@
+const PKG_NAME: &str = env!("CARGO_PKG_NAME");
+const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
+const PKG_VERSION_MAJOR: &str = env!("CARGO_PKG_VERSION_MAJOR");
+const PKG_VERSION_MINOR: &str = env!("CARGO_PKG_VERSION_MINOR");
+const PKG_VERSION_PATCH: &str = env!("CARGO_PKG_VERSION_PATCH");
+const CRATE_NAME: &str = env!("CARGO_CRATE_NAME");
+
+#[no_mangle]
+pub extern "C" fn check_envs() -> i32 {
+    if PKG_NAME != "envcheck" { return 1; }
+    if PKG_VERSION != "1.2.3" { return 2; }
+    if PKG_VERSION_MAJOR != "1" { return 3; }
+    if PKG_VERSION_MINOR != "2" { return 4; }
+    if PKG_VERSION_PATCH != "3" { return 5; }
+    if CRATE_NAME != "envcheck" { return 6; }
+    0
+}


### PR DESCRIPTION
This means using the documented method to set env vars[1] when invoking a process on POSIX, and using a tiny Rust wrapper on Windows, where `cmd /c` is used to spawn processes.

This Rust wrapper is built during setup (only on Windows with a non-nightly Rust) when a cargo workspace is used.

Of course, this means a build-machine Rust toolchain is required in such cases, but that's already a requirement in Cargo due to build.rs

1. https://ninja-build.org/manual.html#ref_rule_command