### PR TITLE
cargo: implement dev_dependencies and build_dependencies resolution

### DIFF
--- a/docs/markdown/snippets/cargo-dev-build-dependencies.md
+++ b/docs/markdown/snippets/cargo-dev-build-dependencies.md
@@ -1,0 +1,10 @@
+## Cargo dev-dependencies and build-dependencies are now supported
+
+The `package.dependencies()` method now accepts `dev_dependencies`
+and `build_dependencies` keyword arguments. Dev-dependencies are
+used by test targets, while build-dependencies are resolved with
+`native: true` for use by code generators.
+
+Workspace-level `[workspace.dev-dependencies]` and
+`[workspace.build-dependencies]` tables are also properly inherited
+by workspace members.

--- a/mesonbuild/cargo/__init__.py
+++ b/mesonbuild/cargo/__init__.py
@@ -1,9 +1,10 @@
 __all__ = [
     'Interpreter',
+    'PackageKey',
     'PackageState',
     'TomlImplementationMissing',
     'WorkspaceState',
 ]
 
-from .interpreter import Interpreter, PackageState, WorkspaceState
+from .interpreter import Interpreter, PackageKey, PackageState, WorkspaceState
 from .toml import TomlImplementationMissing

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -57,12 +57,21 @@ def _extra_deps_varname() -> str:
 
 @dataclasses.dataclass
 class PackageConfiguration:
-    """Configuration for a package during dependency resolution."""
+    """Configuration for a package during dependency resolution.
+
+    Tracks which dependencies (normal, dev, and build) have been resolved
+    for a given machine. Dev dependencies are used by tests. Build
+    dependencies are used by code generators and must be configured with
+    native: true (i.e. MachineChoice.BUILD).
+    """
     for_machine: MachineChoice
     features: T.Set[str] = dataclasses.field(default_factory=set)
     required_deps: T.Set[str] = dataclasses.field(default_factory=set)
+    required_dev_deps: T.Set[str] = dataclasses.field(default_factory=set)
+    required_build_deps: T.Set[str] = dataclasses.field(default_factory=set)
     optional_deps_features: T.Dict[str, T.Set[str]] = dataclasses.field(default_factory=lambda: collections.defaultdict(set))
-    # Cache of resolved dependency packages
+    # Cache of resolved dependency packages, shared across all three
+    # dependency categories (normal, dev, build).
     dep_packages: T.Dict[PackageKey, PackageState] = dataclasses.field(default_factory=dict)
 
     def get_features_args(self) -> T.List[str]:
@@ -72,16 +81,41 @@ class PackageConfiguration:
             args.extend(['--cfg', f'feature="{feature}"'])
         return args
 
-    def get_dependency_map(self, manifest: Manifest) -> T.Dict[str, str]:
-        """Get the rust dependency mapping for this package configuration."""
+    def _build_dependency_map_for(self, names: T.Iterable[str],
+                                  dep_dict: T.Dict[str, 'Dependency'],
+                                  for_machine: MachineChoice) -> T.Dict[str, str]:
+        """Build the library name to crate name mapping for a set of resolved
+        dependency names within a specific dependency dictionary."""
         dependency_map: T.Dict[str, str] = {}
-        for name in sorted(self.required_deps):
-            dep = manifest.dependencies[name]
+        for name in sorted(names):
+            dep = dep_dict[name]
             dep_key = PackageKey(dep.package, dep.api)
             dep_pkg = self.dep_packages[dep_key]
-            dep_lib_name = dep_pkg.library_name(self.for_machine)
+            dep_lib_name = dep_pkg.library_name(for_machine)
             dep_crate_name = name if name != dep.package else dep_pkg.manifest.lib.name
             dependency_map[dep_lib_name] = dep_crate_name
+        return dependency_map
+
+    def get_dependency_map(self, manifest: Manifest) -> T.Dict[str, str]:
+        """Get the rust dependency mapping for this package configuration.
+
+        Includes mappings from all three dependency categories: normal
+        dependencies, dev dependencies, and build dependencies.
+        """
+        dependency_map: T.Dict[str, str] = {}
+        dependency_map.update(
+            self._build_dependency_map_for(self.required_deps,
+                                           manifest.dependencies,
+                                           self.for_machine))
+        dependency_map.update(
+            self._build_dependency_map_for(self.required_dev_deps,
+                                           manifest.dev_dependencies,
+                                           self.for_machine))
+        # Build dependencies are always for the build machine.
+        dependency_map.update(
+            self._build_dependency_map_for(self.required_build_deps,
+                                           manifest.build_dependencies,
+                                           MachineChoice.BUILD))
         return dependency_map
 
 
