### PR TITLE
Replace duck typing with protocols for target and CustomTargetIndex types

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -486,7 +486,7 @@ class Backend:
         return os.path.relpath(os.path.join('dummyprefixdir', todir),
                                os.path.join('dummyprefixdir', fromdir))
 
-    def flatten_object_list(self, target: build.BuildTarget, proj_dir_to_build_root: str = ''
+    def flatten_object_list(self, target: build.BuildTargetProto, proj_dir_to_build_root: str = ''
                             ) -> T.Tuple[T.List[str], T.List[build.BuildTarget]]:
         obj_list, deps = self._flatten_object_list(target, target.get_objects(), proj_dir_to_build_root)
         return unique_list(obj_list), deps
@@ -495,7 +495,7 @@ class Backend:
         obj_list, _ = self._flatten_object_list(objects.target, [objects], '')
         return unique_list(obj_list)
 
-    def _flatten_object_list(self, target: build.BuildTarget,
+    def _flatten_object_list(self, target: build.BuildTargetProto,
                              objects: T.Sequence[build.ObjectTypes],
                              proj_dir_to_build_root: str) -> T.Tuple[T.List[str], T.List[build.BuildTarget]]:
         obj_list: T.List[str] = []

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -315,7 +315,7 @@ class Backend:
     def generate(self, capture: bool = False, vslite_ctx: T.Optional[T.Dict] = None) -> T.Optional[T.Dict]:
         raise RuntimeError(f'generate is not implemented in {type(self).__name__}')
 
-    def get_target_filename(self, t: build.AnyTargetType, *, warn_multi_output: bool = True) -> str:
+    def get_target_filename(self, t: build.BuildTargetTypes, *, warn_multi_output: bool = True) -> str:
         if isinstance(t, build.CustomTarget):
             if warn_multi_output and len(t.get_outputs()) != 1:
                 mlog.warning(f'custom_target {t.name!r} has more than one output! '
@@ -324,7 +324,6 @@ class Backend:
         elif isinstance(t, build.CustomTargetIndex):
             filename = t.get_outputs()[0]
         else:
-            assert isinstance(t, build.BuildTarget), t
             filename = t.get_filename()
         return os.path.join(self.get_target_dir(t), filename)
 
@@ -339,7 +338,7 @@ class Backend:
         linker, _ = t.get_clink_dynamic_linker_and_stdlibs()
         return linker.get_archive_name(filename)
 
-    def get_target_filename_abs(self, target: build.AnyTargetType) -> str:
+    def get_target_filename_abs(self, target: build.BuildTargetTypes) -> str:
         return os.path.join(self.environment.get_build_dir(), self.get_target_filename(target))
 
     def get_target_debug_filename(self, target: build.BuildTarget) -> T.Optional[str]:
@@ -428,7 +427,7 @@ class Backend:
             return os.path.join(self.build_to_src, target_dir)
         return self.build_to_src
 
-    def get_target_private_dir(self, target: build.AnyTargetType) -> str:
+    def get_target_private_dir(self, target: build.BuildTargetTypes) -> str:
         return os.path.join(self.get_target_filename(target, warn_multi_output=False) + '.p')
 
     def get_target_private_dir_abs(self, target: build.BuildTargetTypes) -> str:

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -352,7 +352,7 @@ class Backend:
                 curdir = '.'
         return compiler.get_include_args(curdir, False)
 
-    def get_target_filename_for_linking(self, target: build.AnyTargetType) -> T.Optional[str]:
+    def get_target_filename_for_linking(self, target: build.AnyTargetProto) -> T.Optional[str]:
         # On some platforms (msvc for instance), the file that is used for
         # dynamic linking is not the same as the dynamic library itself. This
         # file is called an import library, and we want to link against that.
@@ -390,13 +390,12 @@ class Backend:
                 dirname = os.path.join(dirname, build_subdir)
         return dirname
 
-    def get_target_dir(self, target: build.AnyTargetType) -> str:
+    def get_target_dir(self, target: build.AnyTargetProto) -> str:
         return self.get_target_dir_cached(target.get_target())
 
     def get_target_dir_relative_to(self,
-                                   t: T.Union[build.Target, build.CustomTargetIndex],
-                                   o: T.Union[build.Target, build.CustomTargetIndex],
-                                   ) -> str:
+                                   t: build.AnyTargetProto,
+                                   o: build.AnyTargetProto) -> str:
         '''Get a target dir relative to another target's directory'''
         target_dir = os.path.join(self.environment.get_build_dir(), self.get_target_dir(t))
         othert_dir = os.path.join(self.environment.get_build_dir(), self.get_target_dir(o))
@@ -1280,7 +1279,7 @@ class Backend:
     def write_test_serialisation(self, tests: T.List['Test'], datafile: T.BinaryIO) -> None:
         pickle.dump(self.create_test_serialisation(tests), datafile)
 
-    def construct_target_rel_paths(self, t: build.BuildTargetTypes, workdir: T.Optional[str]) -> T.List[str]:
+    def construct_target_rel_paths(self, t: build.AnyTargetProto, workdir: T.Optional[str]) -> T.List[str]:
         target_dir = self.get_target_dir(t)
         # ensure that test executables can be run when passed as arguments
         if isinstance(t, build.Executable) and workdir is None:
@@ -1467,7 +1466,7 @@ class Backend:
             srcs += fname
         return srcs
 
-    def get_paths_for_dep_outputs(self, target: build.Target, dep_targets: T.Iterable[build.Target | build.GeneratedList | build.CustomTargetIndex | programs.Program]) -> T.List[str]:
+    def get_paths_for_dep_outputs(self, target: build.Target, dep_targets: T.Iterable[build.AnyTargetProto | build.GeneratedList | programs.Program]) -> T.List[str]:
         """Return a list of strings with the paths to all the outputs of all targets in
            dep_targets."""
         deps = []
@@ -1494,7 +1493,7 @@ class Backend:
                 deps.append(i.rel_to_builddir(self.build_to_src))
         return deps
 
-    def get_custom_target_output_dir(self, target: build.AnyTargetType) -> str:
+    def get_custom_target_output_dir(self, target: build.AnyTargetProto) -> str:
         # The XCode backend is special. A target foo/bar does
         # not go to ${BUILDDIR}/foo/bar but instead to
         # ${BUILDDIR}/${BUILDTYPE}/foo/bar.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -316,16 +316,10 @@ class Backend:
         raise RuntimeError(f'generate is not implemented in {type(self).__name__}')
 
     def get_target_filename(self, t: build.BuildTargetTypes, *, warn_multi_output: bool = True) -> str:
-        if isinstance(t, build.CustomTarget):
-            if warn_multi_output and len(t.get_outputs()) != 1:
-                mlog.warning(f'custom_target {t.name!r} has more than one output! '
-                             f'Using the first one. Consider using `{t.name}[0]`.')
-            filename = t.get_outputs()[0]
-        elif isinstance(t, build.CustomTargetIndex):
-            filename = t.get_outputs()[0]
-        else:
-            filename = t.get_filename()
-        return os.path.join(self.get_target_dir(t), filename)
+        if isinstance(t, build.CustomTarget) and warn_multi_output and len(t.get_outputs()) != 1:
+            mlog.warning(f'custom_target {t.name!r} has more than one output! '
+                         f'Using the first one. Consider using `{t.name}[0]`.')
+        return os.path.join(self.get_target_dir(t), t.get_filename())
 
     def get_aix_so_archive_name(self, t: build.AnyTargetType, filename: str) -> T.Optional[str]:
         '''On AIX shared libraries are stored inside an archive; it is the archive

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1237,7 +1237,7 @@ class Backend:
                     cmd_args.append(a)
                 elif isinstance(a, str):
                     cmd_args.append(a)
-                elif isinstance(a, (build.Target, build.CustomTargetIndex)):
+                elif isinstance(a, (build.BuildTarget, build.CustomTarget, build.CustomTargetIndex)):
                     cmd_args.extend(self.construct_target_rel_paths(a, t.workdir))
                 elif isinstance(a, programs.ExternalProgram):
                     cmd_args.extend(a.get_command())
@@ -1281,7 +1281,7 @@ class Backend:
     def write_test_serialisation(self, tests: T.List['Test'], datafile: T.BinaryIO) -> None:
         pickle.dump(self.create_test_serialisation(tests), datafile)
 
-    def construct_target_rel_paths(self, t: build.AnyTargetType, workdir: T.Optional[str]) -> T.List[str]:
+    def construct_target_rel_paths(self, t: build.BuildTargetTypes, workdir: T.Optional[str]) -> T.List[str]:
         target_dir = self.get_target_dir(t)
         # ensure that test executables can be run when passed as arguments
         if isinstance(t, build.Executable) and workdir is None:

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -307,7 +307,7 @@ class Backend:
     def generate(self, capture: bool = False, vslite_ctx: T.Optional[T.Dict] = None) -> T.Optional[T.Dict]:
         raise RuntimeError(f'generate is not implemented in {type(self).__name__}')
 
-    def get_target_filename(self, t: build.AnyTargetType, *, warn_multi_output: bool = True) -> str:
+    def get_target_filename(self, t: build.BuildTargetTypes, *, warn_multi_output: bool = True) -> str:
         if isinstance(t, build.CustomTarget):
             if warn_multi_output and len(t.get_outputs()) != 1:
                 mlog.warning(f'custom_target {t.name!r} has more than one output! '
@@ -316,11 +316,10 @@ class Backend:
         elif isinstance(t, build.CustomTargetIndex):
             filename = t.get_outputs()[0]
         else:
-            assert isinstance(t, build.BuildTarget), t
             filename = t.get_filename()
         return os.path.join(self.get_target_dir(t), filename)
 
-    def get_target_filename_abs(self, target: build.AnyTargetType) -> str:
+    def get_target_filename_abs(self, target: build.BuildTargetTypes) -> str:
         return os.path.join(self.environment.get_build_dir(), self.get_target_filename(target))
 
     def get_target_debug_filename(self, target: build.BuildTarget) -> T.Optional[str]:
@@ -410,7 +409,7 @@ class Backend:
             return os.path.join(self.build_to_src, target_dir)
         return self.build_to_src
 
-    def get_target_private_dir(self, target: build.AnyTargetType) -> str:
+    def get_target_private_dir(self, target: build.BuildTargetTypes) -> str:
         return os.path.join(self.get_target_filename(target, warn_multi_output=False) + '.p')
 
     def get_target_private_dir_abs(self, target: build.BuildTargetTypes) -> str:

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -307,7 +307,7 @@ class Backend:
     def generate(self, capture: bool = False, vslite_ctx: T.Optional[T.Dict] = None) -> T.Optional[T.Dict]:
         raise RuntimeError(f'generate is not implemented in {type(self).__name__}')
 
-    def get_target_filename(self, t: build.BuildTargetTypes, *, warn_multi_output: bool = True) -> str:
+    def get_target_filename(self, t: build.BuildTargetProto, *, warn_multi_output: bool = True) -> str:
         if isinstance(t, build.CustomTarget):
             if warn_multi_output and len(t.get_outputs()) != 1:
                 mlog.warning(f'custom_target {t.name!r} has more than one output! '
@@ -316,10 +316,11 @@ class Backend:
         elif isinstance(t, build.CustomTargetIndex):
             filename = t.get_outputs()[0]
         else:
+            assert isinstance(t, build.BuildTarget), t
             filename = t.get_filename()
         return os.path.join(self.get_target_dir(t), filename)
 
-    def get_target_filename_abs(self, target: build.BuildTargetTypes) -> str:
+    def get_target_filename_abs(self, target: build.BuildTargetProto) -> str:
         return os.path.join(self.environment.get_build_dir(), self.get_target_filename(target))
 
     def get_target_debug_filename(self, target: build.BuildTarget) -> T.Optional[str]:
@@ -408,15 +409,15 @@ class Backend:
             return os.path.join(self.build_to_src, target_dir)
         return self.build_to_src
 
-    def get_target_private_dir(self, target: build.BuildTargetTypes) -> str:
+    def get_target_private_dir(self, target: build.BuildTargetProto) -> str:
         return os.path.join(self.get_target_filename(target, warn_multi_output=False) + '.p')
 
-    def get_target_private_dir_abs(self, target: build.BuildTargetTypes) -> str:
+    def get_target_private_dir_abs(self, target: build.BuildTargetProto) -> str:
         return os.path.join(self.environment.get_build_dir(), self.get_target_private_dir(target))
 
     @lru_cache(maxsize=None)
     def get_target_generated_dir(
-            self, target: build.BuildTargetTypes,
+            self, target: build.BuildTargetProto,
             gensrc: build.GeneratedTypes,
             src: str) -> str:
         """
@@ -431,11 +432,11 @@ class Backend:
         # target that the GeneratedList is used in
         return os.path.join(self.get_target_private_dir(target), src)
 
-    def get_unity_source_file(self, target: build.BuildTargetTypes,
+    def get_unity_source_file(self, target: build.BuildTargetProto,
                               suffix: str, number: int) -> mesonlib.File:
         # There is a potential conflict here, but it is unlikely that
         # anyone both enables unity builds and has a file called foo-unity.cpp.
-        osrc = f'{target.name}-unity{number}.{suffix}'
+        osrc = f'{target.get_basename()}-unity{number}.{suffix}'
         return mesonlib.File.from_built_file(self.get_target_private_dir(target), osrc)
 
     def generate_unity_files(self, target: build.BuildTarget, unity_src: list[File]) -> list[mesonlib.File]:
@@ -526,7 +527,7 @@ class Backend:
         return obj_list, deps
 
     @staticmethod
-    def is_swift_target(target: build.BuildTargetTypes) -> bool:
+    def is_swift_target(target: build.BuildTargetProto) -> bool:
         if not isinstance(target, build.BuildTarget):
             return False
         for s in target.get_sources():
@@ -543,7 +544,7 @@ class Backend:
     def get_executable_serialisation(
             self, cmd: T.Iterable[build.CommandTypes],
             workdir: T.Optional[str] = None,
-            extra_bdeps: T.Optional[T.Iterable[build.BuildTargetTypes]] = None,
+            extra_bdeps: T.Optional[T.Iterable[build.BuildTargetProto]] = None,
             capture: T.Optional[str] = None,
             feed: T.Optional[str] = None,
             env: T.Optional[mesonlib.EnvironmentVariables] = None,
@@ -634,7 +635,7 @@ class Backend:
     def as_meson_exe_cmdline(self, exe: build.CommandTypes,
                              cmd_args: T.Iterable[build.CommandTypes],
                              workdir: T.Optional[str] = None,
-                             extra_bdeps: T.Optional[T.Iterable[build.BuildTargetTypes]] = None,
+                             extra_bdeps: T.Optional[T.Iterable[build.BuildTargetProto]] = None,
                              capture: T.Optional[str] = None,
                              feed: T.Optional[str] = None,
                              force_serialize: bool = False,
@@ -1041,7 +1042,7 @@ class Backend:
                 commands += compiler.get_include_args(priv_dir, False)
         return commands
 
-    def build_target_link_arguments(self, compiler: Compiler, deps: T.Iterable[build.BuildTargetTypes]) -> T.List[str]:
+    def build_target_link_arguments(self, compiler: Compiler, deps: T.Iterable[build.BuildTargetProto]) -> T.List[str]:
         args: T.List[str] = []
         for d in deps:
             if not d.is_linkable_target():
@@ -1139,15 +1140,15 @@ class Backend:
         return results
 
     def determine_windows_extra_paths(
-            self, target: T.Union[build.BuildTargetTypes, programs.Program, mesonlib.File, str],
-            extra_bdeps: T.Iterable[build.BuildTargetTypes]) -> T.List[str]:
+            self, target: T.Union[build.BuildTargetProto, programs.Program, mesonlib.File, str],
+            extra_bdeps: T.Iterable[build.BuildTargetProto]) -> T.List[str]:
         """On Windows there is no such thing as an rpath.
 
         We must determine all locations of DLLs that this exe
         links to and return them so they can be used in unit
         tests.
         """
-        prospectives: T.Set[build.BuildTargetTypes] = set()
+        prospectives: T.Set[build.BuildTargetProto] = set()
         internal_deps: T.Set[str] = set()
         external_deps: T.Set[str] = set()
 
@@ -1211,7 +1212,7 @@ class Backend:
             exe_wrapper = self.environment.get_exe_wrapper()
             machine = self.environment.machines[exe.for_machine]
             if machine.is_windows() or machine.is_cygwin():
-                extra_bdeps: T.List[build.BuildTargetTypes] = []
+                extra_bdeps: T.List[build.BuildTargetProto] = []
                 if isinstance(exe, build.CustomTarget):
                     extra_bdeps = list(exe.get_transitive_build_target_deps())
                 extra_bdeps.extend(t.depends)
@@ -1221,7 +1222,7 @@ class Backend:
                 extra_paths = []
 
             cmd_args: T.List[str] = []
-            depends: T.Set[build.BuildTargetTypes] = set(t.depends)
+            depends: T.Set[build.BuildTargetProto] = set(t.depends)
             if isinstance(exe, (build.BuildTarget, build.CustomTarget, build.CustomTargetIndex)):
                 depends.add(exe)
             for a in t.cmd_args:
@@ -1279,7 +1280,7 @@ class Backend:
     def write_test_serialisation(self, tests: T.List['Test'], datafile: T.BinaryIO) -> None:
         pickle.dump(self.create_test_serialisation(tests), datafile)
 
-    def construct_target_rel_paths(self, t: build.AnyTargetProto, workdir: T.Optional[str]) -> T.List[str]:
+    def construct_target_rel_paths(self, t: build.BuildTargetProto, workdir: T.Optional[str]) -> T.List[str]:
         target_dir = self.get_target_dir(t)
         # ensure that test executables can be run when passed as arguments
         if isinstance(t, build.Executable) and workdir is None:
@@ -1364,13 +1365,13 @@ class Backend:
             if delta > 0.001:
                 raise MesonException(f'Clock skew detected. File {absf} has a time stamp {delta:.4f}s in the future.')
 
-    def build_target_to_cmd_array(self, bt: T.Union[build.BuildTargetTypes, programs.Program]) -> T.List[str]:
+    def build_target_to_cmd_array(self, bt: T.Union[build.BuildTargetProto, programs.Program]) -> T.List[str]:
         if isinstance(bt, build.LocalProgram):
             bt = bt.program
-        if isinstance(bt, (build.Target, build.CustomTargetIndex)):
-            arr = [os.path.join(self.environment.get_build_dir(), self.get_target_filename(bt))]
-        else:
+        if isinstance(bt, programs.Program):
             arr = bt.get_command()
+        else:
+            arr = [os.path.join(self.environment.get_build_dir(), self.get_target_filename(bt))]
         return arr
 
     def replace_extra_args(self, args: T.List[str], genlist: 'build.GeneratedList') -> T.List[str]:
@@ -1427,7 +1428,7 @@ class Backend:
         return libs
 
     @lru_cache(maxsize=None)
-    def get_custom_target_provided_libraries(self, target: T.Union[build.BuildTarget, build.CustomTarget]) -> 'ImmutableListProtocol[str]':
+    def get_custom_target_provided_libraries(self, target: build.BuildTargetProto) -> 'ImmutableListProtocol[str]':
         libs: T.List[str] = []
         for t in target.get_generated_sources():
             if not isinstance(t, build.CustomTarget):
@@ -2081,7 +2082,7 @@ class Backend:
                               compiler: 'Compiler',
                               sources: T.List[TargetSources],
                               output_templ: str,
-                              depends: T.Optional[T.List[build.BuildTargetTypes]] = None,
+                              depends: T.Optional[T.List[build.BuildTargetProto]] = None,
                               ) -> build.GeneratedList:
         '''
         Some backends don't support custom compilers. This is a convenience

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1582,7 +1582,7 @@ class Backend:
             elif isinstance(i, (build.CustomTarget, build.CustomTargetIndex)):
                 fname = [os.path.join(self.get_custom_target_output_dir(i), p) for p in i.get_outputs()]
             elif isinstance(i, build.GeneratedList):
-                assert not isinstance(target, build.RunTarget)
+                assert isinstance(target, build.CustomTarget)
                 fname = [os.path.join(self.get_target_private_dir(target), p) for p in i.get_outputs()]
             elif isinstance(i, build.ExtractedObjects):
                 fname = self.determine_ext_objs(i)
@@ -1702,7 +1702,7 @@ class Backend:
                 if '@CURRENT_SOURCE_DIR@' in i:
                     i = i.replace('@CURRENT_SOURCE_DIR@', os.path.join(source_root, target.get_subdir()))
                 if '@DEPFILE@' in i:
-                    assert not isinstance(target, build.RunTarget)
+                    assert isinstance(target, build.CustomTarget)
                     if target.depfile is None:
                         msg = f'Custom target {target.name!r} has @DEPFILE@ but no depfile ' \
                               'keyword argument.'
@@ -1710,7 +1710,7 @@ class Backend:
                     dfilename = os.path.join(outdir, target.depfile)
                     i = i.replace('@DEPFILE@', dfilename)
                 if '@PRIVATE_DIR@' in i:
-                    assert not isinstance(target, build.RunTarget)
+                    assert isinstance(target, build.CustomTarget)
                     pdir = self.get_target_private_dir_abs(target)
                     os.makedirs(pdir, exist_ok=True)
                     if not target.absolute_paths:

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -321,7 +321,7 @@ class Backend:
                          f'Using the first one. Consider using `{t.name}[0]`.')
         return os.path.join(self.get_target_dir(t), t.get_filename())
 
-    def get_aix_so_archive_name(self, t: build.AnyTargetType, filename: str) -> T.Optional[str]:
+    def get_aix_so_archive_name(self, t: build.AnyTargetProto, filename: str) -> T.Optional[str]:
         '''On AIX shared libraries are stored inside an archive; it is the archive
         that gets linked against and installed.  Shared modules are not archived.
         Return the name of the archive, or None if TARGET is not archived.'''
@@ -365,7 +365,7 @@ class Backend:
                 curdir = '.'
         return compiler.get_include_args(curdir, False)
 
-    def get_target_filename_for_linking(self, target: build.AnyTargetType) -> T.Optional[str]:
+    def get_target_filename_for_linking(self, target: build.AnyTargetProto) -> T.Optional[str]:
         # On some platforms (msvc for instance), the file that is used for
         # dynamic linking is not the same as the dynamic library itself. This
         # file is called an import library, and we want to link against that.
@@ -402,19 +402,18 @@ class Backend:
                 dirname = os.path.join(dirname, build_subdir)
         return dirname
 
-    def get_target_dir(self, target: build.AnyTargetType) -> str:
+    def get_target_dir(self, target: build.AnyTargetProto) -> str:
         return self.get_target_dir_cached(target.get_target())
 
     def get_target_dir_relative_to(self,
-                                   t: T.Union[build.Target, build.CustomTargetIndex],
-                                   o: T.Union[build.Target, build.CustomTargetIndex],
-                                   ) -> str:
+                                   t: build.AnyTargetProto,
+                                   o: build.AnyTargetProto) -> str:
         '''Get a target dir relative to another target's directory'''
         target_dir = os.path.join(self.environment.get_build_dir(), self.get_target_dir(t))
         othert_dir = os.path.join(self.environment.get_build_dir(), self.get_target_dir(o))
         return os.path.relpath(target_dir, othert_dir)
 
-    def get_target_source_dir(self, target: build.Target) -> str:
+    def get_target_source_dir(self, target: build.AnyTargetProto) -> str:
         # if target dir is empty, avoid extraneous trailing / from os.path.join()
         target_dir = self.get_target_dir(target)
         if target_dir:
@@ -539,7 +538,7 @@ class Backend:
         """Return target dependencies keyed by their introspection IDs."""
         all_deps: T.Dict[str, build.Target] = {}
 
-        def add_dependency(dep: build.AnyTargetType | TargetDepends | File | ExtractedObjects) -> None:
+        def add_dependency(dep: build.AnyTargetProto | TargetDepends | File | ExtractedObjects) -> None:
             if isinstance(dep, build.LocalProgram):
                 dep = dep.get_target()
             if isinstance(dep, build.CustomTargetIndex):
@@ -1405,7 +1404,7 @@ class Backend:
     def write_test_serialisation(self, tests: T.List['Test'], datafile: T.BinaryIO) -> None:
         pickle.dump(self.create_test_serialisation(tests), datafile)
 
-    def construct_target_rel_paths(self, t: build.BuildTargetTypes, workdir: T.Optional[str]) -> T.List[str]:
+    def construct_target_rel_paths(self, t: build.AnyTargetProto, workdir: T.Optional[str]) -> T.List[str]:
         target_dir = self.get_target_dir(t)
         # ensure that test executables can be run when passed as arguments
         if isinstance(t, build.Executable) and workdir is None:
@@ -1521,7 +1520,7 @@ class Backend:
             newargs.append(arg)
         return newargs
 
