### PR TITLE
Handle invalid CMake skip compiler test values

### DIFF
--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -222,7 +222,6 @@ class Properties:
         if 'cmake_skip_compiler_test' not in self.properties:
             return CMakeSkipCompilerTest.DEP_ONLY
         raw = self.properties['cmake_skip_compiler_test']
-        assert isinstance(raw, str)
         try:
             return CMakeSkipCompilerTest(raw)
         except ValueError:

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -38,7 +38,7 @@ from mesonbuild.interpreterbase import typed_pos_args, InvalidArguments, ObjectH
 from mesonbuild.interpreterbase import typed_pos_args, InvalidArguments, typed_kwargs, ContainerTypeInfo, KwargInfo
 from mesonbuild.mesonlib import (
     LibType, MachineChoice, PerMachine, SimpleABC, Version, is_windows, is_osx,
-    is_cygwin, is_openbsd, search_version, MesonException, python_command,
+    is_cygwin, is_openbsd, search_version, MesonException, EnvironmentException, python_command,
     version_check_to_range,
 )
 from mesonbuild.options import OptionKey
@@ -53,6 +53,13 @@ from run_tests import get_fake_env, get_fake_options
 from .helpers import *
 
 class InternalTests(unittest.TestCase):
+
+    def test_cmake_skip_compiler_test_invalid(self):
+        properties = mesonbuild.envconfig.Properties({'cmake_skip_compiler_test': True})
+        with self.assertRaisesRegex(
+                EnvironmentException,
+                '"True" is not a valid value for cmake_skip_compiler_test'):
+            properties.get_cmake_skip_compiler_test()
 
     def test_machine_info_is_ohos(self):
         def machine(system: str, subsystem: str) -> mesonbuild.envconfig.MachineInfo:


### PR DESCRIPTION
## Summary

- route invalid non-string `cmake_skip_compiler_test` values through Meson's existing configuration error
- add a regression for the reported boolean value

Fixes #13391.

## Root cause

`Properties.get_cmake_skip_compiler_test()` asserted that the raw property was a
string before its enum conversion. That prevented boolean input from reaching
the existing `ValueError` handler, so Meson exposed an internal
`AssertionError` instead of a normal `EnvironmentException`.

The documented values (`always`, `never`, and `dep_only`) are unchanged.

## Validation

- regression observed failing with `AssertionError` before the fix
- focused regression: 1 passed
- complete `InternalTests` class: 70 passed, 2 skipped
- `python run_format_tests.py`
- `python -m compileall -q mesonbuild unittests/internaltests.py`
- `python -m flake8 mesonbuild`
- `python -m pylint mesonbuild/envconfig.py`
- valid/default enum behavior and invalid boolean/integer/list inputs checked directly

A broader Windows run completed with 478 passed and 194 skipped; its 15 failures
were in unrelated platform/toolchain cases (including C#/Rust discovery and
Windows path handling). Repository-wide Pylint and MyPy were also limited by
pre-existing Python 3.14 deprecations and POSIX-only attributes on Windows.

## AI assistance

OpenAI Codex assisted with issue triage, implementation, regression coverage,
validation, and diff review. The final two-file diff and recorded test evidence
were reviewed before submission.
