### PR TITLE
docs: document Ninja reconfigure target

### DIFF
--- a/docs/markdown/Running-Meson.md
+++ b/docs/markdown/Running-Meson.md
@@ -148,6 +148,13 @@ build) and others only every now and then (such as a "static analysis"
 build). Any configuration can be built just by `cd`'ing to the
 corresponding directory and running Ninja.
 
+To force Meson to reconfigure without building any targets, use the
+`reconfigure` target.
+
+```sh
+ninja -C builddir reconfigure
+```
+
 ## Running tests
 
 Meson provides native support for running tests. The command to do


### PR DESCRIPTION
Closes #2409.

Document ninja -C builddir reconfigure in the existing “Building directly with Ninja” section and clarify that it forces Meson reconfiguration without building targets.

Validation:
- verified the documented command against a generated Ninja build; it reconfigured successfully and built no targets
- python3 run_format_tests.py
- added lines remain within the documentation 70-character guideline
- git diff --check

The full Hotdoc build could not start because the local system lacks json-glib-1.0; the changed fenced Markdown and command were checked independently.