### PR TITLE
move /showIncludes from always_args to ninja_compile_args

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3132,6 +3132,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         # Add compiler args and include paths from several sources; defaults,
         # build options, external dependencies, etc.
         commands = self.generate_basic_compiler_args(target, compiler)
+        commands += compiler.get_show_dep_args()
         # Add custom target dirs as includes automatically, but before
         # target-specific include directories.
         if target.implicit_include_directories:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1704,3 +1704,7 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
     def get_target_libdir(self) -> str:
         """Where is the libdir for the current machine located"""
         raise EnvironmentException(f'{self.get_id()} does not support Rust target libdir')
+
+    def get_show_dep_args(self) -> T.List[str]:
+        """Arguments for printing depfile information in MSVC compatible format"""
+        return []

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -87,13 +87,11 @@ class VisualStudioLikeCompiler(Compiler, metaclass=mesonlib.SimpleABC):
         'mtd': ['/MTd'],
     }
 
-    # /showIncludes is needed for build dependency tracking in Ninja
-    # See: https://ninja-build.org/manual.html#_deps
     # Assume UTF-8 sources by default, but self.unix_args_to_native() removes it
     # if `/source-charset` is set too.
     # It is also dropped if Visual Studio 2013 or earlier is used, since it would
     # not be supported in that case.
-    always_args = ['/nologo', '/showIncludes', '/utf-8']
+    always_args = ['/nologo', '/utf-8']
     warn_args: T.Dict[str, T.List[str]] = {
         '0': [],
         '1': ['/W2'],
@@ -353,6 +351,11 @@ class VisualStudioLikeCompiler(Compiler, metaclass=mesonlib.SimpleABC):
 
     def get_pie_args(self) -> T.List[str]:
         return []
+
+    def get_show_dep_args(self) -> T.List[str]:
+        # /showIncludes is needed for build dependency tracking in Ninja
+        # See: https://ninja-build.org/manual.html#_deps
+        return ['/showIncludes']
 
 class MSVCCompiler(VisualStudioLikeCompiler):
 

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -275,19 +275,24 @@ class InternalTests(unittest.TestCase):
         cc = VisualStudioCPPCompiler([], [], '20.00', MachineChoice.HOST, env, 'x64', linker=linker)
 
         a = cc.compiler_args(cc.get_always_args())
-        self.assertEqual(a.to_native(copy=True), ['/nologo', '/showIncludes', '/utf-8', '/Zc:__cplusplus'])
+        self.assertEqual(a.to_native(copy=True), ['/nologo', '/utf-8', '/Zc:__cplusplus'])
 
         # Ensure /source-charset: removes /utf-8
         a.append('/source-charset:utf-8')
-        self.assertEqual(a.to_native(copy=True), ['/nologo', '/showIncludes', '/Zc:__cplusplus', '/source-charset:utf-8'])
+        self.assertEqual(a.to_native(copy=True), ['/nologo', '/Zc:__cplusplus', '/source-charset:utf-8'])
 
         # Ensure /execution-charset: removes /utf-8
         a = cc.compiler_args(cc.get_always_args() + ['/execution-charset:utf-8'])
-        self.assertEqual(a.to_native(copy=True), ['/nologo', '/showIncludes', '/Zc:__cplusplus', '/execution-charset:utf-8'])
+        self.assertEqual(a.to_native(copy=True), ['/nologo', '/Zc:__cplusplus', '/execution-charset:utf-8'])
 
         # Ensure /validate-charset- removes /utf-8
         a = cc.compiler_args(cc.get_always_args() + ['/validate-charset-'])
-        self.assertEqual(a.to_native(copy=True), ['/nologo', '/showIncludes', '/Zc:__cplusplus', '/validate-charset-'])
+        self.assertEqual(a.to_native(copy=True), ['/nologo', '/Zc:__cplusplus', '/validate-charset-'])
+
+        # /showIncludes is needed for build dependency tracking in Ninja
+        # See: https://ninja-build.org/manual.html#_deps
+        a = cc.compiler_args(cc.get_show_dep_args())
+        self.assertEqual(a.to_native(copy=True), ['/showIncludes'])
 
 
     def test_msvc_unix_args_to_native(self):


### PR DESCRIPTION
The /showIncludes flag is required by ninja, but not by any of the other backends. Since this is a ninja-specific requirement, it makes sense to include it with the ninja backend.

Fixes a compile performance regression with the vs backend when using Visual Studio 2026 version 18.7

Fixes #15959