### PR TITLE
brew command to check for installed libomp only

### DIFF
--- a/mesonbuild/compilers/mixins/apple.py
+++ b/mesonbuild/compilers/mixins/apple.py
@@ -16,7 +16,7 @@ def _get_libomp_prefix() -> T.Optional[str]:
     """Call `brew --prefix libomp` once and cache it. Returns None if unavailable."""
     try:
         return subprocess.run(
-            ['brew', '--prefix', 'libomp'],
+            ['brew', '--prefix', '--installed', 'libomp'],
             capture_output=True,
             encoding='utf-8',
             check=True,


### PR DESCRIPTION
`brew --prefix foobar` does return a value for uninstalled `foobar`, too. Thus `--installed` is the missing option to make sure Meson doesn't stumble upon an non-installed `libomp`.
