### PR TITLE
[1.12 regression] add_arguments not processed correctly for non-cross builds

### DIFF
--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -254,12 +254,14 @@ class IntrospectionInterpreter(AstInterpreter):
                 assert extraf_nodes is None
                 extraf_nodes = v
 
+        for_machine = MachineChoice.BUILD if kwargs.get('native', False) else MachineChoice.HOST
+
         # Make sure nothing can crash when creating the build class
         _kwargs_reduced = {k: v for k, v in kwargs.items() if k in _TARGET_KWARGS[targetclass.typename] and k in {'install', 'build_by_default', 'build_always', 'name_prefix'}}
         _kwargs_reduced = {k: v.value if isinstance(v, ElementaryNode) else v for k, v in _kwargs_reduced.items()}
         _kwargs_reduced = {k: v for k, v in _kwargs_reduced.items() if not isinstance(v, (BaseNode, UnknownValue))}
+        _kwargs_reduced['native'] = for_machine
         kwargs_reduced = T.cast('BuildTargetKeywordArguments', _kwargs_reduced)
-        for_machine = MachineChoice.BUILD if kwargs.get('native', False) else MachineChoice.HOST
         objects: T.List[T.Any] = []
         empty_sources: T.List[T.Any] = []
         # Passing the unresolved sources list causes errors

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -76,7 +76,7 @@ class IntrospectionInterpreter(AstInterpreter):
 
         self.cross_file = cross_file
         self.backend = backend
-        self.build_project = BuildProject(subproject, '', subproject, MachineChoice.HOST)
+        self.build_project = BuildProject(subproject, '', subproject, MachineChoice.HOST, MachineChoice.HOST)
         self.project_data: T.Dict[str, T.Any] = {}
         self.targets: T.List[IntrospectionBuildTarget] = []
         self.dependencies: T.List[IntrospectionDependency] = []

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -970,7 +970,7 @@ class Backend:
         commands += self.build.get_project_args(compiler, target)
         # Add compile args added using add_global_arguments()
         # These override per-project arguments
-        commands += self.build.get_global_args(compiler, target.for_machine)
+        commands += self.build.get_global_args(compiler, target)
         # Compile args added from the env: CFLAGS/CXXFLAGS, etc, or the cross
         # file. We want these to override all the defaults, but not the
         # per-target compile args.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1896,7 +1896,7 @@ class NinjaBackend(backends.Backend):
         args += cython.get_optimization_args(optimization)
         args += cython.get_option_compile_args(target, target.subproject)
         args += cython.get_option_std_args(target, target.subproject)
-        args += self.build.get_global_args(cython, target.for_machine)
+        args += self.build.get_global_args(cython, target)
         args += self.build.get_project_args(cython, target)
         args += target.get_extra_args('cython')
 
@@ -2416,7 +2416,7 @@ class NinjaBackend(backends.Backend):
         compile_args += swiftc.get_module_args(module_name)
         compile_args += swiftc.get_cxx_interoperability_args(target)
         compile_args += self.build.get_project_args(swiftc, target)
-        compile_args += self.build.get_global_args(swiftc, target.for_machine)
+        compile_args += self.build.get_global_args(swiftc, target)
         if isinstance(target, (build.StaticLibrary, build.SharedLibrary)):
             # swiftc treats modules with a single source file, and the main.swift file in multi-source file modules
             # as top-level code. This is undesirable in library targets since it emits a main function. Add the
@@ -2430,7 +2430,7 @@ class NinjaBackend(backends.Backend):
         compile_args += target.get_extra_args('swift')
         link_args = swiftc.get_output_args(os.path.join(self.environment.get_build_dir(), self.get_target_filename(target)))
         link_args += self.build.get_project_link_args(swiftc, target)
-        link_args += self.build.get_global_link_args(swiftc, target.for_machine)
+        link_args += self.build.get_global_link_args(swiftc, target)
         rundir = self.get_target_private_dir(target)
         out_module_name = self.swift_module_file_name(target)
         in_module_files = self.determine_swift_dep_modules(target)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1066,7 +1066,7 @@ class Vs2010Backend(backends.Backend):
         # Add compile args added using add_project_arguments() and add_global_arguments()
         for l, comp in target.compilers.items():
             file_args[l] += self.build.get_project_args(comp, target)
