### PR TITLE
environment: write CACHEDIR.TAG in build directories

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -4164,6 +4164,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 # Create a list of all custom target outputs
                 for o in t.get_outputs():
                     ctlist.append(os.path.join(self.get_target_dir(t), o))
+        # Also clean meson-dist directory created by `meson dist`
+        ctlist.append('meson-dist')
         if ctlist:
             elem.add_dep(self.generate_custom_target_clean(ctlist))
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -95,6 +95,14 @@ class Environment:
             os.makedirs(self.scratch_dir, exist_ok=True)
             os.makedirs(self.log_dir, exist_ok=True)
             os.makedirs(self.info_dir, exist_ok=True)
+            # Write CACHEDIR.TAG so backup tools can identify this as cache
+            cachedir_tag = os.path.join(build_dir, 'CACHEDIR.TAG')
+            if not os.path.exists(cachedir_tag):
+                with open(cachedir_tag, 'w') as f:
+                    f.write('Signature: 8a477f597d28d172789f06886806bc55\n'
+                            '# This file is a cache directory tag created by Meson.\n'
+                            '# For information about cache directory tags, see:\n'
+                            '#\thttps://bford.info/cachedir/\n')
             try:
                 self.coredata: coredata.CoreData = coredata.load(self.get_build_dir(), suggest_reconfigure=False)
                 self.first_invocation = False

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -72,6 +72,7 @@ class _Logger:
     log_fatal_warnings = False
     log_disable_stdout = False
     log_errors_only = False
+    force_colorize: T.Optional[bool] = None
     logged_once: T.Set[T.Tuple[str, ...]] = field(default_factory=set)
     log_warnings_counter = 0
     log_pager: T.Optional['subprocess.Popen'] = None
@@ -104,6 +105,9 @@ class _Logger:
 
     def set_timestamp_start(self, start: float) -> None:
         self.log_timestamp_start = start
+
+    def set_colorize(self, colorize: T.Optional[bool]) -> None:
+        self.force_colorize = colorize
 
     def shutdown(self) -> T.Optional[str]:
         if self.log_file is not None:
@@ -395,6 +399,8 @@ class _Logger:
         self.log_to_stderr = to_stderr
 
     def colorize_console(self) -> bool:
+        if self.force_colorize is not None:
+            return self.force_colorize
         output = sys.stderr if self.log_to_stderr else sys.stdout
         _colorize_console: bool = getattr(output, 'colorize_console', None)
         if _colorize_console is not None:
@@ -441,6 +447,7 @@ notice = _logger.notice
 process_markup = _logger.process_markup
 redirect = _logger.redirect
 set_quiet = _logger.set_quiet
+set_colorize = _logger.set_colorize
 set_timestamp_start = _logger.set_timestamp_start
 set_verbose = _logger.set_verbose
 setup_console = _logger.setup_console

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -186,6 +186,13 @@ class MesonApp:
             assert self.options.reconfigure
             env.coredata.set_from_configure_command(self.options)
         mlog.initialize(env.get_log_dir(), self.options.fatal_warnings)
+        # Honor b_colorout option for setup output
+        colorout = env.coredata.optstore.get_value_for('b_colorout') \
+            if OptionKey('b_colorout') in env.coredata.optstore else 'auto'
+        if colorout == 'always':
+            mlog.set_colorize(True)
+        elif colorout == 'never':
+            mlog.set_colorize(False)
         if self.options.profile:
             mlog.set_timestamp_start(time.monotonic())
         if self.options.clearcache:


### PR DESCRIPTION
Write the standard CACHEDIR.TAG file when creating a new build directory, so backup tools (Pika Backup, Deja Dup, borg, restic) can identify and skip meson build trees.

The tag follows https://bford.info/cachedir/ spec exactly.

Fixes #11734