### PR TITLE
Make strict_optional opt out for mesonbuild, not opt in

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -27,53 +27,194 @@ check_untyped_defs            = True
 allow_redefinition_new        = True
 local_partial_types           = True
 
-[mypy-mesonbuild.cmdline]
+[mypy-mesonbuild.*]
 strict_optional               = True
 
-[mypy-mesonbuild.coredata]
-strict_optional               = True
+[mypy-mesonbuild.ast.interpreter]
+strict_optional               = False
 
-[mypy-mesonbuild.depfile]
-strict_optional               = True
+[mypy-mesonbuild.ast.introspection]
+strict_optional               = False
 
-[mypy-mesonbuild.envconfig]
-strict_optional               = True
+[mypy-mesonbuild.backend.backends]
+strict_optional               = False
 
-[mypy-mesonbuild.environment]
-strict_optional               = True
+[mypy-mesonbuild.backend.ninjabackend]
+strict_optional               = False
 
-[mypy-mesonbuild.machinefile]
-strict_optional               = True
+[mypy-mesonbuild.backend.nonebackend]
+strict_optional               = False
 
-[mypy-mesonbuild.mcompile]
-strict_optional               = True
+[mypy-mesonbuild.backend.vs2010backend]
+strict_optional               = False
 
-[mypy-mesonbuild.mconf]
-strict_optional               = True
+[mypy-mesonbuild.backend.xcodebackend]
+strict_optional               = False
 
-[mypy-mesonbuild.mdevenv]
-strict_optional               = True
+[mypy-mesonbuild.build]
+strict_optional               = False
 
-[mypy-mesonbuild.mdist]
-strict_optional               = True
+[mypy-mesonbuild.cargo.interpreter]
+strict_optional               = False
 
-[mypy-mesonbuild.mesondata]
-strict_optional               = True
+[mypy-mesonbuild.cmake.executor]
+strict_optional               = False
 
-[mypy-mesonbuild.mesonmain]
-strict_optional               = True
+[mypy-mesonbuild.cmake.interpreter]
+strict_optional               = False
 
-[mypy-mesonbuild.minit]
-strict_optional               = True
+[mypy-mesonbuild.cmake.toolchain]
+strict_optional               = False
 
-[mypy-mesonbuild.minstall]
-strict_optional               = True
+[mypy-mesonbuild.cmake.tracetargets]
+strict_optional               = False
 
-[mypy-mesonbuild.mlog]
-strict_optional               = True
+[mypy-mesonbuild.compilers.*]
+strict_optional               = False
 
-[mypy-mesonbuild.programs]
-strict_optional               = True
+[mypy-mesonbuild.dependencies.base]
+strict_optional               = False
 
-[mypy-mesonbuild.tooldetect]
-strict_optional               = True
+[mypy-mesonbuild.dependencies.boost]
+strict_optional               = False
+
+[mypy-mesonbuild.dependencies.configtool]
+strict_optional               = False
+
+[mypy-mesonbuild.dependencies.cuda]
+strict_optional               = False
+
+[mypy-mesonbuild.dependencies.detect]
+strict_optional               = False
+
+[mypy-mesonbuild.dependencies.dev]
+strict_optional               = False
+
+[mypy-mesonbuild.dependencies.dub]
+strict_optional               = False
+
+[mypy-mesonbuild.dependencies.framework]
+strict_optional               = False
+
+[mypy-mesonbuild.dependencies.hdf5]
+strict_optional               = False
+
+[mypy-mesonbuild.dependencies.misc]
+strict_optional               = False
+
+[mypy-mesonbuild.dependencies.mpi]
+strict_optional               = False
+
+[mypy-mesonbuild.dependencies.pkgconfig]
+strict_optional               = False
+
+[mypy-mesonbuild.dependencies.python]
+strict_optional               = False
+
+[mypy-mesonbuild.dependencies.qt]
+strict_optional               = False
+
+[mypy-mesonbuild.dependencies.ui]
+strict_optional               = False
+
+[mypy-mesonbuild.interpreterbase.interpreterbase]
+strict_optional               = False
+
+[mypy-mesonbuild.interpreterbase.baseobjects]
+strict_optional               = False
+
+[mypy-mesonbuild.interpreterbase.decorators]
+strict_optional               = False
+
+[mypy-mesonbuild.interpreter.interpreter]
+strict_optional               = False
+
+[mypy-mesonbuild.interpreter.interpreterobjects]
+strict_optional               = False
+
+[mypy-mesonbuild.interpreter.compiler]
+strict_optional               = False
+
+[mypy-mesonbuild.interpreter.dependencyfallbacks]
+strict_optional               = False
+
+[mypy-mesonbuild.linkers.detect]
+strict_optional               = False
+
+[mypy-mesonbuild.mformat]
+strict_optional               = False
+
+[mypy-mesonbuild.mintro]
+strict_optional               = False
+
+[mypy-mesonbuild.modules]
+strict_optional               = False
+
+[mypy-mesonbuild.modules.cmake]
+strict_optional               = False
+
+[mypy-mesonbuild.modules.codegen]
+strict_optional               = False
+
+[mypy-mesonbuild.modules.cuda]
+strict_optional               = False
+
+[mypy-mesonbuild.modules.gnome]
+strict_optional               = False
+
+[mypy-mesonbuild.modules.rust]
+strict_optional               = False
+
+[mypy-mesonbuild.modules.pkgconfig]
+strict_optional               = False
+
+[mypy-mesonbuild.modules.python]
+strict_optional               = False
+
+[mypy-mesonbuild.modules._qt]
+strict_optional               = False
+
+[mypy-mesonbuild.modules.i18n]
+strict_optional               = False
+
+[mypy-mesonbuild.mparser]
+strict_optional               = False
+
+[mypy-mesonbuild.msetup]
+strict_optional               = False
+
+[mypy-mesonbuild.msubprojects]
+strict_optional               = False
+
+[mypy-mesonbuild.mtest]
+strict_optional               = False
+
+[mypy-mesonbuild.optinterpreter]
+strict_optional               = False
+
+[mypy-mesonbuild.options]
+strict_optional               = False
+
+[mypy-mesonbuild.rewriter]
+strict_optional               = False
+
+[mypy-mesonbuild.wrap.wrap]
+strict_optional               = False
+
+[mypy-mesonbuild.wrap.wraptool]
+strict_optional               = False
+
+[mypy-mesonbuild.scripts.coverage]
+strict_optional               = False
+
+[mypy-mesonbuild.scripts.symbolextractor]
+strict_optional               = False
+
+[mypy-mesonbuild.scripts.scanbuild]
+strict_optional               = False
+
+[mypy-mesonbuild.scripts.depfixer]
+strict_optional               = False
+
+[mypy-mesonbuild.utils.universal]
+strict_optional               = False

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -27,62 +27,181 @@ check_untyped_defs            = True
 allow_redefinition_new        = True
 local_partial_types           = True
 