-            file_args[l] += self.build.get_global_args(comp, target.for_machine)
+            file_args[l] += self.build.get_global_args(comp, target)
 
         # Compile args added from the env or cross file: CFLAGS/CXXFLAGS, etc. We want these
         # to override all the defaults, but not the per-target compile args.

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1063,15 +1063,11 @@ class Vs2010Backend(backends.Backend):
                 file_args[l] += comp.get_option_std_args(
                     target, target.subproject)
 
-        # Add compile args added using add_project_arguments()
+        # Add compile args added using add_project_arguments() and add_global_arguments()
         for l, comp in target.compilers.items():
             file_args[l] += self.build.get_project_args(comp, target)
+            file_args[l] += self.build.get_global_args(comp, target.for_machine)
 
-        # Add compile args added using add_global_arguments()
-        # These override per-project arguments
-        for l, args in self.build.global_args[target.for_machine].items():
-            if l in file_args:
-                file_args[l] += args
         # Compile args added from the env or cross file: CFLAGS/CXXFLAGS, etc. We want these
         # to override all the defaults, but not the per-target compile args.
         for lang in file_args.keys():

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -307,6 +307,13 @@ class BuildProject:
     name: str
     version: str
     subproject: SubProject
+    # orig_for_machine in BuildProject and BuildTarget is used to choose
+    # between "native: true" and "native: false" global arguments
+    #    proj.o_f_m     target.o_f_m        global arguments used
+    #    BUILD          HOST                BUILD ("native: true")
+    #    BUILD          BUILD               BUILD ("native: true")
+    #    HOST           HOST                HOST ("native: false")
+    #    HOST           BUILD               BUILD ("native: true")
     orig_for_machine: MachineChoice
     for_machine: MachineChoice
     project_args: PerMachine[T.Dict[Language, T.List[str]]] = field(default_factory=lambda: PerMachine({}, {}))
@@ -480,7 +487,14 @@ class Build:
         return self.install_dirs
 
     def get_global_args(self, compiler: 'Compiler', target: BuildTarget) -> T.List[str]:
-        d = self.global_args[target.orig_for_machine]
+        # for build-machine subprojects, even "native: false" targets use
+        # the global build-machine arguments (using the host machine would
+        # make no sense when cross compiling)
+        args_machine = MachineChoice.BUILD \
+            if target.build_project.orig_for_machine is MachineChoice.BUILD \
+            else target.orig_for_machine
+
+        d = self.global_args[args_machine]
         return d.get(compiler.get_language(), [])
 
     def get_project_args(self, compiler: 'Compiler', target: BuildTarget) -> T.List[str]:
@@ -491,7 +505,11 @@ class Build:
         return args.get(compiler.get_language(), [])
 
     def get_global_link_args(self, compiler: 'Compiler', target: BuildTarget) -> T.List[str]:
-        d = self.global_link_args[target.orig_for_machine]
+        args_machine = MachineChoice.BUILD \
+            if target.build_project.orig_for_machine is MachineChoice.BUILD \
+            else target.orig_for_machine
+
+        d = self.global_link_args[args_machine]
         return d.get(compiler.get_language(), [])
 
     def get_project_link_args(self, compiler: 'Compiler', target: BuildTarget) -> T.List[str]:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -307,6 +307,7 @@ class BuildProject:
     name: str
     version: str
     subproject: SubProject
+    orig_for_machine: MachineChoice
     for_machine: MachineChoice
     project_args: PerMachine[T.Dict[Language, T.List[str]]] = field(default_factory=lambda: PerMachine({}, {}))
     project_link_args: PerMachine[T.Dict[Language, T.List[str]]] = field(default_factory=lambda: PerMachine({}, {}))
