### PR TITLE
cargo: fixes for cxx crate

### DIFF
--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -23,7 +23,10 @@ from pathlib import PurePath
 from . import builder, version
 from .cfg import eval_cfg
 from .toml import load_toml
-from .manifest import Manifest, CargoLock, CargoLockPackage, Workspace, fixup_meson_varname
+from .manifest import (
+    Manifest, CargoLock, CargoLockPackage, Workspace, fixup_meson_varname,
+    validate_patch,
+)
 from ..mesonlib import (
     is_parent_path, lazy_property, MesonException, MachineChoice,
     PerMachine, unique_list, SubProject,
@@ -332,6 +335,10 @@ class Interpreter:
         manifest, cached = self._load_manifest(subdir)
         ws = self._get_workspace(manifest, subdir, extra_members, False)
         if not cached:
+            # [patch] only takes effect in the top-level Cargo.toml
+            for warning in validate_patch(ws.workspace.patch, ws.packages_to_member):
+                mlog.warning(warning)
+
             self._prepare_entry_point(ws)
         return ws
 

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -338,6 +338,8 @@ class Interpreter:
             # [patch] only takes effect in the top-level Cargo.toml
             for warning in validate_patch(ws.workspace.patch, ws.packages_to_member):
                 mlog.warning(warning)
+            if ws.workspace.profile:
+                mlog.warning('[profile] entries are not implemented yet')
 
             self._prepare_entry_point(ws)
         return ws

--- a/mesonbuild/cargo/manifest.py
+++ b/mesonbuild/cargo/manifest.py
@@ -534,6 +534,9 @@ class Manifest:
     features: T.Dict[str, T.List[str]] = dataclasses.field(default_factory=dict)
     target: T.Dict[str, T.Dict[str, Dependency]] = dataclasses.field(default_factory=dict)
     lints: T.List[Lint] = dataclasses.field(default_factory=list)
+    # Kept in raw form: Meson does not implement [patch], it only validates it
+    # for the entry-point crate (see validate_patch).
+    patch: object = None
 
     # missing: profile
 
@@ -642,6 +645,9 @@ class Workspace:
     # A workspace can also have a root package.
     root_package: T.Optional[Manifest] = None
 
+    # Top-level [patch] table, kept in raw form (see Manifest.validate_patch).
+    patch: object = None
+
     @lazy_property
     def inheritable(self) -> T.Dict[str, object]:
         # the whole lints table is inherited.  Do not add package, dependencies
@@ -655,6 +661,10 @@ class Workspace:
         ws = _raw_to_dataclass(raw['workspace'], cls, 'Workspace')
         if 'package' in raw:
             ws.root_package = Manifest.from_raw(raw, path, ws, '.')
+            ws.patch = ws.root_package.patch
+        else:
+            ws.patch = raw.get('patch')
+
         ws.members = list(PurePath(m).as_posix() for m in ws.members)
         if ws.default_members:
             ws.default_members = list(PurePath(m).as_posix() for m in ws.default_members)
@@ -731,3 +741,27 @@ class CargoLock:
     def from_raw(cls, raw: raw.CargoLock) -> Self:
         return _raw_to_dataclass(raw, cls, 'Cargo.lock',
                                  package=ConvertValue(lambda x: [CargoLockPackage.from_raw(p) for p in x]))
+
+
+def validate_patch(patch: object, resolved: T.Mapping[str, str]) -> T.Iterator[str]:
+    # Meson does not implement [patch]; recognize entries that simply point
+    # at a package Meson already builds from the workspace ('resolved' maps
+    # each such package name to its path), and warn for everything else.
+    # This is only done for the top-level Cargo.toml, since Cargo ignores
+    # [patch] in a dependency's manifest too.
+    if not patch:
+        return
+    if not isinstance(patch, dict):
+        yield '[patch] format not recognized'
+    elif list(patch.keys()) != ['crates-io']:
+        yield 'Found [patch] for a registry other than crates.io'
+    elif not isinstance(patch['crates-io'], dict):
+        yield '[patch.crates-io] format not recognized'
+    else:
+        for name, value in patch['crates-io'].items():
+            if not isinstance(value, dict) or not isinstance(value.get('path'), str):
+                yield f'Unrecognized [patch.crates-io] entry {name!r}'
+            elif resolved.get(name) == os.path.normpath(value['path']):
+                continue
+            else:
+                yield f'[patch.crates-io] entry {name!r} is not for a dependency'

--- a/mesonbuild/cargo/manifest.py
+++ b/mesonbuild/cargo/manifest.py
@@ -537,8 +537,7 @@ class Manifest:
     # Kept in raw form: Meson does not implement [patch], it only validates it
     # for the entry-point crate (see validate_patch).
     patch: object = None
-
-    # missing: profile
+    profile: object = None
 
     def __post_init__(self) -> None:
         self.features.setdefault('default', [])
@@ -647,6 +646,7 @@ class Workspace:
 
     # Top-level [patch] table, kept in raw form (see Manifest.validate_patch).
     patch: object = None
+    profile: object = None
 
     @lazy_property
     def inheritable(self) -> T.Dict[str, object]:
@@ -662,8 +662,10 @@ class Workspace:
         if 'package' in raw:
             ws.root_package = Manifest.from_raw(raw, path, ws, '.')
             ws.patch = ws.root_package.patch
+            ws.profile = ws.root_package.profile
         else:
             ws.patch = raw.get('patch')
+            ws.profile = raw.get('profile')
 
         ws.members = list(PurePath(m).as_posix() for m in ws.members)
         if ws.default_members:

--- a/mesonbuild/cargo/manifest.py
+++ b/mesonbuild/cargo/manifest.py
@@ -448,6 +448,7 @@ class Example(BuildTarget):
     def from_raw(cls, raw: raw.BuildTarget, pkg: Package) -> Self:
         name = raw["name"]
         return _raw_to_dataclass(raw, cls, f'Example entry {name}',
+                                 ignored_fields=['doc-scrape-examples'],
                                  path=DefaultValue(f'examples/{name}.rs'),
                                  edition=DefaultValue(pkg.edition),
                                  test=DefaultValue(False),

--- a/mesonbuild/cargo/raw.py
+++ b/mesonbuild/cargo/raw.py
@@ -159,6 +159,32 @@ class Workspace(TypedDict):
     dependencies: T.Dict[str, DependencyV]
 
 
+Profile = TypedDict(
+    'Profile',
+    {
+        'opt-level': T.Union[int, str],
+        'debug': T.Union[bool, int, str],
+        'split-debuginfo': str,
+        'strip': T.Union[bool, str],
+        'debug-assertions': bool,
+        'overflow-checks': bool,
+        'lto': T.Union[bool, str],
+        'panic': str,
+        'incremental': bool,
+        'codegen-units': int,
+        'rpath': bool,
+        'inherits': str,
+        'package': T.Dict[str, 'Profile'],
+        'build-override': 'Profile',
+    },
+    total=False,
+)
+"""An entry in the [profile] section.
+
+See https://doc.rust-lang.org/cargo/reference/profiles.html
+"""
+
+
 Manifest = TypedDict(
     'Manifest',
     {
@@ -177,6 +203,7 @@ Manifest = TypedDict(
         'workspace': Workspace,
         'lints': T.Union[FromWorkspace, T.Dict[str, T.Dict[str, LintV]]],
         'patch': T.Dict[str, object],
+        'profile': T.Dict[str, Profile],
 
         # TODO: replace?
     },

--- a/mesonbuild/cargo/raw.py
+++ b/mesonbuild/cargo/raw.py
@@ -176,8 +176,8 @@ Manifest = TypedDict(
         'target': T.Dict[str, Target],
         'workspace': Workspace,
         'lints': T.Union[FromWorkspace, T.Dict[str, T.Dict[str, LintV]]],
+        'patch': T.Dict[str, object],
 
-        # TODO: patch?
         # TODO: replace?
     },
     total=False,

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3935,7 +3935,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         self.apply_machine_map_to_kwargs(kwargs)
         for_machine = kwargs['native']
 
-        if kwargs.get('rust_crate_type') == 'proc-macro':
+        if self.environment.is_cross_build() and kwargs.get('rust_crate_type') == 'proc-macro':
             # Silently force to native because that's the only sensible value
             # and rust_crate_type is deprecated any way.
             for_machine = MachineChoice.BUILD

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -354,7 +354,12 @@ class RustPackage(RustCrate):
         return None, args[0]
 
     def merge_kw_args(self, state: ModuleState, kwargs: T.Union[RustPackageExecutable, RustPackageLibrary]) -> None:
-        kwargs.setdefault('native', self.for_machine)
+        if state.environment.is_cross_build():
+            kwargs.setdefault('native', self.for_machine)
+        else:
+            # dependent crates are not compiled separately for build and host;
+            # do not use 'native: true' to allow linking to them without warnings
+            kwargs.setdefault('native', MachineChoice.HOST)
         cfg = self.package.cfg[kwargs['native']]
         if not cfg:
             raise MesonException(f"package {self.package.manifest.package.name}-{self.package.manifest.package.version} not configured for {self.for_machine}")
@@ -1025,6 +1030,8 @@ class RustModule(ExtensionModule):
     @typed_pos_args('rust.proc_macro', str, varargs=SOURCES_VARARGS)
     @typed_kwargs('rust.proc_macro', *_PROC_MACRO_KWS)
     def proc_macro(self, state: ModuleState, args: T.Tuple[str, SourcesVarargsType], kwargs: _kwargs.SharedLibrary) -> SharedLibrary:
+        # Silently force to native; rust.proc_macro() has always done
+        # that even when not cross compiling.
         kwargs['native'] = MachineChoice.BUILD
         kwargs['rust_crate_type'] = 'proc-macro'
         kwargs['rust_args'] = kwargs['rust_args'] + ['--extern', 'proc_macro']

--- a/unittests/cargotests.py
+++ b/unittests/cargotests.py
@@ -11,7 +11,7 @@ import typing as T
 from mesonbuild.cargo import cfg
 from mesonbuild.cargo.cfg import TokenType
 from mesonbuild.cargo.interpreter import load_cargo_lock
-from mesonbuild.cargo.manifest import Dependency, Lint, Manifest, Package, Workspace
+from mesonbuild.cargo.manifest import Dependency, Lint, Manifest, Package, Workspace, validate_patch
 from mesonbuild.cargo.toml import load_toml
 from mesonbuild.cargo.version import api, cargo_parse, SemVer
 from mesonbuild.mesonlib import MesonException
@@ -679,3 +679,38 @@ class CargoTomlTest(unittest.TestCase):
         self.assertEqual(manifest.features['v1_42'], ['pango-sys/v1_42'])
         self.assertEqual(manifest.features['v1_44'], ['v1_42', 'pango-sys/v1_44'])
         self.assertEqual(manifest.features['default'], [])
+
+    def test_validate_patch(self) -> None:
+        # packages_to_member values are normalized with os.path.normpath (see
+        # _load_workspace_member), so do the same here
+        resolved = {
+            'cxx': '.',
+            'cxx-build': os.path.normpath('gen/build'),
+            'member': os.path.normpath('vendor/member'),
+        }
+
+        patch = {'crates-io': {
+            'cxx': {'path': '.'},
+            'cxx-build': {'path': 'gen/build'},
+            'member': {'version': '1', 'path': 'vendor/member'},
+        }}
+
+        # Empty or absent [patch]
+        self.assertFalse(list(validate_patch(None, resolved)))
+        self.assertFalse(list(validate_patch({}, resolved)))
+
+        # Invalid [patch] tables
+        self.assertTrue(list(validate_patch({'crates-io': {}, 'https://example.com': {}}, resolved)))
+        self.assertTrue(list(validate_patch({'crates-io': 'nonsense'}, resolved)))
+        self.assertTrue(list(validate_patch('nonsense', resolved)))
+
+        # Invalid entries
+        self.assertTrue(list(validate_patch({'crates-io': {'cxx': {'git': 'https://example.com'}}}, resolved)))
+        self.assertTrue(list(validate_patch({'crates-io': {'cxx': '1.0'}}, resolved)))
+
+        # Unknown crate
+        self.assertTrue(list(validate_patch({'crates-io': {'unknown': {'path': 'foo'}}}, resolved)))
+
+        # The only entries that don't warn point at a package that Meson already builds
+        self.assertFalse(list(validate_patch(patch, resolved)))
+        self.assertTrue(list(validate_patch({'crates-io': {'cxx-build': {'path': 'elsewhere'}}}, resolved)))


### PR DESCRIPTION
This removes a few warnings found while porting cxx to Meson (https://github.com/dtolnay/cxx/pull/1722).

The larger (and planned) issue of supporting dev-dependencies and build-dependencies, which is needed to use cxx in cross compilation scenarios, is reported at #15944.