### PR TITLE
Add win_subsystem to SharedLibrary and SharedModule

### DIFF
--- a/docs/markdown/snippets/win_subsystem_for_more.md
+++ b/docs/markdown/snippets/win_subsystem_for_more.md
@@ -1,0 +1,10 @@
+## Added `win_subsystem` to `shared_library()` and `shared_module()`
+
+Synonym for the one found in `executable()`.
+
+Mostly useful for setting the subsystem version in PE headers.
+This can affects Windows's ShimEngine, but not SxS lookups. Usually you still
+want to provide a manifest when targeting modern Windows.
+Sometime also useful for targeting other subsystems.
+
+Visual Studio backends now also properly supports setting subsystem versions.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3611,7 +3611,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
 
     def get_target_type_link_args_post_dependencies(self, target: build.BuildTarget, linker: T.Union[Compiler, StaticLinker]) -> T.List[str]:
         commands: T.List[str] = []
-        if isinstance(target, build.Executable):
+        if isinstance(target, (build.Executable, build.SharedLibrary)):
             assert isinstance(linker, Compiler)
 
             # If win_subsystem is significant on this platform, add the appropriate linker arguments.

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1352,7 +1352,8 @@ class Vs2010Backend(backends.Backend):
             type_config: ET.Element,
             target: build.BuildTarget,
             platform: str,
-            subsystem: str,
+            subsystem: str | None,
+            version: str | None,
             build_args: list[str],
             target_args: list[str],
             target_defines: list[str],
@@ -1583,8 +1584,13 @@ class Vs2010Backend(backends.Backend):
             ET.SubElement(link, 'AdditionalDependencies').text = ';'.join(additional_links)
         ofile = ET.SubElement(link, 'OutputFile')
         ofile.text = f'$(OutDir){target.get_filename()}'
-        subsys = ET.SubElement(link, 'SubSystem')
-        subsys.text = subsystem
+        if subsystem is not None:
+            subsys = ET.SubElement(link, 'SubSystem')
+            subsys.text = subsystem
+        if version is not None:
+            # Undocumented, but you can find a reference in WDK props
+            minver = ET.SubElement(link, 'MinimumRequiredVersion')
+            minver.text = version
         if isinstance(target, (build.SharedLibrary, build.Executable)) and target.get_import_filename():
             # DLLs built with MSVC always have an import library except when
             # they're data-only DLLs, but we don't support those yet.
@@ -1647,7 +1653,8 @@ class Vs2010Backend(backends.Backend):
     # we need to respect that not all targets will have generated a project.
     def gen_vcxproj(self, target: build.Target, ofname: str, guid: str, vslite_ctx: _VSLITE_CTX | None = None) -> bool:
         mlog.debug(f'Generating vcxproj {target.name}.')
-        subsystem = 'Windows'
+        subsystem: str | None = None
+        version: str | None = None
         self.handled_target_deps[target.get_id()] = []
 
         # vs backend does not support link_early_args
@@ -1664,13 +1671,12 @@ class Vs2010Backend(backends.Backend):
             conftype = 'Makefile'
         elif isinstance(target, build.Executable):
             conftype = 'Application'
-            # If someone knows how to set the version properly,
-            # please send a patch.
-            subsystem = target.win_subsystem.split(',')[0]
+            subsystem, _, version = target.win_subsystem.partition(',')
         elif isinstance(target, build.StaticLibrary):
             conftype = 'StaticLibrary'
         elif isinstance(target, build.SharedLibrary):
             conftype = 'DynamicLibrary'
+            subsystem, _, version = target.win_subsystem.partition(',')
         elif isinstance(target, build.CustomTarget):
             self.gen_custom_target_vcxproj(target, ofname, guid)
             return True
@@ -1730,7 +1736,7 @@ class Vs2010Backend(backends.Backend):
             primary_src_lang = get_primary_source_lang(target.sources, custom_src)
             self.add_gen_lite_makefile_vcxproj_elements(root, platform, tfilename[1], vslite_ctx, target, proj_to_build_root, primary_src_lang)
         else:
