### PR TITLE
backend/ninja: clean meson-dist directory during ninja clean

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -4164,6 +4164,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 # Create a list of all custom target outputs
                 for o in t.get_outputs():
                     ctlist.append(os.path.join(self.get_target_dir(t), o))
+        # Also clean meson-dist directory created by `meson dist`
+        ctlist.append('meson-dist')
         if ctlist:
             elem.add_dep(self.generate_custom_target_clean(ctlist))
 


### PR DESCRIPTION
ninja -t clean left meson-dist behind because it's not tracked by ninja. The meson-clean target now passes 'meson-dist' to the cleantrees script so it gets removed along with custom target dirs.

Fixes #3789