### PR TITLE
VS backend typing part 2.5

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -484,7 +484,7 @@ class Backend:
         return result
 
     @staticmethod
-    def relpath(todir: str, fromdir: str) -> str:
+    def relpath(todir: str | os.PathLike[str], fromdir: str | os.PathLike[str]) -> str:
         return os.path.relpath(os.path.join('dummyprefixdir', todir),
                                os.path.join('dummyprefixdir', fromdir))
 

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1472,6 +1472,23 @@ class Backend:
             srcs += fname
         return srcs
 
+    def get_paths_for_dep_outputs(self, target: build.Target, dep_targets: T.Iterable[build.Target | build.GeneratedList | build.CustomTargetIndex | programs.Program]) -> T.List[str]:
+        """Return a list of strings with the paths to all the outputs of all targets in
+           dep_targets."""
+        deps = []
+        for i in dep_targets:
+            if isinstance(i, build.LocalProgram):
+                i = i.program
+            if isinstance(i, programs.Program):
+                continue
+            for output in i.get_outputs():
+                if isinstance(i, build.GeneratedList):
+                    assert isinstance(target, (build.BuildTarget, build.CustomTarget, build.CustomTargetIndex))
+                    deps.append(os.path.join(self.get_target_private_dir(target), output))
+                else:
+                    deps.append(os.path.join(self.get_target_dir(i), output))
+        return deps
+
     def get_target_depend_files(self, target: T.Union[build.Target, build.GeneratedList], absolute_paths: bool = False) -> T.List[str]:
         deps: T.List[str] = []
         for i in target.depend_files:

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1492,17 +1492,11 @@ class Backend:
     def get_target_depend_files(self, target: T.Union[build.Target, build.GeneratedList], absolute_paths: bool = False) -> T.List[str]:
         deps: T.List[str] = []
         for i in target.depend_files:
-            if isinstance(i, mesonlib.File):
-                if absolute_paths:
-                    deps.append(i.absolute_path(self.environment.get_source_dir(),
-                                                self.environment.get_build_dir()))
-                else:
-                    deps.append(i.rel_to_builddir(self.build_to_src))
+            if absolute_paths:
+                deps.append(i.absolute_path(self.environment.get_source_dir(),
+                                            self.environment.get_build_dir()))
             else:
-                if absolute_paths:
-                    deps.append(os.path.join(self.environment.get_source_dir(), target.get_subdir(), i))
-                else:
-                    deps.append(os.path.join(self.build_to_src, target.get_subdir(), i))
+                deps.append(i.rel_to_builddir(self.build_to_src))
         return deps
 
     def get_custom_target_output_dir(self, target: build.AnyTargetType) -> str:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -24,7 +24,6 @@ from .. import mesonlib
 from .. import build
 from .. import mlog
 from .. import compilers
-from .. import programs
 from .. import tooldetect
 from ..arglist import CompilerArgs
 from ..compilers import Compiler, is_library
@@ -1250,26 +1249,10 @@ class NinjaBackend(backends.Backend):
             if isinstance(s, build.GeneratedList):
                 self.generate_genlist_for_target(s, target)
 
-    def unwrap_dep_list(self, target: build.Target, dep_targets: T.Iterable[build.Target | build.GeneratedList | build.CustomTargetIndex | programs.Program]) -> T.List[str]:
-        deps = []
-        for i in dep_targets:
-            # Add a dependency on all the outputs of this target
-            if isinstance(i, build.LocalProgram):
-                i = i.program
-            if isinstance(i, programs.Program):
-                continue
-            for output in i.get_outputs():
-                if isinstance(i, GeneratedList):
-                    assert isinstance(target, (build.BuildTarget, build.CustomTarget, build.CustomTargetIndex))
-                    deps.append(os.path.join(self.get_target_private_dir(target), output))
-                else:
-                    deps.append(os.path.join(self.get_target_dir(i), output))
-        return deps
-
     def generate_custom_target(self, target: build.CustomTarget) -> None:
         self.custom_target_generator_inputs(target)
         (srcs, ofilenames, cmd) = self.eval_custom_target_command(target)
-        deps = self.unwrap_dep_list(target, target.get_dependencies())
+        deps = self.get_paths_for_dep_outputs(target, target.get_dependencies())
         deps += self.get_target_depend_files(target)
         if target.build_always_stale:
             deps.append('PHONY')
@@ -1335,7 +1318,7 @@ class NinjaBackend(backends.Backend):
             elem.add_item('COMMAND', meson_exe_cmd)
             elem.add_item('description', f'Running external command {target.name}{cmd_type}')
             elem.add_item('pool', 'console')
-        deps = self.unwrap_dep_list(target, target.get_dependencies())
+        deps = self.get_paths_for_dep_outputs(target, target.get_dependencies())
         deps += self.get_target_depend_files(target)
         elem.add_dep(deps)
         self.add_build(elem)