-            self.add_non_makefile_vcxproj_elements(root, type_config, target, platform, subsystem, build_args, target_args, target_defines, target_inc_dirs, file_args)
+            self.add_non_makefile_vcxproj_elements(root, type_config, target, platform, subsystem, version, build_args, target_args, target_defines, target_inc_dirs, file_args)
 
         meson_file_group = ET.SubElement(root, 'ItemGroup')
         ET.SubElement(meson_file_group, 'None', Include=os.path.join(proj_to_src_dir, build_filename))

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -137,6 +137,7 @@ if T.TYPE_CHECKING:
     class SharedModuleKeywordArguments(BuildTargetKeywordArguments, total=False):
 
         vs_module_defs: T.Union[File, CustomTarget, CustomTargetIndex]
+        win_subsystem: str
 
     class SharedLibraryKeywordArguments(SharedModuleKeywordArguments, total=False):
 
@@ -2481,6 +2482,8 @@ class SharedLibrary(BuildTarget, LinkableTarget):
             if self.darwin_versions is None and self.soversion is not None:
                 # If unspecified, pick the soversion
                 self.darwin_versions = (self.soversion, self.soversion)
+
+        self.win_subsystem = kwargs.get('win_subsystem') or 'console'
 
         self.vs_module_defs: File | None = None
         # Visual Studio module-definitions file

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3739,6 +3739,8 @@ class Interpreter(InterpreterBase, HoldableObject):
             kwargs['rust_abi'], kwargs['rust_crate_type'], 'dylib', 'cdylib',
             build.SharedLibrary.typename, extra_valid_types={'proc-macro'})
 
+        final['win_subsystem'] = kwargs['win_subsystem'] or 'console'
+
         return final
 
     def __convert_shared_module_kwargs(self, node: mparser.BaseNode, kwargs: kwtypes.SharedModule) -> build.SharedModuleKeywordArguments:
@@ -3760,6 +3762,8 @@ class Interpreter(InterpreterBase, HoldableObject):
         final['rust_crate_type'] = self._handle_rust_abi(
             kwargs['rust_abi'], kwargs['rust_crate_type'], 'dylib', 'cdylib',
             build.SharedModule.typename, extra_valid_types={'proc-macro'})
+
+        final['win_subsystem'] = kwargs['win_subsystem'] or 'console'
 
         return final
 

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -435,9 +435,10 @@ class _LibraryMixin(TypedDict):
     rust_abi: T.Optional[RustAbi]
 
 
-class _VsModuleDefsMixin(TypedDict):
+class _LinkableTargetMixin(TypedDict):
 
     vs_module_defs: T.Optional[T.Union[str, File, build.CustomTarget, build.CustomTargetIndex]]
+    win_subsystem: T.Optional[str]
 
 
 class _ExecutableMixin(TypedDict):
@@ -446,11 +447,10 @@ class _ExecutableMixin(TypedDict):
     gui_app: T.Optional[bool]
     implib: T.Optional[T.Union[str, bool]]
     pie: T.Optional[bool]
-    win_subsystem: T.Optional[str]
     android_exe_type: T.Optional[Literal['application', 'executable']]
 
 
-class Executable(BuildTarget, _ExecutableMixin, _VsModuleDefsMixin):
+class Executable(BuildTarget, _ExecutableMixin, _LinkableTargetMixin):
     pass
 
 
@@ -472,15 +472,15 @@ class _SharedLibMixin(TypedDict):
     shortname: str
 
 
-class SharedLibrary(BuildTarget, _SharedLibMixin, _LibraryMixin, _VsModuleDefsMixin):
+class SharedLibrary(BuildTarget, _SharedLibMixin, _LibraryMixin, _LinkableTargetMixin):
     pass
 
 
-class SharedModule(BuildTarget, _LibraryMixin, _VsModuleDefsMixin):
+class SharedModule(BuildTarget, _LibraryMixin, _LinkableTargetMixin):
     pass
 
 
