### PR TITLE
ci: Disable git repository ownership checks

### DIFF
--- a/.github/workflows/os_comp.yml
+++ b/.github/workflows/os_comp.yml
@@ -61,6 +61,8 @@ jobs:
 
         source /ci/env_vars.sh
         cd $GITHUB_WORKSPACE
+        # disable git ownership checks
+        git config --global safe.directory '*'
         ./run_tests.py $CI_ARGS
 
   pypy:


### PR DESCRIPTION
Disable the new feature that ensures that the git repository is owned by the same user that runs the command.  This apparently is not true when running the test suite and breaks at least the Gentoo CI job.