### PR TITLE
install: Delay install script errors to install time

### DIFF
--- a/docs/markdown/snippets/delayed_install_script_errors.md
+++ b/docs/markdown/snippets/delayed_install_script_errors.md
@@ -1,0 +1,7 @@
+## Delay install script errors to install time
+
+Previously, `gnome.post_install` might've caused a configure to fail
+due to tools such as `update-desktop-database` not being installed or
+due to an `exe_wrapper` missing when cross-building glib. Those
+errors will now be delayed to install time, or not emitted at all
+if installing with `DESTDIR` set, since then they'll be skipped.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -27,7 +27,7 @@ from .. import compilers
 from ..compilers import detect, lang_suffixes
 from ..mesonlib import (
     File, MachineChoice, MesonException, MesonBugException, OrderedSet,
-    ExecutableSerialisation, EnvironmentException, FileMode,
+    ExecutableSerialisation, EnvironmentException, FileMode, InstallScriptFailure,
     classify_unity_sources, get_compiler_for_source,
     get_rsp_threshold, unique_list
 )
@@ -42,6 +42,7 @@ if T.TYPE_CHECKING:
     from ..environment import Environment
     from ..interpreter import Test
     from ..linkers import StaticLinker
+    from ..mesonlib import InstallScript
     from ..options import ElementaryOptionValues
 
     from typing_extensions import Literal, TypedDict, NotRequired, TypeAlias
@@ -133,7 +134,7 @@ class InstallData:
         self.emptydir: T.List[InstallEmptyDir] = []
         self.data: T.List[InstallDataBase] = []
         self.symlinks: T.List[InstallSymlinkData] = []
-        self.install_scripts: T.List[ExecutableSerialisation] = []
+        self.install_scripts: T.List[InstallScript] = []
         self.install_subdirs: T.List[SubdirInstallData] = []
 
 @dataclass(eq=False)
@@ -1849,7 +1850,8 @@ class Backend:
         d.install_scripts = self.build.install_scripts
         for i in d.install_scripts:
             if not i.tag:
-                mlog.debug('Failed to guess install tag for install script:', ' '.join(i.cmd_args))
+                name = i.name if isinstance(i, InstallScriptFailure) else ' '.join(i.cmd_args)
+                mlog.debug('Failed to guess install tag for install script:', name)
 
     def generate_header_install(self, d: InstallData) -> None:
         incroot = self.environment.get_includedir()

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -51,7 +51,7 @@ if T.TYPE_CHECKING:
     from .interpreter.interpreterobjects import Test, Doctest
     from .interpreter.kwargs import TargetDepends
     from .linkers import StaticLinker
-    from .mesonlib import ExecutableSerialisation, FileMode, FileOrString
+    from .mesonlib import ExecutableSerialisation, FileMode, FileOrString, InstallScript
     from .mparser import BaseNode
     from .options import ElementaryOptionValues
 
@@ -342,7 +342,7 @@ class Build:
         self.symlinks: T.List[SymlinkData] = []
         self.static_linker: PerMachine[T.Optional[StaticLinker]] = PerMachine(None, None)
         self.subproject_dir = ''
-        self.install_scripts: T.List['ExecutableSerialisation'] = []
+        self.install_scripts: T.List[InstallScript] = []
         self.postconf_scripts: T.List['ExecutableSerialisation'] = []
         self.dist_scripts: T.List['ExecutableSerialisation'] = []
         self.install_dirs: T.List[InstallDir] = []

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -20,8 +20,8 @@ from .. import envconfig
 from ..wrap import wrap, WrapMode
 from .. import mesonlib
 from ..mesonlib import (EnvironmentVariables, ExecutableSerialisation, MesonBugException, MesonException, HoldableObject,
-                        FileMode, MachineChoice, PerMachine, PerMachineDefaultable, is_parent_path, listify,
-                        has_path_sep, path_has_root, path_is_in_root)
+                        FileMode, InstallScriptFailure, MachineChoice, PerMachine, PerMachineDefaultable, is_parent_path,
+                        listify, has_path_sep, path_has_root, path_is_in_root)
 from ..options import OptionKey
 from ..programs import ExternalProgram, NonExistingExternalProgram, Program
 from ..dependencies import Dependency
@@ -124,7 +124,7 @@ if T.TYPE_CHECKING:
     from ..compilers.compilers import CompilerDict, Language
     from ..interpreterbase.baseobjects import InterpreterObject, TYPE_var, TYPE_kwargs
     from ..options import OptionDict