+[mypy-mesonbuild.*]
+strict_optional               = True
+
+[mypy-mesonbuild.ast.interpreter]
+strict_optional               = False
+
+[mypy-mesonbuild.ast.introspection]
+strict_optional               = False
+
+[mypy-mesonbuild.backend.backends]
+strict_optional               = False
+
+[mypy-mesonbuild.backend.ninjabackend]
+strict_optional               = False
+
+[mypy-mesonbuild.backend.nonebackend]
+strict_optional               = False
+
+[mypy-mesonbuild.backend.vs2010backend]
+strict_optional               = False
+
+[mypy-mesonbuild.backend.xcodebackend]
+strict_optional               = False
+
 [mypy-mesonbuild.build]
+strict_optional               = False
 warn_unreachable              = False
 
-[mypy-mesonbuild.cmdline]
-strict_optional               = True
+[mypy-mesonbuild.cargo.interpreter]
+strict_optional               = False
 
-[mypy-mesonbuild.coredata]
-strict_optional               = True
+[mypy-mesonbuild.cmake.executor]
+strict_optional               = False
 
-[mypy-mesonbuild.depfile]
-strict_optional               = True
+[mypy-mesonbuild.cmake.interpreter]
+strict_optional               = False
 
-[mypy-mesonbuild.envconfig]
-strict_optional               = True
+[mypy-mesonbuild.cmake.toolchain]
+strict_optional               = False
 
-[mypy-mesonbuild.environment]
-strict_optional               = True
+[mypy-mesonbuild.cmake.tracetargets]
+strict_optional               = False
 
-[mypy-mesonbuild.machinefile]
-strict_optional               = True
+[mypy-mesonbuild.compilers.*]
+strict_optional               = False
 
-[mypy-mesonbuild.mcompile]
-strict_optional               = True
+[mypy-mesonbuild.dependencies.base]
+strict_optional               = False
 
-[mypy-mesonbuild.mconf]
-strict_optional               = True
+[mypy-mesonbuild.dependencies.boost]
+strict_optional               = False
 
-[mypy-mesonbuild.mdevenv]
-strict_optional               = True
+[mypy-mesonbuild.dependencies.configtool]
+strict_optional               = False
 
-[mypy-mesonbuild.mdist]
-strict_optional               = True
+[mypy-mesonbuild.dependencies.cuda]
+strict_optional               = False
 
-[mypy-mesonbuild.mesondata]
-strict_optional               = True
+[mypy-mesonbuild.dependencies.detect]
+strict_optional               = False
 
-[mypy-mesonbuild.mesonmain]
-strict_optional               = True
+[mypy-mesonbuild.dependencies.dev]
+strict_optional               = False
+
+[mypy-mesonbuild.dependencies.dub]
+strict_optional               = False
+
+[mypy-mesonbuild.dependencies.framework]
+strict_optional               = False
+
+[mypy-mesonbuild.dependencies.hdf5]
+strict_optional               = False
+
+[mypy-mesonbuild.dependencies.misc]
+strict_optional               = False
+
+[mypy-mesonbuild.dependencies.mpi]
+strict_optional               = False
+
+[mypy-mesonbuild.dependencies.pkgconfig]
+strict_optional               = False
+
+[mypy-mesonbuild.dependencies.python]
+strict_optional               = False
+
+[mypy-mesonbuild.dependencies.qt]
+strict_optional               = False
+
+[mypy-mesonbuild.dependencies.ui]
+strict_optional               = False
+
+[mypy-mesonbuild.interpreterbase.interpreterbase]
+strict_optional               = False
+
+[mypy-mesonbuild.interpreter.interpreter]
+strict_optional               = False
+
+[mypy-mesonbuild.interpreter.compiler]
+strict_optional               = False
+
+[mypy-mesonbuild.interpreter.dependencyfallbacks]
+strict_optional               = False
+
+[mypy-mesonbuild.linkers.detect]
+strict_optional               = False
 
 [mypy-mesonbuild.mformat]
+strict_optional               = False
 warn_unreachable              = False
 
-[mypy-mesonbuild.minit]
-strict_optional               = True
+[mypy-mesonbuild.mintro]
+strict_optional               = False
 
-[mypy-mesonbuild.minstall]
-strict_optional               = True
+[mypy-mesonbuild.modules]
+strict_optional               = False
 
-[mypy-mesonbuild.mlog]
-strict_optional               = True
+[mypy-mesonbuild.modules.cmake]
+strict_optional               = False
 
-[mypy-mesonbuild.programs]
-strict_optional               = True
+[mypy-mesonbuild.modules.codegen]
+strict_optional               = False
 
-[mypy-mesonbuild.scripts.symbolextractor]
-strict_optional               = True
+[mypy-mesonbuild.modules.cuda]
+strict_optional               = False
 
-[mypy-mesonbuild.tooldetect]
-strict_optional               = True
+[mypy-mesonbuild.modules.gnome]
+strict_optional               = False
+
+[mypy-mesonbuild.modules.rust]
+strict_optional               = False
+
+[mypy-mesonbuild.modules.pkgconfig]
+strict_optional               = False
+
+[mypy-mesonbuild.modules.python]
+strict_optional               = False
+
+[mypy-mesonbuild.modules._qt]
+strict_optional               = False
+
+[mypy-mesonbuild.modules.i18n]
+strict_optional               = False
+
+[mypy-mesonbuild.msetup]
+strict_optional               = False
+
+[mypy-mesonbuild.msubprojects]
+strict_optional               = False
+
+[mypy-mesonbuild.mtest]
+strict_optional               = False
+
+[mypy-mesonbuild.optinterpreter]
+strict_optional               = False
+
+[mypy-mesonbuild.options]
+strict_optional               = False
+
+[mypy-mesonbuild.rewriter]
+strict_optional               = False
+
+[mypy-mesonbuild.wrap.wrap]
+strict_optional               = False
+
+[mypy-mesonbuild.wrap.wraptool]
+strict_optional               = False
+
+[mypy-mesonbuild.scripts.coverage]
+strict_optional               = False
+
+[mypy-mesonbuild.scripts.scanbuild]
+strict_optional               = False
+
+[mypy-mesonbuild.scripts.depfixer]
+strict_optional               = False
+
+[mypy-mesonbuild.utils.universal]
+strict_optional               = False

--- a/mesonbuild/cargo/manifest.py
+++ b/mesonbuild/cargo/manifest.py
@@ -107,7 +107,7 @@ class DictMergeValue(ConvertValue):
     def __init__(self, func: T.Callable[[T.Any], T.List[object]],
                  merge_key: T.Callable[[T.Any], str],
                  out_key: T.Callable[[T.Any], str],
-                 base: T.Mapping[str, object] = None) -> None:
+                 base: T.Mapping[str, object]) -> None:
         super().__init__(func, base)
         self.merge_key = merge_key
         self.out_key = out_key

--- a/mesonbuild/cargo/manifest.py
+++ b/mesonbuild/cargo/manifest.py
@@ -108,7 +108,7 @@ class DictMergeValue(ConvertValue):
     def __init__(self, func: T.Callable[[T.Any], T.List[object]],
                  merge_key: T.Callable[[T.Any], str],
                  out_key: T.Callable[[T.Any], str],
-                 base: T.Mapping[str, object] = None) -> None:
+                 base: T.Mapping[str, object]) -> None:
         super().__init__(func, base)
         self.merge_key = merge_key
         self.out_key = out_key