-    def get_build_by_default_targets(self) -> dict[str, build.Target]:
+    def get_build_by_default_targets(self) -> dict[str, build.AnyTargetProto]:
         return {k: v for k, v in self.build.targets.items() if v.build_by_default}
 
     def get_testlike_targets(self, benchmark: bool = False) -> T.Iterable[T.Union[build.BuildTarget, build.CustomTarget]]:
@@ -1590,7 +1589,7 @@ class Backend:
             srcs += fname
         return srcs
 
-    def get_paths_for_dep_outputs(self, target: build.Target, dep_targets: T.Iterable[build.Target | build.GeneratedList | build.CustomTargetIndex | programs.Program]) -> T.List[str]:
+    def get_paths_for_dep_outputs(self, target: build.AnyTargetProto, dep_targets: T.Iterable[build.AnyTargetProto | build.GeneratedList | programs.Program]) -> T.List[str]:
         """Return a list of strings with the paths to all the outputs of all targets in
            dep_targets."""
         deps = []
@@ -1617,7 +1616,7 @@ class Backend:
                 deps.append(i.rel_to_builddir(self.build_to_src))
         return deps
 
-    def get_custom_target_output_dir(self, target: build.AnyTargetType) -> str:
+    def get_custom_target_output_dir(self, target: build.AnyTargetProto) -> str:
         # The XCode backend is special. A target foo/bar does
         # not go to ${BUILDDIR}/foo/bar but instead to
         # ${BUILDDIR}/${BUILDTYPE}/foo/bar.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1560,7 +1560,7 @@ class Backend:
             libs.extend(self.get_custom_target_provided_by_generated_source(t))
         return libs
 
-    def get_custom_target_sources(self, target: build.RunTarget | build.CustomTarget) -> T.List[str]:
+    def get_custom_target_sources(self, target: build.CommandTargetProto) -> T.List[str]:
         '''
         Custom target sources can be of various object types; strings, File,
         BuildTarget, even other CustomTargets.
@@ -1657,7 +1657,7 @@ class Backend:
         return incs
 
     def eval_custom_target_command(
-            self, target: build.RunTarget | build.CustomTarget, absolute_outputs: bool = False) -> \
+            self, target: build.CommandTargetProto, absolute_outputs: bool = False) -> \
             T.Tuple[T.List[str], T.List[str], T.List[str | programs.Program]]:
         # We want the outputs to be absolute only when using the VS backend
         # XXX: Maybe allow the vs backend to use relative paths too?

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1368,7 +1368,7 @@ class Backend:
                     cmd_args.append(a)
                 elif isinstance(a, str):
                     cmd_args.append(a)
-                elif isinstance(a, (build.Target, build.CustomTargetIndex)):
+                elif isinstance(a, (build.BuildTarget, build.CustomTarget, build.CustomTargetIndex)):
                     cmd_args.extend(self.construct_target_rel_paths(a, t.workdir))
                 elif isinstance(a, programs.ExternalProgram):
                     cmd_args.extend(a.get_command())
@@ -1412,7 +1412,7 @@ class Backend:
     def write_test_serialisation(self, tests: T.List['Test'], datafile: T.BinaryIO) -> None:
         pickle.dump(self.create_test_serialisation(tests), datafile)
 
-    def construct_target_rel_paths(self, t: build.AnyTargetType, workdir: T.Optional[str]) -> T.List[str]:
+    def construct_target_rel_paths(self, t: build.BuildTargetTypes, workdir: T.Optional[str]) -> T.List[str]:
         target_dir = self.get_target_dir(t)
         # ensure that test executables can be run when passed as arguments
         if isinstance(t, build.Executable) and workdir is None:

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -315,7 +315,7 @@ class Backend:
     def generate(self, capture: bool = False, vslite_ctx: T.Optional[T.Dict] = None) -> T.Optional[T.Dict]:
         raise RuntimeError(f'generate is not implemented in {type(self).__name__}')
 
-    def get_target_filename(self, t: build.BuildTargetTypes, *, warn_multi_output: bool = True) -> str:
+    def get_target_filename(self, t: build.BuildTargetProto, *, warn_multi_output: bool = True) -> str:
         if isinstance(t, build.CustomTarget) and warn_multi_output and len(t.get_outputs()) != 1:
             mlog.warning(f'custom_target {t.name!r} has more than one output! '
                          f'Using the first one. Consider using `{t.name}[0]`.')
@@ -332,7 +332,7 @@ class Backend:
         linker, _ = t.get_clink_dynamic_linker_and_stdlibs()
         return linker.get_archive_name(filename)
 
-    def get_target_filename_abs(self, target: build.BuildTargetTypes) -> str:
+    def get_target_filename_abs(self, target: build.BuildTargetProto) -> str:
         return os.path.join(self.environment.get_build_dir(), self.get_target_filename(target))
 
     def get_target_debug_filename(self, target: build.BuildTarget) -> T.Optional[str]:
@@ -420,15 +420,15 @@ class Backend:
             return os.path.join(self.build_to_src, target_dir)
         return self.build_to_src
 
-    def get_target_private_dir(self, target: build.BuildTargetTypes) -> str:
+    def get_target_private_dir(self, target: build.BuildTargetProto) -> str:
         return os.path.join(self.get_target_filename(target, warn_multi_output=False) + '.p')
 
-    def get_target_private_dir_abs(self, target: build.BuildTargetTypes) -> str:
+    def get_target_private_dir_abs(self, target: build.BuildTargetProto) -> str:
         return os.path.join(self.environment.get_build_dir(), self.get_target_private_dir(target))
 
     @lru_cache(maxsize=None)
     def get_target_generated_dir(
-            self, target: build.BuildTargetTypes,
+            self, target: build.BuildTargetProto,
             gensrc: build.GeneratedTypes,
             src: str) -> str:
         """
@@ -443,11 +443,11 @@ class Backend:
         # target that the GeneratedList is used in
         return os.path.join(self.get_target_private_dir(target), src)
 
-    def get_unity_source_file(self, target: build.BuildTargetTypes,
+    def get_unity_source_file(self, target: build.BuildTargetProto,
                               suffix: str, number: int) -> mesonlib.File:
         # There is a potential conflict here, but it is unlikely that
         # anyone both enables unity builds and has a file called foo-unity.cpp.
-        osrc = f'{target.name}-unity{number}.{suffix}'
+        osrc = f'{target.get_basename()}-unity{number}.{suffix}'
         return mesonlib.File.from_built_file(self.get_target_private_dir(target), osrc)
 
     def generate_unity_files(self, target: build.BuildTarget, unity_src: list[File]) -> list[mesonlib.File]:
@@ -497,7 +497,7 @@ class Backend:
         return os.path.relpath(os.path.join('dummyprefixdir', todir),
                                os.path.join('dummyprefixdir', fromdir))
 
-    def get_all_linked_targets(self, target: build.BuildTarget) -> T.Iterator[build.BuildTargetTypes]:
+    def get_all_linked_targets(self, target: build.BuildTarget) -> T.Iterator[build.BuildTargetProto]:
         """Get all targets that have been linked with this one, including internal and
         indirect static libraries unlike :method:`build.BuildTarget.get_all_link_deps`
         and :method:`build.all_dependencies_recurse`, and targets whose objects
@@ -507,7 +507,7 @@ class Backend:
         for module information.
         """
         seen: T.Set[build.BuildTarget] = set()
-        stack: T.Deque[build.BuildTargetTypes] = deque()
+        stack: T.Deque[build.BuildTargetProto] = deque()
 
         def add_linked_targets(t: build.BuildTarget) -> None:
             stack.extendleft(t.link_targets)
@@ -525,7 +525,7 @@ class Backend:
             yield t
         assert target not in seen, 'should not have self'
 
-    def flatten_object_list(self, target: build.BuildTarget, proj_dir_to_build_root: str = ''
+    def flatten_object_list(self, target: build.BuildTargetProto, proj_dir_to_build_root: str = ''
                             ) -> T.Tuple[T.List[str], T.Iterable[build.BuildTarget]]:
         obj_list, deps = self._flatten_object_list(target.get_objects(), proj_dir_to_build_root)
         return unique_list(obj_list), deps
@@ -639,7 +639,7 @@ class Backend:
         return flatten_one(objects), deps
 
     @staticmethod
-    def is_swift_target(target: build.BuildTargetTypes) -> bool:
+    def is_swift_target(target: build.BuildTargetProto) -> bool:
         if not isinstance(target, build.BuildTarget):
             return False
         for s in target.get_sources():
@@ -673,7 +673,7 @@ class Backend:
     def get_executable_serialisation(
             self, cmd: T.Iterable[build.CommandTypes],
             workdir: T.Optional[str] = None,
-            extra_bdeps: T.Optional[T.Iterable[build.BuildTargetTypes]] = None,
+            extra_bdeps: T.Optional[T.Iterable[build.BuildTargetProto]] = None,
             capture: T.Optional[str] = None,
             feed: T.Optional[str] = None,
             env: T.Optional[mesonlib.EnvironmentVariables] = None,
@@ -764,7 +764,7 @@ class Backend:
     def as_meson_exe_cmdline(self, exe: build.CommandTypes,
                              cmd_args: T.Iterable[build.CommandTypes],
                              workdir: T.Optional[str] = None,
-                             extra_bdeps: T.Optional[T.Iterable[build.BuildTargetTypes]] = None,
+                             extra_bdeps: T.Optional[T.Iterable[build.BuildTargetProto]] = None,
                              capture: T.Optional[str] = None,
                              feed: T.Optional[str] = None,
                              force_serialize: bool = False,
@@ -1164,7 +1164,7 @@ class Backend:
                 commands += compiler.get_include_args(priv_dir, False)
         return commands
 
-    def build_target_link_arguments(self, compiler: Compiler, deps: T.Iterable[build.BuildTargetTypes]) -> T.List[str]:
+    def build_target_link_arguments(self, compiler: Compiler, deps: T.Iterable[build.BuildTargetProto]) -> T.List[str]:
         args: T.List[str] = []
         for d in deps:
             if not d.is_linkable_target():
@@ -1262,15 +1262,15 @@ class Backend:
         return results
 
     def determine_windows_extra_paths(
-            self, target: T.Union[build.BuildTargetTypes, programs.Program, mesonlib.File, str],
-            extra_bdeps: T.Iterable[build.BuildTargetTypes]) -> T.List[str]:
+            self, target: T.Union[build.BuildTargetProto, programs.Program, mesonlib.File, str],
+            extra_bdeps: T.Iterable[build.BuildTargetProto]) -> T.List[str]:
         """On Windows there is no such thing as an rpath.
 
         We must determine all locations of DLLs that this exe
         links to and return them so they can be used in unit
         tests.
         """
-        prospectives: T.Set[build.BuildTargetTypes] = set()
+        prospectives: T.Set[build.BuildTargetProto] = set()
         internal_deps: T.Set[str] = set()
         external_deps: T.Set[str] = set()
 
@@ -1336,7 +1336,7 @@ class Backend:
             exe_fname = cmd[0]
             cmd = self.get_exe_interpreter(cmd, test_for_machine) + cmd
             if machine.is_windows() or machine.is_cygwin():
-                extra_bdeps: T.List[build.BuildTargetTypes] = []
+                extra_bdeps: T.List[build.BuildTargetProto] = []
                 if isinstance(exe, build.CustomTarget):
                     extra_bdeps = list(exe.get_transitive_build_target_deps())
                 extra_bdeps.extend(t.depends)
@@ -1346,7 +1346,7 @@ class Backend:
                 extra_paths = []
 
             cmd_args: T.List[str] = []
-            depends: T.Set[build.BuildTargetTypes] = set(t.depends)
+            depends: T.Set[build.BuildTargetProto] = set(t.depends)
             if isinstance(exe, (build.BuildTarget, build.CustomTarget, build.CustomTargetIndex)):
                 depends.add(exe)
             for a in t.cmd_args:
@@ -1404,7 +1404,7 @@ class Backend:
     def write_test_serialisation(self, tests: T.List['Test'], datafile: T.BinaryIO) -> None:
         pickle.dump(self.create_test_serialisation(tests), datafile)
 
-    def construct_target_rel_paths(self, t: build.AnyTargetProto, workdir: T.Optional[str]) -> T.List[str]:
+    def construct_target_rel_paths(self, t: build.BuildTargetProto, workdir: T.Optional[str]) -> T.List[str]:
         target_dir = self.get_target_dir(t)
         # ensure that test executables can be run when passed as arguments
         if isinstance(t, build.Executable) and workdir is None:
@@ -1489,13 +1489,13 @@ class Backend:
             if delta > 0.001:
                 raise MesonException(f'Clock skew detected. File {absf} has a time stamp {delta:.4f}s in the future.')
 
-    def build_target_to_cmd_array(self, bt: T.Union[build.BuildTargetTypes, programs.Program]) -> T.List[str]:
+    def build_target_to_cmd_array(self, bt: T.Union[build.BuildTargetProto, programs.Program]) -> T.List[str]:
         if isinstance(bt, build.LocalProgram):
             bt = bt.program
-        if isinstance(bt, (build.Target, build.CustomTargetIndex)):
-            arr = [os.path.join(self.environment.get_build_dir(), self.get_target_filename(bt))]
-        else:
+        if isinstance(bt, programs.Program):
             arr = bt.get_command()
+        else:
+            arr = [os.path.join(self.environment.get_build_dir(), self.get_target_filename(bt))]
         return arr
 
     def replace_extra_args(self, args: T.List[str], genlist: 'build.GeneratedList') -> T.List[str]:
@@ -1523,7 +1523,7 @@ class Backend:
     def get_build_by_default_targets(self) -> dict[str, build.AnyTargetProto]:
         return {k: v for k, v in self.build.targets.items() if v.build_by_default}
 
-    def get_testlike_targets(self, benchmark: bool = False) -> T.Iterable[T.Union[build.BuildTarget, build.CustomTarget]]:
+    def get_testlike_targets(self, benchmark: bool = False) -> T.Iterable[build.BuildTargetProto]:
         targets = self.build.get_benchmarks() if benchmark else self.build.get_tests()
         for t in targets:
             exe = t.exe
@@ -1552,7 +1552,7 @@ class Backend:
         return libs
 
     @lru_cache(maxsize=None)
-    def get_custom_target_provided_libraries(self, target: T.Union[build.BuildTarget, build.CustomTarget]) -> 'ImmutableListProtocol[str]':
+    def get_custom_target_provided_libraries(self, target: build.BuildTargetProto) -> 'ImmutableListProtocol[str]':
         libs: T.List[str] = []
         for t in target.get_generated_sources():
             if not isinstance(t, build.CustomTarget):
@@ -1630,7 +1630,7 @@ class Backend:
     def get_normpath_target(self, source: str) -> str:
         return os.path.normpath(source)
 
-    def get_custom_target_dirs(self, target: build.BuildTarget | build.CustomTarget, compiler: 'Compiler', *,
+    def get_custom_target_dirs(self, target: build.BuildTargetProto, compiler: 'Compiler', *,
                                absolute_path: bool = False) -> T.List[str]:
         custom_target_include_dirs: T.List[str] = []
         for i in target.get_generated_sources():
@@ -1649,7 +1649,7 @@ class Backend:
         return custom_target_include_dirs
 
     def get_custom_target_dir_include_args(
-            self, target: build.BuildTarget | build.CustomTarget, compiler: 'Compiler', *,
+            self, target: build.BuildTargetProto, compiler: 'Compiler', *,
             absolute_path: bool = False) -> T.List[str]:
         incs: T.List[str] = []
         for i in self.get_custom_target_dirs(target, compiler, absolute_path=absolute_path):
@@ -2208,7 +2208,7 @@ class Backend:
                               compiler: 'Compiler',
                               sources: T.List[TargetSources],
                               output_templ: str,
-                              depends: T.Optional[T.List[build.BuildTargetTypes]] = None,
+                              depends: T.Optional[T.List[build.BuildTargetProto]] = None,
                               ) -> build.GeneratedList:
         '''
         Some backends don't support custom compilers. This is a convenience

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1204,7 +1204,7 @@ class NinjaBackend(backends.Backend):
                 elem = NinjaBuildElement(self.all_outputs, linker.get_archive_name(outname), 'AIX_LINKER', [outname])
                 self.add_build(elem)
 
-    def should_use_dyndeps_for_target(self, target: build.BuildTargetTypes) -> bool:
+    def should_use_dyndeps_for_target(self, target: build.BuildTargetProto) -> bool:
         if not self.ninja_has_dyndeps:
             return False
         if not isinstance(target, build.BuildTarget):
@@ -3900,7 +3900,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         # Add link args to link to all internal libraries (link_with:) and
         # internal dependencies needed by this target.
         dep_targets: T.List[str] = []
-        dependencies: T.Iterable[build.BuildTargetTypes]
+        dependencies: T.Iterable[build.BuildTargetProto]
         if isinstance(target, build.StaticLibrary):
             # Link arguments of static libraries are not put in the command
             # line of the library. They are instead appended to the command
@@ -3995,7 +3995,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             return []
         return self.import_std.gen_objects
 
-    def get_dependency_filename(self, t: T.Union[File, build.BuildTargetTypes]) -> str:
+    def get_dependency_filename(self, t: T.Union[File, build.BuildTargetProto]) -> str:
         if isinstance(t, build.SharedLibrary):
             if t.uses_rust() and t.rust_crate_type == 'proc-macro':
                 return self.get_target_filename(t)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3696,12 +3696,13 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         if use_custom:
             objects_from_static_libs: T.List[str] = []
             for dep in target.link_whole_targets:
-                if not isinstance(dep, build.BuildTarget):
+                try:
+                    l = dep.extract_all_objects(False)
+                except MesonException:
                     raise MesonException(
-                        f'Cannot extract objects from custom target {dep.name!r} to '
+                        f'Cannot extract objects from custom target {dep.get_basename()!r} to '
                         f'link_whole it into {target.name!r}: this is not supported '
                         'with versions of MSVC older than Visual Studio 2015 Update 2.')
-                l = dep.extract_all_objects(False)
                 objects_from_static_libs += self.determine_ext_objs(l)
                 objects_from_static_libs.extend(self.flatten_object_list(dep)[0])
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1817,7 +1817,7 @@ class NinjaBackend(backends.Backend):
         args += ['--directory', c_out_dir]
         args += ['--basedir', srcbasedir]
         if target.is_linkable_target():
-            assert isinstance(target, build.LinkableTarget)
+            assert isinstance(target, (build.StaticLibrary, build.SharedLibrary, build.Executable))
             # Library name
             args += ['--library', target.name]
             # Outputted header
@@ -2389,9 +2389,9 @@ class NinjaBackend(backends.Backend):
             cpp_targets = [t for t in target.link_targets if t.uses_swift_cpp_interop()]
             if cpp_targets != []:
                 target_word = 'targets' if len(cpp_targets) > 1 else 'target'
-                first = ', '.join(repr(t.name) for t in cpp_targets[:-1])
+                first = ', '.join(repr(t.get_basename()) for t in cpp_targets[:-1])
                 and_word = ' and ' if len(cpp_targets) > 1 else ''
