### PR TITLE
Unset IFS in external project test

### DIFF
--- a/test cases/common/230 external project/libfoo/configure
+++ b/test cases/common/230 external project/libfoo/configure
@@ -18,6 +18,7 @@ then
     exit 1
 fi
 done
+unset IFS
 
 for i in "$@"
 do


### PR DESCRIPTION
We set IFS to do some parsing, but never unset it. This is a problem in our Windows setups because paths have a colon, which separates the drive letter from the rest of the path.

    /d/a/meson/meson/test cases/common/230 external project/libfoo/configure: line 47: D: command not found