### PR TITLE
gtest: fix XML filename collisions

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1123,7 +1123,7 @@ TestRun.PROTOCOL_TO_CLASS[TestProtocol.EXITCODE] = TestRunExitCode
 
 class TestRunGTest(TestRunExitCode):
     def complete(self) -> None:
-        filename = f'{self.test.name}.xml'
+        filename = '-'.join(self.test.suite + [self.test.name]) + '.xml'
         if self.test.workdir:
             filename = os.path.join(self.test.workdir, filename)
 
@@ -1639,9 +1639,9 @@ class SingleTestRunner:
 
         extra_cmd: T.List[str] = []
         if self.test.protocol is TestProtocol.GTEST:
-            gtestname = self.test.name
+            gtestname = '-'.join(self.test.suite + [self.test.name])
             if self.test.workdir:
-                gtestname = os.path.join(self.test.workdir, self.test.name)
+                gtestname = os.path.join(self.test.workdir, gtestname)
             extra_cmd.append(f'--gtest_output=xml:{gtestname}.xml')
 
         p = await self._run_subprocess(cmd + extra_cmd,


### PR DESCRIPTION
**Summary**

Fix gtest log filename collisions when multiple tests share the same name across different suites.

Previously, gtest XML log filenames were generated using only the test name. When identical test names existed in multiple suites, they could write to the same output file, causing overwrites, race conditions, and inconsistent results during parallel execution.

This change ensures uniqueness by incorporating the full suite path along with the test name when generating gtest log filenames.

**Problem**

Given tests such as:

suite_1 / basic_test_1
suite_2 / basic_test_1

both produced the same XML filename:

basic_test_1.xml

This led to:
overwritten test results
intermittent XML parsing errors
non-deterministic failures in parallel runs
Solution

Update gtest log filename generation to include the suite name:

'-'.join(self.test.suite + [self.test.name]) + '.xml'

This guarantees each test instance produces a unique XML output file.

**Testing**
Reproduced the issue using the scenario described in issue #15757
Ran the test suite locally
Verified that identical test names across different suites generate unique XML files
Verified no collisions during parallel execution
Confirmed backward compatibility for tests without suite names

**Fixes**
Fixes #15757