--- a/mesonbuild/cargo/version.py
+++ b/mesonbuild/cargo/version.py
@@ -90,7 +90,7 @@ class SemVer:
 
     __slots__ = ('_v', 'specified_count')
 
-    def __init__(self, in_: str | list[int | str] = None) -> None:
+    def __init__(self, in_: str | list[int | str]) -> None:
         vec: list[int | str]
         if isinstance(in_, str):
             vec = []

--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -75,6 +75,7 @@ class CMakeTarget:
             self.properties[key] = [x.strip() for x in val]
             assert all(';' not in x for x in self.properties[key])
 
+# FIXME: name can be empty here, so this is not quite a CMakeTarget
 class CMakeGeneratorTarget(CMakeTarget):
     def __init__(self, name: str) -> None:
         super().__init__(name, 'CUSTOM', {})
@@ -395,7 +396,7 @@ class CMakeTraceParser:
         else:
             self.targets[args[0]] = CMakeTarget(args[0], 'NORMAL', {}, tline=tline)
 
-    def _cmake_add_custom_command(self, tline: CMakeTraceLine, name: T.Optional[str] = None) -> None:
+    def _cmake_add_custom_command(self, tline: CMakeTraceLine, name: str = '') -> None:
         # DOC: https://cmake.org/cmake/help/latest/command/add_custom_command.html
         args = self._flatten_args(list(tline.args))  # Commands can be passed as ';' separated lists
 

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -293,8 +293,8 @@ class Properties:
 @dataclass(unsafe_hash=True)
 class MachineInfo(HoldableObject):
     system: str
-    cpu_family: str | None
-    cpu: str | None
+    cpu_family: str
+    cpu: str
     endian: str
     kernel: T.Optional[str]
     subsystem: T.Optional[str]
@@ -780,16 +780,16 @@ def detect_msys2_arch() -> T.Optional[str]:
 def detect_machine_info(compilers: T.Optional[CompilerDict] = None) -> MachineInfo:
     """Detect the machine we're running on
 
-    If compilers are not provided, we cannot know as much. None out those
-    fields to avoid accidentally depending on partial knowledge. The
+    If compilers are not provided, we cannot know as much. Write a dummy
+    value to avoid accidentally depending on partial knowledge. The
     underlying ''detect_*'' method can be called to explicitly use the
     partial information.
     """
     system = detect_system()
     return MachineInfo(
         system,
-        detect_cpu_family(compilers) if compilers is not None else None,
-        detect_cpu(compilers) if compilers is not None else None,
+        detect_cpu_family(compilers) if compilers is not None else 'unknown',
+        detect_cpu(compilers) if compilers is not None else 'unknown',
         sys.byteorder,
         detect_kernel(system),
         detect_subsystem(system))

--- a/mesonbuild/interpreter/decorators.py
+++ b/mesonbuild/interpreter/decorators.py
@@ -40,6 +40,8 @@ def apply_machine_map(f: TV_func) -> TV_func:
             raise MesonBugException(f'cannot use @apply_machine_map if the object is a {type(wrapped_args[0])}')
 
         _, _, kwargs, _ = get_callee_args(wrapped_args)
+        if kwargs is None:
+            raise MesonBugException(f'cannot use @apply_machine_map if the function does not take keyword arguments')
         if 'native' in kwargs:
             s.apply_machine_map_to_kwargs(T.cast('MachineMapArgs', kwargs))
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -97,7 +97,8 @@ from .type_checking import (
     TEST_KWS,
     NoneType,
     in_set_validator,
-    env_convertor_with_method
+    env_convertor,
+    env_validator,
 )
 from . import primitives as P_OBJ
 
@@ -3209,13 +3210,13 @@ class Interpreter(InterpreterBase, HoldableObject):
         init = args[0]
         if init is not None:
             FeatureNew.single_use('environment positional arguments', '0.52.0', self.subproject, location=node)
-            msg = ENV_KW.validator(init)
+            msg = env_validator(init)
             if msg:
                 raise InvalidArguments(f'"environment": {msg}')
             if isinstance(init, dict) and any(i for i in init.values() if isinstance(i, list)):
                 FeatureNew.single_use('List of string in dictionary value', '0.62.0', self.subproject, location=node)
             # the validator call above ensured that we have the correct type
-            return env_convertor_with_method(T.cast('FullEnvInitValueType', init), kwargs['method'], kwargs['separator'])
+            return env_convertor(T.cast('FullEnvInitValueType', init), kwargs['method'], kwargs['separator'])
         return EnvironmentVariables()
 
     @typed_pos_args('join_paths', varargs=str, min_varargs=1)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -98,7 +98,8 @@ from .type_checking import (
     TEST_KWS,
     NoneType,
     in_set_validator,
-    env_convertor_with_method
+    env_convertor,
+    env_validator,
 )
 from . import primitives as P_OBJ
 
@@ -3226,13 +3227,13 @@ class Interpreter(InterpreterBase, HoldableObject):
         init = args[0]
         if init is not None:
             FeatureNew.single_use('environment positional arguments', '0.52.0', self.subproject, location=node)
-            msg = ENV_KW.validator(init)
+            msg = env_validator(init)
             if msg:
                 raise InvalidArguments(f'"environment": {msg}')
             if isinstance(init, dict) and any(i for i in init.values() if isinstance(i, list)):
                 FeatureNew.single_use('List of string in dictionary value', '0.62.0', self.subproject, location=node)
             # the validator call above ensured that we have the correct type
-            return env_convertor_with_method(T.cast('FullEnvInitValueType', init), kwargs['method'], kwargs['separator'])
+            return env_convertor(T.cast('FullEnvInitValueType', init), kwargs['method'], kwargs['separator'])
         return EnvironmentVariables()
 
     @typed_pos_args('join_paths', varargs=str, min_varargs=1)

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -937,7 +937,7 @@ class SubprojectHolder(MesonInterpreterObject):
         return self.get_variable(args, kwargs)
 
 class ModuleObjectHolder(ObjectHolder[ModuleObject]):
