### PR TITLE
mtest: avoid GTest XML filename collisions across suites

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -41,13 +41,9 @@ from .programs import ExternalProgram
 from .backend.backends import TestProtocol, TestSerialisation
 
 if T.TYPE_CHECKING:
-    TYPE_TAPResult = T.Union['TAPParser.Test',
-                             'TAPParser.Error',
-                             'TAPParser.Version',
-                             'TAPParser.Plan',
-                             'TAPParser.UnknownLine',
-                             'TAPParser.Bailout']
-
+    TYPE_TAPResult = T.Union['TAPParser.Test', 'TAPParser.Error',
+                             'TAPParser.Version', 'TAPParser.Plan',
+                             'TAPParser.UnknownLine', 'TAPParser.Bailout']
 
 # GNU autotools interprets a return code of 77 from tests it executes to
 # mean that the test should be skipped.
@@ -62,22 +58,28 @@ MAX_CTRLC = 3
 
 # Define unencodable xml characters' regex for replacing them with their
 # printable representation
-UNENCODABLE_XML_UNICHRS: T.List[T.Tuple[int, int]] = [
-    (0x00, 0x08), (0x0B, 0x0C), (0x0E, 0x1F), (0x7F, 0x84),
-    (0x86, 0x9F), (0xFDD0, 0xFDEF), (0xFFFE, 0xFFFF)]
+UNENCODABLE_XML_UNICHRS: T.List[T.Tuple[int,
+                                        int]] = [(0x00, 0x08), (0x0B, 0x0C),
+                                                 (0x0E, 0x1F), (0x7F, 0x84),
+                                                 (0x86, 0x9F),
+                                                 (0xFDD0, 0xFDEF),
+                                                 (0xFFFE, 0xFFFF)]
 # Not narrow build
 if sys.maxunicode >= 0x10000:
-    UNENCODABLE_XML_UNICHRS.extend([
-        (0x1FFFE, 0x1FFFF), (0x2FFFE, 0x2FFFF),
-        (0x3FFFE, 0x3FFFF), (0x4FFFE, 0x4FFFF),
-        (0x5FFFE, 0x5FFFF), (0x6FFFE, 0x6FFFF),
-        (0x7FFFE, 0x7FFFF), (0x8FFFE, 0x8FFFF),
-        (0x9FFFE, 0x9FFFF), (0xAFFFE, 0xAFFFF),
-        (0xBFFFE, 0xBFFFF), (0xCFFFE, 0xCFFFF),
-        (0xDFFFE, 0xDFFFF), (0xEFFFE, 0xEFFFF),
-        (0xFFFFE, 0xFFFFF), (0x10FFFE, 0x10FFFF)])
-UNENCODABLE_XML_CHR_RANGES = [fr'{chr(low)}-{chr(high)}' for (low, high) in UNENCODABLE_XML_UNICHRS]
-UNENCODABLE_XML_CHRS_RE = re.compile('([' + ''.join(UNENCODABLE_XML_CHR_RANGES) + '])')
+    UNENCODABLE_XML_UNICHRS.extend([(0x1FFFE, 0x1FFFF), (0x2FFFE, 0x2FFFF),
+                                    (0x3FFFE, 0x3FFFF), (0x4FFFE, 0x4FFFF),
+                                    (0x5FFFE, 0x5FFFF), (0x6FFFE, 0x6FFFF),
+                                    (0x7FFFE, 0x7FFFF), (0x8FFFE, 0x8FFFF),
+                                    (0x9FFFE, 0x9FFFF), (0xAFFFE, 0xAFFFF),
+                                    (0xBFFFE, 0xBFFFF), (0xCFFFE, 0xCFFFF),
+                                    (0xDFFFE, 0xDFFFF), (0xEFFFE, 0xEFFFF),
+                                    (0xFFFFE, 0xFFFFF), (0x10FFFE, 0x10FFFF)])
+UNENCODABLE_XML_CHR_RANGES = [
+    fr'{chr(low)}-{chr(high)}' for (low, high) in UNENCODABLE_XML_UNICHRS
+]
+UNENCODABLE_XML_CHRS_RE = re.compile('([' +
+                                     ''.join(UNENCODABLE_XML_CHR_RANGES) +
+                                     '])')
 
 RUST_TEST_RE = re.compile(r'^test (?!result)(.*) \.\.\. (.*)$')
 RUST_DOCTEST_RE = re.compile(r'^(.*?) - (.*? |)\(line (\d+)\)')
@@ -87,13 +89,18 @@ def is_windows() -> bool:
     platname = platform.system().lower()
     return platname == 'windows'
 
+
 def is_cygwin() -> bool:
     return sys.platform == 'cygwin'
+
 
 def is_os2() -> bool:
     return platform.system().lower() == 'os/2'
 
+
 UNIWIDTH_MAPPING = {'F': 2, 'H': 1, 'W': 2, 'Na': 1, 'N': 1, 'A': 1}
+
+
 def uniwidth(s: str) -> int:
     result = 0
     for c in s:
@@ -101,17 +108,20 @@ def uniwidth(s: str) -> int:
         result += UNIWIDTH_MAPPING[w]
     return result
 
+
 def test_slice(arg: str) -> T.Tuple[int, int]:
     values = arg.split('/')
     if len(values) != 2:
-        raise argparse.ArgumentTypeError("value does not conform to format 'SLICE/NUM_SLICES'")
+        raise argparse.ArgumentTypeError(
+            "value does not conform to format 'SLICE/NUM_SLICES'")
 
     try:
         nrslices = int(values[1])
     except ValueError:
         raise argparse.ArgumentTypeError('NUM_SLICES is not an integer')
     if nrslices <= 0:
-        raise argparse.ArgumentTypeError('NUM_SLICES is not a positive integer')
+        raise argparse.ArgumentTypeError(
+            'NUM_SLICES is not a positive integer')
 
     try:
         subslice = int(values[0])
@@ -124,64 +134,143 @@ def test_slice(arg: str) -> T.Tuple[int, int]:
 
     return subslice, nrslices
 