-    from ..mesonlib import SubProject
+    from ..mesonlib import InstallScript, SubProject
     from ..cmdline import SharedCMDOptions
     from .type_checking import SourcesVarargsType, FullEnvInitValueType
 
@@ -512,7 +512,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             held_type: holder_type
         })
 
-    def process_new_values(self, invalues: list[TYPE_var | ExecutableSerialisation] | list[build.GeneratedTypes | mesonlib.File]) -> None:
+    def process_new_values(self, invalues: list[TYPE_var | InstallScript] | list[build.GeneratedTypes | mesonlib.File]) -> None:
         for v in invalues:
             if isinstance(v, ObjectHolder):
                 raise InterpreterException('Modules must not return ObjectHolders')
@@ -520,7 +520,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                 self.add_target(v.name, v)
             elif isinstance(v, list):
                 self.process_new_values(v)
-            elif isinstance(v, ExecutableSerialisation):
+            elif isinstance(v, (ExecutableSerialisation, InstallScriptFailure)):
                 v.subproject = self.subproject
                 self.build.install_scripts.append(v)
             elif isinstance(v, build.Data):

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -17,8 +17,8 @@ import re
 
 from . import build, tooldetect
 from .backend.backends import InstallData
-from .mesonlib import (MesonException, Popen_safe, RealPathAction, is_windows,
-                       is_aix, setup_vsenv, path_has_root, pickle_load, is_osx,
+from .mesonlib import (InstallScriptFailure, MesonException, Popen_safe, RealPathAction,
+                       is_windows, is_aix, setup_vsenv, path_has_root, pickle_load, is_osx,
                        unwrap)
 from .options import OptionKey
 from .scripts import depfixer, destdir_join
@@ -36,7 +36,7 @@ if T.TYPE_CHECKING:
             InstallDataBase, InstallEmptyDir,
             InstallSymlinkData, TargetInstallData
     )
-    from .mesonlib import FileMode, EnvironOrDict, ExecutableSerialisation
+    from .mesonlib import FileMode, EnvironOrDict, ExecutableSerialisation, InstallScript
 
     try:
         from typing import Protocol
@@ -389,7 +389,7 @@ class Installer:
 
     def should_install(self, d: T.Union[TargetInstallData, InstallEmptyDir,
                                         InstallDataBase, InstallSymlinkData,
-                                        ExecutableSerialisation]) -> bool:
+                                        InstallScript]) -> bool:
         if d.subproject and (d.subproject in self.skip_subprojects or '*' in self.skip_subprojects):
             return False
         if self.tags and d.tag not in self.tags:
@@ -706,6 +706,12 @@ class Installer:
             self.set_mode(outfilename, t.install_mode, d.install_umask)
 
     def run_install_script(self, d: InstallData, destdir: str, fullprefix: str) -> None:
