### PR TITLE
compiler: correctly mark a run() result as `compiled=False` when the program fails

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -793,7 +793,7 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
         mlog.debug(so)
         mlog.debug('Program stderr:\n')
         mlog.debug(se)
-        return RunResult(True, pe.returncode, so, se)
+        return RunResult(pe.returncode == 0, pe.returncode, so, se)
 
     # Caching run() in general seems too risky (no way to know what the program
     # depends on), but some callers know more about the programs they intend to


### PR DESCRIPTION
We correctly catch that the program failed to compile and mark it as "result failed" but we don't do the same if the program fails to actually run.