-                last = repr(cpp_targets[-1].name)
+                last = repr(cpp_targets[-1].get_basename())
                 enable_word = 'enable' if len(cpp_targets) > 1 else 'enables'
                 raise MesonException('Swift target {0} links against {1} {2}{3}{4} which {5} C++ interoperability. '
                                      'This requires {0} to also have it enabled. '
@@ -3602,12 +3602,12 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             self.all_pch[compiler.id].update(objs + [dst])
         return pch_objects
 
-    def get_target_shsym_filename(self, target: build.BuildTarget) -> str:
+    def get_target_shsym_filename(self, target: build.LinkableProto) -> str:
         # Always name the .symbols file after the primary build output because it always exists
         targetdir = self.get_target_private_dir(target)
         return os.path.join(targetdir, target.get_filename() + '.symbols')
 
-    def generate_shsym(self, target: build.BuildTarget) -> None:
+    def generate_shsym(self, target: build.LinkableProto) -> None:
         # On OS/2, an import library is generated after linking a DLL, so
         # if a DLL is used as a target, import library is not generated.
         if self.environment.machines[target.for_machine].is_os2():

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1818,7 +1818,7 @@ class NinjaBackend(backends.Backend):
         args += ['--directory', c_out_dir]
         args += ['--basedir', srcbasedir]
         if target.is_linkable_target():
-            assert isinstance(target, build.LinkableTarget)
+            assert isinstance(target, (build.StaticLibrary, build.SharedLibrary, build.Executable))
             # Library name
             args += ['--library', target.name]
             # Outputted header
@@ -2394,9 +2394,9 @@ class NinjaBackend(backends.Backend):
             cpp_targets = [t for t in target.link_targets if t.uses_swift_cpp_interop()]
             if cpp_targets != []:
                 target_word = 'targets' if len(cpp_targets) > 1 else 'target'
-                first = ', '.join(repr(t.name) for t in cpp_targets[:-1])
+                first = ', '.join(repr(t.get_basename()) for t in cpp_targets[:-1])
                 and_word = ' and ' if len(cpp_targets) > 1 else ''
-                last = repr(cpp_targets[-1].name)
+                last = repr(cpp_targets[-1].get_basename())
                 enable_word = 'enable' if len(cpp_targets) > 1 else 'enables'
                 raise MesonException('Swift target {0} links against {1} {2}{3}{4} which {5} C++ interoperability. '
                                      'This requires {0} to also have it enabled. '
@@ -3607,12 +3607,12 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             self.all_pch[compiler.id].update(objs + [dst])
         return pch_objects
 
-    def get_target_shsym_filename(self, target: build.BuildTarget) -> str:
+    def get_target_shsym_filename(self, target: build.LinkableTargetProto) -> str:
         # Always name the .symbols file after the primary build output because it always exists
         targetdir = self.get_target_private_dir(target)
         return os.path.join(targetdir, target.get_filename() + '.symbols')
 
-    def generate_shsym(self, target: build.BuildTarget) -> None:
+    def generate_shsym(self, target: build.LinkableTargetProto) -> None:
         # On OS/2, an import library is generated after linking a DLL, so
         # if a DLL is used as a target, import library is not generated.
         if self.environment.machines[target.for_machine].is_os2():

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3699,12 +3699,13 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         if use_custom:
             objects_from_static_libs: T.List[str] = []
             for dep in target.link_whole_targets:
-                if not isinstance(dep, build.BuildTarget):
+                try:
+                    l = dep.extract_all_objects(False)
+                except MesonException:
                     raise MesonException(
-                        f'Cannot extract objects from custom target {dep.name!r} to '
+                        f'Cannot extract objects from custom target {dep.get_basename()!r} to '
                         f'link_whole it into {target.name!r}: this is not supported '
                         'with versions of MSVC older than Visual Studio 2015 Update 2.')
-                l = dep.extract_all_objects(False)
                 objects_from_static_libs += self.determine_ext_objs(l)
                 objects_from_static_libs.extend(self.flatten_object_list(dep)[0])
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1206,7 +1206,7 @@ class NinjaBackend(backends.Backend):
             elem = NinjaBuildElement(self.all_outputs, archive_name, 'AIX_LINKER', [outname])
             self.add_build(elem)
 
-    def should_use_dyndeps_for_target(self, target: build.BuildTargetTypes) -> bool:
+    def should_use_dyndeps_for_target(self, target: build.BuildTargetProto) -> bool:
         if not self.ninja_has_dyndeps:
             return False
         if not isinstance(target, build.BuildTarget):
@@ -2861,7 +2861,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 continue
             self.generate_genlist_for_target(genlist, target)
 
-    def replace_paths(self, target: build.BuildTarget | build.CustomTarget, args: T.List[str], override_subdir: T.Optional[str] = None) -> T.List[str]:
+    def replace_paths(self, target: build.BuildTargetProto, args: T.List[str], override_subdir: T.Optional[str] = None) -> T.List[str]:
         if override_subdir:
             source_target_dir = os.path.join(self.build_to_src, override_subdir)
         else:
@@ -2875,7 +2875,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         args = [x.replace('\\', '/') for x in args]
         return args
 
-    def generate_genlist_for_target(self, genlist: build.GeneratedList, target: build.BuildTarget | build.CustomTarget) -> None:
+    def generate_genlist_for_target(self, genlist: build.GeneratedList, target: build.BuildTargetProto) -> None:
         for x in genlist.depends:
             if isinstance(x, build.GeneratedList):
                 self.generate_genlist_for_target(x, target)
@@ -3903,7 +3903,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         # Add link args to link to all internal libraries (link_with:) and
         # internal dependencies needed by this target.
         dep_targets: T.List[str] = []
-        dependencies: T.Iterable[build.BuildTargetTypes]
+        dependencies: T.Iterable[build.BuildTargetProto]
         if isinstance(target, build.StaticLibrary):
             # Link arguments of static libraries are not put in the command
             # line of the library. They are instead appended to the command
@@ -3998,7 +3998,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             return []
         return self.import_std.gen_objects
 
-    def get_dependency_filename(self, t: T.Union[File, build.BuildTargetTypes]) -> str:
+    def get_dependency_filename(self, t: T.Union[File, build.BuildTargetProto]) -> str:
         if isinstance(t, build.SharedLibrary):
             if t.uses_rust() and t.rust_crate_type == 'proc-macro':
                 return self.get_target_filename(t)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -160,7 +160,7 @@ class Vs2010Backend(backends.Backend):
     def detect_toolset(self) -> None:
         pass
 
-    def get_target_private_dir(self, target: build.AnyTargetType) -> str:
+    def get_target_private_dir(self, target: build.BuildTargetTypes) -> str:
         return os.path.join(self.get_target_dir(target), target.get_id())
 
     def generate_genlist_for_target(
@@ -609,7 +609,7 @@ class Vs2010Backend(backends.Backend):
                 headers.append(i)
         return sources, headers, objects, languages
 
-    def target_to_build_root(self, target: build.AnyTargetType) -> str:
+    def target_to_build_root(self, target: build.BuildTargetTypes) -> str:
         if self.get_target_dir(target) == '':
             return ''
 

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1281,7 +1281,7 @@ class Vs2010Backend(backends.Backend):
                                                platform: str,
                                                target_ext: str,
                                                vslite_ctx: _VSLITE_CTX,
-                                               target: build.AnyTargetType,
+                                               target: build.Target,
                                                proj_to_build_root: str,
                                                primary_src_lang: T.Optional[Language]) -> None:
         ET.SubElement(root, 'ImportGroup', Label='ExtensionSettings')
@@ -1633,7 +1633,7 @@ class Vs2010Backend(backends.Backend):
     # once a build/compile has generated these sources.
     #
     # This modifies the paths in 'gen_files' in place, as opposed to returning a new list of modified paths.
-    def relocate_generated_file_paths_to_concrete_build_dir(self, gen_files: T.List[str], target: build.AnyTargetType) -> None:
+    def relocate_generated_file_paths_to_concrete_build_dir(self, gen_files: T.List[str], target: build.BuildTarget) -> None:
         (_, build_dir_tail) = os.path.split(self.src_to_build)
         meson_build_dir_for_buildtype = build_dir_tail[:-2] + coredata.get_genvs_default_buildtype_list()[0] # Get the first buildtype suffixed dir (i.e. '[builddir]_debug') from '[builddir]_vs'
         # Relative path from this .vcxproj to the directory containing the set of '..._[debug/debugoptimized/release]' setup meson build dirs.

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1309,7 +1309,7 @@ class Vs2010Backend(backends.Backend):
             ET.SubElement(per_config_prop_group, 'OutDir').text = f'{proj_to_build_dir_for_buildtype}\\'
             ET.SubElement(per_config_prop_group, 'IntDir').text = f'{proj_to_build_dir_for_buildtype}\\'
             ET.SubElement(per_config_prop_group, 'NMakeBuildCommandLine').text = f'{nmake_base_meson_command} compile -C "{proj_to_build_dir_for_buildtype}"'
-            ET.SubElement(per_config_prop_group, 'NMakeOutput').text = f'$(OutDir){target.name}{target_ext}'
+            ET.SubElement(per_config_prop_group, 'NMakeOutput').text = f'$(OutDir){target.get_basename()}{target_ext}'
             captured_build_args = vslite_ctx[buildtype][target.get_id()]
             # 'captured_build_args' is a dictionary, mapping from each src file type to a list of compile args to use for that type.
             # Usually, there's just one but we could have multiple src types.  However, since there's only one field for the makefile

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1254,7 +1254,7 @@ class Vs2010Backend(backends.Backend):
             ET.SubElement(per_config_prop_group, 'OutDir').text = f'{proj_to_build_dir_for_buildtype}\\'
             ET.SubElement(per_config_prop_group, 'IntDir').text = f'{proj_to_build_dir_for_buildtype}\\'
             ET.SubElement(per_config_prop_group, 'NMakeBuildCommandLine').text = f'{nmake_base_meson_command} compile -C "{proj_to_build_dir_for_buildtype}"'
-            ET.SubElement(per_config_prop_group, 'NMakeOutput').text = f'$(OutDir){target.name}{target_ext}'
+            ET.SubElement(per_config_prop_group, 'NMakeOutput').text = f'$(OutDir){target.get_basename()}{target_ext}'
             captured_build_args = vslite_ctx[buildtype][target.get_id()]
             # 'captured_build_args' is a dictionary, mapping from each src file type to a list of compile args to use for that type.
             # Usually, there's just one but we could have multiple src types.  However, since there's only one field for the makefile

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -158,12 +158,12 @@ class Vs2010Backend(backends.Backend):
     def detect_toolset(self) -> None:
         pass
 
-    def get_target_private_dir(self, target: build.BuildTargetTypes) -> str:
+    def get_target_private_dir(self, target: build.BuildTargetProto) -> str:
         return os.path.join(self.get_target_dir(target), target.get_id())
 
     def generate_gensrc_for_target(
             self, genlist: build.GeneratedTypes,
-            target: build.BuildTarget | build.CustomTarget,
+            target: build.BuildTargetProto,
             parent_node: ET.Element,
             generator_output_files: T.List[str],
             custom_target_include_dirs: T.List[str],
@@ -183,7 +183,7 @@ class Vs2010Backend(backends.Backend):
 
     def generate_genlist_for_target(
             self, genlist: build.GeneratedList,
-            target: build.BuildTarget | build.CustomTarget,
+            target: build.BuildTargetProto,
             parent_node: ET.Element,
             generator_output_files: T.List[str]) -> None:
         for x in genlist.depends:
@@ -242,7 +242,7 @@ class Vs2010Backend(backends.Backend):
             ET.SubElement(cbs, 'AdditionalInputs').text = ';'.join(deps)
 
     def generate_custom_generator_commands(
-            self, target: build.BuildTarget | build.CustomTarget, parent_node: ET.Element
+            self, target: build.BuildTargetProto, parent_node: ET.Element
             ) -> tuple[list[str], list[str], list[str]]:
         generator_output_files: list[str] = []
         custom_target_include_dirs: list[str] = []
@@ -554,7 +554,7 @@ class Vs2010Backend(backends.Backend):
                 headers.append(i)
         return sources, headers, objects, languages
 
-    def target_to_build_root(self, target: build.BuildTargetTypes) -> str:
+    def target_to_build_root(self, target: build.BuildTargetProto) -> str:
         if self.get_target_dir(target) == '':
             return ''
 
@@ -1470,7 +1470,7 @@ class Vs2010Backend(backends.Backend):
                     # Expand our object lists manually if we are on pre-Visual Studio 2015 Update 2
                     if not isinstance(t, build.BuildTarget):
                         raise MesonException(
-                            f'Cannot extract objects from custom target {t.name!r} to '
+                            f'Cannot extract objects from custom target {t.get_basename()!r} to '
                             f'link_whole it into {target.name!r}: this is not supported '
                             'with versions of MSVC older than Visual Studio 2015 Update 2.')
                     l = t.extract_all_objects(False)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -158,7 +158,7 @@ class Vs2010Backend(backends.Backend):
     def detect_toolset(self) -> None:
         pass
 
-    def get_target_private_dir(self, target: build.AnyTargetType) -> str:
+    def get_target_private_dir(self, target: build.BuildTargetTypes) -> str:
         return os.path.join(self.get_target_dir(target), target.get_id())
 
     def generate_gensrc_for_target(
@@ -554,7 +554,7 @@ class Vs2010Backend(backends.Backend):
                 headers.append(i)
         return sources, headers, objects, languages
 
-    def target_to_build_root(self, target: build.AnyTargetType) -> str:
+    def target_to_build_root(self, target: build.BuildTargetTypes) -> str:
         if self.get_target_dir(target) == '':
             return ''
 

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -160,7 +160,7 @@ class Vs2010Backend(backends.Backend):
     def detect_toolset(self) -> None:
         pass
 
-    def get_target_private_dir(self, target: build.BuildTargetTypes) -> str:
+    def get_target_private_dir(self, target: build.BuildTargetProto) -> str:
         return os.path.join(self.get_target_dir(target), target.get_id())
 
     def generate_genlist_for_target(
@@ -609,7 +609,7 @@ class Vs2010Backend(backends.Backend):
                 headers.append(i)
         return sources, headers, objects, languages
 
-    def target_to_build_root(self, target: build.BuildTargetTypes) -> str:
+    def target_to_build_root(self, target: build.BuildTargetProto) -> str:
         if self.get_target_dir(target) == '':
             return ''
 
@@ -1525,7 +1525,7 @@ class Vs2010Backend(backends.Backend):
                     # Expand our object lists manually if we are on pre-Visual Studio 2015 Update 2
                     if not isinstance(t, build.BuildTarget):
                         raise MesonException(
-                            f'Cannot extract objects from custom target {t.name!r} to '
+                            f'Cannot extract objects from custom target {t.get_basename()!r} to '
                             f'link_whole it into {target.name!r}: this is not supported '
                             'with versions of MSVC older than Visual Studio 2015 Update 2.')
                     l = t.extract_all_objects(False)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1532,11 +1532,11 @@ class Vs2010Backend(backends.Backend):
             # Undocumented, but you can find a reference in WDK props
             minver = ET.SubElement(link, 'MinimumRequiredVersion')
             minver.text = version
-        if isinstance(target, (build.SharedLibrary, build.Executable)) and target.get_import_filename():
-            # DLLs built with MSVC always have an import library except when
-            # they're data-only DLLs, but we don't support those yet.
-            ET.SubElement(link, 'ImportLibrary').text = target.get_import_filename()
         if isinstance(target, (build.SharedLibrary, build.Executable)):
+            if target.get_import_filename():
+                # DLLs built with MSVC always have an import library except when
+                # they're data-only DLLs, but we don't support those yet.
+                ET.SubElement(link, 'ImportLibrary').text = target.get_import_filename()
             # Add module definitions file, if provided
             if target.vs_module_defs:
                 relpath = os.path.join(down, target.vs_module_defs.rel_to_builddir(self.build_to_src))

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -556,7 +556,7 @@ class XCodeBackend(backends.Backend):
                 generator_id += 1
 
     def gen_single_target_map(self, genlist: build.GeneratedList, tname: str,
-                              t: build.BuildTargetTypes, generator_id: int) -> None:
+                              t: build.BuildTargetProto, generator_id: int) -> None:
         k = (tname, generator_id)
         assert k not in self.shell_targets
         if genlist.extra_depends:
@@ -1464,7 +1464,7 @@ class XCodeBackend(backends.Backend):
                     self.generate_single_generator_phase(tname, t, genlist, generator_id, objects_dict)
                     generator_id += 1
 
-    def generate_single_generator_phase(self, tname: str, t: build.BuildTargetTypes,
+    def generate_single_generator_phase(self, tname: str, t: build.BuildTargetProto,
                                         genlist: build.GeneratedList, generator_id: int, objects_dict: PbxDict) -> None:
         # TODO: this should be rewritten to use the meson wrapper, like the other generators do
         # Currently it doesn't handle a host binary that requires an exe wrapper correctly.

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -308,7 +308,7 @@ class XCodeBackend(backends.Backend):
         dirname = os.path.join(target.get_subdir(), T.cast('str', self.environment.coredata.optstore.get_value_for(OptionKey('buildtype'))))
         return dirname
 
-    def get_custom_target_output_dir(self, target: build.AnyTargetType) -> str:
+    def get_custom_target_output_dir(self, target: build.AnyTargetProto) -> str:
         dirname = target.get_subdir()
         os.makedirs(os.path.join(self.environment.get_build_dir(), dirname), exist_ok=True)
         return dirname
@@ -1502,7 +1502,7 @@ class XCodeBackend(backends.Backend):
                 for arg in base_args:
                     arg = arg.replace("@INPUT@", infilename)
                     arg = arg.replace('@OUTPUT@', o).replace('@BUILD_DIR@', self.get_target_private_dir(t))
-                    arg = arg.replace("@CURRENT_SOURCE_DIR@", os.path.join(self.build_to_src, t.subdir))
+                    arg = arg.replace("@CURRENT_SOURCE_DIR@", os.path.join(self.build_to_src, t.get_subdir()))
                     args.append(arg)
                 args = self.replace_outputs(args, self.get_target_private_dir(t), outfilelist)
                 args = self.replace_extra_args(args, genlist)

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -556,7 +556,7 @@ class XCodeBackend(backends.Backend):
                 generator_id += 1
 
     def gen_single_target_map(self, genlist: build.GeneratedList, tname: str,
-                              t: build.AnyTargetType, generator_id: int) -> None:
+                              t: build.BuildTargetTypes, generator_id: int) -> None:
         k = (tname, generator_id)
         assert k not in self.shell_targets
         if genlist.extra_depends:
@@ -1464,7 +1464,7 @@ class XCodeBackend(backends.Backend):
                     self.generate_single_generator_phase(tname, t, genlist, generator_id, objects_dict)
                     generator_id += 1
 
-    def generate_single_generator_phase(self, tname: str, t: build.AnyTargetType,
+    def generate_single_generator_phase(self, tname: str, t: build.BuildTargetTypes,
                                         genlist: build.GeneratedList, generator_id: int, objects_dict: PbxDict) -> None:
         # TODO: this should be rewritten to use the meson wrapper, like the other generators do
         # Currently it doesn't handle a host binary that requires an exe wrapper correctly.

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -541,7 +541,7 @@ class XCodeBackend(backends.Backend):
                 generator_id += 1
 
     def gen_single_target_map(self, genlist: build.GeneratedList, tname: str,
-                              t: build.BuildTargetTypes, generator_id: int) -> None:
+                              t: build.BuildTargetProto, generator_id: int) -> None:
         k = (tname, generator_id)
         assert k not in self.shell_targets
         if genlist.extra_depends:
@@ -1421,7 +1421,7 @@ class XCodeBackend(backends.Backend):
                     self.generate_single_generator_phase(tname, t, genlist, generator_id, objects_dict)
                     generator_id += 1
 
-    def generate_single_generator_phase(self, tname: str, t: build.BuildTargetTypes,
+    def generate_single_generator_phase(self, tname: str, t: build.BuildTargetProto,
                                         genlist: build.GeneratedList, generator_id: int, objects_dict: PbxDict) -> None:
         # TODO: this should be rewritten to use the meson wrapper, like the other generators do
         # Currently it doesn't handle a host binary that requires an exe wrapper correctly.

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -541,7 +541,7 @@ class XCodeBackend(backends.Backend):
                 generator_id += 1
 
     def gen_single_target_map(self, genlist: build.GeneratedList, tname: str,
-                              t: build.AnyTargetType, generator_id: int) -> None:
+                              t: build.BuildTargetTypes, generator_id: int) -> None:
         k = (tname, generator_id)
         assert k not in self.shell_targets
         if genlist.extra_depends:
@@ -1421,7 +1421,7 @@ class XCodeBackend(backends.Backend):
                     self.generate_single_generator_phase(tname, t, genlist, generator_id, objects_dict)
                     generator_id += 1
 
-    def generate_single_generator_phase(self, tname: str, t: build.AnyTargetType,
+    def generate_single_generator_phase(self, tname: str, t: build.BuildTargetTypes,
                                         genlist: build.GeneratedList, generator_id: int, objects_dict: PbxDict) -> None:
         # TODO: this should be rewritten to use the meson wrapper, like the other generators do
         # Currently it doesn't handle a host binary that requires an exe wrapper correctly.

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -304,7 +304,7 @@ class XCodeBackend(backends.Backend):
         dirname = os.path.join(target.get_subdir(), T.cast('str', self.environment.coredata.optstore.get_value_for(OptionKey('buildtype'))))
         return dirname
 
-    def get_custom_target_output_dir(self, target: build.AnyTargetType) -> str:
+    def get_custom_target_output_dir(self, target: build.AnyTargetProto) -> str:
         dirname = target.get_subdir()
         os.makedirs(os.path.join(self.environment.get_build_dir(), dirname), exist_ok=True)
         return dirname
@@ -1459,7 +1459,7 @@ class XCodeBackend(backends.Backend):
                 for arg in base_args:
                     arg = arg.replace("@INPUT@", infilename)
                     arg = arg.replace('@OUTPUT@', o).replace('@BUILD_DIR@', self.get_target_private_dir(t))
-                    arg = arg.replace("@CURRENT_SOURCE_DIR@", os.path.join(self.build_to_src, t.subdir))
+                    arg = arg.replace("@CURRENT_SOURCE_DIR@", os.path.join(self.build_to_src, t.get_subdir()))
                     args.append(arg)
                 args = self.replace_outputs(args, self.get_target_private_dir(t), outfilelist)
                 args = self.replace_extra_args(args, genlist)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -39,7 +39,7 @@ from .compilers import (
 from .interpreterbase import FeatureNew, FeatureDeprecated
 
 if T.TYPE_CHECKING:
-    from typing_extensions import Literal, Self, TypeAlias, TypedDict
+    from typing_extensions import Literal, Self, TypeAlias, TypedDict, Protocol
 
     from .arglist import CompilerArgs
     from .environment import Environment
@@ -63,9 +63,20 @@ if T.TYPE_CHECKING:
     BuildTargetTypes: TypeAlias = T.Union['BuildTarget', 'CustomTarget', 'CustomTargetIndex']
     StaticTargetTypes: TypeAlias = T.Union['StaticLibrary', 'CustomTarget', 'CustomTargetIndex']
     ObjectTypes: TypeAlias = T.Union['File', 'ExtractedObjects']
-    AnyTargetType: TypeAlias = T.Union['Target', 'CustomTargetIndex']
     RustCrateType: TypeAlias = Literal['bin', 'lib', 'rlib', 'dylib', 'cdylib', 'staticlib', 'proc-macro']
     _LibraryType: TypeAlias = Literal['auto', 'shared', 'static']
+
+    class AnyTargetProto(Protocol):
+        @property
+        def depend_files(self) -> T.List[File]: ...
+
+        def get_basename(self) -> str: ...
+        def get_build_subdir(self) -> str: ...
+        def get_builddir(self) -> str: ...
+        def get_id(self) -> str: ...
+        def get_outputs(self) -> T.List[str]: ...
+        def get_subdir(self) -> str: ...
+        def get_target(self) -> Target: ...
 
     class DFeatures(TypedDict):
 
@@ -158,6 +169,8 @@ if T.TYPE_CHECKING:
         java_args: T.List[str]
         java_resources: T.Optional[StructuredSources]
         main_class: str
+else:
+    AnyTargetProto = object
 
 
 _T = T.TypeVar('_T')
@@ -677,7 +690,7 @@ class StructuredSources(HoldableObject):
 
 
 @dataclass(eq=False)
-class Target(HoldableObject, metaclass=SimpleABC):
+class Target(HoldableObject, AnyTargetProto, metaclass=SimpleABC):
 
     typename: T.ClassVar[str]
 
@@ -2966,7 +2979,7 @@ def flatten_command(cmd: T.Iterable[CommandTypes],
     return final_cmd, depend_files, dependencies
 
 
-class CustomTargetBase(LinkableTarget, metaclass=SimpleABC):
+class CustomTargetBase(LinkableTarget, AnyTargetProto, metaclass=SimpleABC):
     ''' Base class for CustomTarget and CustomTargetIndex
 
     This base class can be used to provide a dummy implementation of some
@@ -3304,7 +3317,7 @@ class RunTarget(Target):
     def __init__(self, name: str,
                  command: T.Sequence[CommandTypes],
                  # the RunTarget case is used by gnome.yelp()
-                 dependencies: T.Sequence[Target | CustomTargetIndex | GeneratedList | programs.Program],
+                 dependencies: T.Sequence[AnyTargetProto | GeneratedList | programs.Program],
                  subdir: str,
                  environment: Environment,
                  build_project: BuildProject,
@@ -3323,7 +3336,7 @@ class RunTarget(Target):
         repr_str = "<{0} {1}: {2}>"
         return repr_str.format(self.__class__.__name__, self.get_id(), self.command[0])
 
-    def get_dependencies(self) -> T.List[Target | CustomTargetIndex | GeneratedList | programs.Program]:
+    def get_dependencies(self) -> T.Iterable[AnyTargetProto | GeneratedList | programs.Program]:
         return self.dependencies
 
     def get_generated_sources(self) -> T.List[GeneratedTypes]:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -3440,14 +3440,15 @@ class CustomTargetIndex(CustomTargetBase, HoldableObject):
     target: T.Union[CustomTarget, CompileTarget]
     output: str
 
-    def __post_init__(self) -> None:
-        self.for_machine = self.target.for_machine
-
     @lazy_property
     def __index(self) -> int:
         # Must be detected lazily becuase preporcessed sources don't end up in the
         # outputs, but can still be in a CustomTargetIndex.
         return self.target.outputs.index(self.output)
+
+    @property
+    def for_machine(self) -> MachineChoice:
+        return self.target.for_machine
 
     @property
     def name(self) -> str:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -58,9 +58,7 @@ if T.TYPE_CHECKING:
     TargetSources: TypeAlias = T.Union['File', 'GeneratedTypes']
     CommandTypes: TypeAlias = T.Union['programs.Program', 'BuildTargetTypes', File, str]
     GeneratedTypes: TypeAlias = T.Union['CustomTarget', 'CustomTargetIndex', 'GeneratedList']
-    LibTypes: TypeAlias = T.Union['SharedLibrary', 'StaticLibrary', 'CustomTarget', 'CustomTargetIndex']
     BuildTargetTypes: TypeAlias = T.Union['BuildTarget', 'CustomTarget', 'CustomTargetIndex']
-    StaticTargetTypes: TypeAlias = T.Union['StaticLibrary', 'CustomTarget', 'CustomTargetIndex']
     ObjectTypes: TypeAlias = T.Union['File', 'ExtractedObjects']
     RustCrateType: TypeAlias = Literal['bin', 'lib', 'rlib', 'dylib', 'cdylib', 'staticlib', 'proc-macro']
     _LibraryType: TypeAlias = Literal['auto', 'shared', 'static']
@@ -90,8 +88,8 @@ if T.TYPE_CHECKING:
         def get_dependencies_recurse(self, result: OrderedSet[BuildTargetProto], visited: T.Set[T.Tuple[BuildTargetProto, bool, bool]], include_internals: bool = True, handled_by_rustc: bool = False) -> None: ...
         def get_filename(self) -> str: ...
         def get_generated_sources(self) -> T.Iterable[GeneratedTypes]: ...
-        def get_internal_static_libraries(self) -> OrderedSet[StaticTargetTypes]: ...
-        def get_internal_static_libraries_recurse(self, result: OrderedSet[StaticTargetTypes]) -> None: ...
+        def get_internal_static_libraries(self) -> OrderedSet[StaticTargetProto]: ...
+        def get_internal_static_libraries_recurse(self, result: OrderedSet[StaticTargetProto]) -> None: ...
         def get_link_dep_subdirs(self) -> T.AbstractSet[str]: ...
         def get_link_deps_mapping(self, prefix: str) -> T.Mapping[str, str]: ...
         def get_objects(self) -> T.List[ObjectTypes]: ...
@@ -109,6 +107,21 @@ if T.TYPE_CHECKING:
 
     class LinkableProto(BuildTargetProto):
         def get(self, lib_type: _LibraryType, recursive: bool = False) -> LinkableProto: ...
+
+    class LibProto(LinkableProto):
+        name_prefix_set: bool
+        prefix: str
+
+        # FIXME: convert pkgconfig.py to use install_dir_names()
+        @property
+        def install_dir(self) -> T.List[T.Union[str, Literal[False]]]: ...
+        @property
+        def has_custom_install_dir(self) -> bool: ...
+        @property
+        def name(self) -> str: ...
+
+    class StaticTargetProto(LibProto):
+        def extract_all_objects(self, recursive: bool = True) -> ExtractedObjects: ...
 
     class DFeatures(TypedDict):
 
@@ -147,7 +160,7 @@ if T.TYPE_CHECKING:
         link_early_args: T.List[str]
         link_depends: T.Sequence[T.Union[File, BuildTargetProto]]
         link_language: Language
-        link_whole: T.List[StaticTargetTypes]
+        link_whole: T.List[StaticTargetProto]
         link_with: T.List[LinkableProto]
         name_prefix: T.Optional[str]
         name_suffix: T.Optional[str]
@@ -205,6 +218,8 @@ else:
     AnyTargetProto = object
     BuildTargetProto = object
     LinkableProto = object
+    LibProto = object
+    StaticTargetProto = object
 
 
 _T = T.TypeVar('_T')
@@ -890,7 +905,7 @@ class BuildTarget(Target, BuildTargetProto):
         self.include_dirs: T.List['IncludeDirs'] = []
         self.link_language: T.Optional[Language] = kwargs.get('link_language')
         self.link_targets: T.List[LinkableProto] = []
-        self.link_whole_targets: T.List[StaticTargetTypes] = []
+        self.link_whole_targets: T.List[StaticTargetProto] = []
         self.depend_files = kwargs.get('depend_files', [])
         self.link_depends = list(kwargs.get('link_depends', []))
         self.added_deps: T.Set[dependencies.Dependency] = set()
@@ -1651,19 +1666,19 @@ class BuildTarget(Target, BuildTargetProto):
 
     def link_whole(
             self,
-            targets: T.Iterable[StaticTargetTypes],
+            targets: T.Iterable[StaticTargetProto],
             promoted: bool = False) -> None:
         for t in targets:
             self.check_can_link_together(t)
             self.link_whole_targets.append(t)
 
     @lru_cache(maxsize=None)
-    def get_internal_static_libraries(self) -> OrderedSet[StaticTargetTypes]:
-        result: OrderedSet[StaticTargetTypes] = OrderedSet()
+    def get_internal_static_libraries(self) -> OrderedSet[StaticTargetProto]:
+        result: OrderedSet[StaticTargetProto] = OrderedSet()
         self.get_internal_static_libraries_recurse(result)
         return result
 
-    def get_internal_static_libraries_recurse(self, result: OrderedSet[StaticTargetTypes]) -> None:
+    def get_internal_static_libraries_recurse(self, result: OrderedSet[StaticTargetProto]) -> None:
         for t in self.link_targets:
             if t.is_internal() and t not in result:
                 assert isinstance(t, (StaticLibrary, CustomTarget, CustomTargetIndex)), 'for mypy'
@@ -1904,8 +1919,8 @@ class BuildTarget(Target, BuildTargetProto):
                 lib_list.append(lib.get(bl_type))
         return lib_list
 
-    def _extract_link_whole(self, kwargs: BuildTargetKeywordArguments) -> list[StaticTargetTypes]:
-        lib_list: list[StaticTargetTypes] = []
+    def _extract_link_whole(self, kwargs: BuildTargetKeywordArguments) -> list[StaticTargetProto]:
+        lib_list: list[StaticTargetProto] = []
         for lib in itertools.chain(kwargs.get('link_whole', []), self.link_whole_targets):
             if isinstance(lib, BothLibraries):
                 lib = lib.get('static')
@@ -2380,7 +2395,7 @@ class Executable(BuildTarget, LinkableProto):
         return self.is_linkwithable
 
 
-class StaticLibrary(BuildTarget, LinkableProto):
+class StaticLibrary(BuildTarget, StaticTargetProto):
     typename = 'static library'
 
     def __init__(
@@ -2512,7 +2527,7 @@ class StaticLibrary(BuildTarget, LinkableProto):
 
     def link_whole(
             self,
-            targets: T.Iterable[StaticTargetTypes],
+            targets: T.Iterable[StaticTargetProto],
             promoted: bool = False) -> None:
         for t in targets:
             self.check_can_link_together(t)
@@ -2539,27 +2554,27 @@ class StaticLibrary(BuildTarget, LinkableProto):
             self.check_can_link_together(t)
             self.link_targets.append(t)
 
-    def _bundle_static_library(self, t: StaticTargetTypes, promoted: bool = False) -> None:
+    def _bundle_static_library(self, t: StaticTargetProto, promoted: bool = False) -> None:
         if self.uses_rust():
             # Rustc can bundle static libraries, no need to extract objects.
             self.link_whole_targets.append(t)
-        elif isinstance(t, (CustomTarget, CustomTargetIndex)) or t.uses_rust():
+        elif not isinstance(t, StaticLibrary) or t.uses_rust():
             # To extract objects from a custom target we would have to extract
             # the archive, WIP implementation can be found in
             # https://github.com/mesonbuild/meson/pull/9218.
             # For Rust C ABI we could in theory have access to objects, but we
             # don't currently build them in such a way that this is possible:
             # https://github.com/mesonbuild/meson/issues/10724
-            m = (f'Cannot link_whole a custom or Rust target {t.name!r} into a static library {self.name!r}. '
+            m = (f'Cannot link_whole a custom or Rust target {t.get_basename()!r} into a static library {self.get_basename()!r}. '
                  'Instead, pass individual object files with the "objects:" keyword argument if possible.')
             if promoted:
-                m += (f' Meson had to promote link to link_whole because {self.name!r} is installed but not {t.name!r},'
-                      f' and thus has to include objects from {t.name!r} to be usable.')
+                m += (f' Meson had to promote link to link_whole because {self.get_basename()!r} is installed but not {t.get_basename()!r},'
+                      f' and thus has to include objects from {t.get_basename()!r} to be usable.')
             raise InvalidArguments(m)
         else:
             self.objects.append(t.extract_all_objects())
 
-class SharedLibrary(BuildTarget, LinkableProto):
+class SharedLibrary(BuildTarget, LibProto):
     typename = 'shared library'
 
     # Used by AIX to decide whether to archive shared library or not.
@@ -2876,12 +2891,12 @@ class SharedLibrary(BuildTarget, LinkableProto):
 
     def link_whole(
             self,
-            targets: T.Iterable[StaticTargetTypes],
+            targets: T.Iterable[StaticTargetProto],
             promoted: bool = False) -> None:
         for t in targets:
             self.check_can_link_together(t)
             if not getattr(t, 'pic', True):
-                msg = f"Can't link non-PIC static library {t.name!r} into shared library {self.name!r}. "
+                msg = f"Can't link non-PIC static library {t.get_basename()!r} into shared library {self.get_basename()!r}. "
                 msg += "Use the 'pic' option to static_library to build with PIC."
                 raise InvalidArguments(msg)
             self.link_whole_targets.append(t)
@@ -2889,7 +2904,7 @@ class SharedLibrary(BuildTarget, LinkableProto):
     def link(self, targets: T.Iterable[LinkableProto]) -> None:
         for t in targets:
             if isinstance(t, StaticLibrary) and not t.pic:
-                msg = f"Can't link non-PIC static library {t.name!r} into shared library {self.name!r}. "
+                msg = f"Can't link non-PIC static library {t.get_basename()!r} into shared library {self.get_basename()!r}. "
                 msg += "Use the 'pic' option to static_library to build with PIC."
                 raise InvalidArguments(msg)
             self.check_can_link_together(t)
@@ -3006,7 +3021,7 @@ def flatten_command(cmd: T.Iterable[CommandTypes],
     return final_cmd, depend_files, dependencies
 
 
-class CustomTargetBase(LinkableProto, metaclass=SimpleABC):
+class CustomTargetBase(StaticTargetProto, metaclass=SimpleABC):
     ''' Base class for CustomTarget and CustomTargetIndex
 
     This base class can be used to provide a dummy implementation of some
@@ -3015,6 +3030,9 @@ class CustomTargetBase(LinkableProto, metaclass=SimpleABC):
     '''
 
     rust_crate_type = ''
+
+    def extract_all_objects(self, recursive: bool = True) -> ExtractedObjects:
+        raise MesonException(f'Cannot extract objects from custom target {self.get_basename()!r}')
 
     def get_objects(self) -> T.List[ObjectTypes]:
         return []
@@ -3025,10 +3043,10 @@ class CustomTargetBase(LinkableProto, metaclass=SimpleABC):
                                  handled_by_rustc: bool = False) -> None:
         pass
 
-    def get_internal_static_libraries(self) -> OrderedSet[StaticTargetTypes]:
+    def get_internal_static_libraries(self) -> OrderedSet[StaticTargetProto]:
         return OrderedSet()
 
-    def get_internal_static_libraries_recurse(self, result: OrderedSet[StaticTargetTypes]) -> None:
+    def get_internal_static_libraries_recurse(self, result: OrderedSet[StaticTargetProto]) -> None:
         pass
 
     def get_all_linked_targets(self) -> ImmutableListProtocol[BuildTargetProto]:
@@ -3107,8 +3125,8 @@ class CustomTarget(Target, CustomTargetBase):
         self.depfile_type = 'gcc' if depfile else depfile_type
         self.env = env or EnvironmentVariables()
         self.feed = feed
-        self.install_dir = list(install_dir or [])
-        self.has_custom_install_dir = bool(self.install_dir)
+        self.install_dir: T.List[T.Union[str, T.Literal[False]]] = list(install_dir or [])
+        self.has_custom_install_dir: bool = bool(self.install_dir)
         self.install_mode = install_mode
         self.install_tag = _process_install_tag(install_tag, len(self.outputs))
         self.name = name if name else self.outputs[0]

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -59,7 +59,6 @@ if T.TYPE_CHECKING:
     CommandTypes: TypeAlias = T.Union['programs.Program', 'BuildTargetTypes', File, str]
     GeneratedTypes: TypeAlias = T.Union['CustomTarget', 'CustomTargetIndex', 'GeneratedList']
     LibTypes: TypeAlias = T.Union['SharedLibrary', 'StaticLibrary', 'CustomTarget', 'CustomTargetIndex']
-    LinkableTargetTypes: TypeAlias = T.Union['SharedLibrary', 'StaticLibrary', 'CustomTarget', 'CustomTargetIndex', 'Executable']
     BuildTargetTypes: TypeAlias = T.Union['BuildTarget', 'CustomTarget', 'CustomTargetIndex']
     StaticTargetTypes: TypeAlias = T.Union['StaticLibrary', 'CustomTarget', 'CustomTargetIndex']
     ObjectTypes: TypeAlias = T.Union['File', 'ExtractedObjects']
@@ -108,6 +107,9 @@ if T.TYPE_CHECKING:
     # if not, this will be a mypy error
     def _assert_BuildTargetProto(x: BuildTargetTypes) -> BuildTargetProto: return x
 
+    class LinkableProto(BuildTargetProto):
+        def get(self, lib_type: _LibraryType, recursive: bool = False) -> LinkableProto: ...
+
     class DFeatures(TypedDict):
 
         unittest: bool
@@ -146,7 +148,7 @@ if T.TYPE_CHECKING:
         link_depends: T.Sequence[T.Union[File, BuildTargetProto]]
         link_language: Language
         link_whole: T.List[StaticTargetTypes]
-        link_with: T.List[LinkableTargetTypes]
+        link_with: T.List[LinkableProto]
         name_prefix: T.Optional[str]
         name_suffix: T.Optional[str]
         native: MachineChoice
@@ -202,6 +204,7 @@ if T.TYPE_CHECKING:
 else:
     AnyTargetProto = object
     BuildTargetProto = object
+    LinkableProto = object
 
 
 _T = T.TypeVar('_T')
@@ -886,7 +889,7 @@ class BuildTarget(Target, BuildTargetProto):
         self.external_deps: T.List[dependencies.Dependency] = []
         self.include_dirs: T.List['IncludeDirs'] = []
         self.link_language: T.Optional[Language] = kwargs.get('link_language')
-        self.link_targets: T.List[LinkableTargetTypes] = []
+        self.link_targets: T.List[LinkableProto] = []
         self.link_whole_targets: T.List[StaticTargetTypes] = []
         self.depend_files = kwargs.get('depend_files', [])
         self.link_depends = list(kwargs.get('link_depends', []))
@@ -1178,7 +1181,7 @@ class BuildTarget(Target, BuildTargetProto):
         # the languages of those libraries as well.
         if self.link_targets or self.link_whole_targets:
             for t in itertools.chain(self.link_targets, self.link_whole_targets):
-                if isinstance(t, (CustomTarget, CustomTargetIndex)):
+                if not isinstance(t, BuildTarget):
                     continue # We can't know anything about these.
                 target_langs = [t.link_language] if t.link_language else list(t.compilers)
                 for lang in target_langs:
@@ -1641,7 +1644,7 @@ class BuildTarget(Target, BuildTargetProto):
     def is_internal(self) -> bool:
         return False
 
-    def link(self, targets: T.Iterable[LinkableTargetTypes]) -> None:
+    def link(self, targets: T.Iterable[LinkableProto]) -> None:
         for t in targets:
             self.check_can_link_together(t)
             self.link_targets.append(t)
@@ -1712,7 +1715,7 @@ class BuildTarget(Target, BuildTargetProto):
         # Check if any of the internal libraries this target links to were
         # written in this language
         for t in itertools.chain(self.link_targets, self.link_whole_targets):
-            if isinstance(t, (CustomTarget, CustomTargetIndex)):
+            if not isinstance(t, BuildTarget):
                 continue
             target_langs = [t.link_language] if t.link_language else list(t.compilers)
             for language in target_langs:
@@ -1890,10 +1893,10 @@ class BuildTarget(Target, BuildTargetProto):
         assert isinstance(bl_type, str), 'for mypy'
         return T.cast('_LibraryType', bl_type)
 
-    def _extract_link_with(self, kwargs: BuildTargetKeywordArguments) -> list[LinkableTargetTypes]:
+    def _extract_link_with(self, kwargs: BuildTargetKeywordArguments) -> list[LinkableProto]:
         bl_type = self._default_library_type()
 
-        lib_list: list[LinkableTargetTypes] = []
+        lib_list: list[LinkableProto] = []
         for lib in itertools.chain(kwargs.get('link_with', []), self.link_targets):
             if isinstance(lib, (CustomTarget, CustomTargetIndex)):
                 lib_list.append(lib)
@@ -2037,13 +2040,6 @@ class BuildTarget(Target, BuildTargetProto):
             return 'darwin'
         else:
             return 'unix'
-
-
-class LinkableTarget(metaclass=SimpleABC):
-    @abc.abstractmethod
-    def get(self, lib_type: _LibraryType) -> LinkableTargetTypes:
-        """If applicable, return the shared or static "part" of this target.
-           Otherwise, just return self."""
 
 
 class FileInTargetPrivateDir:
@@ -2251,7 +2247,7 @@ class GeneratedList(HoldableObject):
         return self.generator.name
 
 
-class Executable(BuildTarget, LinkableTarget):
+class Executable(BuildTarget, LinkableProto):
     typename = 'executable'
 
     def __init__(
@@ -2354,7 +2350,7 @@ class Executable(BuildTarget, LinkableTarget):
                 name += '_' + self.suffix
             self.debug_filename = name + '.pdb'
 
-    def get(self, lib_type: _LibraryType, recursive: bool = False) -> LinkableTargetTypes:
+    def get(self, lib_type: _LibraryType, recursive: bool = False) -> Self:
         """Base case used by BothLibraries"""
         return self
 
@@ -2384,7 +2380,7 @@ class Executable(BuildTarget, LinkableTarget):
         return self.is_linkwithable
 
 
-class StaticLibrary(BuildTarget, LinkableTarget):
+class StaticLibrary(BuildTarget, LinkableProto):
     typename = 'static library'
 
     def __init__(
@@ -2506,7 +2502,7 @@ class StaticLibrary(BuildTarget, LinkableTarget):
         self.both_lib = copy.copy(shared_library)
         self.both_lib.both_lib = None
 
-    def get(self, lib_type: _LibraryType, recursive: bool = False) -> LinkableTargetTypes:
+    def get(self, lib_type: _LibraryType, recursive: bool = False) -> SharedLibrary | StaticLibrary:
         result = self
         if lib_type == 'shared':
             result = self.both_lib or self
@@ -2532,7 +2528,7 @@ class StaticLibrary(BuildTarget, LinkableTarget):
                     self._bundle_static_library(lib, True)
             self.link_whole_targets.append(t)
 
-    def link(self, targets: T.Iterable[LinkableTargetTypes]) -> None:
+    def link(self, targets: T.Iterable[LinkableProto]) -> None:
         for t in targets:
             if self.install and t.is_internal():
                 # When we're a static library and we link_with to an
@@ -2563,7 +2559,7 @@ class StaticLibrary(BuildTarget, LinkableTarget):
         else:
             self.objects.append(t.extract_all_objects())
 
-class SharedLibrary(BuildTarget, LinkableTarget):
+class SharedLibrary(BuildTarget, LinkableProto):
     typename = 'shared library'
 
     # Used by AIX to decide whether to archive shared library or not.
@@ -2870,7 +2866,7 @@ class SharedLibrary(BuildTarget, LinkableTarget):
         self.both_lib = copy.copy(static_library)
         self.both_lib.both_lib = None
 
-    def get(self, lib_type: _LibraryType, recursive: bool = False) -> LinkableTargetTypes:
+    def get(self, lib_type: _LibraryType, recursive: bool = False) -> SharedLibrary | StaticLibrary:
         result = self
         if lib_type == 'static':
             result = self.both_lib or self
@@ -2890,7 +2886,7 @@ class SharedLibrary(BuildTarget, LinkableTarget):
                 raise InvalidArguments(msg)
             self.link_whole_targets.append(t)
 
-    def link(self, targets: T.Iterable[LinkableTargetTypes]) -> None:
+    def link(self, targets: T.Iterable[LinkableProto]) -> None:
         for t in targets:
             if isinstance(t, StaticLibrary) and not t.pic:
                 msg = f"Can't link non-PIC static library {t.name!r} into shared library {self.name!r}. "
@@ -2930,7 +2926,7 @@ class SharedModule(SharedLibrary):
     def get_default_install_dir(self) -> T.Tuple[str, str]:
         return self.environment.get_shared_module_dir(), '{moduledir_shared}'
 
-class BothLibraries(SecondLevelHolder, LinkableTarget):
+class BothLibraries(SecondLevelHolder):
     typename: T.ClassVar[str] = 'both libraries'
 
     def __init__(self, shared: SharedLibrary, static: StaticLibrary, preferred_library: Literal['shared', 'static']) -> None:
@@ -3010,7 +3006,7 @@ def flatten_command(cmd: T.Iterable[CommandTypes],
     return final_cmd, depend_files, dependencies
 
 
-class CustomTargetBase(LinkableTarget, BuildTargetProto, metaclass=SimpleABC):
+class CustomTargetBase(LinkableProto, metaclass=SimpleABC):
     ''' Base class for CustomTarget and CustomTargetIndex
 
     This base class can be used to provide a dummy implementation of some
@@ -3038,7 +3034,7 @@ class CustomTargetBase(LinkableTarget, BuildTargetProto, metaclass=SimpleABC):
     def get_all_linked_targets(self) -> ImmutableListProtocol[BuildTargetProto]:
         return []
 
-    def get(self, lib_type: _LibraryType, recursive: bool = False) -> LinkableTargetTypes:
+    def get(self, lib_type: _LibraryType, recursive: bool = False) -> Self:
         """Base case used by BothLibraries"""
         assert isinstance(self, (CustomTarget, CustomTargetIndex))
         return self
@@ -3431,7 +3427,7 @@ class Jar(BuildTarget):
         self.main_class = kwargs.get('main_class', '')
         self.java_resources: T.Optional[StructuredSources] = kwargs.get('java_resources', None)
 
-    def _extract_link_with(self, kwargs: BuildTargetKeywordArguments) -> list[LinkableTargetTypes]:
+    def _extract_link_with(self, kwargs: BuildTargetKeywordArguments) -> list[LinkableProto]:
         return kwargs['link_with']
 
     def get_main_class(self) -> str:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -78,6 +78,36 @@ if T.TYPE_CHECKING:
         def get_subdir(self) -> str: ...
         def get_target(self) -> Target: ...
 
+    class BuildTargetProto(AnyTargetProto):
+        @property
+        def for_machine(self) -> MachineChoice: ...
+
+        @property
+        def rust_crate_type(self) -> str: ...
+
+        def get_all_link_deps(self) -> ImmutableListProtocol[BuildTargetProto]: ...
+        def get_all_linked_targets(self) -> ImmutableListProtocol[BuildTargetProto]: ...
+        def get_dependencies(self) -> T.Iterable[BuildTargetProto]: ...
+        def get_dependencies_recurse(self, result: OrderedSet[BuildTargetProto], visited: T.Set[T.Tuple[BuildTargetProto, bool, bool]], include_internals: bool = True, handled_by_rustc: bool = False) -> None: ...
+        def get_filename(self) -> str: ...
+        def get_generated_sources(self) -> T.Iterable[GeneratedTypes]: ...
+        def get_internal_static_libraries(self) -> OrderedSet[StaticTargetTypes]: ...
+        def get_internal_static_libraries_recurse(self, result: OrderedSet[StaticTargetTypes]) -> None: ...
+        def get_link_dep_subdirs(self) -> T.AbstractSet[str]: ...
+        def get_link_deps_mapping(self, prefix: str) -> T.Mapping[str, str]: ...
+        def get_objects(self) -> T.List[ObjectTypes]: ...
+        def install_dir_names(self) -> T.List[T.Optional[str]]: ...
+        def is_internal(self) -> bool: ...
+        def is_linkable_target(self) -> bool: ...
+        def uses_fortran(self) -> bool: ...
+        def uses_rust(self) -> bool: ...
+        def uses_rust_abi(self) -> bool: ...
+        def uses_swift_cpp_interop(self) -> bool: ...
+
+    # all types included in BuildTargetTypes must implement BuildTargetProto;
+    # if not, this will be a mypy error
+    def _assert_BuildTargetProto(x: BuildTargetTypes) -> BuildTargetProto: return x
+
     class DFeatures(TypedDict):
 
         unittest: bool
@@ -113,7 +143,7 @@ if T.TYPE_CHECKING:
         language_args: T.DefaultDict[Language, T.List[str]]
         link_args: T.List[str]
         link_early_args: T.List[str]
-        link_depends: T.List[T.Union[File, BuildTargetTypes]]
+        link_depends: T.Sequence[T.Union[File, BuildTargetProto]]
         link_language: Language
         link_whole: T.List[StaticTargetTypes]
         link_with: T.List[LinkableTargetTypes]
@@ -171,6 +201,7 @@ if T.TYPE_CHECKING:
         main_class: str
 else:
     AnyTargetProto = object
+    BuildTargetProto = object
 
 
 _T = T.TypeVar('_T')
@@ -814,7 +845,7 @@ class Target(HoldableObject, AnyTargetProto, metaclass=SimpleABC):
     def should_install(self) -> bool:
         return False
 
-class BuildTarget(Target):
+class BuildTarget(Target, BuildTargetProto):
     rust_crate_type: RustCrateType
 
     # This set contains all the languages a linker can link natively
@@ -858,7 +889,7 @@ class BuildTarget(Target):
         self.link_targets: T.List[LinkableTargetTypes] = []
         self.link_whole_targets: T.List[StaticTargetTypes] = []
         self.depend_files = kwargs.get('depend_files', [])
-        self.link_depends = kwargs.get('link_depends', [])
+        self.link_depends = list(kwargs.get('link_depends', []))
         self.added_deps: T.Set[dependencies.Dependency] = set()
         self.name_prefix_set = False
         self.name_suffix_set = False
@@ -1310,15 +1341,15 @@ class BuildTarget(Target):
                                 recursive, pch=True)
 
     @lru_cache(maxsize=None)
-    def get_all_link_deps(self) -> ImmutableListProtocol[BuildTargetTypes]:
+    def get_all_link_deps(self) -> ImmutableListProtocol[BuildTargetProto]:
         """ Get all shared libraries dependencies
         This returns all shared libraries in the entire dependency tree. Those
         are libraries needed at runtime which is different from the set needed
         at link time, see get_dependencies() for that.
         """
-        result: OrderedSet[BuildTargetTypes] = OrderedSet()
-        nonresults: T.Set[BuildTargetTypes] = set()
-        stack: T.Deque[BuildTargetTypes] = deque()
+        result: OrderedSet[BuildTargetProto] = OrderedSet()
+        nonresults: T.Set[BuildTargetProto] = set()
+        stack: T.Deque[BuildTargetProto] = deque()
         stack.appendleft(self)
         while stack:
             t = stack.pop()
@@ -1337,7 +1368,7 @@ class BuildTarget(Target):
         return list(result)
 
     @lru_cache(maxsize=None)
-    def get_all_linked_targets(self) -> ImmutableListProtocol[BuildTargetTypes]:
+    def get_all_linked_targets(self) -> ImmutableListProtocol[BuildTargetProto]:
         """Get all targets that have been linked with this one.
 
         This is useful for cases where we need to analyze these links, such as
@@ -1351,8 +1382,8 @@ class BuildTarget(Target):
 
         :returns: An immutable list of BuildTargets
         """
-        result: OrderedSet[BuildTargetTypes] = OrderedSet()
-        stack: T.Deque[BuildTargetTypes] = deque()
+        result: OrderedSet[BuildTargetProto] = OrderedSet()
+        stack: T.Deque[BuildTargetProto] = deque()
         stack.extendleft(self.link_targets)
         stack.extendleft(self.link_whole_targets)
         while stack:
@@ -1489,14 +1520,14 @@ class BuildTarget(Target):
         return self.extra_args[language]
 
     @lru_cache(maxsize=None)
-    def get_dependencies(self) -> OrderedSet[BuildTargetTypes]:
+    def get_dependencies(self) -> T.Iterable[BuildTargetProto]:
         # Get all targets needed for linking. This includes all link_with and
         # link_whole targets, and also all dependencies of static libraries
         # recursively. The algorithm here is closely related to what we do in
         # get_internal_static_libraries(): Installed static libraries include
         # objects from all their dependencies already.
-        result: OrderedSet[BuildTargetTypes] = OrderedSet()
-        visited: T.Set[T.Tuple[BuildTargetTypes, bool, bool]] = set()
+        result: OrderedSet[BuildTargetProto] = OrderedSet()
+        visited: T.Set[T.Tuple[BuildTargetProto, bool, bool]] = set()
         for t in itertools.chain(self.link_targets, self.link_whole_targets):
             if t not in result:
                 result.add(t)
@@ -1504,8 +1535,8 @@ class BuildTarget(Target):
                     t.get_dependencies_recurse(result, visited, handled_by_rustc=self.uses_rust())
         return result
 
-    def get_dependencies_recurse(self, result: OrderedSet[BuildTargetTypes],
-                                 visited: T.Set[T.Tuple[BuildTargetTypes, bool, bool]],
+    def get_dependencies_recurse(self, result: OrderedSet[BuildTargetProto],
+                                 visited: T.Set[T.Tuple[BuildTargetProto, bool, bool]],
                                  include_internals: bool = True, handled_by_rustc: bool = False) -> None:
         # self is always a static library because we don't need to pull dependencies
         # of shared libraries. If self is installed (not internal) it already
@@ -1552,7 +1583,7 @@ class BuildTarget(Target):
     def get_objects(self) -> T.List[ObjectTypes]:
         return self.objects
 
-    def get_generated_sources(self) -> T.List['GeneratedTypes']:
+    def get_generated_sources(self) -> T.Iterable['GeneratedTypes']:
         return self.generated
 
     def should_install(self) -> bool:
@@ -1639,12 +1670,12 @@ class BuildTarget(Target):
             if t.is_internal():
                 t.get_internal_static_libraries_recurse(result)
 
-    def check_can_link_together(self, t: BuildTargetTypes) -> None:
-        links_with_rust_abi = isinstance(t, BuildTarget) and t.uses_rust_abi()
+    def check_can_link_together(self, t: BuildTargetProto) -> None:
+        links_with_rust_abi = t.uses_rust_abi()
         if not self.uses_rust() and links_with_rust_abi:
-            raise InvalidArguments(f'Try to link Rust ABI library {t.name!r} with a non-Rust target {self.name!r}')
+            raise InvalidArguments(f'Try to link Rust ABI library {t.get_basename()!r} with a non-Rust target {self.get_basename()!r}')
         if self.for_machine is not t.for_machine and (not links_with_rust_abi or t.rust_crate_type != 'proc-macro'):
-            msg = f'Tried to mix a {t.for_machine} library ("{t.name}") with a {self.for_machine} target "{self.name}"'
+            msg = f'Tried to mix a {t.for_machine} library ("{t.get_basename()}") with a {self.for_machine} target "{self.get_basename()}"'
             if self.environment.is_cross_build():
                 raise InvalidArguments(msg + ' This is not possible in a cross build.')
             else:
@@ -2979,7 +3010,7 @@ def flatten_command(cmd: T.Iterable[CommandTypes],
     return final_cmd, depend_files, dependencies
 
 
-class CustomTargetBase(LinkableTarget, AnyTargetProto, metaclass=SimpleABC):
+class CustomTargetBase(LinkableTarget, BuildTargetProto, metaclass=SimpleABC):
     ''' Base class for CustomTarget and CustomTargetIndex
 
     This base class can be used to provide a dummy implementation of some
@@ -2989,8 +3020,11 @@ class CustomTargetBase(LinkableTarget, AnyTargetProto, metaclass=SimpleABC):
 
     rust_crate_type = ''
 
-    def get_dependencies_recurse(self, result: OrderedSet[BuildTargetTypes],
-                                 visited: T.Set[tuple[BuildTargetTypes, bool, bool]],
+    def get_objects(self) -> T.List[ObjectTypes]:
+        return []
+
+    def get_dependencies_recurse(self, result: OrderedSet[BuildTargetProto],
+                                 visited: T.Set[tuple[BuildTargetProto, bool, bool]],
                                  include_internals: bool = True,
                                  handled_by_rustc: bool = False) -> None:
         pass
@@ -3001,13 +3035,16 @@ class CustomTargetBase(LinkableTarget, AnyTargetProto, metaclass=SimpleABC):
     def get_internal_static_libraries_recurse(self, result: OrderedSet[StaticTargetTypes]) -> None:
         pass
 
-    def get_all_linked_targets(self) -> ImmutableListProtocol[BuildTargetTypes]:
+    def get_all_linked_targets(self) -> ImmutableListProtocol[BuildTargetProto]:
         return []
 
     def get(self, lib_type: _LibraryType, recursive: bool = False) -> LinkableTargetTypes:
         """Base case used by BothLibraries"""
         assert isinstance(self, (CustomTarget, CustomTargetIndex))
         return self
+
+    def uses_rust(self) -> bool:
+        return False
 
     def uses_rust_abi(self) -> bool:
         return False
@@ -3087,7 +3124,7 @@ class CustomTarget(Target, CustomTargetBase):
         # Whether to enable using response files for the underlying tool
         self.rspable = rspable
 
-        self.extra_depends: T.List[T.Union[GeneratedTypes, BuildTarget]] = []
+        self.extra_depends: T.List[T.Union[GeneratedList, BuildTargetProto]] = []
         if extra_depends:
             for d in extra_depends:
                 if isinstance(d, LocalProgram):
@@ -3144,7 +3181,7 @@ class CustomTarget(Target, CustomTargetBase):
                 bdeps.update(d.get_transitive_build_target_deps())
         return bdeps
 
-    def get_dependencies(self) -> T.List[T.Union[CustomTarget, BuildTarget]]:
+    def get_dependencies(self) -> T.Iterable[BuildTargetProto]:
         return self.dependencies
 
     def should_install(self) -> bool:
@@ -3172,7 +3209,7 @@ class CustomTarget(Target, CustomTargetBase):
                 genlists.append(c)
         return genlists
 
-    def get_generated_sources(self) -> T.List[GeneratedList]:
+    def get_generated_sources(self) -> T.Iterable[GeneratedTypes]:
         return self.get_generated_lists()
 
     def get_dep_outname(self, infilenames: list[str]) -> str:
@@ -3216,7 +3253,7 @@ class CustomTarget(Target, CustomTargetBase):
     def get_link_dep_subdirs(self) -> T.AbstractSet[str]:
         return OrderedSet()
 
-    def get_all_link_deps(self) -> ImmutableListProtocol[BuildTargetTypes]:
+    def get_all_link_deps(self) -> ImmutableListProtocol[BuildTargetProto]:
         return []
 
     def is_internal(self) -> bool:
@@ -3266,7 +3303,7 @@ class CompileTarget(BuildTarget):
                  include_directories: T.List[IncludeDirs],
                  dependencies: T.List[dependencies.Dependency],
                  build_project: BuildProject,
-                 depends: T.List[BuildTargetTypes]):
+                 depends: T.Sequence[BuildTargetProto]):
         compilers = {compiler.get_language(): compiler}
         kwargs: BuildTargetKeywordArguments = {
             'build_by_default': False,
@@ -3304,7 +3341,7 @@ class CompileTarget(BuildTarget):
     def get_generated_headers(self) -> T.List[File]:
         gen_headers: T.List[File] = []
         for dep in self.depends:
-            gen_headers += [File(True, dep.subdir, o) for o in dep.get_outputs()]
+            gen_headers += [File(True, dep.get_subdir(), o) for o in dep.get_outputs()]
         return gen_headers
 
     def is_linkable_output(self, output: str) -> bool:
@@ -3339,7 +3376,7 @@ class RunTarget(Target):
     def get_dependencies(self) -> T.Iterable[AnyTargetProto | GeneratedList | programs.Program]:
         return self.dependencies
 
-    def get_generated_sources(self) -> T.List[GeneratedTypes]:
+    def get_generated_sources(self) -> T.Iterable[GeneratedTypes]:
         return []
 
     def get_sources(self) -> T.List[File]:
@@ -3473,6 +3510,9 @@ class CustomTargetIndex(CustomTargetBase, HoldableObject):
     def __repr__(self) -> str:
         return '<CustomTargetIndex: {!r}[{}]>'.format(self.target, self.output)
 
+    def get_generated_sources(self) -> T.Iterable[GeneratedTypes]:
+        return self.target.get_generated_sources()
+
     def get_outputs(self) -> T.List[str]:
         return [self.output]
 
@@ -3494,7 +3534,7 @@ class CustomTargetIndex(CustomTargetBase, HoldableObject):
     def get_target(self) -> BuildTarget | CustomTarget:
         return self.target
 
-    def get_all_link_deps(self) -> ImmutableListProtocol[BuildTargetTypes]:
+    def get_all_link_deps(self) -> ImmutableListProtocol[BuildTargetProto]:
         return self.target.get_all_link_deps()
 
     def get_link_deps_mapping(self, prefix: str) -> T.Mapping[str, str]:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -3394,14 +3394,15 @@ class CustomTargetIndex(CustomTargetBase, HoldableObject):
     target: T.Union[CustomTarget, CompileTarget]
     output: str
 
-    def __post_init__(self) -> None:
-        self.for_machine = self.target.for_machine
-
     @lazy_property
     def __index(self) -> int:
         # Must be detected lazily becuase preporcessed sources don't end up in the
         # outputs, but can still be in a CustomTargetIndex.
         return self.target.outputs.index(self.output)
+
+    @property
+    def for_machine(self) -> MachineChoice:
+        return self.target.for_machine
 
     @property
     def name(self) -> str:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -75,6 +75,34 @@ if T.TYPE_CHECKING:
         def get_subdir(self) -> str: ...
         def get_target(self) -> Target: ...
 
+    class BuildTargetProto(AnyTargetProto, Protocol):
+        @property
+        def for_machine(self) -> MachineChoice: ...
+
+        @property
+        def rust_crate_type(self) -> str: ...
+
+        def get_all_link_deps(self) -> ImmutableListProtocol[BuildTargetProto]: ...
+        def get_dependencies(self) -> T.Iterable[BuildTargetProto]: ...
+        def get_filename(self) -> str: ...
+        def get_generated_sources(self) -> T.Iterable[GeneratedTypes]: ...
+        def get_internal_static_libraries(self) -> OrderedSet[StaticTargetTypes]: ...
+        def get_internal_static_libraries_recurse(self, result: OrderedSet[StaticTargetTypes]) -> None: ...
+        def get_link_dep_subdirs(self) -> T.AbstractSet[str]: ...
+        def get_link_deps_mapping(self, prefix: str) -> T.Mapping[str, str]: ...
+        def get_objects(self) -> T.List[ObjectTypes]: ...
+        def install_dir_names(self) -> T.List[T.Optional[str]]: ...
+        def is_internal(self) -> bool: ...
+        def is_linkable_target(self) -> bool: ...
+        def uses_fortran(self) -> bool: ...
+        def uses_rust(self) -> bool: ...
+        def uses_rust_abi(self) -> bool: ...
+        def uses_swift_cpp_interop(self) -> bool: ...
+
+    # all types included in BuildTargetTypes must implement BuildTargetProto;
+    # if not, this will be a mypy error
+    def _assert_BuildTargetProto(x: BuildTargetTypes) -> BuildTargetProto: return x
+
     class DFeatures(TypedDict):
 
         unittest: bool
@@ -110,7 +138,7 @@ if T.TYPE_CHECKING:
         language_args: T.DefaultDict[Language, T.List[str]]
         link_args: T.List[str]
         link_early_args: T.List[str]
-        link_depends: T.List[T.Union[File, BuildTargetTypes]]
+        link_depends: T.Sequence[T.Union[File, BuildTargetProto]]
         link_language: Language
         link_whole: T.List[StaticTargetTypes]
         link_with: T.List[LinkableTargetTypes]
@@ -168,6 +196,7 @@ if T.TYPE_CHECKING:
         main_class: str
 else:
     AnyTargetProto = object
+    BuildTargetProto = object
 
 
 _T = T.TypeVar('_T')
@@ -857,7 +886,7 @@ class Target(HoldableObject, AnyTargetProto, metaclass=SimpleABC):
     def should_install(self) -> bool:
         return False
 
-class BuildTarget(Target):
+class BuildTarget(Target, BuildTargetProto):
     rust_crate_type: RustCrateType
 
     # This set contains all the languages a linker can link natively
@@ -901,7 +930,7 @@ class BuildTarget(Target):
         self.link_targets: T.List[LinkableTargetTypes] = []
         self.link_whole_targets: T.List[StaticTargetTypes] = []
         self.depend_files = kwargs.get('depend_files', [])
-        self.link_depends = kwargs.get('link_depends', [])
+        self.link_depends = list(kwargs.get('link_depends', []))
         self.added_deps: T.Set[dependencies.Dependency] = set()
         self.name_prefix_set = False
         self.name_suffix_set = False
@@ -1353,15 +1382,15 @@ class BuildTarget(Target):
                                 recursive, pch=True)
 
     @lru_cache(maxsize=None)
-    def get_all_link_deps(self) -> ImmutableListProtocol[BuildTargetTypes]:
+    def get_all_link_deps(self) -> ImmutableListProtocol[BuildTargetProto]:
         """ Get all shared libraries dependencies
         This returns all shared libraries in the entire dependency tree. Those
         are libraries needed at runtime which is different from the set needed
         at link time, see get_dependencies() for that.
         """
-        result: OrderedSet[BuildTargetTypes] = OrderedSet()
-        nonresults: T.Set[BuildTargetTypes] = set()
-        stack: T.Deque[BuildTargetTypes] = deque()
+        result: OrderedSet[BuildTargetProto] = OrderedSet()
+        nonresults: T.Set[BuildTargetProto] = set()
+        stack: T.Deque[BuildTargetProto] = deque()
         stack.appendleft(self)
         while stack:
             t = stack.pop()
@@ -1499,13 +1528,13 @@ class BuildTarget(Target):
         return self.extra_args[language]
 
     @lru_cache(maxsize=None)
-    def get_dependencies(self) -> OrderedSet[BuildTargetTypes]:
+    def get_dependencies(self) -> T.Iterable[BuildTargetProto]:
         # Get all targets needed for linking. This includes all link_with and
         # link_whole targets, and also all dependencies of static libraries
         # recursively. The algorithm here is closely related to what we do in
         # get_internal_static_libraries(): Installed static libraries include
         # objects from all their dependencies already.
-        result: OrderedSet[BuildTargetTypes] = OrderedSet()
+        result: OrderedSet[BuildTargetProto] = OrderedSet()
         result.update(self.link_targets)
         result.update(self.link_whole_targets)
 
@@ -1523,7 +1552,7 @@ class BuildTarget(Target):
     def get_objects(self) -> T.List[ObjectTypes]:
         return self.objects
 
-    def get_generated_sources(self) -> T.List['GeneratedTypes']:
+    def get_generated_sources(self) -> T.Iterable['GeneratedTypes']:
         return self.generated
 
     def should_install(self) -> bool:
@@ -1610,12 +1639,12 @@ class BuildTarget(Target):
             if t.is_internal():
                 t.get_internal_static_libraries_recurse(result)
 
-    def check_can_link_together(self, t: BuildTargetTypes) -> None:
-        links_with_rust_abi = isinstance(t, BuildTarget) and t.uses_rust_abi()
+    def check_can_link_together(self, t: BuildTargetProto) -> None:
+        links_with_rust_abi = t.uses_rust_abi()
         if not self.uses_rust() and links_with_rust_abi:
-            raise InvalidArguments(f'Try to link Rust ABI library {t.name!r} with a non-Rust target {self.name!r}')
+            raise InvalidArguments(f'Try to link Rust ABI library {t.get_basename()!r} with a non-Rust target {self.get_basename()!r}')
         if self.for_machine is not t.for_machine and (not links_with_rust_abi or t.rust_crate_type != 'proc-macro'):
-            msg = f'Tried to mix a {t.for_machine} library ("{t.name}") with a {self.for_machine} target "{self.name}"'
+            msg = f'Tried to mix a {t.for_machine} library ("{t.get_basename()}") with a {self.for_machine} target "{self.get_basename()}"'
             if self.environment.is_cross_build():
                 raise InvalidArguments(msg + ' This is not possible in a cross build.')
             else:
@@ -2909,11 +2938,10 @@ class BothLibraries(SecondLevelHolder, LinkableTarget):
 
 
 def flatten_command(cmd: T.Iterable[CommandTypes],
-                    subproject: SubProject) -> tuple[list[CommandTypes],
-                                                     list[File], list[BuildTarget | CustomTarget]]:
+                    subproject: SubProject) -> tuple[list[CommandTypes], list[File], list[BuildTargetProto]]:
     final_cmd: list[CommandTypes] = []
     depend_files: list[File] = []
-    dependencies: list[BuildTarget | CustomTarget] = []
+    dependencies: list[BuildTargetProto] = []
     for c in cmd:
         if isinstance(c, LocalProgram):
             c = c.program
@@ -2942,7 +2970,7 @@ def flatten_command(cmd: T.Iterable[CommandTypes],
     return final_cmd, depend_files, dependencies
 
 
-class CustomTargetBase(LinkableTarget, AnyTargetProto, metaclass=SimpleABC):
+class CustomTargetBase(LinkableTarget, BuildTargetProto, metaclass=SimpleABC):
     ''' Base class for CustomTarget and CustomTargetIndex
 
     This base class can be used to provide a dummy implementation of some
@@ -2951,6 +2979,9 @@ class CustomTargetBase(LinkableTarget, AnyTargetProto, metaclass=SimpleABC):
     '''
 
     rust_crate_type = ''
+
+    def get_objects(self) -> T.List[ObjectTypes]:
+        return []
 
     def get_internal_static_libraries(self) -> OrderedSet[StaticTargetTypes]:
         return OrderedSet()
@@ -2962,6 +2993,9 @@ class CustomTargetBase(LinkableTarget, AnyTargetProto, metaclass=SimpleABC):
         """Base case used by BothLibraries"""
         assert isinstance(self, (CustomTarget, CustomTargetIndex))
         return self
+
+    def uses_rust(self) -> bool:
+        return False
 
     def uses_rust_abi(self) -> bool:
         return False
@@ -3018,7 +3052,7 @@ class CustomTarget(Target, CustomTargetBase):
         self.capture = capture
         self.console = console
         self.depend_files = list(depend_files or [])
-        self.dependencies: T.List[T.Union[CustomTarget, BuildTarget]] = []
+        self.dependencies: T.List[BuildTargetProto] = []
         # must be after depend_files and dependencies
         c, df, d = flatten_command(command, build_project.subproject)
         self.command = c
@@ -3041,7 +3075,7 @@ class CustomTarget(Target, CustomTargetBase):
         # Whether to enable using response files for the underlying tool
         self.rspable = rspable
 
-        self.extra_depends: T.List[T.Union[GeneratedTypes, BuildTarget]] = []
+        self.extra_depends: T.List[T.Union[GeneratedList, BuildTargetProto]] = []
         if extra_depends:
             for d in extra_depends:
                 if isinstance(d, LocalProgram):
@@ -3080,7 +3114,7 @@ class CustomTarget(Target, CustomTargetBase):
                 deps.append(c)
         return deps
 
-    def get_transitive_build_target_deps(self) -> T.Set[T.Union[BuildTarget, 'CustomTarget']]:
+    def get_transitive_build_target_deps(self) -> T.Set[BuildTargetProto]:
         '''
         Recursively fetch the build targets that this custom target depends on,
         whether through `command:`, `depends:`, or `sources:` The recursion is
@@ -3089,7 +3123,7 @@ class CustomTarget(Target, CustomTargetBase):
         F.ex, if you have a python script that loads a C module that links to
         other DLLs in your project.
         '''
-        bdeps: T.Set[T.Union[BuildTarget, 'CustomTarget']] = set()
+        bdeps: T.Set[BuildTargetProto] = set()
         deps = self.get_target_dependencies()
         for d in deps:
             if isinstance(d, BuildTarget):
@@ -3098,7 +3132,7 @@ class CustomTarget(Target, CustomTargetBase):
                 bdeps.update(d.get_transitive_build_target_deps())
         return bdeps
 
-    def get_dependencies(self) -> T.List[T.Union[CustomTarget, BuildTarget]]:
+    def get_dependencies(self) -> T.Iterable[BuildTargetProto]:
         return self.dependencies
 
     def should_install(self) -> bool:
@@ -3126,7 +3160,7 @@ class CustomTarget(Target, CustomTargetBase):
                 genlists.append(c)
         return genlists
 
-    def get_generated_sources(self) -> T.List[GeneratedList]:
+    def get_generated_sources(self) -> T.Iterable[GeneratedTypes]:
         return self.get_generated_lists()
 
     def get_dep_outname(self, infilenames: list[str]) -> str:
@@ -3170,7 +3204,7 @@ class CustomTarget(Target, CustomTargetBase):
     def get_link_dep_subdirs(self) -> T.AbstractSet[str]:
         return OrderedSet()
 
-    def get_all_link_deps(self) -> ImmutableListProtocol[BuildTargetTypes]:
+    def get_all_link_deps(self) -> ImmutableListProtocol[BuildTargetProto]:
         return []
 
     def is_internal(self) -> bool:
@@ -3220,7 +3254,7 @@ class CompileTarget(BuildTarget):
                  include_directories: T.List[IncludeDirs],
                  dependencies: T.List[dependencies.Dependency],
                  build_project: BuildProject,
-                 depends: T.List[BuildTargetTypes]):
+                 depends: T.Sequence[BuildTargetProto]):
         compilers = {compiler.get_language(): compiler}
         kwargs: BuildTargetKeywordArguments = {
             'build_by_default': False,
@@ -3258,7 +3292,7 @@ class CompileTarget(BuildTarget):
     def get_generated_headers(self) -> T.List[File]:
         gen_headers: T.List[File] = []
         for dep in self.depends:
-            gen_headers += [File(True, dep.subdir, o) for o in dep.get_outputs()]
+            gen_headers += [File(True, dep.get_subdir(), o) for o in dep.get_outputs()]
         return gen_headers
 
     def is_linkable_output(self, output: str) -> bool:
@@ -3293,7 +3327,7 @@ class RunTarget(Target):
     def get_dependencies(self) -> T.Iterable[AnyTargetProto | programs.Program]:
         return self.dependencies
 
-    def get_generated_sources(self) -> T.List[GeneratedTypes]:
+    def get_generated_sources(self) -> T.Iterable[GeneratedTypes]:
         return []
 
     def get_sources(self) -> T.List[File]:
@@ -3430,6 +3464,9 @@ class CustomTargetIndex(CustomTargetBase, HoldableObject):
     def __str__(self) -> str:
         return self.name
 
+    def get_generated_sources(self) -> T.Iterable[GeneratedTypes]:
+        return self.target.get_generated_sources()
+
     def get_outputs(self) -> T.List[str]:
         return [self.output]
 
@@ -3451,8 +3488,11 @@ class CustomTargetIndex(CustomTargetBase, HoldableObject):
     def get_target(self) -> BuildTarget | CustomTarget:
         return self.target
 
-    def get_all_link_deps(self) -> ImmutableListProtocol[BuildTargetTypes]:
+    def get_all_link_deps(self) -> ImmutableListProtocol[BuildTargetProto]:
         return self.target.get_all_link_deps()
+
+    def get_dependencies(self) -> T.Iterable[BuildTargetProto]:
+        return self.target.get_dependencies()
 
     def get_link_deps_mapping(self, prefix: str) -> T.Mapping[str, str]:
         return self.target.get_link_deps_mapping(prefix)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -58,9 +58,7 @@ if T.TYPE_CHECKING:
     TargetSources: TypeAlias = T.Union['File', 'GeneratedTypes']
     CommandTypes: TypeAlias = T.Union['programs.Program', 'BuildTargetTypes', File, str]
     GeneratedTypes: TypeAlias = T.Union['CustomTarget', 'CustomTargetIndex', 'GeneratedList']
-    LibTypes: TypeAlias = T.Union['SharedLibrary', 'StaticLibrary', 'CustomTarget', 'CustomTargetIndex']
     BuildTargetTypes: TypeAlias = T.Union['BuildTarget', 'CustomTarget', 'CustomTargetIndex']
-    StaticTargetTypes: TypeAlias = T.Union['StaticLibrary', 'CustomTarget', 'CustomTargetIndex']
     ObjectTypes: TypeAlias = T.Union['File', 'ExtractedObjects']
     RustCrateType: TypeAlias = Literal['bin', 'lib', 'rlib', 'dylib', 'cdylib', 'staticlib', 'proc-macro']
     _LibraryType: TypeAlias = Literal['auto', 'shared', 'static']
@@ -85,8 +83,8 @@ if T.TYPE_CHECKING:
         def get_dependencies(self) -> T.Iterable[BuildTargetProto]: ...
         def get_filename(self) -> str: ...
         def get_generated_sources(self) -> T.Iterable[GeneratedTypes]: ...
-        def get_internal_static_libraries(self) -> OrderedSet[StaticTargetTypes]: ...
-        def get_internal_static_libraries_recurse(self, result: OrderedSet[StaticTargetTypes]) -> None: ...
+        def get_internal_static_libraries(self) -> OrderedSet[StaticTargetProto]: ...
+        def get_internal_static_libraries_recurse(self, result: OrderedSet[StaticTargetProto]) -> None: ...
         def get_link_dep_subdirs(self) -> T.AbstractSet[str]: ...
         def get_link_deps_mapping(self, prefix: str) -> T.Mapping[str, str]: ...
         def get_objects(self) -> T.List[ObjectTypes]: ...
@@ -104,6 +102,18 @@ if T.TYPE_CHECKING:
 
     class LinkableTargetProto(BuildTargetProto, Protocol):
         def get(self, lib_type: _LibraryType, recursive: bool = False) -> LinkableTargetProto: ...
+
+    class LibTargetProto(LinkableTargetProto, Protocol):
+        # FIXME: convert pkgconfig.py to use install_dir_names()
+        @property
+        def install_dir(self) -> T.List[T.Union[str, Literal[False]]]: ...
+        @property
+        def has_custom_install_dir(self) -> bool: ...
+
+        def get_import_filename(self) -> T.Optional[str]: ...
+
+    class StaticTargetProto(LibTargetProto, Protocol):
+        def extract_all_objects(self, recursive: bool = True) -> ExtractedObjects: ...
 
     class DFeatures(TypedDict):
 
@@ -142,7 +152,7 @@ if T.TYPE_CHECKING:
         link_early_args: T.List[str]
         link_depends: T.Sequence[T.Union[File, BuildTargetProto]]
         link_language: Language
-        link_whole: T.List[StaticTargetTypes]
+        link_whole: T.List[StaticTargetProto]
         link_with: T.List[LinkableTargetProto]
         name_prefix: T.Optional[str]
         name_suffix: T.Optional[str]
@@ -200,6 +210,8 @@ else:
     AnyTargetProto = object
     BuildTargetProto = object
     LinkableTargetProto = object
+    LibTargetProto = object
+    StaticTargetProto = object
 
 
 _T = T.TypeVar('_T')
@@ -241,7 +253,7 @@ def get_target_macos_dylib_install_name(ld: SharedLibrary) -> str:
 
 def all_dependencies_recurse(source: object,
                              link_targets: T.Sequence[LinkableTargetProto],
-                             link_whole_targets: T.Sequence[StaticTargetTypes],
+                             link_whole_targets: T.Sequence[StaticTargetProto],
                              visited: T.Set[T.Tuple[object, bool, bool]],
                              include_internals: bool = True, handled_by_rustc: bool = False) -> T.Iterator[tuple[LinkableTargetProto, bool]]:
     key = (source, include_internals, handled_by_rustc)
@@ -931,7 +943,7 @@ class BuildTarget(Target, BuildTargetProto):
         self.include_dirs: T.List['IncludeDirs'] = []
         self.link_language: T.Optional[Language] = kwargs.get('link_language')
         self.link_targets: T.List[LinkableTargetProto] = []
-        self.link_whole_targets: T.List[StaticTargetTypes] = []
+        self.link_whole_targets: T.List[StaticTargetProto] = []
         self.depend_files = kwargs.get('depend_files', [])
         self.link_depends = list(kwargs.get('link_depends', []))
         self.added_deps: T.Set[dependencies.Dependency] = set()
@@ -1620,19 +1632,19 @@ class BuildTarget(Target, BuildTargetProto):
 
     def link_whole(
             self,
-            targets: T.Iterable[StaticTargetTypes],
+            targets: T.Iterable[StaticTargetProto],
             promoted: bool = False) -> None:
         for t in targets:
             self.check_can_link_together(t)
             self.link_whole_targets.append(t)
 
     @lru_cache(maxsize=None)
-    def get_internal_static_libraries(self) -> OrderedSet[StaticTargetTypes]:
-        result: OrderedSet[StaticTargetTypes] = OrderedSet()
+    def get_internal_static_libraries(self) -> OrderedSet[StaticTargetProto]:
+        result: OrderedSet[StaticTargetProto] = OrderedSet()
         self.get_internal_static_libraries_recurse(result)
         return result
 
-    def get_internal_static_libraries_recurse(self, result: OrderedSet[StaticTargetTypes]) -> None:
+    def get_internal_static_libraries_recurse(self, result: OrderedSet[StaticTargetProto]) -> None:
         for t in self.link_targets:
             if t.is_internal() and t not in result:
                 assert isinstance(t, (StaticLibrary, CustomTarget, CustomTargetIndex)), 'for mypy'
@@ -1871,8 +1883,8 @@ class BuildTarget(Target, BuildTargetProto):
                 lib_list.append(lib.get(bl_type))
         return lib_list
 
-    def _extract_link_whole(self, link_whole: list[StaticTargetTypes]) -> list[StaticTargetTypes]:
-        lib_list: list[StaticTargetTypes] = []
+    def _extract_link_whole(self, link_whole: list[StaticTargetProto]) -> list[StaticTargetProto]:
+        lib_list: list[StaticTargetProto] = []
         for lib in itertools.chain(link_whole, self.link_whole_targets):
             if isinstance(lib, BothLibraries):
                 lib = lib.get('static')
@@ -2351,7 +2363,7 @@ class Executable(BuildTarget, LinkableTargetProto):
         return self.is_linkwithable
 
 
-class StaticLibrary(BuildTarget, LinkableTargetProto):
+class StaticLibrary(BuildTarget, StaticTargetProto):
     typename = 'static library'
 
     def __init__(
@@ -2465,6 +2477,9 @@ class StaticLibrary(BuildTarget, LinkableTargetProto):
     def type_suffix(self) -> str:
         return "@rlib" if self.uses_rust_abi() else "@sta"
 
+    def get_import_filename(self) -> T.Optional[str]:
+        return None
+
     def is_linkable_target(self) -> bool:
         return True
 
@@ -2485,7 +2500,7 @@ class StaticLibrary(BuildTarget, LinkableTargetProto):
 
     def link_whole(
             self,
-            targets: T.Iterable[StaticTargetTypes],
+            targets: T.Iterable[StaticTargetProto],
             promoted: bool = False) -> None:
         for t in targets:
             self.check_can_link_together(t)
@@ -2512,27 +2527,27 @@ class StaticLibrary(BuildTarget, LinkableTargetProto):
             self.check_can_link_together(t)
             self.link_targets.append(t)
 
-    def _bundle_static_library(self, t: StaticTargetTypes, promoted: bool = False) -> None:
+    def _bundle_static_library(self, t: StaticTargetProto, promoted: bool = False) -> None:
         if self.uses_rust():
             # Rustc can bundle static libraries, no need to extract objects.
             self.link_whole_targets.append(t)
-        elif isinstance(t, (CustomTarget, CustomTargetIndex)) or t.uses_rust():
+        elif not isinstance(t, StaticLibrary) or t.uses_rust():
             # To extract objects from a custom target we would have to extract
             # the archive, WIP implementation can be found in
             # https://github.com/mesonbuild/meson/pull/9218.
             # For Rust C ABI we could in theory have access to objects, but we
             # don't currently build them in such a way that this is possible:
             # https://github.com/mesonbuild/meson/issues/10724
-            m = (f'Cannot link_whole a custom or Rust target {t.name!r} into a static library {self.name!r}. '
+            m = (f'Cannot link_whole a custom or Rust target {t.get_basename()!r} into a static library {self.get_basename()!r}. '
                  'Instead, pass individual object files with the "objects:" keyword argument if possible.')
             if promoted:
-                m += (f' Meson had to promote link to link_whole because {self.name!r} is installed but not {t.name!r},'
-                      f' and thus has to include objects from {t.name!r} to be usable.')
+                m += (f' Meson had to promote link to link_whole because {self.get_basename()!r} is installed but not {t.get_basename()!r},'
+                      f' and thus has to include objects from {t.get_basename()!r} to be usable.')
             raise InvalidArguments(m)
         else:
             self.objects.append(t.extract_all_objects())
 
-class SharedLibrary(BuildTarget, LinkableTargetProto):
+class SharedLibrary(BuildTarget, LibTargetProto):
     typename = 'shared library'
 
     # Used by AIX to decide whether to archive shared library or not.
@@ -2849,12 +2864,12 @@ class SharedLibrary(BuildTarget, LinkableTargetProto):
 
     def link_whole(
             self,
-            targets: T.Iterable[StaticTargetTypes],
+            targets: T.Iterable[StaticTargetProto],
             promoted: bool = False) -> None:
         for t in targets:
             self.check_can_link_together(t)
             if not getattr(t, 'pic', True):
-                msg = f"Can't link non-PIC static library {t.name!r} into shared library {self.name!r}. "
+                msg = f"Can't link non-PIC static library {t.get_basename()!r} into shared library {self.get_basename()!r}. "
                 msg += "Use the 'pic' option to static_library to build with PIC."
                 raise InvalidArguments(msg)
             self.link_whole_targets.append(t)
@@ -2862,7 +2877,7 @@ class SharedLibrary(BuildTarget, LinkableTargetProto):
     def link(self, targets: T.Iterable[LinkableTargetProto]) -> None:
         for t in targets:
             if isinstance(t, StaticLibrary) and not t.pic:
-                msg = f"Can't link non-PIC static library {t.name!r} into shared library {self.name!r}. "
+                msg = f"Can't link non-PIC static library {t.get_basename()!r} into shared library {self.get_basename()!r}. "
                 msg += "Use the 'pic' option to static_library to build with PIC."
                 raise InvalidArguments(msg)
             self.check_can_link_together(t)
@@ -2970,7 +2985,7 @@ def flatten_command(cmd: T.Iterable[CommandTypes],
     return final_cmd, depend_files, dependencies
 
 
-class CustomTargetBase(LinkableTargetProto, metaclass=SimpleABC):
+class CustomTargetBase(StaticTargetProto, metaclass=SimpleABC):
     ''' Base class for CustomTarget and CustomTargetIndex
 
     This base class can be used to provide a dummy implementation of some
@@ -2980,19 +2995,25 @@ class CustomTargetBase(LinkableTargetProto, metaclass=SimpleABC):
 
     rust_crate_type = ''
 
+    def extract_all_objects(self, recursive: bool = True) -> ExtractedObjects:
+        raise MesonException(f'Cannot extract objects from custom target {self.get_basename()!r}')
+
     def get_objects(self) -> T.List[ObjectTypes]:
         return []
 
-    def get_internal_static_libraries(self) -> OrderedSet[StaticTargetTypes]:
+    def get_internal_static_libraries(self) -> OrderedSet[StaticTargetProto]:
         return OrderedSet()
 
-    def get_internal_static_libraries_recurse(self, result: OrderedSet[StaticTargetTypes]) -> None:
+    def get_internal_static_libraries_recurse(self, result: OrderedSet[StaticTargetProto]) -> None:
         pass
 
     def get(self, lib_type: _LibraryType, recursive: bool = False) -> Self:
         """Base case used by BothLibraries"""
         assert isinstance(self, (CustomTarget, CustomTargetIndex))
         return self
+
+    def get_import_filename(self) -> T.Optional[str]:
+        return None
 
     def uses_rust(self) -> bool:
         return False
@@ -3062,8 +3083,8 @@ class CustomTarget(Target, CustomTargetBase):
         self.depfile_type = 'gcc' if depfile else depfile_type
         self.env = env or EnvironmentVariables()
         self.feed = feed
-        self.install_dir = list(install_dir or [])
-        self.has_custom_install_dir = bool(self.install_dir)
+        self.install_dir: T.List[T.Union[str, T.Literal[False]]] = list(install_dir or [])
+        self.has_custom_install_dir: bool = bool(self.install_dir)
         self.install_mode = install_mode
         self.install_tag = _process_install_tag(install_tag, len(self.outputs))
         self.name = name if name else self.outputs[0]

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -59,7 +59,6 @@ if T.TYPE_CHECKING:
     CommandTypes: TypeAlias = T.Union['programs.Program', 'BuildTargetTypes', File, str]
     GeneratedTypes: TypeAlias = T.Union['CustomTarget', 'CustomTargetIndex', 'GeneratedList']
     LibTypes: TypeAlias = T.Union['SharedLibrary', 'StaticLibrary', 'CustomTarget', 'CustomTargetIndex']
-    LinkableTargetTypes: TypeAlias = T.Union['SharedLibrary', 'StaticLibrary', 'CustomTarget', 'CustomTargetIndex', 'Executable']
     BuildTargetTypes: TypeAlias = T.Union['BuildTarget', 'CustomTarget', 'CustomTargetIndex']
     StaticTargetTypes: TypeAlias = T.Union['StaticLibrary', 'CustomTarget', 'CustomTargetIndex']
     ObjectTypes: TypeAlias = T.Union['File', 'ExtractedObjects']
@@ -103,6 +102,9 @@ if T.TYPE_CHECKING:
     # if not, this will be a mypy error
     def _assert_BuildTargetProto(x: BuildTargetTypes) -> BuildTargetProto: return x
 
+    class LinkableTargetProto(BuildTargetProto, Protocol):
+        def get(self, lib_type: _LibraryType) -> LinkableTargetProto: ...
+
     class DFeatures(TypedDict):
 
         unittest: bool
@@ -141,7 +143,7 @@ if T.TYPE_CHECKING:
         link_depends: T.Sequence[T.Union[File, BuildTargetProto]]
         link_language: Language
         link_whole: T.List[StaticTargetTypes]
-        link_with: T.List[LinkableTargetTypes]
+        link_with: T.List[LinkableTargetProto]
         name_prefix: T.Optional[str]
         name_suffix: T.Optional[str]
         native: MachineChoice
@@ -197,6 +199,7 @@ if T.TYPE_CHECKING:
 else:
     AnyTargetProto = object
     BuildTargetProto = object
+    LinkableTargetProto = object
 
 
 _T = T.TypeVar('_T')
@@ -237,10 +240,10 @@ def get_target_macos_dylib_install_name(ld: SharedLibrary) -> str:
 
 
 def all_dependencies_recurse(source: object,
-                             link_targets: T.Sequence[LinkableTargetTypes],
+                             link_targets: T.Sequence[LinkableTargetProto],
                              link_whole_targets: T.Sequence[StaticTargetTypes],
                              visited: T.Set[T.Tuple[object, bool, bool]],
-                             include_internals: bool = True, handled_by_rustc: bool = False) -> T.Iterator[tuple[LinkableTargetTypes, bool]]:
+                             include_internals: bool = True, handled_by_rustc: bool = False) -> T.Iterator[tuple[LinkableTargetProto, bool]]:
     key = (source, include_internals, handled_by_rustc)
     if key in visited:
         return
@@ -927,7 +930,7 @@ class BuildTarget(Target, BuildTargetProto):
         self.external_deps: T.List[dependencies.Dependency] = []
         self.include_dirs: T.List['IncludeDirs'] = []
         self.link_language: T.Optional[Language] = kwargs.get('link_language')
-        self.link_targets: T.List[LinkableTargetTypes] = []
+        self.link_targets: T.List[LinkableTargetProto] = []
         self.link_whole_targets: T.List[StaticTargetTypes] = []
         self.depend_files = kwargs.get('depend_files', [])
         self.link_depends = list(kwargs.get('link_depends', []))
@@ -1219,7 +1222,7 @@ class BuildTarget(Target, BuildTargetProto):
         # the languages of those libraries as well.
         if self.link_targets or self.link_whole_targets:
             for t in itertools.chain(self.link_targets, self.link_whole_targets):
-                if isinstance(t, (CustomTarget, CustomTargetIndex)):
+                if not isinstance(t, BuildTarget):
                     continue # We can't know anything about these.
                 target_langs = [t.link_language] if t.link_language else list(t.compilers)
                 for lang in target_langs:
@@ -1610,7 +1613,7 @@ class BuildTarget(Target, BuildTargetProto):
     def is_internal(self) -> bool:
         return False
 
-    def link(self, targets: T.Iterable[LinkableTargetTypes]) -> None:
+    def link(self, targets: T.Iterable[LinkableTargetProto]) -> None:
         for t in targets:
             self.check_can_link_together(t)
             self.link_targets.append(t)
@@ -1676,7 +1679,7 @@ class BuildTarget(Target, BuildTargetProto):
         # Check if any of the internal libraries this target links to were
         # written in this language
         for t in itertools.chain(self.link_targets, self.link_whole_targets):
-            if isinstance(t, (CustomTarget, CustomTargetIndex)):
+            if not isinstance(t, BuildTarget):
                 continue
             target_langs = [t.link_language] if t.link_language else list(t.compilers)
             for language in target_langs:
@@ -1854,10 +1857,10 @@ class BuildTarget(Target, BuildTargetProto):
         assert isinstance(bl_type, str), 'for mypy'
         return T.cast('_LibraryType', bl_type)
 
-    def _extract_link_with(self, link_with: list[LinkableTargetTypes]) -> list[LinkableTargetTypes]:
+    def _extract_link_with(self, link_with: list[LinkableTargetProto]) -> list[LinkableTargetProto]:
         bl_type = self._default_library_type()
 
-        lib_list: list[LinkableTargetTypes] = []
+        lib_list: list[LinkableTargetProto] = []
         for lib in itertools.chain(link_with, self.link_targets):
             if isinstance(lib, (CustomTarget, CustomTargetIndex)):
                 lib_list.append(lib)
@@ -2006,13 +2009,6 @@ class BuildTarget(Target, BuildTargetProto):
             return 'darwin'
         else:
             return 'unix'
-
-
-class LinkableTarget(metaclass=SimpleABC):
-    @abc.abstractmethod
-    def get(self, lib_type: _LibraryType) -> LinkableTargetTypes:
-        """If applicable, return the shared or static "part" of this target.
-           Otherwise, just return self."""
 
 
 class FileInTargetPrivateDir:
@@ -2220,7 +2216,7 @@ class GeneratedList(HoldableObject):
         return self.generator.name
 
 
-class Executable(BuildTarget, LinkableTarget):
+class Executable(BuildTarget, LinkableTargetProto):
     typename = 'executable'
 
     def __init__(
@@ -2325,7 +2321,7 @@ class Executable(BuildTarget, LinkableTarget):
                 name += '_' + self.suffix
             self.debug_filename = name + '.pdb'
 
-    def get(self, lib_type: _LibraryType, recursive: bool = False) -> LinkableTargetTypes:
+    def get(self, lib_type: _LibraryType, recursive: bool = False) -> LinkableTargetProto:
         """Base case used by BothLibraries"""
         return self
 
@@ -2355,7 +2351,7 @@ class Executable(BuildTarget, LinkableTarget):
         return self.is_linkwithable
 
 
-class StaticLibrary(BuildTarget, LinkableTarget):
+class StaticLibrary(BuildTarget, LinkableTargetProto):
     typename = 'static library'
 
     def __init__(
@@ -2479,7 +2475,7 @@ class StaticLibrary(BuildTarget, LinkableTarget):
         self.both_lib = copy.copy(shared_library)
         self.both_lib.both_lib = None
 
-    def get(self, lib_type: _LibraryType, recursive: bool = False) -> LinkableTargetTypes:
+    def get(self, lib_type: _LibraryType, recursive: bool = False) -> LinkableTargetProto:
         result = self
         if lib_type == 'shared':
             result = self.both_lib or self
@@ -2505,7 +2501,7 @@ class StaticLibrary(BuildTarget, LinkableTarget):
                     self._bundle_static_library(lib, True)
             self.link_whole_targets.append(t)
 
-    def link(self, targets: T.Iterable[LinkableTargetTypes]) -> None:
+    def link(self, targets: T.Iterable[LinkableTargetProto]) -> None:
         for t in targets:
             if self.install and t.is_internal():
                 # When we're a static library and we link_with to an
@@ -2536,7 +2532,7 @@ class StaticLibrary(BuildTarget, LinkableTarget):
         else:
             self.objects.append(t.extract_all_objects())
 
-class SharedLibrary(BuildTarget, LinkableTarget):
+class SharedLibrary(BuildTarget, LinkableTargetProto):
     typename = 'shared library'
 
     # Used by AIX to decide whether to archive shared library or not.
@@ -2843,7 +2839,7 @@ class SharedLibrary(BuildTarget, LinkableTarget):
         self.both_lib = copy.copy(static_library)
         self.both_lib.both_lib = None
 
-    def get(self, lib_type: _LibraryType, recursive: bool = False) -> LinkableTargetTypes:
+    def get(self, lib_type: _LibraryType, recursive: bool = False) -> LinkableTargetProto:
         result = self
         if lib_type == 'static':
             result = self.both_lib or self
@@ -2863,7 +2859,7 @@ class SharedLibrary(BuildTarget, LinkableTarget):
                 raise InvalidArguments(msg)
             self.link_whole_targets.append(t)
 
-    def link(self, targets: T.Iterable[LinkableTargetTypes]) -> None:
+    def link(self, targets: T.Iterable[LinkableTargetProto]) -> None:
         for t in targets:
             if isinstance(t, StaticLibrary) and not t.pic:
                 msg = f"Can't link non-PIC static library {t.name!r} into shared library {self.name!r}. "
@@ -2903,7 +2899,7 @@ class SharedModule(SharedLibrary):
     def get_default_install_dir(self) -> T.Tuple[str, str]:
         return self.environment.get_shared_module_dir(), '{moduledir_shared}'
 
-class BothLibraries(SecondLevelHolder, LinkableTarget):
+class BothLibraries(SecondLevelHolder):
     typename: T.ClassVar[str] = 'both libraries'
 
     def __init__(self, shared: SharedLibrary, static: StaticLibrary, preferred_library: Literal['shared', 'static']) -> None:
@@ -2970,7 +2966,7 @@ def flatten_command(cmd: T.Iterable[CommandTypes],
     return final_cmd, depend_files, dependencies
 
 
-class CustomTargetBase(LinkableTarget, BuildTargetProto, metaclass=SimpleABC):
+class CustomTargetBase(LinkableTargetProto, metaclass=SimpleABC):
     ''' Base class for CustomTarget and CustomTargetIndex
 
     This base class can be used to provide a dummy implementation of some
@@ -2989,7 +2985,7 @@ class CustomTargetBase(LinkableTarget, BuildTargetProto, metaclass=SimpleABC):
     def get_internal_static_libraries_recurse(self, result: OrderedSet[StaticTargetTypes]) -> None:
         pass
 
-    def get(self, lib_type: _LibraryType, recursive: bool = False) -> LinkableTargetTypes:
+    def get(self, lib_type: _LibraryType, recursive: bool = False) -> LinkableTargetProto:
         """Base case used by BothLibraries"""
         assert isinstance(self, (CustomTarget, CustomTargetIndex))
         return self
@@ -3382,7 +3378,7 @@ class Jar(BuildTarget):
         self.main_class = kwargs.get('main_class', '')
         self.java_resources: T.Optional[StructuredSources] = kwargs.get('java_resources', None)
 
-    def _extract_link_with(self, link_with: list[LinkableTargetTypes]) -> list[LinkableTargetTypes]:
+    def _extract_link_with(self, link_with: list[LinkableTargetProto]) -> list[LinkableTargetProto]:
         return link_with
 
     def get_main_class(self) -> str:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -115,6 +115,16 @@ if T.TYPE_CHECKING:
     class StaticTargetProto(LibTargetProto, Protocol):
         def extract_all_objects(self, recursive: bool = True) -> ExtractedObjects: ...
 
+    class CommandTargetProto(AnyTargetProto, Protocol):
+        @property
+        def command(self) -> list[CommandTypes]: ...
+        @property
+        def absolute_paths(self) -> bool: ...
+        @property
+        def depend_files(self) -> T.List[File]: ...
+
+        def get_sources(self) -> T.Sequence[CustomTargetSources]: ...
+
     class DFeatures(TypedDict):
 
         unittest: bool
@@ -212,6 +222,7 @@ else:
     LinkableTargetProto = object
     LibTargetProto = object
     StaticTargetProto = object
+    CommandTargetProto = object
 
 
 _T = T.TypeVar('_T')
@@ -3028,9 +3039,11 @@ class CustomTargetBase(StaticTargetProto, metaclass=SimpleABC):
         return False
 
 
-class CustomTarget(Target, CustomTargetBase):
+class CustomTarget(Target, CustomTargetBase, CommandTargetProto):
 
     typename = 'custom'
+    absolute_paths: bool
+    command: list[CommandTypes]
 
     def __init__(self,
                  name: T.Optional[str],
@@ -3319,9 +3332,11 @@ class CompileTarget(BuildTarget):
     def is_linkable_output(self, output: str) -> bool:
         return False
 
-class RunTarget(Target):
+class RunTarget(Target, CommandTargetProto):
 
     typename = 'run'
+    absolute_paths: bool = False
+    command: list[CommandTypes]
 
     def __init__(self, name: str,
                  command: T.Sequence[CommandTypes],
@@ -3337,7 +3352,6 @@ class RunTarget(Target):
         self.dependencies = list(dependencies)
         self.command, self.depend_files, d = flatten_command(command, build_project.subproject)
         self.dependencies.extend(d)
-        self.absolute_paths = False
         self.env = env
         self.default_env = default_env
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -103,7 +103,7 @@ if T.TYPE_CHECKING:
     def _assert_BuildTargetProto(x: BuildTargetTypes) -> BuildTargetProto: return x
 
     class LinkableTargetProto(BuildTargetProto, Protocol):
-        def get(self, lib_type: _LibraryType) -> LinkableTargetProto: ...
+        def get(self, lib_type: _LibraryType, recursive: bool = False) -> LinkableTargetProto: ...
 
     class DFeatures(TypedDict):
 
@@ -2321,7 +2321,7 @@ class Executable(BuildTarget, LinkableTargetProto):
                 name += '_' + self.suffix
             self.debug_filename = name + '.pdb'
 
-    def get(self, lib_type: _LibraryType, recursive: bool = False) -> LinkableTargetProto:
+    def get(self, lib_type: _LibraryType, recursive: bool = False) -> Self:
         """Base case used by BothLibraries"""
         return self
 
@@ -2475,7 +2475,7 @@ class StaticLibrary(BuildTarget, LinkableTargetProto):
         self.both_lib = copy.copy(shared_library)
         self.both_lib.both_lib = None
 
-    def get(self, lib_type: _LibraryType, recursive: bool = False) -> LinkableTargetProto:
+    def get(self, lib_type: _LibraryType, recursive: bool = False) -> T.Union[SharedLibrary, StaticLibrary]:
         result = self
         if lib_type == 'shared':
             result = self.both_lib or self
@@ -2839,7 +2839,7 @@ class SharedLibrary(BuildTarget, LinkableTargetProto):
         self.both_lib = copy.copy(static_library)
         self.both_lib.both_lib = None
 
-    def get(self, lib_type: _LibraryType, recursive: bool = False) -> LinkableTargetProto:
+    def get(self, lib_type: _LibraryType, recursive: bool = False) -> T.Union[SharedLibrary, StaticLibrary]:
         result = self
         if lib_type == 'static':
             result = self.both_lib or self
@@ -2911,12 +2911,16 @@ class BothLibraries(SecondLevelHolder):
     def __repr__(self) -> str:
         return f'<BothLibraries: static={repr(self.static)}; shared={repr(self.shared)}>'
 
-    def get(self, lib_type: _LibraryType) -> T.Union[StaticLibrary, SharedLibrary]:
+    def get(self, lib_type: _LibraryType, recursive: bool = False) -> T.Union[StaticLibrary, SharedLibrary]:
         if lib_type == 'static':
-            return self.static
-        if lib_type == 'shared':
-            return self.shared
-        return self.get_default_object()
+            result = self.static
+        elif lib_type == 'shared':
+            result = self.shared
+        else:
+            result = self.get_default_object()
+        if recursive:
+            return result.get(lib_type, True)
+        return result
 
     def get_default_object(self) -> T.Union[StaticLibrary, SharedLibrary]:
         if self._preferred_library == 'shared':
@@ -2985,7 +2989,7 @@ class CustomTargetBase(LinkableTargetProto, metaclass=SimpleABC):
     def get_internal_static_libraries_recurse(self, result: OrderedSet[StaticTargetTypes]) -> None:
         pass
 
-    def get(self, lib_type: _LibraryType, recursive: bool = False) -> LinkableTargetProto:
+    def get(self, lib_type: _LibraryType, recursive: bool = False) -> Self:
         """Base case used by BothLibraries"""
         assert isinstance(self, (CustomTarget, CustomTargetIndex))
         return self

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -39,7 +39,7 @@ from .compilers import (
 from .interpreterbase import FeatureNew, FeatureDeprecated
 
 if T.TYPE_CHECKING:
-    from typing_extensions import Literal, Self, TypeAlias, TypedDict
+    from typing_extensions import Literal, Self, TypeAlias, TypedDict, Protocol
 
     from .arglist import CompilerArgs
     from .environment import Environment
@@ -63,9 +63,17 @@ if T.TYPE_CHECKING:
     BuildTargetTypes: TypeAlias = T.Union['BuildTarget', 'CustomTarget', 'CustomTargetIndex']
     StaticTargetTypes: TypeAlias = T.Union['StaticLibrary', 'CustomTarget', 'CustomTargetIndex']
     ObjectTypes: TypeAlias = T.Union['File', 'ExtractedObjects']
-    AnyTargetType: TypeAlias = T.Union['Target', 'CustomTargetIndex']
     RustCrateType: TypeAlias = Literal['bin', 'lib', 'rlib', 'dylib', 'cdylib', 'staticlib', 'proc-macro']
     _LibraryType: TypeAlias = Literal['auto', 'shared', 'static']
+
+    class AnyTargetProto(Protocol):
+        def get_basename(self) -> str: ...
+        def get_build_subdir(self) -> str: ...
+        def get_builddir(self) -> str: ...
+        def get_id(self) -> str: ...
+        def get_outputs(self) -> T.List[str]: ...
+        def get_subdir(self) -> str: ...
+        def get_target(self) -> Target: ...
 
     class DFeatures(TypedDict):
 
@@ -158,6 +166,8 @@ if T.TYPE_CHECKING:
         java_args: T.List[str]
         java_resources: T.Optional[StructuredSources]
         main_class: str
+else:
+    AnyTargetProto = object
 
 
 _T = T.TypeVar('_T')
@@ -723,7 +733,7 @@ class StructuredSources(HoldableObject):
 
 
 @dataclass(eq=False)
-class Target(HoldableObject, metaclass=SimpleABC):
+class Target(HoldableObject, AnyTargetProto, metaclass=SimpleABC):
 
     typename: T.ClassVar[str]
 
@@ -2932,7 +2942,7 @@ def flatten_command(cmd: T.Iterable[CommandTypes],
     return final_cmd, depend_files, dependencies
 
 
-class CustomTargetBase(LinkableTarget, metaclass=SimpleABC):
+class CustomTargetBase(LinkableTarget, AnyTargetProto, metaclass=SimpleABC):
     ''' Base class for CustomTarget and CustomTargetIndex
 
     This base class can be used to provide a dummy implementation of some
@@ -3261,7 +3271,7 @@ class RunTarget(Target):
     def __init__(self, name: str,
                  command: T.Sequence[CommandTypes],
                  # the RunTarget case is used by gnome.yelp()
-                 dependencies: T.Sequence[AnyTargetType | programs.Program],
+                 dependencies: T.Sequence[AnyTargetProto | programs.Program],
                  subdir: str,
                  environment: Environment,
                  build_project: BuildProject,
@@ -3280,7 +3290,7 @@ class RunTarget(Target):
         repr_str = "<{0} {1}: {2}>"
         return repr_str.format(self.__class__.__name__, self.get_id(), self.command[0])
 
-    def get_dependencies(self) -> T.List[AnyTargetType | programs.Program]:
+    def get_dependencies(self) -> T.Iterable[AnyTargetProto | programs.Program]:
         return self.dependencies
 
     def get_generated_sources(self) -> T.List[GeneratedTypes]:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -3416,6 +3416,9 @@ class CustomTargetIndex(CustomTargetBase, HoldableObject):
     def __repr__(self) -> str:
         return '<CustomTargetIndex: {!r}[{}]>'.format(self.target, self.output)
 
+    def __str__(self) -> str:
+        return self.name
+
     def get_outputs(self) -> T.List[str]:
         return [self.output]
 

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -28,8 +28,8 @@ if T.TYPE_CHECKING:
     from ..environment import Environment
     from ..interpreterbase import FeatureCheckBase
     from ..build import (
-        CustomTarget, IncludeDirs, CustomTargetIndex, LinkableProto,
-        StaticLibrary, ExtractedObjects, TargetSources
+        IncludeDirs, LinkableProto,
+        ExtractedObjects, TargetSources, StaticTargetProto,
     )
     from ..interpreter.type_checking import PkgConfigDefineType
 
@@ -310,7 +310,7 @@ class InternalDependency(Dependency):
                  compile_args: T.Optional[T.List[str]] = None,
                  link_args: T.Optional[T.List[str]] = None,
                  libraries: T.Optional[T.List[LinkableProto]] = None,
-                 whole_libraries: T.Optional[T.List[T.Union[StaticLibrary, CustomTarget, CustomTargetIndex]]] = None,
+                 whole_libraries: T.Optional[T.List[StaticTargetProto]] = None,
                  sources: T.Optional[T.Sequence[TargetSources]] = None,
                  extra_files: T.Optional[T.Sequence[mesonlib.File]] = None,
                  ext_deps: T.Optional[T.List[Dependency]] = None, variables: T.Optional[T.Dict[str, str]] = None,
@@ -402,8 +402,7 @@ class InternalDependency(Dependency):
                                      'CustomTarget or CustomTargetIndex which is a shared library')
 
         # Mypy doesn't understand that the above is a TypeGuard
-        new_dep.whole_libraries += T.cast('T.List[T.Union[StaticLibrary, CustomTarget, CustomTargetIndex]]',
-                                          new_dep.libraries)
+        new_dep.whole_libraries += T.cast('T.List[StaticTargetProto]', new_dep.libraries)
         new_dep.libraries = []
         return new_dep
 

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -28,7 +28,7 @@ if T.TYPE_CHECKING:
     from ..environment import Environment
     from ..interpreterbase import FeatureCheckBase
     from ..build import (
-        CustomTarget, IncludeDirs, CustomTargetIndex, LinkableTargetTypes,
+        CustomTarget, IncludeDirs, CustomTargetIndex, LinkableProto,
         StaticLibrary, ExtractedObjects, TargetSources
     )
     from ..interpreter.type_checking import PkgConfigDefineType
@@ -309,7 +309,7 @@ class InternalDependency(Dependency):
     def __init__(self, version: str, incdirs: T.Optional[T.List['IncludeDirs']] = None,
                  compile_args: T.Optional[T.List[str]] = None,
                  link_args: T.Optional[T.List[str]] = None,
-                 libraries: T.Optional[T.List[LinkableTargetTypes]] = None,
+                 libraries: T.Optional[T.List[LinkableProto]] = None,
                  whole_libraries: T.Optional[T.List[T.Union[StaticLibrary, CustomTarget, CustomTargetIndex]]] = None,
                  sources: T.Optional[T.Sequence[TargetSources]] = None,
                  extra_files: T.Optional[T.Sequence[mesonlib.File]] = None,

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -28,7 +28,7 @@ if T.TYPE_CHECKING:
     from ..environment import Environment
     from ..interpreterbase import FeatureCheckBase
     from ..build import (
-        CustomTarget, IncludeDirs, CustomTargetIndex, LinkableTargetTypes,
+        CustomTarget, IncludeDirs, CustomTargetIndex, LinkableTargetProto,
         StaticLibrary, ExtractedObjects, TargetSources
     )
     from ..interpreter.type_checking import PkgConfigDefineType
@@ -309,7 +309,7 @@ class InternalDependency(Dependency):
     def __init__(self, version: str, incdirs: T.Optional[T.List['IncludeDirs']] = None,
                  compile_args: T.Optional[T.List[str]] = None,
                  link_args: T.Optional[T.List[str]] = None,
-                 libraries: T.Optional[T.List[LinkableTargetTypes]] = None,
+                 libraries: T.Optional[T.List[LinkableTargetProto]] = None,
                  whole_libraries: T.Optional[T.List[T.Union[StaticLibrary, CustomTarget, CustomTargetIndex]]] = None,
                  sources: T.Optional[T.Sequence[TargetSources]] = None,
                  extra_files: T.Optional[T.Sequence[mesonlib.File]] = None,

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -28,8 +28,8 @@ if T.TYPE_CHECKING:
     from ..environment import Environment
     from ..interpreterbase import FeatureCheckBase
     from ..build import (
-        CustomTarget, IncludeDirs, CustomTargetIndex, LinkableTargetProto,
-        StaticLibrary, ExtractedObjects, TargetSources
+        IncludeDirs, LinkableTargetProto,
+        ExtractedObjects, TargetSources, StaticTargetProto,
     )
     from ..interpreter.type_checking import PkgConfigDefineType
 
@@ -310,7 +310,7 @@ class InternalDependency(Dependency):
                  compile_args: T.Optional[T.List[str]] = None,
                  link_args: T.Optional[T.List[str]] = None,
                  libraries: T.Optional[T.List[LinkableTargetProto]] = None,
-                 whole_libraries: T.Optional[T.List[T.Union[StaticLibrary, CustomTarget, CustomTargetIndex]]] = None,
+                 whole_libraries: T.Optional[T.List[StaticTargetProto]] = None,
                  sources: T.Optional[T.Sequence[TargetSources]] = None,
                  extra_files: T.Optional[T.Sequence[mesonlib.File]] = None,
                  ext_deps: T.Optional[T.List[Dependency]] = None, variables: T.Optional[T.Dict[str, str]] = None,
@@ -409,8 +409,7 @@ class InternalDependency(Dependency):
                                      'CustomTarget or CustomTargetIndex which is a shared library')
 
         # Mypy doesn't understand that the above is a TypeGuard
-        new_dep.whole_libraries += T.cast('T.List[T.Union[StaticLibrary, CustomTarget, CustomTargetIndex]]',
-                                          new_dep.libraries)
+        new_dep.whole_libraries += T.cast('T.List[StaticTargetProto]', new_dep.libraries)
         new_dep.libraries = []
         return new_dep
 

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -95,7 +95,7 @@ if T.TYPE_CHECKING:
         compile_args: T.List[str]
         include_directories: T.List[T.Union[build.IncludeDirs, str]]
         dependencies: T.List[dependencies.Dependency]
-        depends: T.List[build.BuildTargetTypes]
+        depends: T.List[build.BuildTargetProto]
 
 
 class _TestMode(enum.Enum):
@@ -147,7 +147,7 @@ _DEPENDENCIES_KW: KwargInfo[T.List['dependencies.Dependency']] = KwargInfo(
     listify=True,
     default=[],
 )
-_DEPENDS_KW: KwargInfo[T.List[build.BuildTargetTypes]] = KwargInfo(
+_DEPENDS_KW: KwargInfo[T.List[build.BuildTargetProto]] = KwargInfo(
     'depends',
     ContainerTypeInfo(list, (build.BuildTarget, build.CustomTarget, build.CustomTargetIndex)),
     listify=True,

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3332,7 +3332,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     def source_strings_to_files(self, sources: list[T.Union[mesonlib.FileOrString, build.CustomTarget, build.CustomTargetIndex]]) -> list[T.Union[mesonlib.File, build.CustomTarget, build.CustomTargetIndex]]: ...
 
     @T.overload
-    def source_strings_to_files(self, sources: list[T.Union[mesonlib.FileOrString, build.BuildTargetTypes]]) -> list[T.Union[mesonlib.File, build.BuildTargetTypes]]: ...  # type: ignore[overload-overlap]
+    def source_strings_to_files(self, sources: list[T.Union[mesonlib.FileOrString, build.BuildTargetProto]]) -> list[T.Union[mesonlib.File, build.BuildTargetProto]]: ... # type: ignore[overload-overlap]
 
     @T.overload
     def source_strings_to_files(self, sources: list[T.Union[str, build.TargetSources]]) -> list[build.TargetSources]: ...
@@ -3363,7 +3363,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                                     list[str],
                                     list[mesonlib.File | str],
                                     list[mesonlib.File | str | build.CustomTarget | build.CustomTargetIndex],
-                                    list[mesonlib.File | str | build.BuildTargetTypes],
+                                    list[mesonlib.File | str | build.BuildTargetProto],
                                     list[str | build.TargetSources],
                                     list[str | build.TargetSources | build.StructuredSources],
                                     list[kwtypes.CustomTargetInputs],
@@ -3373,7 +3373,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                                     list[SourcesVarargsType],
                                 ]
                                 ) -> T.Union[list[mesonlib.File],
-                                             list[mesonlib.File | build.BuildTargetTypes],
+                                             list[mesonlib.File | build.BuildTargetProto],
                                              list[mesonlib.File | build.CustomTarget | build.CustomTargetIndex],
                                              list[build.TargetSources],
                                              list[build.TargetSources | build.StructuredSources],

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3359,7 +3359,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     def source_strings_to_files(self, sources: list[T.Union[mesonlib.FileOrString, build.CustomTarget, build.CustomTargetIndex]]) -> list[T.Union[mesonlib.File, build.CustomTarget, build.CustomTargetIndex]]: ...
 
     @T.overload
-    def source_strings_to_files(self, sources: list[T.Union[mesonlib.FileOrString, build.BuildTargetTypes]]) -> list[T.Union[mesonlib.File, build.BuildTargetTypes]]: ...  # type: ignore[overload-overlap]
+    def source_strings_to_files(self, sources: list[T.Union[mesonlib.FileOrString, build.BuildTargetProto]]) -> list[T.Union[mesonlib.File, build.BuildTargetProto]]: ... # type: ignore[overload-overlap]
 
     @T.overload
     def source_strings_to_files(self, sources: list[T.Union[str, build.TargetSources]]) -> list[build.TargetSources]: ...
@@ -3393,7 +3393,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                                     list[str],
                                     list[mesonlib.File | str],
                                     list[mesonlib.File | str | build.CustomTarget | build.CustomTargetIndex],
-                                    list[mesonlib.File | str | build.BuildTargetTypes],
+                                    list[mesonlib.File | str | build.BuildTargetProto],
                                     list[str | build.TargetSources],
                                     list[str | build.TargetSources | build.StructuredSources],
                                     list[str | build.TargetSources | build.BuildTarget],
@@ -3404,7 +3404,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                                     list[SourcesVarargsType],
                                 ]
                                 ) -> T.Union[list[mesonlib.File],
-                                             list[mesonlib.File | build.BuildTargetTypes],
+                                             list[mesonlib.File | build.BuildTargetProto],
                                              list[mesonlib.File | build.CustomTarget | build.CustomTargetIndex],
                                              list[build.TargetSources],
                                              list[build.TargetSources | build.StructuredSources],

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -864,7 +864,7 @@ class Test(MesonInterpreterObject):
         self.priority = priority
         self.verbose = verbose
 
-        self.depends: T.List[build.BuildTargetTypes] = []
+        self.depends: T.List[build.BuildTargetProto] = []
         for d in depends:
             if isinstance(d, build.GeneratedList):
                 raise MesonException('generated_list not allowed as a dependency for test')

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -857,7 +857,7 @@ class Test(MesonInterpreterObject):
         self.priority = priority
         self.verbose = verbose
 
-        self.depends: T.List[build.BuildTargetTypes] = []
+        self.depends: T.List[build.BuildTargetProto] = []
         for d in depends:
             if isinstance(d, build.GeneratedList):
                 raise MesonException('generated_list not allowed as a dependency for test')

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -381,7 +381,7 @@ class BaseBuildTarget(TypedDict):
     implicit_include_directories: bool
     link_depends: T.List[T.Union[str, File, build.BuildTargetProto]]
     link_language: T.Optional[Language]
-    link_whole: T.List[build.StaticTargetTypes]
+    link_whole: T.List[build.StaticTargetProto]
     link_with: T.List[build.LinkableProto]
     name_prefix: T.Optional[str]
     name_suffix: T.Optional[str]
@@ -543,7 +543,7 @@ class FuncDeclareDependency(TypedDict):
     extra_files: T.List[FileOrString]
     include_directories: T.List[T.Union[build.IncludeDirs, str]]
     link_args: T.List[str]
-    link_whole: T.List[build.StaticTargetTypes]
+    link_whole: T.List[build.StaticTargetProto]
     link_with: T.List[build.LinkableProto]
     objects: T.List[build.ExtractedObjects]
     sources: T.List[str | build.TargetSources]

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -382,7 +382,7 @@ class BaseBuildTarget(TypedDict):
     link_depends: T.List[T.Union[str, File, build.BuildTargetProto]]
     link_language: T.Optional[Language]
     link_whole: T.List[build.StaticTargetTypes]
-    link_with: T.List[build.LinkableTargetTypes]
+    link_with: T.List[build.LinkableProto]
     name_prefix: T.Optional[str]
     name_suffix: T.Optional[str]
     native: MachineChoice
@@ -544,7 +544,7 @@ class FuncDeclareDependency(TypedDict):
     include_directories: T.List[T.Union[build.IncludeDirs, str]]
     link_args: T.List[str]
     link_whole: T.List[build.StaticTargetTypes]
-    link_with: T.List[build.LinkableTargetTypes]
+    link_with: T.List[build.LinkableProto]
     objects: T.List[build.ExtractedObjects]
     sources: T.List[str | build.TargetSources]
     variables: T.Dict[str, str]

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -21,7 +21,7 @@ from ..modules.cmake import CMakeSubprojectOptions
 from ..programs import Program, ExternalProgram
 from .type_checking import PkgConfigDefineType, SourcesVarargsType
 
-TargetDepends = T.Union[build.CustomTarget, build.CustomTargetIndex, build.BuildTarget, build.GeneratedList, Program]
+TargetDepends = T.Union[build.BuildTargetProto, build.GeneratedList, Program]
 CustomTargetInputs = T.Union[str, build.BuildTarget, build.GeneratedTypes,
                              build.ExtractedObjects, Program, File]
 BuildTargetObjects = T.Union[str, File, build.ExtractedObjects, build.GeneratedTypes]
@@ -379,7 +379,7 @@ class BaseBuildTarget(TypedDict):
     install_tag: T.Optional[str]
     install_rpath: str
     implicit_include_directories: bool
-    link_depends: T.List[T.Union[str, File, build.BuildTargetTypes]]
+    link_depends: T.List[T.Union[str, File, build.BuildTargetProto]]
     link_language: T.Optional[Language]
     link_whole: T.List[build.StaticTargetTypes]
     link_with: T.List[build.LinkableTargetTypes]

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -381,7 +381,7 @@ class BaseBuildTarget(TypedDict):
     implicit_include_directories: bool
     link_depends: T.List[T.Union[str, File, build.BuildTargetProto]]
     link_language: T.Optional[Language]
-    link_whole: T.List[build.StaticTargetTypes]
+    link_whole: T.List[build.StaticTargetProto]
     link_with: T.List[build.LinkableTargetProto]
     name_prefix: T.Optional[str]
     name_suffix: T.Optional[str]
@@ -543,7 +543,7 @@ class FuncDeclareDependency(TypedDict):
     extra_files: T.List[FileOrString]
     include_directories: T.List[T.Union[build.IncludeDirs, str]]
     link_args: T.List[str]
-    link_whole: T.List[build.StaticTargetTypes]
+    link_whole: T.List[build.StaticTargetProto]
     link_with: T.List[build.LinkableTargetProto]
     objects: T.List[build.ExtractedObjects]
     sources: T.List[str | build.TargetSources]

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -382,7 +382,7 @@ class BaseBuildTarget(TypedDict):
     link_depends: T.List[T.Union[str, File, build.BuildTargetProto]]
     link_language: T.Optional[Language]
     link_whole: T.List[build.StaticTargetTypes]
-    link_with: T.List[build.LinkableTargetTypes]
+    link_with: T.List[build.LinkableTargetProto]
     name_prefix: T.Optional[str]
     name_suffix: T.Optional[str]
     native: MachineChoice
@@ -544,7 +544,7 @@ class FuncDeclareDependency(TypedDict):
     include_directories: T.List[T.Union[build.IncludeDirs, str]]
     link_args: T.List[str]
     link_whole: T.List[build.StaticTargetTypes]
-    link_with: T.List[build.LinkableTargetTypes]
+    link_with: T.List[build.LinkableTargetProto]
     objects: T.List[build.ExtractedObjects]
     sources: T.List[str | build.TargetSources]
     variables: T.Dict[str, str]

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -201,7 +201,7 @@ class FuncAddLanguages(ExtractRequired):
 class RunTarget(TypedDict):
 
     command: T.List[build.CommandTypes]
-    depends: T.List[build.AnyTargetType | Program]
+    depends: T.List[build.AnyTargetProto | Program]
     env: EnvironmentVariables
 
 

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -19,14 +19,14 @@ from ..mesonlib import File, MesonException, has_path_sep, is_windows, path_is_i
 
 if T.TYPE_CHECKING:
     from . import ModuleState
-    from ..build import BuildTargetTypes
+    from ..build import BuildTargetProto
     from ..interpreter import Interpreter
     from ..interpreterbase import TYPE_kwargs
     from ..mesonlib import FileOrString, FileMode
 
     from typing_extensions import TypedDict
 
-    FilePathTypes = str | File | BuildTargetTypes
+    FilePathTypes = str | File | BuildTargetProto
 
     class ReadKwArgs(TypedDict):
         """Keyword Arguments for fs.read."""
@@ -332,10 +332,10 @@ class FSModule(ExtensionModule):
         def to_path(arg: FilePathTypes) -> str:
             if isinstance(arg, File):
                 return arg.absolute_path(state.environment.source_dir, state.environment.build_dir)
-            elif isinstance(arg, (CustomTarget, CustomTargetIndex, BuildTarget)):
-                return state.backend.get_target_filename_abs(arg)
-            else:
+            elif isinstance(arg, str):
                 return os.path.join(state.environment.source_dir, state.subdir, arg)
+            else:
+                return state.backend.get_target_filename_abs(arg)
 
         t = to_path(args[0])
         f = to_path(args[1])

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -2240,8 +2240,8 @@ class GnomeModule(ExtensionModule):
                 ofile.write(package + '\n')
         return build.Data([mesonlib.File(True, outdir, fname)], install_dir, install_dir, mesonlib.FileMode(), state.subproject, install_tag='devel')
 
-    def _get_vapi_link_with(self, target: CustomTarget) -> T.List[build.LibTypes]:
-        link_with: T.List[build.LibTypes] = []
+    def _get_vapi_link_with(self, target: CustomTarget) -> T.List[build.LinkableProto]:
+        link_with: T.List[build.LinkableProto] = []
         for dep in target.get_target_dependencies():
             if isinstance(dep, build.SharedLibrary):
                 link_with.append(dep)
@@ -2280,7 +2280,7 @@ class GnomeModule(ExtensionModule):
         cmd += ['--metadatadir=' + source_dir]
 
         inputs: T.List[T.Union[mesonlib.File, GirTarget]] = []
-        link_with: T.List[build.LinkableTargetTypes] = []
+        link_with: T.List[build.LinkableProto] = []
         i: CustomTargetInputs
         for i in kwargs['sources']:
             if isinstance(i, str):

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -665,7 +665,7 @@ class GnomeModule(ExtensionModule):
         return link_command, new_depends
 
     def _get_dependencies_flags_raw(
-            self, deps: T.Sequence[T.Union['Dependency', build.BuildTargetTypes]],
+            self, deps: T.Sequence[T.Union['Dependency', build.BuildTargetProto]],
             state: 'ModuleState',
             depends: T.Sequence[TargetDepends],
             include_rpath: bool,
@@ -758,7 +758,7 @@ class GnomeModule(ExtensionModule):
         return cflags, internal_ldflags, external_ldflags, gi_includes, depends
 
     def _get_dependencies_flags(
-            self, deps: T.Sequence[T.Union['Dependency', build.BuildTargetTypes]],
+            self, deps: T.Sequence[T.Union['Dependency', build.BuildTargetProto]],
             state: 'ModuleState',
             depends: T.Sequence[TargetDepends],
             include_rpath: bool = False,
@@ -911,8 +911,8 @@ class GnomeModule(ExtensionModule):
 
     @staticmethod
     def _get_gir_targets_deps(girtargets: T.Sequence[build.BuildTarget]
-                              ) -> T.List[T.Union[build.BuildTargetTypes, Dependency]]:
-        ret: T.List[T.Union[build.BuildTargetTypes, Dependency]] = []
+                              ) -> T.List[T.Union[build.BuildTargetProto, Dependency]]:
+        ret: T.List[T.Union[build.BuildTargetProto, Dependency]] = []
         for girtarget in girtargets:
             ret += girtarget.get_all_link_deps()
             ret += girtarget.get_external_deps()
@@ -1071,7 +1071,7 @@ class GnomeModule(ExtensionModule):
     @staticmethod
     def _gather_typelib_includes_and_update_depends(
             state: 'ModuleState',
-            deps: T.Sequence[T.Union[Dependency, build.BuildTargetTypes]],
+            deps: T.Sequence[T.Union[Dependency, build.BuildTargetProto]],
             depends: T.Sequence[TargetDepends]
             ) -> T.Tuple[T.List[str], T.List[TargetDepends]]:
         # Need to recursively add deps on GirTarget sources from our
@@ -2073,7 +2073,7 @@ class GnomeModule(ExtensionModule):
             *,
             install: bool = False,
             install_dir: T.Optional[T.Sequence[T.Union[str, bool]]] = None,
-            depends: T.Optional[T.Sequence[build.BuildTargetTypes]] = None
+            depends: T.Optional[T.Sequence[build.BuildTargetProto]] = None
             ) -> build.CustomTarget:
         real_cmd: CommandList = [self._find_tool(state, 'glib-mkenums')]
         real_cmd.extend(cmd)

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -2253,8 +2253,8 @@ class GnomeModule(ExtensionModule):
                 ofile.write(package + '\n')
         return build.Data([mesonlib.File(True, outdir, fname)], install_dir, install_dir, mesonlib.FileMode(), state.subproject, install_tag='devel')
 
-    def _get_vapi_link_with(self, target: CustomTarget) -> T.List[build.LibTypes]:
-        link_with: T.List[build.LibTypes] = []
+    def _get_vapi_link_with(self, target: CustomTarget) -> T.List[build.LinkableTargetProto]:
+        link_with: T.List[build.LinkableTargetProto] = []
         for dep in target.get_target_dependencies():
             if isinstance(dep, build.SharedLibrary):
                 link_with.append(dep)
@@ -2293,7 +2293,7 @@ class GnomeModule(ExtensionModule):
         cmd += ['--metadatadir=' + source_dir]
 
         inputs: T.List[T.Union[mesonlib.File, GirTarget]] = []
-        link_with: T.List[build.LinkableTargetTypes] = []
+        link_with: T.List[build.LinkableTargetProto] = []
         i: CustomTargetInputs
         for i in kwargs['sources']:
             if isinstance(i, str):

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -665,7 +665,7 @@ class GnomeModule(ExtensionModule):
         return link_command, new_depends
 
     def _get_dependencies_flags_raw(
-            self, deps: T.Sequence[T.Union['Dependency', build.BuildTargetTypes]],
+            self, deps: T.Sequence[T.Union['Dependency', build.BuildTargetProto]],
             state: 'ModuleState',
             depends: T.Sequence[TargetDepends],
             include_rpath: bool,
@@ -758,7 +758,7 @@ class GnomeModule(ExtensionModule):
         return cflags, internal_ldflags, external_ldflags, gi_includes, depends
 
     def _get_dependencies_flags(
-            self, deps: T.Sequence[T.Union['Dependency', build.BuildTargetTypes]],
+            self, deps: T.Sequence[T.Union['Dependency', build.BuildTargetProto]],
             state: 'ModuleState',
             depends: T.Sequence[TargetDepends],
             include_rpath: bool = False,
@@ -911,8 +911,8 @@ class GnomeModule(ExtensionModule):
 
     @staticmethod
     def _get_gir_targets_deps(girtargets: T.Sequence[build.BuildTarget]
-                              ) -> T.List[T.Union[build.BuildTargetTypes, Dependency]]:
-        ret: T.List[T.Union[build.BuildTargetTypes, Dependency]] = []
+                              ) -> T.List[T.Union[build.BuildTargetProto, Dependency]]:
+        ret: T.List[T.Union[build.BuildTargetProto, Dependency]] = []
         for girtarget in girtargets:
             ret += girtarget.get_all_link_deps()
             ret += girtarget.get_external_deps()
@@ -1073,7 +1073,7 @@ class GnomeModule(ExtensionModule):
     @staticmethod
     def _gather_typelib_includes_and_update_depends(
             state: 'ModuleState',
-            deps: T.Sequence[T.Union[Dependency, build.BuildTargetTypes]],
+            deps: T.Sequence[T.Union[Dependency, build.BuildTargetProto]],
             depends: T.Sequence[TargetDepends]
             ) -> T.Tuple[T.List[str], T.List[TargetDepends]]:
         # Need to recursively add deps on GirTarget sources from our
@@ -2086,7 +2086,7 @@ class GnomeModule(ExtensionModule):
             *,
             install: bool = False,
             install_dir: T.Optional[T.Sequence[T.Union[str, bool]]] = None,
-            depends: T.Optional[T.Sequence[build.BuildTargetTypes]] = None
+            depends: T.Optional[T.Sequence[build.BuildTargetProto]] = None
             ) -> build.CustomTarget:
         real_cmd: CommandList = [self._find_tool(state, 'glib-mkenums')]
         real_cmd.extend(cmd)

--- a/mesonbuild/modules/hotdoc.py
+++ b/mesonbuild/modules/hotdoc.py
@@ -91,7 +91,7 @@ class HotdocTargetBuilder:
                                       '--output', os.path.join(self.builddir, self.subdir, self.name + '-doc')]
 
         self._extra_extension_paths: set[str] = set()
-        self.extra_depends: list[build.BuildTargetTypes] = []
+        self.extra_depends: list[build.BuildTargetProto] = []
         self._subprojects: list[HotdocTarget] = []
 
     def process_known_arg(self, option: str, argname: T.Optional[str] = None, value_processor: T.Optional[T.Callable] = None) -> None:

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -64,7 +64,7 @@ if T.TYPE_CHECKING:
         install_dir: T.Optional[str]
         install_tag: T.Optional[str]
         its_files: T.List[str]
-        mo_targets: T.List[build.BuildTargetTypes]
+        mo_targets: T.List[build.BuildTargetProto]
 
     class XgettextProgramT(TypedDict):
 
@@ -74,7 +74,7 @@ if T.TYPE_CHECKING:
         install_dir: T.Optional[str]
         install_tag: T.Optional[str]
 
-    SourcesType = T.Union[str, mesonlib.File, build.BuildTargetTypes, build.BothLibraries]
+    SourcesType = T.Union[str, mesonlib.File, build.BuildTargetProto, build.BothLibraries]
 
 
 _ARGS: KwargInfo[T.List[str]] = KwargInfo(

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -30,7 +30,7 @@ if T.TYPE_CHECKING:
     from .. import mparser
     from ..interpreter import Interpreter
 
-    ANY_DEP = T.Union[dependencies.Dependency, build.LinkableTargetTypes, str]
+    ANY_DEP = T.Union[dependencies.Dependency, build.LinkableProto, str]
     REQS = T.Union[dependencies.Dependency, build.LibTypes, str]
     LIBS = T.Union[build.LibTypes, str]
 
@@ -267,7 +267,7 @@ class DependenciesHelper:
         return processed_libs, processed_reqs, processed_cflags
 
     def _add_lib_dependencies(
-            self, link_targets: T.Sequence[build.LinkableTargetTypes],
+            self, link_targets: T.Sequence[build.LinkableProto],
             link_whole_targets: T.Sequence[build.StaticTargetTypes],
             external_deps: T.List[dependencies.Dependency],
             public: bool,

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -31,8 +31,8 @@ if T.TYPE_CHECKING:
     from ..interpreter import Interpreter
 
     ANY_DEP = T.Union[dependencies.Dependency, build.LinkableProto, str]
-    REQS = T.Union[dependencies.Dependency, build.LibTypes, str]
-    LIBS = T.Union[build.LibTypes, str]
+    REQS = T.Union[dependencies.Dependency, build.LibProto, str]
+    LIBS = T.Union[build.LibProto, str]
 
     class GenerateKw(TypedDict):
 
@@ -104,7 +104,7 @@ class DependenciesHelper:
         self.cflags: T.List[str] = []
         self.cflags_private: T.List[str] = []
         self.version_reqs: T.DefaultDict[str, T.Set[str]] = defaultdict(set)
-        self.link_whole_targets: T.List[build.StaticTargetTypes] = []
+        self.link_whole_targets: T.List[build.StaticTargetProto] = []
         self.uninstalled_incdirs: mesonlib.OrderedSet[str] = mesonlib.OrderedSet()
 
     def add_pub_libs(self, libs: T.List[ANY_DEP]) -> None:
@@ -124,7 +124,7 @@ class DependenciesHelper:
     def add_priv_reqs(self, reqs: T.List[REQS]) -> None:
         self.priv_reqs += self._process_reqs(reqs)
 
-    def _check_generated_pc_deprecation(self, obj: build.LibTypes) -> None:
+    def _check_generated_pc_deprecation(self, obj: build.LibProto) -> None:
         if obj.get_id() in self.metadata:
             return
         data = self.metadata[obj.get_id()]
@@ -268,7 +268,7 @@ class DependenciesHelper:
 
     def _add_lib_dependencies(
             self, link_targets: T.Sequence[build.LinkableProto],
-            link_whole_targets: T.Sequence[build.StaticTargetTypes],
+            link_whole_targets: T.Sequence[build.StaticTargetProto],
             external_deps: T.List[dependencies.Dependency],
             public: bool,
             private_external_deps: bool = False) -> None:
@@ -292,7 +292,7 @@ class DependenciesHelper:
         else:
             add_libs(T.cast('T.List[ANY_DEP]', external_deps))
 
-    def _add_link_whole(self, t: build.StaticTargetTypes, public: bool) -> None:
+    def _add_link_whole(self, t: build.StaticTargetProto, public: bool) -> None:
         # Don't include static libraries that we link_whole. But we still need to
         # include their dependencies: a static library we link_whole
         # could itself link to a shared library or an installed static library.
@@ -427,7 +427,7 @@ class PkgConfigModule(NewExtensionModule):
         if self.devenv is not None:
             b.devenv.append(self.devenv)
 
-    def _get_lname(self, l: build.LibTypes, msg: str, pcfile: str) -> str:
+    def _get_lname(self, l: build.LibProto, msg: str, pcfile: str) -> str:
         if isinstance(l, (build.CustomTargetIndex, build.CustomTarget)):
             basename = os.path.basename(l.get_filename())
             name = os.path.splitext(basename)[0]
@@ -610,12 +610,15 @@ class PkgConfigModule(NewExtensionModule):
                                 install_dir = _i[0] if _i else ''
                         if install_dir is False:
                             continue
+                        lname = self._get_lname(l, msg, pcfile)
+                        lflag = f'-l{lname}'
                         if isinstance(l, build.BuildTarget) and 'cs' in l.compilers:
                             if custom_install_dir:
                                 Lflag = '-r{}/{}'.format(self._escape(self._make_relative(prefix, install_dir, pure_path_class)),
                                                          l.filename)
                             else:
                                 Lflag = '-r${libdir}/%s' % l.filename
+                            lflag = None
                         else:
                             if custom_install_dir:
                                 Lflag = '-L{}'.format(self._escape(self._make_relative(prefix, install_dir, pure_path_class)))
@@ -624,13 +627,12 @@ class PkgConfigModule(NewExtensionModule):
                         if Lflag not in Lflags:
                             Lflags.append(Lflag)
                             yield Lflag
-                        lname = self._get_lname(l, msg, pcfile)
                         # If using a custom suffix, the compiler may not be able to
                         # find the library
                         if isinstance(l, build.BuildTarget) and l.name_suffix_set:
                             mlog.warning(msg.format(l.name, 'name_suffix', lname, pcfile))
-                        if isinstance(l, (build.CustomTarget, build.CustomTargetIndex)) or 'cs' not in l.compilers:
-                            yield f'-l{lname}'
+                        if lflag is not None:
+                            yield lflag
 
             if deps.pub_libs:
                 ofile.write('Libs: {}\n'.format(' '.join(generate_libs_flags(deps.pub_libs))))

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -30,7 +30,7 @@ if T.TYPE_CHECKING:
     from .. import mparser
     from ..interpreter import Interpreter
 
-    ANY_DEP = T.Union[dependencies.Dependency, build.LinkableTargetTypes, str]
+    ANY_DEP = T.Union[dependencies.Dependency, build.LinkableTargetProto, str]
     REQS = T.Union[dependencies.Dependency, build.LibTypes, str]
     LIBS = T.Union[build.LibTypes, str]
 
@@ -98,7 +98,7 @@ class _LibDeps:
     '''One pending step of the target graph walk in DependenciesHelper.'''
 
     source: object
-    link_targets: T.Sequence[build.LinkableTargetTypes]
+    link_targets: T.Sequence[build.LinkableTargetProto]
     link_whole_targets: T.Sequence[build.StaticTargetTypes]
     external_deps: T.List[dependencies.Dependency]
     public: bool

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -147,7 +147,7 @@ class DependenciesHelper:
         data = self.metadata[obj.get_id()]
         if data.warned:
             return
-        mlog.deprecation('Library', mlog.bold(obj.name), 'was passed to the '
+        mlog.deprecation('Library', mlog.bold(str(obj)), 'was passed to the '
                          '"libraries" keyword argument of a previous call '
                          'to generate() method instead of first positional '
                          'argument.', 'Adding', mlog.bold(data.display_name),

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -31,8 +31,8 @@ if T.TYPE_CHECKING:
     from ..interpreter import Interpreter
 
     ANY_DEP = T.Union[dependencies.Dependency, build.LinkableTargetProto, str]
-    REQS = T.Union[dependencies.Dependency, build.LibTypes, str]
-    LIBS = T.Union[build.LibTypes, str]
+    REQS = T.Union[dependencies.Dependency, build.LibTargetProto, str]
+    LIBS = T.Union[build.LibTargetProto, str]
 
     class GenerateKw(TypedDict):
 
@@ -99,7 +99,7 @@ class _LibDeps:
 
     source: object
     link_targets: T.Sequence[build.LinkableTargetProto]
-    link_whole_targets: T.Sequence[build.StaticTargetTypes]
+    link_whole_targets: T.Sequence[build.StaticTargetProto]
     external_deps: T.List[dependencies.Dependency]
     public: bool
 
@@ -118,7 +118,7 @@ class DependenciesHelper:
         self.cflags: T.List[str] = []
         self.cflags_private: T.List[str] = []
         self.version_reqs: T.DefaultDict[str, T.Set[str]] = defaultdict(set)
-        self.link_whole_targets: T.List[build.StaticTargetTypes] = []
+        self.link_whole_targets: T.List[build.StaticTargetProto] = []
         self.uninstalled_incdirs: mesonlib.OrderedSet[str] = mesonlib.OrderedSet()
         # Libraries whose recursive dependencies still have to be added.
         self._dep_stack: T.List[_LibDeps] = []
@@ -141,7 +141,7 @@ class DependenciesHelper:
     def add_priv_reqs(self, reqs: T.List[REQS]) -> None:
         self.priv_reqs += self._process_reqs(reqs)
 
-    def _check_generated_pc_deprecation(self, obj: build.LibTypes) -> None:
+    def _check_generated_pc_deprecation(self, obj: build.LibTargetProto) -> None:
         if obj.get_id() in self.metadata:
             return
         data = self.metadata[obj.get_id()]
@@ -442,8 +442,8 @@ class PkgConfigModule(NewExtensionModule):
         if self.devenv is not None:
             b.devenv.append(self.devenv)
 
-    def _get_lname(self, l: build.LibTypes, msg: str, pcfile: str) -> str:
-        if isinstance(l, (build.CustomTargetIndex, build.CustomTarget)):
+    def _get_lname(self, l: build.LibTargetProto, msg: str, pcfile: str) -> str:
+        if not isinstance(l, build.BuildTarget):
             basename = os.path.basename(l.get_filename())
             name = os.path.splitext(basename)[0]
             if name.startswith('lib'):
@@ -459,7 +459,7 @@ class PkgConfigModule(NewExtensionModule):
             return l.name[3:]
         # If the library is imported via an import library which is always
         # named after the target name, '-lfoo' is correct.
-        if isinstance(l, build.SharedLibrary) and l.import_filename:
+        if l.get_import_filename():
             return l.name
         # In other cases, we can't guarantee that the compiler will be able to
         # find the library via '-lfoo', so tell the user that.
@@ -625,12 +625,15 @@ class PkgConfigModule(NewExtensionModule):
                                 install_dir = _i[0] if _i else ''
                         if install_dir is False:
                             continue
+                        lname = self._get_lname(l, msg, pcfile)
+                        lflag = f'-l{lname}'
                         if isinstance(l, build.BuildTarget) and 'cs' in l.compilers:
                             if custom_install_dir:
                                 Lflag = '-r{}/{}'.format(self._escape(self._make_relative(prefix, install_dir, pure_path_class)),
                                                          l.filename)
                             else:
                                 Lflag = '-r${libdir}/%s' % l.filename
+                            lflag = None
                         else:
                             if custom_install_dir:
                                 Lflag = '-L{}'.format(self._escape(self._make_relative(prefix, install_dir, pure_path_class)))
@@ -639,13 +642,12 @@ class PkgConfigModule(NewExtensionModule):
                         if Lflag not in Lflags:
                             Lflags.append(Lflag)
                             yield Lflag
-                        lname = self._get_lname(l, msg, pcfile)
                         # If using a custom suffix, the compiler may not be able to
                         # find the library
                         if isinstance(l, build.BuildTarget) and l.name_suffix_set:
                             mlog.warning(msg.format(l.name, 'name_suffix', lname, pcfile))
-                        if isinstance(l, (build.CustomTarget, build.CustomTargetIndex)) or 'cs' not in l.compilers:
-                            yield f'-l{lname}'
+                        if lflag is not None:
+                            yield lflag
 
             if deps.pub_libs:
                 ofile.write('Libs: {}\n'.format(' '.join(generate_libs_flags(deps.pub_libs))))

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -32,7 +32,7 @@ from ..programs import ExternalProgram, NonExistingExternalProgram
 if T.TYPE_CHECKING:
     from . import ModuleState
     from .. import cargo
-    from ..build import ExecutableKeywordArguments, GeneratedTypes, IncludeDirs, LinkableTargetTypes, CommandTypes
+    from ..build import ExecutableKeywordArguments, GeneratedTypes, IncludeDirs, LinkableProto, CommandTypes
     from ..cargo.interpreter import RUST_ABI, PackageConfiguration
     from ..compilers.compilers import Language
     from ..compilers.rust import RustCompiler
@@ -55,7 +55,7 @@ if T.TYPE_CHECKING:
         args: T.List[ArgsType]
         dependencies: T.List[T.Union[Dependency, ExternalLibrary]]
         is_parallel: bool
-        link_with: T.List[LinkableTargetTypes]
+        link_with: T.List[LinkableProto]
         link_whole: T.List[T.Union[StaticLibrary, CustomTarget, CustomTargetIndex]]
         rust_args: T.List[str]
 

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -32,7 +32,7 @@ from ..programs import ExternalProgram, NonExistingExternalProgram
 if T.TYPE_CHECKING:
     from . import ModuleState
     from .. import cargo
-    from ..build import ExecutableKeywordArguments, GeneratedTypes, IncludeDirs, LinkableTargetTypes, CommandTypes
+    from ..build import ExecutableKeywordArguments, GeneratedTypes, IncludeDirs, LinkableTargetProto, CommandTypes
     from ..cargo.interpreter import RUST_ABI, PackageConfiguration
     from ..compilers.compilers import Language
     from ..compilers.rust import RustCompiler
@@ -55,7 +55,7 @@ if T.TYPE_CHECKING:
         args: T.List[ArgsType]
         dependencies: T.List[T.Union[Dependency, ExternalLibrary]]
         is_parallel: bool
-        link_with: T.List[LinkableTargetTypes]
+        link_with: T.List[LinkableTargetProto]
         link_whole: T.List[T.Union[StaticLibrary, CustomTarget, CustomTargetIndex]]
         rust_args: T.List[str]
 

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -32,7 +32,10 @@ from ..programs import ExternalProgram, NonExistingExternalProgram
 if T.TYPE_CHECKING:
     from . import ModuleState
     from .. import cargo
-    from ..build import ExecutableKeywordArguments, GeneratedTypes, IncludeDirs, LinkableProto, CommandTypes
+    from ..build import (
+        ExecutableKeywordArguments, GeneratedTypes, IncludeDirs, LinkableProto,
+        CommandTypes, StaticTargetProto
+    )
     from ..cargo.interpreter import RUST_ABI, PackageConfiguration
     from ..compilers.compilers import Language
     from ..compilers.rust import RustCompiler
@@ -56,7 +59,7 @@ if T.TYPE_CHECKING:
         dependencies: T.List[T.Union[Dependency, ExternalLibrary]]
         is_parallel: bool
         link_with: T.List[LinkableProto]
-        link_whole: T.List[T.Union[StaticLibrary, CustomTarget, CustomTargetIndex]]
+        link_whole: T.List[StaticTargetProto]
         rust_args: T.List[str]
 
     FuncTest = FuncRustTest[CommandTypes]

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -32,7 +32,7 @@ from ..programs import ExternalProgram, NonExistingExternalProgram
 if T.TYPE_CHECKING:
     from . import ModuleState
     from .. import cargo
-    from ..build import ExecutableKeywordArguments, GeneratedTypes, IncludeDirs, LinkableTargetProto, CommandTypes
+    from ..build import ExecutableKeywordArguments, GeneratedTypes, IncludeDirs, LinkableTargetProto, CommandTypes, StaticTargetProto
     from ..cargo.interpreter import RUST_ABI, PackageConfiguration
     from ..compilers.compilers import Language
     from ..compilers.rust import RustCompiler
@@ -56,7 +56,7 @@ if T.TYPE_CHECKING:
         dependencies: T.List[T.Union[Dependency, ExternalLibrary]]
         is_parallel: bool
         link_with: T.List[LinkableTargetProto]
-        link_whole: T.List[T.Union[StaticLibrary, CustomTarget, CustomTargetIndex]]
+        link_whole: T.List[StaticTargetProto]
         rust_args: T.List[str]
 
     FuncTest = FuncRustTest[CommandTypes]


### PR DESCRIPTION
This PR continues the idea of limiting Union to cases where individual members are categorized with `isinstance` tests. Instead, cases where Meson mostly uses duck typing between CustomTargetBase and BuildTarget are now handled with protocols. While `isinstance` tests *are* occasionally used with types declared as `*Proto` types, this use is relatively rare, especially in the interpreter->build interface.