### PR TITLE
Fix cython_args build option handling

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1898,6 +1898,7 @@ class NinjaBackend(backends.Backend):
         args += cython.get_option_std_args(target, target.subproject)
         args += self.build.get_global_args(cython, target.for_machine)
         args += self.build.get_project_args(cython, target)
+        args += self.environment.coredata.get_external_args(target.for_machine, cython.get_language())
         args += target.get_extra_args('cython')
 
         ext = self.get_target_option(target, OptionKey('cython_language', machine=target.for_machine))

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1898,7 +1898,10 @@ class NinjaBackend(backends.Backend):
         args += cython.get_option_std_args(target, target.subproject)
         args += self.build.get_global_args(cython, target.for_machine)
         args += self.build.get_project_args(cython, target)
-        args += self.environment.coredata.get_external_args(target.for_machine, cython.get_language())
+        cython_args = self.environment.coredata.optstore.get_value_for(
+            OptionKey('cython_args', target.subproject, target.for_machine))
+        assert isinstance(cython_args, list), 'for mypy'
+        args += cython_args
         args += target.get_extra_args('cython')
 
         ext = self.get_target_option(target, OptionKey('cython_language', machine=target.for_machine))

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1898,6 +1898,10 @@ class NinjaBackend(backends.Backend):
         args += cython.get_option_std_args(target, target.subproject)
         args += self.build.get_global_args(cython, target)
         args += self.build.get_project_args(cython, target)
+        cython_args = self.environment.coredata.optstore.get_value_for(
+            OptionKey('cython_args', target.subproject, target.for_machine))
+        assert isinstance(cython_args, list), 'for mypy'
+        args += cython_args
         args += target.get_extra_args('cython')
 
         ext = self.get_target_option(target, OptionKey('cython_language', machine=target.for_machine))

--- a/test cases/cython/3 cython_args/builtincythonargs.pyx
+++ b/test cases/cython/3 cython_args/builtincythonargs.pyx
@@ -1,0 +1,5 @@
+def test():
+    IF BUILTIN_VALUE:
+        return 1
+    ELSE:
+        return 0

--- a/test cases/cython/3 cython_args/meson.build
+++ b/test cases/cython/3 cython_args/meson.build
@@ -24,6 +24,11 @@ mod = python.extension_module(
   ],
 )
 
+builtin_mod = python.extension_module(
+  'builtincythonargs',
+  files('builtincythonargs.pyx'),
+)
+
 test(
   'test',
   python,

--- a/test cases/cython/3 cython_args/test.json
+++ b/test cases/cython/3 cython_args/test.json
@@ -1,0 +1,9 @@
+{
+  "matrix": {
+    "options": {
+      "cython_args": [
+        { "val": "--compile-time-env BUILTIN_VALUE=1" }
+      ]
+    }
+  }
+}

--- a/test cases/cython/3 cython_args/test.py
+++ b/test cases/cython/3 cython_args/test.py
@@ -1,3 +1,5 @@
 import cythonargs
+import builtincythonargs
 
 assert cythonargs.test() == 1
+assert builtincythonargs.test() == 1


### PR DESCRIPTION
Fixes #15989.

## Summary
- Add configured `cython_args` (`-Dcython_args=...` / machine-file built-in option) to Cython transpile commands.
- Extend the existing Cython args test with a module that only builds when `cython_args` from build options is passed through.

## Tests
- `python run_project_tests.py --use-tmpdir --only 'cython/3 cython_args' --failfast -v` — passed (1 passed, 0 failed, 0 skipped)
- `python run_project_tests.py --use-tmpdir --only cython --failfast` — passed (6 passed, 0 failed, 0 skipped)
- Manual setup/build/test of `test cases/cython/3 cython_args` with `-Dcython_args='--compile-time-env BUILTIN_VALUE=1'` — passed; `build.ninja` contains the expected `--compile-time-env BUILTIN_VALUE=1` Cython args.
