### PR TITLE
Fix absolute fname produced by source_strings_to_files().

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -32,7 +32,7 @@ from ..mesonlib import (
     File, LibType, MachineChoice, MesonBugException, MesonException, OrderedSet, PerMachine,
     ProgressBar, quote_arg, unique_list
 )
-from ..mesonlib import get_compiler_for_source, has_path_sep, is_parent_path, lookbehind
+from ..mesonlib import get_compiler_for_source, has_path_sep, is_parent_path, lookbehind, path_has_root
 from ..options import OptionKey
 from .backends import CleanTrees
 from ..build import GeneratedList, InvalidArguments
@@ -3239,13 +3239,9 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
 
         build_dir = self.environment.get_build_dir()
         if isinstance(src, File):
+            if src.is_built and path_has_root(src.fname):
+                raise MesonBugException('absolute file name for built file ' + src.relative_name())
             rel_src = src.rel_to_builddir(self.build_to_src)
-            if os.path.isabs(rel_src):
-                # Source files may not be from the source directory if they originate in source-only libraries,
-                # so we can't assert that the absolute path is anywhere in particular.
-                if src.is_built:
-                    assert rel_src.startswith(build_dir)
-                    rel_src = rel_src[len(build_dir) + 1:]
         elif is_generated:
             raise AssertionError(f'BUG: broken generated source file handling for {src!r}')
         else:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3290,7 +3290,17 @@ class Interpreter(InterpreterBase, HoldableObject):
                     if InterpreterRuleRelaxation.ALLOW_BUILD_DIR_FILE_REFERENCES not in self.relaxations:
                         #raise
                         mlog.warning(str(e), location=self.current_node)
-                    results.append(mesonlib.File.from_built_file(self.subdir, s))
+                    if path_has_root(s):
+                        # A built File's name must be relative to the build
+                        # root, otherwise the absolute fname leaks through
+                        # File.relative_name() and breaks the backend.
+                        # Use join and relpath together to handle paths without
+                        # the drive part.
+                        rel = os.path.relpath(os.path.join(self.environment.build_dir, s),
+                                              self.environment.build_dir)
+                        results.append(mesonlib.File.from_built_relative(rel))
+                    else:
+                        results.append(mesonlib.File.from_built_file(self.subdir, s))
                 else:
                     results.append(mesonlib.File.from_source_file(self.environment.source_dir, self.subdir, s))
             elif isinstance(s, (mesonlib.File, build.GeneratedList, Program,

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -179,7 +179,7 @@ class BuiltFileByNameError(InterpreterException):
     name: str
 
     def __str__(self) -> str:
-        return (f'{self.name} is a generated file, and should be passed by reference instead of string name. '
+        return (f'{self.name!r} is a generated file, and should be passed by reference instead of string name. '
                 'This will become a hard error in Meson 2.0')
 
 
@@ -3279,10 +3279,6 @@ class Interpreter(InterpreterBase, HoldableObject):
         mesonlib.check_direntry_issues(sources)
         results: list[mesonlib.File | build.GeneratedTypes | build.BuildTarget | build.ExtractedObjects | build.StructuredSources | Program] = []
 
-        # In Meson 2.0 this shoul not add ALLOW_BUILD_DIR_FILE_REFERENCES
-        # universally, and we should just use self.relaxations
-        relaxations: set[InterpreterRuleRelaxation] = self.relaxations | {InterpreterRuleRelaxation.ALLOW_BUILD_DIR_FILE_REFERENCES}
-
         for s in sources:
             if isinstance(s, str):
                 if s.endswith(' '):
@@ -3290,9 +3286,10 @@ class Interpreter(InterpreterBase, HoldableObject):
                 try:
                     self.validate_within_subproject(self.subdir, s)
                 except BuiltFileByNameError as e:
-                    if InterpreterRuleRelaxation.ALLOW_BUILD_DIR_FILE_REFERENCES not in relaxations:
-                        raise
-                    mlog.warning(str(e), location=self.current_node)
+                    # In Meson 2.0 this should just raise
+                    if InterpreterRuleRelaxation.ALLOW_BUILD_DIR_FILE_REFERENCES not in self.relaxations:
+                        #raise
+                        mlog.warning(str(e), location=self.current_node)
                     results.append(mesonlib.File.from_built_file(self.subdir, s))
                 else:
                     results.append(mesonlib.File.from_source_file(self.environment.source_dir, self.subdir, s))

--- a/test cases/common/299 built file by path/main.c
+++ b/test cases/common/299 built file by path/main.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main()
+{
+	printf("hello world\n");
+}

--- a/test cases/common/299 built file by path/main.c
+++ b/test cases/common/299 built file by path/main.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-int main()
+int main(void)
 {
-	printf("hello world\n");
+  printf("hello world\n");
 }

--- a/test cases/common/299 built file by path/meson.build
+++ b/test cases/common/299 built file by path/meson.build
@@ -1,4 +1,13 @@
 project('a', 'c')
 configure_file(output: 'fullpath.c', input: 'main.c', copy: true)
-exe = executable('fullpath', meson.project_build_root() / 'fullpath.c')
+
+path = meson.project_build_root() / 'fullpath.c'
+if build_machine.system() == 'windows'
+  if '\\' in meson.project_build_root()
+    path = path.replace('\\', '/')
+  else
+    path = path.replace('/', '\\')
+  endif
+endif
+exe = executable('fullpath', path)
 test('fullpath', exe)

--- a/test cases/common/299 built file by path/meson.build
+++ b/test cases/common/299 built file by path/meson.build
@@ -1,0 +1,4 @@
+project('a', 'c')
+configure_file(output: 'fullpath.c', input: 'main.c', copy: true)
+exe = executable('fullpath', meson.project_build_root() / 'fullpath.c')
+test('fullpath', exe)

--- a/test cases/common/299 built file by path/test.json
+++ b/test cases/common/299 built file by path/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-       "line": "test cases/common/299 built file by path/meson.build:3: WARNING: '.*/fullpath.c' is a generated file, and should be passed by reference instead of string name. This will become a hard error in Meson 2.0",
+       "line": "test cases/common/299 built file by path/meson.build:12: WARNING: '.*/fullpath.c' is a generated file, and should be passed by reference instead of string name. This will become a hard error in Meson 2.0",
        "match": "re"
     }
   ]

--- a/test cases/common/299 built file by path/test.json
+++ b/test cases/common/299 built file by path/test.json
@@ -1,0 +1,8 @@
+{
+  "stdout": [
+    {
+       "line": "test cases/common/299 built file by path/meson.build:3: WARNING: '.*/fullpath.c' is a generated file, and should be passed by reference instead of string name. This will become a hard error in Meson 2.0",
+       "match": "re"
+    }
+  ]
+}


### PR DESCRIPTION
@og-mrk can you please test?
    
generate_single_compile has code to handle files that return an absolute path from rel_to_builddir(), but while a user reported a bug with it, the situation it tried to handle should not arise at all.
    
For a built File, rel_to_builddir() returns relative_name(), i.e. os.path.join(subdir, fname).  Neither component is supposed to be absolute: subdir is a directory relative to the build root and fname is a bare basename.  So an absolute result means a malformed File was constructed somewhere upstream, and the current code is silently papering over it instead of catching it.

This can happen with build files with an absolute path, for which source_strings_to_files creates (via File.from_built_file) malformed files with an absolute fname part.  Catch them, properly make everything relative, and reject an absolute fname outright in the ninja backend.

Fixes: #15871