@@ -323,6 +324,7 @@ class Build:
     """
 
     def __init__(self, environment: Environment):
+        self.for_machine = MachineChoice.HOST
         self.version = coredata.version
         self._def_files: T.Optional[T.List[str]] = None
         self.project_name = 'name of master project'
@@ -414,6 +416,7 @@ class Build:
         new = self.copy()
         new.machine_map = MachineMap(self.machine_map.build, self.machine_map.build,
                                      ThreeMachineChoice(self.machine_map.host))
+        new.for_machine = MachineChoice.BUILD
         return new
 
     def merge(self, other: Build) -> None:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -477,23 +477,23 @@ class Build:
         return self.install_dirs
 
     def get_global_args(self, compiler: 'Compiler', target: BuildTarget) -> T.List[str]:
-        d = self.global_args[target.for_machine]
+        d = self.global_args[target.orig_for_machine]
         return d.get(compiler.get_language(), [])
 
     def get_project_args(self, compiler: 'Compiler', target: BuildTarget) -> T.List[str]:
         d = target.build_project
-        args = d.project_args[target.for_machine]
+        args = d.project_args[target.orig_for_machine]
         if not args:
             return []
         return args.get(compiler.get_language(), [])
 
     def get_global_link_args(self, compiler: 'Compiler', target: BuildTarget) -> T.List[str]:
-        d = self.global_link_args[target.for_machine]
+        d = self.global_link_args[target.orig_for_machine]
         return d.get(compiler.get_language(), [])
 
     def get_project_link_args(self, compiler: 'Compiler', target: BuildTarget) -> T.List[str]:
         d = target.build_project
-        link_args = d.project_link_args[target.for_machine]
+        link_args = d.project_link_args[target.orig_for_machine]
         if not link_args:
             return []
 
@@ -796,7 +796,7 @@ class BuildTarget(Target):
             self,
             name: str,
             subdir: str,
-            for_machine: MachineChoice,
+            orig_for_machine: MachineChoice,
             sources: T.List['SourceOutputs'],
             structured_sources: T.Optional[StructuredSources],
             objects: T.Sequence[ObjectTypes | GeneratedTypes],
@@ -805,10 +805,11 @@ class BuildTarget(Target):
             build_project: BuildProject,
             kwargs: BuildTargetKeywordArguments):
         super().__init__(name, subdir, kwargs.get('build_by_default', True),
-                         for_machine, environment,
+                         kwargs['native'], environment,
                          install=kwargs.get('install', False),
                          build_subdir=kwargs.get('build_subdir', ''),
                          build_project=build_project)
+        self.orig_for_machine = orig_for_machine
         self.original_kwargs = kwargs
         # all_compilers is a reference to Interpreter.compilers, as such we
         # cannot mutate it inside build. Use a Mapping to get help from the
@@ -2192,7 +2193,7 @@ class Executable(BuildTarget, LinkableTarget):
             self,
             name: str,
             subdir: str,
-            for_machine: MachineChoice,
+            orig_for_machine: MachineChoice,
             sources: T.List['SourceOutputs'],
             structured_sources: T.Optional[StructuredSources],
             objects: T.Sequence[ObjectTypes | GeneratedTypes],
@@ -2202,7 +2203,7 @@ class Executable(BuildTarget, LinkableTarget):
             kwargs: ExecutableKeywordArguments):
         self.export_dynamic = kwargs.get('export_dynamic', False)
         self.rust_crate_type = kwargs.get('rust_crate_type', 'bin')
-        super().__init__(name, subdir, for_machine, sources, structured_sources, objects,
+        super().__init__(name, subdir, orig_for_machine, sources, structured_sources, objects,
                          environment, compilers, build_project, kwargs)
         self.win_subsystem = kwargs.get('win_subsystem') or 'console'
         self.pie = self._extract_pic_pie(kwargs, 'pie', 'b_pie')
@@ -2325,7 +2326,7 @@ class StaticLibrary(BuildTarget, LinkableTarget):
             self,
             name: str,
             subdir: str,
-            for_machine: MachineChoice,
+            orig_for_machine: MachineChoice,
             sources: T.List['SourceOutputs'],
             structured_sources: T.Optional[StructuredSources],
             objects: T.Sequence[ObjectTypes | GeneratedTypes],
@@ -2335,7 +2336,7 @@ class StaticLibrary(BuildTarget, LinkableTarget):
             kwargs: StaticLibraryKeywordArguments):
         self.prelink = kwargs.get('prelink', False)
         self.rust_crate_type = kwargs.get('rust_crate_type', 'rlib')
-        super().__init__(name, subdir, for_machine, sources, structured_sources, objects,
+        super().__init__(name, subdir, orig_for_machine, sources, structured_sources, objects,
                          environment, compilers, build_project, kwargs)
         self.pic = self._extract_pic_pie(kwargs, 'pic', 'b_staticpic')
         if not self.pic:
@@ -2507,7 +2508,7 @@ class SharedLibrary(BuildTarget, LinkableTarget):
             self,
             name: str,
             subdir: str,
-            for_machine: MachineChoice,
+            orig_for_machine: MachineChoice,
             sources: T.List['SourceOutputs'],
             structured_sources: T.Optional[StructuredSources],
             objects: T.Sequence[ObjectTypes | GeneratedTypes],
@@ -2515,7 +2516,7 @@ class SharedLibrary(BuildTarget, LinkableTarget):
             compilers: CompilerDict,
             build_project: BuildProject,
             kwargs: SharedLibraryKeywordArguments):
-        super().__init__(name, subdir, for_machine, sources, structured_sources, objects,
+        super().__init__(name, subdir, orig_for_machine, sources, structured_sources, objects,
                          environment, compilers, build_project, kwargs)
         # Max length 2, first element is compatibility_version, second is current_version
         self.darwin_versions: T.Optional[T.Tuple[str, str]] = None
@@ -2845,7 +2846,7 @@ class SharedModule(SharedLibrary):
             self,
             name: str,
             subdir: str,
-            for_machine: MachineChoice,
+            orig_for_machine: MachineChoice,
             sources: T.List['SourceOutputs'],
             structured_sources: T.Optional[StructuredSources],
             objects: T.Sequence[ObjectTypes | GeneratedTypes],
@@ -2853,7 +2854,7 @@ class SharedModule(SharedLibrary):
             compilers: CompilerDict,
             build_project: BuildProject,
             kwargs: SharedModuleKeywordArguments):
-        super().__init__(name, subdir, for_machine, sources,
+        super().__init__(name, subdir, orig_for_machine, sources,
                          structured_sources, objects, environment, compilers, build_project,
                          # SharedModuleKeywordArguments is a subclass, it's annoying mypy can't figure this out
                          T.cast('SharedLibraryKeywordArguments', kwargs))
@@ -3238,6 +3239,7 @@ class CompileTarget(BuildTarget):
             'language_args': defaultdict(list, [(compiler.language, compile_args)]),
             'include_directories': include_directories,
             'dependencies': dependencies,
+            'native': compiler.for_machine,
         }
         super().__init__(name, subdir, compiler.for_machine,
                          sources, None, [], environment, compilers,
@@ -3338,11 +3340,11 @@ class Jar(BuildTarget):
     typename = 'jar'
     rust_crate_type = ''  # type: ignore[assignment]
 
-    def __init__(self, name: str, subdir: str, for_machine: MachineChoice,
+    def __init__(self, name: str, subdir: str, orig_for_machine: MachineChoice,
                  sources: T.List[SourceOutputs], structured_sources: T.Optional['StructuredSources'],
                  objects: T.Sequence[ObjectTypes | GeneratedTypes], environment: Environment, compilers: CompilerDict,
                  build_project: BuildProject, kwargs: JarKeywordArguments):
-        super().__init__(name, subdir, for_machine, sources, structured_sources, objects,
+        super().__init__(name, subdir, orig_for_machine, sources, structured_sources, objects,
                          environment, compilers, build_project, kwargs)
         for s in self.sources:
             if not s.endswith('.java'):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -476,8 +476,8 @@ class Build:
     def get_install_subdirs(self) -> T.List['InstallDir']:
         return self.install_dirs
 
-    def get_global_args(self, compiler: 'Compiler', for_machine: 'MachineChoice') -> T.List[str]:
-        d = self.global_args[for_machine]
+    def get_global_args(self, compiler: 'Compiler', target: BuildTarget) -> T.List[str]:
+        d = self.global_args[target.for_machine]
         return d.get(compiler.get_language(), [])
 
     def get_project_args(self, compiler: 'Compiler', target: BuildTarget) -> T.List[str]:
@@ -487,8 +487,8 @@ class Build:
             return []
         return args.get(compiler.get_language(), [])
 
-    def get_global_link_args(self, compiler: 'Compiler', for_machine: 'MachineChoice') -> T.List[str]:
-        d = self.global_link_args[for_machine]
+    def get_global_link_args(self, compiler: 'Compiler', target: BuildTarget) -> T.List[str]:
+        d = self.global_link_args[target.for_machine]
         return d.get(compiler.get_language(), [])
 
     def get_project_link_args(self, compiler: 'Compiler', target: BuildTarget) -> T.List[str]:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1196,7 +1196,7 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
         # per-project link arguments.  Link args added from the env (LDFLAGS)
         # override all the defaults but not the per-target link args.
         return build.get_project_link_args(self, target) \
-            + build.get_global_link_args(self, self.for_machine) \
+            + build.get_global_link_args(self, target) \
             + self.environment.coredata.get_external_link_args(self.for_machine, self.get_language())
 
     def get_target_link_args(self, target: 'BuildTarget') -> T.List[str]:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -3089,26 +3089,22 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     @typed_pos_args('add_global_arguments', varargs=str)
     @typed_kwargs('add_global_arguments', NATIVE_KW, LANGUAGE_KW)
-    @apply_machine_map
     def func_add_global_arguments(self, node: mparser.FunctionNode, args: T.Tuple[T.List[str]], kwargs: 'kwtypes.FuncAddProjectArgs') -> None:
         self._add_global_arguments(node, self.build.global_args[kwargs['native']], args[0], kwargs)
 
     @typed_pos_args('add_global_link_arguments', varargs=str)
     @typed_kwargs('add_global_link_arguments', NATIVE_KW, LANGUAGE_KW)
-    @apply_machine_map
     def func_add_global_link_arguments(self, node: mparser.FunctionNode, args: T.Tuple[T.List[str]], kwargs: 'kwtypes.FuncAddProjectArgs') -> None:
         self._add_global_arguments(node, self.build.global_link_args[kwargs['native']], args[0], kwargs)
 
     @typed_pos_args('add_project_arguments', varargs=str)
     @typed_kwargs('add_project_arguments', NATIVE_KW, LANGUAGE_KW)
-    @apply_machine_map
     def func_add_project_arguments(self, node: mparser.FunctionNode, args: T.Tuple[T.List[str]], kwargs: 'kwtypes.FuncAddProjectArgs') -> None:
         self._add_project_arguments(node, self.current_build_project().project_args[kwargs['native']],
                                     args[0], kwargs)
 
     @typed_pos_args('add_project_link_arguments', varargs=str)
     @typed_kwargs('add_project_link_arguments', NATIVE_KW, LANGUAGE_KW)
-    @apply_machine_map
     def func_add_project_link_arguments(self, node: mparser.FunctionNode, args: T.Tuple[T.List[str]], kwargs: 'kwtypes.FuncAddProjectArgs') -> None:
         self._add_project_arguments(node, self.current_build_project().project_link_args[kwargs['native']],
                                     args[0], kwargs)
@@ -3120,7 +3116,6 @@ class Interpreter(InterpreterBase, HoldableObject):
     @FeatureNew('add_project_dependencies', '0.63.0')
     @typed_pos_args('add_project_dependencies', varargs=dependencies.Dependency)
     @typed_kwargs('add_project_dependencies', NATIVE_KW, LANGUAGE_KW)
-    @apply_machine_map
     def func_add_project_dependencies(self, node: mparser.FunctionNode, args: T.Tuple[T.List[dependencies.Dependency]], kwargs: 'kwtypes.FuncAddProjectArgs') -> None:
         for_machine = kwargs['native']
         for lang in kwargs['language']:
@@ -3186,18 +3181,8 @@ class Interpreter(InterpreterBase, HoldableObject):
                                args: T.List[str], kwargs: 'kwtypes.FuncAddProjectArgs') -> None:
         self._add_arguments(node, argsdict, self.project_args_frozen, args, kwargs)
 
-    def is_dup_machine(self, for_machine: MachineChoice) -> bool:
-        # Return whether applying the caller's effect to the build and
-        # host machine would duplicate the effect
-        return \
-            for_machine is not MachineChoice.HOST and \
-            self.build.machine_map[for_machine] is self.build.machine_map.host
-
     def _add_arguments(self, node: mparser.FunctionNode, argsdict: T.Dict[Language, T.List[str]],
                        args_frozen: bool, args: T.List[str], kwargs: 'kwtypes.FuncAddProjectArgs') -> None:
-        if self.is_dup_machine(kwargs['native']):
-            return
-
         if args_frozen:
             msg = f'Tried to use \'{node.func_name.value}\' after a build target has been declared.\n' \
                   'This is not permitted. Please declare all arguments before your targets.'
@@ -3886,7 +3871,8 @@ class Interpreter(InterpreterBase, HoldableObject):
         # copy common arguments directly
         for arg in ('build_by_default', 'build_subdir', 'dependencies',
                     'install', 'install_mode', 'implicit_include_directories',
-                    'link_with', 'java_args', 'java_resources', 'main_class'):
+                    'link_with', 'java_args', 'java_resources', 'main_class',
+                    'native'):
             final[arg] = kwargs[arg]
 
         # this is not accessable from the DSL, so we need to initialize it
@@ -3939,6 +3925,8 @@ class Interpreter(InterpreterBase, HoldableObject):
             mlog.debug('Unknown target type:', str(targetclass))
             raise RuntimeError('Unreachable code')
 
+        # preserved for global and project arguments
+        orig_for_machine = kwargs['native']
         self.apply_machine_map_to_kwargs(kwargs)
         for_machine = kwargs['native']
 
@@ -4012,29 +4000,29 @@ class Interpreter(InterpreterBase, HoldableObject):
         if targetclass is build.Executable:
             nkwargs = self.__convert_executable_kwargs(
                 node, T.cast('kwtypes.Executable', kwargs))
-            target = build.Executable(name, self.subdir, for_machine, srcs, struct, objs,
+            target = build.Executable(name, self.subdir, orig_for_machine, srcs, struct, objs,
                                       self.environment, self.compilers[for_machine], self.current_build_project(), nkwargs)
         elif targetclass is build.StaticLibrary:
             nkwargs = self.__convert_static_library_kwargs(
                 node, T.cast('kwtypes.StaticLibrary', kwargs))
-            target = build.StaticLibrary(name, self.subdir, for_machine, srcs, struct, objs,
+            target = build.StaticLibrary(name, self.subdir, orig_for_machine, srcs, struct, objs,
                                          self.environment, self.compilers[for_machine], self.current_build_project(), nkwargs)
         elif targetclass is build.SharedLibrary:
             nkwargs = self.__convert_shared_library_kwargs(
                 node, T.cast('kwtypes.SharedLibrary', kwargs))
-            target = build.SharedLibrary(name, self.subdir, for_machine, srcs, struct, objs,
+            target = build.SharedLibrary(name, self.subdir, orig_for_machine, srcs, struct, objs,
                                          self.environment, self.compilers[for_machine], self.current_build_project(), nkwargs)
             target.shared_library_only = shared_library_only
         elif targetclass is build.SharedModule:
             nkwargs = self.__convert_shared_module_kwargs(
                 node, T.cast('kwtypes.SharedModule', kwargs))
-            target = build.SharedModule(name, self.subdir, for_machine, srcs, struct, objs,
+            target = build.SharedModule(name, self.subdir, orig_for_machine, srcs, struct, objs,
                                         self.environment, self.compilers[for_machine], self.current_build_project(), nkwargs)
             target.shared_library_only = shared_library_only
         else:
             nkwargs = self.__convert_jar_kwargs(
                 node, T.cast('kwtypes.Jar', kwargs))
-            target = build.Jar(name, self.subdir, for_machine, srcs, struct, objs,
+            target = build.Jar(name, self.subdir, orig_for_machine, srcs, struct, objs,
                                self.environment, self.compilers[for_machine], self.current_build_project(), nkwargs)
 
         if objs and target.uses_rust():

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1389,7 +1389,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         if self.cargo is None:
             self.load_root_cargo_lock_file()
 
-        build_project = build.BuildProject(proj_name, self.project_version, self.subproject, for_machine)
+        build_project = build.BuildProject(proj_name, self.project_version, self.subproject, self.build.for_machine, for_machine)
         self.build.projects[for_machine][self.subproject] = build_project
 
         extra_args: T.List[mlog.TV_Loggable] = []

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -14,7 +14,6 @@ from ..dependencies import NotFoundDependency
 from ..dependencies.detect import get_dep_identifier, find_external_dependency
 from ..dependencies.python import BasicPythonExternalProgram, python_factory, _PythonDependencyBase
 from ..interpreter import extract_required_kwarg, primitives as P_OBJ
-from ..interpreter.decorators import apply_machine_map
 from ..interpreter.interpreterobjects import ProgramHolder
 from ..interpreter.type_checking import NoneType, DEPENDENCY_KWS, PRESERVE_PATH_KW, REQUIRED_KW, SHARED_MOD_KWS
 from ..interpreterbase import (
@@ -153,7 +152,6 @@ class PythonInstallation(ProgramHolder['PythonExternalProgram']):
         _LIMITED_API_KW,
         KwargInfo('install_dir', (str, bool, NoneType)),
     )
-    @apply_machine_map
     @InterpreterObject.method('extension_module')
     def extension_module_method(self, args: T.Tuple[str, T.List[BuildTargetSource]], kwargs: ExtensionModuleKw) -> 'SharedModule':
         target_kwargs = T.cast('SharedModuleKw', {k: v for k, v in kwargs.items() if k not in {'install_dir', 'subdir', 'limited_api'}})
@@ -202,7 +200,8 @@ class PythonInstallation(ProgramHolder['PythonExternalProgram']):
             target_kwargs['cpp_args'] = new_cpp_args
 
             # On Windows, the limited API DLL is python3.dll, not python3X.dll.
-            for_machine = kwargs['native']
+            # FIXME: pydep.for_machine is nicer, but InternalDependency does not have the attribute
+            for_machine = self.interpreter.build.machine_map[kwargs['native']]
             if self.interpreter.environment.machines[for_machine].is_windows():
                 pydep_copy = copy.copy(pydep)
                 if isinstance(pydep_copy, _PythonDependencyBase):
@@ -269,7 +268,9 @@ class PythonInstallation(ProgramHolder['PythonExternalProgram']):
         return '0x{:02x}{:02x}0000'.format(major, minor)
 
     def _dependency_method_impl(self, kwargs: DependencyObjectKWs) -> Dependency:
-        for_machine = kwargs['native']
+        for_machine = self.interpreter.build.machine_map[kwargs['native']]
+        kwargs['native'] = for_machine
+
         identifier = get_dep_identifier(self._full_path(), kwargs)
 
         dep = self.interpreter.coredata.deps[for_machine].get(identifier)

--- a/test cases/native/12 add_project_arguments native true/include/stdio.h
+++ b/test cases/native/12 add_project_arguments native true/include/stdio.h
@@ -1,0 +1,3 @@
+#define USING_LOCAL_STDIO 1
+
+#include_next <stdio.h>

--- a/test cases/native/12 add_project_arguments native true/meson.build
+++ b/test cases/native/12 add_project_arguments native true/meson.build
@@ -1,0 +1,10 @@
+project('test include path', 'c')
+
+if meson.get_compiler('c').get_id() not in ['gcc', 'clang']
+  error('MESON_SKIP_TEST: test needs #include_next <>')
+endif
+
+add_project_arguments('-iquote', meson.current_source_dir() / 'include', language: ['c'])
+
+e = executable('executable', 'test.c', native: true)
+test('executable', e)

--- a/test cases/native/12 add_project_arguments native true/test.c
+++ b/test cases/native/12 add_project_arguments native true/test.c
@@ -1,0 +1,7 @@
+#include "stdio.h"
+
+#ifdef USING_LOCAL_STDIO
+#error unexpected argument for native: true
+#endif
+
+int main(void) {}

--- a/test cases/native/13 add_global_arguments native true/include/stdio.h
+++ b/test cases/native/13 add_global_arguments native true/include/stdio.h
@@ -1,0 +1,3 @@
+#define USING_LOCAL_STDIO 1
+
+#include_next <stdio.h>

--- a/test cases/native/13 add_global_arguments native true/meson.build
+++ b/test cases/native/13 add_global_arguments native true/meson.build
@@ -1,0 +1,17 @@
+project('test include path', 'c')
+
+if meson.get_compiler('c').get_id() not in ['gcc', 'clang']
+  error('MESON_SKIP_TEST: test needs #include_next <>')
+endif
+
+add_global_arguments('-iquote', meson.current_source_dir() / 'include', language: ['c'])
+
+e = executable('executable', 'test.c', native: true)
+test('executable', e)
+
+subproject('hostsub')
+
+# run the same test in a build-side subproject.  Even if that subproject
+# uses "native: false", it has to use the build-side global arguments
+# because nothing else would make sense in a cross compilation scenario.
+subproject('buildsub', native: true)

--- a/test cases/native/13 add_global_arguments native true/subprojects/buildsub/meson.build
+++ b/test cases/native/13 add_global_arguments native true/subprojects/buildsub/meson.build
@@ -1,0 +1,4 @@
+project('test include path subproject', 'c')
+
+e = executable('executable', 'test.c')
+test('executable', e)

--- a/test cases/native/13 add_global_arguments native true/subprojects/buildsub/test.c
+++ b/test cases/native/13 add_global_arguments native true/subprojects/buildsub/test.c
@@ -1,0 +1,7 @@
+#include "stdio.h"
+
+#ifdef USING_LOCAL_STDIO
+#error unexpected argument for native: true
+#endif
+
+int main(void) {}

--- a/test cases/native/13 add_global_arguments native true/subprojects/hostsub/meson.build
+++ b/test cases/native/13 add_global_arguments native true/subprojects/hostsub/meson.build
@@ -1,0 +1,4 @@
+project('test include path subproject', 'c')
+
+e = executable('executable', 'test.c', native: true)
+test('executable', e)

--- a/test cases/native/13 add_global_arguments native true/subprojects/hostsub/test.c
+++ b/test cases/native/13 add_global_arguments native true/subprojects/hostsub/test.c
@@ -1,0 +1,7 @@
+#include "stdio.h"
+
+#ifdef USING_LOCAL_STDIO
+#error unexpected argument for native: true
+#endif
+
+int main(void) {}

--- a/test cases/native/13 add_global_arguments native true/test.c
+++ b/test cases/native/13 add_global_arguments native true/test.c
@@ -1,0 +1,7 @@
+#include "stdio.h"
+
+#ifdef USING_LOCAL_STDIO
+#error unexpected argument for native: true
+#endif
+
+int main(void) {}

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -5128,7 +5128,7 @@ class AllPlatformTests(BasePlatformTests):
                            orig_for_machine=MachineChoice.HOST, sources=[],
                            structured_sources=None,
                            objects=[], environment=env, compilers=env.coredata.compilers[MachineChoice.HOST],
-                           build_project=BuildProject('', '', SubProject(''), MachineChoice.HOST),
+                           build_project=BuildProject('', '', SubProject(''), MachineChoice.HOST, MachineChoice.HOST),
                            kwargs={'native': MachineChoice.HOST})
             target.process_compilers_late()
             return target.filename

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -5125,10 +5125,11 @@ class AllPlatformTests(BasePlatformTests):
 
         def output_name(name, type_):
             target = type_(name=name, subdir='',
-                           for_machine=MachineChoice.HOST, sources=[],
+                           orig_for_machine=MachineChoice.HOST, sources=[],
                            structured_sources=None,
                            objects=[], environment=env, compilers=env.coredata.compilers[MachineChoice.HOST],
-                           build_project=BuildProject('', '', SubProject(''), MachineChoice.HOST), kwargs={})
+                           build_project=BuildProject('', '', SubProject(''), MachineChoice.HOST),
+                           kwargs={'native': MachineChoice.HOST})
             target.process_compilers_late()
             return target.filename
 


### PR DESCRIPTION
Reduced from QEMU.

The root cause of the issue is that `native: true` and `native: false` global_arguments and project_arguments are separate even when not cross-compiling. I didn't take that into account when writing the special case machine map code for `add_*_arguments`.

 A separate problem (which I think was also present in @dcbaker's version) is that global arguments are resolved always with the toplevel Build object, because they are handled by the backend. This is fixed as well.