### PR TITLE
Strict null checking part 1

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -63,6 +63,9 @@ strict_optional               = True
 [mypy-mesonbuild.mesonmain]
 strict_optional               = True
 
+[mypy-mesonbuild.minit]
+strict_optional               = True
+
 [mypy-mesonbuild.mlog]
 strict_optional               = True
 

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -27,5 +27,8 @@ check_untyped_defs            = True
 allow_redefinition_new        = True
 local_partial_types           = True
 
+[mypy-mesonbuild.depfile]
+strict_optional               = True
+
 [mypy-mesonbuild.tooldetect]
 strict_optional               = True

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -57,6 +57,9 @@ strict_optional               = True
 [mypy-mesonbuild.mdist]
 strict_optional               = True
 
+[mypy-mesonbuild.mesondata]
+strict_optional               = True
+
 [mypy-mesonbuild.mlog]
 strict_optional               = True
 

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -66,6 +66,9 @@ strict_optional               = True
 [mypy-mesonbuild.minit]
 strict_optional               = True
 
+[mypy-mesonbuild.minstall]
+strict_optional               = True
+
 [mypy-mesonbuild.mlog]
 strict_optional               = True
 

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -48,6 +48,9 @@ strict_optional               = True
 [mypy-mesonbuild.mcompile]
 strict_optional               = True
 
+[mypy-mesonbuild.mconf]
+strict_optional               = True
+
 [mypy-mesonbuild.mlog]
 strict_optional               = True
 

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -30,5 +30,8 @@ local_partial_types           = True
 [mypy-mesonbuild.depfile]
 strict_optional               = True
 
+[mypy-mesonbuild.machinefile]
+strict_optional               = True
+
 [mypy-mesonbuild.tooldetect]
 strict_optional               = True

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -60,6 +60,9 @@ strict_optional               = True
 [mypy-mesonbuild.mesondata]
 strict_optional               = True
 
+[mypy-mesonbuild.mesonmain]
+strict_optional               = True
+
 [mypy-mesonbuild.mlog]
 strict_optional               = True
 

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -54,6 +54,9 @@ strict_optional               = True
 [mypy-mesonbuild.mdevenv]
 strict_optional               = True
 
+[mypy-mesonbuild.mdist]
+strict_optional               = True
+
 [mypy-mesonbuild.mlog]
 strict_optional               = True
 

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -26,3 +26,6 @@ check_untyped_defs            = True
 # future default behaviors
 allow_redefinition_new        = True
 local_partial_types           = True
+
+[mypy-mesonbuild.tooldetect]
+strict_optional               = True

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -33,5 +33,8 @@ strict_optional               = True
 [mypy-mesonbuild.machinefile]
 strict_optional               = True
 
+[mypy-mesonbuild.mlog]
+strict_optional               = True
+
 [mypy-mesonbuild.tooldetect]
 strict_optional               = True

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -39,6 +39,9 @@ strict_optional               = True
 [mypy-mesonbuild.envconfig]
 strict_optional               = True
 
+[mypy-mesonbuild.environment]
+strict_optional               = True
+
 [mypy-mesonbuild.machinefile]
 strict_optional               = True
 

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -27,6 +27,9 @@ check_untyped_defs            = True
 allow_redefinition_new        = True
 local_partial_types           = True
 
+[mypy-mesonbuild.coredata]
+strict_optional               = True
+
 [mypy-mesonbuild.depfile]
 strict_optional               = True
 

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -72,5 +72,8 @@ strict_optional               = True
 [mypy-mesonbuild.mlog]
 strict_optional               = True
 
+[mypy-mesonbuild.programs]
+strict_optional               = True
+
 [mypy-mesonbuild.tooldetect]
 strict_optional               = True

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -45,6 +45,9 @@ strict_optional               = True
 [mypy-mesonbuild.machinefile]
 strict_optional               = True
 
+[mypy-mesonbuild.mcompile]
+strict_optional               = True
+
 [mypy-mesonbuild.mlog]
 strict_optional               = True
 

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -51,6 +51,9 @@ strict_optional               = True
 [mypy-mesonbuild.mconf]
 strict_optional               = True
 
+[mypy-mesonbuild.mdevenv]
+strict_optional               = True
+
 [mypy-mesonbuild.mlog]
 strict_optional               = True
 

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -36,6 +36,9 @@ strict_optional               = True
 [mypy-mesonbuild.depfile]
 strict_optional               = True
 
+[mypy-mesonbuild.envconfig]
+strict_optional               = True
+
 [mypy-mesonbuild.machinefile]
 strict_optional               = True
 

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -27,6 +27,9 @@ check_untyped_defs            = True
 allow_redefinition_new        = True
 local_partial_types           = True
 
+[mypy-mesonbuild.cmdline]
+strict_optional               = True
+
 [mypy-mesonbuild.coredata]
 strict_optional               = True
 

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -225,7 +225,7 @@ class TestSerialisation:
             assert isinstance(self.exe_wrapper, programs.ExternalProgram)
 
 
-def get_backend_from_name(backend: str, build: T.Optional[build.Build] = None) -> T.Optional['Backend']:
+def get_backend_from_name(backend: str, build: T.Optional[build.Build] = None) -> Backend:
     if backend == 'ninja':
         from . import ninjabackend
         return ninjabackend.NinjaBackend(build)
@@ -262,17 +262,17 @@ def get_backend_from_name(backend: str, build: T.Optional[build.Build] = None) -
     elif backend == 'none':
         from . import nonebackend
         return nonebackend.NoneBackend(build)
-    return None
+    raise MesonException(f'Unknown backend {backend}')
 
 
-def get_genvslite_backend(genvsname: str, build: T.Optional[build.Build] = None) -> T.Optional['Backend']:
+def get_genvslite_backend(genvsname: str, build: T.Optional[build.Build] = None) -> Backend:
     if genvsname == 'vs2022':
         from . import vs2022backend
         return vs2022backend.Vs2022Backend(build, gen_lite = True)
     if genvsname == 'vs2026':
         from . import vs2026backend
         return vs2026backend.Vs2026Backend(build, gen_lite = True)
-    return None
+    raise MesonException(f'Unknown genvslite backend {genvsname}')
 
 # This class contains the basic functionality that is needed by all backends.
 # Feel free to move stuff in and out of it as you see fit.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1455,8 +1455,7 @@ class Backend:
                 fname = self.determine_ext_objs(i)
             elif isinstance(i, programs.Program):
                 assert i.found(), "This shouldn't be possible"