@@ -2857,8 +2840,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         exe = generator.get_exe()
         infilelist = genlist.get_inputs()
         dependencies = self.get_target_depend_files(genlist)
-        dependencies += self.unwrap_dep_list(target, generator.depends)
-        dependencies += self.unwrap_dep_list(target, genlist.extra_depends)
+        dependencies += self.get_paths_for_dep_outputs(target, generator.depends)
+        dependencies += self.get_paths_for_dep_outputs(target, genlist.extra_depends)
         for curfile in infilelist:
             infilename = curfile.rel_to_builddir(self.build_to_src, self.get_target_private_dir(target))
             base_args = generator.get_arglist(infilename)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1254,6 +1254,7 @@ class NinjaBackend(backends.Backend):
         (srcs, ofilenames, cmd) = self.eval_custom_target_command(target)
         deps = self.get_paths_for_dep_outputs(target, target.get_dependencies())
         deps += self.get_target_depend_files(target)
+        deps += self.get_paths_for_dep_outputs(target, target.extra_depends)
         if target.build_always_stale:
             deps.append('PHONY')
         if target.depfile_type == 'gcc':
@@ -1264,10 +1265,6 @@ class NinjaBackend(backends.Backend):
             rulename = 'CUSTOM_COMMAND'
         elem = NinjaBuildElement(self.all_outputs, ofilenames, rulename, srcs)
         elem.add_dep(deps)
