### PR TITLE
mtest: allow ignore reasons in rust unittests

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1209,7 +1209,7 @@ class TestRunRust(TestRun):
         def parse_res(n: int, name: str, result: str) -> TAPParser.Test:
             if result == 'ok':
                 return TAPParser.Test(n, name, TestResult.OK, None)
-            elif result == 'ignored':
+            elif result.startswith('ignored'):
                 return TAPParser.Test(n, name, TestResult.SKIP, None)
             elif result == 'FAILED':
                 return TAPParser.Test(n, name, TestResult.FAIL, None)

--- a/test cases/rust/9 unit tests/test.rs
+++ b/test cases/rust/9 unit tests/test.rs
@@ -21,4 +21,10 @@ mod tests {
     fn test_add_intentional_fail2() {
         assert_eq!(add(1, 7), 5);
     }
+
+    #[test]
+    #[ignore = "Ignore this with a reason"]
+    fn test_add_intentional_fail3() {
+        assert_eq!(add(1, 9), 7)
+    }
 }


### PR DESCRIPTION
Allow reasons to be stated to ignore rust unittests.

This allows the rust unittest attribute `#[ignore = reason]` to not error the test but skip the result of the subtest.