### PR TITLE
test cases: disable werror=true for python/12 rust extmodule

### DIFF
--- a/test cases/python/12 rust extmodule/meson.build
+++ b/test cases/python/12 rust extmodule/meson.build
@@ -1,5 +1,5 @@
 project('Python extension module', 'c',
-  default_options : ['buildtype=release', 'werror=true', 'python.bytecompile=-1'])
+  default_options : ['buildtype=release', 'python.bytecompile=-1'])
 # Because Windows Python ships only with optimized libs,
 # we must build this project the same way.
 


### PR DESCRIPTION
This fails on macOS due to Rust adding -mmacosx-version-min=... automatically, and ld reporting a mismatch between the .c and .rs objects.