### PR TITLE
build, backends: remove broken extract_all_objects code for custom targets

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -41,7 +41,6 @@ if T.TYPE_CHECKING:
     from typing_extensions import Literal, TypedDict
 
     from .._typing import ImmutableListProtocol
-    from ..build import ExtractedObjects
     from ..compilers.compilers import Language
     from ..compilers.cs import CsCompiler
     from ..compilers.fortran import FortranCompiler
@@ -3647,8 +3646,13 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 use_custom = True
 
         if use_custom:
-            objects_from_static_libs: T.List[ExtractedObjects] = []
+            objects_from_static_libs: T.List[str] = []
             for dep in target.link_whole_targets:
+                if not isinstance(dep, build.BuildTarget):
+                    raise MesonException(
+                        f'Cannot extract objects from custom target {dep.name!r} to '
+                        f'link_whole it into {target.name!r}: this is not supported '
+                        'with versions of MSVC older than Visual Studio 2015 Update 2.')
                 l = dep.extract_all_objects(False)
                 objects_from_static_libs += self.determine_ext_objs(l)
                 objects_from_static_libs.extend(self.flatten_object_list(dep)[0])

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1496,6 +1496,11 @@ class Vs2010Backend(backends.Backend):
             if t in target.link_whole_targets:
                 if compiler.id == 'msvc' and version_compare(compiler.version, '<19.00.23918'):
                     # Expand our object lists manually if we are on pre-Visual Studio 2015 Update 2
+                    if not isinstance(t, build.BuildTarget):
+                        raise MesonException(
+                            f'Cannot extract objects from custom target {t.name!r} to '
+                            f'link_whole it into {target.name!r}: this is not supported '
+                            'with versions of MSVC older than Visual Studio 2015 Update 2.')
                     l = t.extract_all_objects(False)
 
                     # Unfortunately, we can't use self.object_filename_from_source()

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1518,7 +1518,7 @@ class Vs2010Backend(backends.Backend):
                             rel_obj = self.object_filename_from_source(t, compiler, src, target_private_dir)
                             extra_link_args.append(rel_obj)
 
-                    extra_link_args.extend(self.flatten_object_list(t))
+                    extra_link_args.extend(self.flatten_object_list(t)[0])
                 else:
                     # /WHOLEARCHIVE:foo must go into AdditionalOptions
                     extra_link_args += compiler.get_link_whole_for(linkname)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -3206,9 +3206,6 @@ class CustomTarget(Target, CustomTargetBase):
             return False
         return CustomTargetIndex(self, self.outputs[0]).is_internal()
 
-    def extract_all_objects(self) -> T.List[T.Union[str, 'ExtractedObjects']]:
-        return T.cast('list[str | ExtractedObjects]', self.get_outputs())
-
     def type_suffix(self) -> str:
         return "@cus"
 
@@ -3505,9 +3502,6 @@ class CustomTargetIndex(CustomTargetBase, HoldableObject):
         '''
         suf = os.path.splitext(self.output)[-1]
         return suf in {'.a', '.lib'} and not self.should_install()
-
-    def extract_all_objects(self) -> T.Union[str, 'ExtractedObjects']:
-        return self.output
 
     def get_custom_install_dir(self) -> T.List[T.Union[str, Literal[False]]]:
         return self.target.get_custom_install_dir()


### PR DESCRIPTION
CustomTarget.extract_all_objects and CustomTargetIndex.extract_all_objects are effectively dead. No path consumes their str/list[str] return value:
    
- the extract_all_objects() DSL method is defined on BuildTargetHolder only.
    
- _bundle_static_library() runs t.extract_all_objects() only for a StaticLibrary, whereas custom targets raise InvalidArguments
    
- vs2010backend.py and ninjabackend.py's link_whole workaround call it but immediately treat the result as an ExtractedObjects
    
The custom target here would be a .a file, therefore there is no way to
extract objects from it.  Remove the code and raise an exception instead.
This fixes 7 mypy issues in the ninja backend and 8 in the vs2010 backend.
