### PR TITLE
Adjust a few "since" values for 1.12.0

### DIFF
--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -132,7 +132,7 @@ Generates a marshal file using the `glib-genmarshal` tool. The first
 argument is the basename of the output files.
 
 * `depends` [](BuildTarget | CustomTarget | CustomTargetIndex | Program):
-  passed directly to CustomTarget (*since 0.61.0*; `program` *since 1.11.2*)
+  passed directly to CustomTarget (*since 0.61.0*; `program` *since 1.12.0*)
 * `depend_files` [](str | File): Passed directly to CustomTarget (*since 0.61.0*)
 * `extra_args`: (*Added 0.42.0*) additional command line arguments to pass
 * `install_dir`: directory to install header to

--- a/docs/markdown/Release-notes-for-1.11.0.md
+++ b/docs/markdown/Release-notes-for-1.11.0.md
@@ -203,15 +203,3 @@ as dependencies.
 now has an `implicit_include_directories` keyword argument to automatically
 add current build and source directories to the included paths when compiling
 a resource.
-
-## External programs as inputs and dependencies to custom targets
-
-Custom targets now allow specifying an external program in
-the `input` and `depends` keyword arguments.  This also applies
-to several methods provided by modules, as they are lowered to
-custom targets internally. (*Added in 1.11.2*).
-
-## External programs as dependencies to tests
-
-Tests now allow specifying an external program in
-the `depends` keyword argument. (*Added in 1.11.2*).

--- a/docs/markdown/snippets/programs-in-more-places.md
+++ b/docs/markdown/snippets/programs-in-more-places.md
@@ -1,0 +1,12 @@
+## External programs as inputs and dependencies to custom targets
+
+Custom targets now allow specifying an external program in
+the `input` and `depends` keyword arguments.  This also applies
+to several methods provided by modules, as they are lowered to
+custom targets internally.
+
+## External programs as dependencies to tests
+
+Tests now allow specifying an external program in
+the `depends` keyword argument.
+

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3501,6 +3501,17 @@ class Interpreter(InterpreterBase, HoldableObject):
             tobj.process_compilers_late()
             self.add_stdlib_info(tobj)
 
+            if tobj.uses_cython():
+                for gensrc in tobj.get_generated_sources():
+                    # a generator producing a .pyx has always worked; feeding
+                    # anything else from a generator into Cython triggered a bug
+                    # in the ninja backend and was effectively a new feature.
+                    if isinstance(gensrc, build.GeneratedList) and \
+                            any(not o.endswith('.pyx') for o in gensrc.get_outputs()):
+                        FeatureNew.single_use('Generators for non-.pyx Cython sources',
+                                              '1.12.0', self.subproject, location=self.current_node)
+                        break
+
         self.build.targets[idname] = tobj
         # Only need to add executables to this set
         if isinstance(tobj, build.Executable):

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -277,7 +277,7 @@ DEPENDS_KW: KwargInfo[T.List[T.Union[BuildTarget, CustomTarget, CustomTargetInde
     ContainerTypeInfo(list, (BuildTarget, CustomTarget, CustomTargetIndex, Program)),
     listify=True,
     default=[],
-    since_values={CustomTargetIndex: '1.5.0', ExternalProgram: '1.11.2'},
+    since_values={CustomTargetIndex: '1.5.0', ExternalProgram: '1.12.0'},
 )
 
 DEPEND_FILES_KW: KwargInfo[T.List[T.Union[str, File]]] = KwargInfo(
@@ -367,7 +367,7 @@ CT_INPUT_KW: KwargInfo[T.List[T.Union[str, File, BuildTarget, GeneratedTypes, Ex
     listify=True,
     default=[],
     convertor=_local_program_convertor,
-    since_values={ExternalProgram: '1.11.2'},
+    since_values={ExternalProgram: '1.12.0'},
 )
 
 CT_INSTALL_TAG_KW: KwargInfo[T.List[T.Union[str, bool]]] = KwargInfo(

--- a/test cases/cython/2 generated sources/answer.c.in
+++ b/test cases/cython/2 generated sources/answer.c.in
@@ -1,0 +1,3 @@
+const char *c_func(void) {
+    return "Hello, World!";
+}

--- a/test cases/cython/2 generated sources/genc.pyx.in
+++ b/test cases/cython/2 generated sources/genc.pyx.in
@@ -1,0 +1,9 @@
+cdef extern from *:
+    """
+    const char *c_func(void);
+    """
+    const char *c_func()
+
+cpdef func():
+    cdef bytes b = c_func()
+    return b.decode('utf-8')

--- a/test cases/cython/2 generated sources/meson.build
+++ b/test cases/cython/2 generated sources/meson.build
@@ -2,6 +2,7 @@ project(
   'generated cython sources',
   ['cython', 'c'],
   default_options : ['buildtype=release'],
+  meson_version : '>= 1.10.0',
 )
 
 if meson.backend() != 'ninja'
@@ -71,6 +72,26 @@ test(
   'generator',
   py3,
   args : [files('test.py'), 'g'],
+  env : ['PYTHONPATH=' + meson.current_build_dir()]
+)
+
+# A generator whose output is *not* a .pyx file, mixed with a Cython .pyx
+# source in the same target.
+gen_c = generator(
+  find_program('generator.py'),
+  arguments : ['@INPUT@', '@OUTPUT@'],
+  output : '@BASENAME@',
+)
+
+genc_ext = py3.extension_module(
+  'genc',
+  gen_c.process('genc.pyx.in', 'answer.c.in'),
+)
+
+test(
+  'generator with non-pyx output',
+  py3,
+  args : [files('test.py'), 'genc'],
   env : ['PYTHONPATH=' + meson.current_build_dir()]
 )
 

--- a/test cases/cython/2 generated sources/test.json
+++ b/test cases/cython/2 generated sources/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/cython/2 generated sources/meson.build:86: WARNING: Project targets '>= 1.10.0' but uses feature introduced in '1.12.0': Generators for non-.pyx Cython sources."
+    }
+  ]
+}


### PR DESCRIPTION
Add two "since 1.12.0" that were requested by @eli-schwartz:
* External programs as inputs and dependencies to custom targets, and external programs as dependencies to tests, were added as part of fixing #15774. #15774 is a regression where 1.10.x and earlier versions allowed overridden programs but 1.11 does not. I considered the bug to be that the result of `find_program()` was allowed in some cases and not in others, and would have considered that a bug worth fixing in 1.11.x. Eli disagreed when preparing 1.11.2, so bump the release introducing the fix from 1.11.2 to 1.12.0.
* mypy reported a potential AttributeError with Cython, which was fixed as part of completing the typing effort in 1.12.0. This later was reported as a genuine issue, caused by Generators that produce a non-`.pyx` source. Eli asks to consider this as a DSL extension and warn about it (which makes sense because non-Ninja backends don't support Cython at all). The situation is not handled by KwargInfo; detect it specifically as part of `add_target`'s postprocessing.

In both cases, any decision on whether to introduce the fixes in 1.11.3 can be taken later. These are an ugly corner case that sits between bug (incorrect typing, manifestly inconsistent DSL constraints) and new feature, and more discussion seems to be needed.