### PR TITLE
docs: correct dep.as_system() default value

### DIFF
--- a/docs/yaml/objects/dep.yaml
+++ b/docs/yaml/objects/dep.yaml
@@ -90,7 +90,7 @@ methods:
     description: |
       Returns a copy of the dependency object, which has changed the value of `include_type`
       to `value`. The `value` argument is optional and
-      defaults to `'preserve'`.
+      defaults to `'system'`.
 
     optargs:
       value:


### PR DESCRIPTION
The reference manual states that the optional value argument to dep.as_system() defaults to 'preserve'. In practice, omitting the argument makes the dependency use the 'system' include type.

Update the documentation to describe the actual default behavior.

Fixes #13294

Note I found another PR also fixing this but it includes other changes as well and seem to have stalled (was created in 2024): https://github.com/mesonbuild/meson/pull/13861