### PR TITLE
qt: don't put path separators in compile_translations target names

### DIFF
--- a/mesonbuild/modules/_qt.py
+++ b/mesonbuild/modules/_qt.py
@@ -750,8 +750,13 @@ class QtBaseModule(ExtensionModule):
                 outdir = state.subdir
                 ts_file = ts
             cmd: CommandList = [self.tools['lrelease'], '@INPUT@', '-qm', '@OUTPUT@']
+            # A .ts file may live in a subdirectory, which would put a path
+            # separator into the target name; that is not allowed. Replace the
+            # separators while keeping the full (relative) path so that files
+            # with the same basename in different directories stay unique. (#5019)
+            lrelease_name = f'qt{self.qt_version}-compile-{ts}'.replace('/', '_').replace('\\', '_')
             lrelease_target = build.CustomTarget(
-                f'qt{self.qt_version}-compile-{ts}',
+                lrelease_name,
                 outdir,
                 state.environment,
                 cmd,

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -120,6 +120,11 @@ foreach qt : ['qt4', 'qt5', 'qt6']
       # do not have an X server.
 
       translations = qtmodule.compile_translations(ts_files : qt+'core_fr.ts', build_by_default : true)
+
+      # Regression test for https://github.com/mesonbuild/meson/issues/5019:
+      # a .ts file located in a subdirectory must not put a path separator into
+      # the generated compile-translations target name.
+      qtmodule.compile_translations(ts_files : 'subtranslations/' + qt + 'sub_fr.ts', build_by_default : true)
     endif
 
     qtcore = dependency(qt, modules : 'Core', method : get_option('method'))

--- a/test cases/frameworks/4 qt/subtranslations/qt4sub_fr.ts
+++ b/test cases/frameworks/4 qt/subtranslations/qt4sub_fr.ts
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr_FR">
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="q5core.cpp" line="23"/>
+        <source>Translate me!</source>
+        <translation>Traduisez moi!</translation>
+    </message>
+</context>
+</TS>

--- a/test cases/frameworks/4 qt/subtranslations/qt5sub_fr.ts
+++ b/test cases/frameworks/4 qt/subtranslations/qt5sub_fr.ts
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr_FR">
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="q5core.cpp" line="23"/>
+        <source>Translate me!</source>
+        <translation>Traduisez moi!</translation>
+    </message>
+</context>
+</TS>

--- a/test cases/frameworks/4 qt/subtranslations/qt6sub_fr.ts
+++ b/test cases/frameworks/4 qt/subtranslations/qt6sub_fr.ts
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr_FR">
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="q5core.cpp" line="23"/>
+        <source>Translate me!</source>
+        <translation>Traduisez moi!</translation>
+    </message>
+</context>
+</TS>

--- a/test cases/frameworks/4 qt/test.json
+++ b/test cases/frameworks/4 qt/test.json
@@ -12,5 +12,8 @@
       ]
     }
   },
+  "stdout": [
+    { "comment": "regression test for #5019: a .ts file in a subdirectory must not warn about a path separator in the generated target name", "line": ".*has a path separator in its name.*", "match": "re", "count": 0 }
+  ],
   "expect_skip_on_jobname": ["cygwin", "msys2", "azure", "windows"]
 }


### PR DESCRIPTION
## What

`qt.compile_translations()` builds each `lrelease` target's name as
`qt<ver>-compile-<ts>`. When the `.ts` file lives in a subdirectory, `<ts>` still
contains the path separator, so the target name ends up like
`qt5-compile-po/foo.ts`. A target name that contains a path separator triggers the
"Target ... has a path separator in its name" warning, which is documented as
becoming a hard error in the future.

Fixes #5019.

## Change

Replace the path separators in the generated target name with `_`, keeping the
full relative path (not just the basename) so that `.ts` files sharing a basename
across different directories still get distinct target names. This matches the way
target names are already sanitized in the `windows`, `rust` and `gnome` modules.

## Test

Added a case to `test cases/frameworks/4 qt`: a `.ts` file placed in a
`subtranslations/` subdirectory is passed to `compile_translations()`, and
`test.json` asserts (via `count: 0`) that the path-separator warning is no longer
emitted. Without the change the warning is printed and the test fails.