-                assert i.get_path() is not None, 'for mypy'
-                fname = [i.get_path()]
+                fname = [mesonlib.unwrap(i.get_path())]
             else:
                 fname = [i.rel_to_builddir(self.build_to_src)]
             if target.absolute_paths:

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -749,9 +749,7 @@ class Backend:
         Otherwise, we query the target for the dynamic linker.
         '''
         if isinstance(target, build.StaticLibrary):
-            static_linker = self.build.static_linker[target.for_machine]
-            assert static_linker is not None, "Compiler.needs_static_linker does not match backend logic"
-            return static_linker, []
+            return self.build.get_static_linker(target), []
         l, stdlib_args = target.get_clink_dynamic_linker_and_stdlibs()
         return l, stdlib_args
 

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -27,7 +27,7 @@ from .. import compilers
 from ..compilers import detect, lang_suffixes
 from ..mesonlib import (
     File, MachineChoice, MesonException, MesonBugException, OrderedSet,
-    ExecutableSerialisation, EnvironmentException,
+    ExecutableSerialisation, EnvironmentException, FileMode,
     classify_unity_sources, get_compiler_for_source,
     get_rsp_threshold, unique_list
 )
@@ -42,7 +42,6 @@ if T.TYPE_CHECKING:
     from ..environment import Environment
     from ..interpreter import Test
     from ..linkers import StaticLinker
-    from ..mesonlib import FileMode
     from ..options import ElementaryOptionValues
 
     from typing_extensions import Literal, TypedDict, NotRequired, TypeAlias
@@ -146,8 +145,7 @@ class TargetInstallData:
     install_name_mappings: T.Mapping[str, str]
     rpath_dirs_to_remove: T.Set[bytes]
     install_rpath: str
-    # TODO: install_mode should just always be a FileMode object
-    install_mode: T.Optional['FileMode']
+    install_mode: FileMode
     subproject: str
     system: str
     optional: bool = False
@@ -1728,7 +1726,7 @@ class Backend:
                     'using the default installation directory for an output.'
                 raise MesonException(m.format(t.name, num_out, t.get_outputs(), num_outdirs, outdirs))
             assert len(t.install_tag) == num_out
-            install_mode = t.get_custom_install_mode()
+            install_mode = t.get_custom_install_mode() or FileMode()
             # because mypy gets confused type narrowing in lists
             first_outdir = outdirs[0]
             first_outdir_name = install_dir_names[0]

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -191,8 +191,7 @@ class NinjaRule:
                 # shell constructs shouldn't be shell quoted
                 return NinjaCommandArg(c, Quoting.notShell)
             if c.startswith('$'):
-                varp = re.match(r'\$\{?(\w*)\}?', c)
-                assert varp is not None, 'for mypy'
+                varp = mesonlib.unwrap(re.match(r'\$\{?(\w*)\}?', c))
                 var: str = varp.group(1)
                 if var not in raw_names:
                     # ninja variables shouldn't be ninja quoted, and their value

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -470,7 +470,6 @@ class RustCrate:
     edition: RUST_EDITIONS
     deps: T.List[RustDep]
     cfg: T.List[str]
-    is_proc_macro: bool
 
     # This is set to True for members of this project, and False for all
     # subprojects
@@ -483,13 +482,12 @@ class RustCrate:
             "root_module": self.root_module,
             "edition": self.edition,
             "cfg": self.cfg,
-            "is_proc_macro": self.is_proc_macro,
+            "is_proc_macro": self.proc_macro_dylib_path is not None,
             "deps": [d.to_json() for d in self.deps],
         }
 
-        if self.is_proc_macro:
-            assert self.proc_macro_dylib_path is not None, "This shouldn't happen"
-            ret["proc_macro_dylib_path"] = self.proc_macro_dylib_path
+        if (proc_macro := self.proc_macro_dylib_path) is not None:
+            ret["proc_macro_dylib_path"] = proc_macro
 
         return ret
 
@@ -1982,7 +1980,6 @@ class NinjaBackend(backends.Backend):
             deps,
             cfg,
             is_workspace_member=not from_subproject,
-            is_proc_macro=proc_macro_dylib_path is not None,
             proc_macro_dylib_path=proc_macro_dylib_path,
         )
 

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1225,7 +1225,7 @@ class Vs2010Backend(backends.Backend):
     @staticmethod
     def get_nmake_base_meson_command_and_exe_search_paths() -> T.Tuple[str, str]:
         meson_cmd_list = mesonlib.get_meson_command()
-        assert (len(meson_cmd_list) == 1) or (len(meson_cmd_list) == 2)
+        assert len(meson_cmd_list) in {1, 2}
         # We expect get_meson_command() to either be of the form -
         #   1:  ['path/to/meson.exe']
         # or -

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -498,6 +498,12 @@ class Build:
 
         return link_args.get(compiler.get_language(), [])
 
+    def get_static_linker(self, target: BuildTarget) -> StaticLinker:
+        archiver = self.static_linker[target.for_machine]
+        if archiver is None:
+            raise MesonBugException(f'Required static_linker for {target.for_machine} not found')
+        return archiver
+
 @dataclass(eq=False)
 class IncludeDirs(HoldableObject):
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -27,6 +27,7 @@ from .mesonlib import (
     get_filenames_templates_dict, substitute_values, has_path_sep,
     is_parent_path, relpath, PerMachineDefaultable,
     MesonBugException, EnvironmentVariables, pickle_load, lazy_property,
+    unwrap,
 )
 from .options import OptionKey
 
@@ -1400,7 +1401,6 @@ class BuildTarget(Target):
         # PIC is always on for Windows (all code is position-independent
         # since library loading is done differently)
         m = self.environment.machines[self.for_machine]
-        assert m is not None, 'for mypy'
         if arg == 'pic' and (m.is_darwin() or m.is_windows()):
             return True
 
@@ -2915,9 +2915,8 @@ def flatten_command(cmd: T.Iterable[CommandTypes],
         elif isinstance(c, programs.Program):
             if not c.found():
                 raise InvalidArguments('Tried to use not-found external program in "command"')
-            path = c.get_path()
-            # We know path is not non if c.found()
-            assert path is not None, 'for mypy'
+            # We know path is not none if c.found()
+            path = unwrap(c.get_path())
             if os.path.isabs(path):
                 # Can only add a dependency on an external program which we
                 # know the absolute path of

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -458,9 +458,8 @@ class ConverterTarget:
         for gen_file in self.generated_raw:
             ctgt = output_target_map.generated(gen_file)
             if ctgt:
-                assert isinstance(ctgt, ConverterCustomTarget)
                 ref = ctgt.get_ref(gen_file)
-                assert isinstance(ref, CustomTargetReference) and ref.valid()
+                assert ref.valid()
                 self.generated_ctgt += [ref]
             else:
                 self.generated += [gen_file]
@@ -759,7 +758,6 @@ class ConverterCustomTarget:
                 self.depends += [tgt]
             elif gen:
                 ctgt_ref = gen.get_ref(raw)
-                assert ctgt_ref is not None
                 self.inputs += [ctgt_ref]
 
     def process_inter_target_dependencies(self) -> None:
@@ -775,15 +773,16 @@ class ConverterCustomTarget:
                 new_deps += [i]
         self.depends = list(OrderedSet(new_deps))
 
-    def get_ref(self, fname: Path) -> T.Optional[CustomTargetReference]:
+    def get_ref(self, fname: Path) -> CustomTargetReference:
         name = fname.name
+        if name in self.conflict_map:
+            name = self.conflict_map[name]
         try:
-            if name in self.conflict_map:
-                name = self.conflict_map[name]
             idx = self.outputs.index(name)
-            return CustomTargetReference(self, idx)
         except ValueError:
-            return None
+            raise mesonlib.MesonBugException(f'Attempted to get an output for {fname}, but none exists')
+
+        return CustomTargetReference(self, idx)
 
     def log(self) -> None:
         mlog.log('Custom Target', mlog.bold(self.name), f'({self.cmake_name})')

--- a/mesonbuild/cmdline.py
+++ b/mesonbuild/cmdline.py
@@ -64,7 +64,7 @@ def read_cmd_line_file(build_dir: str, options: SharedCMDOptions) -> None:
 
     # Do a copy because config is not really a dict. options.cmd_line_options
     # overrides values from the file.
-    d = {OptionKey.from_string(k): v for k, v in config['options'].items()}
+    d: dict[OptionKey, str | None] = {OptionKey.from_string(k): v for k, v in config['options'].items()}
     d.update(options.cmd_line_options)
     options.cmd_line_options = d
     options.builtin_keys = set()
@@ -131,7 +131,7 @@ class KeyNoneAction(argparse.Action):
         super().__init__(option_strings, dest, nargs=1, **kwargs)
 
     def __call__(self, parser: argparse.ArgumentParser, namespace: argparse.Namespace,
-                 arg: T.List[str], option_string: str = None) -> None: # type: ignore[override]
+                 arg: T.List[str], option_string: str | None = None) -> None: # type: ignore[override]
         current_dict = getattr(namespace, self.dest)
         if current_dict is None:
             current_dict = {}
@@ -168,7 +168,7 @@ class BuiltinAction(argparse.Action):
                          help=f'{h}{help_suffix}.', **kwargs)
 
     def __call__(self, parser: argparse.ArgumentParser, namespace: argparse.Namespace,
-                 arg: T.Optional[T.List[str]], option_string: str = None) -> None: # type: ignore[override]
+                 arg: T.Optional[T.List[str]], option_string: str | None = None) -> None: # type: ignore[override]
         current_dict = getattr(namespace, self.dest)
         if current_dict is None:
             current_dict = {}
@@ -189,7 +189,7 @@ class KeyValueAction(argparse.Action):
         super().__init__(option_strings, dest, nargs=1, **kwargs)
 
     def __call__(self, parser: argparse.ArgumentParser, namespace: argparse.Namespace,
-                 arg: T.List[str], option_string: str = None) -> None: # type: ignore[override]
+                 arg: T.List[str], option_string: str | None = None) -> None: # type: ignore[override]
         current_dict = getattr(namespace, self.dest)
         if current_dict is None:
             current_dict = {}

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1460,9 +1460,8 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
         :param command: The string list of commands to run
         :return: The list of commands wrapped by the exe_wrapper if it is needed, otherwise the original commands
         """
-        if self.is_cross and self.environment.has_exe_wrapper():
-            assert self.environment.exe_wrapper is not None, 'for mypy'
-            return self.environment.exe_wrapper.get_command() + command
+        if self.is_cross and (exe_wrapper := self.environment.get_exe_wrapper()):
+            return exe_wrapper.get_command() + command
         return command
 
     def _run_sanity_check(self, cmdlist: T.List[str], work_dir: str) -> None:

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from ..mesonlib import (
     MesonException, EnvironmentException, MachineChoice, join_args,
     search_version, is_windows, Popen_safe, Popen_safe_logged, version_compare, windows_proof_rm,
+    unwrap,
 )
 from ..programs import ExternalProgram
 from ..envconfig import BinaryTable, detect_cpu_family
@@ -396,8 +397,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
                 linker=linker, full_version=full_version)
 
         if 'Arm C/C++/Fortran Compiler' in out:
-            arm_ver_match = re.search(r'version (\d+)\.(\d+)\.?(\d+)? \(build number (\d+)\)', out)
-            assert arm_ver_match is not None, 'for mypy'  # because mypy *should* be complaining that this could be None
+            arm_ver_match = unwrap(re.search(r'version (\d+)\.(\d+)\.?(\d+)? \(build number (\d+)\)', out))
             version = '.'.join([x for x in arm_ver_match.groups() if x is not None])
             if lang == 'c':
                 cls = c.ArmLtdClangCCompiler
@@ -624,8 +624,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
                 cls = c.MetrowerksCCompilerEmbeddedPowerPC if lang == 'c' else cpp.MetrowerksCPPCompilerEmbeddedPowerPC
                 lnk = linkers.MetrowerksLinkerEmbeddedPowerPC
 
-            mwcc_ver_match = re.search(r'Version (\d+)\.(\d+)\.?(\d+)? build (\d+)', out)
-            assert mwcc_ver_match is not None, 'for mypy'  # because mypy *should* be complaining that this could be None
+            mwcc_ver_match = unwrap(re.search(r'Version (\d+)\.(\d+)\.?(\d+)? build (\d+)', out))
             compiler_version = '.'.join(x for x in mwcc_ver_match.groups() if x is not None)
 
             env.add_lang_args(cls.language, cls, for_machine)
@@ -634,8 +633,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
             if ld is not None:
                 _, o_ld, _ = Popen_safe(ld + ['--version'])
 
-                mwld_ver_match = re.search(r'Version (\d+)\.(\d+)\.?(\d+)? build (\d+)', o_ld)
-                assert mwld_ver_match is not None, 'for mypy'  # because mypy *should* be complaining that this could be None
+                mwld_ver_match = unwrap(re.search(r'Version (\d+)\.(\d+)\.?(\d+)? build (\d+)', o_ld))
                 linker_version = '.'.join(x for x in mwld_ver_match.groups() if x is not None)
 
                 linker = lnk(ld, env, for_machine, version=linker_version)
@@ -649,8 +647,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
             cls = c.TaskingCCompiler
             lnk = linkers.TaskingLinker
 
-            tasking_ver_match = re.search(r'v([0-9]+)\.([0-9]+)r([0-9]+) Build ([0-9]+)', err)
-            assert tasking_ver_match is not None, 'for mypy'
+            tasking_ver_match = unwrap(re.search(r'v([0-9]+)\.([0-9]+)r([0-9]+) Build ([0-9]+)', err))
             tasking_version = '.'.join(x for x in tasking_ver_match.groups() if x is not None)
 
             env.add_lang_args(cls.language, cls, for_machine)
@@ -776,8 +773,7 @@ def detect_fortran_compiler(env: 'Environment', for_machine: MachineChoice) -> C
 
             if 'Arm C/C++/Fortran Compiler' in out:
                 cls = fortran.ArmLtdFlangFortranCompiler
-                arm_ver_match = re.search(r'version (\d+)\.(\d+)\.?(\d+)? \(build number (\d+)\)', out)
-                assert arm_ver_match is not None, 'for mypy'  # because mypy *should* be complaining that this could be None
+                arm_ver_match = unwrap(re.search(r'version (\d+)\.(\d+)\.?(\d+)? \(build number (\d+)\)', out))
                 version = '.'.join([x for x in arm_ver_match.groups() if x is not None])
                 linker = guess_nix_linker(env, compiler, cls, version, for_machine)
                 return cls(

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -167,8 +167,7 @@ class RustCompiler(Compiler):
                                    ) -> T.Tuple[T.List[str], T.List[str]]:
         cmdlist = self.exelist.copy()
         largs: T.List[str] = []
-        assert self.linker is not None, 'for mypy'
-        if self.info.kernel == 'none' and 'ld.' in self.linker.id:
+        if self.info.kernel == 'none' and 'ld.' in self.get_linker_id():
             largs.extend(rustc_link_args(['-nostartfiles']))
         cmdlist.extend(self.get_output_args(binname))
         cmdlist.append(sourcename)

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -267,8 +267,8 @@ class Properties:
 @dataclass(unsafe_hash=True)
 class MachineInfo(HoldableObject):
     system: str
-    cpu_family: str
-    cpu: str
+    cpu_family: str | None
+    cpu: str | None
     endian: str
     kernel: T.Optional[str]
     subsystem: T.Optional[str]

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -111,6 +111,8 @@ class Environment:
     log_dir = 'meson-logs'
     info_dir = 'meson-info'
 
+    exe_wrapper: ExternalProgram | None
+
     def __init__(self, source_dir: str, build_dir: T.Optional[str], cmd_options: cmdline.SharedCMDOptions) -> None:
         self.source_dir = source_dir
         # Do not try to create build directories when build_dir is none.
@@ -258,6 +260,7 @@ class Environment:
                         if k.machine is MachineChoice.HOST or self.coredata.optstore.is_per_machine_option(k)}
 
         exe_wrapper = self.lookup_binary_entry(MachineChoice.HOST, 'exe_wrapper')
+        self.exe_wrapper: ExternalProgram | None
         if exe_wrapper is not None:
             self.exe_wrapper = ExternalProgram.from_bin_list(self, MachineChoice.HOST, 'exe_wrapper')
         else:

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -444,11 +444,10 @@ class Environment:
         # re-initialized with project options by the interpreter during
         # build file parsing.
         # meson_command is used by the regenchecker script, which runs meson
-        meson_command = mesonlib.get_meson_command()
-        if meson_command is None:
+        try:
+            meson_command = mesonlib.get_meson_command().copy()
+        except MesonBugException:
             meson_command = []
-        else:
-            meson_command = meson_command.copy()
         self.coredata = coredata.CoreData(options, self.scratch_dir, meson_command)
         self.first_invocation = True
 
@@ -477,10 +476,7 @@ class Environment:
 
     @staticmethod
     def get_build_command(unbuffered: bool = False) -> T.List[str]:
-        cmd = mesonlib.get_meson_command()
-        if cmd is None:
-            raise MesonBugException('No command?')
-        cmd = cmd.copy()
+        cmd = mesonlib.get_meson_command().copy()
         if unbuffered and 'python' in os.path.basename(cmd[0]):
             cmd.insert(1, '-u')
         return cmd

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1225,8 +1225,6 @@ class Interpreter(InterpreterBase, HoldableObject):
             assert isinstance(backend_name, str), 'for mypy'
             self.backend = backends.get_backend_from_name(backend_name, self.build)
 
-        if self.backend is None:
-            raise InterpreterException(f'Unknown backend "{backend_name}".')
         if backend_name != self.backend.name:
             if self.backend.name.startswith('vs'):
                 mlog.log('Auto detected Visual Studio backend:', mlog.bold(self.backend.name))

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1321,7 +1321,6 @@ class Interpreter(InterpreterBase, HoldableObject):
         self.active_projectname = proj_name
 
         version = kwargs['version']
-        assert version is not None, 'for mypy'
         if isinstance(version, mesonlib.File):
             FeatureNew.single_use('version from file', '0.57.0', self.subproject, location=node)
             self.add_build_def_file(version)
@@ -1383,7 +1382,6 @@ class Interpreter(InterpreterBase, HoldableObject):
             wrap_mode = WrapMode.from_string(wrap_mode_s)
             self.environment.wrap_resolver = wrap.Resolver(self.environment.get_source_dir(), subprojects_dir, self.subproject, wrap_mode)
         else:
-            assert self.environment.wrap_resolver is not None, 'for mypy'
             self.environment.wrap_resolver.load_and_merge(subprojects_dir, self.subproject)
 
         if self.cargo is None:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import io, sys, traceback
 import dataclasses
+import functools
 
 from .. import mparser
 from .. import environment
@@ -272,6 +273,8 @@ implicit_check_false_warning = """You should add the boolean check kwarg to the 
          See also: https://github.com/mesonbuild/meson/issues/9300"""
 class Interpreter(InterpreterBase, HoldableObject):
 
+    backend: mesonlib.late_property[Backend] = mesonlib.late_property()
+
     def __init__(
                 self,
                 _build: build.Build,
@@ -288,7 +291,8 @@ class Interpreter(InterpreterBase, HoldableObject):
         super().__init__(_build.environment.get_source_dir(), subdir, subproject, subproject_dir, _build.environment)
         self.active_projectname = ''
         self.build = _build
-        self.backend = backend
+        if backend is not None:
+            self.backend = backend
         self.cargo = cargo
         self.summary: T.Dict[str, 'Summary'] = {}
         self.modules: T.Dict[str, NewExtensionModule] = {}
@@ -1208,10 +1212,8 @@ class Interpreter(InterpreterBase, HoldableObject):
                         f'"configuration_data": initial value dictionary key "{k!r}"" must be "str | int | bool", not "{v!r}"')
         return build.ConfigurationData(initial_values)
 
+    @functools.lru_cache(None)
     def set_backend(self) -> None:
-        # The backend is already set when parsing subprojects
-        if self.backend is not None:
-            return
         from ..backend import backends
 
         if OptionKey('genvslite') in self.user_defined_options.cmd_line_options:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1262,7 +1262,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         KwargInfo('meson_version', (str, NoneType)),
         KwargInfo(
             'version',
-            (str, mesonlib.File, NoneType, list),
+            (str, mesonlib.File, list),
             default='undefined',
             validator=_project_version_validator,
             convertor=lambda x: x[0] if isinstance(x, list) else x,

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -689,9 +689,7 @@ class ProgramHolder(ObjectHolder[_PROG]):
             assert isinstance(self.held_object, build.LocalProgram) and \
                 isinstance(self.held_object.program, (build.BuildTarget, build.CustomTargetIndex))
             return self.interpreter.backend.get_target_filename_abs(self.held_object.program)
-        path = self.held_object.get_path()
-        assert path is not None
-        return path
+        return mesonlib.unwrap(self.held_object.get_path())
 
     @noPosargs
     @noKwargs
@@ -702,9 +700,7 @@ class ProgramHolder(ObjectHolder[_PROG]):
             raise InterpreterException('Unable to get the path of a not-found external program')
         if not self.held_object.runnable():
             return [self._full_path()]
-        cmd = self.held_object.get_command()
-        assert cmd is not None
-        return cmd
+        return self.held_object.get_command()
 
     @noPosargs
     @noKwargs
@@ -1098,9 +1094,9 @@ class BuildTargetHolder(ObjectHolder[_BuildTarget]):
         if self._target_object.vala_header is None:
             raise mesonlib.MesonException("Attempted to get a Vala header from a target that doesn't generate one")
 
-        assert self.interpreter.backend is not None, 'for mypy'
         return mesonlib.File.from_built_file(
-            self.interpreter.backend.get_target_dir(self._target_object), self._target_object.vala_header)
+            self.interpreter.backend.get_target_dir(self._target_object),
+            self._target_object.vala_header)
 
     @FeatureNew('vala_vapi', '1.10.0')
     @noPosargs
@@ -1110,9 +1106,9 @@ class BuildTargetHolder(ObjectHolder[_BuildTarget]):
         if self._target_object.vala_vapi is None:
             raise mesonlib.MesonException("Attempted to get a Vala VAPI from a target that doesn't generate one")
 
-        assert self.interpreter.backend is not None, 'for mypy'
         return mesonlib.File.from_built_file(
-            self.interpreter.backend.get_target_dir(self._target_object), self._target_object.vala_vapi)
+            self.interpreter.backend.get_target_dir(self._target_object),
+            self._target_object.vala_vapi)
 
     @FeatureNew('vala_gir', '1.10.0')
     @noPosargs
@@ -1122,9 +1118,9 @@ class BuildTargetHolder(ObjectHolder[_BuildTarget]):
         if self._target_object.vala_gir is None:
             raise mesonlib.MesonException("Attempted to get a Vala GIR from a target that doesn't generate one")
 
-        assert self.interpreter.backend is not None, 'for mypy'
         return mesonlib.File.from_built_file(
-            self.interpreter.backend.get_target_dir(self._target_object), self._target_object.vala_gir)
+            self.interpreter.backend.get_target_dir(self._target_object),
+            self._target_object.vala_gir)
 
 
 class ExecutableHolder(BuildTargetHolder[build.Executable]):
@@ -1177,7 +1173,6 @@ class CustomTargetIndexHolder(ObjectHolder[build.CustomTargetIndex]):
     @noKwargs
     @InterpreterObject.method('full_path')
     def full_path_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> str:
-        assert self.interpreter.backend is not None
         return self.interpreter.backend.get_target_filename_abs(self.held_object)
 
 _CT = T.TypeVar('_CT', bound=build.CustomTarget)

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -238,7 +238,7 @@ class AddTestSetup(TypedDict):
 
 class Project(TypedDict):
 
-    version: T.Optional[FileOrString]
+    version: FileOrString
     meson_version: T.Optional[str]
     default_options: options.OptionDict
     license: T.List[str]

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -21,7 +21,7 @@ from . import mesonlib
 from . import mintro
 from . import mlog
 from .ast import AstIDGenerator, IntrospectionInterpreter
-from .mesonlib import MachineChoice
+from .mesonlib import MachineChoice, unwrap
 from .options import OptionKey
 from .optinterpreter import OptionInterpreter
 
@@ -189,8 +189,8 @@ class Conf:
                 mlog.log(*items)
 
     def split_options_per_subproject(self, opts: T.Union[options.MutableKeyedOptionDictType, options.OptionStore]
-                                     ) -> T.Dict[str, options.MutableKeyedOptionDictType]:
-        result: T.Dict[str, options.MutableKeyedOptionDictType] = {}
+                                     ) -> T.Dict[str | None, options.MutableKeyedOptionDictType]:
+        result: T.Dict[str | None, options.MutableKeyedOptionDictType] = {}
         for k, o in opts.items():
             if k.subproject is not None:
                 self.all_subprojects.add(k.subproject)
@@ -278,10 +278,9 @@ class Conf:
                 dir_options[k] = v
             elif k in test_option_names:
                 test_options[k] = v
-            elif k.has_module_prefix():
+            elif (modname := k.get_module_prefix()) is not None:
                 # Ignore module options if we did not use that module during
                 # configuration.
-                modname = k.get_module_prefix()
                 if self.build and modname not in self.build.modules:
                     continue
                 module_options[modname][k] = v
@@ -293,7 +292,7 @@ class Conf:
         host_compiler_options = self.split_options_per_subproject({k: v for k, v in self.coredata.optstore.items() if self.coredata.optstore.is_compiler_option(k) and k.machine is MachineChoice.HOST})
         build_compiler_options = self.split_options_per_subproject({k: v for k, v in self.coredata.optstore.items() if self.coredata.optstore.is_compiler_option(k) and k.machine is MachineChoice.BUILD})
         project_options = self.split_options_per_subproject({k: v for k, v in self.coredata.optstore.items() if self.coredata.optstore.is_project_option(k)})
-        show_build_options = self.default_values_only or self.build.environment.is_cross_build()
+        show_build_options = self.default_values_only or unwrap(self.build).environment.is_cross_build()
 
         self.add_section('Global build options')
         self.print_options('Core options', host_core_options[None])
@@ -390,8 +389,9 @@ def run_impl(options: CMDOptions, builddir: str) -> int:
             save = True
         if save:
             c.save()
-            mintro.update_build_options(c.coredata, c.build.environment.info_dir)
-            mintro.write_meson_info_file(c.build, [])
+            build = unwrap(c.build)
+            mintro.update_build_options(c.coredata, build.environment.info_dir)
+            mintro.write_meson_info_file(build, [])
     except ConfException as e:
         mlog.log('Meson configurator encountered an error:')
         if c is not None and c.build is not None:

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from mesonbuild.environment import Environment
 from mesonbuild.tooldetect import detect_ninja
 from mesonbuild.mesonlib import (GIT, MesonException, RealPathAction, SimpleABC, get_meson_command, quiet_git,
-                                 windows_proof_rmtree, setup_vsenv, determine_worker_count)
+                                 windows_proof_rmtree, setup_vsenv, determine_worker_count, unwrap_err)
 from .options import OptionKey
 from mesonbuild.msetup import add_arguments as msetup_argparse
 from mesonbuild.wrap import wrap
@@ -337,7 +337,8 @@ def check_dist(packagename: str, _meson_command: ImmutableListProtocol[str], ext
         if os.path.exists(p):
             windows_proof_rmtree(p)
         os.mkdir(p)
-    ninja_args = detect_ninja() + [f'-j{num_processes}']
+    ninja = unwrap_err(detect_ninja(), 'Ninja is required but could not be found')
+    ninja_args = ninja + [f'-j{num_processes}']
     shutil.unpack_archive(packagename, unpackdir)
     unpacked_files = glob(os.path.join(unpackdir, '*'))
     assert len(unpacked_files) == 1
@@ -387,7 +388,9 @@ def run(options: argparse.Namespace) -> int:
     bld_root = b.environment.build_dir
     priv_dir = os.path.join(bld_root, 'meson-private')
 
-    dist_name = b.project_name + '-' + b.project_version
+    dist_name = b.project_name
+    if b.project_version is not None:
+        dist_name = f'{dist_name}-{b.project_version}'
 
     archives = determine_archives_to_generate(options)
 

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -57,7 +57,7 @@ def errorhandler(e: Exception, command: str) -> int:
         elif isinstance(e, OSError):
             mlog.exception(Exception("Unhandled python OSError. This is probably not a Meson bug, "
                            "but an issue with your build environment."))
-            return e.errno
+            return e.errno or 0
         else: # Exception
             msg = 'Unhandled python exception'
             if all(getattr(e, a, None) is not None for a in ['file', 'lineno', 'colno']):
@@ -126,7 +126,8 @@ class CommandLineParser:
                          help_msg=argparse.SUPPRESS)
 
     def add_command(self, name: str, add_arguments_func: T.Callable[[argparse.ArgumentParser], None],
-                    run_func: T.Callable[[argparse.Namespace], int], help_msg: str, aliases: T.List[str] = None) -> None:
+                    run_func: T.Callable[[argparse.Namespace], int], help_msg: str,
+                    aliases: T.List[str] | None = None) -> None:
         aliases = aliases or []
         # FIXME: Cannot have hidden subparser:
         # https://bugs.python.org/issue22848
@@ -185,7 +186,7 @@ class CommandLineParser:
             command = None
 
         from . import mesonlib
-        args = mesonlib.expand_arguments(args)
+        args = mesonlib.unwrap_err(mesonlib.expand_arguments(args), 'Failed to expand arguments')
         options = T.cast('MesonMainCMDOptions', parser.parse_args(args))
 
         if command is None:

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -198,7 +198,8 @@ def run(options: Arguments) -> int:
         if vsenv_active:
             mlog.log(mlog.green('INFO:'), 'automatically activated MSVC compiler environment')
 
-        cmd = detect_ninja() + ['-C', options.builddir]
+        ninja = mesonlib.unwrap_err(detect_ninja(), 'Could not detect ninja and it is required')
+        cmd = ninja + ['-C', options.builddir]
         ret = subprocess.run(cmd)
         if ret.returncode:
             raise SystemExit

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -18,10 +18,12 @@ import re
 from . import build, tooldetect
 from .backend.backends import InstallData
 from .mesonlib import (MesonException, Popen_safe, RealPathAction, is_windows,
-                       is_aix, setup_vsenv, path_has_root, pickle_load, is_osx)
+                       is_aix, setup_vsenv, path_has_root, pickle_load, is_osx,
+                       unwrap)
 from .options import OptionKey
 from .scripts import depfixer, destdir_join
 from .scripts.meson_exe import run_exe
+main_file: str | None
 try:
     from __main__ import __file__ as main_file
 except ImportError:
@@ -165,7 +167,11 @@ def set_chown(path: str, user: T.Union[str, int, None] = None,
     if sys.version_info >= (3, 13):
         # pylint: disable=unexpected-keyword-arg
         # cannot handle sys.version_info, https://github.com/pylint-dev/pylint/issues/9622
-        shutil.chown(path, user, group, dir_fd=dir_fd, follow_symlinks=follow_symlinks)
+        #
+        # Mypy does not understand that the assert above ensures that user,
+        # group is either `None, int | str` or `int | str, None`, so we need to
+        # ignore the warning
+        shutil.chown(path, user, group, dir_fd=dir_fd, follow_symlinks=follow_symlinks)  # type: ignore[arg-type]
     else:
         real_os_chown = os.chown
 
@@ -181,7 +187,10 @@ def set_chown(path: str, user: T.Union[str, int, None] = None,
 
         try:
             os.chown = chown
-            shutil.chown(path, user, group)
+            # Mypy does not understand that the assert above ensures that user,
+            # group is either `None, int | str` or `int | str, None`, so we need to
+            # ignore the warning
+            shutil.chown(path, user, group)  # type: ignore[arg-type]
         finally:
             os.chown = real_os_chown
 
@@ -577,6 +586,7 @@ class Installer:
             if is_windows() or destdir != '' or not os.isatty(sys.stdout.fileno()) or not os.isatty(sys.stderr.fileno()):
                 # can't elevate to root except in an interactive unix environment *and* when not doing a destdir install
                 raise
+
             rootcmd = (
                 os.environ.get('MESON_ROOT_CMD')
                 or shutil.which('sudo')
@@ -606,7 +616,8 @@ class Installer:
                     if ans is not None:
                         raise MesonException('Answer not one of [y/n]')
                 if ans == 'y':
-                    os.execlp(rootcmd, rootcmd, sys.executable, main_file, *sys.argv[1:],
+                    mf = unwrap(main_file, 'main_file should only be None on Windows')
+                    os.execlp(rootcmd, rootcmd, sys.executable, mf, *sys.argv[1:],
                               '-C', os.getcwd(), '--no-rebuild')
             raise
 

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -530,7 +530,6 @@ def run(options: argparse.Namespace) -> int:
         # Make sure that log entries in other parts of meson don't interfere with the JSON output
         with redirect_stdout(sys.stderr):
             backend = backends.get_backend_from_name(options.backend)
-            assert backend is not None
             intr = IntrospectionInterpreter(sourcedir, '', backend.name, visitors = [AstIDGenerator(), AstIndentationGenerator(), AstConditionLevel()])
             intr.analyze()
 

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -160,10 +160,10 @@ class _Logger:
                 raise MesonException(f'Failed to start pager: {str(e)}')
 
     def stop_pager(self) -> None:
-        if self.log_pager:
+        if self.log_pager and (stdin := self.log_pager.stdin) is not None:
             try:
-                self.log_pager.stdin.flush()
-                self.log_pager.stdin.close()
+                stdin.flush()
+                stdin.close()
             except OSError:
                 pass
             self.log_pager.wait()
@@ -374,6 +374,7 @@ class _Logger:
             self.log_depth.pop()
 
     def get_log_dir(self) -> str:
+        assert self.log_dir is not None, 'attempted to use logger without initializing'
         return self.log_dir
 
     def get_log_depth(self) -> int:
@@ -396,7 +397,7 @@ class _Logger:
 
     def colorize_console(self) -> bool:
         output = sys.stderr if self.log_to_stderr else sys.stdout
-        _colorize_console: bool = getattr(output, 'colorize_console', None)
+        _colorize_console: bool | None = getattr(output, 'colorize_console', None)
         if _colorize_console is not None:
             return _colorize_console
         try:

--- a/mesonbuild/modules/codegen.py
+++ b/mesonbuild/modules/codegen.py
@@ -310,7 +310,6 @@ class CodeGenModule(ExtensionModule):
         if kwargs['implementations']:
             names = kwargs['implementations']
         else:
-            assert state.environment.machines[kwargs['native']] is not None, 'for mypy'
             if state.environment.machines[kwargs['native']].system == 'windows':
                 names.append('win_flex')
             names.extend(['flex', 'reflex', 'lex'])
@@ -389,7 +388,6 @@ class CodeGenModule(ExtensionModule):
         if kwargs['implementations']:
             names = kwargs['implementations']
         else:
-            assert state.environment.machines[kwargs['native']] is not None, 'for mypy'
             if state.environment.machines[kwargs['native']].system == 'windows':
                 names = ['win_bison', 'bison', 'yacc']
             else:

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1522,8 +1522,7 @@ class GnomeModule(ExtensionModule):
         for tool in ['scan', 'scangobj', 'mkdb', 'mkhtml', 'fixxref']:
             program_name = 'gtkdoc-' + tool
             program = state.find_program(program_name)
-            path = program.get_path()
-            assert path is not None, "This shouldn't be possible since program should be found"
+            path = mesonlib.unwrap(program.get_path())
             t_args.append(f'--{program_name}={path}')
         if namespace:
             t_args.append('--namespace=' + namespace)

--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -74,6 +74,7 @@ class ExternalProgram(Program):
     :param exclude_paths: A list of directories to exclude when searching in PATH"""
 
     windows_exts = ('exe', 'msc', 'com', 'bat', 'cmd')
+    command: list[str]
 
     def __init__(self, name: str, command: T.Optional[T.List[str]] = None,
                  silent: bool = False, search_dirs: T.Optional[T.List[T.Optional[str]]] = None,
@@ -83,7 +84,7 @@ class ExternalProgram(Program):
         self.cached_version: T.Optional[str] = None
         self.version_arg = '--version'
         if command is not None:
-            self.command = mesonlib.listify(command)
+            self.command = command.copy()
             if mesonlib.is_windows():
                 cmd = self.command[0]
                 args = self.command[1:]
@@ -130,7 +131,7 @@ class ExternalProgram(Program):
             else:
                 mlog.log('Program', mlog.bold(name), 'found:', mlog.red('NO'))
 
-    def summary_value(self) -> T.Union[str, mlog.AnsiDecorator]:
+    def summary_value(self) -> T.Union[str, mlog.AnsiDecorator, None]:
         if not self.found():
             return mlog.red('NO')
         return self.path
@@ -222,7 +223,7 @@ class ExternalProgram(Program):
         return ExternalProgram(command, silent=True)
 
     @staticmethod
-    def _shebang_to_cmd(script: str) -> T.Optional[T.List[str]]:
+    def _shebang_to_cmd(script: str) -> list[str]:
         """
         Check if the file has a shebang and manually parse it to figure out
         the interpreter to use. This is useful if the script is not executable
@@ -266,7 +267,7 @@ class ExternalProgram(Program):
         except Exception as e:
             mlog.debug(str(e))
         mlog.debug(f'Unusable script {script!r}')
-        return None
+        return []
 
     def _is_executable(self, path: str) -> bool:
         suffix = os.path.splitext(path)[-1].lower()[1:]
@@ -278,9 +279,9 @@ class ExternalProgram(Program):
             return not os.path.isdir(path)
         return False
 
-    def _search_dir(self, name: str, search_dir: T.Optional[str]) -> T.Optional[list]:
+    def _search_dir(self, name: str, search_dir: T.Optional[str]) -> list[str]:
         if search_dir is None:
-            return None
+            return []
         trial = os.path.join(search_dir, name)
         if os.path.exists(trial):
             if self._is_executable(trial):
@@ -295,9 +296,9 @@ class ExternalProgram(Program):
                     trial_ext = f'{trial}.{ext}'
                     if os.path.exists(trial_ext):
                         return [trial_ext]
-        return None
+        return []
 
-    def _search_windows_special_cases(self, name: str, command: T.Optional[str], exclude_paths: T.Optional[T.List[str]]) -> T.List[T.Optional[str]]:
+    def _search_windows_special_cases(self, name: str, command: T.Optional[str], exclude_paths: T.Optional[T.List[str]]) -> list[str]:
         '''
         Lots of weird Windows quirks:
         1. PATH search for @name returns files with extensions from PATHEXT,
