### PR TITLE
interpreter: create build_subdir at setup time

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -882,6 +882,9 @@ class Interpreter(InterpreterBase, HoldableObject):
         self.subprojects[subp_name] = sub
         return sub
 
+    def create_build_subdir(self, subdir: str) -> None:
+        os.makedirs(os.path.join(self.build.environment.get_build_dir(), subdir), exist_ok=True)
+
     def do_subproject(self, subp_name: SubProject, kwargs: kwtypes.DoSubproject, force_method: T.Optional[wrap.Method] = None,
                       forced_options: T.Optional[OptionDict] = None) -> SubprojectHolder:
         disabled, required, feature = extract_required_kwarg(kwargs, self.subproject)
@@ -943,7 +946,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             mlog.error(*msg)
             raise e
 
-        os.makedirs(os.path.join(self.build.environment.get_build_dir(), subdir), exist_ok=True)
+        self.create_build_subdir(subdir)
         self.global_args_frozen = True
 
         stack = ':'.join(self.subproject_stack + [subp_name])
@@ -2517,7 +2520,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         if not is_new:
             raise InvalidArguments(f'Tried to enter directory "{subdir}", which has already been visited.')
 
-        os.makedirs(os.path.join(self.environment.build_dir, subdir), exist_ok=True)
+        self.create_build_subdir(subdir)
 
         if InterpreterRuleRelaxation.CARGO_SUBDIR in self.relaxations and \
            os.path.exists(os.path.join(self.environment.get_source_dir(), subdir, 'Cargo.toml')):
@@ -2657,6 +2660,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                 raise InvalidArguments(f'Build subdir "{build_subdir}" in "{target}" exists in source tree.')
             if '..' in build_subdir:
                 raise InvalidArguments(f'Build subdir "{build_subdir}" in "{target}" contains ..')
+            self.create_build_subdir(os.path.join(self.subdir, build_subdir))
 
     @noPosargs
     @typed_kwargs(
@@ -2834,7 +2838,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         elif kwargs['copy']:
             if len(inputs_abs) != 1:
                 raise InterpreterException('Exactly one input file must be given in copy mode')
-            os.makedirs(os.path.join(self.environment.build_dir, self.subdir), exist_ok=True)
+            self.create_build_subdir(self.subdir)
             shutil.copy2(inputs_abs[0], ofile_abs)
 
         # Install file if requested, we check for the empty string

--- a/test cases/common/257 generated header dep/meson.build
+++ b/test cases/common/257 generated header dep/meson.build
@@ -1,4 +1,4 @@
-project('generated header dep', 'c')
+project('generated header dep', 'c', meson_version : '>= 1.10.0')
 
 # Regression test case for a very specific case:
 # - Uses both_libraries(), or library() with default_library=both.
@@ -20,3 +20,19 @@ sources_dep = declare_dependency(sources: files('foo.c'))
 both_libraries('foo', header,
   dependencies: sources_dep,
 )
+
+# include_directories() can point to a build_subdir that a custom_target()
+# generated into, so the subdir must exist in the build tree at setup time
+subheader = custom_target(
+  output: 'sub.h',
+  capture: true,
+  command: [python, '-c', 'print("#define SUB 0")'],
+  build_subdir: 'generated_includes',
+)
+
+inc = include_directories('generated_includes')
+
+subprog = executable('subprog', 'subprog.c', subheader,
+  include_directories: inc,
+)
+test('subprog', subprog)

--- a/test cases/common/257 generated header dep/subprog.c
+++ b/test cases/common/257 generated header dep/subprog.c
@@ -1,0 +1,5 @@
+#include "sub.h"
+
+int main(void) {
+    return SUB;
+}


### PR DESCRIPTION
include_directories() can point to a build_subdir that a custom_target() generated into, so the subdir must exist in the build tree at setup time.

Create a new function to abstract os.makedirs() and use it validate_build_subdir().

Fixes: #15902