+
 # Note: when adding arguments, please also add them to the completion
 # scripts in $MESONSRC/data/shell-completions/
 def add_arguments(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument('-k', '--maxfail', default=0, type=int,
-                        help='Number of failing tests before aborting the '
-                        'test run. (default: 0, to disable aborting on failure)')
-    parser.add_argument('--repeat', default=1, dest='repeat', type=int,
+    parser.add_argument(
+        '-k',
+        '--maxfail',
+        default=0,
+        type=int,
+        help='Number of failing tests before aborting the '
+        'test run. (default: 0, to disable aborting on failure)')
+    parser.add_argument('--repeat',
+                        default=1,
+                        dest='repeat',
+                        type=int,
                         help='Number of times to run the tests.')
-    parser.add_argument('--no-rebuild', default=False, action='store_true',
+    parser.add_argument('--no-rebuild',
+                        default=False,
+                        action='store_true',
                         help='Do not rebuild before running tests.')
-    parser.add_argument('--gdb', default=False, dest='gdb', action='store_true',
+    parser.add_argument('--gdb',
+                        default=False,
+                        dest='gdb',
+                        action='store_true',
                         help='Run test under gdb.')
-    parser.add_argument('--gdb-path', default='gdb', dest='gdb_path',
+    parser.add_argument('--gdb-path',
+                        default='gdb',
+                        dest='gdb_path',
                         help='Path to the gdb binary (default: gdb).')
-    parser.add_argument('-i', '--interactive', default=False, dest='interactive',
-                        action='store_true', help='Run tests with interactive input/output.')
-    parser.add_argument('--list', default=False, dest='list', action='store_true',
+    parser.add_argument('-i',
+                        '--interactive',
+                        default=False,
+                        dest='interactive',
+                        action='store_true',
+                        help='Run tests with interactive input/output.')
+    parser.add_argument('--list',
+                        default=False,
+                        dest='list',
+                        action='store_true',
                         help='List available tests.')
-    parser.add_argument('--wrapper', default=None, dest='wrapper', type=split_args,
+    parser.add_argument('--wrapper',
+                        default=None,
+                        dest='wrapper',
+                        type=split_args,
                         help='wrapper to run tests with (e.g. Valgrind)')
-    parser.add_argument('-C', dest='wd', action=RealPathAction,
+    parser.add_argument('-C',
+                        dest='wd',
+                        action=RealPathAction,
                         help='directory to cd into before running')
-    parser.add_argument('--suite', default=[], dest='include_suites', action='append', metavar='SUITE',
+    parser.add_argument('--suite',
+                        default=[],
+                        dest='include_suites',
+                        action='append',
+                        metavar='SUITE',
                         help='Only run tests belonging to the given suite.')
-    parser.add_argument('--no-suite', default=[], dest='exclude_suites', action='append', metavar='SUITE',
+    parser.add_argument('--no-suite',
+                        default=[],
+                        dest='exclude_suites',
+                        action='append',
+                        metavar='SUITE',
                         help='Do not run tests belonging to the given suite.')
-    parser.add_argument('--exclude', default=[], dest='exclude', action='append',
+    parser.add_argument('--exclude',
+                        default=[],
+                        dest='exclude',
+                        action='append',
                         help='Exclude tests with the given name.')
-    parser.add_argument('--no-stdsplit', default=True, dest='split', action='store_false',
+    parser.add_argument('--no-stdsplit',
+                        default=True,
+                        dest='split',
+                        action='store_false',
                         help='Do not split stderr and stdout in test logs.')
-    parser.add_argument('--print-errorlogs', default=False, action='store_true',
+    parser.add_argument('--print-errorlogs',
+                        default=False,
+                        action='store_true',
                         help="Whether to print failing tests' logs.")
-    parser.add_argument('--benchmark', default=False, action='store_true',
+    parser.add_argument('--benchmark',
+                        default=False,
+                        action='store_true',
                         help="Run benchmarks instead of tests.")
-    parser.add_argument('--logbase', default='testlog',
+    parser.add_argument('--logbase',
+                        default='testlog',
                         help="Base name for log file.")
-    parser.add_argument('-j', '--num-processes', default=determine_worker_count(['MESON_TESTTHREADS']), type=int,
+    parser.add_argument('-j',
+                        '--num-processes',
+                        default=determine_worker_count(['MESON_TESTTHREADS']),
+                        type=int,
                         help='How many parallel processes to use.')
-    parser.add_argument('-v', '--verbose', default=False, action='store_true',
+    parser.add_argument('-v',
+                        '--verbose',
+                        default=False,
+                        action='store_true',
                         help='Do not redirect stdout and stderr')
-    parser.add_argument('-q', '--quiet', default=False, action='store_true',
+    parser.add_argument('-q',
+                        '--quiet',
+                        default=False,
+                        action='store_true',
                         help='Produce less output to the terminal.')
-    parser.add_argument('-t', '--timeout-multiplier', type=float, default=None,
-                        help='Define a multiplier for test timeout, for example '
-                        ' when running tests in particular conditions they might take'
-                        ' more time to execute. (<= 0 to disable timeout)')
-    parser.add_argument('--setup', default=None, dest='setup',
+    parser.add_argument(
+        '-t',
+        '--timeout-multiplier',
+        type=float,
+        default=None,
+        help='Define a multiplier for test timeout, for example '
+        ' when running tests in particular conditions they might take'
+        ' more time to execute. (<= 0 to disable timeout)')
+    parser.add_argument('--setup',
+                        default=None,
+                        dest='setup',
                         help='Which test setup to use.')
-    parser.add_argument('--test-args', default=[], type=split_args,
-                        help='Arguments to pass to the specified test(s) or all tests')
-    parser.add_argument('--max-lines', default=100, dest='max_lines', type=int,
-                        help='Maximum number of lines to show from a long test log. Since 1.5.0.')
-    parser.add_argument('--slice', default=None, type=test_slice, metavar='SLICE/NUM_SLICES',
-                        help='Split tests into NUM_SLICES slices and execute slice SLICE. Since 1.8.0.')
-    parser.add_argument('args', nargs='*',
-                        help='Optional list of test names to run. "testname" to run all tests with that name, '
-                        '"subprojname:testname" to specifically run "testname" from "subprojname", '
-                        '"subprojname:" to run all tests defined by "subprojname".')
+    parser.add_argument(
+        '--test-args',
+        default=[],
+        type=split_args,
+        help='Arguments to pass to the specified test(s) or all tests')
+    parser.add_argument(
+        '--max-lines',
+        default=100,
+        dest='max_lines',
+        type=int,
+        help=
+        'Maximum number of lines to show from a long test log. Since 1.5.0.')
+    parser.add_argument(
+        '--slice',
+        default=None,
+        type=test_slice,
+        metavar='SLICE/NUM_SLICES',
+        help=
+        'Split tests into NUM_SLICES slices and execute slice SLICE. Since 1.8.0.'
+    )
+    parser.add_argument(
+        'args',
+        nargs='*',
+        help=
+        'Optional list of test names to run. "testname" to run all tests with that name, '
+        '"subprojname:testname" to specifically run "testname" from "subprojname", '
+        '"subprojname:" to run all tests defined by "subprojname".')
+
 
 def print_safe(s: str) -> None:
     end = '' if s[-1] == '\n' else '\n'
@@ -191,12 +280,14 @@ def print_safe(s: str) -> None:
         s = s.encode('ascii', errors='backslashreplace').decode('ascii')
         print(s, end=end)
 
+
 def join_lines(a: str, b: str) -> str:
     if not a:
         return b
     if not b:
         return a
     return a + '\n' + b
+
 
 def dashes(s: str, dash: str, cols: int) -> str:
     if not s:
@@ -206,6 +297,7 @@ def dashes(s: str, dash: str, cols: int) -> str:
     first = (cols - width) // 2
     s = dash * first + s
     return s + dash * (cols - first - width)
+
 
 def returncode_to_status(retcode: int) -> str:
     # Note: We can't use `os.WIFSIGNALED(result.returncode)` and the related
@@ -235,10 +327,12 @@ def returncode_to_status(retcode: int) -> str:
 
     return f'(exit status {retcode} or {hex(retcode)})'
 
+
 # TODO for Windows
 sh_quote: T.Callable[[str], str] = lambda x: x
 if not is_windows():
     sh_quote = shlex.quote
+
 
 def env_tuple_to_str(env: T.Iterable[T.Tuple[str, str]]) -> str:
     return ''.join(["{}={} ".format(k, sh_quote(v)) for k, v in env])
@@ -284,8 +378,10 @@ class TestResult(enum.Enum):
         return self in {TestResult.OK, TestResult.EXPECTEDFAIL}
 
     def is_bad(self) -> bool:
-        return self in {TestResult.FAIL, TestResult.TIMEOUT, TestResult.INTERRUPT,
-                        TestResult.UNEXPECTEDPASS, TestResult.ERROR}
+        return self in {
+            TestResult.FAIL, TestResult.TIMEOUT, TestResult.INTERRUPT,
+            TestResult.UNEXPECTEDPASS, TestResult.ERROR
+        }
 
     def is_finished(self) -> bool:
         return self not in {TestResult.PENDING, TestResult.RUNNING}
@@ -296,7 +392,8 @@ class TestResult(enum.Enum):
     def colorize(self, s: str) -> mlog.AnsiDecorator:
         if self.is_bad():
             decorator = mlog.red
-        elif self in (TestResult.SKIP, TestResult.IGNORED, TestResult.EXPECTEDFAIL):
+        elif self in (TestResult.SKIP, TestResult.IGNORED,
+                      TestResult.EXPECTEDFAIL):
             decorator = mlog.yellow
         elif self.is_finished():
             decorator = mlog.green
@@ -305,7 +402,8 @@ class TestResult(enum.Enum):
         return decorator(s)
 
     def get_text(self, colorize: bool) -> str:
-        result_str = '{res:{reslen}}'.format(res=self.value, reslen=self.maxlen())
+        result_str = '{res:{reslen}}'.format(res=self.value,
+                                             reslen=self.maxlen())
         return self.colorize(result_str).get_text(colorize)
 
     def get_command_marker(self) -> str:
@@ -313,6 +411,7 @@ class TestResult(enum.Enum):
 
 
 class TAPParser:
+
     class Plan(T.NamedTuple):
         num_tests: int
         late: bool
@@ -346,9 +445,11 @@ class TAPParser:
     _YAML = 3
 
     _RE_BAILOUT = re.compile(r'Bail out!\s*(.*)')
-    _RE_DIRECTIVE = re.compile(r'(?:\s*\#\s*([Ss][Kk][Ii][Pp]\S*|[Tt][Oo][Dd][Oo])\b\s*(.*))?')
+    _RE_DIRECTIVE = re.compile(
+        r'(?:\s*\#\s*([Ss][Kk][Ii][Pp]\S*|[Tt][Oo][Dd][Oo])\b\s*(.*))?')
     _RE_PLAN = re.compile(r'1\.\.([0-9]+)' + _RE_DIRECTIVE.pattern)
-    _RE_TEST = re.compile(r'((?:not )?ok)\s*(?:([0-9]+)\s*)?([^#]*)' + _RE_DIRECTIVE.pattern)
+    _RE_TEST = re.compile(r'((?:not )?ok)\s*(?:([0-9]+)\s*)?([^#]*)' +
+                          _RE_DIRECTIVE.pattern)
     _RE_VERSION = re.compile(r'TAP version ([0-9]+)')
     _RE_YAML_START = re.compile(r'(\s+)---.*')
     _RE_YAML_END = re.compile(r'\s+\.\.\.\s*')
@@ -376,14 +477,19 @@ class TAPParser:
                     yield self.Test(num, name, TestResult.SKIP, explanation)
                     return
             elif directive == 'TODO':
-                yield self.Test(num, name, TestResult.UNEXPECTEDPASS if ok else TestResult.EXPECTEDFAIL, explanation)
+                yield self.Test(
+                    num, name, TestResult.UNEXPECTEDPASS
+                    if ok else TestResult.EXPECTEDFAIL, explanation)
                 return
             else:
                 yield self.Error(f'invalid directive "{directive}"')
 
-        yield self.Test(num, name, TestResult.OK if ok else TestResult.FAIL, explanation)
+        yield self.Test(num, name, TestResult.OK if ok else TestResult.FAIL,
+                        explanation)
 
-    async def parse_async(self, lines: T.AsyncIterator[str]) -> T.AsyncIterator[TYPE_TAPResult]:
+    async def parse_async(
+            self,
+            lines: T.AsyncIterator[str]) -> T.AsyncIterator[TYPE_TAPResult]:
         async for line in lines:
             for event in self.parse_line(line):
                 yield event
@@ -416,7 +522,9 @@ class TAPParser:
                     return
                 if line.startswith(self.yaml_indent):
                     return
-                yield self.Error(f'YAML block not terminated (started on line {self.yaml_lineno})')
+                yield self.Error(
+                    f'YAML block not terminated (started on line {self.yaml_lineno})'
+                )
                 self.state = self._MAIN
 
             line = line.rstrip()
@@ -431,12 +539,15 @@ class TAPParser:
                     yield self.Error('unexpected test after late plan')
                     self.found_late_test = True
                 self.num_tests += 1
-                self.last_test = self.last_test + 1 if m.group(2) is None else int(m.group(2))
+                self.last_test = self.last_test + 1 if m.group(
+                    2) is None else int(m.group(2))
                 self.highest_test = max(self.highest_test, self.last_test)
                 if self.plan and self.last_test > self.plan.num_tests:
-                    yield self.Error('test number exceeds maximum specified in test plan')
-                yield from self.parse_test(m.group(1) == 'ok', self.last_test,
-                                           m.group(3), m.group(4), m.group(5))
+                    yield self.Error(
+                        'test number exceeds maximum specified in test plan')
+                yield from self.parse_test(
+                    m.group(1) == 'ok', self.last_test, m.group(3), m.group(4),
+                    m.group(5))
                 self.state = self._AFTER_TEST
                 return
 
@@ -450,12 +561,15 @@ class TAPParser:
                     if m.group(2):
                         if m.group(2).upper().startswith('SKIP'):
                             if num_tests > 0:
-                                yield self.Error('invalid SKIP directive for plan')
+                                yield self.Error(
+                                    'invalid SKIP directive for plan')
                             skipped = True
                         else:
                             yield self.Error('invalid directive for plan')
-                    self.plan = self.Plan(num_tests=num_tests, late=(self.num_tests > 0),
-                                          skipped=skipped, explanation=m.group(3))
+                    self.plan = self.Plan(num_tests=num_tests,
+                                          late=(self.num_tests > 0),
+                                          skipped=skipped,
+                                          explanation=m.group(3))
                     yield self.plan
                 return
 
@@ -469,7 +583,8 @@ class TAPParser:
             if m:
                 # The TAP version is only accepted as the first line
                 if self.lineno != 1:
-                    yield self.Error('version number must be on the first line')
+                    yield self.Error(
+                        'version number must be on the first line')
                     return
                 self.version = int(m.group(1))
                 if self.version < 13:
@@ -483,25 +598,37 @@ class TAPParser:
         else:
             # end of file
             if self.state == self._YAML:
-                yield self.Error(f'YAML block not terminated (started on line {self.yaml_lineno})')
+                yield self.Error(
+                    f'YAML block not terminated (started on line {self.yaml_lineno})'
+                )
 
             if self.bailed_out:
                 return
 
             if self.plan and self.num_tests != self.plan.num_tests:
                 if self.num_tests < self.plan.num_tests:
-                    yield self.Error(f'Too few tests run (expected {self.plan.num_tests}, got {self.num_tests})')
+                    yield self.Error(
+                        f'Too few tests run (expected {self.plan.num_tests}, got {self.num_tests})'
+                    )
                 else:
-                    yield self.Error(f'Too many tests run (expected {self.plan.num_tests}, got {self.num_tests})')
+                    yield self.Error(
+                        f'Too many tests run (expected {self.plan.num_tests}, got {self.num_tests})'
+                    )
                 return
 
             if self.highest_test != self.num_tests:
                 if self.highest_test < self.num_tests:
-                    yield self.Error(f'Duplicate test numbers (expected {self.num_tests}, got test numbered {self.highest_test}')
+                    yield self.Error(
+                        f'Duplicate test numbers (expected {self.num_tests}, got test numbered {self.highest_test}'
+                    )
                 else:
-                    yield self.Error(f'Missing test numbers (expected {self.num_tests}, got test numbered {self.highest_test}')
+                    yield self.Error(
+                        f'Missing test numbers (expected {self.num_tests}, got test numbered {self.highest_test}'
+                    )
+
 
 class TestLogger:
+
     def flush(self) -> None:
         pass
 
@@ -511,8 +638,8 @@ class TestLogger:
     def start_test(self, harness: 'TestHarness', test: 'TestRun') -> None:
         pass
 
-    def log_subtest(self, harness: 'TestHarness', test: 'TestRun', s: str, res: TestResult,
-                    explanation: T.Optional[str]) -> None:
+    def log_subtest(self, harness: 'TestHarness', test: 'TestRun', s: str,
+                    res: TestResult, explanation: T.Optional[str]) -> None:
         pass
 
     def log(self, harness: 'TestHarness', result: 'TestRun') -> None:
@@ -526,6 +653,7 @@ class TestLogger:
 
 
 class TestFileLogger(TestLogger):
+
     def __init__(self, filename: str, errors: str = 'replace') -> None:
         self.filename = filename
         self.file = open(filename, 'w', encoding='utf-8', errors=errors)
@@ -538,8 +666,10 @@ class TestFileLogger(TestLogger):
 
 class ConsoleLogger(TestLogger):
     ASCII_SPINNER = ['..', ':.', '.:']
-    SPINNER = ["\U0001f311", "\U0001f312", "\U0001f313", "\U0001f314",
-               "\U0001f315", "\U0001f316", "\U0001f317", "\U0001f318"]
+    SPINNER = [
+        "\U0001f311", "\U0001f312", "\U0001f313", "\U0001f314", "\U0001f315",
+        "\U0001f316", "\U0001f317", "\U0001f318"
+    ]
 
     SCISSORS = "\u2700 "
     HLINE = "\u2015"
@@ -602,8 +732,9 @@ class ConsoleLogger(TestLogger):
         if len(self.running_tests) == 1:
             count = f'{self.started_tests}/{self.test_count}'
         else:
-            count = '{}-{}/{}'.format(self.started_tests - len(self.running_tests) + 1,
-                                      self.started_tests, self.test_count)
+            count = '{}-{}/{}'.format(
+                self.started_tests - len(self.running_tests) + 1,
+                self.started_tests, self.test_count)
 
         left = '[{}] {} '.format(count, self.spinner[self.spinner_index])
         self.spinner_index = (self.spinner_index + 1) % len(self.spinner)
@@ -621,12 +752,15 @@ class ConsoleLogger(TestLogger):
         if details:
             right += '   ' + details
 
-        line = harness.format(self.progress_test, colorize=True,
+        line = harness.format(self.progress_test,
+                              colorize=True,
                               max_left_width=self.max_left_width,
-                              left=left, right=right)
+                              left=left,
+                              right=right)
         self.print_progress(line)
 
     def start(self, harness: 'TestHarness') -> None:
+
         async def report_progress() -> None:
             loop = asyncio.get_running_loop()
             next_update = 0.0
@@ -642,8 +776,8 @@ class ConsoleLogger(TestLogger):
                     next_update = loop.time() + 1
                     loop.call_at(next_update, self.request_update)
 
-                if (self.progress_test and
-                        self.progress_test.res is not TestResult.RUNNING):
+                if (self.progress_test
+                        and self.progress_test.res is not TestResult.RUNNING):
                     self.progress_test = None
 
                 if not self.progress_test:
@@ -668,9 +802,12 @@ class ConsoleLogger(TestLogger):
     def start_test(self, harness: 'TestHarness', test: 'TestRun') -> None:
         if test.verbose and test.cmdline:
             self.flush()
-            print(harness.format(test, mlog.colorize_console(),
-                                 max_left_width=self.max_left_width,
-                                 right=test.res.get_text(mlog.colorize_console())))
+            print(
+                harness.format(test,
+                               mlog.colorize_console(),
+                               max_left_width=self.max_left_width,
+                               right=test.res.get_text(
+                                   mlog.colorize_console())))
             print(test.res.get_command_marker() + test.cmdline)
             if test.direct_stdout:
                 print(self.output_start, flush=True)
@@ -695,7 +832,10 @@ class ConsoleLogger(TestLogger):
         if len(lines) < self.max_lines:
             return log
         else:
-            return str(mlog.bold(f'Listing only the last {self.max_lines} lines from a long log.\n')) + '\n'.join(lines[-self.max_lines:])
+            return str(
+                mlog.bold(
+                    f'Listing only the last {self.max_lines} lines from a long log.\n'
+                )) + '\n'.join(lines[-self.max_lines:])
 
     def print_log(self, harness: 'TestHarness', result: 'TestRun') -> None:
         if not result.verbose:
@@ -711,23 +851,32 @@ class ConsoleLogger(TestLogger):
             print_safe(log)
             print(self.output_end)
 
-    def log_subtest(self, harness: 'TestHarness', test: 'TestRun', s: str, result: TestResult, explanation: T.Optional[str]) -> None:
-        if test.verbose or (harness.options.print_errorlogs and result.is_bad()):
+    def log_subtest(self, harness: 'TestHarness', test: 'TestRun', s: str,
+                    result: TestResult, explanation: T.Optional[str]) -> None:
+        if test.verbose or (harness.options.print_errorlogs
+                            and result.is_bad()):
             self.flush()
-            print(harness.format(test, mlog.colorize_console(), max_left_width=self.max_left_width,
+            print(harness.format(test,
+                                 mlog.colorize_console(),
+                                 max_left_width=self.max_left_width,
                                  prefix=self.sub,
                                  middle=s,
-                                 right=result.get_text(mlog.colorize_console())), flush=True)
+                                 right=result.get_text(
+                                     mlog.colorize_console())),
+                  flush=True)
 
             if explanation is not None:
-                print(result.colorize(f"{' ' * len(self.sub)}Reason: {explanation}").get_text(mlog.colorize_console()))
+                print(
+                    result.colorize(
+                        f"{' ' * len(self.sub)}Reason: {explanation}").
+                    get_text(mlog.colorize_console()))
 
             self.request_update()
 
     def log(self, harness: 'TestHarness', result: 'TestRun') -> None:
         self.running_tests.remove(result)
-        if result.res is TestResult.TIMEOUT and (result.verbose or
-                                                 harness.options.print_errorlogs):
+        if result.res is TestResult.TIMEOUT and (
+                result.verbose or harness.options.print_errorlogs):
             self.flush()
             print(f'{result.name} time out (After {result.timeout} seconds)')
 
@@ -735,9 +884,14 @@ class ConsoleLogger(TestLogger):
             self.flush()
             if result.cmdline and result.direct_stdout:
                 print(self.output_end)
-                print(harness.format(result, mlog.colorize_console(), max_left_width=self.max_left_width))
+                print(
+                    harness.format(result,
+                                   mlog.colorize_console(),
+                                   max_left_width=self.max_left_width))
             else:
-                print(harness.format(result, mlog.colorize_console(), max_left_width=self.max_left_width),
+                print(harness.format(result,
+                                     mlog.colorize_console(),
+                                     max_left_width=self.max_left_width),
                       flush=True)
                 if result.verbose or harness.is_bad_result(result):
                     self.print_log(harness, result)
@@ -767,8 +921,11 @@ class ConsoleLogger(TestLogger):
 
 
 class TextLogfileBuilder(TestFileLogger):
+
     def start(self, harness: 'TestHarness') -> None:
-        self.file.write(f'Log of Meson test suite run on {datetime.datetime.now().isoformat()}\n\n')
+        self.file.write(
+            f'Log of Meson test suite run on {datetime.datetime.now().isoformat()}\n\n'
+        )
         inherit_env = env_tuple_to_str(os.environ.items())
         self.file.write(f'Inherited environment: {inherit_env}\n\n')
 
@@ -776,7 +933,8 @@ class TextLogfileBuilder(TestFileLogger):
         title = f'{result.num}/{harness.test_count}'
         self.file.write(dashes(title, '=', 78) + '\n')
         self.file.write('test:         ' + result.name + '\n')
-        starttime_str = time.strftime("%H:%M:%S", time.gmtime(result.starttime))
+        starttime_str = time.strftime("%H:%M:%S",
+                                      time.gmtime(result.starttime))
         self.file.write('start time:   ' + starttime_str + '\n')
         self.file.write('duration:     ' + '%.2fs' % result.duration + '\n')
         self.file.write('result:       ' + result.get_exit_status() + '\n')
@@ -802,6 +960,7 @@ class TextLogfileBuilder(TestFileLogger):
 
 
 class JsonLogfileBuilder(TestFileLogger):
+
     def log(self, harness: 'TestHarness', result: 'TestRun') -> None:
         jresult: T.Dict[str, T.Any] = {
             'name': result.name,
@@ -820,7 +979,6 @@ class JsonLogfileBuilder(TestFileLogger):
 
 
 class JunitBuilder(TestLogger):
-
     """Builder for Junit test results.
 
     Junit is impossible to stream out, it requires attributes counting the
@@ -838,8 +996,10 @@ class JunitBuilder(TestLogger):
 
     def __init__(self, filename: str) -> None:
         self.filename = filename
-        self.root = et.Element(
-            'testsuites', tests='0', errors='0', failures='0')
+        self.root = et.Element('testsuites',
+                               tests='0',
+                               errors='0',
+                               failures='0')
         self.suites: T.Dict[str, et.Element] = {}
 
     def log(self, harness: 'TestHarness', test: 'TestRun') -> None:
@@ -847,7 +1007,8 @@ class JunitBuilder(TestLogger):
         if test.junit is not None:
             for suite in test.junit.findall('.//testsuite'):
                 # Assume that we don't need to merge anything here...
-                suite.attrib['name'] = '{}.{}.{}'.format(test.project, test.name, suite.attrib['name'])
+                suite.attrib['name'] = '{}.{}.{}'.format(
+                    test.project, test.name, suite.attrib['name'])
 
                 # GTest can inject invalid attributes
                 for case in suite.findall('.//testcase[@result]'):
@@ -872,19 +1033,28 @@ class JunitBuilder(TestLogger):
                 'testsuite',
                 name=suitename,
                 tests=str(len(test.results)),
-                errors=str(sum(1 for r in test.results if r.result in
-                               {TestResult.INTERRUPT, TestResult.ERROR})),
-                failures=str(sum(1 for r in test.results if r.result in
-                                 {TestResult.FAIL, TestResult.UNEXPECTEDPASS, TestResult.TIMEOUT})),
-                skipped=str(sum(1 for r in test.results if r.result in
-                                {TestResult.SKIP, TestResult.IGNORED})),
+                errors=str(
+                    sum(1 for r in test.results if r.result in
+                        {TestResult.INTERRUPT, TestResult.ERROR})),
+                failures=str(
+                    sum(
+                        1 for r in test.results if r.result in {
+                            TestResult.FAIL, TestResult.UNEXPECTEDPASS,
+                            TestResult.TIMEOUT
+                        })),
+                skipped=str(
+                    sum(1 for r in test.results
+                        if r.result in {TestResult.SKIP, TestResult.IGNORED})),
                 time=str(test.duration),
             )
 
             for subtest in test.results:
                 # Both name and classname are required. Use the suite name as
                 # the class name, so that e.g. GitLab groups testcases correctly.
-                testcase = et.SubElement(suite, 'testcase', name=str(subtest), classname=suitename)
+                testcase = et.SubElement(suite,
+                                         'testcase',
+                                         name=str(subtest),
+                                         classname=suitename)
                 if subtest.result is TestResult.SKIP:
                     et.SubElement(testcase, 'skipped')
                 elif subtest.result is TestResult.IGNORED:
@@ -904,7 +1074,8 @@ class JunitBuilder(TestLogger):
                     fail = et.SubElement(testcase, 'error')
                     fail.text = 'Test did not finish before configured timeout.'
                 if subtest.explanation:
-                    et.SubElement(testcase, 'system-out').text = subtest.explanation
+                    et.SubElement(testcase,
+                                  'system-out').text = subtest.explanation
             if test.stdo:
                 out = et.SubElement(suite, 'system-out')
                 out.text = replace_unencodable_xml_chars(test.stdo.rstrip())
@@ -914,14 +1085,22 @@ class JunitBuilder(TestLogger):
         else:
             if test.project not in self.suites:
                 suite = self.suites[test.project] = et.Element(
-                    'testsuite', name=test.project, tests='1', errors='0',
-                    failures='0', skipped='0', time=str(test.duration))
+                    'testsuite',
+                    name=test.project,
+                    tests='1',
+                    errors='0',
+                    failures='0',
+                    skipped='0',
+                    time=str(test.duration))
             else:
                 suite = self.suites[test.project]
                 suite.attrib['tests'] = str(int(suite.attrib['tests']) + 1)
 
-            testcase = et.SubElement(suite, 'testcase', name=test.name,
-                                     classname=test.project, time=str(test.duration))
+            testcase = et.SubElement(suite,
+                                     'testcase',
+                                     name=test.name,
+                                     classname=test.project,
+                                     time=str(test.duration))
             if test.res is TestResult.SKIP:
                 et.SubElement(testcase, 'skipped')
                 suite.attrib['skipped'] = str(int(suite.attrib['skipped']) + 1)
@@ -934,11 +1113,13 @@ class JunitBuilder(TestLogger):
                 suite.attrib['errors'] = str(int(suite.attrib['errors']) + 1)
             elif test.res is TestResult.FAIL:
                 et.SubElement(testcase, 'failure')
-                suite.attrib['failures'] = str(int(suite.attrib['failures']) + 1)
+                suite.attrib['failures'] = str(
+                    int(suite.attrib['failures']) + 1)
             elif test.res is TestResult.UNEXPECTEDPASS:
                 fail = et.SubElement(testcase, 'failure')
                 fail.text = 'Test unexpectedly passed.'
-                suite.attrib['failures'] = str(int(suite.attrib['failures']) + 1)
+                suite.attrib['failures'] = str(
+                    int(suite.attrib['failures']) + 1)
             elif test.res is TestResult.INTERRUPT:
                 fail = et.SubElement(testcase, 'error')
                 fail.text = 'Test was interrupted by user.'
@@ -960,7 +1141,8 @@ class JunitBuilder(TestLogger):
             self.root.append(suite)
             # Skipped is really not allowed in the "testsuits" element
             for attr in ['tests', 'errors', 'failures']:
-                self.root.attrib[attr] = str(int(self.root.attrib[attr]) + int(suite.attrib[attr]))
+                self.root.attrib[attr] = str(
+                    int(self.root.attrib[attr]) + int(suite.attrib[attr]))
 
         tree = et.ElementTree(self.root)
         with open(self.filename, 'wb') as f:
@@ -971,12 +1153,13 @@ class TestRun:
     TEST_NUM = 0
     PROTOCOL_TO_CLASS: T.Dict[TestProtocol, T.Type['TestRun']] = {}
 
-    def __new__(cls, test: TestSerialisation, *args: T.Any, **kwargs: T.Any) -> T.Any:
+    def __new__(cls, test: TestSerialisation, *args: T.Any,
+                **kwargs: T.Any) -> T.Any:
         return super().__new__(TestRun.PROTOCOL_TO_CLASS[test.protocol])
 
     def __init__(self, test: TestSerialisation, test_env: T.Dict[str, str],
-                 name: str, timeout: T.Optional[int], is_parallel: bool, verbose: bool,
-                 interactive: bool):
+                 name: str, timeout: T.Optional[int], is_parallel: bool,
+                 verbose: bool, interactive: bool):
         self.res = TestResult.PENDING
         self.test = test
         self._num: T.Optional[int] = None
@@ -1029,7 +1212,8 @@ class TestRun:
         if self.results:
             # running or succeeded
             passed = sum(x.result.is_ok() for x in self.results)
-            ran = sum(x.result not in {TestResult.SKIP, TestResult.IGNORED} for x in self.results)
+            ran = sum(x.result not in {TestResult.SKIP, TestResult.IGNORED}
+                      for x in self.results)
             if passed == ran:
                 return f'{passed} subtests passed'
             else:
@@ -1077,7 +1261,9 @@ class TestRun:
     def complete(self) -> None:
         self._complete()
 
-    def get_log(self, colorize: bool = False, stderr_only: bool = False) -> str:
+    def get_log(self,
+                colorize: bool = False,
+                stderr_only: bool = False) -> str:
         stdo = '' if stderr_only else self.stdo
         if self.stde or self.additional_error:
             res = ''
@@ -1098,7 +1284,8 @@ class TestRun:
     def needs_parsing(self) -> bool:
         return False
 
-    async def parse(self, harness: 'TestHarness', lines: T.AsyncIterator[str]) -> None:
+    async def parse(self, harness: 'TestHarness',
+                    lines: T.AsyncIterator[str]) -> None:
         async for l in lines:
             pass
 
@@ -1118,10 +1305,12 @@ class TestRunExitCode(TestRun):
             self.res = TestResult.FAIL
         super().complete()
 
+
 TestRun.PROTOCOL_TO_CLASS[TestProtocol.EXITCODE] = TestRunExitCode
 
 
 class TestRunGTest(TestRunExitCode):
+
     def complete(self) -> None:
         filename = f'{self.test.name}.xml'
         if self.test.workdir:
@@ -1141,10 +1330,12 @@ class TestRunGTest(TestRunExitCode):
 
         super().complete()
 
+
 TestRun.PROTOCOL_TO_CLASS[TestProtocol.GTEST] = TestRunGTest
 
 
 class TestRunTAP(TestRun):
+
     @property
     def needs_parsing(self) -> bool:
         return True
@@ -1156,7 +1347,8 @@ class TestRunTAP(TestRun):
             self.stde += f'\n(test program exited with status code {self.returncode})'
         super().complete()
 
-    async def parse(self, harness: 'TestHarness', lines: T.AsyncIterator[str]) -> None:
+    async def parse(self, harness: 'TestHarness',
+                    lines: T.AsyncIterator[str]) -> None:
         res = None
         warnings: T.List[TAPParser.UnknownLine] = []
         version = 12
@@ -1171,7 +1363,8 @@ class TestRunTAP(TestRun):
                 self.results.append(i)
                 if i.result.is_bad():
                     res = TestResult.FAIL
-                harness.log_subtest(self, i.name or f'subtest {i.number}', i.result, i.explanation)
+                harness.log_subtest(self, i.name or f'subtest {i.number}',
+                                    i.result, i.explanation)
             elif isinstance(i, TAPParser.UnknownLine):
                 warnings.append(i)
             elif isinstance(i, TAPParser.Error):
@@ -1182,13 +1375,19 @@ class TestRunTAP(TestRun):
             unknown = str(mlog.yellow('UNKNOWN'))
             width = len(str(max(i.lineno for i in warnings)))
             for w in warnings:
-                self.warnings.append(f'stdout: {w.lineno:{width}}: {unknown}: {w.message}')
+                self.warnings.append(
+                    f'stdout: {w.lineno:{width}}: {unknown}: {w.message}')
             if version > 13:
-                self.warnings.append('Unknown TAP output lines have been ignored. Please open a feature request to\n'
-                                     'implement them, or prefix them with a # if they are not TAP syntax.')
+                self.warnings.append(
+                    'Unknown TAP output lines have been ignored. Please open a feature request to\n'
+                    'implement them, or prefix them with a # if they are not TAP syntax.'
+                )
             else:
-                self.warnings.append(str(mlog.red('ERROR')) + ': Unknown TAP output lines for a supported TAP version.\n'
-                                     'This is probably a bug in the test; if they are not TAP syntax, prefix them with a #')
+                self.warnings.append(
+                    str(mlog.red('ERROR')) +
+                    ': Unknown TAP output lines for a supported TAP version.\n'
+                    'This is probably a bug in the test; if they are not TAP syntax, prefix them with a #'
+                )
         if all(t.result is TestResult.SKIP for t in self.results):
             # This includes the case where self.results is empty
             if res != TestResult.ERROR:
@@ -1197,15 +1396,19 @@ class TestRunTAP(TestRun):
         if res and self.res == TestResult.RUNNING:
             self.res = res
 
+
 TestRun.PROTOCOL_TO_CLASS[TestProtocol.TAP] = TestRunTAP
 
 
 class TestRunRust(TestRun):
+
     @property
     def needs_parsing(self) -> bool:
         return True
 
-    async def parse(self, harness: 'TestHarness', lines: T.AsyncIterator[str]) -> None:
+    async def parse(self, harness: 'TestHarness',
+                    lines: T.AsyncIterator[str]) -> None:
+
         def parse_res(n: int, name: str, result: str) -> TAPParser.Test:
             if result == 'ok':
                 return TAPParser.Test(n, name, TestResult.OK, None)
@@ -1213,8 +1416,9 @@ class TestRunRust(TestRun):
                 return TAPParser.Test(n, name, TestResult.SKIP, None)
             elif result == 'FAILED':
                 return TAPParser.Test(n, name, TestResult.FAIL, None)
-            return TAPParser.Test(n, name, TestResult.ERROR,
-                                  f'Unsupported output from rust test: {result}')
+            return TAPParser.Test(
+                n, name, TestResult.ERROR,
+                f'Unsupported output from rust test: {result}')
 
         n = 1
         async for line in lines:
@@ -1223,7 +1427,8 @@ class TestRunRust(TestRun):
                 name, result = match.groups()
                 doctest = RUST_DOCTEST_RE.match(name)
                 if doctest:
-                    name = ':'.join((x.rstrip() for x in doctest.groups() if x))
+                    name = ':'.join(
+                        (x.rstrip() for x in doctest.groups() if x))
                 else:
                     name = name.rstrip()
                 name = name.replace('::', '.')
@@ -1245,7 +1450,9 @@ class TestRunRust(TestRun):
         if res and self.res == TestResult.RUNNING:
             self.res = res
 
+
 TestRun.PROTOCOL_TO_CLASS[TestProtocol.RUST] = TestRunRust
+
 
 # Check unencodable characters in xml output and replace them with
 # their printable representation
@@ -1255,6 +1462,7 @@ def replace_unencodable_xml_chars(original_str: str) -> str:
     replacement_lambda = lambda illegal_chr: repr(illegal_chr.group())[1:-1]
     return UNENCODABLE_XML_CHRS_RE.sub(replacement_lambda, original_str)
 
+
 def decode(stream: T.Union[None, bytes]) -> str:
     if stream is None:
         return ''
@@ -1262,6 +1470,7 @@ def decode(stream: T.Union[None, bytes]) -> str:
         return stream.decode('utf-8')
     except UnicodeDecodeError:
         return stream.decode('iso-8859-1', errors='ignore')
+
 
 async def read_decode(reader: asyncio.StreamReader,
                       queue: T.Optional['asyncio.Queue[T.Optional[str]]'],
@@ -1290,10 +1499,14 @@ async def read_decode(reader: asyncio.StreamReader,
         if queue:
             await queue.put(None)
 
-def run_with_mono(fname: str) -> bool:
-    return fname.endswith('.exe') and not (is_windows() or is_cygwin() or is_os2())
 
-def check_testdata(objs: T.List[TestSerialisation]) -> T.List[TestSerialisation]:
+def run_with_mono(fname: str) -> bool:
+    return fname.endswith('.exe') and not (is_windows() or is_cygwin()
+                                           or is_os2())
+
+
+def check_testdata(
+        objs: T.List[TestSerialisation]) -> T.List[TestSerialisation]:
     if not isinstance(objs, list):
         raise MesonVersionMismatchException('<unknown>', coredata_version)
     for obj in objs:
@@ -1305,15 +1518,19 @@ def check_testdata(objs: T.List[TestSerialisation]) -> T.List[TestSerialisation]
             raise MesonVersionMismatchException(obj.version, coredata_version)
     return objs
 
+
 # Custom waiting primitives for asyncio
 
-async def queue_iter(q: 'asyncio.Queue[T.Optional[str]]') -> T.AsyncIterator[str]:
+
+async def queue_iter(
+        q: 'asyncio.Queue[T.Optional[str]]') -> T.AsyncIterator[str]:
     while True:
         item = await q.get()
         q.task_done()
         if item is None:
             break
         yield item
+
 
 async def complete(future: asyncio.Future) -> None:
     """Wait for completion of the given future, ignoring cancellation."""
@@ -1322,8 +1539,10 @@ async def complete(future: asyncio.Future) -> None:
     except asyncio.CancelledError:
         pass
 
-async def complete_all(futures: T.Iterable[asyncio.Future],
-                       timeout: T.Optional[T.Union[int, float]] = None) -> None:
+
+async def complete_all(
+        futures: T.Iterable[asyncio.Future],
+        timeout: T.Optional[T.Union[int, float]] = None) -> None:
     """Wait for completion of all the given futures, ignoring cancellation.
        If timeout is not None, raise an asyncio.TimeoutError after the given
        time has passed.  asyncio.TimeoutError is only raised if some futures
@@ -1346,7 +1565,8 @@ async def complete_all(futures: T.Iterable[asyncio.Future],
     loop = asyncio.get_running_loop()
     deadline = None if timeout is None else loop.time() + timeout
     while futures and (timeout is None or timeout > 0):
-        done, futures = await asyncio.wait(futures, timeout=timeout,
+        done, futures = await asyncio.wait(futures,
+                                           timeout=timeout,
                                            return_when=asyncio.FIRST_EXCEPTION)
         check_futures(done)
         if deadline:
@@ -1356,8 +1576,11 @@ async def complete_all(futures: T.Iterable[asyncio.Future],
 
 
 class TestSubprocess:
-    def __init__(self, p: asyncio.subprocess.Process,
-                 stdout: T.Optional[int], stderr: T.Optional[int],
+
+    def __init__(self,
+                 p: asyncio.subprocess.Process,
+                 stdout: T.Optional[int],
+                 stderr: T.Optional[int],
                  postwait_fn: T.Callable[[], None] = None):
         self._process = p
         self.stdout = stdout
@@ -1372,28 +1595,28 @@ class TestSubprocess:
         self.queue = asyncio.Queue()
         return queue_iter(self.queue)
 
-    def communicate(self,
-                    test: 'TestRun',
-                    console_mode: ConsoleUser) -> T.Tuple[T.Optional[T.Awaitable[str]],
-                                                          T.Optional[T.Awaitable[str]]]:
-        async def collect_stdo(test: 'TestRun',
-                               reader: asyncio.StreamReader,
+    def communicate(
+        self, test: 'TestRun', console_mode: ConsoleUser
+    ) -> T.Tuple[T.Optional[T.Awaitable[str]], T.Optional[T.Awaitable[str]]]:
+
+        async def collect_stdo(test: 'TestRun', reader: asyncio.StreamReader,
                                console_mode: ConsoleUser) -> None:
             test.stdo = await read_decode(reader, self.queue, console_mode)
 
-        async def collect_stde(test: 'TestRun',
-                               reader: asyncio.StreamReader,
+        async def collect_stde(test: 'TestRun', reader: asyncio.StreamReader,
                                console_mode: ConsoleUser) -> None:
             test.stde = await read_decode(reader, None, console_mode)
 
         # asyncio.ensure_future ensures that printing can
         # run in the background, even before it is awaited
         if self.stdo_task is None and self.stdout is not None:
-            decode_coro = collect_stdo(test, self._process.stdout, console_mode)
+            decode_coro = collect_stdo(test, self._process.stdout,
+                                       console_mode)
             self.stdo_task = asyncio.ensure_future(decode_coro)
             self.all_futures.append(self.stdo_task)
         if self.stderr is not None and self.stderr != asyncio.subprocess.STDOUT:
-            decode_coro = collect_stde(test, self._process.stderr, console_mode)
+            decode_coro = collect_stde(test, self._process.stderr,
+                                       console_mode)
             self.stde_task = asyncio.ensure_future(decode_coro)
             self.all_futures.append(self.stde_task)
 
@@ -1466,25 +1689,25 @@ class TestSubprocess:
 
         test.returncode = p.returncode or 0
 
+
 class SingleTestRunner:
 
-    def __init__(self, test: TestSerialisation, env: T.Dict[str, str], name: str,
-                 options: argparse.Namespace):
+    def __init__(self, test: TestSerialisation, env: T.Dict[str, str],
+                 name: str, options: argparse.Namespace):
         self.test = test
         self.options = options
         self.cmd = self._get_cmd()
 
         if self.cmd and self.test.extra_paths:
-            env['PATH'] = os.pathsep.join(self.test.extra_paths + ['']) + env['PATH']
+            env['PATH'] = os.pathsep.join(self.test.extra_paths +
+                                          ['']) + env['PATH']
             winecmd = []
             for c in self.cmd:
                 winecmd.append(c)
                 if os.path.basename(c).startswith('wine'):
                     env['WINEPATH'] = get_wine_shortpath(
-                        winecmd,
-                        ['Z:' + p for p in self.test.extra_paths] + env.get('WINEPATH', '').split(';'),
-                        self.test.workdir
-                    )
+                        winecmd, ['Z:' + p for p in self.test.extra_paths] +
+                        env.get('WINEPATH', '').split(';'), self.test.workdir)
                     break
 
         # If MALLOC_PERTURB_ is not set, or if it is set to an empty value,
@@ -1492,7 +1715,8 @@ class SingleTestRunner:
         # it ourselves. We do this unconditionally for regular tests
         # because it is extremely useful to have.
         # Setting MALLOC_PERTURB_="0" will completely disable this feature.
-        if ('MALLOC_PERTURB_' not in env or not env['MALLOC_PERTURB_']) and not options.benchmark:
+        if ('MALLOC_PERTURB_' not in env
+                or not env['MALLOC_PERTURB_']) and not options.benchmark:
             env['MALLOC_PERTURB_'] = str(random.randint(1, 255))
 
         # Sanitizers do not default to aborting on error. This is counter to
@@ -1525,8 +1749,10 @@ class SingleTestRunner:
             timeout = self.test.timeout * self.options.timeout_multiplier
 
         is_parallel = test.is_parallel and self.options.num_processes > 1 and not self.options.interactive
-        verbose = (test.verbose or self.options.verbose) and not self.options.quiet
-        self.runobj = TestRun(test, env, name, timeout, is_parallel, verbose, self.options.interactive)
+        verbose = (test.verbose
+                   or self.options.verbose) and not self.options.quiet
+        self.runobj = TestRun(test, env, name, timeout, is_parallel, verbose,
+                              self.options.interactive)
 
     @property
     def console_mode(self) -> ConsoleUser:
@@ -1534,8 +1760,11 @@ class SingleTestRunner:
 
     def _get_test_cmd(self) -> T.Optional[T.List[str]]:
         testentry = self.test.fname[0]
-        if self.options.no_rebuild and self.test.cmd_is_built and not os.path.isfile(testentry):
-            raise TestException(f'The test program {testentry!r} does not exist. Cannot run tests before building them.')
+        if self.options.no_rebuild and self.test.cmd_is_built and not os.path.isfile(
+                testentry):
+            raise TestException(
+                f'The test program {testentry!r} does not exist. Cannot run tests before building them.'
+            )
         if testentry.endswith('.jar'):
             return ['java', '-jar'] + self.test.fname
         elif not self.test.is_cross_built and run_with_mono(testentry):
@@ -1549,11 +1778,14 @@ class SingleTestRunner:
                 # If the command is not built (ie, its a python script),
                 # then we don't check for the exe-wrapper
                 if not self.test.exe_wrapper.found():
-                    msg = ('The exe_wrapper defined in the cross file {!r} was not '
-                           'found. Please check the command and/or add it to PATH.')
+                    msg = (
+                        'The exe_wrapper defined in the cross file {!r} was not '
+                        'found. Please check the command and/or add it to PATH.'
+                    )
                     raise TestException(msg.format(self.test.exe_wrapper.name))
                 return self.test.exe_wrapper.get_command() + self.test.fname
-        elif self.test.cmd_is_built and not self.test.cmd_is_exe and is_windows():
+        elif self.test.cmd_is_built and not self.test.cmd_is_exe and is_windows(
+        ):
             test_cmd = ExternalProgram._shebang_to_cmd(self.test.fname[0])
             if test_cmd is not None:
                 test_cmd += self.test.fname[1:]
@@ -1590,9 +1822,10 @@ class SingleTestRunner:
             await self._run_cmd(harness, cmd)
         return self.runobj
 
-    async def _run_subprocess(self, args: T.List[str], *, stdin: T.Optional[int],
-                              stdout: T.Optional[int], stderr: T.Optional[int],
-                              env: T.Dict[str, str], cwd: T.Optional[str]) -> TestSubprocess:
+    async def _run_subprocess(self, args: T.List[str], *,
+                              stdin: T.Optional[int], stdout: T.Optional[int],
+                              stderr: T.Optional[int], env: T.Dict[str, str],
+                              cwd: T.Optional[str]) -> TestSubprocess:
         # Let gdb handle ^C instead of us
         if self.options.interactive:
             previous_sigint_handler = signal.getsignal(signal.SIGINT)
@@ -1615,15 +1848,19 @@ class SingleTestRunner:
                 # Let us accept ^C again
                 signal.signal(signal.SIGINT, previous_sigint_handler)
 
-        p = await asyncio.create_subprocess_exec(*args,
-                                                 stdin=stdin,
-                                                 stdout=stdout,
-                                                 stderr=stderr,
-                                                 env=env,
-                                                 cwd=cwd,
-                                                 preexec_fn=preexec_fn if not (is_windows() or is_os2()) else None)
-        return TestSubprocess(p, stdout=stdout, stderr=stderr,
-                              postwait_fn=postwait_fn if not is_windows() else None)
+        p = await asyncio.create_subprocess_exec(
+            *args,
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+            env=env,
+            cwd=cwd,
+            preexec_fn=preexec_fn if not (is_windows() or is_os2()) else None)
+        return TestSubprocess(
+            p,
+            stdout=stdout,
+            stderr=stderr,
+            postwait_fn=postwait_fn if not is_windows() else None)
 
     async def _run_cmd(self, harness: 'TestHarness', cmd: T.List[str]) -> None:
         if self.console_mode is ConsoleUser.INTERACTIVE:
@@ -1671,6 +1908,7 @@ class SingleTestRunner:
 
 
 class TestHarness:
+
     def __init__(self, options: argparse.Namespace):
         self.options = options
         self.collected_failures: T.List[TestRun] = []
@@ -1694,7 +1932,8 @@ class TestHarness:
         self.logfile_base: T.Optional[str] = None
         if self.options.logbase and not self.options.interactive:
             namebase = None
-            self.logfile_base = os.path.join(self.options.wd, 'meson-logs', self.options.logbase)
+            self.logfile_base = os.path.join(self.options.wd, 'meson-logs',
+                                             self.options.logbase)
 
             if self.options.wrapper:
                 namebase = os.path.basename(self.get_wrapper(self.options)[0])
@@ -1740,12 +1979,15 @@ class TestHarness:
             # happen before rebuild_deps(), because we need the correct list of
             # tests and their dependencies to compute
             if not self.options.no_rebuild:
-                teststdo = subprocess.run(self.ninja + ['-n', 'build.ninja'], capture_output=True).stdout
+                teststdo = subprocess.run(self.ninja + ['-n', 'build.ninja'],
+                                          capture_output=True).stdout
                 if b'ninja: no work to do.' not in teststdo and b'samu: nothing to do' not in teststdo:
                     stdo = sys.stderr if self.options.list else sys.stdout
-                    ret = subprocess.run(self.ninja + ['build.ninja'], stdout=stdo.fileno())
+                    ret = subprocess.run(self.ninja + ['build.ninja'],
+                                         stdout=stdo.fileno())
                     if ret.returncode != 0:
-                        raise TestException(f'Could not configure {self.options.wd!r}')
+                        raise TestException(
+                            f'Could not configure {self.options.wd!r}')
 
             self.build_data = build.load(os.getcwd())
             if not self.options.setup:
@@ -1760,7 +2002,9 @@ class TestHarness:
     def load_tests(self, file_name: str) -> T.List[TestSerialisation]:
         datafile = Path('meson-private') / file_name
         if not datafile.is_file():
-            raise TestException(f'Directory {self.options.wd!r} does not seem to be a Meson build directory.')
+            raise TestException(
+                f'Directory {self.options.wd!r} does not seem to be a Meson build directory.'
+            )
         with datafile.open('rb') as f:
             objs = check_testdata(pickle.load(f))
         return objs
@@ -1768,7 +2012,8 @@ class TestHarness:
     def __enter__(self) -> 'TestHarness':
         return self
 
-    def __exit__(self, exc_type: T.Any, exc_value: T.Any, traceback: T.Any) -> None:
+    def __exit__(self, exc_type: T.Any, exc_value: T.Any,
+                 traceback: T.Any) -> None:
         self.close_logfiles()
 
     def close_logfiles(self) -> None:
@@ -1776,7 +2021,8 @@ class TestHarness:
             l.close()
         self.console_logger = None
 
-    def get_test_setup(self, test: T.Optional[TestSerialisation]) -> build.TestSetup:
+    def get_test_setup(self,
+                       test: T.Optional[TestSerialisation]) -> build.TestSetup:
         if ':' in self.options.setup:
             if self.options.setup not in self.build_data.test_setups:
                 sys.exit(f"Unknown test setup '{self.options.setup}'.")
@@ -1784,10 +2030,13 @@ class TestHarness:
         else:
             full_name = test.project_name + ":" + self.options.setup
             if full_name not in self.build_data.test_setups:
-                sys.exit(f"Test setup '{self.options.setup}' not found from project '{test.project_name}'.")
+                sys.exit(
+                    f"Test setup '{self.options.setup}' not found from project '{test.project_name}'."
+                )
             return self.build_data.test_setups[full_name]
 
-    def merge_setup_options(self, options: argparse.Namespace, test: TestSerialisation) -> T.Dict[str, str]:
+    def merge_setup_options(self, options: argparse.Namespace,
+                            test: TestSerialisation) -> T.Dict[str, str]:
         current = self.get_test_setup(test)
         if not options.gdb:
             options.gdb = current.gdb
@@ -1796,15 +2045,19 @@ class TestHarness:
             options.verbose = True
         if options.timeout_multiplier is None:
             options.timeout_multiplier = current.timeout_multiplier
+
     #    if options.env is None:
     #        options.env = current.env # FIXME, should probably merge options here.
         if options.wrapper is None:
             options.wrapper = current.exe_wrapper
         elif current.exe_wrapper:
-            sys.exit('Conflict: both test setup and command line specify an exe wrapper.')
+            sys.exit(
+                'Conflict: both test setup and command line specify an exe wrapper.'
+            )
         return current.env.get_env(os.environ.copy())
 
-    def get_test_runner(self, test: TestSerialisation, iteration: int) -> SingleTestRunner:
+    def get_test_runner(self, test: TestSerialisation,
+                        iteration: int) -> SingleTestRunner:
         name = self.get_pretty_suite(test)
         options = deepcopy(self.options)
         if self.options.setup:
@@ -1813,9 +2066,10 @@ class TestHarness:
             env = os.environ.copy()
         test_env = test.env.get_env(env)
         env.update(test_env)
-        if (test.is_cross_built and test.needs_exe_wrapper and
-                test.exe_wrapper and test.exe_wrapper.found()):
-            env['MESON_EXE_WRAPPER'] = join_args(test.exe_wrapper.get_command())
+        if (test.is_cross_built and test.needs_exe_wrapper and test.exe_wrapper
+                and test.exe_wrapper.found()):
+            env['MESON_EXE_WRAPPER'] = join_args(
+                test.exe_wrapper.get_command())
         env['MESON_TEST_ITERATION'] = str(iteration + 1)
         return SingleTestRunner(test, env, name, options)
 
@@ -1828,7 +2082,9 @@ class TestHarness:
             self.ignored_count += 1
         elif result.res is TestResult.OK:
             self.success_count += 1
-        elif result.res in {TestResult.FAIL, TestResult.ERROR, TestResult.INTERRUPT}:
+        elif result.res in {
+                TestResult.FAIL, TestResult.ERROR, TestResult.INTERRUPT
+        }:
             self.fail_count += 1
         elif result.res is TestResult.EXPECTEDFAIL:
             self.expectedfail_count += 1
@@ -1843,7 +2099,8 @@ class TestHarness:
             l.log(self, result)
 
     def is_bad_result(self, result: TestRun) -> bool:
-        return result.res.is_bad() and not (result.res is TestResult.INTERRUPT and self.maxfail_reached)
+        return result.res.is_bad() and not (result.res is TestResult.INTERRUPT
+                                            and self.maxfail_reached)
 
     @property
     def numlen(self) -> int:
@@ -1858,7 +2115,9 @@ class TestHarness:
                                                     num=num,
                                                     testcount=self.test_count)
 
-    def format(self, result: TestRun, colorize: bool,
+    def format(self,
+               result: TestRun,
+               colorize: bool,
                max_left_width: int = 0,
                prefix: str = '',
                left: T.Optional[str] = None,
@@ -1873,7 +2132,8 @@ class TestHarness:
 
         if middle is None:
             middle = result.name
-        extra_mid_width = max_left_width + self.name_max_len + 1 - uniwidth(middle) - uniwidth(left) - uniwidth(prefix)
+        extra_mid_width = max_left_width + self.name_max_len + 1 - uniwidth(
+            middle) - uniwidth(left) - uniwidth(prefix)
         middle += ' ' * max(1, extra_mid_width)
 
         if right is None:
@@ -1888,18 +2148,19 @@ class TestHarness:
 
     def summary(self) -> str:
         results = {
-          'Ok:                ': self.success_count,
-          'Expected Fail:     ': self.expectedfail_count,
-          'Fail:              ': self.fail_count,
-          'Unexpected Pass:   ': self.unexpectedpass_count,
-          'Skipped:           ': self.skip_count,
-          'Ignored:           ': self.ignored_count,
-          'Timeout:           ': self.timeout_count,
+            'Ok:                ': self.success_count,
+            'Expected Fail:     ': self.expectedfail_count,
+            'Fail:              ': self.fail_count,
+            'Unexpected Pass:   ': self.unexpectedpass_count,
+            'Skipped:           ': self.skip_count,
+            'Ignored:           ': self.ignored_count,
+            'Timeout:           ': self.timeout_count,
         }
 
         summary = []
         for result, count in results.items():
-            if count > 0 or result.startswith('Ok:') or result.startswith('Fail:'):
+            if count > 0 or result.startswith('Ok:') or result.startswith(
+                    'Fail:'):
                 summary.append(result + '{:<4}'.format(count))
 
         return '\n{}\n'.format('\n'.join(summary))
@@ -1920,7 +2181,9 @@ class TestHarness:
         rebuild_only_tests = tests if tests != self.tests else []
         if not tests:
             return 0
-        if not self.options.no_rebuild and not rebuild_deps(self.ninja, self.options.wd, rebuild_only_tests, self.options.benchmark):
+        if not self.options.no_rebuild and not rebuild_deps(
+                self.ninja, self.options.wd, rebuild_only_tests,
+                self.options.benchmark):
             # We return 125 here in case the build failed.
             # The reason is that exit code 125 tells `git bisect run` that the current
             # commit should be skipped.  Thus users can directly use `meson test` to
@@ -1928,7 +2191,8 @@ class TestHarness:
             # wrapper script.
             sys.exit(125)
 
-        self.name_max_len = max(uniwidth(self.get_pretty_suite(test)) for test in tests)
+        self.name_max_len = max(
+            uniwidth(self.get_pretty_suite(test)) for test in tests)
         self.options.num_processes = min(self.options.num_processes,
                                          len(tests) * self.options.repeat)
         startdir = os.getcwd()
@@ -1938,11 +2202,13 @@ class TestHarness:
             for i in range(self.options.repeat):
                 runners.extend(self.get_test_runner(test, i) for test in tests)
                 if i == 0:
-                    self.duration_max_len = max(len(str(int(runner.timeout or 99)))
-                                                for runner in runners)
+                    self.duration_max_len = max(
+                        len(str(int(runner.timeout or 99)))
+                        for runner in runners)
                     # Disable the progress report if it gets in the way
-                    self.need_console = any(runner.console_mode is not ConsoleUser.LOGGER
-                                            for runner in runners)
+                    self.need_console = any(
+                        runner.console_mode is not ConsoleUser.LOGGER
+                        for runner in runners)
 
             self.test_count = len(runners)
             self.run_tests(runners)
@@ -1984,7 +2250,8 @@ class TestHarness:
                         return True
         return False
 
-    def test_suitable(self, test: TestSerialisation, excluded_tests: set[str]) -> bool:
+    def test_suitable(self, test: TestSerialisation,
+                      excluded_tests: set[str]) -> bool:
         if TestHarness.test_in_suites(test, self.options.exclude_suites):
             return False
 
@@ -1999,7 +2266,8 @@ class TestHarness:
         if self.options.include_suites:
             # Both force inclusion (overriding add_test_setup) and exclude
             # everything else
-            return TestHarness.test_in_suites(test, self.options.include_suites)
+            return TestHarness.test_in_suites(test,
+                                              self.options.include_suites)
 
         if self.options.setup:
             setup = self.get_test_setup(test)
@@ -2008,7 +2276,9 @@ class TestHarness:
 
         return True
 
-    def tests_from_args(self, tests: T.List[TestSerialisation]) -> T.Generator[TestSerialisation, None, None]:
+    def tests_from_args(
+        self, tests: T.List[TestSerialisation]
+    ) -> T.Generator[TestSerialisation, None, None]:
         '''
         Allow specifying test names like "meson test foo1 foo2", where test('foo1', ...)
 
@@ -2052,29 +2322,38 @@ class TestHarness:
                     # ... if it matches a test, then it wasn't used because another
                     # pattern matched the same test before.
                     # Report it as a warning.
-                    if fnmatch(t.project_name, subproj) and fnmatch(t.name, name):
-                        mlog.warning(f'{arg} test name is redundant and was not used')
+                    if fnmatch(t.project_name, subproj) and fnmatch(
+                            t.name, name):
+                        mlog.warning(
+                            f'{arg} test name is redundant and was not used')
                         break
                 else:
                     # If the pattern doesn't match any test,
                     # report it as an error. We don't want the `test` command to
                     # succeed on an invalid pattern.
-                    raise MesonException(f'{arg} test name does not match any test')
+                    raise MesonException(
+                        f'{arg} test name does not match any test')
 
-    def get_tests(self, errorfile: T.Optional[T.IO] = None) -> T.List[TestSerialisation]:
+    def get_tests(
+            self,
+            errorfile: T.Optional[T.IO] = None) -> T.List[TestSerialisation]:
         if not self.tests:
             print('No tests defined.', file=errorfile)
             return []
 
         excluded_tests = set(self.options.exclude)
-        tests = [t for t in self.tests if self.test_suitable(t, excluded_tests)]
+        tests = [
+            t for t in self.tests if self.test_suitable(t, excluded_tests)
+        ]
 
         if self.options.args:
             tests = list(self.tests_from_args(tests))
         if self.options.slice:
             our_slice, nslices = self.options.slice
             if nslices > len(tests):
-                raise MesonException(f'number of slices ({nslices}) exceeds number of tests ({len(tests)})')
+                raise MesonException(
+                    f'number of slices ({nslices}) exceeds number of tests ({len(tests)})'
+                )
             tests = tests[our_slice - 1::nslices]
 
         if not tests:
@@ -2093,7 +2372,9 @@ class TestHarness:
 
         self.loggers.append(JunitBuilder(self.logfile_base + '.junit.xml'))
         self.loggers.append(JsonLogfileBuilder(self.logfile_base + '.json'))
-        self.loggers.append(TextLogfileBuilder(self.logfile_base + '.txt', errors='surrogateescape'))
+        self.loggers.append(
+            TextLogfileBuilder(self.logfile_base + '.txt',
+                               errors='surrogateescape'))
 
     @staticmethod
     def get_wrapper(options: argparse.Namespace) -> T.List[str]:
@@ -2129,13 +2410,15 @@ class TestHarness:
 
             # TODO: this is the default for python 3.8
             if sys.platform == 'win32' and sys.version_info < (3, 8):
-                asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+                asyncio.set_event_loop_policy(
+                    asyncio.WindowsProactorEventLoopPolicy())
 
             asyncio.run(self._run_tests(runners))
         finally:
             self.close_logfiles()
 
-    def log_subtest(self, test: TestRun, s: str, res: TestResult, explanation: T.Optional[str]) -> None:
+    def log_subtest(self, test: TestRun, s: str, res: TestResult,
+                    explanation: T.Optional[str]) -> None:
         for l in self.loggers:
             l.log_subtest(self, test, s, res, explanation)
 
@@ -2153,7 +2436,8 @@ class TestHarness:
 
         async def run_test(test: SingleTestRunner) -> None:
             async with semaphore:
-                if interrupted or (self.options.repeat > 1 and self.fail_count):
+                if interrupted or (self.options.repeat > 1
+                                   and self.fail_count):
                     return
                 res = await test.run(self)
                 self.process_test_result(res)
@@ -2176,7 +2460,8 @@ class TestHarness:
             futures.append(future)
             if warn:
                 self.flush_logfiles()
-                mlog.warning('CTRL-C detected, interrupting {}'.format(running_tests[future]))
+                mlog.warning('CTRL-C detected, interrupting {}'.format(
+                    running_tests[future]))
             del running_tests[future]
             future.cancel()
 
@@ -2200,7 +2485,8 @@ class TestHarness:
             if interrupted:
                 return
             ctrlc_times.append(loop.time())
-            if len(ctrlc_times) == MAX_CTRLC and ctrlc_times[-1] - ctrlc_times[0] < 1:
+            if len(ctrlc_times
+                   ) == MAX_CTRLC and ctrlc_times[-1] - ctrlc_times[0] < 1:
                 self.flush_logfiles()
                 mlog.warning('CTRL-C detected, exiting')
                 cancel_all_tests()
@@ -2241,13 +2527,17 @@ class TestHarness:
             for l in self.loggers:
                 await l.finish(self)
 
+
 def list_tests(th: TestHarness) -> bool:
     tests = th.get_tests(errorfile=sys.stderr)
     for t in tests:
         print(th.get_pretty_suite(t))
     return not tests
 
-def rebuild_deps(ninja: T.List[str], wd: str, tests: T.List[TestSerialisation], benchmark: bool) -> bool:
+
+def rebuild_deps(ninja: T.List[str], wd: str, tests: T.List[TestSerialisation],
+                 benchmark: bool) -> bool:
+
     def convert_path_to_target(path: str) -> str:
         path = os.path.relpath(path, wd)
         if os.sep != '/':
@@ -2266,8 +2556,8 @@ def rebuild_deps(ninja: T.List[str], wd: str, tests: T.List[TestSerialisation], 
         intro_targets: T.Dict[str, T.List[str]] = {}
         for target in targets_info:
             intro_targets[target['id']] = [
-                convert_path_to_target(f)
-                for f in target['filename']]
+                convert_path_to_target(f) for f in target['filename']
+            ]
         for t in tests:
             for d in t.depends:
                 if d in depends:
@@ -2291,6 +2581,7 @@ def rebuild_deps(ninja: T.List[str], wd: str, tests: T.List[TestSerialisation], 
         return False
 
     return True
+
 
 def run(options: argparse.Namespace) -> int:
     if options.benchmark or options.interactive:
@@ -2321,16 +2612,21 @@ def run(options: argparse.Namespace) -> int:
             return 1
 
     b = build.load(options.wd)
-    need_vsenv = T.cast('bool', b.environment.coredata.optstore.get_value_for(OptionKey('vsenv')))
+    need_vsenv = T.cast(
+        'bool',
+        b.environment.coredata.optstore.get_value_for(OptionKey('vsenv')))
     setup_vsenv(need_vsenv)
 
     if not options.no_rebuild:
-        backend = b.environment.coredata.optstore.get_value_for(OptionKey('backend'))
+        backend = b.environment.coredata.optstore.get_value_for(
+            OptionKey('backend'))
         if backend == 'none':
             # nothing to build...
             options.no_rebuild = True
         elif backend != 'ninja':
-            print('Only ninja backend is supported to rebuild tests before running them.')
+            print(
+                'Only ninja backend is supported to rebuild tests before running them.'
+            )
             # Disable, no point in trying to build anything later
             options.no_rebuild = True
 
@@ -2346,6 +2642,7 @@ def run(options: argparse.Namespace) -> int:
             else:
                 print(e)
             return 1
+
 
 def run_with_args(args: T.List[str]) -> int:
     parser = argparse.ArgumentParser(prog='meson test')


### PR DESCRIPTION
### Summary

Fix gtest log filename collisions when multiple tests share the same name across different suites.

Previously, gtest XML log filenames were generated using only the test name. When the same test name appeared in multiple suites, different test instances could write to the same output file, causing file overwrites and race conditions during parallel execution.

This change makes the generated log filenames unique by incorporating the suite name in addition to the test name.

### Problem

Given tests such as:

* suite_1 / basic_test_1
* suite_2 / basic_test_1

both tests could generate the same XML filename, resulting in:

* overwritten test results
* intermittent XML parsing errors
* non-deterministic failures when running tests in parallel

### Solution

Include the suite name when generating gtest log filenames so that each test instance receives a unique output file.

### Testing

* Reproduced the issue using the example provided in #15757.
* Ran the test suite locally.
* Verified that tests with identical names in different suites generate distinct XML log files.
* Verified that parallel test execution no longer produces filename collisions.

Fixes #15757