-        for d in target.extra_depends:
-            # Add a dependency on all the outputs of this target
-            for output in d.get_outputs():
-                elem.add_dep(os.path.join(self.get_target_dir(d), output))
 
         cmd, reason = self.as_meson_exe_cmdline(target.command[0], cmd[1:],
                                                 extra_bdeps=target.get_transitive_build_target_deps(),

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -31,6 +31,7 @@ if T.TYPE_CHECKING:
     from ..compilers.compilers import Language
 
     Project = T.Tuple[str, Path, str, MachineChoice]
+    FileLike = T.TypeVar('FileLike', bound=File | str)
 
 def autodetect_vs_version(build: T.Optional[build.Build]) -> backends.Backend:
     vs_version = os.getenv('VisualStudioVersion', None)
@@ -567,11 +568,11 @@ class Vs2010Backend(backends.Backend):
 
         return projlist
 
-    def split_sources(self, srclist):
-        sources = []
-        headers = []
-        objects = []
-        languages = []
+    def split_sources(self, srclist: list[FileLike]) -> tuple[list[FileLike], list[FileLike], list[FileLike], list[str]]:
+        sources: list[FileLike] = []
+        headers: list[FileLike] = []
+        objects: list[FileLike] = []
+        languages: list[str] = []
         for i in srclist:
             if compilers.is_header(i):
                 headers.append(i)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1035,8 +1035,8 @@ class Vs2010Backend(backends.Backend):
         # file_args is also later split out into defines and include_dirs in
         # case someone passed those in there
         file_args: T.Dict[Language, CompilerArgs] = {l: c.compiler_args() for l, c in target.compilers.items()}
-        file_defines: dict[str, list[str]] = {l: [] for l in target.compilers}
-        file_inc_dirs: dict[str, list[str]] = {l: [] for l in target.compilers}
+        file_defines: dict[Language, list[str]] = {l: [] for l in target.compilers}
+        file_inc_dirs: dict[Language, list[str]] = {l: [] for l in target.compilers}
         # The order in which these compile args are added must match
         # generate_single_compile() and generate_basic_compiler_args()
         for l, comp in target.compilers.items():

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -836,27 +836,27 @@ class Vs2010Backend(backends.Backend):
             return 'masm'
         raise MesonException(f'Could not guess language from source file {src}.')
 
-    def add_pch(self, pch_sources: T.Dict[str, T.Tuple[str, T.Optional[str], str, T.Optional[str]]],
-                lang, inc_cl) -> None:
+    def add_pch(self, pch_sources: T.Dict[Language, T.Tuple[str, T.Optional[str], str, T.Optional[str]]],
+                lang: Language, inc_cl: ET.Element) -> None:
         if lang in pch_sources:
             self.use_pch(pch_sources, lang, inc_cl)
 
-    def create_pch(self, pch_sources: T.Dict[str, T.Tuple[str, T.Optional[str], str, T.Optional[str]]],
-                   lang, inc_cl) -> None:
+    def create_pch(self, pch_sources: T.Dict[Language, T.Tuple[str, T.Optional[str], str, T.Optional[str]]],
+                   lang: Language, inc_cl: ET.Element) -> None:
         pch = ET.SubElement(inc_cl, 'PrecompiledHeader')
         pch.text = 'Create'
         self.add_pch_files(pch_sources, lang, inc_cl)
 
-    def use_pch(self, pch_sources: T.Dict[str, T.Tuple[str, T.Optional[str], str, T.Optional[str]]],
-                lang, inc_cl) -> None:
+    def use_pch(self, pch_sources: T.Dict[Language, T.Tuple[str, T.Optional[str], str, T.Optional[str]]],
+                lang: Language, inc_cl: ET.Element) -> None:
         pch = ET.SubElement(inc_cl, 'PrecompiledHeader')
         pch.text = 'Use'
         header = self.add_pch_files(pch_sources, lang, inc_cl)
         pch_include = ET.SubElement(inc_cl, 'ForcedIncludeFiles')
         pch_include.text = header + ';%(ForcedIncludeFiles)'
 
-    def add_pch_files(self, pch_sources: T.Dict[str, T.Tuple[str, T.Optional[str], str, T.Optional[str]]],
-                      lang, inc_cl) -> str:
+    def add_pch_files(self, pch_sources: T.Dict[Language, T.Tuple[str, T.Optional[str], str, T.Optional[str]]],
+                      lang: Language, inc_cl: ET.Element) -> str:
         header = os.path.basename(pch_sources[lang][0])
         pch_file = ET.SubElement(inc_cl, 'PrecompiledHeaderFile')
         # When USING PCHs, MSVC will not do the regular include
@@ -1728,7 +1728,7 @@ class Vs2010Backend(backends.Backend):
             else:
                 return False
 
-        pch_sources: T.Dict[str, T.Tuple[str, T.Optional[str], str, T.Optional[str]]] = {}
+        pch_sources: T.Dict[Language, T.Tuple[str, T.Optional[str], str, T.Optional[str]]] = {}
         if self.target_uses_pch(target):
             for lang in T.cast('T.Tuple[Language]', ('c', 'cpp')):
                 pch = target.pch[lang]

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -186,10 +186,7 @@ class Vs2010Backend(backends.Backend):
                     sole_output = ''
                 infilename = os.path.join(down, curfile.rel_to_builddir(self.build_to_src, self.get_target_private_dir(target)))
                 deps = self.get_target_depend_files(genlist, True)
-                for d in genlist.extra_depends:
-                    # Add a dependency on all the outputs of this target
-                    for output in d.get_outputs():
-                        deps.append(os.path.join(self.get_target_dir(d), output))
+                deps += self.get_paths_for_dep_outputs(target, genlist.extra_depends)
                 base_args = generator.get_arglist(infilename)
                 outfiles_rel = genlist.get_outputs_for(curfile)
                 outfiles = [os.path.join(target_private_dir, of) for of in outfiles_rel]

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -277,13 +277,25 @@ class Vs2010Backend(backends.Backend):
         else:
             raise MesonException('Unsupported Visual Studio platform: ' + build_machine)
 
-        self.buildtype = self.environment.coredata.optstore.get_value_for(OptionKey('buildtype'))
-        self.optimization = self.environment.coredata.optstore.get_value_for(OptionKey('optimization'))
-        self.debug = self.environment.coredata.optstore.get_value_for(OptionKey('debug'))
+        buildtype = self.environment.coredata.optstore.get_value_for(OptionKey('buildtype'))
+        assert isinstance(buildtype, str), 'for mypy'
+        self.buildtype = buildtype
+
+        optimization = self.environment.coredata.optstore.get_value_for(OptionKey('optimization'))
+        assert isinstance(optimization, str), 'for mypy'
+        self.optimization = optimization
+
+        debug = self.environment.coredata.optstore.get_value_for(OptionKey('debug'))
+        assert isinstance(debug, bool), 'for mypy'
+        self.debug = debug
+
         try:
-            self.sanitize = self.environment.coredata.optstore.get_value_for(OptionKey('b_sanitize'))
+            sanitize = self.environment.coredata.optstore.get_value_for(OptionKey('b_sanitize'))
+            assert isinstance(sanitize, list), 'for mypy'
         except KeyError:
-            self.sanitize = []
+            sanitize = []
+        self.sanitize = sanitize
+
         sln_filename = os.path.join(self.environment.get_build_dir(), self.build.project_name + '.sln')
         projlist = self.generate_projects(vslite_ctx)
         self.gen_testproj()
@@ -1049,7 +1061,9 @@ class Vs2010Backend(backends.Backend):
         # Compile args added from the env or cross file: CFLAGS/CXXFLAGS, etc. We want these
         # to override all the defaults, but not the per-target compile args.
         for lang in file_args.keys():
-            file_args[lang] += self.get_target_option(target, OptionKey(f'{lang}_args', machine=target.for_machine))
+            l_args = self.get_target_option(target, OptionKey(f'{lang}_args', machine=target.for_machine))
+            assert isinstance(l_args, list), 'for mypy'
+            file_args[lang] += l_args
         for args in file_args.values():
             # This is where Visual Studio will insert target_args, target_defines,
             # etc, which are added later from external deps (see below).
@@ -1355,6 +1369,7 @@ class Vs2010Backend(backends.Backend):
             ET.SubElement(clconf, 'OpenMPSupport').text = 'true'
         # CRT type; debug or release
         vscrt_type = self.get_target_option(target, 'b_vscrt')
+        assert isinstance(vscrt_type, str), 'for mypy'
         vscrt_val = compiler.get_crt_val(vscrt_type)
         if vscrt_val == 'mdd':
             ET.SubElement(type_config, 'UseDebugLibraries').text = 'true'

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -222,10 +222,10 @@ class Vs2010Backend(backends.Backend):
                 ET.SubElement(cbs, 'Outputs').text = ';'.join(outfiles)
                 ET.SubElement(cbs, 'AdditionalInputs').text = ';'.join(deps)
 
-    def generate_custom_generator_commands(self, target, parent_node):
-        generator_output_files = []
-        custom_target_include_dirs = []
-        custom_target_output_files = []
+    def generate_custom_generator_commands(self, target: build.BuildTarget, parent_node: ET.Element) -> tuple[list[str], list[str], list[str]]:
+        generator_output_files: list[str] = []
+        custom_target_include_dirs: list[str] = []
+        custom_target_output_files: list[str] = []
         for genlist in target.get_generated_sources():
             self.generate_genlist_for_target(genlist, target, parent_node, generator_output_files, custom_target_include_dirs, custom_target_output_files)
         return generator_output_files, custom_target_output_files, custom_target_include_dirs

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -348,7 +348,7 @@ class Vs2010Backend(backends.Backend):
                 result[o.target.get_id()] = o.target
         return result.items()
 
-    def get_target_deps(self, t: T.Dict[T.Any, build.AnyTargetType], recursive=False):
+    def get_target_deps(self, t: T.Mapping[str, build.AnyTargetType], recursive: bool = False) -> T.Dict[str, build.Target]:
         all_deps: T.Dict[str, build.Target] = {}
         for target in t.values():
             if isinstance(target, build.CustomTargetIndex):
@@ -2183,7 +2183,7 @@ class Vs2010Backend(backends.Backend):
 
     # Returns if a target generates a manifest or not.
     # Returns 'embed' if the generated manifest is embedded.
-    def get_gen_manifest(self, target: T.Optional[build.BuildTarget]) -> bool | T.Literal['embed']:
+    def get_gen_manifest(self, target: T.Optional[build.Target]) -> bool | T.Literal['embed']:
         if not isinstance(target, build.BuildTarget):
             return True
 

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1338,12 +1338,12 @@ class Vs2010Backend(backends.Backend):
             type_config: ET.Element,
             target: build.BuildTarget,
             platform: str,
-            subsystem,
-            build_args,
-            target_args,
-            target_defines,
-            target_inc_dirs,
-            file_args
+            subsystem: str,
+            build_args: list[str],
+            target_args: list[str],
+            target_defines: list[str],
+            target_inc_dirs: list[str],
+            file_args: dict[Language, CompilerArgs]
             ) -> None:
         compiler = self._get_cl_compiler(target)
         buildtype_link_args = compiler.get_optimization_link_args(self.optimization)
