### PR TITLE
GnuCompiler.has_arguments: detect "not supported for this target" warnings

### DIFF
--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -604,6 +604,8 @@ class GnuCompiler(GnuLikeCompiler):
                 result = False
             if self.language in {'c', 'objc'} and 'is valid for C++/ObjC++' in p.stderr:
                 result = False
+            if 'not supported for this target' in p.stderr:
+                result = False
         return result, p.cached
 
     def get_has_func_attribute_extra_args(self, name: str) -> T.List[str]:


### PR DESCRIPTION
## Summary

- GCC may exit with code 0 while emitting a warning that an option is `"not supported for this target"` (e.g., HPPA with `-fstack-protector`). Previously, `has_arguments()` only checked for cross-language warnings (`"is valid for C/ObjC"` / `"is valid for C++/ObjC++"`).
- Added the `"not supported for this target"` pattern to the stderr inspection in `has_arguments()` so such flags are correctly reported as unsupported.

Partially fixes: #5355

## Test plan

- [ ] Verify that `compiler.get_supported_arguments()` correctly returns `false` for target-unsupported flags (e.g., `-fstack-protector` on HPPA)
- [ ] Verify existing cross-language warning detection still works
- [ ] Verify that genuinely supported flags are not affected