### PR TITLE
Fix formatting for man page test --slice option

### DIFF
--- a/man/meson.1
+++ b/man/meson.1
@@ -326,7 +326,7 @@ a multiplier to use for test timeout values (usually something like 100 for Valg
 .TP
 \fB\-\-setup\fR
 use the specified test setup
-.Tp
+.TP
 \fB\-\-slice SLICE/NUM_SLICES\fR
 Split tests into NUM_SLICES slices and execute slice number SLICE.  (Since 1.8.0)
 


### PR DESCRIPTION
Currently, the `--slice` option renders on the same line as the `--setup` due to wrong formatting character initializing the indented block.

This is fixing the case of the formatting character and renders the manual page correctly.