### PR TITLE
options: add forceabsolutepath core option

### DIFF
--- a/data/shell-completions/bash/meson
+++ b/data/shell-completions/bash/meson
@@ -256,6 +256,7 @@ _meson_common_setup_configure_longopts=(
   unity-size
   warnlevel
   werror
+  forceabsolutepath
   wrap-mode
   force-fallback-for
   vsenv

--- a/data/shell-completions/zsh/_meson
+++ b/data/shell-completions/zsh/_meson
@@ -62,6 +62,7 @@ local -a __meson_common=(
   '--unity=[unity builds on/off]:whether to do unity builds:(on off subprojects)'
   '--warnlevel=[compiler warning level]:compiler warning level:warning level:(1 2 3)'
   '--werror[treat warnings as errors]'
+  '--forceabsolutepath[use absolute paths to sources in generated build files]'
   '--wrap-mode=[special wrap mode]:wrap mode:'"$__meson_wrap_modes"
   '--force-fallback-for=[force fallback for listed subprojects]'
   '--pkg-config-path=[extra paths for HOST pkg-config to search]:paths:_dir_list -s ,'

--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -99,6 +99,7 @@ machine](#specifying-options-per-machine) section for details.
 | force_fallback_for                     | []            | Force fallback for those dependencies                          | no             | no                |
 | vsenv                                  | false         | Activate Visual Studio environment                             | no             | no                |
 | os2_emxomf                             | false         | Use OMF format on OS/2                                         | no             | no                |
+| forceabsolutepath                      | false         | Use absolute paths to sources in generated build files        | no             | no                |
 
 (For the Rust language only, `warning_level=0` disables all warnings).
 

--- a/docs/markdown/snippets/forceabsolutepath.md
+++ b/docs/markdown/snippets/forceabsolutepath.md
@@ -1,0 +1,11 @@
+## New `forceabsolutepath` core option
+
+A new boolean core option `forceabsolutepath` (default `false`) has been added.
+When enabled (`meson setup --forceabsolutepath builddir` or
+`-Dforceabsolutepath=true`), Meson emits absolute paths to source files and
+include directories (`-I`) in the generated build files instead of paths
+relative to the build directory.
+
+This is useful when generating coverage reports, where tools such as gcov/lcov
+record source paths as seen by the compiler: relative paths like `../src/foo.c`
+then end up in the report instead of clean absolute paths rooted at the project.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -287,8 +287,12 @@ class Backend:
         self.processed_targets: T.Set[str] = set()
         self.build_dir = self.environment.get_build_dir()
         self.source_dir = self.environment.get_source_dir()
-        self.build_to_src = mesonlib.relpath(self.environment.get_source_dir(),
-                                             self.environment.get_build_dir())
+        self.force_absolute_path = self.environment.coredata.optstore.get_value_for(OptionKey('forceabsolutepath'))
+        if self.force_absolute_path:
+            self.build_to_src = self.environment.get_source_dir()
+        else:
+            self.build_to_src = mesonlib.relpath(self.environment.get_source_dir(),
+                                                 self.environment.get_build_dir())
         self.src_to_build = mesonlib.relpath(self.environment.get_build_dir(),
                                              self.environment.get_source_dir())
 
@@ -878,6 +882,8 @@ class Backend:
     def get_pch_include_args(self, compiler: 'Compiler', target: build.BuildTarget) -> T.List[str]:
         args: T.List[str] = []
         pchpath = self.get_target_private_dir(target)
+        if self.force_absolute_path:
+            pchpath = os.path.join(self.environment.get_build_dir(), pchpath)
         includeargs = compiler.get_include_args(pchpath, False)
         p = target.pch.get(compiler.get_language())
         if p:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3087,7 +3087,10 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         #
         # But never subdir()s into the actual dir.
         if os.path.isdir(os.path.join(self.environment.get_build_dir(), expdir)):
-            bargs = compiler.get_include_args(expdir, is_system)
+            builddir = expdir
+            if self.force_absolute_path:
+                builddir = os.path.join(self.environment.get_build_dir(), expdir)
+            bargs = compiler.get_include_args(builddir, is_system)
         else:
             bargs = []
         return (sargs, bargs)
@@ -3105,7 +3108,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         # Add custom target dirs as includes automatically, but before
         # target-specific include directories.
         if target.implicit_include_directories:
-            commands += self.get_custom_target_dir_include_args(target, compiler)
+            commands += self.get_custom_target_dir_include_args(target, compiler, absolute_path=self.force_absolute_path)
         # Add include dirs from the `include_directories:` kwarg on the target
         # and from `include_directories:` of internal deps of the target.
         #
@@ -3164,12 +3167,15 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         # in their source tree. Many projects that are moving to Meson have
         # both Meson and Autotools in parallel as part of the transition.
         if target.implicit_include_directories:
-            commands += self.get_source_dir_include_args(target, compiler)
+            commands += self.get_source_dir_include_args(target, compiler, absolute_path=self.force_absolute_path)
         if target.implicit_include_directories:
-            commands += self.get_build_dir_include_args(target, compiler)
+            commands += self.get_build_dir_include_args(target, compiler, absolute_path=self.force_absolute_path)
         # Finally add the private dir for the target to the include path. This
         # must override everything else and must be the final path added.
-        commands += compiler.get_include_args(self.get_target_private_dir(target), False)
+        private_dir = self.get_target_private_dir(target)
+        if self.force_absolute_path:
+            private_dir = os.path.join(self.environment.get_build_dir(), private_dir)
+        commands += compiler.get_include_args(private_dir, False)
         return list(commands)
 
     # Returns a dictionary, mapping from each compiler src type (e.g. 'c', 'cpp', etc.) to a list of compiler arg strings

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -100,6 +100,7 @@ _BUILTIN_NAMES = {
     'cmake_prefix_path',
     'vsenv',
     'os2_emxomf',
+    'forceabsolutepath',
 }
 
 _BAD_VALUE = 'Qwert Zuiopü'
@@ -704,6 +705,7 @@ BUILTIN_CORE_OPTIONS: T.Mapping[OptionKey, AnyOptionType] = {
         UserStringArrayOption('force_fallback_for', 'Force fallback for those subprojects', []),
         UserBooleanOption('vsenv', 'Activate Visual Studio environment', False, readonly=True),
         UserBooleanOption('os2_emxomf', 'Use OMF format on OS/2', False),
+        UserBooleanOption('forceabsolutepath', 'Use absolute paths to sources in generated build files', False),
 
         # Pkgconfig module
         UserBooleanOption('pkgconfig.relocatable', 'Generate pkgconfig files as relocatable', False),

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -2320,6 +2320,7 @@ _BUILTIN_NAMES = {
     'cmake_prefix_path',
     'vsenv',
     'os2_emxomf',
+    'forceabsolutepath',
 }
 
 


### PR DESCRIPTION
## What does this do?

Adds a new boolean core option `forceabsolutepath` (`--forceabsolutepath` /
`-Dforceabsolutepath=true`, default `false`). When enabled, the backend emits
**absolute** paths to source files and include directories (`-I`) in the
generated build files, instead of paths relative to the build directory.

## Why

Meson generates `build.ninja` with source paths relative to the build directory
(e.g. `../src/foo.c`). This is awkward for coverage reports: gcov/lcov record
the source paths exactly as the compiler saw them, so the report ends up full of
relative `../`-style paths instead of clean absolute paths rooted at the project.
With `forceabsolutepath`, those paths come out absolute.

## How

A single `force_absolute_path` flag is computed once in `Backend.__init__`:

- When set, `build_to_src` is set to the absolute source directory. Since
  `build_to_src` is the common prefix used by `File.rel_to_builddir()` and the
  source-tree include helpers, this transparently makes all source-file
  references and source-tree `-I` flags absolute.
- The remaining **build-tree** include paths are made absolute too: the
  build-tree copy in `generate_inc_dir()`, `get_source_dir_include_args()` /
  `get_build_dir_include_args()` and `get_custom_target_dir_include_args()`
  (reusing their existing `absolute_path=` parameter), the target private dir,
  and `get_pch_include_args()`.

`src_to_build` is intentionally left untouched, as the VS backend relies on it
being relative (`os.path.split`).

## Notes

- Default behaviour is unchanged (`false`): relative paths are emitted exactly
  as before.
- Docs (`Builtin-options.md`), a release-note snippet, and the bash/zsh
  completions are updated.

Verified on small projects (including ones with `subdir()`, a `custom_target`
generated header, and `-Db_coverage=true`): with the option, no relative `-I`
remains and source paths are absolute; `ninja` builds successfully; without the
option output is byte-for-byte the same as before.