@@ -1505,7 +1505,10 @@ class Vs2010Backend(backends.Backend):
                 lobj = t
             else:
                 lobj = self.build.targets[t.get_id()]
-            linkname = os.path.join(down, self.get_target_filename_for_linking(lobj))
+            targetname = self.get_target_filename_for_linking(lobj)
+            if targetname is None:
+                continue
+            linkname = os.path.join(down, targetname)
             if t in target.link_whole_targets:
                 if compiler.id == 'msvc' and version_compare(compiler.version, '<19.00.23918'):
                     # Expand our object lists manually if we are on pre-Visual Studio 2015 Update 2
@@ -1534,7 +1537,7 @@ class Vs2010Backend(backends.Backend):
                     extra_link_args.extend(self.flatten_object_list(t)[0])
                 else:
                     # /WHOLEARCHIVE:foo must go into AdditionalOptions
-                    extra_link_args += compiler.get_link_whole_for(linkname)
+                    extra_link_args += compiler.get_link_whole_for([linkname])
                 # To force Visual Studio to build this project even though it
                 # has no sources, we include a reference to the vcxproj file
                 # that builds this target. Technically we should add this only
@@ -2175,7 +2178,7 @@ class Vs2010Backend(backends.Backend):
             regen_vcxproj = os.path.join(self.environment.get_build_dir(), 'REGEN.vcxproj')
             self.add_project_reference(root, regen_vcxproj, self.environment.coredata.regen_guid)
 
-    def generate_lang_standard_info(self, file_args: T.Dict[str, CompilerArgs], clconf: ET.Element) -> None:
+    def generate_lang_standard_info(self, file_args: T.Dict[Language, CompilerArgs], clconf: ET.Element) -> None:
         pass
 
     # Returns if a target generates a manifest or not.

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -602,7 +602,7 @@ class Vs2010Backend(backends.Backend):
                 headers.append(i)
         return sources, headers, objects, languages
 
