### PR TITLE
compilers/cpp: add vc++23 to ALL_STDS (fix clang-cl AssertionError)

### DIFF
--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -48,7 +48,7 @@ else:
 ALL_STDS = ['c++98', 'c++0x', 'c++03', 'c++1y', 'c++1z', 'c++11', 'c++14', 'c++17']
 ALL_STDS += ['c++2a', 'c++2b', 'c++2c', 'c++20', 'c++23', 'c++26']
 ALL_STDS += [f'gnu{std[1:]}' for std in ALL_STDS]
-ALL_STDS += ['vc++11', 'vc++14', 'vc++17', 'vc++20', 'vc++latest', 'c++latest']
+ALL_STDS += ['vc++11', 'vc++14', 'vc++17', 'vc++20', 'vc++23', 'vc++latest', 'c++latest']
 
 
 def non_msvc_eh_options(eh: str, args: T.List[str]) -> None:


### PR DESCRIPTION
## What / why

`ClangClCPPCompiler.get_options()` advertises `vc++23` as a supported `cpp_std` value:

```python
cpp_stds = list(self.VC_VERSION_MAP) + ['c++23', 'vc++23']
return self._get_options_impl(super().get_options(), cpp_stds)
```

but `vc++23` was never added to the `ALL_STDS` list that backs the `cpp_std`
`UserStdOption` (`ALL_STDS` has `c++23` but no `vc++23`). `UserStdOption.set_versions()`
then trips its assertion:

```python
def set_versions(self, versions, ...):
    assert all(std in self.all_stds for std in versions)   # <-- vc++23 not in all_stds
```

the moment a **clang-cl** C++ compiler is detected — i.e. for *any* C++ project,
regardless of what `cpp_std` the project actually selects. Configuration aborts with:

```
subprojects\...\meson.build:1:0: ERROR: Unhandled python exception
  File ".../mesonbuild/compilers/cpp.py", line 958, in get_options
    return self._get_options_impl(super().get_options(), cpp_stds)
  File ".../mesonbuild/compilers/cpp.py", line 823, in _get_options_impl
    std_opt.set_versions(cpp_stds)
  File ".../mesonbuild/options.py", line 599, in set_versions
    assert all(std in self.all_stds for std in versions)
AssertionError
```

Regression from 3b7c81d4 (`clang-cl: add c++23 support via /clang:-std= and remove
CPP11AsCPP14Mixin`), which added `vc++23` to the compiler's registered stds but not to
`ALL_STDS`. Present in 1.12.0rc1. MSVC (`cl`) is unaffected because it never registers
`vc++23`.

## Fix

Add the missing `vc++23` entry to `ALL_STDS` so the compiler's advertised stds are a
subset of `ALL_STDS` again.

Spotted via clang-cl CI failures on wrapdb once `meson --pre` started resolving to
1.12.0rc1.
