### PR TITLE
envconfig: warn on unknown system in cross files

### DIFF
--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -77,6 +77,23 @@ known_cpu_families = (
     'tricore'
 )
 
+known_systems = (
+    'aix',
+    'android',
+    'cygwin',
+    'darwin',
+    'dragonfly',
+    'freebsd',
+    'gnu',
+    'haiku',
+    'linux',
+    'netbsd',
+    'openbsd',
+    'os/2',
+    'sunos',
+    'windows',
+)
+
 # It would feel more natural to call this "64_BIT_CPU_FAMILIES", but
 # python identifiers cannot start with numbers
 CPU_FAMILIES_64_BIT = [
@@ -302,6 +319,8 @@ class MachineInfo(HoldableObject):
             mlog.warning(f'Unknown endian {endian}')
 
         system = literal['system']
+        if system not in known_systems:
+            mlog.warning(f'Unknown system {system}, please report this at https://github.com/mesonbuild/meson/issues/new')
         kernel = literal.get('kernel', None)
         subsystem = literal.get('subsystem', None)
 

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -77,6 +77,23 @@ known_cpu_families = (
     'tricore'
 )
 
+KNOWN_SYSTEMS = frozenset({
+    'aix',
+    'android',
+    'cygwin',
+    'darwin',
+    'dragonfly',
+    'freebsd',
+    'gnu',
+    'haiku',
+    'linux',
+    'netbsd',
+    'openbsd',
+    'os/2',
+    'sunos',
+    'windows',
+})
+
 # It would feel more natural to call this "64_BIT_CPU_FAMILIES", but
 # python identifiers cannot start with numbers
 CPU_FAMILIES_64_BIT = [
@@ -302,6 +319,8 @@ class MachineInfo(HoldableObject):
             mlog.warning(f'Unknown endian {endian}')
 
         system = literal['system']
+        if system not in KNOWN_SYSTEMS:
+            mlog.warning(f'Unknown system {system}, please report this at https://github.com/mesonbuild/meson/issues/new')
         kernel = literal.get('kernel', None)
         subsystem = literal.get('subsystem', None)
 


### PR DESCRIPTION
CPU family validation already warned on unknown values. Add the same check for the system field so cross-file authors get feedback when they use non-standard system names.

Also adds a known_systems tuple documenting all supported values.

Fixes #3751