### PR TITLE
cmake: fix typo in documentation

### DIFF
--- a/docs/markdown/CMake-module.md
+++ b/docs/markdown/CMake-module.md
@@ -187,7 +187,7 @@ from CMake will be used.
 
 Meson will try to automatically guess most of the required CMake
 toolchain variables from existing entries in the cross and native
-files. These variables will be stored in an automatically generate
+files. These variables will be stored in an automatically generated
 CMake toolchain file in the build directory. The remaining variables
 that can't be guessed can be added by the user in the `[cmake]`
 cross/native file section (*new in 0.56.0*).


### PR DESCRIPTION
Hi. This is self-explanatory.