-    def method_call(self, method_name: str, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> TYPE_var:
+    def method_call(self, method_name: str, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> TYPE_var | None:
         modobj = self.held_object
         method = modobj.methods.get(method_name)
         if not method:

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -1198,7 +1198,6 @@ class _CustomTargetHolder(ObjectHolder[_CT]):
     def to_list_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> T.List[build.CustomTargetIndex]:
         return list(self.held_object)
 
-    @noKwargs
     @typed_operator(MesonOperator.INDEX, int)
     @InterpreterObject.operator(MesonOperator.INDEX)
     def op_index(self, other: int) -> build.CustomTargetIndex:

--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -15,13 +15,13 @@ from .. import mlog
 from ..mesonlib import MachineChoice
 from ..options import OptionKey
 from ..programs import Program, ExternalProgram
-from ..interpreter.type_checking import ENV_KW, ENV_METHOD_KW, ENV_SEPARATOR_KW, env_convertor_with_method
+from ..interpreter.type_checking import ENV_KW, ENV_METHOD_KW, ENV_SEPARATOR_KW, env_convertor
 from ..interpreterbase import (MesonInterpreterObject, FeatureNew, FeatureDeprecated, FeatureBroken,
                                typed_pos_args,  noArgsFlattening, noPosargs, noKwargs,
                                typed_kwargs, KwargInfo, InterpreterException, InterpreterObject)
 from .decorators import apply_machine_map
 from .primitives import MesonVersionString
-from .type_checking import NATIVE_KW, NoneType
+from .type_checking import NATIVE_KW, NoneType, env_validator
 
 if T.TYPE_CHECKING:
     from typing_extensions import Literal, TypedDict
@@ -488,10 +488,10 @@ class MesonMain(MesonInterpreterObject):
     def add_devenv_method(self, args: T.Tuple[T.Union[str, list, dict, mesonlib.EnvironmentVariables]],
                           kwargs: 'AddDevenvKW') -> None:
         env = args[0]
-        msg = ENV_KW.validator(env)
+        msg = env_validator(env)
         if msg:
             raise build.InvalidArguments(f'"add_devenv": {msg}')
-        converted = env_convertor_with_method(env, kwargs['method'], kwargs['separator'])
+        converted = env_convertor(env, kwargs['method'], kwargs['separator'])
         assert isinstance(converted, mesonlib.EnvironmentVariables)
         self.build.devenv.append(converted)
 

--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -15,13 +15,13 @@ from .. import mlog
 from ..mesonlib import MachineChoice
 from ..options import OptionKey
 from ..programs import Program, ExternalProgram
-from ..interpreter.type_checking import ENV_KW, ENV_METHOD_KW, ENV_SEPARATOR_KW, env_convertor_with_method
+from ..interpreter.type_checking import ENV_METHOD_KW, ENV_SEPARATOR_KW, env_convertor
 from ..interpreterbase import (MesonInterpreterObject, FeatureNew, FeatureDeprecated, FeatureBroken,
                                typed_pos_args,  noArgsFlattening, noPosargs, noKwargs,
                                typed_kwargs, KwargInfo, InterpreterException, InterpreterObject)
 from .decorators import apply_machine_map
 from .primitives import MesonVersionString
-from .type_checking import NATIVE_KW, NoneType
+from .type_checking import NATIVE_KW, NoneType, env_validator
 
 if T.TYPE_CHECKING:
     from typing_extensions import Literal, TypedDict
@@ -488,10 +488,10 @@ class MesonMain(MesonInterpreterObject):
     def add_devenv_method(self, args: T.Tuple[T.Union[str, list, dict, mesonlib.EnvironmentVariables]],
                           kwargs: 'AddDevenvKW') -> None:
         env = args[0]
-        msg = ENV_KW.validator(env)
+        msg = env_validator(env)
         if msg:
             raise build.InvalidArguments(f'"add_devenv": {msg}')
-        converted = env_convertor_with_method(env, kwargs['method'], kwargs['separator'])
+        converted = env_convertor(env, kwargs['method'], kwargs['separator'])
         assert isinstance(converted, mesonlib.EnvironmentVariables)
         self.build.devenv.append(converted)
 

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -195,7 +195,7 @@ REQUIRED_KW: KwargInfo[T.Union[bool, Feature]] = KwargInfo(
 
 DISABLER_KW: KwargInfo[bool] = KwargInfo('disabler', bool, default=False)
 
-def _env_validator(value: T.Union[EnvironmentVariables, T.List['TYPE_var'], T.Dict[str, 'TYPE_var'], str, None],
+def env_validator(value: T.Union[EnvironmentVariables, T.List['TYPE_var'], T.Dict[str, 'TYPE_var'], str, None],
                    only_dict_str: bool = True) -> T.Optional[str]:
     def _splitter(v: str) -> T.Optional[str]:
         split = v.split('=', 1)
@@ -231,7 +231,7 @@ def _env_validator(value: T.Union[EnvironmentVariables, T.List['TYPE_var'], T.Di
 
 def _options_validator(value: T.Union[EnvironmentVariables, T.List['TYPE_var'], T.Dict[str, 'TYPE_var'], str, None]) -> T.Optional[str]:
     # Reusing the env validator is a little overkill, but nicer than duplicating the code
-    return _env_validator(value, only_dict_str=False)
+    return env_validator(value, only_dict_str=False)
 
 def split_equal_string(input: str) -> T.Tuple[str, str]:
     """Split a string in the form `x=y`
@@ -241,11 +241,9 @@ def split_equal_string(input: str) -> T.Tuple[str, str]:
     a, b = input.split('=', 1)
     return (a, b)
 
-# Split _env_convertor() and env_convertor_with_method() to make mypy happy.
-# It does not want extra arguments in KwargInfo convertor callable.
-def env_convertor_with_method(value: FullEnvInitValueType,
-                              init_method: Literal['set', 'prepend', 'append'] = 'set',
-                              separator: str = os.pathsep) -> EnvironmentVariables:
+def env_convertor(value: FullEnvInitValueType,
+                  init_method: Literal['set', 'prepend', 'append'] = 'set',
+                  separator: str = os.pathsep) -> EnvironmentVariables:
     if isinstance(value, str):
         return EnvironmentVariables(dict([split_equal_string(value)]), init_method, separator)
     elif isinstance(value, list):
@@ -256,14 +254,11 @@ def env_convertor_with_method(value: FullEnvInitValueType,
         return EnvironmentVariables()
     return value
 
-def _env_convertor(value: FullEnvInitValueType) -> EnvironmentVariables:
-    return env_convertor_with_method(value)
-
 ENV_KW: KwargInfo[T.Union[EnvironmentVariables, T.List, T.Dict, str, None]] = KwargInfo(
     'env',
     (EnvironmentVariables, list, dict, str, NoneType),
-    validator=_env_validator,
-    convertor=_env_convertor,
+    validator=env_validator,
+    convertor=env_convertor,
 )
 
 DEPFILE_KW: KwargInfo[T.Optional[str]] = KwargInfo(

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -196,8 +196,8 @@ REQUIRED_KW: KwargInfo[T.Union[bool, Feature]] = KwargInfo(
 
 DISABLER_KW: KwargInfo[bool] = KwargInfo('disabler', bool, default=False)
 
-def _env_validator(value: T.Union[EnvironmentVariables, T.List['TYPE_var'], T.Dict[str, 'TYPE_var'], str, None],
-                   only_dict_str: bool = True) -> T.Optional[str]:
+def env_validator(value: T.Union[EnvironmentVariables, T.List['TYPE_var'], T.Dict[str, 'TYPE_var'], str, None],
+                  only_dict_str: bool = True) -> T.Optional[str]:
     def _splitter(v: str) -> T.Optional[str]:
         split = v.split('=', 1)
         if len(split) == 1:
@@ -232,7 +232,7 @@ def _env_validator(value: T.Union[EnvironmentVariables, T.List['TYPE_var'], T.Di
 
 def _options_validator(value: T.Union[EnvironmentVariables, T.List['TYPE_var'], T.Dict[str, 'TYPE_var'], str, None]) -> T.Optional[str]:
     # Reusing the env validator is a little overkill, but nicer than duplicating the code
-    return _env_validator(value, only_dict_str=False)
+    return env_validator(value, only_dict_str=False)
 
 def split_equal_string(input: str) -> T.Tuple[str, str]:
     """Split a string in the form `x=y`
@@ -242,11 +242,9 @@ def split_equal_string(input: str) -> T.Tuple[str, str]:
     a, b = input.split('=', 1)
     return (a, b)
 
-# Split _env_convertor() and env_convertor_with_method() to make mypy happy.
-# It does not want extra arguments in KwargInfo convertor callable.
-def env_convertor_with_method(value: FullEnvInitValueType,
-                              init_method: Literal['set', 'prepend', 'append'] = 'set',
-                              separator: str = os.pathsep) -> EnvironmentVariables:
+def env_convertor(value: FullEnvInitValueType,
+                  init_method: Literal['set', 'prepend', 'append'] = 'set',
+                  separator: str = os.pathsep) -> EnvironmentVariables:
     if isinstance(value, str):
         return EnvironmentVariables(dict([split_equal_string(value)]), init_method, separator)
     elif isinstance(value, list):
@@ -257,14 +255,11 @@ def env_convertor_with_method(value: FullEnvInitValueType,
         return EnvironmentVariables()
     return value
 
-def _env_convertor(value: FullEnvInitValueType) -> EnvironmentVariables:
-    return env_convertor_with_method(value)
-
 ENV_KW: KwargInfo[T.Union[EnvironmentVariables, T.List, T.Dict, str, None]] = KwargInfo(
     'env',
     (EnvironmentVariables, list, dict, str, NoneType),
-    validator=_env_validator,
-    convertor=_env_convertor,
+    validator=env_validator,
+    convertor=env_convertor,
 )
 
 DEPFILE_KW: KwargInfo[T.Optional[str]] = KwargInfo(

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -1003,7 +1003,7 @@ SHARED_MOD_KWS = [
 _EXCLUSIVE_JAR_KWS: T.List[KwargInfo] = [
     KwargInfo('main_class', str, default=''),
     KwargInfo('java_resources', (StructuredSources, NoneType), since='0.62.0'),
-    _JAVA_LANG_KW.evolve(deprecated=None, deprecated_message=None),
+    _JAVA_LANG_KW.evolve(deprecated=None),
 ]
 
 # The total list of arguments used by JAR

--- a/mesonbuild/interpreterbase/baseobjects.py
+++ b/mesonbuild/interpreterbase/baseobjects.py
@@ -36,7 +36,7 @@ class InterpreterObject:
     TRIVIAL_OPERATORS: T.Dict[
         MesonOperator,
         T.Tuple[
-            T.Union[T.Type, T.Tuple[T.Type, ...]],
+            T.Type | T.Tuple[T.Type, ...] | None,
             TYPE_op_func
         ]
     ] = {}

--- a/mesonbuild/interpreterbase/baseobjects.py
+++ b/mesonbuild/interpreterbase/baseobjects.py
@@ -34,7 +34,7 @@ class InterpreterObject:
     TRIVIAL_OPERATORS: T.Dict[
         MesonOperator,
         T.Tuple[
-            T.Union[T.Type, T.Tuple[T.Type, ...]],
+            T.Type | T.Tuple[T.Type, ...] | None,
             TYPE_op_func
         ]
     ] = {}
@@ -99,7 +99,7 @@ class InterpreterObject:
     def __init__(self, *, subproject: T.Optional['SubProject'] = None) -> None:
         # Current node set during a method call. This can be used as location
         # when printing a warning message during a method call.
-        self.current_node:  mparser.BaseNode = None
+        self.current_node: mparser.BaseNode | None = None
         self.subproject = subproject or ROOT_SUBPROJECT
 
     # The type of the object that can be printed to the user

--- a/mesonbuild/interpreterbase/baseobjects.py
+++ b/mesonbuild/interpreterbase/baseobjects.py
@@ -28,7 +28,7 @@ TYPE_kwargs = T.Dict[str, TYPE_var]
 TYPE_key_resolver = T.Callable[[mparser.BaseNode], str]
 TYPE_op_arg = T.TypeVar('TYPE_op_arg', bound='TYPE_var', contravariant=True)
 TYPE_op_func = T.Callable[[TYPE_op_arg, TYPE_op_arg], TYPE_var]
-TYPE_method_func = T.Callable[['InterpreterObject', T.List[TYPE_var], TYPE_kwargs], TYPE_var]
+TYPE_method_func = T.Callable[['InterpreterObject', T.List[TYPE_var], TYPE_kwargs], TYPE_var | None]
 
 class InterpreterObject:
     TRIVIAL_OPERATORS: T.Dict[
@@ -111,7 +111,7 @@ class InterpreterObject:
                 method_name: str,
                 args: T.List[TYPE_var],
                 kwargs: TYPE_kwargs
-            ) -> TYPE_var:
+            ) -> TYPE_var | None:
         if method_name in self.METHODS:
             method = self.METHODS[method_name]
             if not getattr(method, 'no-args-flattening', False):

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -392,7 +392,7 @@ class KwargInfo(T.Generic[_T]):
     :param as_default: Extra values to treat as empty values. These are always considered to be broken.
     """
     def __init__(self, name: str,
-                 types: T.Union[T.Type[_T], T.Tuple[T.Union[T.Type[_T], ContainerTypeInfo], ...], ContainerTypeInfo],
+                 types: T.Union[T.Type[None], T.Type[_T], T.Tuple[T.Union[T.Type[None], T.Type[_T], ContainerTypeInfo], ...], ContainerTypeInfo],
                  *, required: bool = False, listify: bool = False,
                  default: T.Optional[_T] = None,
                  since: T.Optional[str] = None,

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -26,7 +26,7 @@ if T.TYPE_CHECKING:
     from ..modules import ModuleObject, ModuleState
     from ..mparser import FunctionNode
     from ..optinterpreter import OptionInterpreter
-    from .baseobjects import InterpreterObject, ObjectHolder, TV_func, TYPE_var, TYPE_kwargs
+    from .baseobjects import InterpreterObject, TV_func, TYPE_var, TYPE_kwargs
     from .interpreterbase import InterpreterBase
     from .operator import MesonOperator
 
@@ -37,7 +37,7 @@ if T.TYPE_CHECKING:
         def __call__(s, self: _TV_IntegerObject, other: _TV_ARG1) -> TYPE_var: ...
     _TV_FN_Operator = T.TypeVar('_TV_FN_Operator', bound=FN_Operator)
 
-    CalleeArgs: TypeAlias = T.Tuple[mparser.BaseNode, T.Optional[T.List[TYPE_var]], T.Optional[TYPE_kwargs], SubProject]
+    CalleeArgs: TypeAlias = T.Tuple[mparser.BaseNode, T.List[TYPE_var], TYPE_kwargs, SubProject]
 
     MesonVersionTarget = mesonlib.Range[mesonlib.Version] | mesonlib.NoProjectVersion | None
 
@@ -73,10 +73,6 @@ def get_callee_args(wrapped_args: T.Tuple[InterpreterObject, T.List[TYPE_var], T
 
 
 @T.overload
-def get_callee_args(wrapped_args: T.Tuple[ObjectHolder, object]) -> CalleeArgs: ...
-
-
-@T.overload
 def get_callee_args(wrapped_args: T.Tuple[InterpreterBase, FunctionNode, T.List[TYPE_var], TYPE_kwargs]) -> CalleeArgs: ...
 
 
@@ -90,7 +86,6 @@ def get_callee_args(wrapped_args: T.Tuple[OptionInterpreter, T.List[TYPE_var], T
 
 def get_callee_args(wrapped_args: T.Union[
             T.Tuple[InterpreterObject, T.List[TYPE_var], TYPE_kwargs],
-            T.Tuple[ObjectHolder, object],
             T.Tuple[InterpreterBase, FunctionNode, T.List[TYPE_var], TYPE_kwargs],
             T.Tuple[ModuleObject, ModuleState, T.List[TYPE_var], TYPE_kwargs],
             T.Tuple[OptionInterpreter, T.List[TYPE_var], TYPE_kwargs],
@@ -99,14 +94,7 @@ def get_callee_args(wrapped_args: T.Union[
         s = wrapped_args[1]
     else:
         s = wrapped_args[0]
-    node = s.current_node
-    subproject = s.subproject
-    args: T.Optional[T.List[TYPE_var]] = None
-    kwargs: T.Optional[TYPE_kwargs] = None
-    if len(wrapped_args) >= 3:
-        args = wrapped_args[-2]
-        kwargs = wrapped_args[-1]
-    return node, args, kwargs, subproject
+    return s.current_node, wrapped_args[-2], wrapped_args[-1], s.subproject
 
 
 def noPosargs(f: TV_func) -> TV_func:
@@ -749,8 +737,6 @@ class FeatureCheckBase(metaclass=mesonlib.SimpleABC):
         @wraps(f)
         def wrapped(*wrapped_args: T.Any, **wrapped_kwargs: T.Any) -> T.Any:
             node, _, _, subproject = get_callee_args(wrapped_args)
-            if subproject is None:
-                raise AssertionError(f'{wrapped_args!r}')
             self.use(subproject, node)
             return f(*wrapped_args, **wrapped_kwargs)
         return T.cast('TV_func', wrapped)

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -37,7 +37,7 @@ if T.TYPE_CHECKING:
         def __call__(s, self: _TV_IntegerObject, other: _TV_ARG1) -> TYPE_var: ...
     _TV_FN_Operator = T.TypeVar('_TV_FN_Operator', bound=FN_Operator)
 
-    CalleeArgs: TypeAlias = T.Tuple[mparser.BaseNode, T.List[TYPE_var], TYPE_kwargs, SubProject]
+    CalleeArgs: TypeAlias = T.Tuple[mparser.BaseNode | None, T.List[TYPE_var], TYPE_kwargs, SubProject]
 
     MesonVersionTarget = mesonlib.Range[mesonlib.Version] | mesonlib.NoProjectVersion | None
 
@@ -306,6 +306,7 @@ def typed_pos_args(name: str, *types: T.Union[T.Type, T.Tuple[T.Type, ...]],
                 raise InvalidArguments(f'"{name}" takes exactly {num_types} arguments, but got {num_args}.')
 
             for i, (arg, type_) in enumerate(itertools.zip_longest(args, a_types, fillvalue=varargs), start=1):
+                assert type_ is not None, 'variadic arguments should have been filtered above'
                 if not isinstance(arg, type_):
                     # if DefaultObject is an explicit allowed allowed type allow
                     # it through.
@@ -464,7 +465,7 @@ class KwargInfo(T.Generic[_T]):
     """
 
     name: str
-    types: type[_T] | ContainerTypeInfo | tuple[type[_T] | ContainerTypeInfo, ...]
+    types: type[None] | type[_T] | ContainerTypeInfo | tuple[type[None] | type[_T] | ContainerTypeInfo, ...]
     required: bool = dataclasses.field(default=False, kw_only=True)
     listify: bool = dataclasses.field(default=False, kw_only=True)
     default: _T | None = dataclasses.field(default=None, kw_only=True)

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -51,10 +51,10 @@ if T.TYPE_CHECKING:
         listify: bool
         default: _T | None
         since: str | None
-        since_message: str | None
+        since_message: str
         since_values: _FeatureValues | None
         deprecated: str | None
-        deprecated_message: str | None
+        deprecated_message: str
         deprecated_values: _FeatureValues | None
         feature_validator: T.Callable[[_T], T.Iterable[FeatureCheckBase]] | None
         validator: T.Callable[[T.Any], str | None] | None
@@ -470,10 +470,10 @@ class KwargInfo(T.Generic[_T]):
     listify: bool = dataclasses.field(default=False, kw_only=True)
     default: _T | None = dataclasses.field(default=None, kw_only=True)
     since: str | None = dataclasses.field(default=None, kw_only=True)
-    since_message: str | None = dataclasses.field(default=None, kw_only=True)
+    since_message: str = dataclasses.field(default='', kw_only=True)
     since_values: _FeatureValues | None = dataclasses.field(default=None, kw_only=True)
     deprecated: str | None = dataclasses.field(default=None, kw_only=True)
-    deprecated_message: str | None = dataclasses.field(default=None, kw_only=True)
+    deprecated_message: str = dataclasses.field(default='', kw_only=True)
     deprecated_values: _FeatureValues | None = dataclasses.field(default=None, kw_only=True)
     feature_validator: T.Callable[[_T], T.Iterable[FeatureCheckBase]] | None = \
         dataclasses.field(default=None, kw_only=True)
@@ -526,7 +526,7 @@ def typed_kwargs(name: str, *types: KwargInfo, allow_unknown: bool = False) -> T
                     if isinstance(version, tuple):
                         version, msg = version
                     else:
-                        msg = None
+                        msg = ''
 
                     warning: T.Optional[str] = None
                     if isinstance(n, ContainerTypeInfo):

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -1471,7 +1471,11 @@ class VisualStudioLikeLinkerMixin(DynamicLinkerBase):
         return not self.direct
 
     def get_output_args(self, outputname: str) -> T.List[str]:
-        return self._apply_prefix(['/MACHINE:' + self.machine, '/OUT:' + outputname])
+        args: T.List[str] = []
+        if self.machine:
+            args += ['/MACHINE:' + self.machine]
+        args += ['/OUT:' + outputname]
+        return args
 
     def get_always_args(self) -> T.List[str]:
         parent = super().get_always_args()

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -1510,7 +1510,11 @@ class VisualStudioLikeLinkerMixin(DynamicLinkerBase):
         return not self.direct
 
     def get_output_args(self, outputname: str) -> T.List[str]:
-        return self._apply_prefix(['/MACHINE:' + self.machine, '/OUT:' + outputname])
+        args: T.List[str] = []
+        if self.machine:
+            args += ['/MACHINE:' + self.machine]
+        args += ['/OUT:' + outputname]
+        return self._apply_prefix(args)
 
     def get_always_args(self) -> T.List[str]:
         parent = super().get_always_args()

--- a/mesonbuild/modules/external_project.py
+++ b/mesonbuild/modules/external_project.py
@@ -20,7 +20,7 @@ from ..interpreterbase import FeatureNew
 from ..interpreter.type_checking import ENV_KW, DEPENDS_KW
 from ..interpreterbase.decorators import ContainerTypeInfo, KwargInfo, typed_kwargs, typed_pos_args
 from ..mesonlib import (EnvironmentException, MesonException, Popen_safe, MachineChoice,
-                        get_variable_regex, do_replacement, join_args)
+                        FileMode, get_variable_regex, do_replacement, join_args)
 from ..options import OptionKey
 
 if T.TYPE_CHECKING:
@@ -265,8 +265,8 @@ class ExternalProject(NewExtensionModule):
                                 Path('dist', self.rel_prefix).as_posix(),
                                 install_dir='.',
                                 install_dir_name='.',
-                                install_mode=None,
-                                exclude=None,
+                                install_mode=FileMode(),
+                                exclude=(set(), set()),
                                 strip_directory=True,
                                 from_source_dir=False,
                                 subproject=self.subproject)

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -288,7 +288,8 @@ class FSModule(ExtensionModule):
         INSTALL_KW,
         INSTALL_MODE_KW,
         INSTALL_TAG_KW,
-        KwargInfo('install_dir', (str, NoneType)),
+        KwargInfo('install_dir', (str, NoneType),
+                  convertor=lambda x: [] if x is None else [x]),
         BUILD_SUBDIR_KW.evolve(since='1.12.0'),
     )
     def copyfile(self, state: ModuleState, args: T.Tuple[FileOrString, T.Optional[str]],
@@ -315,7 +316,7 @@ class FSModule(ExtensionModule):
             state.current_build_project,
             build_by_default=True,
             install=kwargs['install'],
-            install_dir=[kwargs['install_dir']],
+            install_dir=[kwargs['install_dir']] if kwargs['install_dir'] is not None else None,
             install_mode=kwargs['install_mode'],
             install_tag=[kwargs['install_tag']],
             backend=state.backend,

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -315,7 +315,7 @@ class FSModule(ExtensionModule):
             state.current_build_project,
             build_by_default=True,
             install=kwargs['install'],
-            install_dir=[kwargs['install_dir']],
+            install_dir=[kwargs['install_dir']] if kwargs['install_dir'] is not None else [],
             install_mode=kwargs['install_mode'],
             install_tag=[kwargs['install_tag']],
             backend=state.backend,

--- a/mesonbuild/modules/hotdoc.py
+++ b/mesonbuild/modules/hotdoc.py
@@ -283,7 +283,7 @@ class HotdocTargetBuilder:
             if arg in self.kwargs:
                 raise InvalidArguments(f'Argument "{arg}" is forbidden.')
 
-    def make_targets(self) -> T.Tuple[HotdocTarget, mesonlib.ExecutableSerialisation]:
+    def make_targets(self) -> T.Tuple[HotdocTarget, mesonlib.ExecutableSerialisation | None]:
         self.check_forbidden_args()
         self.process_known_arg("--index", value_processor=self.ensure_file)
         self.process_known_arg("--project-version")

--- a/mesonbuild/modules/hotdoc.py
+++ b/mesonbuild/modules/hotdoc.py
@@ -281,7 +281,7 @@ class HotdocTargetBuilder:
             if arg in self.kwargs:
                 raise InvalidArguments(f'Argument "{arg}" is forbidden.')
 
-    def make_targets(self) -> T.Tuple[HotdocTarget, mesonlib.ExecutableSerialisation]:
+    def make_targets(self) -> T.Tuple[HotdocTarget, mesonlib.ExecutableSerialisation | None]:
         self.check_forbidden_args()
         self.process_known_arg("--index", value_processor=self.ensure_file)
         self.process_known_arg("--project-version")

--- a/mesonbuild/modules/modtest.py
+++ b/mesonbuild/modules/modtest.py
@@ -8,7 +8,7 @@ from . import NewExtensionModule, ModuleInfo
 from ..interpreterbase import noKwargs, noPosargs
 
 if T.TYPE_CHECKING:
-    from . import ModuleState
+    from . import ModuleState, ModuleReturnValue
     from ..interpreter.interpreter import Interpreter
     from ..interpreterbase.baseobjects import TYPE_kwargs, TYPE_var
 
@@ -25,8 +25,9 @@ class TestModule(NewExtensionModule):
 
     @noKwargs
     @noPosargs
-    def print_hello(self, state: ModuleState, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> None:
+    def print_hello(self, state: ModuleState, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> ModuleReturnValue:
         print('Hello from a Meson module')
+        return ModuleReturnValue(None, [])
 
 
 def initialize(interp: Interpreter) -> TestModule:

--- a/mesonbuild/modules/modtest.py
+++ b/mesonbuild/modules/modtest.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 import typing as T
 
-from . import NewExtensionModule, ModuleInfo
+from . import NewExtensionModule, ModuleInfo, ModuleReturnValue
 from ..interpreterbase import noKwargs, noPosargs
 
 if T.TYPE_CHECKING:
@@ -25,8 +25,9 @@ class TestModule(NewExtensionModule):
 
     @noKwargs
     @noPosargs
-    def print_hello(self, state: ModuleState, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> None:
+    def print_hello(self, state: ModuleState, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> ModuleReturnValue:
         print('Hello from a Meson module')
+        return ModuleReturnValue(None, [])
 
 
 def initialize(interp: Interpreter) -> TestModule:

--- a/mesonbuild/scripts/clippy.py
+++ b/mesonbuild/scripts/clippy.py
@@ -10,7 +10,7 @@ import subprocess
 
 from .run_tool import run_tool_on_targets, run_with_buffered_output
 from .. import build, mlog
-from ..mesonlib import MachineChoice, PerMachine
+from ..mesonlib import MachineChoice, PerMachine, unwrap
 from ..tooldetect import detect_ninja
 
 if T.TYPE_CHECKING:
@@ -80,7 +80,7 @@ def run(args: T.List[str]) -> int:
     # Build as much of the project as possible, or else
     # we get errors about missing libraries in the build directory and
     # other related errors.
-    subprocess.run(detect_ninja() + ['clippy-json-prereq', '-k0'])
+    subprocess.run(unwrap(detect_ninja()) + ['clippy-json-prereq', '-k0'])
 
     with tempfile.TemporaryDirectory() as d:
         return run_tool_on_targets(ClippyDriver(build_data, d, args[1:]))

--- a/mesonbuild/scripts/run_tool.py
+++ b/mesonbuild/scripts/run_tool.py
@@ -46,7 +46,7 @@ async def run_with_buffered_output(cmdlist: T.List[str], env: T.Optional[T.Dict[
     if stdo:
         print(mlog.blue('>>>'), quoted_cmdline, flush=True)
         sys.stdout.buffer.write(stdo)
-    return p.returncode
+    return p.returncode or 0
 
 async def _run_workers(infos: T.Iterable[Info],
                        fn: T.Callable[[Info], T.Iterable[T.Coroutine[None, None, int]]]) -> int:

--- a/mesonbuild/scripts/run_tool.py
+++ b/mesonbuild/scripts/run_tool.py
@@ -49,7 +49,7 @@ async def run_with_buffered_output(cmdlist: T.List[str], env: T.Optional[T.Dict[
     if stdo:
         print(mlog.blue('>>>'), quoted_cmdline, flush=True)
         sys.stdout.buffer.write(stdo)
-    return p.returncode
+    return p.returncode or 0
 
 async def _run_workers(infos: T.Iterable[Info],
                        fn: T.Callable[[Info], T.Iterable[T.Coroutine[None, None, int]]]) -> int:

--- a/mesonbuild/scripts/vcstagger.py
+++ b/mesonbuild/scripts/vcstagger.py
@@ -7,11 +7,14 @@ import sys, os, subprocess, re
 import typing as T
 
 def config_vcs_tag(infile: str, outfile: str, fallback: str, source_dir: str, replace_string: str, regex_selector: str, cmd: T.List[str]) -> None:
+    new_string = fallback
     try:
         output = subprocess.check_output(cmd, cwd=source_dir, stderr=subprocess.DEVNULL)
-        new_string = re.search(regex_selector, output.decode()).group(1).rstrip('\r\n')
     except Exception:
-        new_string = fallback
+        pass
+    else:
+        if (m := re.search(regex_selector, output.decode())) is not None:
+            new_string = m.group(1).rstrip('\r\n')
 
     with open(infile, encoding='utf-8') as f:
         new_data = f.read().replace(replace_string, new_string)

--- a/mesonbuild/templates/sampleimpl.py
+++ b/mesonbuild/templates/sampleimpl.py
@@ -77,9 +77,10 @@ class SampleImpl(metaclass=SimpleABC):
     def _detect_sources(self, srcfiles: T.List[Path], transform: T.Callable[[str], str]) -> T.Tuple[str, T.List[Path]]:
         # Try a source based on the executable name, fallback to one based
         # on the project name if none is found.
-        expected_name = f'{transform(self.executable_name)}.{self.source_ext}'
-        if any(str(x) == expected_name for x in srcfiles):
-            return expected_name, srcfiles
+        if self.executable_name:
+            expected_name = f'{transform(self.executable_name)}.{self.source_ext}'
+            if any(str(x) == expected_name for x in srcfiles):
+                return expected_name, srcfiles
         expected_name = f'{transform(self.lowercase_token)}.{self.source_ext}'
         if any(str(x) == expected_name for x in srcfiles):
             return expected_name, srcfiles

--- a/mesonbuild/utils/vsenv.py
+++ b/mesonbuild/utils/vsenv.py
@@ -49,6 +49,8 @@ def _setup_vsenv(force: bool) -> bool:
             return False
 
     root = os.environ.get("ProgramFiles(x86)") or os.environ.get("ProgramFiles")
+    if not root:
+        raise MesonException(f'Could not find Program Files path')
     bat_locator_bin = pathlib.Path(root, 'Microsoft Visual Studio/Installer/vswhere.exe')
     if not bat_locator_bin.exists():
         raise MesonException(f'Could not find {bat_locator_bin}')

--- a/mesonbuild/utils/vsenv.py
+++ b/mesonbuild/utils/vsenv.py
@@ -49,6 +49,8 @@ def _setup_vsenv(force: bool) -> bool:
             return False
 
     root = os.environ.get("ProgramFiles(x86)") or os.environ.get("ProgramFiles")
+    if not root:
+        raise MesonException('Could not find Program Files path')
     bat_locator_bin = pathlib.Path(root, 'Microsoft Visual Studio/Installer/vswhere.exe')
     if not bat_locator_bin.exists():
         raise MesonException(f'Could not find {bat_locator_bin}')


### PR DESCRIPTION
I'm not too interested in getting this forward, but I can at least try to avoid making it worse.

Fix some of the lowest hanging fruit and list all failing modules in `.mypy.ini`.

Here are the remaining files with 10 or less errors (80% of the files, 25% of the errors):

```
mesonbuild/scripts/coverage.py 10
mesonbuild/ast/introspection.py 10
mesonbuild/interpreter/dependencyfallbacks.py 9
mesonbuild/dependencies/python.py 9
mesonbuild/dependencies/configtool.py 9
mesonbuild/msetup.py 8
mesonbuild/modules/python.py 8
mesonbuild/modules/__init__.py 8
mesonbuild/interpreterbase/decorators.py 8
mesonbuild/dependencies/dev.py 8
mesonbuild/compilers/mixins/clike.py 8
mesonbuild/utils/universal.py 7
mesonbuild/dependencies/misc.py 7
mesonbuild/compilers/rust.py 7
mesonbuild/compilers/mixins/visualstudio.py 7
mesonbuild/cmake/interpreter.py 7
mesonbuild/linkers/detect.py 6
mesonbuild/dependencies/qt.py 6
mesonbuild/wrap/wrap.py 5
mesonbuild/scripts/scanbuild.py 5
mesonbuild/msubprojects.py 5
mesonbuild/modules/pkgconfig.py 5
mesonbuild/compilers/d.py 5
mesonbuild/options.py 4
mesonbuild/modules/cmake.py 4
mesonbuild/mintro.py 4
mesonbuild/dependencies/boost.py 4
mesonbuild/compilers/detect.py 4
mesonbuild/cmake/toolchain.py 4
mesonbuild/modules/_qt.py 3
mesonbuild/modules/gnome.py 3
mesonbuild/interpreter/interpreterobjects.py 3
mesonbuild/dependencies/pkgconfig.py 3
mesonbuild/dependencies/detect.py 3
mesonbuild/dependencies/base.py 3
mesonbuild/compilers/mixins/islinker.py 3
mesonbuild/cmake/tracetargets.py 3
mesonbuild/wrap/wraptool.py 2
mesonbuild/modules/cuda.py 2
mesonbuild/modules/codegen.py 2
mesonbuild/dependencies/ui.py 2
mesonbuild/dependencies/framework.py 2
mesonbuild/compilers/mixins/clang.py 2
mesonbuild/compilers/mixins/apple.py 2
mesonbuild/mparser.py 1
mesonbuild/interpreterbase/baseobjects.py 1
mesonbuild/dependencies/mpi.py 1
mesonbuild/dependencies/hdf5.py 1
mesonbuild/dependencies/dub.py 1
mesonbuild/compilers/vala.py 1
mesonbuild/compilers/mixins/elbrus.py 1
mesonbuild/compilers/mixins/arm.py 1
mesonbuild/compilers/cython.py 1
mesonbuild/compilers/cuda.py 1
```

The worst offenders (10% of the files, 50% of the issues) are

```
mesonbuild/backend/ninjabackend.py 150
mesonbuild/backend/backends.py 118
mesonbuild/mformat.py 90
mesonbuild/backend/vs2010backend.py 68
mesonbuild/scripts/depfixer.py 48
mesonbuild/backend/xcodebackend.py 43
```

and it's likely that something clever will fix most of the issues.