### PR TITLE
tests: set read encoding to help the VS backend

### DIFF
--- a/test cases/common/182 find override/subdir/converter.py
+++ b/test cases/common/182 find override/subdir/converter.py
@@ -10,6 +10,6 @@ ftempl = '''int %s(void) {
 }
 '''
 
-d = pathlib.Path(ifilename).read_text().split('\n')[0].strip()
+d = pathlib.Path(ifilename).read_text(encoding='utf-8').split('\n')[0].strip()
 
 pathlib.Path(ofilename).write_text(ftempl % d, encoding='utf-8')

--- a/test cases/common/182 find override/subdir/gencodegen.py.in
+++ b/test cases/common/182 find override/subdir/gencodegen.py.in
@@ -10,6 +10,6 @@ ftempl = '''int %s(void) {
 }
 '''
 
-d = pathlib.Path(ifilename).read_text().split('\n')[0].strip()
+d = pathlib.Path(ifilename).read_text(encoding='utf-8').split('\n')[0].strip()
 
 pathlib.Path(ofilename).write_text(ftempl % d, encoding='utf-8')

--- a/test cases/common/216 custom target input extracted objects/libdir/gen.py
+++ b/test cases/common/216 custom target input extracted objects/libdir/gen.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 import sys
-with open(sys.argv[1], 'r') as f:
+with open(sys.argv[1], 'r', encoding='utf-8') as f:
     for l in f:
         l = l.rstrip()
         print(l.replace(sys.argv[2], sys.argv[3]))

--- a/test cases/common/262 generator chain/stage1.py
+++ b/test cases/common/262 generator chain/stage1.py
@@ -2,5 +2,5 @@
 import sys
 from pathlib import Path
 
-assert(Path(sys.argv[1]).read_text() == 'stage1\n')
+assert(Path(sys.argv[1]).read_text(encoding='utf-8') == 'stage1\n')
 Path(sys.argv[2]).write_text('stage2\n', encoding='utf-8')

--- a/test cases/common/262 generator chain/stage2.py
+++ b/test cases/common/262 generator chain/stage2.py
@@ -2,5 +2,5 @@
 import sys
 from pathlib import Path
 
-assert(Path(sys.argv[1]).read_text() == 'stage2\n')
+assert(Path(sys.argv[1]).read_text(encoding='utf-8') == 'stage2\n')
 Path(sys.argv[2]).write_text('int main(void){}\n', encoding='utf-8')

--- a/test cases/common/271 env in generator.process/generate_main.py
+++ b/test cases/common/271 env in generator.process/generate_main.py
@@ -5,7 +5,7 @@ import sys
 ENV_VAR_VALUE = os.environ.get('ENV_VAR_VALUE')
 assert ENV_VAR_VALUE is not None
 
-with open(sys.argv[1], 'r') as infile, \
+with open(sys.argv[1], 'r', encoding='utf-8') as infile, \
      open(sys.argv[2], 'w', encoding='utf-8') as outfile:
 
     outfile.write(infile.read().replace('ENV_VAR_VALUE', ENV_VAR_VALUE))

--- a/test cases/common/295 depends in generator.process/generate_main.py
+++ b/test cases/common/295 depends in generator.process/generate_main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import sys
 
-with open(sys.argv[1], 'r') as infile, \
+with open(sys.argv[1], 'r', encoding='utf-8') as infile, \
      open(sys.argv[2], 'w', encoding='utf-8') as outfile:
 
     outfile.write(infile.read())

--- a/test cases/format/5 transform/file_compare.py
+++ b/test cases/format/5 transform/file_compare.py
@@ -13,9 +13,9 @@ def main() -> int:
     parser.add_argument('expected', help='the contents we expected')
     args = parser.parse_args()
 
-    with open(args.actual, 'r') as f:
+    with open(args.actual, 'r', encoding='utf-8') as f:
         actual = f.readlines()
-    with open(args.expected, 'r') as f:
+    with open(args.expected, 'r', encoding='utf-8') as f:
         expected = f.readlines()
 
     if actual == expected:

--- a/test cases/unit/132 custom target index test/meson.build
+++ b/test cases/unit/132 custom target index test/meson.build
@@ -10,7 +10,7 @@ foobar_txt = custom_target(command: [python3, '-c', gen_code, '@OUTPUT@'], outpu
 
 test_code = '''
 import sys, pathlib
-sys.exit(0 if pathlib.Path(sys.argv[1]).read_text() == sys.argv[2] else 4)'''
+sys.exit(0 if pathlib.Path(sys.argv[1]).read_text(encoding='utf-8') == sys.argv[2] else 4)'''
 
 test('foo.txt', python3, args: ['-c', test_code, foobar_txt[0], 'foo'])
 test('bar.txt', python3, args: ['-c', test_code, foobar_txt[1], 'bar'])

--- a/test cases/unit/35 dist script/replacer.py
+++ b/test cases/unit/35 dist script/replacer.py
@@ -11,6 +11,6 @@ source_root = pathlib.Path(os.environ['MESON_DIST_ROOT'])
 
 modfile = source_root / 'prog.c'
 
-contents = modfile.read_text()
+contents = modfile.read_text(encoding='utf-8')
 contents = contents.replace(sys.argv[1], sys.argv[2])
 modfile.write_text(contents, encoding='utf-8')


### PR DESCRIPTION
Not setting this seems to cause intermittent test failures in the VS backend.

The following VSCode substitutions where used to generate this patch
- `open\((.*), 'r'\)` -> `open($1, 'r', encoding='utf-8')`
- `read_text()` -> `read_text(encoding='utf-8')`