### PR TITLE
Add options for Rust compiler features and Cargo.toml [profile]

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -323,6 +323,11 @@ or compiler being used:
 | fortran_std      | none          | [none, legacy, f95, f2003, f2008, f2018] | Fortran language standard to use |
 | rust_dynamic_std | false         | true, false                              | Whether to link dynamically to the Rust standard library *(Added in 1.9.0)* |
 | rust_nightly     | auto          | enabled, disabled, auto                  | Nightly Rust compiler (enabled=required, disabled=don't use nightly feature, auto=use nightly feature if available) *(Added in 1.10.0)* |
+| rust_panic       | none          | none, unwind, abort                      | Panic strategy (none=use the compiler default) *(Added in 1.12.0)* |
+| rust_overflow_checks | false     | true, false                              | Whether to enable runtime integer overflow checks *(Added in 1.12.0)* |
+| rust_codegen_units | 0           | integer value ≥ 0                        | Number of code generation units to split the crate into (0=use the compiler default) *(Added in 1.12.0)* |
+| rust_incremental | false         | true, false                              | Whether to enable incremental compilation *(Added in 1.12.0)* |
+| rust_incremental_cache_dir |     | filesystem path                          | Directory used to store incremental compilation data (empty=pick a default under the build directory) *(Added in 1.12.0)* |
 | cuda_ccbindir    |               | filesystem path                          | CUDA non-default toolchain directory to use (-ccbin) *(Added in 0.57.1)* |
 
 The default values of `c_winlibs` and `cpp_winlibs` are in

--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -323,6 +323,11 @@ or compiler being used:
 | fortran_std      | none          | [none, legacy, f95, f2003, f2008, f2018] | Fortran language standard to use |
 | rust_dynamic_std | false         | true, false                              | Whether to link dynamically to the Rust standard library *(Added in 1.9.0)* |
 | rust_nightly     | auto          | enabled, disabled, auto                  | Nightly Rust compiler (enabled=required, disabled=don't use nightly feature, auto=use nightly feature if available) *(Added in 1.10.0)* |
+| rust_panic       | none          | none, unwind, abort                      | Panic strategy (none=use the compiler default) *(Added in 1.13.0)* |
+| rust_overflow_checks | false     | true, false                              | Whether to enable runtime integer overflow checks *(Added in 1.13.0)* |
+| rust_codegen_units | 0           | integer value ≥ 0                        | Number of code generation units to split the crate into (0=use the compiler default) *(Added in 1.13.0)* |
+| rust_incremental | false         | true, false                              | Whether to enable incremental compilation *(Added in 1.13.0)* |
+| rust_incremental_cache_dir |     | filesystem path                          | Directory used to store incremental compilation data (empty=pick a default under the build directory) *(Added in 1.13.0)* |
 | cuda_ccbindir    |               | filesystem path                          | CUDA non-default toolchain directory to use (-ccbin) *(Added in 0.57.1)* |
 
 The default values of `c_winlibs` and `cpp_winlibs` are in

--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -417,7 +417,7 @@ information.
 #### package.rust_args()
 
 ```meson
-args = pkg.rustc_args()
+args = pkg.rust_args()
 ```
 
 Returns rustc arguments for this package.

--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -378,7 +378,7 @@ information.
 #### package.rust_args()
 
 ```meson
-args = pkg.rustc_args()
+args = pkg.rust_args()
 ```
 
 Returns rustc arguments for this package.

--- a/docs/markdown/Rust.md
+++ b/docs/markdown/Rust.md
@@ -127,6 +127,40 @@ Furthermore, these arguments are only included when creating binary or
 shared library crates.  Likewise, methods such as `has_link_argument()`
 wrap the arguments being tested with `-Clink-arg=`.
 
+## Interaction between `rust_panic=abort` and testing
+
+Cargo and Meson build tests differently.  `cargo test` recompiles the whole
+dependency tree from scratch using the dedicated `test` profile, so the test
+build is wholly independent from the artifacts produced by `cargo build`.
+Meson instead reuses the libraries that were already built and only compiles an
+additional test-harness binary out of the crate's own sources.
+
+Each approach has tradeoffs.  Rebuilding everything lets the `test` profile
+differ arbitrarily from the `dev` profile, but it is slow and, in the common
+case where the two profiles are essentially the same, it duplicates a lot of
+work for no benefit.  Reusing the libraries is much faster and detects bugs
+caused by e.g. compiler optimizations; but it requires the test harness and
+the libraries it links against to be ABI compatible.
+
+This has a consequence for the `rust_panic` option, and therefore for the
+`panic` key of a Cargo `[profile]`.  Rust's test harness relies on catching
+panics in order to report failures, so it must be compiled with the default
+`unwind` strategy; `rust.test()` and `rust.doctest()` honor this by resetting
+`rust_panic` to `none` for the harness even when the rest of the build uses
+`rust_panic=abort`.  The harness recompiles the crate's own sources with
+`unwind`, but `rustc` refuses to link it against a dependency that was compiled
+with `-Cpanic=abort`:
+
+```
+error: the linked panic runtime `panic_unwind` is not compiled with this crate's panic strategy `abort`
+```
+
+As a result, a crate built with `rust_panic=abort` is effectively
+untestable unless it has no dependencies.  Therefore, `rust_panic=abort`
+is only recommended if you are building a simple `cdylib` or `staticlib`
+with most or all of your dependencies in subprojects.  In that case,
+you can test the dependencies by building the subprojects on their own.
+
 ## Cargo interaction
 
 *Since 1.11.0*

--- a/docs/markdown/snippets/rust-profile-options.md
+++ b/docs/markdown/snippets/rust-profile-options.md
@@ -19,3 +19,6 @@ settings found in a Cargo `[profile]` section can be expressed natively:
 The remaining Cargo profile keys map onto existing built-in options:
 `opt-level` to `optimization`, `debug` to `debug`, `debug-assertions`
 to `b_ndebug` and `lto` to `b_lto`.
+
+The Cargo workspace object will also add these automatically based on
+the value of another new option, `rust_cargo_profile`.

--- a/docs/markdown/snippets/rust-profile-options.md
+++ b/docs/markdown/snippets/rust-profile-options.md
@@ -1,0 +1,21 @@
+## New Rust compiler options matching Cargo profile keys
+
+Several new per-machine Rust compiler options have been added so that the
+settings found in a Cargo `[profile]` section can be expressed natively:
+
+- `rust_panic` (`none`, `unwind`, `abort`): selects the panic strategy
+  (`-C panic=`).  It is ignored for `dylib` and `proc-macro` crates, which must
+  always unwind.
+- `rust_overflow_checks` (`true`, `false`): toggles runtime integer overflow
+  checks (`-C overflow-checks=`).
+- `rust_codegen_units` (integer, `0` to use the compiler default): number of
+  code generation units to split a crate into (`-C codegen-units=`).
+- `rust_incremental` (`true`, `false`): enables incremental compilation
+  (`-C incremental=`).
+- `rust_incremental_cache_dir` (path): directory used to store the incremental
+  compilation data.  When left empty a per-target directory under the build
+  directory is used.
+
+The remaining Cargo profile keys map onto existing built-in options:
+`opt-level` to `optimization`, `debug` to `debug`, `debug-assertions`
+to `b_ndebug` and `lto` to `b_lto`.

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -39,9 +39,10 @@ if T.TYPE_CHECKING:
     from .. import mparser
     from typing_extensions import Literal
 
-    from .manifest import Dependency
+    from .manifest import Dependency, Profile
     from ..environment import Environment
     from ..compilers.rust import RustCompiler
+    from ..options import ElementaryOptionValues
 
     RUST_ABI = Literal['rust', 'c', 'proc-macro']
 
@@ -297,6 +298,8 @@ class Interpreter:
         self.packages: T.Dict[PackageKey, PackageState] = {}
         # Map subdir to workspace
         self.workspaces: T.Dict[str, WorkspaceState] = {}
+        # [profile] tables from the top-level Cargo.toml
+        self.profiles: T.Dict[str, Profile] = {}
         # Files that should trigger a reconfigure if modified
         self.build_def_files: T.List[str] = []
         # Cargo packages
@@ -338,9 +341,8 @@ class Interpreter:
             # [patch] only takes effect in the top-level Cargo.toml
             for warning in validate_patch(ws.workspace.patch, ws.packages_to_member):
                 mlog.warning(warning)
-            if ws.workspace.profile:
-                mlog.warning('[profile] entries are not implemented yet')
 
+            self.profiles = ws.workspace.profile
             self._prepare_entry_point(ws)
         return ws
 
@@ -366,6 +368,45 @@ class Interpreter:
         if is_parent_path(self.subprojects_dir, path):
             raise MesonException('argument to package() cannot be a subproject')
         return ws.packages[path]
+
+    def _selected_profile(self, override: T.Optional[ElementaryOptionValues] = None) -> T.Optional[str]:
+        """Resolve the rust_cargo_profile selection to a Cargo profile name.
+           override takes precedence over the rust_cargo_profile option, and
+           comes from a target's own override_options."""
+        optstore = self.environment.coredata.optstore
+        if override is not None:
+            selection = override
+        else:
+            try:
+                selection = optstore.get_value_for('rust_cargo_profile')
+            except KeyError:
+                return None
+
+        assert isinstance(selection, str)
+        if selection == 'none':
+            return None
+        if selection != 'from_buildtype':
+            return selection
+
+        buildtype = optstore.get_value_for('buildtype')
+        if buildtype in {'plain', 'custom'}:
+            return None
+        return 'dev' if buildtype == 'debug' else 'release'
+
+    def get_override_options(self, pkg: PackageState, for_machine: MachineChoice,
+                             profile: str | None = None) -> T.Dict[str, ElementaryOptionValues]:
+        """Return override_options implied by the Cargo manifest: the package
+           edition (rust_std) and the options implied by a [profile], using
+           ``profile`` if not None or otherwise rust_cargo_profile selects."""
+        opts: T.Dict[str, ElementaryOptionValues] = {
+            'rust_std': pkg.manifest.package.edition,
+        }
+        profile_name = self._selected_profile(profile)
+        if profile_name is not None and self.profiles is not None:
+            if (profile_obj := self.profiles.get(profile_name)) is not None:
+                opts.update(profile_obj.to_meson_options(for_machine))
+
+        return opts
 
     def interpret(self, subdir: str, project_root: T.Optional[str] = None) -> mparser.CodeBlockNode:
         filename = os.path.join(self.environment.source_dir, subdir, 'Cargo.toml')

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -40,9 +40,10 @@ if T.TYPE_CHECKING:
     from .. import mparser
     from typing_extensions import Literal
 
-    from .manifest import Dependency
+    from .manifest import Dependency, Profile
     from ..environment import Environment
     from ..compilers.rust import RustCompiler
+    from ..options import ElementaryOptionValues
 
     RUST_ABI = Literal['rust', 'c', 'proc-macro']
 
@@ -282,6 +283,8 @@ class Interpreter:
         self.packages: T.Dict[PackageKey, PackageState] = {}
         # Map subdir to workspace
         self.workspaces: T.Dict[str, WorkspaceState] = {}
+        # [profile] tables from the top-level Cargo.toml
+        self.profiles: T.Dict[str, Profile] = {}
         # Files that should trigger a reconfigure if modified
         self.build_def_files: T.List[str] = []
         # Cargo packages
@@ -321,9 +324,8 @@ class Interpreter:
             # [patch] only takes effect in the top-level Cargo.toml
             for warning in validate_patch(ws.workspace.patch, ws.packages_to_member):
                 mlog.warning(warning)
-            if ws.workspace.profile:
-                mlog.warning('[profile] entries are not implemented yet')
 
+            self.profiles = ws.workspace.profile
             self._prepare_entry_point(ws)
         return ws
 
@@ -349,6 +351,45 @@ class Interpreter:
         if is_parent_path(self.subprojects_dir, path):
             raise MesonException('argument to package() cannot be a subproject')
         return ws.packages[path]
+
+    def _selected_profile(self, override: T.Optional[ElementaryOptionValues] = None) -> T.Optional[str]:
+        """Resolve the rust_cargo_profile selection to a Cargo profile name.
+           override takes precedence over the rust_cargo_profile option, and
+           comes from a target's own override_options."""
+        optstore = self.environment.coredata.optstore
+        if override is not None:
+            selection = override
+        else:
+            try:
+                selection = optstore.get_value_for('rust_cargo_profile')
+            except KeyError:
+                return None
+
+        assert isinstance(selection, str)
+        if selection == 'none':
+            return None
+        if selection != 'from_buildtype':
+            return selection
+
+        buildtype = optstore.get_value_for('buildtype')
+        if buildtype in {'plain', 'custom'}:
+            return None
+        return 'dev' if buildtype == 'debug' else 'release'
+
+    def get_override_options(self, pkg: PackageState, for_machine: MachineChoice,
+                             profile: str | None = None) -> T.Dict[str, ElementaryOptionValues]:
+        """Return override_options implied by the Cargo manifest: the package
+           edition (rust_std) and the options implied by a [profile], using
+           ``profile`` if not None or otherwise rust_cargo_profile selects."""
+        opts: T.Dict[str, ElementaryOptionValues] = {
+            'rust_std': pkg.manifest.package.edition,
+        }
+        profile_name = self._selected_profile(profile)
+        if profile_name is not None and self.profiles is not None:
+            if (profile_obj := self.profiles.get(profile_name)) is not None:
+                opts.update(profile_obj.to_meson_options(for_machine))
+
+        return opts
 
     def interpret(self, subdir: str, project_root: T.Optional[str] = None) -> mparser.CodeBlockNode:
         filename = os.path.join(self.environment.source_dir, subdir, 'Cargo.toml')

--- a/mesonbuild/cargo/manifest.py
+++ b/mesonbuild/cargo/manifest.py
@@ -509,6 +509,49 @@ class Lint:
 
 
 @dataclasses.dataclass
+class Profile:
+
+    """Representation of a Cargo [profile.NAME] entry.
+
+    The polymorphic Cargo values are canonicalized to the types used by the
+    corresponding Meson options.  Cargo's ``lto`` maps onto two options and is
+    therefore split into ``lto`` (b_lto) and ``lto_mode`` (b_lto_mode).  Unset
+    keys are left as None so that those options keep their default value.
+    See https://doc.rust-lang.org/cargo/reference/profiles.html
+    """
+
+    opt_level: T.Optional[str] = None
+    debug: T.Optional[bool] = None
+    strip: T.Optional[bool] = None
+    debug_assertions: T.Optional[bool] = None
+    overflow_checks: T.Optional[bool] = None
+    lto: T.Optional[bool] = None
+    lto_mode: T.Optional[str] = None
+    panic: T.Optional[str] = None
+    incremental: T.Optional[bool] = None
+    codegen_units: T.Optional[int] = None
+    build_override: T.Optional[Profile] = None
+
+    # missing: package, split_debuginfo, inherits, rpath
+
+    @classmethod
+    def from_raw(cls, raw_profile: raw.Profile) -> Self:
+        profile = _raw_to_dataclass(raw_profile, cls, 'Profile entry',
+                                    opt_level=ConvertValue(str),
+                                    codegen_units=ConvertValue(int),
+                                    debug=ConvertValue(lambda v: v if isinstance(v, bool) else v not in {0, '0', 'none'}),
+                                    debug_assertions=ConvertValue(lambda v: v if isinstance(v, bool) else v != 'false'),
+                                    incremental=ConvertValue(lambda v: v if isinstance(v, bool) else v != 'false'),
+                                    strip=ConvertValue(lambda v: v if isinstance(v, bool) else v != 'none'),
+                                    lto=ConvertValue(lambda v: v if isinstance(v, bool) else v != 'off'),
+                                    build_override=ConvertValue(cls.from_raw))
+        # Cargo's single 'lto' key also selects thin vs fat LTO (b_lto_mode).
+        if profile.lto:
+            profile.lto_mode = 'thin' if raw_profile.get('lto') == 'thin' else 'default'
+        return profile
+
+
+@dataclasses.dataclass
 class Manifest:
 
     """Cargo Manifest definition.
@@ -534,10 +577,11 @@ class Manifest:
     features: T.Dict[str, T.List[str]] = dataclasses.field(default_factory=dict)
     target: T.Dict[str, T.Dict[str, Dependency]] = dataclasses.field(default_factory=dict)
     lints: T.List[Lint] = dataclasses.field(default_factory=list)
+    profile: T.Dict[str, Profile] = dataclasses.field(default_factory=dict)
+
     # Kept in raw form: Meson does not implement [patch], it only validates it
     # for the entry-point crate (see validate_patch).
     patch: object = None
-    profile: object = None
 
     def __post_init__(self) -> None:
         self.features.setdefault('default', [])
@@ -621,7 +665,8 @@ class Manifest:
                                  test=ConvertValue(lambda x: [Test.from_raw(b, pkg) for b in x]),
                                  bench=ConvertValue(lambda x: [Benchmark.from_raw(b, pkg) for b in x]),
                                  example=ConvertValue(lambda x: [Example.from_raw(b, pkg) for b in x]),
-                                 target=ConvertValue(lambda x: {k: dependencies_from_raw(v.get('dependencies', {})) for k, v in x.items()}))
+                                 target=ConvertValue(lambda x: {k: dependencies_from_raw(v.get('dependencies', {})) for k, v in x.items()}),
+                                 profile=ConvertValue(lambda x: {k: Profile.from_raw(v) for k, v in x.items()}))
 
 
 @dataclasses.dataclass
@@ -640,13 +685,13 @@ class Workspace:
     dependencies: T.Dict[str, raw.Dependency] = dataclasses.field(default_factory=dict)
     lints: T.Dict[str, T.Dict[str, raw.LintV]] = dataclasses.field(default_factory=dict)
     metadata: T.Dict[str, T.Any] = dataclasses.field(default_factory=dict)
+    profile: T.Dict[str, Profile] = dataclasses.field(default_factory=dict)
 
     # A workspace can also have a root package.
     root_package: T.Optional[Manifest] = None
 
     # Top-level [patch] table, kept in raw form (see Manifest.validate_patch).
     patch: object = None
-    profile: object = None
 
     @lazy_property
     def inheritable(self) -> T.Dict[str, object]:
@@ -665,7 +710,7 @@ class Workspace:
             ws.profile = ws.root_package.profile
         else:
             ws.patch = raw.get('patch')
-            ws.profile = raw.get('profile')
+            ws.profile = {k: Profile.from_raw(v) for k, v in raw.get('profile', {}).items()}
 
         ws.members = list(PurePath(m).as_posix() for m in ws.members)
         if ws.default_members:

--- a/mesonbuild/cargo/manifest.py
+++ b/mesonbuild/cargo/manifest.py
@@ -23,6 +23,7 @@ if T.TYPE_CHECKING:
 
     from . import raw
     from .raw import EDITION, CRATE_TYPE, LINT_LEVEL
+    from ..options import ElementaryOptionValues
     from ..wrap.wrap import PackageDefinition
 
     # Copied from typeshed. Blarg that they don't expose this
@@ -549,6 +550,36 @@ class Profile:
         if profile.lto:
             profile.lto_mode = 'thin' if raw_profile.get('lto') == 'thin' else 'default'
         return profile
+
+    def to_meson_options(self, for_machine: MachineChoice) -> T.Dict[str, ElementaryOptionValues]:
+        """Map the profile onto Meson option values, only for keys that are set.
+           For the build machine, the [build-override] settings are layered on top
+           (Cargo applies those to build scripts, proc macros and their deps)."""
+        opts: T.Dict[str, ElementaryOptionValues] = {}
+        if self.opt_level is not None:
+            # Meson's 'optimization' has no 'z'; fall back to 's'.
+            opts['optimization'] = 's' if self.opt_level == 'z' else self.opt_level
+        if self.debug is not None:
+            opts['debug'] = self.debug
+        # Meson only handles strip at install time
+        if self.debug_assertions is not None:
+            # note inverted polarity
+            opts['b_ndebug'] = 'false' if self.debug_assertions else 'true'
+        if self.overflow_checks is not None:
+            opts['rust_overflow_checks'] = self.overflow_checks
+        if self.lto is not None:
+            opts['b_lto'] = self.lto
+        if self.lto_mode is not None:
+            opts['b_lto_mode'] = self.lto_mode
+        if self.panic is not None:
+            opts['rust_panic'] = self.panic
+        if self.incremental is not None:
+            opts['rust_incremental'] = self.incremental
+        if self.codegen_units is not None:
+            opts['rust_codegen_units'] = self.codegen_units
+        if for_machine is MachineChoice.BUILD and self.build_override is not None:
+            opts.update(self.build_override.to_meson_options(for_machine))
+        return opts
 
 
 @dataclasses.dataclass

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -375,6 +375,38 @@ class RustCompiler(Compiler):
             "Nightly Rust compiler (enabled=required, disabled=don't use nightly feature, auto=use nightly feature if available)",
             'auto')
 
+        key = self.form_compileropt_key('panic')
+        opts[key] = options.UserComboOption(
+            self.make_option_name(key),
+            'Panic strategy (none=use the compiler default)',
+            'none',
+            choices=['none', 'unwind', 'abort'])
+
+        key = self.form_compileropt_key('overflow_checks')
+        opts[key] = options.UserBooleanOption(
+            self.make_option_name(key),
+            'Whether to enable runtime integer overflow checks',
+            False)
+
+        key = self.form_compileropt_key('codegen_units')
+        opts[key] = options.UserIntegerOption(
+            self.make_option_name(key),
+            'Number of code generation units to split the crate into (0=use the compiler default)',
+            0,
+            min_value=0)
+
+        key = self.form_compileropt_key('incremental')
+        opts[key] = options.UserBooleanOption(
+            self.make_option_name(key),
+            'Whether to enable incremental compilation',
+            False)
+
+        key = self.form_compileropt_key('incremental_cache_dir')
+        opts[key] = options.UserStringOption(
+            self.make_option_name(key),
+            'Directory used to store incremental compilation data (empty=pick a default under the build directory)',
+            '')
+
         return opts
 
     def get_dependency_compile_args(self, dep: 'Dependency') -> T.List[str]:
@@ -391,6 +423,36 @@ class RustCompiler(Compiler):
         assert isinstance(std, str)
         if std != 'none':
             args.append('--edition=' + std)
+        return args
+
+    def get_option_compile_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+        args: T.List[str] = []
+
+        panic = self.get_compileropt_value('panic', target, subproject)
+        assert isinstance(panic, str)
+        if panic != 'none':
+            args += ['-C', f'panic={panic}']
+
+        overflow_checks = self.get_compileropt_value('overflow_checks', target, subproject)
+        assert isinstance(overflow_checks, bool)
+        args += ['-C', 'overflow-checks=' + ('yes' if overflow_checks else 'no')]
+
+        codegen_units = self.get_compileropt_value('codegen_units', target, subproject)
+        assert isinstance(codegen_units, int)
+        if codegen_units > 0:
+            args += ['-C', f'codegen-units={codegen_units}']
+
+        incremental = self.get_compileropt_value('incremental', target, subproject)
+        assert isinstance(incremental, bool)
+        if incremental and target:
+            path = self.get_compileropt_value('incremental_cache_dir', target, subproject)
+            assert isinstance(path, str)
+            if not path:
+                # rustc locks the incremental directory while it runs, so give
+                # each target its own to avoid clashes between parallel builds.
+                path = os.path.join(self.environment.get_scratch_dir(), 'rust-incremental', target.get_id())
+            args += ['-C', f'incremental={path}']
+
         return args
 
     def get_crt_compile_args(self, crt_val: str) -> T.List[str]:
@@ -526,7 +588,7 @@ class RustCompiler(Compiler):
 
     def get_assert_args(self, disable: bool) -> T.List[str]:
         action = "no" if disable else "yes"
-        return ['-C', f'debug-assertions={action}', '-C', 'overflow-checks=no']
+        return ['-C', f'debug-assertions={action}']
 
     def get_rust_tool(self, name: str) -> T.List[str]:
         if self.rustup_run_and_args:

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -407,6 +407,13 @@ class RustCompiler(Compiler):
             'Directory used to store incremental compilation data (empty=pick a default under the build directory)',
             '')
 
+        key = self.form_compileropt_key('cargo_profile')
+        opts[key] = options.UserComboOption(
+            self.make_option_name(key),
+            'Cargo [profile] to apply when building Cargo subprojects',
+            'from_buildtype',
+            choices=['none', 'dev', 'release', 'from_buildtype'])
+
         return opts
 
     def get_dependency_compile_args(self, dep: 'Dependency') -> T.List[str]:

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -372,6 +372,38 @@ class RustCompiler(Compiler):
             "Nightly Rust compiler (enabled=required, disabled=don't use nightly feature, auto=use nightly feature if available)",
             'auto')
 
+        key = self.form_compileropt_key('panic')
+        opts[key] = options.UserComboOption(
+            self.make_option_name(key),
+            'Panic strategy (none=use the compiler default)',
+            'none',
+            choices=['none', 'unwind', 'abort'])
+
+        key = self.form_compileropt_key('overflow_checks')
+        opts[key] = options.UserBooleanOption(
+            self.make_option_name(key),
+            'Whether to enable runtime integer overflow checks',
+            False)
+
+        key = self.form_compileropt_key('codegen_units')
+        opts[key] = options.UserIntegerOption(
+            self.make_option_name(key),
+            'Number of code generation units to split the crate into (0=use the compiler default)',
+            0,
+            min_value=0)
+
+        key = self.form_compileropt_key('incremental')
+        opts[key] = options.UserBooleanOption(
+            self.make_option_name(key),
+            'Whether to enable incremental compilation',
+            False)
+
+        key = self.form_compileropt_key('incremental_cache_dir')
+        opts[key] = options.UserStringOption(
+            self.make_option_name(key),
+            'Directory used to store incremental compilation data (empty=pick a default under the build directory)',
+            '')
+
         return opts
 
     def get_dependency_compile_args(self, dep: 'Dependency') -> T.List[str]:
@@ -388,6 +420,36 @@ class RustCompiler(Compiler):
         assert isinstance(std, str)
         if std != 'none':
             args.append('--edition=' + std)
+        return args
+
+    def get_option_compile_args(self, target: BuildTarget, subproject: T.Optional[str] = None) -> T.List[str]:
+        args: T.List[str] = []
+
+        panic = self.get_compileropt_value('panic', target, subproject)
+        assert isinstance(panic, str)
+        if panic != 'none':
+            args += ['-C', f'panic={panic}']
+
+        overflow_checks = self.get_compileropt_value('overflow_checks', target, subproject)
+        assert isinstance(overflow_checks, bool)
+        args += ['-C', 'overflow-checks=' + ('yes' if overflow_checks else 'no')]
+
+        codegen_units = self.get_compileropt_value('codegen_units', target, subproject)
+        assert isinstance(codegen_units, int)
+        if codegen_units > 0:
+            args += ['-C', f'codegen-units={codegen_units}']
+
+        incremental = self.get_compileropt_value('incremental', target, subproject)
+        assert isinstance(incremental, bool)
+        if incremental and target:
+            path = self.get_compileropt_value('incremental_cache_dir', target, subproject)
+            assert isinstance(path, str)
+            if not path:
+                # rustc locks the incremental directory while it runs, so give
+                # each target its own to avoid clashes between parallel builds.
+                path = os.path.join(self.environment.get_scratch_dir(), 'rust-incremental', target.get_id())
+            args += ['-C', f'incremental={path}']
+
         return args
 
     def get_crt_compile_args(self, crt_val: str) -> T.List[str]:
@@ -526,7 +588,7 @@ class RustCompiler(Compiler):
 
     def get_assert_args(self, disable: bool) -> T.List[str]:
         action = "no" if disable else "yes"
-        return ['-C', f'debug-assertions={action}', '-C', 'overflow-checks=no']
+        return ['-C', f'debug-assertions={action}']
 
     def get_rust_tool(self, name: str) -> T.List[str]:
         if self.rustup_run_and_args:

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -404,6 +404,13 @@ class RustCompiler(Compiler):
             'Directory used to store incremental compilation data (empty=pick a default under the build directory)',
             '')
 
+        key = self.form_compileropt_key('cargo_profile')
+        opts[key] = options.UserComboOption(
+            self.make_option_name(key),
+            'Cargo [profile] to apply when building Cargo subprojects',
+            'from_buildtype',
+            choices=['none', 'dev', 'release', 'from_buildtype'])
+
         return opts
 
     def get_dependency_compile_args(self, dep: 'Dependency') -> T.List[str]:

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -381,7 +381,11 @@ class RustPackage(RustCrate):
             self.package.get_rustc_args(state.environment, state.subdir, kwargs['native'])
         kwargs['rust_args'].extend(rust_args)
 
-        kwargs['override_options'].setdefault('rust_std', self.package.manifest.package.edition)
+        profile = kwargs['override_options'].get('rust_cargo_profile')
+        assert profile is None or isinstance(profile, str), 'for mypy'
+        overrides = self.rust_ws.interpreter.cargo.get_override_options(self.package, kwargs['native'], profile)
+        for key, value in overrides.items():
+            kwargs['override_options'].setdefault(key, value)
 
     def _library_method(self, state: ModuleState, args: T.Tuple[
             T.Optional[T.Union[str, StructuredSources]],

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -432,6 +432,7 @@ class RustPackage(RustCrate):
         kwargs['rust_abi'] = None
         kwargs['rust_crate_type'] = 'proc-macro'
         kwargs['rust_args'] = kwargs['rust_args'] + ['--extern', 'proc_macro']
+        kwargs['override_options'].setdefault('rust_panic', 'none')
         result = self._library_method(state, args, kwargs, shared=True, static=False)
         return T.cast('SharedLibrary', result)
 
@@ -691,6 +692,12 @@ class RustModule(ExtensionModule):
                 del new_target_kwargs[kw]  # type: ignore[misc]
 
         new_target_kwargs['install'] = False
+        # Compiling tests with panic=abort is not supported
+        # (https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/panic-abort-tests.html)
+        new_target_kwargs['override_options'] = {
+            'rust_panic': 'none',
+            **new_target_kwargs.get('override_options', {}),
+        }
         new_target_kwargs['dependencies'] = new_target_kwargs.get('dependencies', []) + kwargs['dependencies']
         new_target_kwargs['link_with'] = new_target_kwargs.get('link_with', []) + kwargs['link_with']
         new_target_kwargs['link_whole'] = new_target_kwargs.get('link_whole', []) + kwargs['link_whole']
@@ -1035,6 +1042,7 @@ class RustModule(ExtensionModule):
         kwargs['native'] = MachineChoice.BUILD
         kwargs['rust_crate_type'] = 'proc-macro'
         kwargs['rust_args'] = kwargs['rust_args'] + ['--extern', 'proc_macro']
+        kwargs['override_options'].setdefault('rust_panic', 'none')
 
         # Set any kwargs to default that haven't already been set
         for s in SHARED_LIB_KWS:

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -391,7 +391,11 @@ class RustPackage(RustCrate):
             self.package.get_rustc_args(state.environment, state.subdir, kwargs['native'])
         kwargs['rust_args'].extend(rust_args)
 
-        kwargs['override_options'].setdefault('rust_std', self.package.manifest.package.edition)
+        profile = kwargs['override_options'].get('rust_cargo_profile')
+        assert profile is None or isinstance(profile, str), 'for mypy'
+        overrides = self.rust_ws.interpreter.cargo.get_override_options(self.package, kwargs['native'], profile)
+        for key, value in overrides.items():
+            kwargs['override_options'].setdefault(key, value)
 
     def _library_method(self, state: ModuleState, args: T.Tuple[
             T.Optional[T.Union[str, StructuredSources]],

--- a/mesonbuild/modules/rust.py
+++ b/mesonbuild/modules/rust.py
@@ -442,6 +442,7 @@ class RustPackage(RustCrate):
         kwargs['rust_abi'] = None
         kwargs['rust_crate_type'] = 'proc-macro'
         kwargs['rust_args'] = kwargs['rust_args'] + ['--extern', 'proc_macro']
+        kwargs['override_options'].setdefault('rust_panic', 'none')
         result = self._library_method(state, args, kwargs, shared=True, static=False)
         return T.cast('SharedLibrary', result)
 
@@ -712,6 +713,12 @@ class RustModule(ExtensionModule):
                 del new_target_kwargs[kw]  # type: ignore[misc]
 
         new_target_kwargs['install'] = False
+        # Compiling tests with panic=abort is not supported
+        # (https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/panic-abort-tests.html)
+        new_target_kwargs['override_options'] = {
+            'rust_panic': 'none',
+            **new_target_kwargs.get('override_options', {}),
+        }
         new_target_kwargs['dependencies'] = new_target_kwargs.get('dependencies', []) + kwargs['dependencies']
         new_target_kwargs['link_with'] = new_target_kwargs.get('link_with', []) + kwargs['link_with']
         new_target_kwargs['link_whole'] = new_target_kwargs.get('link_whole', []) + kwargs['link_whole']
@@ -1056,6 +1063,7 @@ class RustModule(ExtensionModule):
         kwargs['native'] = MachineChoice.BUILD
         kwargs['rust_crate_type'] = 'proc-macro'
         kwargs['rust_args'] = kwargs['rust_args'] + ['--extern', 'proc_macro']
+        kwargs['override_options'].setdefault('rust_panic', 'none')
 
         # Set any kwargs to default that haven't already been set
         for s in SHARED_LIB_KWS:

--- a/test cases/rust/1 basic/test.json
+++ b/test cases/rust/1 basic/test.json
@@ -1,4 +1,12 @@
 {
+  "matrix": {
+    "options": {
+      "rust_incremental": [
+        { "val": true },
+        { "val": false }
+      ]
+    }
+  },
   "installed": [
     {"type": "exe", "file": "usr/bin/rust-program"},
     {"type": "pdb", "file": "usr/bin/rust-program"},

--- a/test cases/rust/18 proc-macro/test.json
+++ b/test cases/rust/18 proc-macro/test.json
@@ -1,0 +1,10 @@
+{
+  "matrix": {
+    "options": {
+      "rust_panic": [
+        { "val": "abort" },
+        { "val": "unwind" }
+      ]
+    }
+  }
+}

--- a/test cases/rust/9 unit tests/meson.build
+++ b/test cases/rust/9 unit tests/meson.build
@@ -3,6 +3,7 @@ project('rust unit tests', 'rust', meson_version: '>=1.11.0')
 t = executable(
   'rust_test',
   ['test.rs'],
+  override_options: {'rust_panic': 'none'},
   rust_args : ['--test'],
 )
 
@@ -41,11 +42,15 @@ if rustdoc.found()
     suite : ['doctests'],
   )
 
-  doclib = shared_library('rust_doc_lib', ['doctest1.rs'], build_by_default : false)
-  rust.doctest('rust shared doctests', doclib,
-    protocol : 'rust',
-    suite : ['doctests'],
-  )
+  # abort not valid for shared libraries:
+  #   error: the linked panic runtime `panic_unwind` is not compiled with this crate's panic strategy `abort`
+  if get_option('rust_panic') != 'abort'
+    doclib = shared_library('rust_doc_lib', ['doctest1.rs'], build_by_default : false)
+    rust.doctest('rust shared doctests', doclib,
+      protocol : 'rust',
+      suite : ['doctests'],
+    )
+  endif
 endif
 
 exe = executable('rust_exe', ['test2.rs', 'test.rs'], build_by_default : false)
@@ -58,6 +63,10 @@ rust.test('rust_test_from_static', lib, args: ['--skip', 'test_add_intentional_f
 lib = shared_library('rust_shared', ['test.rs'], build_by_default : false)
 rust.test('rust_test_from_shared', lib, args: ['--skip', 'test_add_intentional_fail'])
 
-helper = static_library('helper', 'helper.rs')
-lib = static_library('rust_link_with', 'test3.rs', build_by_default : false)
-rust.test('rust_test_link_with', lib, link_with : helper, rust_args : ['--cfg', 'broken="false"'])
+if get_option('rust_panic') != 'abort'
+  # abort not valid when linking into tests:
+  #   error: the crate `helper` requires panic strategy `abort` which is incompatible with this crate's strategy of `unwind`
+  helper = static_library('helper', 'helper.rs')
+  lib = static_library('rust_link_with', 'test3.rs', build_by_default : false)
+  rust.test('rust_test_link_with', lib, link_with : helper, rust_args : ['--cfg', 'broken="false"'])
+endif

--- a/test cases/rust/9 unit tests/test.json
+++ b/test cases/rust/9 unit tests/test.json
@@ -1,0 +1,10 @@
+{
+  "matrix": {
+    "options": {
+      "rust_panic": [
+        { "val": "abort" },
+        { "val": "unwind" }
+      ]
+    }
+  }
+}

--- a/unittests/cargotests.py
+++ b/unittests/cargotests.py
@@ -375,6 +375,31 @@ class CargoTomlTest(unittest.TestCase):
         crate-type = ["lib"] # ignored
     ''')
 
+    CARGO_TOML_PROFILE = textwrap.dedent('''\
+        [package]
+        name = "demo"
+        version = "0.1.0"
+        edition = "2021"
+
+        [profile.release]
+        opt-level = 3
+        debug = false
+        strip = "symbols"
+        debug-assertions = false
+        overflow-checks = false
+        lto = "thin"
+        panic = "abort"
+        incremental = false
+        codegen-units = 16
+
+        [profile.release.build-override]
+        opt-level = 0
+        codegen-units = 256
+
+        [profile.dev]
+        opt-level = "s"
+    ''')
+
     CARGO_TOML_WS = textwrap.dedent('''\
         [workspace]
         resolver = "2"
@@ -679,6 +704,36 @@ class CargoTomlTest(unittest.TestCase):
         self.assertEqual(manifest.features['v1_42'], ['pango-sys/v1_42'])
         self.assertEqual(manifest.features['v1_44'], ['v1_42', 'pango-sys/v1_44'])
         self.assertEqual(manifest.features['default'], [])
+
+    def test_cargo_toml_profile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fname = os.path.join(tmpdir, 'Cargo.toml')
+            with open(fname, 'w', encoding='utf-8') as f:
+                f.write(self.CARGO_TOML_PROFILE)
+            manifest_toml = load_toml(fname)
+            manifest = Manifest.from_raw(manifest_toml, 'Cargo.toml')
+
+        self.assertEqual(sorted(manifest.profile), ['dev', 'release'])
+        release = manifest.profile['release']
+        self.assertEqual(release.opt_level, '3')
+        self.assertEqual(release.debug, False)
+        self.assertEqual(release.strip, True)
+        self.assertEqual(release.debug_assertions, False)
+        self.assertEqual(release.overflow_checks, False)
+        self.assertEqual(release.lto, True)
+        self.assertEqual(release.lto_mode, 'thin')
+        self.assertEqual(release.panic, 'abort')
+        self.assertEqual(release.incremental, False)
+        self.assertEqual(release.codegen_units, 16)
+
+        build_override = release.build_override
+        assert build_override is not None
+        self.assertEqual(build_override.opt_level, '0')
+        self.assertEqual(build_override.codegen_units, 256)
+        self.assertIsNone(build_override.lto)
+        self.assertIsNone(build_override.lto_mode)
+
+        self.assertEqual(manifest.profile['dev'].opt_level, 's')
 
     def test_validate_patch(self) -> None:
         # packages_to_member values are normalized with os.path.normpath (see

--- a/unittests/cargotests.py
+++ b/unittests/cargotests.py
@@ -14,7 +14,7 @@ from mesonbuild.cargo.interpreter import load_cargo_lock
 from mesonbuild.cargo.manifest import Dependency, Lint, Manifest, Package, Workspace, validate_patch
 from mesonbuild.cargo.toml import load_toml
 from mesonbuild.cargo.version import api, cargo_parse, SemVer
-from mesonbuild.mesonlib import MesonException
+from mesonbuild.mesonlib import MachineChoice, MesonException
 
 
 class CargoVersionTest(unittest.TestCase):
@@ -734,6 +734,28 @@ class CargoTomlTest(unittest.TestCase):
         self.assertIsNone(build_override.lto_mode)
 
         self.assertEqual(manifest.profile['dev'].opt_level, 's')
+
+    def test_cargo_toml_profile_to_meson_options(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fname = os.path.join(tmpdir, 'Cargo.toml')
+            with open(fname, 'w', encoding='utf-8') as f:
+                f.write(self.CARGO_TOML_PROFILE)
+            manifest = Manifest.from_raw(load_toml(fname), 'Cargo.toml')
+
+        release = manifest.profile['release']
+        host = release.to_meson_options(MachineChoice.HOST)
+        self.assertEqual(host['optimization'], '3')
+        self.assertEqual(host['rust_codegen_units'], 16)
+        self.assertEqual(host['b_lto_mode'], 'thin')
+        self.assertEqual(host['rust_panic'], 'abort')
+
+        build = release.to_meson_options(MachineChoice.BUILD)
+        # On the build machine the [build-override] keys are layered on top.
+        self.assertEqual(build['optimization'], '0')
+        self.assertEqual(build['rust_codegen_units'], 256)
+        # keys not set by build-override stay from the base profile
+        self.assertEqual(build['b_lto_mode'], 'thin')
+        self.assertEqual(build['rust_panic'], 'abort')
 
     def test_validate_patch(self) -> None:
         # packages_to_member values are normalized with os.path.normpath (see

--- a/unittests/cargotests.py
+++ b/unittests/cargotests.py
@@ -386,6 +386,31 @@ class CargoTomlTest(unittest.TestCase):
         crate-type = ["lib"] # ignored
     ''')
 
+    CARGO_TOML_PROFILE = textwrap.dedent('''\
+        [package]
+        name = "demo"
+        version = "0.1.0"
+        edition = "2021"
+
+        [profile.release]
+        opt-level = 3
+        debug = false
+        strip = "symbols"
+        debug-assertions = false
+        overflow-checks = false
+        lto = "thin"
+        panic = "abort"
+        incremental = false
+        codegen-units = 16
+
+        [profile.release.build-override]
+        opt-level = 0
+        codegen-units = 256
+
+        [profile.dev]
+        opt-level = "s"
+    ''')
+
     CARGO_TOML_WS = textwrap.dedent('''\
         [workspace]
         resolver = "2"
@@ -690,6 +715,36 @@ class CargoTomlTest(unittest.TestCase):
         self.assertEqual(manifest.features['v1_42'], ['pango-sys/v1_42'])
         self.assertEqual(manifest.features['v1_44'], ['v1_42', 'pango-sys/v1_44'])
         self.assertEqual(manifest.features['default'], [])
+
+    def test_cargo_toml_profile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fname = os.path.join(tmpdir, 'Cargo.toml')
+            with open(fname, 'w', encoding='utf-8') as f:
+                f.write(self.CARGO_TOML_PROFILE)
+            manifest_toml = load_toml(fname)
+            manifest = Manifest.from_raw(manifest_toml, 'Cargo.toml')
+
+        self.assertEqual(sorted(manifest.profile), ['dev', 'release'])
+        release = manifest.profile['release']
+        self.assertEqual(release.opt_level, '3')
+        self.assertEqual(release.debug, False)
+        self.assertEqual(release.strip, True)
+        self.assertEqual(release.debug_assertions, False)
+        self.assertEqual(release.overflow_checks, False)
+        self.assertEqual(release.lto, True)
+        self.assertEqual(release.lto_mode, 'thin')
+        self.assertEqual(release.panic, 'abort')
+        self.assertEqual(release.incremental, False)
+        self.assertEqual(release.codegen_units, 16)
+
+        build_override = release.build_override
+        assert build_override is not None
+        self.assertEqual(build_override.opt_level, '0')
+        self.assertEqual(build_override.codegen_units, 256)
+        self.assertIsNone(build_override.lto)
+        self.assertIsNone(build_override.lto_mode)
+
+        self.assertEqual(manifest.profile['dev'].opt_level, 's')
 
     def test_validate_patch(self) -> None:
         # packages_to_member values are normalized with os.path.normpath (see

--- a/unittests/cargotests.py
+++ b/unittests/cargotests.py
@@ -14,7 +14,7 @@ from mesonbuild.cargo.interpreter import load_cargo_lock
 from mesonbuild.cargo.manifest import Dependency, Lint, Manifest, Package, Workspace, validate_patch
 from mesonbuild.cargo.toml import load_toml
 from mesonbuild.cargo.version import api, cargo_parse, SemVer
-from mesonbuild.mesonlib import MesonException
+from mesonbuild.mesonlib import MachineChoice, MesonException
 
 
 class CargoVersionTest(unittest.TestCase):
@@ -745,6 +745,28 @@ class CargoTomlTest(unittest.TestCase):
         self.assertIsNone(build_override.lto_mode)
 
         self.assertEqual(manifest.profile['dev'].opt_level, 's')
+
+    def test_cargo_toml_profile_to_meson_options(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fname = os.path.join(tmpdir, 'Cargo.toml')
+            with open(fname, 'w', encoding='utf-8') as f:
+                f.write(self.CARGO_TOML_PROFILE)
+            manifest = Manifest.from_raw(load_toml(fname), 'Cargo.toml')
+
+        release = manifest.profile['release']
+        host = release.to_meson_options(MachineChoice.HOST)
+        self.assertEqual(host['optimization'], '3')
+        self.assertEqual(host['rust_codegen_units'], 16)
+        self.assertEqual(host['b_lto_mode'], 'thin')
+        self.assertEqual(host['rust_panic'], 'abort')
+
+        build = release.to_meson_options(MachineChoice.BUILD)
+        # On the build machine the [build-override] keys are layered on top.
+        self.assertEqual(build['optimization'], '0')
+        self.assertEqual(build['rust_codegen_units'], 256)
+        # keys not set by build-override stay from the base profile
+        self.assertEqual(build['b_lto_mode'], 'thin')
+        self.assertEqual(build['rust_panic'], 'abort')
 
     def test_validate_patch(self) -> None:
         # packages_to_member values are normalized with os.path.normpath (see


### PR DESCRIPTION
Add options to Meson that map to features exposed in Cargo.toml's `[profile]` section.

While `[profile]` is not super important because it only applies to the top-level workspace (so it corresponds to project options), it is possible to map buildtypes to profiles and therefore declare different code generation options that apply to optimizing and non-optimizing buildtypes.