### PR TITLE
windows: disable the RC dependency detection script for Microsoft clang

### DIFF
--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -185,12 +185,13 @@ class WindowsModule(ExtensionModule):
 
             if rescomp_type == ResourceCompilerType.rc:
                 compiler = self.detect_compiler(state.environment.coredata.compilers[MachineChoice.HOST])
-                depfile_type = 'msvc'
+                if compiler.id in {'msvc', 'clang-cl'}:
+                    depfile_type = 'msvc'
 
-                command.extend(state.environment.get_build_command())
-                command.extend(['--internal', 'rc',
-                                '--cl', compiler.get_exelist(False)[0],
-                                '--rc'])
+                    command.extend(state.environment.get_build_command())
+                    command.extend(['--internal', 'rc',
+                                    '--cl', compiler.get_exelist(False)[0],
+                                    '--rc'])
 
             command.append(rescomp)
             command.extend(res_args)


### PR DESCRIPTION
Hi all,

This PR disables the depfile generation script when using Microsoft-supplied Clang. Currently, whenever a Windows resource is compiled, the console gets spammed with e.g.:

```
[19/1419] Compiling Windows resource subprojects/ffmpeg/windows_compile_resources_0_avfilterres.rc
clang: error: no such file or directory: '/showIncludes'
clang: error: no such file or directory: '/EP'
clang: error: no such file or directory: '/nologo'
clang: error: no such file or directory: '/DRC_INVOKED'
clang: error: no such file or directory: '/Tcsubprojects/ffmpeg/avfilterres.rc'
clang: error: no input files
```

Fixes #15709