### PR TITLE
nasm: use the correct flag for response file support

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -255,6 +255,8 @@ class NinjaRule:
             if rsp == '_RSP':
                 if self.rspfile_quote_style is RSPFileSyntax.TASKING:
                     outfile.write(' command = {} --option-file=$out.rsp\n'.format(' '.join([self._quoter(x) for x in self.command])))
+                elif self.rspfile_quote_style is RSPFileSyntax.NASM:
+                    outfile.write(' command = {} -@$out.rsp\n'.format(' '.join([self._quoter(x) for x in self.command])))
                 else:
                     outfile.write(' command = {} @$out.rsp\n'.format(' '.join([self._quoter(x) for x in self.command])))
                 outfile.write(' rspfile = $out.rsp\n')

--- a/mesonbuild/compilers/asm.py
+++ b/mesonbuild/compilers/asm.py
@@ -6,6 +6,7 @@ import typing as T
 from ..mesonlib import EnvironmentException, get_meson_command
 from ..options import OptionKey
 from .compilers import Compiler
+from ..linkers import RSPFileSyntax
 from ..linkers.linkers import VisualStudioLikeLinkerMixin
 from .mixins.metrowerks import MetrowerksCompiler, mwasmarm_instruction_set_args, mwasmeppc_instruction_set_args
 from .mixins.ti import TICompiler
@@ -158,6 +159,10 @@ class NasmCompiler(ASMCompiler):
         if not isinstance(self.linker, VisualStudioLikeLinkerMixin):
             return []
         return self.crt_args[self.get_crt_val(crt_val)]
+
+    # It uses '-@' instead of the normal '@' for denoting response files.
+    def rsp_file_syntax(self) -> RSPFileSyntax:
+        return RSPFileSyntax.NASM
 
 class YasmCompiler(NasmCompiler):
     id = 'yasm'

--- a/mesonbuild/linkers/base.py
+++ b/mesonbuild/linkers/base.py
@@ -19,6 +19,7 @@ class RSPFileSyntax(enum.Enum):
     MSVC = enum.auto()
     GCC = enum.auto()
     TASKING = enum.auto()
+    NASM = enum.auto()
 
 
 class ArLikeLinker:


### PR DESCRIPTION
Hi all,

This is a PR to fix the Ninja backend failing to pass response files properly to Nasm. Unlike GCC-style compilers, response files for Nasm must be passed with the '-@foo.rsp' flag.

This fixes building MPV on Windows with sufficiently long include paths, which are necessary to trigger response file usage.

See https://gitlab.freedesktop.org/gstreamer/meson-ports/ffmpeg/-/work_items/75

cc @og-mrk