### PR TITLE
mtest: fix tap tests with nonzero exit code reported as passed

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1150,7 +1150,7 @@ class TestRunTAP(TestRun):
         return True
 
     def complete(self) -> None:
-        if self.returncode != 0 and self.res.is_ok():
+        if self.returncode != 0 and not self.res.is_bad():
             self.res = TestResult.ERROR
             self.stde = self.stde or ''
             self.stde += f'\n(test program exited with status code {self.returncode})'


### PR DESCRIPTION
## Summary
- Commit daa443188 narrowed the exit-code check from `not was_killed()` to `is_ok()`, but TAP parsing leaves `self.res` as RUNNING when no explicit FAIL/Bailout is found
- RUNNING is not in `is_ok()`, so nonzero exit codes were not upgraded to ERROR and `_complete()` defaulted RUNNING to OK
- Fix by using `not is_bad()` which covers RUNNING and all other non-failure states

Fixes #15885