+        failing_scripts = [script for script in d.install_scripts if isinstance(script, InstallScriptFailure)]
+        if not destdir and len(failing_scripts) > 0:
+            for script in failing_scripts:
+                self.log(f'ERROR: Failed to run install script {script.name}: {script.reason}')
+            raise MesonException('Install scripts failed to run')
+
         env = {'MESON_SOURCE_ROOT': d.source_dir,
                'MESON_BUILD_ROOT': d.build_dir,
                'MESONINTROSPECT': ' '.join([shlex.quote(x) for x in d.mesonintrospect]),
@@ -719,6 +725,13 @@ class Installer:
             if not self.should_install(i):
                 continue
 
+            name = i.name if isinstance(i, InstallScriptFailure) else ' '.join(i.cmd_args)
+            if destdir and (isinstance(i, InstallScriptFailure) or i.skip_if_destdir):
+                self.log(f'Skipping custom install script because DESTDIR is set {name!r}')
+                continue
+
+            assert not isinstance(i, InstallScriptFailure) # Should part of failing_scripts and thus this is not reached
+
             if i.installdir_map is not None:
                 mapp = i.installdir_map
             else:
@@ -727,10 +740,6 @@ class Installer:
             localenv.update({'MESON_INSTALL_'+k.upper(): os.path.join(d.prefix, v) for k, v in mapp.items()})
             localenv.update({'MESON_INSTALL_DESTDIR_'+k.upper(): get_destdir_path(destdir, fullprefix, v) for k, v in mapp.items()})
 
-            name = ' '.join(i.cmd_args)
-            if i.skip_if_destdir and destdir:
-                self.log(f'Skipping custom install script because DESTDIR is set {name!r}')
-                continue
             self.did_install_something = True  # Custom script must report itself if it does nothing.
             self.log(f'Running custom install script {name!r}')
             try:

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -275,11 +275,11 @@ def is_module_library(fname: mesonlib.FileOrString) -> bool:
 
 
 class ModuleReturnValue:
-    def __init__(self, return_value: T.Optional['TYPE_var'],
-                 new_objects: T.Sequence[T.Union['TYPE_var', 'mesonlib.ExecutableSerialisation']]) -> None:
+    def __init__(self, return_value: T.Optional[TYPE_var],
+                 new_objects: T.Sequence[T.Union[TYPE_var, mesonlib.InstallScript]]) -> None:
         self.return_value = return_value
         assert isinstance(new_objects, list)
-        self.new_objects: T.List[T.Union['TYPE_var', 'mesonlib.ExecutableSerialisation']] = new_objects
+        self.new_objects: T.List[T.Union[TYPE_var, mesonlib.InstallScript]] = new_objects
 
 class GResourceTarget(build.CustomTarget):
     source_dirs: T.List[str] = []

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -31,7 +31,7 @@ from ..interpreterbase import noPosargs, noKwargs, FeatureNew, FeatureDeprecated
 from ..interpreterbase import typed_kwargs, KwargInfo, ContainerTypeInfo
 from ..interpreterbase.decorators import typed_pos_args
 from ..mesonlib import (
-    MachineChoice, MesonException, OrderedSet, Popen_safe, join_args, quote_arg
+    InstallScriptFailure, MachineChoice, MesonException, OrderedSet, Popen_safe, join_args, quote_arg
 )
 from ..options import OptionKey
 from ..scripts.gettext import read_linguas
@@ -47,7 +47,7 @@ if T.TYPE_CHECKING:
     from ..interpreter.interpreter import CustomTargetSources
     from ..interpreter.kwargs import CustomTargetInputs, TargetDepends
     from ..interpreterbase import TYPE_var, TYPE_kwargs
-    from ..mesonlib import EnvironmentVariables, FileOrString
+    from ..mesonlib import EnvironmentVariables, FileOrString, InstallScript
     from ..programs import Program, CommandList, CommandListEntry
 
     class PostInstall(TypedDict):
@@ -313,7 +313,7 @@ class GnomeModule(ExtensionModule):
                      once=True, fatal=False)
 
     @staticmethod
-    def _find_tool(state: 'ModuleState', tool: str) -> Program:
+    def _find_tool(state: 'ModuleState', tool: str, required: bool = True) -> Program:
         tool_map = {
             'gio-querymodules': 'gio-2.0',
             'glib-compile-schemas': 'gio-2.0',
@@ -326,7 +326,20 @@ class GnomeModule(ExtensionModule):
         }
         depname = tool_map[tool]
         varname = tool.replace('-', '_')
