### PR TITLE
universal.py: search_version: make the version regex a bit more robust

### DIFF
--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -1222,7 +1222,8 @@ def search_version(text: str) -> str:
         (
             -[a-zA-Z0-9]+   # Hyphen and one or more alphanumeric
         )?              # Zero or one occurrence
-    )                   # One occurrence
+    )
+    (?!\S)              # Must not be followed by non-space char
     """, re.VERBOSE)
     match = version_regex.search(text)
     if match:

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -84,6 +84,10 @@ class InternalTests(unittest.TestCase):
         self.assertEqual(search_version('2016.x'), 'unknown version')
         self.assertEqual(search_version(r'something version is \033[32;2m1.2.0\033[0m.'), '1.2.0')
 
+        self.assertEqual(search_version(r'''(FooBar LLVM-Linux 5.0.0) clang version 21.9.0
+Target: riscv64-unknown-linux-gnu
+Thread model: posix'''), '21.9.0')
+
         # Literal output of mvn
         self.assertEqual(search_version(r'''\
             \033[1mApache Maven 3.8.1 (05c21c65bdfed0f71a2f2ada8b84da59348c4c5d)\033[0m


### PR DESCRIPTION
This change basically adds another check: the version number should not be followed by something other than a space.

As an example, this is the output of 'clang --version' in a custom LLVM toolchain:

(FooBar LLVM-Linux 5.0.0) clang version 21.9.0
Target: riscv64-unknown-linux-gnu
Thread model: posix
(...)

where "5.0.0" is an internal tag, unrelated to clang's version itself.

With the current regex, meson detects that clang's version is "5.0.0", and this breaks the build of some packages (e.g., appstream):

| ../sources/AppStream-1.0.6/meson.build:1:0: ERROR: None of values ['gnu17'] are supported by the C compiler. Possible values for option "c_std" are ['none', 'c89', 'c99', 'c11', 'gnu89', 'gnu99', 'gnu11']

While I understand the root cause is this spurious internal version number being present left to clang's version, I belive the current regex would be more robust if it also checks what comes next after the 'X.Y.Z' pattern.