### PR TITLE
nasm: use the correct flag for response file support, try 2

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -551,10 +551,11 @@ class Backend:
             feed: T.Optional[str] = None,
             env: T.Optional[mesonlib.EnvironmentVariables] = None,
             can_use_rsp_file: bool = False,
+            separator: str = ' ',
+            rsp_file_flag: str = '@',
             tag: T.Optional[str] = None,
             verbose: bool = False,
             installdir_map: T.Optional[T.Dict[str, str]] = None) -> 'ExecutableSerialisation':
-
         # XXX: cmd_args either need to be lowered to strings, or need to be checked for non-string arguments, right?
         exe, *raw_cmd_args = cmd
         if isinstance(exe, build.LocalProgram):
@@ -620,14 +621,14 @@ class Backend:
 
         if needs_rsp_file:
             hasher = hashlib.sha1()
-            args = ' '.join(mesonlib.quote_arg(arg) for arg in cmd_args)
+            args = separator.join(mesonlib.quote_arg(arg) for arg in cmd_args)
             hasher.update(args.encode(encoding='utf-8', errors='ignore'))
             digest = hasher.hexdigest()
             scratch_file = f'meson_rsp_{digest}.rsp'
             rsp_file = os.path.join(self.environment.get_scratch_dir(), scratch_file)
             with open(rsp_file, 'w', encoding='utf-8', newline='\n') as f:
                 f.write(args)