-    def target_to_build_root(self, target: build.BuildTargetTypes) -> str:
+    def target_to_build_root(self, target: build.AnyTargetType) -> str:
         if self.get_target_dir(target) == '':
             return ''
 

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -889,7 +889,7 @@ class Vs2010Backend(backends.Backend):
             return True
         return entry[1:].startswith('M')
 
-    def add_additional_options(self, lang, parent_node, file_args):
+    def add_additional_options(self, lang: Language, parent_node: ET.Element, file_args: dict[Language, CompilerArgs]) -> None:
         args = []
         for arg in file_args[lang].to_native():
             if self.is_argument_with_msbuild_xml_entry(arg):
@@ -930,7 +930,7 @@ class Vs2010Backend(backends.Backend):
             ET.SubElement(parent_node, 'AdditionalIncludeDirectories').text = '$(NMakeIncludeSearchPath)'
             ET.SubElement(parent_node, 'AdditionalOptions').text = '$(AdditionalOptions)'
 
-    def add_preprocessor_defines(self, lang, parent_node, file_defines):
+    def add_preprocessor_defines(self, lang: Language, parent_node: ET.Element, file_defines: dict[Language, CompilerArgs]) -> None:
         defines = []
         for define in file_defines[lang]:
             if define == '%(PreprocessorDefinitions)':
@@ -939,7 +939,7 @@ class Vs2010Backend(backends.Backend):
                 defines.append(self.escape_preprocessor_define(define))
         ET.SubElement(parent_node, "PreprocessorDefinitions").text = ';'.join(defines)
 
-    def add_include_dirs(self, lang, parent_node, file_inc_dirs):
+    def add_include_dirs(self, lang: Language, parent_node: ET.Element, file_inc_dirs: dict[Language, list[str]]) -> None:
         dirs = file_inc_dirs[lang]
         ET.SubElement(parent_node, "AdditionalIncludeDirectories").text = ';'.join(dirs)
 

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -126,7 +126,7 @@ def get_primary_source_lang(target_sources: T.List[File], custom_sources: T.List
 def get_non_primary_lang_intellisense_fields(vslite_ctx: dict,
                                              target_id: str,
                                              primary_src_lang: str) -> T.Dict[str, T.Dict[str, T.Tuple[str, str, str]]]:
-    defs_paths_opts_per_lang_and_buildtype = {}
+    defs_paths_opts_per_lang_and_buildtype: dict[str, dict[str, tuple[str, str, str]]] = {}
     for buildtype in coredata.get_genvs_default_buildtype_list():
         captured_build_args = vslite_ctx[buildtype][target_id] # Results in a 'Src types to compile args' dict
         non_primary_build_args_per_src_lang = [(lang, build_args) for lang, build_args in captured_build_args.items() if lang != primary_src_lang] # Only need to individually populate intellisense fields for sources of non-primary types.
@@ -149,7 +149,7 @@ class Vs2010Backend(backends.Backend):
         self.vs_version = '2010'
         self.windows_target_platform_version = None
         self.subdirs: dict[PurePath, tuple[str, str | None]] = {}
-        self.handled_target_deps = {}
+        self.handled_target_deps: dict[str, list[str]] = {}
         self.gen_lite = gen_lite  # Synonymous with generating the simpler makefile-style multi-config projects that invoke 'meson compile' builds, avoiding native MSBuild complications
 
     def detect_toolset(self) -> None:
@@ -341,7 +341,7 @@ class Vs2010Backend(backends.Backend):
                     (script_path, os.environ['VSCMD_ARG_TGT_ARCH'], os.environ['VSCMD_ARG_HOST_ARCH'])
         return ''
 
-    def get_obj_target_deps(self, obj_list):
+    def get_obj_target_deps(self, obj_list: list[build.ObjectTypes]) -> T.Iterable[tuple[str, build.BuildTarget]]:
         result = {}
         for o in obj_list:
             if isinstance(o, build.ExtractedObjects):
@@ -454,7 +454,7 @@ class Vs2010Backend(backends.Backend):
                     self.environment.coredata.lang_guids[lang],
                     prj[0], prj[1], prj[2])
                 ofile.write(prj_line)
-                target_dict = {target.get_id(): target}
+                target_dict: dict[str, build.AnyTargetType] = {target.get_id(): target}
                 # Get recursive deps
                 recursive_deps = self.get_target_deps(
                     target_dict, recursive=True)
@@ -622,8 +622,8 @@ class Vs2010Backend(backends.Backend):
             # objects and .lib files manually.
             ET.SubElement(pref, 'LinkLibraryDependencies').text = 'false'
 
-    def add_target_deps(self, root: ET.Element, target):
-        target_dict = {target.get_id(): target}
+    def add_target_deps(self, root: ET.Element, target: build.AnyTargetType) -> None:
+        target_dict: T.Dict[str, build.AnyTargetType] = {target.get_id(): target}
         for dep in self.get_target_deps(target_dict).values():
             if dep.get_id() in self.handled_target_deps[target.get_id()]:
                 # This dependency was already handled manually.