@@ -327,7 +328,7 @@ class ExternalProgram(Program):
             commands = self._shebang_to_cmd(command)
             if commands:
                 return commands
-            return [None]
+            return []
         # Maybe the name is an absolute path to a native Windows
         # executable, but without the extension. This is technically wrong,
         # but many people do it because it works in the MinGW shell.
@@ -346,9 +347,9 @@ class ExternalProgram(Program):
             commands = self._search_dir(name, search_dir)
             if commands:
                 return commands
-        return [None]
+        return []
 
-    def _search(self, name: str, search_dirs: T.List[T.Optional[str]], exclude_paths: T.Optional[T.List[str]]) -> T.List[T.Optional[str]]:
+    def _search(self, name: str, search_dirs: T.List[T.Optional[str]], exclude_paths: T.Optional[T.List[str]]) -> list[str]:
         '''
         Search in the specified dirs for the specified executable by name
         and if not found search in PATH
@@ -359,7 +360,7 @@ class ExternalProgram(Program):
                 return commands
         # If there is a directory component, do not look in PATH
         if os.path.dirname(name) and not os.path.isabs(name):
-            return [None]
+            return []
         # Do a standard search in PATH
         path = os.environ.get('PATH', os.defpath)
         if mesonlib.is_windows() and path:
@@ -377,13 +378,13 @@ class ExternalProgram(Program):
             return self._search_windows_special_cases(name, command, exclude_paths)
         # On UNIX-like platforms, shutil.which() is enough to find
         # all executables whether in PATH or with an absolute path
-        return [command]
+        return [command] if command is not None else []
 
     def runnable(self) -> bool:
         return self.found()
 
     def found(self) -> bool:
-        return self.command[0] is not None
+        return bool(self.command)
 
     def get_command(self) -> T.List[str]:
         return self.command[:]
@@ -400,7 +401,7 @@ class NonExistingExternalProgram(ExternalProgram):  # lgtm [py/missing-call-to-i
 
     def __init__(self, name: str = 'nonexistingprogram') -> None:
         self.name = name
-        self.command = [None]
+        self.command = []
         self.path = None
 
     def __repr__(self) -> str:

--- a/mesonbuild/scripts/env2mfile.py
+++ b/mesonbuild/scripts/env2mfile.py
@@ -537,7 +537,7 @@ class AndroidDetector:
                 ofile.write("endian = 'little'\n")
 
 
-def run(options: T.Any) -> None:
+def run(options: argparse.Namespace) -> int:
     mlog.notice('This functionality is experimental and subject to change.')
     if options.cross:
         if options.use_for_build:
@@ -554,3 +554,5 @@ def run(options: T.Any) -> None:
         ad.detect_toolchains()
     else:
         raise ValueError("Encountered unreachable code-path")
+
+    return 0

--- a/mesonbuild/scripts/reprotest.py
+++ b/mesonbuild/scripts/reprotest.py
@@ -114,10 +114,10 @@ class ReproTester:
         self.check_contents('buildrepro', 'buildrepro.1st', True)
         self.check_contents('buildrepro.1st', 'buildrepro', False)
 
-def run(options: T.Any) -> None:
+def run(options: argparse.Namespace) -> int:
     rt = ReproTester(options)
     try:
-        sys.exit(rt.run())
+        return rt.run()
     except Exception as e:
         print(e)
-        sys.exit(1)
+        return 1

--- a/mesonbuild/tooldetect.py
+++ b/mesonbuild/tooldetect.py
@@ -78,11 +78,13 @@ def compute_llvm_suffix(coredata: coredata.CoreData) -> T.Optional[str]:
     # Neither compiler is a Clang, or no compilers are for C or C++
     return None
 
-def detect_lcov_genhtml(lcov_exe: str = 'lcov', genhtml_exe: str = 'genhtml') \
-        -> T.Tuple[str, T.Optional[str], str]:
-    lcov_exe, lcov_version = detect_lcov(lcov_exe)
-    if shutil.which(genhtml_exe) is None:
+def detect_lcov_genhtml(lcov_exe_: str = 'lcov', genhtml_exe_: str = 'genhtml') \
+        -> tuple[str | None, str | None, str | None]:
+    lcov_exe, lcov_version = detect_lcov(lcov_exe_)
+    if shutil.which(genhtml_exe_) is None:
         genhtml_exe = None
+    else:
+        genhtml_exe = genhtml_exe_
 
     return lcov_exe, lcov_version, genhtml_exe
 

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -228,8 +228,7 @@ class GitException(MesonException):
 
 GIT = shutil.which('git')
 def git(cmd: T.List[str], workingdir: StrOrBytesPath, check: bool = False, **kwargs: T.Any) -> T.Tuple[subprocess.Popen[str], str, str]:
-    assert GIT is not None, 'Callers should make sure it exists'
-    cmd = [GIT, *cmd]
+    cmd = [unwrap(GIT, 'Callers should make sure it exists'), *cmd]
     p, o, e = Popen_safe(cmd, cwd=workingdir, **kwargs)
     if check and p.returncode != 0:
         raise GitException('Git command failed: ' + str(cmd), e)
@@ -690,8 +689,8 @@ class PerMachineDefaultable(PerMachine[T.Optional[_T]]):
         This allows just specifying nothing in the native case, and just host in the
         cross non-compiler case.
         """
-        assert self.build is not None, 'Cannot fill in missing when all fields are empty'
-        return PerMachine(self.build, self.host if self.host is not None else self.build)
+        build = unwrap(self.build, 'Cannot fill in missing when all fields are empty')
+        return PerMachine(build, self.host if self.host is not None else build)
 
     @classmethod
     def default(cls, is_cross: bool, build: _T, host: _T) -> PerMachine[_T]:
@@ -722,10 +721,10 @@ class PerThreeMachineDefaultable(PerMachineDefaultable[T.Optional[_T]], PerThree
         cross non-compiler case, and just target in the native-built
         cross-compiler case.
         """
-        assert self.build is not None, 'Cannot default a PerMachine when all values are None'
-        host = self.host if self.host is not None else self.build
+        build = unwrap(self.build, 'Cannot fill in missing when all fields are empty')
+        host = self.host if self.host is not None else build
         target = self.target if self.target is not None else host
-        return PerThreeMachine(self.build, host, target)
+        return PerThreeMachine(build, host, target)
 
 
 _PLATFORM_SYSTEM_LOWER = platform.system().lower()

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -28,7 +28,7 @@ import json
 import dataclasses
 
 from mesonbuild import mlog
-from .core import MesonException, HoldableObject
+from .core import MesonException, MesonBugException, HoldableObject
 
 if T.TYPE_CHECKING:
     from typing_extensions import Literal, Protocol, Self
@@ -179,6 +179,8 @@ __all__ = [
     'substring_is_in_list',
     'typeslistify',
     'unique_list',
+    'unwrap',
+    'unwrap_err',
     'verbose_git',
     'version_check_to_range',
     'version_compare',
@@ -2812,3 +2814,38 @@ def pathname_sort_key(key: str) -> tuple[tuple[bool, tuple[int | str, ...]], ...
 
     return tuple((key.count('/') <= idx, alphanum_key(x))
                  for idx, x in enumerate(key.split('/')))
+
+
+def unwrap(value: _T | None, msg: str | None = None) -> _T:
+    """Remove None from a union type when it is a Meson bug.
+
+    This is used for cases where None being in the Union is a bug in Meson
+    itself.
+
+    :param value: The Union
+    :param msg: A message to print when a buggy value occurs, defaults to None
+    :raises MesonBugException: When None is in value
+    :return: The value union with None removed
+    """
+    if value is not None:
+        return value
+    raise MesonBugException(msg or 'Unexpected None value')
+
+
+def unwrap_err(value: _T | None, msg: str) -> _T:
+    """Remove None from a union type when it is not a Meson bug.
+
+    This is for cases where None is possible, but it represents a problem
+    outside of Meson itself.
+
+    For example, a missing external program, or a read only file system, or a
+    missing file
+
+    :param value: The Union to remove None from
+    :param msg: The message to print when None is found
+    :raises MesonException: When None is found in the union
+    :return: The Union with None removed
+    """
+    if value is not None:
+        return value
+    raise MesonException(msg)

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -637,14 +637,14 @@ class PerThreeMachine(PerMachine[_T]):
     def __setitem__(self, machine: MachineChoice | ThreeMachineChoice, val: _T) -> None:
         setattr(self, machine.get_lower_case_name(), val)
 
-    def miss_defaulting(self) -> "PerThreeMachineDefaultable[T.Optional[_T]]":
+    def miss_defaulting(self) -> "PerThreeMachineDefaultable[_T]":
         """Unset definition duplicated from their previous to None
 
         This is the inverse of ''default_missing''. By removing defaulted
         machines, we can elaborate the original and then redefault them and thus
         avoid repeating the elaboration explicitly.
         """
-        unfreeze: PerThreeMachineDefaultable[T.Optional[_T]] = PerThreeMachineDefaultable()
+        unfreeze: PerThreeMachineDefaultable[_T] = PerThreeMachineDefaultable()
         unfreeze.build = self.build
         unfreeze.host = self.host
         unfreeze.target = self.target

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -268,7 +268,9 @@ def set_meson_command(mainfile: str) -> None:
         mlog.log(f'meson_command is {_meson_command!r}')
 
 
-def get_meson_command() -> T.Optional['ImmutableListProtocol[str]']:
+def get_meson_command() -> ImmutableListProtocol[str]:
+    if _meson_command is None:
+        raise MesonBugException('Attempting to use meson_command before it is set')
     return _meson_command
 
 

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -152,6 +152,7 @@ __all__ = [
     'is_wsl',
     'iter_regexin_iter',
     'join_args',
+    'late_property',
     'lazy_property',
     'listify',
     'listify_array_value',
@@ -2708,6 +2709,28 @@ class lazy_property(T.Generic[_T]):
         value = self.__func(instance)
         setattr(instance, self.__name, value)
         return value
+
+
+class late_property(T.Generic[_T]):
+    """Descriptor that allows setting a property late and erroring if it's
+    accessed early.
+
+    This property allows a more ergonomically typed equivalent of
+    self.value: T | None = None, since you then don't need to worry about
+    whether self.value is None.
+    """
+
+    def __init__(self) -> None:
+        self.__name: str | None = None
+
+    def __set_name__(self, owner: object, name: str) -> None:
+        if self.__name is None:
+            self.__name = name
+        else:
+            assert self.__name == name
+
+    def __get__(self, instance: T.Any, cls: type) -> _T:
+        raise MesonBugException(f'Attempted to access attribute {self.__name} before it is set')
 
 
 def get_subproject_dir(directory: str = '.') -> T.Optional[str]:

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -64,6 +64,7 @@ if T.TYPE_CHECKING:
 
 FileOrString = T.Union['File', str]
 
+_P = T.ParamSpec('_P')
 _T = T.TypeVar('_T')
 _U = T.TypeVar('_U')
 
@@ -2592,11 +2593,11 @@ def get_wine_shortpath(winecmd: T.List[str], wine_paths: T.List[str],
     return wine_path
 
 
-def run_once(func: T.Callable[..., _T]) -> T.Callable[..., _T]:
+def run_once(func: T.Callable[_P, _T]) -> T.Callable[_P, _T]:
     ret: T.List[_T] = []
 
     @wraps(func)
-    def wrapper(*args: T.Any, **kwargs: T.Any) -> _T:
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
         if ret:
             return ret[0]
 
@@ -2607,9 +2608,9 @@ def run_once(func: T.Callable[..., _T]) -> T.Callable[..., _T]:
     return wrapper
 
 
-def generate_list(func: T.Callable[..., T.Generator[_T, None, None]]) -> T.Callable[..., T.List[_T]]:
+def generate_list(func: T.Callable[_P, T.Generator[_T, None, None]]) -> T.Callable[_P, T.List[_T]]:
     @wraps(func)
-    def wrapper(*args: T.Any, **kwargs: T.Any) -> T.List[_T]:
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> T.List[_T]:
         return list(func(*args, **kwargs))
 
     return wrapper

--- a/mesonbuild/wrap/wraptool.py
+++ b/mesonbuild/wrap/wraptool.py
@@ -192,8 +192,7 @@ def promote(options: 'argparse.Namespace') -> None:
 
 def status(options: 'argparse.Namespace') -> None:
     print('Subproject status')
-    subdir = mesonlib.get_subproject_dir()
-    assert subdir is not None, "This should only happen in a non-native subproject"
+    subdir = mesonlib.unwrap(mesonlib.get_subproject_dir(), "This should only happen in a non-native subproject")
     for w in glob(f'{subdir}/*.wrap'):
         name = os.path.basename(w)[:-5]
         try:

--- a/unittests/failuretests.py
+++ b/unittests/failuretests.py
@@ -38,7 +38,7 @@ def no_pkgconfig():
 
     def new_search(self, name, search_dirs, exclude_paths):
         if name == 'pkg-config':
-            return [None]
+            return []
         return old_search(self, name, search_dirs, exclude_paths)
 
     def new_which(cmd, **kwargs):

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -773,33 +773,36 @@ class InternalTests(unittest.TestCase):
                         for lib in ('pthread', 'm', 'c', 'dl', 'rt'):
                             self.assertNotIn(f'lib{lib}.a', link_arg, msg=link_args)
 
-    def test_program_version(self):
+    def test_program_version(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             script_path = Path(tmpdir) / 'script.py'
             script_path.write_text('import sys\nprint(sys.argv[1])\n', encoding='utf-8')
             script_path.chmod(0o755)
 
-            for output, expected in {
-                    '': None,
-                    '1': None,
-                    '1.2.4': '1.2.4',
-                    '1 1.2.4': '1.2.4',
-                    'foo version 1.2.4': '1.2.4',
-                    'foo 1.2.4.': '1.2.4',
-                    'foo 1.2.4': '1.2.4',
-                    'foo 1.2.4 bar': '1.2.4',
-                    'foo 10.0.0': '10.0.0',
-                    '50 5.4.0': '5.4.0',
-                    'This is perl 5, version 40, subversion 0 (v5.40.0)': '5.40.0',
-                    'git version 2.48.0.rc1': '2.48.0',
-            }.items():
-                prog = ExternalProgram('script', command=[python_command, str(script_path), output], silent=True)
+            inputs: list[tuple[str, str | None]] = [
+                ('',  None),
+                ('1',  None),
+                ('1.2.4',  '1.2.4'),
+                ('1 1.2.4',  '1.2.4'),
+                ('foo version 1.2.4',  '1.2.4'),
+                ('foo 1.2.4.',  '1.2.4'),
+                ('foo 1.2.4',  '1.2.4'),
+                ('foo 1.2.4 bar',  '1.2.4'),
+                ('foo 10.0.0',  '10.0.0'),
+                ('50 5.4.0',  '5.4.0'),
+                ('This is perl 5, version 40, subversion 0 (v5.40.0)',  '5.40.0'),
+                ('git version 2.48.0.rc1',  '2.48.0'),
+            ]
 
-                if expected is None:
-                    with self.assertRaisesRegex(MesonException, 'Could not find a version number'):
-                        prog.get_version()
-                else:
-                    self.assertEqual(prog.get_version(), expected)
+            for output, expected in inputs:
+                prog = ExternalProgram('script', command=python_command + [str(script_path), output], silent=True)
+
+                with self.subTest(output=output, expected=expected):
+                    if expected is None:
+                        with self.assertRaisesRegex(MesonException, 'Could not find a version number'):
+                            prog.get_version()
+                    else:
+                        self.assertEqual(prog.get_version(), expected)
 
     def test_version_compare(self):
         comparefunc = mesonbuild.mesonlib.version_compare_many


### PR DESCRIPTION
This is a first (and easy) set of changes to migrate toward strict null checking with mypy.

The plan is to make incremental changes to get there, and to do this I'm making use of the mypy.ini to set per-file overrides for the `strict_optional` setting. This allows us to enforce correctness in small pieces, while also not requiring a whole-sale fix up, which will likely be quite involved.