### PR TITLE
fix: handle empty stdout in sizeof test instead of crashing with ValueError

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -545,7 +545,12 @@ class CLikeCompiler(Compiler):
             return -1, False
         if res.returncode != 0:
             raise mesonlib.EnvironmentException('Could not run sizeof test binary.')
-        return int(res.stdout), res.cached
+        try:
+            return int(res.stdout), res.cached
+        except ValueError:
+            raise mesonlib.EnvironmentException(
+                f'Could not determine size of {typename}: compiler output was empty or invalid.'
+            )
 
     def _cross_alignment(self, typename: str, prefix: str, *,
                          extra_args: T.Optional[T.List[str]] = None,


### PR DESCRIPTION
## Description\n\nWhen sanitizer flags cause the test binary to produce empty stdout, int(res.stdout) raises a bare ValueError that crashes meson setup. Now catches ValueError and raises EnvironmentException.\n\nFixes #14452\n\n## Changes\n- Wrapped int(res.stdout) in sizeof method with try/except