### PR TITLE
cmake/interpreter: propagate object library pie flag

### DIFF
--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -534,6 +534,9 @@ class ConverterTarget:
         # Filter out object files from the sources
         self.generated = [x for x in self.generated if not any(x.name.endswith('.' + y) for y in obj_suffixes)]
 
+        if not self.sources and not self.generated and self.object_libs:
+            self.pie |= all(x.pie for x in self.object_libs)
+
     def _append_objlib_sources(self, tgt: 'ConverterTarget') -> None:
         self.includes += tgt.includes
         self.sources += tgt.sources

--- a/test cases/cmake/29 object library pic/meson.build
+++ b/test cases/cmake/29 object library pic/meson.build
@@ -1,0 +1,7 @@
+project('29 object library pic', 'c')
+
+cm = import('cmake')
+sub_pro = cm.subproject('cmTest')
+sub_dep = sub_pro.dependency('cmTestLib')
+
+shared_library('slib', 'slib.c', dependencies: sub_dep)

--- a/test cases/cmake/29 object library pic/slib.c
+++ b/test cases/cmake/29 object library pic/slib.c
@@ -1,0 +1,3 @@
+extern void f(void);
+
+void g(void) { f(); }

--- a/test cases/cmake/29 object library pic/subprojects/cmTest/CMakeLists.txt
+++ b/test cases/cmake/29 object library pic/subprojects/cmTest/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
+
+project(cmTest C)
+
+add_library(cmTestLib_objs OBJECT "x.c")
+set_target_properties(cmTestLib_objs PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+
+add_library(cmTestLib STATIC $<TARGET_OBJECTS:cmTestLib_objs>)
+set_target_properties(cmTestLib PROPERTIES POSITION_INDEPENDENT_CODE TRUE)

--- a/test cases/cmake/29 object library pic/subprojects/cmTest/x.c
+++ b/test cases/cmake/29 object library pic/subprojects/cmTest/x.c
@@ -1,0 +1,1 @@
+void f(void) { }


### PR DESCRIPTION
If the target has no ordinary or generated sources, then propagate the "pie" flag from the object libraries. Otherwise it will not use position independent code, making it impossible to link into shared libraries.

Fixes #10764

---

No idea if this is on the right path, or what else could be done. Another potentially problematic thing is that meson forces each `OBJECT_LIBRARY` to have `pie==True`, but cmake does not do that, I think.