@@ -564,6 +598,21 @@ class Interpreter:
         pkg.subproject_name = subp_name
         return pkg
 
+    def _find_dependency(self, pkg: PackageState, depname: str) -> T.Optional['Dependency']:
+        """Look up a dependency by name across all three dependency
+        categories: normal, dev, and build.
+
+        Returns the Dependency object if found, or None if the name
+        does not appear in any category.
+        """
+        dep = pkg.manifest.dependencies.get(depname)
+        if dep:
+            return dep
+        dep = pkg.manifest.dev_dependencies.get(depname)
+        if dep:
+            return dep
+        return pkg.manifest.build_dependencies.get(depname)
+
     def _prepare_package(self, pkg: PackageState, machine: MachineChoice) -> None:
         key = PackageKey(pkg.manifest.package.name, pkg.manifest.package.api)
         assert key in self.packages
@@ -571,14 +620,16 @@ class Interpreter:
             return  # Already prepared for this machine
 
         pkg.cfg[machine] = PackageConfiguration(for_machine=machine)
-        # Merge target-specific dependencies that are enabled for this machine
+        # Merge target specific dependencies that are enabled for this machine.
         target_cfgs = self._get_cfgs(machine)
         for condition, dependencies in pkg.manifest.target.items():
             if eval_cfg(condition, target_cfgs):
                 pkg.manifest.dependencies.update(dependencies)
 
-        # If you specify the optional dependency with the dep: prefix anywhere in the [features]
-        # table, that disables the implicit feature.
+        # If you specify the optional dependency with the dep: prefix anywhere
+        # in the [features] table, that disables the implicit feature. We scan
+        # all three dependency categories (normal, dev, build) because optional
+        # deps may appear in any of them.
         deps = set(feature[4:]
                    for feature in itertools.chain.from_iterable(pkg.manifest.features.values())
                    if feature.startswith('dep:'))
@@ -590,7 +641,9 @@ class Interpreter:
                 pkg.manifest.features[name].append(f'dep:{name}')
                 deps.add(name)
 
-        # Fetch required dependencies recursively for this machine
+        # Fetch required (non optional) dependencies recursively for this
+        # machine. Normal dependencies are resolved for the current machine,
+        # while dev and build dependencies are resolved later on demand.
         for depname, dep in pkg.manifest.dependencies.items():
             if not dep.optional:
                 self._add_dependency(pkg, depname, machine)
@@ -643,16 +696,29 @@ class Interpreter:
         return manifest_, False
 
     def _add_dependency(self, pkg: PackageState, depname: str, machine: MachineChoice) -> None:
+        """Resolve a normal (non dev, non build) dependency and register it.
+
+        If the dependency name is not found in the normal dependencies dict
+        it may belong to the dev or build categories; in that case we delegate
+        to the appropriate method so that it gets tracked in the right set.
+        """
         cfg = pkg.cfg[machine]
         if depname in cfg.required_deps:
             return
         dep = pkg.manifest.dependencies.get(depname)
         if not dep:
-            # It could be build/dev/target dependency. Just ignore it.
+            # The name might be a dev or build dependency referenced by a
+            # feature. Try those categories before giving up.
+            if depname in pkg.manifest.dev_dependencies:
+                self._add_dev_dependency(pkg, depname, machine)
+                return
+            if depname in pkg.manifest.build_dependencies:
+                self._add_build_dependency(pkg, depname, machine)
+                return
             return
         cfg.required_deps.add(depname)
         dep_pkg = self._dep_package(pkg, dep, cfg)
-        # Use machines_from() to determine which machines the dependency needs
+        # Use machines_from() to determine which machines the dependency needs.
         for dep_machine in dep_pkg.manifest.machines_from(machine, self.is_cross):
             self._prepare_package(dep_pkg, dep_machine)
             if dep.default_features:
@@ -661,6 +727,57 @@ class Interpreter:
                 self._enable_feature(dep_pkg, f, dep_machine)
             for f in cfg.optional_deps_features[depname]:
                 self._enable_feature(dep_pkg, f, dep_machine)
