### PR TITLE
Fix issues with ld64 version detection

### DIFF
--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -228,17 +228,15 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
         cmd = compiler + comp_class.LINKER_OPTION_STYLE.wrap(['-v']) + extra_args
         _, newo, newerr = Popen_safe_logged(cmd, msg='Detecting Apple linker via')
 
-        is_dyld: bool
         for line in newerr.split('\n'):
             if 'PROJECT:ld' in line or 'PROJECT:dyld' in line:
                 v = line.split('-')[1]
-                is_dyld = 'PROJECT:dyld' in line
                 break
         else:
             __failed_to_detect_linker(compiler, check_args, o, e)
         linker = linkers.AppleDynamicLinker(
             compiler, env, for_machine, comp_class.LINKER_OPTION_STYLE, override,
-            system=system, version=v, is_dyld=is_dyld
+            system=system, version=v
         )
     elif 'ld.exe: unrecognized option' in e or 'ld: unrecognized option' in e:
         linker = linkers.OS2AoutDynamicLinker(

--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -213,8 +213,14 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
             compiler, env, for_machine, comp_class.LINKER_OPTION_STYLE, override, version=v)
     # detect xtools first, bug #10805
     elif 'xtools-' in o.split('\n', maxsplit=1)[0]:
-        xtools = o.split(' ', maxsplit=1)[0]
-        v = xtools.split('-', maxsplit=2)[1]
+        # See https://github.com/iains/darwin-xtools/blob/darwin-xtools-3-3-0/ld64/src/ld/ld_vers.c.in
+        # for the format
+        for line in o.split('\n'):
+            if line.startswith('Based on Apple Inc. ld64-'):
+                v = line.split()[4][5:]
+                break
+        else:
+            __failed_to_detect_linker(compiler, check_args, o, e)
         linker = linkers.AppleDynamicLinker(
             compiler, env, for_machine, comp_class.LINKER_OPTION_STYLE, override,
             system=system, version=v

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -959,7 +959,9 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
 
     def get_lto_obj_cache_path(self, path: str) -> T.List[str]:
         # https://clang.llvm.org/docs/CommandGuide/clang.html#cmdoption-flto
-        return ["-Wl,-object_path_lto," + path]
+        if mesonlib.version_compare(self.version, '>=123.2'):
+            return self._apply_prefix(['-object_path_lto', path])
+        return []
 
     def export_dynamic_args(self) -> T.List[str]:
         if mesonlib.version_compare(self.version, '>=224.1'):

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -853,13 +853,6 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
 
     id = 'ld64'
 
-    def __init__(self, exelist: T.List[str], env: Environment,
-                 for_machine: mesonlib.MachineChoice, prefix_arg: T.Optional[LinkerOptionStyle],
-                 always_args: T.List[str], *, system: str,
-                 version: str, is_dyld: bool = False):
-        super().__init__(exelist, env, for_machine, prefix_arg, always_args, system=system, version=version)
-        self.is_dyld = is_dyld
-
     def get_asneeded_args(self) -> T.List[str]:
         return self._apply_prefix('-dead_strip_dylibs')
 
@@ -966,8 +959,6 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
 
     def get_lto_obj_cache_path(self, path: str) -> T.List[str]:
         # https://clang.llvm.org/docs/CommandGuide/clang.html#cmdoption-flto
-        if self.is_dyld:
-            return []
         return ["-Wl,-object_path_lto," + path]
 
     def export_dynamic_args(self) -> T.List[str]:


### PR DESCRIPTION
Fix the -object_path_lto handling as requested in #15808:

* due to my mistake/locating the wrong man page, #15809 disabled -object_path_lto for Apple's new dyld linker, but dyld does have it.
* it's ld64 that has it only for some versions
* In addition, the reporter was using xtools. Version checks used the xtools version instead of the ld64 version (bug unrelated to #15809).

Fixes: #15808