### PR TITLE
Revert "nasm: use the correct flag for response file support"

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -254,8 +254,6 @@ class NinjaRule:
             if rsp == '_RSP':
                 if self.rspfile_quote_style is RSPFileSyntax.TASKING:
                     outfile.write(' command = {} --option-file=$out.rsp\n'.format(' '.join([self._quoter(x) for x in self.command])))
-                elif self.rspfile_quote_style is RSPFileSyntax.NASM:
-                    outfile.write(' command = {} -@$out.rsp\n'.format(' '.join([self._quoter(x) for x in self.command])))
                 else:
                     outfile.write(' command = {} @$out.rsp\n'.format(' '.join([self._quoter(x) for x in self.command])))
                 outfile.write(' rspfile = $out.rsp\n')

--- a/mesonbuild/compilers/asm.py
+++ b/mesonbuild/compilers/asm.py
@@ -159,6 +159,12 @@ class NasmCompiler(ASMCompiler):
             return []
         return self.crt_args[self.get_crt_val(crt_val)]
 
+    def can_linker_accept_rsp(self) -> bool:
+        """
+        Determines whether the linker can accept arguments using the @rsp syntax.
+        """
+        return False
+
 class YasmCompiler(NasmCompiler):
     id = 'yasm'
 

--- a/mesonbuild/compilers/asm.py
+++ b/mesonbuild/compilers/asm.py
@@ -6,7 +6,6 @@ import typing as T
 from ..mesonlib import EnvironmentException, get_meson_command
 from ..options import OptionKey
 from .compilers import Compiler
-from ..linkers import RSPFileSyntax
 from ..linkers.linkers import VisualStudioLikeLinkerMixin
 from .mixins.metrowerks import MetrowerksCompiler, mwasmarm_instruction_set_args, mwasmeppc_instruction_set_args
 from .mixins.ti import TICompiler
@@ -159,10 +158,6 @@ class NasmCompiler(ASMCompiler):
         if not isinstance(self.linker, VisualStudioLikeLinkerMixin):
             return []
         return self.crt_args[self.get_crt_val(crt_val)]
-
-    # It uses '-@' instead of the normal '@' for denoting response files.
-    def rsp_file_syntax(self) -> RSPFileSyntax:
-        return RSPFileSyntax.NASM
 
 class YasmCompiler(NasmCompiler):
     id = 'yasm'

--- a/mesonbuild/linkers/base.py
+++ b/mesonbuild/linkers/base.py
@@ -19,7 +19,6 @@ class RSPFileSyntax(enum.Enum):
     MSVC = enum.auto()
     GCC = enum.auto()
     TASKING = enum.auto()
-    NASM = enum.auto()
 
 
 class ArLikeLinker:


### PR DESCRIPTION
Hi all,

Upon further work on #15867 with a more complex project, I realised that Nasm wants newlines and does NOT accept quotes+spaces for splitting arguments, unlike e.g. what I did with gobject-introspection back in https://github.com/mesonbuild/meson/issues/6710. So for proper escaping this must be done with a custom generator à la GNOME module, with a CustomTarget.

I'm not yet sure how to approach this now that Nasm is a first-class language, so I can only send a revert for now.

This reverts commit 173d7605f266c5e8019dafea1159b4700ef56e5c.