-                cmd_args = [f'@{rsp_file}']
+                cmd_args = [f'{rsp_file_flag}{rsp_file}']
 
         return ExecutableSerialisation(exe_cmd + cmd_args, env,
                                        exe_wrapper, workdir,
@@ -642,6 +643,8 @@ class Backend:
                              force_serialize: bool = False,
                              env: T.Optional[mesonlib.EnvironmentVariables] = None,
                              can_use_rsp_file: bool = False,
+                             separator: str = ' ',
+                             rsp_file_flag: str = '@',
                              verbose: bool = False) -> T.Tuple[T.List[str], str]:
         '''
         Serialize an executable for running with a generator or a custom target
@@ -649,7 +652,7 @@ class Backend:
         cmd: T.List[build.CommandTypes] = []
         cmd.append(exe)
         cmd.extend(cmd_args)
-        es = self.get_executable_serialisation(cmd, workdir, extra_bdeps, capture, feed, env, can_use_rsp_file, verbose=verbose)
+        es = self.get_executable_serialisation(cmd, workdir, extra_bdeps, capture, feed, env, can_use_rsp_file, separator=separator, rsp_file_flag=rsp_file_flag, verbose=verbose)
         reasons: T.List[str] = []
         if es.extra_paths:
             reasons.append('to set PATH')
@@ -666,6 +669,9 @@ class Backend:
         if env and env.varnames:
             reasons.append('to set env')
 
+        if separator != ' ':
+            reasons.append('to use a custom argument separator')
+
         # force_serialize passed to this function means that the VS backend has
         # decided it absolutely cannot use real commands. This is "always",
         # because it's not clear what will work (other than compilers) and so
@@ -675,7 +681,7 @@ class Backend:
         # It's also overridden for a few conditions that can't be handled
         # inside a command line
 
-        can_use_env = env.can_use_env and not force_serialize
+        can_use_env = env and env.can_use_env and not force_serialize
         force_serialize = force_serialize or bool(reasons)
 
         if capture:
@@ -689,7 +695,7 @@ class Backend:
                 envlist.append(f'{k}={v}')
             return ['env'] + envlist + es.cmd_args, ', '.join(reasons)
 
-        if any(a.startswith('@') for a in es.cmd_args):
+        if can_use_rsp_file and any(a.startswith(rsp_file_flag) for a in es.cmd_args):
             reasons.append('because command is too long')
 
         if not force_serialize:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -366,6 +366,9 @@ class NinjaBuildElement:
         if self.rulename == 'phony':
             return False
 
+        if not self.rule:
+            raise MesonBugException(f"build statement for {self.outfilenames} references unmapped rule {self.rulename}")
+
         return self.rule.should_use_rspfile(self)
 
     def count_rule_references(self) -> None:
@@ -3374,7 +3377,27 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                     result += c
                 return result
             element.add_item('CUDA_ESCAPED_TARGET', quote_make_target(rel_obj))
-        element.add_item('ARGS', commands)
+        if self.ninja.should_use_rspfile(element) and compiler.rsp_file_syntax() == RSPFileSyntax.NASM:
+            exe = compiler.get_exelist()
+            # Add to commands the args created by generate_compile_rule_for().
+            # commands remain separate from exelist because they must stay
+            # a CompilerArgs.
+            if dep_file:
+                commands += compiler.get_dependency_gen_args(rel_obj, dep_file)
+            commands += [*compiler.get_output_args(rel_obj), *compiler.get_compile_only_args(), rel_src]
+
+            element.rulename = 'CUSTOM_COMMAND'
+            meson_exe_cmd, reason = self.as_meson_exe_cmdline(exe[0],
+                                                              exe[1:] + commands.to_native(),
+                                                              separator='\n',
+                                                              rsp_file_flag='-@',
+                                                              can_use_rsp_file=True,
+                                                              verbose=True)
+            cmd_type = f' (wrapped by meson {reason})' if reason else ''
+            element.add_item('COMMAND', meson_exe_cmd)
+            element.add_item('description', f'Compiling {compiler.get_display_language()} object {rel_obj}{cmd_type}')
+        else:
+            element.add_item('ARGS', commands)
 
         self.add_dependency_scanner_entries_to_element(target, compiler, element, src)
         self.add_build(element)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -274,8 +274,8 @@ class NinjaRule:
                     outfile.write('\n')
             outfile.write('\n')
 
-    def length_estimate(self, infiles: str, outfiles: str,
-                        elems: T.List[T.Tuple[str, T.List[str]]]) -> int:
+    def _length_estimate(self, infiles: str, outfiles: str,
+                         elems: T.List[T.Tuple[str, T.List[str]]]) -> int:
         # determine variables
         # this order of actions only approximates ninja's scoping rules, as
         # documented at: https://ninja-build.org/manual.html#ref_scope
@@ -301,6 +301,17 @@ class NinjaRule:
 
         # determine command length
         return estimate
+
+    def should_use_rspfile(self, element: NinjaBuildElement) -> bool:
+        if not self.rspable:
+            return False
+
+        infilenames = ' '.join([ninja_quote(i, True) for i in element.infilenames])
+        outfilenames = ' '.join([ninja_quote(i, True) for i in element.outfilenames])
+
+        return self._length_estimate(infilenames,
+                                     outfilenames,
+                                     element.elems) >= rsp_threshold
 
 class NinjaBuildElement:
 
@@ -354,15 +365,7 @@ class NinjaBuildElement:
         if self.rulename == 'phony':
             return False
 
-        if not self.rule.rspable:
-            return False
-
-        infilenames = ' '.join([ninja_quote(i, True) for i in self.infilenames])
-        outfilenames = ' '.join([ninja_quote(i, True) for i in self.outfilenames])
-
-        return self.rule.length_estimate(infilenames,
-                                         outfilenames,
-                                         self.elems) >= rsp_threshold
+        return self.rule.should_use_rspfile(self)
 
     def count_rule_references(self) -> None:
         if self.rulename != 'phony':

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -10,6 +10,7 @@ from enum import Enum, unique
 from functools import lru_cache
 from pathlib import PurePath, Path
 from textwrap import dedent
+import dataclasses
 import itertools
 import json
 import os
@@ -446,6 +447,59 @@ class NinjaBuildElement:
             self.all_outputs.add(n)
 
 @dataclass
+class NinjaBuild:
+    rules: list[NinjaRule | NinjaComment] = dataclasses.field(default_factory=list, init=False)
+    ruledict: dict[str, NinjaRule] = dataclasses.field(default_factory=dict, init=False)
+    build_elements: list[NinjaBuildElement | NinjaComment] = dataclasses.field(default_factory=list, init=False)
+
+    def add_rule_comment(self, comment: NinjaComment) -> None:
+        self.rules.append(comment)
+
+    def add_build_comment(self, comment: NinjaComment) -> None:
+        self.build_elements.append(comment)
+
+    def add_rule(self, rule: NinjaRule) -> None:
+        if rule.name in self.ruledict:
+            raise MesonException(f'Tried to add rule {rule.name} twice.')
+        self.rules.append(rule)
+        self.ruledict[rule.name] = rule
+
+    def has_rule(self, name: str) -> bool:
+        return name in self.ruledict
+
+    def should_use_rspfile(self, build: NinjaBuildElement) -> bool:
+        if build.rulename == 'phony':
+            return False
+
+        if build.rulename in self.ruledict:
+            return self.ruledict[build.rulename].should_use_rspfile(build)
+
+        mlog.warning(f"build statement for {build.outfilenames} references nonexistent rule {build.rulename}")
+        return False
+
+    def add_build(self, build: NinjaBuildElement) -> None:
+        build.check_outputs()
+        self.build_elements.append(build)
+
+        if build.rulename != 'phony':
+            # reference rule
+            if build.rulename in self.ruledict:
+                build.rule = self.ruledict[build.rulename]
+            else:
+                mlog.warning(f"build statement for {build.outfilenames} references nonexistent rule {build.rulename}")
+
+    def write(self, outfile: T.TextIO) -> None:
+        for b in self.build_elements:
+            if isinstance(b, NinjaBuildElement):
+                b.count_rule_references()
+
+        for r in self.rules:
+            r.write(outfile)
+
+        for b in ProgressBar(self.build_elements, desc='Writing build.ninja'):
+            b.write(outfile)
+
+@dataclass
 class RustDep:
 
     name: str
@@ -508,6 +562,7 @@ class NinjaBackend(backends.Backend):
     def __init__(self, build: T.Optional[build.Build]):
         super().__init__(build)
         self.name = 'ninja'
+        self.ninja = NinjaBuild()
         self.ninja_filename = 'build.ninja'
         self.fortran_deps: T.Dict[str, T.Dict[str, File]] = {}
         self.all_outputs: T.Set[str] = set()
@@ -673,8 +728,6 @@ class NinjaBackend(backends.Backend):
 
         with self.detect_vs_dep_prefix(tempfilename) as outfile:
             self.generate_rules()
-
-            self.build_elements: T.List[T.Union[NinjaBuildElement, NinjaComment]] = []
             self.generate_phony()
             self.add_build_comment(NinjaComment('Build rules for targets'))
 
@@ -713,8 +766,8 @@ class NinjaBackend(backends.Backend):
             mlog.log_timestamp("Utils generated")
             self.generate_ending()
 
-            self.write_rules(outfile)
-            self.write_builds(outfile)
+            self.ninja.write(outfile)
+            mlog.log_timestamp("build.ninja generated")
 
             default = 'default all\n\n'
             outfile.write(default)
@@ -1414,9 +1467,6 @@ class NinjaBackend(backends.Backend):
         self.add_build(elem)
 
     def generate_rules(self) -> None:
-        self.rules: T.List[T.Union[NinjaRule, NinjaComment]] = []
-        self.ruledict: T.Dict[str, NinjaRule] = {}
-
         self.add_rule_comment(NinjaComment('Rules for module scanning.'))
         self.generate_scanner_rules()
         self.add_rule_comment(NinjaComment('Rules for compiling.'))
@@ -1452,40 +1502,16 @@ class NinjaBackend(backends.Backend):
                                 extra='generator = 1'))
 
     def add_rule_comment(self, comment: NinjaComment) -> None:
-        self.rules.append(comment)
+        self.ninja.add_rule_comment(comment)
 
     def add_build_comment(self, comment: NinjaComment) -> None:
-        self.build_elements.append(comment)
+        self.ninja.add_build_comment(comment)
 
     def add_rule(self, rule: NinjaRule) -> None:
-        if rule.name in self.ruledict:
-            raise MesonException(f'Tried to add rule {rule.name} twice.')
-        self.rules.append(rule)
-        self.ruledict[rule.name] = rule
+        self.ninja.add_rule(rule)
 
     def add_build(self, build: NinjaBuildElement) -> None:
-        build.check_outputs()
-        self.build_elements.append(build)
-
-        if build.rulename != 'phony':
-            # reference rule
-            if build.rulename in self.ruledict:
-                build.rule = self.ruledict[build.rulename]
-            else:
-                mlog.warning(f"build statement for {build.outfilenames} references nonexistent rule {build.rulename}")
-
-    def write_rules(self, outfile: T.TextIO) -> None:
-        for b in self.build_elements:
-            if isinstance(b, NinjaBuildElement):
-                b.count_rule_references()
-
-        for r in self.rules:
-            r.write(outfile)
-
-    def write_builds(self, outfile: T.TextIO) -> None:
-        for b in ProgressBar(self.build_elements, desc='Writing build.ninja'):
-            b.write(outfile)
-        mlog.log_timestamp("build.ninja generated")
+        self.ninja.add_build(build)
 
     def generate_phony(self) -> None:
         self.add_build_comment(NinjaComment('Phony build target, always out of date'))
@@ -2775,7 +2801,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
 
     def generate_scanner_rules(self) -> None:
         rulename = 'depscan'
-        if rulename in self.ruledict:
+        if self.ninja.has_rule(rulename):
             # Scanning command is the same for native and cross compilation.
             return
 

--- a/mesonbuild/compilers/asm.py
+++ b/mesonbuild/compilers/asm.py
@@ -6,6 +6,7 @@ import typing as T
 from ..mesonlib import EnvironmentException, get_meson_command
 from ..options import OptionKey
 from .compilers import Compiler
+from ..linkers import RSPFileSyntax
 from ..linkers.linkers import VisualStudioLikeLinkerMixin
 from .mixins.metrowerks import MetrowerksCompiler, mwasmarm_instruction_set_args, mwasmeppc_instruction_set_args
 from .mixins.ti import TICompiler
@@ -159,11 +160,8 @@ class NasmCompiler(ASMCompiler):
             return []
         return self.crt_args[self.get_crt_val(crt_val)]
 
-    def can_linker_accept_rsp(self) -> bool:
-        """
-        Determines whether the linker can accept arguments using the @rsp syntax.
-        """
-        return False
+    def rsp_file_syntax(self) -> RSPFileSyntax:
+        return RSPFileSyntax.NASM
 
 class YasmCompiler(NasmCompiler):
     id = 'yasm'

--- a/mesonbuild/linkers/base.py
+++ b/mesonbuild/linkers/base.py
@@ -19,6 +19,7 @@ class RSPFileSyntax(enum.Enum):
     MSVC = enum.auto()
     GCC = enum.auto()
     TASKING = enum.auto()
+    NASM = enum.auto()
 
 
 class ArLikeLinker:


### PR DESCRIPTION
Hi all,

This PR reenables and implements correct response file support for Nasm.

Fortified with the knowledge of #15867 and #15872, and with a quick chat with Nirbheek, I realised that the easiest way to fix this (since Ninja does not support custom argument spacing) is to do it the obvious way, with Meson's custom command support.

This commit implements an abridged version of that: when a non-standard `RspFileSyntax` value is detected, the active `NinjaBuildRule` is temporarily resolved to the corresponding` NinjaRule` on the fly and if the latter says that a response file will be used, the `NinjaBuildRule` is immediately converted into a `CUSTOM_COMMAND`, completing the arguments with the bits for `infile` and `outfile` and triggering the executable serialization. That serializes the response file and pickles the command.

Fixes building mpv with MSVC 2022+ and fdk-aac enabled.

@og-mrk just in case, mind confirming that this works on your side as well?