### PR TITLE
depfixer: don't invoke install_name_tool on non-darwin targets

### DIFF
--- a/mesonbuild/scripts/depfixer.py
+++ b/mesonbuild/scripts/depfixer.py
@@ -836,7 +836,7 @@ def fix_rpath(fname: str, rpath_dirs_to_remove: T.Set[bytes], new_rpath: T.Union
     # on non-mac platforms. That can be expensive on some Windows machines
     # (up to 30ms), which is significant with --only-changed. For details, see:
     # https://github.com/mesonbuild/meson/pull/6612#discussion_r378581401
-    if INSTALL_NAME_TOOL is False:
+    if system == 'darwin' and INSTALL_NAME_TOOL is False:
         INSTALL_NAME_TOOL = bool(shutil.which('install_name_tool'))
     if INSTALL_NAME_TOOL:
         if isinstance(new_rpath, bytes):

--- a/mesonbuild/scripts/depfixer.py
+++ b/mesonbuild/scripts/depfixer.py
@@ -836,9 +836,10 @@ def fix_rpath(fname: str, rpath_dirs_to_remove: T.Set[bytes], new_rpath: T.Union
     # on non-mac platforms. That can be expensive on some Windows machines
     # (up to 30ms), which is significant with --only-changed. For details, see:
     # https://github.com/mesonbuild/meson/pull/6612#discussion_r378581401
-    if INSTALL_NAME_TOOL is False:
-        INSTALL_NAME_TOOL = bool(shutil.which('install_name_tool'))
-    if INSTALL_NAME_TOOL:
-        if isinstance(new_rpath, bytes):
-            new_rpath = new_rpath.decode('utf8')
-        fix_darwin(fname, rpath_dirs_to_remove, new_rpath, final_path, install_name_mappings)
+    if system == 'darwin':
+        if INSTALL_NAME_TOOL is False:
+            INSTALL_NAME_TOOL = bool(shutil.which('install_name_tool'))
+        if INSTALL_NAME_TOOL:
+            if isinstance(new_rpath, bytes):
+                new_rpath = new_rpath.decode('utf8')
+            fix_darwin(fname, rpath_dirs_to_remove, new_rpath, final_path, install_name_mappings)

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -25,6 +25,7 @@ import mesonbuild.dependencies.factory
 import mesonbuild.envconfig
 import mesonbuild.environment
 import mesonbuild.modules.gnome
+import mesonbuild.scripts.depfixer
 import mesonbuild.scripts.env2mfile
 from mesonbuild import coredata
 from mesonbuild.compilers.c import ClangCCompiler, GnuCCompiler
@@ -2233,3 +2234,13 @@ class InternalTests(unittest.TestCase):
                 self.assertEqual(actual.compile_args, expected.compile_args)
                 self.assertEqual(actual.link_args, expected.link_args)
                 self.assertEqual(actual.cmake, expected.cmake)
+
+    def test_depfixer_skips_install_name_tool_on_non_darwin(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix='.so') as f:
+            f.write(b'not an elf file')
+            f.flush()
+            with mock.patch('mesonbuild.scripts.depfixer.INSTALL_NAME_TOOL', True), \
+                 mock.patch('mesonbuild.scripts.depfixer.fix_darwin') as mock_fix_darwin:
+                mesonbuild.scripts.depfixer.fix_rpath(
+                    f.name, set(), '', '', {}, system='linux', verbose=False)
+                mock_fix_darwin.assert_not_called()

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -26,6 +26,7 @@ import mesonbuild.envconfig
 import mesonbuild.environment
 import mesonbuild.modules.cuda
 import mesonbuild.modules.gnome
+import mesonbuild.scripts.depfixer
 import mesonbuild.scripts.env2mfile
 from mesonbuild import coredata
 from mesonbuild.compilers.c import ClangCCompiler, GnuCCompiler
@@ -2407,3 +2408,14 @@ Thread model: posix'''), '21.9.0')
             with self.subTest(cuda_version=cuda_version, arch_list=arch_list):
                 with self.assertRaisesRegex(InvalidArguments, message):
                     flags(cuda_version, arch_list)
+
+    def test_depfixer_skips_install_name_tool_on_non_darwin(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fname = os.path.join(tmpdir, 'libfoo.so')
+            with open(fname, 'wb') as f:
+                f.write(b'not an elf file')
+            with mock.patch('mesonbuild.scripts.depfixer.INSTALL_NAME_TOOL', True), \
+                 mock.patch('mesonbuild.scripts.depfixer.fix_darwin') as mock_fix_darwin:
+                mesonbuild.scripts.depfixer.fix_rpath(
+                    fname, set(), '', '', {}, system='linux', verbose=False)
+                mock_fix_darwin.assert_not_called()


### PR DESCRIPTION
**Summary**
- `fix_rpath()` in `depfixer.py` treated "file isn't ELF" the same on
  every OS: it caught detect_elf_type()'s `sys.exit(0)` and fell through
  to probing for `install_name_tool`. 
- On Linux systems that happen to have `install_name_tool`/`otool` 
  on PATH (e.g. darwin cross-compile toolchain installed), 
  this got invoked on native binaries during `ninja install`.
- Guard the install_name_tool/otool path with `system == 'darwin'`.

Fixes #8027

**Test Added**
- Added `test_depfixer_skips_install_name_tool_on_non_darwin` in
  `unittests/internaltests.py`: non-ELF file + `system='linux'` must
  not call `shutil.which`.
- Confirmed test fails against the old code (falls through and invokes
  `otool`) and passes with the fix.