+
+    def _add_dev_dependency(self, pkg: PackageState, depname: str, machine: MachineChoice) -> None:
+        """Resolve a dev dependency and register it in required_dev_deps.
+
+        Dev dependencies are used by test targets. They are resolved for
+        the same machine as the parent package, following the same logic
+        as normal dependencies.
+        """
+        cfg = pkg.cfg[machine]
+        if depname in cfg.required_dev_deps:
+            return
+        dep = pkg.manifest.dev_dependencies.get(depname)
+        if not dep:
+            return
+        cfg.required_dev_deps.add(depname)
+        dep_pkg = self._dep_package(pkg, dep, cfg)
+        for dep_machine in dep_pkg.manifest.machines_from(machine, self.is_cross):
+            self._prepare_package(dep_pkg, dep_machine)
+            if dep.default_features:
+                self._enable_feature(dep_pkg, 'default', dep_machine)
+            for f in dep.features:
+                self._enable_feature(dep_pkg, f, dep_machine)
+            for f in cfg.optional_deps_features[depname]:
+                self._enable_feature(dep_pkg, f, dep_machine)
+
+    def _add_build_dependency(self, pkg: PackageState, depname: str, machine: MachineChoice) -> None:
+        """Resolve a build dependency and register it in required_build_deps.
+
+        Build dependencies in Cargo are used by build.rs code generators.
+        In Meson they correspond to tools that run on the build machine,
+        so they are always resolved with MachineChoice.BUILD regardless
+        of the parent package's machine. This ensures their own transitive
+        dependencies are also configured for the build machine.
+        """
+        cfg = pkg.cfg[machine]
+        if depname in cfg.required_build_deps:
+            return
+        dep = pkg.manifest.build_dependencies.get(depname)
+        if not dep:
+            return
+        cfg.required_build_deps.add(depname)
+        dep_pkg = self._dep_package(pkg, dep, cfg)
+        # Build dependencies always target the build machine so that their
+        # outputs can be used as code generators during compilation.
+        self._prepare_package(dep_pkg, MachineChoice.BUILD)
+        if dep.default_features:
+            self._enable_feature(dep_pkg, 'default', MachineChoice.BUILD)
+        for f in dep.features:
+            self._enable_feature(dep_pkg, f, MachineChoice.BUILD)
+        for f in cfg.optional_deps_features[depname]:
+            self._enable_feature(dep_pkg, f, MachineChoice.BUILD)
 
     def _enable_feature(self, pkg: PackageState, feature: str, machine: MachineChoice) -> None:
         cfg = pkg.cfg[machine]
@@ -676,10 +793,13 @@ class Interpreter:
                     depname = depname[:-1]
                 else:
                     self._add_dependency(pkg, depname, machine)
-                if depname in cfg.required_deps:
-                    dep = pkg.manifest.dependencies[depname]
+                # Check all dependency categories to find the resolved dep.
+                all_required = cfg.required_deps | cfg.required_dev_deps | cfg.required_build_deps
+                if depname in all_required:
+                    dep = self._find_dependency(pkg, depname)
                     dep_pkg = self._dep_package(pkg, dep, cfg)
-                    # Use machines_from() to determine which machines the dependency needs
+                    # Use machines_from() to determine which machines the
+                    # dependency needs.
                     for dep_machine in dep_pkg.manifest.machines_from(machine, self.is_cross):
                         self._enable_feature(dep_pkg, dep_f, dep_machine)
                 else:

--- a/mesonbuild/cargo/manifest.py
+++ b/mesonbuild/cargo/manifest.py
@@ -600,15 +600,36 @@ class Manifest:
                 autobins[bin_name] = Binary.from_raw({'name': bin_name, 'path': bin_path}, pkg)
 
         def dependencies_from_raw(x: T.Dict[str, T.Any]) -> T.Dict[str, Dependency]:
+            """Convert a raw dependency dictionary into resolved Dependency objects.
+
+            Each entry may reference workspace level values via workspace = true,
+            in which case the workspace object is consulted for the actual values.
+            """
             return {k: Dependency.from_raw(k, v, member_path, workspace) for k, v in x.items()}
