### PR TITLE
Revert "compilers: Deduplicate OpenMP linker arguments"

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -65,7 +65,7 @@ class CLikeCompilerArgs(arglist.CompilerArgs):
     # https://github.com/mesonbuild/meson/pull/4593#pullrequestreview-182016038
     dedup1_prefixes = ('-l', '-Wl,-l', '-Wl,-rpath,', '-Wl,-rpath-link,')
     dedup1_suffixes = ('.lib', '.dll', '.so', '.dylib', '.a')
-    dedup1_args = ('-c', '-S', '-E', '-pipe', '-pthread', '-Wl,--export-dynamic', '-fopenmp', '-qopenmp')
+    dedup1_args = ('-c', '-S', '-E', '-pipe', '-pthread', '-Wl,--export-dynamic')
 
     def to_native(self, copy: bool = False) -> T.List[str]:
         # This seems to be allowed, but could never work?


### PR DESCRIPTION
This reverts commit f7758b9dd2c20a20fac34598e469b9ce99ce324d (from PR #15518). Deduplicating OpenMP linker arguments is in principle a good idea, but it breaks `-Xpreprocessor -fopenmp` because deduplication has no idea of which options have an argument in a separate entry of the array.

Fixes: #15764