-class Library(BuildTarget, _SharedLibMixin, _StaticLibMixin, _LibraryMixin, _VsModuleDefsMixin):
+class Library(BuildTarget, _SharedLibMixin, _StaticLibMixin, _LibraryMixin, _LinkableTargetMixin):
 
     """For library, both_library, and as a base for build_target"""
 

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -849,6 +849,13 @@ def _validate_win_subsystem(value: T.Optional[str]) -> T.Optional[str]:
             return f'Invalid value for win_subsystem: {value}.'
     return None
 
+_WIN_SUBSYSTEM_KW: KwargInfo[T.Optional[str]] = KwargInfo(
+        'win_subsystem',
+        (str, NoneType),
+        convertor=lambda x: x.lower() if isinstance(x, str) else None,
+        validator=_validate_win_subsystem,
+)
+
 
 def _validate_darwin_versions(darwin_versions: T.List[T.Union[str, int]]) -> T.Optional[str]:
     if len(darwin_versions) > 2:
@@ -907,12 +914,6 @@ EXCLUSIVE_EXECUTABLE_KWS: T.List[KwargInfo] = [
     ),
     KwargInfo('pie', (bool, NoneType)),
     KwargInfo(
-        'win_subsystem',
-        (str, NoneType),
-        convertor=lambda x: x.lower() if isinstance(x, str) else None,
-        validator=_validate_win_subsystem,
-    ),
-    KwargInfo(
         'android_exe_type',
         (str, NoneType),
         validator=in_set_validator({'application', 'executable'}),
@@ -925,6 +926,7 @@ EXECUTABLE_KWS = [
     *_BUILD_TARGET_KWS,
     *EXCLUSIVE_EXECUTABLE_KWS,
     _VS_MODULE_DEFS_KW.evolve(since='1.3.0', since_values=None),
+    _WIN_SUBSYSTEM_KW,
     _JAVA_LANG_KW,
 ]
 
@@ -968,6 +970,7 @@ SHARED_LIB_KWS: T.List[KwargInfo] = [
     *_EXCLUSIVE_SHARED_LIB_KWS,
     *_EXCLUSIVE_LIB_KWS,
     _VS_MODULE_DEFS_KW,
+    _WIN_SUBSYSTEM_KW.evolve(since='1.12.0'),
     _JAVA_LANG_KW,
 ]
 
@@ -981,6 +984,7 @@ SHARED_MOD_KWS = [
     *_EXCLUSIVE_SHARED_MOD_KWS,
     *_EXCLUSIVE_LIB_KWS,
     _VS_MODULE_DEFS_KW,
+    _WIN_SUBSYSTEM_KW.evolve(since='1.12.0'),
     _JAVA_LANG_KW,
 ]
 
@@ -1022,10 +1026,11 @@ LIBRARY_KWS = [
     *_EXCLUSIVE_STATIC_LIB_KWS,
     *_SHARED_STATIC_ARGS,
     _VS_MODULE_DEFS_KW,
+    _WIN_SUBSYSTEM_KW,
     _JAVA_LANG_KW,
 ]
 
-# Arguments used by build_Target
+# Arguments used by build_target
 BUILD_TARGET_KWS = [
     *_BUILD_TARGET_KWS,
     *_EXCLUSIVE_SHARED_LIB_KWS,
@@ -1034,6 +1039,7 @@ BUILD_TARGET_KWS = [
     *EXCLUSIVE_EXECUTABLE_KWS,
     *_SHARED_STATIC_ARGS,
     _VS_MODULE_DEFS_KW,
+    _WIN_SUBSYSTEM_KW.evolve(since='1.12.0'),
     RUST_ABI_KW.evolve(since='1.10.0'),
     *[a.evolve(deprecated='1.3.0', deprecated_message='The use of "jar" in "build_target()" is deprecated, and this argument is only used by jar()')
       for a in _EXCLUSIVE_JAR_KWS],


### PR DESCRIPTION
Mostly useful for setting the version for OperatingSystem and Subsystem (affects Ldr's AppCompat lookup), maybe sometimes useful for targeting other subsystems or EFI.