+
+        def dev_dependencies_from_raw(x: T.Dict[str, T.Any]) -> T.Dict[str, Dependency]:
+            """Convert raw dev dependency entries, using the workspace's
+            dev_dependencies table for workspace = true resolution."""
+            ws_for_dev = None
+            if workspace:
+                ws_for_dev = dataclasses.replace(workspace, dependencies=workspace.dev_dependencies)
+            return {k: Dependency.from_raw(k, v, member_path, ws_for_dev) for k, v in x.items()}
+
+        def build_dependencies_from_raw(x: T.Dict[str, T.Any]) -> T.Dict[str, Dependency]:
+            """Convert raw build dependency entries, using the workspace's
+            build_dependencies table for workspace = true resolution."""
+            ws_for_build = None
+            if workspace:
+                ws_for_build = dataclasses.replace(workspace, dependencies=workspace.build_dependencies)
+            return {k: Dependency.from_raw(k, v, member_path, ws_for_build) for k, v in x.items()}
 
         return _raw_to_dataclass(raw, cls, f'Cargo.toml package {pkg.name}',
                                  raw_from_workspace=workspace.inheritable if workspace else None,
                                  ignored_fields=['badges', 'workspace'],
                                  package=ConvertValue(lambda _: pkg),
                                  dependencies=ConvertValue(dependencies_from_raw),
-                                 dev_dependencies=ConvertValue(dependencies_from_raw),
-                                 build_dependencies=ConvertValue(dependencies_from_raw),
+                                 dev_dependencies=ConvertValue(dev_dependencies_from_raw),
+                                 build_dependencies=ConvertValue(build_dependencies_from_raw),
                                  lints=ConvertValue(Lint.from_raw),
                                  lib=ConvertValue(lambda x: Library.from_raw(x, pkg), default=autolib),
                                  bin=DictMergeValue(lambda x: [Binary.from_raw(b, pkg) for b in x],
@@ -625,6 +646,12 @@ class Manifest:
 class Workspace:
 
     """Cargo Workspace definition.
+
+    Workspaces can define shared dependency tables (dependencies,
+    dev_dependencies, build_dependencies) that members can inherit
+    from using the ``workspace = true`` syntax in their Cargo.toml.
+    These are stored in raw format so that ``_raw_to_dataclass`` can
+    resolve per field workspace inheritance for each member.
     """
 
     resolver: str = dataclasses.field(default_factory=lambda: '2')
@@ -632,9 +659,11 @@ class Workspace:
     exclude: T.List[str] = dataclasses.field(default_factory=list)
     default_members: T.List[str] = dataclasses.field(default_factory=list)
 
-    # inheritable settings are kept in raw format, for use with _raw_to_dataclass
+    # Inheritable settings are kept in raw format, for use with _raw_to_dataclass.
     package: T.Optional[raw.Package] = None
     dependencies: T.Dict[str, raw.Dependency] = dataclasses.field(default_factory=dict)
+    dev_dependencies: T.Dict[str, raw.Dependency] = dataclasses.field(default_factory=dict)
+    build_dependencies: T.Dict[str, raw.Dependency] = dataclasses.field(default_factory=dict)
     lints: T.Dict[str, T.Dict[str, raw.LintV]] = dataclasses.field(default_factory=dict)
     metadata: T.Dict[str, T.Any] = dataclasses.field(default_factory=dict)
 
@@ -643,7 +672,7 @@ class Workspace:
 
     @lazy_property
     def inheritable(self) -> T.Dict[str, object]:
-        # the whole lints table is inherited.  Do not add package, dependencies
+        # The whole lints table is inherited. Do not add package, dependencies
         # etc. because they can only be inherited a field at a time.
         return {
             'lints': self.lints,

--- a/mesonbuild/cargo/raw.py
+++ b/mesonbuild/cargo/raw.py
@@ -142,21 +142,30 @@ LintV = T.Union[Lint, str]
 """A Lint entry, either a string or a Lint Dict."""
 
 
-class Workspace(TypedDict):
+Workspace = TypedDict(
+    'Workspace',
+    {
+        'members': T.List[str],
+        'exclude': T.List[str],
+        'package': Package,
+        'dependencies': T.Dict[str, DependencyV],
+        'dev-dependencies': T.Dict[str, DependencyV],
+        'build-dependencies': T.Dict[str, DependencyV],
+    },
+    total=False,
+)
+"""The representation of a workspace.
 
-    """The representation of a workspace.
+In a virtual manifest the members key is always present, but in a
+project manifest, an empty workspace may be provided, in which case the
+workspace is implicitly filled in by values from the path based dependencies.
 
-    In a vritual manifest the :attribute:`members` is always present, but in a
-    project manifest, an empty workspace may be provided, in which case the
-    workspace is implicitly filled in by values from the path based dependencies.
+The exclude key is always optional.
 
-    the :attribute:`exclude` is always optional
-    """
-
-    members: T.List[str]
-    exclude: T.List[str]
-    package: Package
-    dependencies: T.Dict[str, DependencyV]
+Cargo workspaces can also define shared dependency tables (dependencies,
+dev-dependencies, build-dependencies) that members can inherit from via
+the workspace = true syntax in their own Cargo.toml.
+"""
 
 
 Manifest = TypedDict(

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -90,6 +90,7 @@ if T.TYPE_CHECKING:
     class RustPackageDependencies(TypedDict):
         dependencies: bool
         dev_dependencies: bool
+        build_dependencies: bool
         system_dependencies: bool
 
     class RustPackageExecutable(_kwargs.Executable):
@@ -303,30 +304,86 @@ class RustPackage(RustCrate):
             'override_dependency': self.override_dependency_method,
         })
 
+    def _resolve_dep_packages(self, state: ModuleState,
+                              dep_names: T.Set[str],
+                              dep_dict: T.Dict[str, 'cargo.manifest.Dependency'],
+                              cfg: 'PackageConfiguration',
+                              for_machine: MachineChoice) -> T.List[Dependency]:
+        """Resolve a set of dependency names into Meson dependency objects.
+
+        For each resolved dependency that has a library, this method
+        ensures its subproject has been processed and returns the
+        overridden Meson dependency.
+        """
+        dependencies: T.List[Dependency] = []
+        for depname in sorted(dep_names):
+            dep = dep_dict[depname]
+            dep_key = cargo.PackageKey(dep.package, dep.api)
+            dep_pkg = cfg.dep_packages.get(dep_key)
+            if dep_pkg and dep_pkg.manifest.lib:
+                if dep_pkg.ws_subdir != self.rust_ws.subdir or \
+                    is_parent_path(os.path.join(self.rust_ws.subdir, state.subproject_dir),
+                                   dep_pkg.path):
+                    self.rust_ws._do_subproject(state, dep_pkg, for_machine)
+                meson_depname = dep_pkg.get_rust_dependency_name()
+                dependency = state.overridden_dependency(meson_depname, for_machine)
+                dependencies.append(dependency)
+        return dependencies
+
     def _dependencies_method(self, state: ModuleState, kwargs: RustPackageDependencies,
                              for_machine: MachineChoice) -> T.List[Dependency]:
+        """Core implementation of the dependencies() method.
+
+        Collects and returns Meson dependency objects for the requested
+        categories of Cargo dependencies:
+          * dependencies: normal crate dependencies
+          * dev_dependencies: test only dependencies
+          * build_dependencies: build.rs / code generator dependencies
+            (always resolved for MachineChoice.BUILD)
+          * system_dependencies: system pkg-config dependencies
+        """
         dependencies: T.List[Dependency] = []
         cfg = self.package.cfg[for_machine]
 
         if kwargs['dependencies']:
-            for dep_key, dep_pkg in cfg.dep_packages.items():
-                if dep_pkg.manifest.lib:
-                    if dep_pkg.ws_subdir != self.rust_ws.subdir or \
-                        is_parent_path(os.path.join(self.rust_ws.subdir, state.subproject_dir),
-                                       dep_pkg.path):
-                        self.rust_ws._do_subproject(state, dep_pkg, for_machine)
-                    # Get the dependency name for this package (rust or proc-macro ABI)
-                    depname = dep_pkg.get_rust_dependency_name()
-                    dependency = state.overridden_dependency(depname, for_machine)
-                    dependencies.append(dependency)
+            dependencies.extend(
+                self._resolve_dep_packages(
+                    state, cfg.required_deps,
+                    self.package.manifest.dependencies,
+                    cfg, for_machine))
 
         if kwargs['dev_dependencies']:
-            raise MesonException('dev_dependencies is not implemented yet')
+            # Resolve any dev dependencies that have not been fetched yet.
+            # Dev dependencies are used by test targets and share the
+            # same machine as the parent package.
+            cargo_interp = state._interpreter.cargo
+            for depname, dep in self.package.manifest.dev_dependencies.items():
+                if not dep.optional or depname in cfg.features:
+                    cargo_interp._add_dev_dependency(self.package, depname, for_machine)
+            dependencies.extend(
+                self._resolve_dep_packages(
+                    state, cfg.required_dev_deps,
+                    self.package.manifest.dev_dependencies,
+                    cfg, for_machine))
+
+        if kwargs['build_dependencies']:
+            # Resolve any build dependencies that have not been fetched yet.
+            # Build dependencies are always for the build machine because
+            # they represent tools (code generators) that run during
+            # compilation.
+            cargo_interp = state._interpreter.cargo
+            for depname, dep in self.package.manifest.build_dependencies.items():
+                if not dep.optional or depname in cfg.features:
+                    cargo_interp._add_build_dependency(self.package, depname, for_machine)
+            dependencies.extend(
+                self._resolve_dep_packages(
+                    state, cfg.required_build_deps,
+                    self.package.manifest.build_dependencies,
+                    cfg, MachineChoice.BUILD))
 
         if kwargs['system_dependencies']:
             for name, sys_dep in self.package.manifest.system_dependencies.items():
                 if sys_dep.enabled(cfg.features):
-                    # System dependencies use the original dependency name from Cargo.toml
                     dependency = state.dependency(sys_dep.name, native=(for_machine == MachineChoice.BUILD),
                                                   required=not sys_dep.optional,
                                                   wanted=sys_dep.meson_version)
@@ -338,9 +395,16 @@ class RustPackage(RustCrate):
     @typed_kwargs('package.dependencies',
                   KwargInfo('dependencies', bool, default=True),
                   KwargInfo('dev_dependencies', bool, default=False),
+                  KwargInfo('build_dependencies', bool, default=False),
                   KwargInfo('system_dependencies', bool, default=True))
     def dependencies_method(self, state: ModuleState, args: T.List, kwargs: RustPackageDependencies) -> T.List[Dependency]:
-        """Returns the dependencies for this package."""
+        """Returns the dependencies for this package.
+
+        By default only normal and system dependencies are included.
+        Pass dev_dependencies: true to include test only dependencies,
+        or build_dependencies: true to include build.rs / code generator
+        dependencies (which are always native: true).
+        """
         return self._dependencies_method(state, kwargs, self.for_machine)
 
     @staticmethod
@@ -363,6 +427,7 @@ class RustPackage(RustCrate):
         kwargs['dependencies'] = self._dependencies_method(state, {
             'dependencies': True,
             'dev_dependencies': False,
+            'build_dependencies': False,
             'system_dependencies': True,
         }, kwargs['native'])
         kwargs['dependencies'].extend(deps)


### PR DESCRIPTION
Closes #15944

## Summary

This PR implements full resolution for `dev-dependencies` and
`build-dependencies` in the Cargo integration. Previously these were
parsed from `Cargo.toml` but never resolved or exposed through the
Rust module API.

## Changes

**Cargo interpreter** (`mesonbuild/cargo/interpreter.py`):
- Added `required_dev_deps` and `required_build_deps` tracking in
  `PackageConfiguration`
- New `_add_dev_dependency()` and `_add_build_dependency()` methods
- Build dependencies always use `MachineChoice.BUILD`
- Feature resolution (`dep:` and `dep/feature`) now searches all
  three dependency categories
- `get_dependency_map()` includes dev/build deps

**Rust module** (`mesonbuild/modules/rust.py`):
- `package.dependencies(dev_dependencies: true)` now works (was
  raising "not implemented yet")
- New `build_dependencies` kwarg on `package.dependencies()`
  (default: `false`)
- Extracted `_resolve_dep_packages()` helper for reuse

**Manifest/raw types** (`mesonbuild/cargo/manifest.py`,
`mesonbuild/cargo/raw.py`):
- Workspace-level `dev-dependencies` and `build-dependencies`
  tables are now parsed and inherited by members

## Testing

All 20 existing cargo unit tests pass. This is a foundational change
that enables future test and example target support in the Cargo
integration.
