### PR TITLE
windows: Implement RC depfile generation for clang targeting MSVC

### DIFF
--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -81,7 +81,7 @@ class WindowsModule(ExtensionModule):
                 return None
 
             comp = self.detect_compiler(state.environment.coredata.compilers[for_machine])
-            if comp.id in {'msvc', 'clang-cl', 'intel-cl'} or (comp.linker and comp.linker.id in {'link', 'lld-link'}):
+            if comp.linker and comp.linker.id in {'link', 'lld-link'}:
                 rescomp = search_programs(['rc', 'llvm-rc'])
             else:
                 rescomp = search_programs(['windres', 'llvm-windres'])
@@ -185,15 +185,32 @@ class WindowsModule(ExtensionModule):
 
             if rescomp_type == ResourceCompilerType.rc:
                 compiler = self.detect_compiler(state.environment.coredata.compilers[MachineChoice.HOST])
-                if compiler.id in {'msvc', 'clang-cl'}:
+                command.extend(state.environment.get_build_command())
+                command.extend(['--internal', 'rc',
+                                '--rc', *rescomp.get_command(),
+                                '--cl', *compiler.get_exelist(False)])
+
+                if compiler.id in {'msvc', 'clang-cl', 'intel-cl'}:
                     depfile_type = 'msvc'
+                    command.extend(['--Xarg=/showIncludes',
+                                    '--Xarg=/EP',
+                                    '--Xarg=/nologo',
+                                    '--Xarg=/DRC_INVOKED',
+                                    '--Xarg=/Tc@INPUT@',
+                                    ])
+                else:
+                    depfile = f'{output}.d'
+                    depfile_type = 'gcc'
+                    command.extend(['--Xarg=-xc',
+                                    '--Xarg=-E',
+                                    '--Xarg=-MD',
+                                    '--Xarg=-MQ@OUTPUT@',
+                                    '--Xarg=-MF@DEPFILE@',
+                                    '--Xarg=-DRC_INVOKED',
+                                    ])
+            else:
+                command.extend(rescomp.get_command())
 
-                    command.extend(state.environment.get_build_command())
-                    command.extend(['--internal', 'rc',
-                                    '--cl', compiler.get_exelist(False)[0],
-                                    '--rc'])
-
-            command.append(rescomp)
             command.extend(res_args)
 
             # instruct binutils windres to generate a preprocessor depfile

--- a/mesonbuild/scripts/rc.py
+++ b/mesonbuild/scripts/rc.py
@@ -1,41 +1,37 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""Wrapper for rc.exe to make it output included files."""
+"""Wrapper for manually generating depfiles of resource files."""
 
 from __future__ import annotations
 
 import argparse
 import subprocess
-import shutil
+import sys
 import typing as T
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--rc')
-parser.add_argument('--cl')
+parser.add_argument('--rc', nargs='+', required=True)
+parser.add_argument('--cl', nargs='+', required=True)
+parser.add_argument('--Xarg', action='append')
 
 
 def run(args: T.List[str]) -> int:
     options, rc_args = parser.parse_known_args(args)
     target = rc_args[-1] if rc_args else None
 
-    rc = options.rc if options.rc else shutil.which('rc.exe')
-    if rc is None:
-        print('rc.exe not found')
-        return 1
-
-    cl = options.cl if options.cl else shutil.which('cl.exe')
-    if cl is None:
-        print('cl.exe not found')
-        return 1
+    rc = options.rc
+    cl = options.cl
 
     # Use preprocessor to display include files
     include_args = [a for a in rc_args if a.startswith(('/I', '-I'))]
-    cmd = [cl, '/showIncludes', '/EP', '/nologo', '/DRC_INVOKED'] + include_args + ['/Tc' + target]
+    cmd = [*cl, *include_args, *options.Xarg]
+    if target:
+        cmd += [target]
     result = subprocess.call(cmd, stdout=subprocess.DEVNULL)
     if result != 0:
-        print('Error running preprocessor to find resource dependencies')
-        # continue anyway. rc.exe should catch the error later
+        print('Error running preprocessor to find resource dependencies', file=sys.stderr)
+        # continue anyway. the resource compiler should catch the error later
 
-    cmd = [rc] + rc_args
+    cmd = [*rc, *rc_args]
     return subprocess.call(cmd)


### PR DESCRIPTION
Hi all,

This implements https://github.com/mesonbuild/meson/pull/15873#issuecomment-4638069862, completing support for resource depfile generation under MSVC:

> When using Clang with an MSVC target, it's necessary to invoke `llvm-rc` instead of `llvm-windres` (this affects how to locate headers that are included by the RC file), but the compiler is clang which outputs Unix-style dep files, so `depfile_type` should be `'gcc'` and that piece of code for `rescomp_type == ResourceCompilerType.windres` can be reused.

To achieve it, I obtained and reproduced windres's Clang incantation into `compile_resources`. Since the `rc` script now needs to be compiler agnostic, I made it take the relevant arguments by command line and now pass them Meson-side.

I validated this with my FFmpeg port, testing MSVC and clang+lld-link (both 2022).

Let me know what you think.

cc @lhmouse for review