### PR TITLE
Filter extra_paths on Windows to only include SharedLibrary targets

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1148,6 +1148,10 @@ class Backend:
         We must determine all locations of DLLs that this exe
         links to and return them so they can be used in unit
         tests.
+
+        Note that this analysis is semi-incomplete. It is possible that a DLL
+        could be produced by a build.CustomTarget. Unfortunately, we do not
+        currently have the facilities to know that.
         """
         prospectives: T.Set[build.BuildTargetTypes] = set()
         internal_deps: T.Set[str] = set()
@@ -1157,7 +1161,8 @@ class Backend:
             prospectives.update(target.get_all_link_deps())
 
         for bdep in extra_bdeps:
-            prospectives.add(bdep)
+            if isinstance(bdep, build.SharedLibrary):
+                prospectives.add(bdep)
             if isinstance(bdep, build.BuildTarget):
                 prospectives.update(bdep.get_all_link_deps())
 

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1238,6 +1238,10 @@ class Backend:
         We must determine all locations of DLLs that this exe
         links to and return them so they can be used in unit
         tests.
+
+        Note that this analysis is semi-incomplete. It is possible that a DLL
+        could be produced by a build.CustomTarget. Unfortunately, we do not
+        currently have the facilities to know that.
         """
         prospectives: T.Set[build.BuildTargetTypes] = set()
         internal_deps: T.Set[str] = set()
@@ -1247,7 +1251,8 @@ class Backend:
             prospectives.update(target.get_all_link_deps())
 
         for bdep in extra_bdeps:
-            prospectives.add(bdep)
+            if isinstance(bdep, build.SharedLibrary):
+                prospectives.add(bdep)
             if isinstance(bdep, build.BuildTarget):
                 prospectives.update(bdep.get_all_link_deps())
 

--- a/test cases/common/230 external project/libfoo/configure
+++ b/test cases/common/230 external project/libfoo/configure
@@ -18,6 +18,7 @@ then
     exit 1
 fi
 done
+unset IFS
 
 for i in "$@"
 do

--- a/test cases/windows/13 test argument extra paths/test/meson.build
+++ b/test cases/windows/13 test argument extra paths/test/meson.build
@@ -1,3 +1,14 @@
 python3 = find_program('python3')
 
-test('run_exe', python3, args: [files('test_run_exe.py')[0], barexe])
+stamp = custom_target('stamp',
+  output: 'stamp.txt',
+  command: [python3, '-c', 'open("@OUTPUT@", "w").close()'],
+  depends: [libfoo],
+  build_by_default: true,
+)
+
+test('run_exe',
+  python3,
+  args: [files('test_run_exe.py')[0], barexe],
+  depends: [stamp, libfoo],
+)

--- a/unittests/windowstests.py
+++ b/unittests/windowstests.py
@@ -490,3 +490,30 @@ class WindowsTests(BasePlatformTests):
         with mock.patch.object(self, 'install_command', self.meson_command + ['install']):
             out = self.install(override_envvars=env)
             self.assertIn('Activating VS', out)
+
+    def test_extra_paths_content(self):
+        '''
+        Test that when a test depends on a non-SharedLibrary, the extra_paths
+        not include parent directories from that non-SharedLibrary.
+
+        See: https://github.com/mesonbuild/meson/issues/16010
+        '''
+        testdir = os.path.join(self.platform_test_dir, '13 test argument extra paths')
+        self.init(testdir)
+
+        tests = self.introspect('--tests')
+        run_exe = None
+        for t in tests:
+            if t['name'] == 'run_exe':
+                run_exe = t
+                break
+
+        self.assertIsNotNone(run_exe, 'Test run_exe not found')
+
+        extra_paths = run_exe.get('extra_paths', [])
+        self.assertIsInstance(extra_paths, list)
+
+        # The executable 'barexe' links against libfoo, so the lib directory
+        # should be in extra_paths (so the DLL can be found at runtime).
+        self.assertTrue(any('lib' in p for p in extra_paths) and len(extra_paths) == 1,
+            f'extra_paths should contain a lib directory and nothing else: {extra_paths}')


### PR DESCRIPTION
determine_windows_extra_paths() on non-Windows is not used for too much. It is used in two instances. In those two instances, extra_paths has very narrow use cases.

- Backend::get_devenv(): we add to extra_paths for every build.Executable. This also happens on Windows.
- Backend::get_executable_serialisation(): extra_paths is empty on non-Windows.

It is important to remember that Windows has no equivalent to {DY,}LD_LIBRARY_PATH. Instead it looks up DLLs on PATH. Performing this filter will have an adverse effect on adding build outputs from build.CustomTarget to PATH. However, when setting {DY,}LD_LIBRARY_PATH, we filter for build.SharedLibrary explicitly, so it was an oversight in the original patch[0] to include this additional behavior.

Link: https://github.com/mesonbuild/meson/pull/14649 [0]
Fixes: https://github.com/mesonbuild/meson/issues/16010
Supersedes: https://github.com/mesonbuild/meson/pull/16011