### PR TITLE
docs: Document main kwarg of Qt dependency

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -770,6 +770,10 @@ qt6_dep = dependency('qt6', modules : ['Core', 'Gui', 'Widgets'])
 An optional `method` keyword argument can be set: `auto` (default), `pkg-config`, `config-tool` or `qmake` (*deprecated
 since 0.58.0*; use `config-tool` instead).
 
+An optional `main` boolean keyword argument can be set to `true` to add a link
+dependency on `Qt6EntryPoint` on Windows, which is in most cases necessary to
+be able to compile `win_subsystem: 'windows'` executables.
+
 The `modules` keyword receives an array of Qt module names that will be required
 and linked against.
 

--- a/docs/markdown/Qt6-module.md
+++ b/docs/markdown/Qt6-module.md
@@ -115,15 +115,23 @@ inc = include_directories('.')
 qt6 = import('qt6')
 
 # Qml and QmlIntegration are needed here
-qt6_dep = dependency('qt6', modules: ['Core', 'Gui', 'Network', 'Svg', 'Quick', 'Qml', 'QuickWidgets', 'QmlIntegration'])
+qt6_dep = dependency(
+  'qt6',
+  modules: ['Core', 'Gui', 'Network', 'Svg', 'Quick', 'Qml', 'QuickWidgets', 'QmlIntegration'],
+  # To make the `win_subsystem: 'windows'` line below work on windows, the
+  # program must provide a WinMain() or wWinMain() entrypoint. Qt provides a
+  # library which provides these functions (which just call main()). To link
+  # against the Qt6EntryPoint library, `main: true` must be supplied.
+  main: true,
+)
 
 compiled_resources = qt6.compile_resources(sources: files('resources.qrc'))
 
 # compile 'moc_header_files' list with moc
 moc_files = qt6.compile_moc(
-  headers : moc_header_files,
+  headers: moc_header_files,
   include_directories: inc,
-  dependencies: qt6_dep
+  dependencies: qt6_dep,
 )
 
 # everything involved in C++-QML interaction goes in here
@@ -143,7 +151,9 @@ executable('MyExecutable',
   dependencies: [qt6_dep],
   win_subsystem: 'windows', # useful for Windows: displays the app without spawning
                             # a console alongside it, no-op on other platforms.
-  install: true)
+                            # see also comment above on `main: true` dependency()
+  install: true,
+)
 ```
 
 ## Functions


### PR DESCRIPTION
This kwarg is to my knowledge completely undocumented, even in the "QML-C++ integration" example where it is especially relevant since that example uses `win_subsystem: 'windows'`.

I have not thoroughly studied the code handling `Qt6EntryPoint` and `main`, please review this before merging to make sure that the behavior I documented actually matches reality.

I also find that `Qt6EntryPoint` is surprisingly badly documented (not only in Meson). I find this annoying, since this is not some obscure issue. You will encounter this problem when developing even a simple Hello World Qt program for Windows (the most poppular desktop operating system). Perhaps Qt's more native build systems (such as CMake and qmake) somehow handle this automatically or link to `Qt6EntryPoint` by default which alleviates the issue? And since it's automatic, there are little forum posts, bug reports and documentation pages discussing the matter. To quote the singular paragraph of text from [the official documentation](https://doc.qt.io/qt-6/qtentrypoint.html) which hints at this mechanism even existing[^1]:

> _QtEntryPoint_ is a helper library that enables the developer to write a cross-platform main() function on Windows. If you do not use [CMake](https://doc.qt.io/qt-6/cmake-manual.html), [qmake](https://doc.qt.io/qt-6/qmake-manual.html), [qbs](https://doc.qt.io/qbs/index.html), or any other build tool that handles this automatically, then you need to link against the `QtEntryPoint` library.

If they autodetect it, wouldn't it be sensible if Meson did so too? If not, I believe that a deviation from the standard behavior can be compensated by improving the documentation.

I could make a whole section on it that would perhaps go into the different `main()`s on windows (even though most of the details are outside of scope of Meson) and include common compiler error messages caused by this kwarg being missing which would make this more Googlable.

[^1]: At least that's the only official resource I found when Googling the issue.