@@ -633,13 +633,13 @@ class Vs2010Backend(backends.Backend):
             tid = self.environment.coredata.target_guids[dep.get_id()]
             self.add_project_reference(root, vcxproj, tid)
 
-    def create_basic_project(self, target_name, *,
-                             temp_dir,
-                             guid,
-                             conftype='Utility',
-                             target_ext=None,
-                             target_platform=None,
-                             gen_manifest=True,
+    def create_basic_project(self, target_name: str, *,
+                             temp_dir: str,
+                             guid: str,
+                             conftype: str = 'Utility',
+                             target_ext: T.Optional[str] = None,
+                             target_platform: T.Optional[str] = None,
+                             gen_manifest: bool | T.Literal['embed'] = True,
                              masm_type: T.Optional[T.Literal['masm', 'marmasm']] = None) -> T.Tuple[ET.Element, ET.Element]:
         root = ET.Element('Project', {'DefaultTargets': "Build",
                                       'ToolsVersion': '4.0',
@@ -879,7 +879,7 @@ class Vs2010Backend(backends.Backend):
 
         return header
 
-    def is_argument_with_msbuild_xml_entry(self, entry):
+    def is_argument_with_msbuild_xml_entry(self, entry: str) -> bool:
         # Remove arguments that have a top level XML entry so
         # they are not used twice.
         # FIXME add args as needed.
@@ -901,7 +901,7 @@ class Vs2010Backend(backends.Backend):
         ET.SubElement(parent_node, "AdditionalOptions").text = ' '.join(args)
 
     # Set up each project's source file ('CLCompile') element with appropriate preprocessor, include dir, and compile option values for correct intellisense.
-    def add_project_nmake_defs_incs_and_opts(self, parent_node, src: str, defs_paths_opts_per_lang_and_buildtype: dict, platform: str):
+    def add_project_nmake_defs_incs_and_opts(self, parent_node: ET.Element, src: str, defs_paths_opts_per_lang_and_buildtype: dict, platform: str) -> None:
         # For compactness, sources whose type matches the primary src type (i.e. most frequent in the set of source types used in the target/project,
         # according to the 'captured_build_args' map), can simply reference the preprocessor definitions, include dirs, and compile option NMake fields of
         # the project itself.
@@ -1271,7 +1271,7 @@ class Vs2010Backend(backends.Backend):
                                                platform: str,
                                                target_ext: str,
                                                vslite_ctx: dict,
-                                               target,
+                                               target: build.AnyTargetType,
                                                proj_to_build_root: str,
                                                primary_src_lang: T.Optional[str]) -> None:
         ET.SubElement(root, 'ImportGroup', Label='ExtensionSettings')

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1167,7 +1167,7 @@ class Vs2010Backend(backends.Backend):
 
         return (target_args, file_args), (target_defines, file_defines), (target_inc_dirs, file_inc_dirs)
 
-    def get_build_args(self, target: build.BuildTarget, compiler: compilers.Compiler, optimization_level: str, debug: bool, sanitize: str) -> T.List[str]:
+    def get_build_args(self, target: build.BuildTarget, compiler: compilers.Compiler, optimization_level: str, debug: bool, sanitize: list[str]) -> T.List[str]:
         build_args = compiler.get_optimization_args(optimization_level)
         build_args += compiler.get_debug_args(debug)
         build_args += compiler.sanitizer_compile_args(target, sanitize)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -30,7 +30,7 @@ if T.TYPE_CHECKING:
     from ..arglist import CompilerArgs
     from ..compilers.compilers import Language
 
-    Project = T.Tuple[str, Path, str, MachineChoice]
+    Project = T.Tuple[str, PurePath, str, MachineChoice]
     FileLike = T.TypeVar('FileLike', bound=File | str)
 
 def autodetect_vs_version(build: T.Optional[build.Build]) -> backends.Backend:
@@ -410,7 +410,7 @@ class Vs2010Backend(backends.Backend):
         ret.update(all_deps)
         return ret
 
-    def generate_solution_dirs(self, ofile: str, parents: T.Sequence[Path]) -> None:
+    def generate_solution_dirs(self, ofile: T.TextIO, parents: T.Sequence[PurePath]) -> None:
         prj_templ = 'Project("{%s}") = "%s", "%s", "{%s}"\n'
         iterpaths = reversed(parents)
         # Skip first path

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1864,7 +1864,7 @@ class Vs2010Backend(backends.Backend):
             self.gen_vcxproj_filters(target, ofname)
         return True
 
-    def gen_vcxproj_filters(self, target, ofname) -> None:
+    def gen_vcxproj_filters(self, target: build.BuildTarget, ofname: str) -> None:
         # Generate pitchfork of filters based on directory structure.
         root = ET.Element('Project', {'ToolsVersion': '4.0',
                                       'xmlns': 'http://schemas.microsoft.com/developer/msbuild/2003'})
@@ -1872,7 +1872,7 @@ class Vs2010Backend(backends.Backend):
         filter_items = ET.SubElement(root, 'ItemGroup')
         mlog.debug(f'Generating vcxproj filters {target.name}.')
 
-        def relative_to_defined_in(file) -> str:
+        def relative_to_defined_in(file: File) -> str:
             # Get the relative path to file's directory from the location of the meson.build that defines this target.
             return os.path.dirname(self.relpath(PureWindowsPath(file.subdir, file.fname), self.get_target_dir(target)))
 
@@ -1913,7 +1913,7 @@ class Vs2010Backend(backends.Backend):
         sources, headers, objects, _ = self.split_sources(all_files)
         down = self.target_to_build_root(target)
 
-        def add_element(type_name: str, elements: list[ET.Element]) -> None:
+        def add_element(type_name: str, elements: list[File]) -> None:
             for i in elements:
                 if not os.path.isabs(i.fname):
                     dirname = relative_to_defined_in(i)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -346,8 +346,8 @@ class DepManifest:
 class BuildProject:
     name: str
     version: str
-    project_args: PerMachine[T.Dict[str, T.List[str]]] = field(default_factory=lambda: PerMachine({}, {}))
-    project_link_args: PerMachine[T.Dict[str, T.List[str]]] = field(default_factory=lambda: PerMachine({}, {}))
+    project_args: PerMachine[T.Dict[Language, T.List[str]]] = field(default_factory=lambda: PerMachine({}, {}))
+    project_link_args: PerMachine[T.Dict[Language, T.List[str]]] = field(default_factory=lambda: PerMachine({}, {}))
 
 
 # literally everything isn't dataclass stuff
@@ -365,8 +365,8 @@ class Build:
         self.projects: T.Dict[SubProject, BuildProject] = {}
         self.targets: dict[str, Target] = {}
         self.targetnames: T.Set[T.Tuple[str, str]] = set() # Set of executable names and their subdir
-        self.global_args: PerMachine[T.Dict[str, T.List[str]]] = PerMachine({}, {})
-        self.global_link_args: PerMachine[T.Dict[str, T.List[str]]] = PerMachine({}, {})
+        self.global_args: PerMachine[T.Dict[Language, T.List[str]]] = PerMachine({}, {})
+        self.global_link_args: PerMachine[T.Dict[Language, T.List[str]]] = PerMachine({}, {})
         self.tests: T.List['Test'] = []
         self.benchmarks: T.List['Test'] = []
         self.headers: T.List[Headers] = []

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3063,7 +3063,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                 mlog.warning(f'Consider using the built-in option for language standard version instead of using "{arg}".',
                              location=self.current_node)
 
-    def _add_global_arguments(self, node: mparser.FunctionNode, argsdict: T.Dict[str, T.List[str]],
+    def _add_global_arguments(self, node: mparser.FunctionNode, argsdict: T.Dict[Language, T.List[str]],
                               args: T.List[str], kwargs: 'kwtypes.FuncAddProjectArgs') -> None:
         if self.is_subproject():
             msg = f'Function \'{node.func_name.value}\' cannot be used in subprojects because ' \
@@ -3076,11 +3076,11 @@ class Interpreter(InterpreterBase, HoldableObject):
         frozen = self.project_args_frozen or self.global_args_frozen
         self._add_arguments(node, argsdict, frozen, args, kwargs)
 
-    def _add_project_arguments(self, node: mparser.FunctionNode, argsdict: T.Dict[str, T.List[str]],
+    def _add_project_arguments(self, node: mparser.FunctionNode, argsdict: T.Dict[Language, T.List[str]],
                                args: T.List[str], kwargs: 'kwtypes.FuncAddProjectArgs') -> None:
         self._add_arguments(node, argsdict, self.project_args_frozen, args, kwargs)
 
-    def _add_arguments(self, node: mparser.FunctionNode, argsdict: T.Dict[str, T.List[str]],
+    def _add_arguments(self, node: mparser.FunctionNode, argsdict: T.Dict[Language, T.List[str]],
                        args_frozen: bool, args: T.List[str], kwargs: 'kwtypes.FuncAddProjectArgs') -> None:
         if args_frozen:
             msg = f'Tried to use \'{node.func_name.value}\' after a build target has been declared.\n' \

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -42,6 +42,7 @@ if T.TYPE_CHECKING:
     from . import ModuleState
     from ..build import BuildTarget
     from ..compilers import Compiler
+    from ..compilers.compilers import Language
     from ..interpreter import Interpreter
     from ..interpreter.interpreter import CustomTargetSources
     from ..interpreter.kwargs import CustomTargetInputs, TargetDepends
@@ -889,8 +890,8 @@ class GnomeModule(ExtensionModule):
         return ret
 
     @staticmethod
-    def _get_girtargets_langs_compilers(girtargets: T.Sequence[build.BuildTarget]) -> T.List[T.Tuple[str, 'Compiler']]:
-        ret: T.List[T.Tuple[str, 'Compiler']] = []
+    def _get_girtargets_langs_compilers(girtargets: T.Sequence[build.BuildTarget]) -> T.List[T.Tuple[Language, 'Compiler']]:
+        ret: T.List[T.Tuple[Language, 'Compiler']] = []
         for girtarget in girtargets:
             for lang, compiler in girtarget.compilers.items():
                 # XXX: Can you use g-i with any other language?
@@ -917,7 +918,7 @@ class GnomeModule(ExtensionModule):
         return ret
 
     @staticmethod
-    def _get_langs_compilers_flags(state: 'ModuleState', langs_compilers: T.List[T.Tuple[str, 'Compiler']]
+    def _get_langs_compilers_flags(state: 'ModuleState', langs_compilers: T.List[T.Tuple[Language, 'Compiler']]
                                    ) -> T.Tuple[T.List[str], T.List[str], T.List[str]]:
         cflags: T.List[str] = []
         internal_ldflags: T.List[str] = []

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -891,6 +891,9 @@ class RustModule(ExtensionModule):
             else:
                 raise InterpreterException(f'Unknown file type extension for: {name}')
 
+        # Mypy can't figure out that if Literal a is a subset of Literal B it's valid
+        language = T.cast('Language', language)
+
         # We only want include directories and defines, other things may not be valid
         cargs = state.get_option(f'{language}_args', state.subproject)
         assert isinstance(cargs, list), 'for mypy'


### PR DESCRIPTION
Based on #15860. range-diff with #15856:

```
 -:  --------- >  1:  75ab32be8 backends: move and rename unwrap_dep_list
 -:  --------- >  2:  1305b02f6 backends: use get_paths_for_dep_outputs() more
 -:  --------- >  3:  186554ef9 backends: remove dead isinstance check
 1:  db2320da1 =  4:  f50e0b72a backend/vs2010: Add typing information to gen_vcxproj_filters
 2:  d30d835a8 <  -:  --------- backends/backend: generate_unity_files can also take lists of File
 3:  ca2acd56c =  5:  921d915e3 backend/vs2010: Annotate split_sources
 4:  816eaaf94 =  6:  9245addbf backend/vs2010: Add annotations to generate_custom_generator_commands
 5:  35d7e9712 =  7:  624957382 backend/vs2010: Add assertions to help mypy with option values
 6:  eaa35d865 =  8:  8667ba521 backend/vs2010: fix annotations to get_build_args
 7:  0030d164c =  9:  c5b8012fa backend/vs2010: Fix typing of PCH handling
 8:  ccb3b165b = 10:  d5f402528 backend/vs2010: fix uses of str -> Language
 9:  3ec4a2c34 = 11:  c3a6c935e backend/vs2010: Fix annotations for add_*_(args|options)
10:  804aaccb3 = 12:  3b0636cd8 build: Use more Language
11:  52c3c7764 = 13:  c00df839f backend/vs2010: fix target annotation
12:  c368c33da <  -:  --------- backend/vs2010: Correctly handle programs in dependencies
13:  b68da6f61 = 14:  e62df08ca backend/vs2010: Fix annotations for add_non_makefile_vcxproj_elements
 -:  --------- > 15:  c2a60d0c0 backend/vs2010: fix Path/PurePath confusion
 -:  --------- > 16:  759c04398 backend/vs2010: add missing annotations
 -:  --------- > 17:  aabfef15d backend/vs2010: fix variance and subclassing issues
```

d30d835a8 remains and should be fixed in NinjaBackend instead

c368c33da is fixed more appropriately by 1305b02f6.

Remaining issues:

```
vs2010backend.py:358:30: error: Item "GeneratedList" of "CustomTargetIndex | GeneratedList | Program | Target" has no attribute "get_id"  [union-attr]
vs2010backend.py:358:30: error: Item "Program" of "CustomTargetIndex | GeneratedList | Program | Target" has no attribute "get_id"  [union-attr]
vs2010backend.py:358:44: error: Incompatible types in assignment (expression has type "CustomTargetIndex | GeneratedList | Program | Target", target has type "Target")  [assignment]
vs2010backend.py:567:42: error: Argument 1 to "gen_vcxproj" of "Vs2010Backend" has incompatible type "Target"; expected "BuildTarget"  [arg-type]
vs2010backend.py:792:49: error: Argument 1 to "generate_custom_generator_commands" of "Vs2010Backend" has incompatible type "CustomTarget"; expected "BuildTarget"  [arg-type]
vs2010backend.py:1021:5: error: Function is missing a return type annotation  [no-untyped-def]
vs2010backend.py:1021:5: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
vs2010backend.py:1668:57: error: Argument 2 to "generate_unity_files" of "Backend" has incompatible type "list[File]"; expected "list[str]"  [arg-type]
```
