### PR TITLE
modules/rust: use absolute path for bindgen input when output_inline_wrapper is set

### DIFF
--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -932,9 +932,22 @@ class RustModule(ExtensionModule):
                 '--wrap-static-fns-path', os.path.join(state.environment.build_dir, '@OUTPUT1@')
             ]
 
+        # When output_inline_wrapper is set, bindgen embeds the input path
+        # verbatim as an #include in the generated wrapper .c file. A relative
+        # path (from @INPUT@) breaks compilation when the generated file is in
+        # a build subdirectory, because GCC resolves the include relative to
+        # the .c file's directory rather than the build root. Use an absolute
+        # path so the generated #include is always valid. See also:
+        # https://github.com/mesonbuild/meson/issues/13227
+        if kwargs['output_inline_wrapper'] and isinstance(header, File):
+            bindgen_input_arg: T.Union[str, File] = header.absolute_path(
+                state.environment.source_dir, state.environment.build_dir)
+        else:
+            bindgen_input_arg = '@INPUT@'
+
         cmd = self._bindgen_bin.get_command() + \
             [
-                '@INPUT@', '--output',
+                bindgen_input_arg, '--output',
                 os.path.join(state.environment.build_dir, '@OUTPUT0@')
             ] + \
             kwargs['args'] + inline_wrapper_args


### PR DESCRIPTION
## Summary

When `output_inline_wrapper` is used, bindgen embeds the input header path verbatim as an `#include` in the generated wrapper `.c` file:

```c
#include "<whatever-was-passed-as-input>"
```

If the input is `@INPUT@` (a path relative to the build root, e.g. `../src/foo.h`), this `#include` breaks compilation whenever the generated `.c` file resides in a subdirectory of the build root, because GCC resolves the include relative to the `.c` file's directory rather than the build root.

## Real-world impact

- **Gentoo Linux**: multilib/ABI builds use a sub-directory build tree (e.g. `mesa-9999-abi_x86_32.x86/`). The 64-bit pass succeeds but the 32-bit pass fails with: `fatal error: ../mesa-9999/src/compiler/rust/bindings.h: No such file or directory`
- **Arch Linux**: same failure reported for `mesa-git` AUR package (see #13227)

## Fix

When `output_inline_wrapper` is set and `header` is a `File` object, substitute the absolute path to the header instead of `@INPUT@`. Ninja's dependency tracking is unaffected because the header is still listed in the `CustomTarget` inputs.

Fixes #13227