### PR TITLE
mconf: lock configure operations on build directories

### DIFF
--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -369,7 +369,7 @@ def is_print_only(options: CMDOptions) -> bool:
         return False
     return True
 
-def run_impl(options: CMDOptions, builddir: str) -> int:
+def _run_impl(options: CMDOptions, builddir: str) -> int:
     print_only = is_print_only(options)
     c = None
     try:
@@ -401,6 +401,14 @@ def run_impl(options: CMDOptions, builddir: str) -> int:
         # Pager quit before we wrote everything.
         pass
     return 0
+
+def run_impl(options: CMDOptions, builddir: str) -> int:
+    if os.path.exists(os.path.join(builddir, 'meson-private', 'coredata.dat')):
+        with mesonlib.DirectoryLock(builddir, 'meson-private/meson.lock',
+                                    mesonlib.DirectoryLockAction.FAIL,
+                                    'Some other Meson process is already using this build directory. Exiting.'):
+            return _run_impl(options, builddir)
+    return _run_impl(options, builddir)
 
 def run(options: CMDOptions) -> int:
     cmdline.parse_cmd_line_options(options)

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -2654,6 +2654,19 @@ class AllPlatformTests(BasePlatformTests):
                     exception_raised = True
         self.assertTrue(exception_raised, 'Double locking did not raise exception.')
 
+    def test_configure_fails_when_builddir_is_locked(self):
+        testdir = os.path.join(self.common_test_dir, '1 trivial')
+        self.init(testdir)
+        old_prefix = self.getconf('prefix')
+
+        with DirectoryLock(self.builddir, 'meson-private/meson.lock',
+                           DirectoryLockAction.FAIL, 'failed to lock directory'):
+            with self.assertRaises(subprocess.CalledProcessError) as cm:
+                self._run(self.mconf_command + ['-Dprefix=/locked', self.builddir])
+            self.assertIn('Some other Meson process is already using this build directory. Exiting.',
+                          cm.exception.output)
+        self.assertEqual(old_prefix, self.getconf('prefix'))
+
     @skipIf(is_osx(), 'Test not applicable to OSX')
     def test_check_module_linking(self):
         """


### PR DESCRIPTION
Acquire the build directory lock before meson configure reads or modifies an already configured build directory. This keeps configure from racing with setup/regenerate paths that already use the same lock.

Add a regression test that holds the build directory lock and verifies configure fails without changing the configured prefix.

Fixes #2922

Test plan:
- git diff --check
- Not run: run_unittests.py AllPlatformTests.test_configure_fails_when_builddir_is_locked (local Python is 3.7.3, Meson master requires Python 3.10+)