-        return state.find_tool(tool, depname, varname, native=depname != "gobject-introspection-1.0")
+        return state.find_tool(tool, depname, varname, required=required, native=depname != "gobject-introspection-1.0")
+
+    @staticmethod
+    def _get_install_script(state: ModuleState, name: str, exe: Program, args: T.List[str], skip_if_destdir: bool = True) -> InstallScript:
+        if not exe.found():
+            mlog.warning(f'Program {name} was not found, installation without DESTDIR will fail', fatal=False)
+            return InstallScriptFailure(name, 'Executable was not found')
+        try:
+            install_script = state.backend.get_executable_serialisation([exe, *args])
+            install_script.skip_if_destdir = skip_if_destdir
+            return install_script
+        except MesonException as e:
+            mlog.warning(f'Meson will be unable to run {name}, installation without DESTDIR will fail', fatal=False)
+            return InstallScriptFailure(name, str(e))
 
     @typed_kwargs(
         'gnome.post_install',
@@ -339,46 +352,41 @@ class GnomeModule(ExtensionModule):
     @noPosargs
     @FeatureNew('gnome.post_install', '0.57.0')
     def post_install(self, state: 'ModuleState', args: T.List['TYPE_var'], kwargs: 'PostInstall') -> ModuleReturnValue:
-        rv: T.List['mesonlib.ExecutableSerialisation'] = []
+        rv: T.List[InstallScript] = []
         datadir_abs = os.path.join(state.environment.get_prefix(), state.environment.get_datadir())
         if kwargs['glib_compile_schemas'] and not self.install_glib_compile_schemas:
             self.install_glib_compile_schemas = True
-            prog = self._find_tool(state, 'glib-compile-schemas')
+            prog = self._find_tool(state, 'glib-compile-schemas', required=False)
             schemasdir = os.path.join(datadir_abs, 'glib-2.0', 'schemas')
-            script = state.backend.get_executable_serialisation([prog, schemasdir])
-            script.skip_if_destdir = True
+            script = self._get_install_script(state, 'glib-compile-schemas', prog, [schemasdir])
             rv.append(script)
         for d in kwargs['gio_querymodules']:
             if d not in self.install_gio_querymodules:
                 self.install_gio_querymodules.append(d)
-                prog = self._find_tool(state, 'gio-querymodules')
+                prog = self._find_tool(state, 'gio-querymodules', required=False)
                 moduledir = os.path.join(state.environment.get_prefix(), d)
-                script = state.backend.get_executable_serialisation([prog, moduledir])
-                script.skip_if_destdir = True
+                script = self._get_install_script(state, 'gio-querymodules', prog, [moduledir])
                 rv.append(script)
         if kwargs['gtk_update_icon_cache'] and not self.install_gtk_update_icon_cache:
             self.install_gtk_update_icon_cache = True
             prog = state.find_program('gtk4-update-icon-cache', required=False)
             found = isinstance(prog, Executable) or prog.found()
             if not found:
-                prog = state.find_program('gtk-update-icon-cache')
+                prog = state.find_program('gtk-update-icon-cache', required=False)
             icondir = os.path.join(datadir_abs, 'icons', 'hicolor')
-            script = state.backend.get_executable_serialisation([prog, '-q', '-t', '-f', icondir])
-            script.skip_if_destdir = True
+            script = self._get_install_script(state, 'gtk4-update-icon-cache', prog, ['-q', '-t', '-f', icondir])
             rv.append(script)
         if kwargs['update_desktop_database'] and not self.install_update_desktop_database:
             self.install_update_desktop_database = True
-            prog = state.find_program('update-desktop-database')
+            prog = state.find_program('update-desktop-database', required=False)
             appdir = os.path.join(datadir_abs, 'applications')
-            script = state.backend.get_executable_serialisation([prog, '-q', appdir])
-            script.skip_if_destdir = True
+            script = self._get_install_script(state, 'update-desktop-database', prog, ['-q', appdir])
             rv.append(script)
         if kwargs['update_mime_database'] and not self.install_update_mime_database:
             self.install_update_mime_database = True
-            prog = state.find_program('update-mime-database')
+            prog = state.find_program('update-mime-database', required=False)
             appdir = os.path.join(datadir_abs, 'mime')
-            script = state.backend.get_executable_serialisation([prog, appdir])
-            script.skip_if_destdir = True
+            script = self._get_install_script(state, 'update-mime-database', prog, [appdir])
             rv.append(script)
         return ModuleReturnValue(None, rv)
 

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -28,7 +28,7 @@ import json
 import dataclasses
 
 from mesonbuild import mlog
-from .core import MesonException, MesonBugException, HoldableObject
+from .core import MesonException, MesonBugException, HoldableObject, ExecutableSerialisation
 
 if T.TYPE_CHECKING:
     from typing_extensions import Literal, Protocol, Self
@@ -86,6 +86,8 @@ __all__ = [
     'EnvironmentException',
     'FileOrString',
     'GitException',
+    'InstallScript',
+    'InstallScriptFailure',
     'dump_conf_header',
     'OrderedSet',
     'PerMachine',
@@ -726,6 +728,16 @@ class PerThreeMachineDefaultable(PerMachineDefaultable[T.Optional[_T]], PerThree
         target = self.target if self.target is not None else host
         return PerThreeMachine(build, host, target)
 
+@dataclasses.dataclass(eq=False)
+class InstallScriptFailure:
+
+    name: str
+    reason: str
+    tag: T.Optional[str] = None
+
+    subproject = ROOT_SUBPROJECT
+
+InstallScript = T.Union[ExecutableSerialisation, InstallScriptFailure]
 
 _PLATFORM_SYSTEM_LOWER = platform.system().lower()
 _PLATFORM_RELEASE_LOWER = platform.release().lower()


### PR DESCRIPTION
Previously, `gnome.post_install` might've caused a configure to fail due to tools such as `update-desktop-database` not being installed or due to an `exe_wrapper` missing when cross-building glib. Those errors will now be delayed to install time, or not emitted at all if installing with `DESTDIR` set, since then they'll be skipped.

Fixes: #14492