### PR TITLE
mconf: fix crash printing list-valued option augments

### DIFF
--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -355,7 +355,7 @@ class Conf:
         if self.coredata.optstore.augments:
             mlog.log('\nCurrently set option augments:')
             for k, v in self.coredata.optstore.augments.items():
-                mlog.log(f'{k!s:21}{v:10}')
+                mlog.log(f'{k!s:21}{stringify(v):10}')
         else:
             mlog.log('\nThere are no option augments.')
 

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -4190,6 +4190,14 @@ class AllPlatformTests(BasePlatformTests):
         self.init(testdir)
         self._run(self.mconf_command + [self.builddir])
 
+    def test_configure_with_augments(self):
+        # A list-valued augment used to crash `meson configure <builddir>`.
+        testdir = os.path.join(self.unit_test_dir, '47 reconfigure')
+        self.init(testdir, extra_args=['-Dsub1:c_args=-DFOO'])
+        out = self._run(self.mconf_command + [self.builddir])
+        self.assertIn('sub1:c_args', out)
+        self.assertIn('[-DFOO]', out)
+
     def test_summary(self):
         testdir = os.path.join(self.unit_test_dir, '71 summary')
         out = self.init(testdir, extra_args=['-Denabled_opt=enabled', f'-Dpython={sys.executable}'])


### PR DESCRIPTION
print_augments() formatted the raw value with a string width spec, which raises TypeError for list values such as c_args. Use the same stringify() helper as the regular option display.

Fixes #15991.