### PR TITLE
Fix doc build failure and flakiness

### DIFF
--- a/docs/validatelinks.py
+++ b/docs/validatelinks.py
@@ -28,14 +28,20 @@ async def main(filename):
             tasks = []
             for link in LINK.finditer(text):
                 name, url = link.groups()
+                name = name.replace('\n', ' ')
                 task = asyncio.ensure_future(fetch(session, name, url, timeout))
                 tasks.append(task)
             responses = asyncio.gather(*tasks)
             errors = [r for r in await responses if r is not None]
+        bad = False
         for name, url, result in errors:
-            print(f'"{name}" {url} {result}')
+            if re.match(r'https://github.com/(search|topics/)', url) and result == 429:
+                print(f'"{name}" {url} {result} (ignored)')
+            else:
+                print(f'"{name}" {url} {result}')
+                bad = True
         if errors:
-            sys.exit(1)
+            sys.exit(int(bad))
 
 
 if __name__ == '__main__':

--- a/docs/yaml/objects/inc.yaml
+++ b/docs/yaml/objects/inc.yaml
@@ -4,7 +4,7 @@ description: Opaque wrapper for storing include directories
 
 methods:
 - name: to_list
-  returns: list[str]
+  returns: array[str]
   since: 1.12.0
   description: |
     Returns a list of strings of absolute paths to the directories


### PR DESCRIPTION
The doc build is failing, so fix it.

I let the failure slip through because I got a bit too accustomed to the flakiness of the update website job due to GitHub search returning a 429 Too Many Requests error, so ignore that failure too.

Fixes: #15941