### PR TITLE
python: switch (again) default rust_abi for extension modules to C

### DIFF
--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -157,6 +157,8 @@ class PythonInstallation(ProgramHolder['PythonExternalProgram']):
     @InterpreterObject.method('extension_module')
     def extension_module_method(self, args: T.Tuple[str, T.List[BuildTargetSource]], kwargs: ExtensionModuleKw) -> 'SharedModule':
         target_kwargs = T.cast('SharedModuleKw', {k: v for k, v in kwargs.items() if k not in {'install_dir', 'subdir', 'limited_api'}})
+        if kwargs['rust_abi'] is None and kwargs['rust_crate_type'] is None:
+            target_kwargs['rust_abi'] = 'c'
 
         if kwargs['install_dir'] is not None:
             if kwargs['subdir'] is not None:
@@ -247,7 +249,6 @@ class PythonInstallation(ProgramHolder['PythonExternalProgram']):
                 (self.is_pypy or mesonlib.version_compare(self.version, '>=3.9')):
             target_kwargs['gnu_symbol_visibility'] = 'inlineshidden'
 
-        kwargs.setdefault('rust_abi', 'c')
         return self.interpreter.build_target(
             self.current_node, T.cast('T.Tuple[str, SourcesVarargsType]', args),
             target_kwargs, SharedModule)

--- a/test cases/python/12 rust extmodule/blaster.py
+++ b/test cases/python/12 rust extmodule/blaster.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import tachyon
+
+result = tachyon.phaserize('shoot')
+
+if not isinstance(result, int):
+    raise SystemExit('Returned result not an integer.')
+
+if result != 1:
+    raise SystemExit('Returned result {} is not 1.'.format(result))

--- a/test cases/python/12 rust extmodule/ext/meson.build
+++ b/test cases/python/12 rust extmodule/ext/meson.build
@@ -1,0 +1,6 @@
+pylib = py.extension_module('tachyon',
+  'tachyon_module.rs', 'tachyon_module.c',
+  limited_api: '3.7',
+)
+
+pypathdir = meson.current_build_dir()

--- a/test cases/python/12 rust extmodule/ext/tachyon_module.c
+++ b/test cases/python/12 rust extmodule/ext/tachyon_module.c
@@ -1,0 +1,45 @@
+/*
+  Copyright 2018 The Meson development team
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/* A very simple Python extension module. */
+
+#include <Python.h>
+#include <string.h>
+
+static PyObject* phaserize(PyObject *self, PyObject *args) {
+    const char *message;
+    int result;
+
+    if(!PyArg_ParseTuple(args, "s", &message))
+        return NULL;
+
+    result = strcmp(message, "shoot") ? 0 : 1;
+    return PyLong_FromLong(result);
+}
+
+static PyMethodDef TachyonMethods[] = {
+    {"phaserize",  phaserize, METH_VARARGS,
+     "Shoot tachyon cannons."},
+    {NULL, NULL, 0, NULL}
+};
+
+struct PyModuleDef *tachyonmodule = &(struct PyModuleDef){
+   PyModuleDef_HEAD_INIT,
+   "tachyon",
+   NULL,
+   -1,
+   TachyonMethods
+};

--- a/test cases/python/12 rust extmodule/ext/tachyon_module.rs
+++ b/test cases/python/12 rust extmodule/ext/tachyon_module.rs
@@ -1,0 +1,17 @@
+#![allow(improper_ctypes)]
+
+#[repr(C)]
+pub struct PyModuleDef;
+#[repr(C)]
+pub struct PyObject;
+
+extern "C" {
+    pub static mut tachyonmodule: *mut PyModuleDef;
+    pub fn PyModule_Create2(def: *mut PyModuleDef, abiver: i32) -> *mut PyObject;
+}
+
+#[allow(non_snake_case)]
+#[no_mangle]
+pub unsafe extern "C" fn PyInit_tachyon() -> *mut PyObject {
+    PyModule_Create2(tachyonmodule, 3)
+}

--- a/test cases/python/12 rust extmodule/meson.build
+++ b/test cases/python/12 rust extmodule/meson.build
@@ -1,0 +1,36 @@
+project('Python extension module', 'c',
+  default_options : ['buildtype=release', 'werror=true', 'python.bytecompile=-1'])
+# Because Windows Python ships only with optimized libs,
+# we must build this project the same way.
+
+if meson.backend() != 'ninja'
+  error('MESON_SKIP_TEST: Ninja backend required')
+endif
+if not add_languages('rust', required: false, native: false)
+  error('MESON_SKIP_TEST: Rust compiler required')
+endif
+
+py_mod = import('python')
+py = py_mod.find_installation()
+py_dep = py.dependency(required: false)
+
+if not py_dep.found()
+  error('MESON_SKIP_TEST: Python libraries not found.')
+endif
+
+# Rust code cannot rely on #define PyModule_Create, so it calls
+# PyModule_Create2.  But it is also not possible to use has_function()
+# because the function is in the Python executable, so just check
+# for PyPy.
+if run_command(py, '-c', 'import sys; sys.exit("__pypy__" in sys.builtin_module_names)',
+               check: false).returncode() == 1
+  error('MESON_SKIP_TEST: Limited API not supported (PyPy?)')
+endif
+
+subdir('ext')
+
+src = files('blaster.py')
+test('extmod',
+  py,
+  args : src,
+  env : ['PYTHONPATH=' + pypathdir])


### PR DESCRIPTION
Adding `rust_abi: c` automatically was broken by commit b5f61587c ("modules/python: rework extension_module method for typing"), fix it again.

While at it, be more careful - ensure that rust_abi is only added if the caller provided neither of rust_abi and rust_crate_type.

Reported by @lucascolley.