### PR TITLE
envconfig: allow running executables if subsystem is not set

### DIFF
--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -758,7 +758,7 @@ def machine_info_can_run(machine_info: MachineInfo) -> bool:
     system = detect_system()
     if machine_info.system != system:
         return False
-    if machine_info.subsystem != detect_subsystem(system):
+    if machine_info.subsystem and machine_info.subsystem != detect_subsystem(system):
         return False
     true_build_cpu_family = detect_cpu_family({})
     assert machine_info.cpu_family is not None, 'called on incomplete machine_info'


### PR DESCRIPTION
detect_subsystem(system) is just a simple transformation of system; do not require setting machine_info.subsystem at all costs, and if it is unset just assume that it is okay since the system has already been matched.

Regression introduced by commit 61c5859b7 ("envconfig: Cannot run executables if subsystem doesn't match", 2026-02-04).

Fixes: #15840 
Cc @nirbheek 