### PR TITLE
Add CLI implementation to PkgConfigCLI

### DIFF
--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -3,15 +3,14 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 from .base import ExternalDependency, DependencyException, sort_libpaths, DependencyTypeName
 from ..mesonlib import (EnvironmentVariables, OrderedSet, PerMachine, Popen_safe, Popen_safe_logged, MachineChoice,
                         join_args, MesonException, path_has_root)
 from ..options import OptionKey
 from ..programs import find_external_program, ExternalProgram
 from .. import mlog
-from pathlib import PurePath
+from enum import Enum
+from pathlib import Path, PurePath
 from functools import lru_cache
 import re
 import os
@@ -124,6 +123,15 @@ class PkgConfigInterface:
     def list_all(self) -> ImmutableListProtocol[str]:
         '''Return all available pkg-config modules'''
         raise NotImplementedError
+
+class PkgConfigCLIImplementation(str, Enum):
+    FREEDESKTOP = 'pkg-config'
+    '''https://gitlab.freedesktop.org/pkg-config/pkg-config'''
+
+    PKGCONF = 'pkgconf'
+    '''https://github.com/pkgconf/pkgconf'''
+
+    UNKNOWN = 'unknown'
 
 class PkgConfigCLI(PkgConfigInterface):
     '''pkg-config CLI implementation'''
@@ -248,6 +256,12 @@ class PkgConfigCLI(PkgConfigInterface):
             if 'Pure-Perl' in helptext:
                 mlog.log(f'Found pkg-config {command_as_string!r} but it is Strawberry Perl and thus broken. Ignoring...')
                 return None
+            if 'pkgconf' in helptext:
+                self.implementation = PkgConfigCLIImplementation.PKGCONF
+            elif 'pkg-config' in helptext:
+                self.implementation = PkgConfigCLIImplementation.FREEDESKTOP
+            else:
+                self.implementation = PkgConfigCLIImplementation.UNKNOWN
             p, out = Popen_safe(pkgbin.get_command() + ['--version'])[0:2]
             if p.returncode != 0:
                 mlog.warning(f'Found pkg-config {command_as_string!r} but it failed when ran')

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -35,7 +35,9 @@ from mesonbuild.compilers.c import AppleClangCCompiler, ElbrusCompiler
 from mesonbuild.compilers.cpp import AppleClangCPPCompiler
 from mesonbuild.compilers.objc import AppleClangObjCCompiler
 from mesonbuild.compilers.objcpp import AppleClangObjCPPCompiler
-from mesonbuild.dependencies.pkgconfig import PkgConfigDependency, PkgConfigCLI, PkgConfigInterface
+from mesonbuild.dependencies.pkgconfig import (
+    PkgConfigDependency, PkgConfigCLI, PkgConfigCLIImplementation, PkgConfigInterface,
+)
 from mesonbuild.programs import NonExistingExternalProgram
 import mesonbuild.modules.pkgconfig
 
@@ -180,7 +182,17 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertEqual(libhello_nolib.get_variable(pkgconfig='foo'), 'bar')
         self.assertEqual(libhello_nolib.get_variable(pkgconfig='prefix'), self.prefix)
         impl = libhello_nolib.pkgconfig
-        if not isinstance(impl, PkgConfigCLI) or version_compare(impl.pkgbin_version, ">=0.29.1"):
+        if isinstance(impl, PkgConfigCLI) and impl.implementation == PkgConfigCLIImplementation.PKGCONF \
+                and version_compare(impl.pkgbin_version, ">=3.0.4"):
+            # pkgconf >= 3.0.4 unescapes '\ ' when storing a variable's value
+            # (fixing double-escaping when the variable is expanded into a
+            # fragment, see https://github.com/pkgconf/pkgconf/issues/575),
+            # so --variable now returns the canonical (unescaped) value
+            # instead of preserving the literal backslash.
+            self.assertEqual(libhello_nolib.get_variable(pkgconfig='escaped_var'), 'hello world')
+        elif not isinstance(impl, PkgConfigCLI) or (
+                impl.implementation == PkgConfigCLIImplementation.FREEDESKTOP and version_compare(impl.pkgbin_version, ">=0.29.1")) or (
+                impl.implementation == PkgConfigCLIImplementation.PKGCONF and version_compare(impl.pkgbin_version, "<3.0.4")):
             self.assertEqual(libhello_nolib.get_variable(pkgconfig='escaped_var'), r'hello\ world')
         self.assertEqual(libhello_nolib.get_variable(pkgconfig='unescaped_var'), 'hello world')
 

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -35,7 +35,9 @@ from mesonbuild.compilers.c import AppleClangCCompiler, ElbrusCompiler
 from mesonbuild.compilers.cpp import AppleClangCPPCompiler
 from mesonbuild.compilers.objc import AppleClangObjCCompiler
 from mesonbuild.compilers.objcpp import AppleClangObjCPPCompiler
-from mesonbuild.dependencies.pkgconfig import PkgConfigDependency, PkgConfigCLI, PkgConfigInterface
+from mesonbuild.dependencies.pkgconfig import (
+    PkgConfigDependency, PkgConfigCLI, PkgConfigCLIImplementation, PkgConfigInterface,
+)
 from mesonbuild.programs import NonExistingExternalProgram
 import mesonbuild.modules.pkgconfig
 
@@ -180,7 +182,23 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertEqual(libhello_nolib.get_variable(pkgconfig='foo'), 'bar')
         self.assertEqual(libhello_nolib.get_variable(pkgconfig='prefix'), self.prefix)
         impl = libhello_nolib.pkgconfig
-        if not isinstance(impl, PkgConfigCLI) or version_compare(impl.pkgbin_version, ">=0.29.1"):
+        if isinstance(impl, PkgConfigCLI) and impl.implementation == PkgConfigCLIImplementation.PKGCONF \
+                and version_compare(impl.pkgbin_version, ">=3.0.4") \
+                and version_compare(impl.pkgbin_version, "<3.0.5"):
+            # pkgconf 3.0.4 (only) unescapes '\ ' when storing a variable's
+            # value (fixing double-escaping when the variable is expanded into a
+            # fragment, see https://github.com/pkgconf/pkgconf/issues/575), so
+            # --variable returns the canonical (unescaped) value instead of
+            # preserving the literal backslash. This was superseded in 3.0.5,
+            # which fixes the double-escaping differently (consuming quoting
+            # after expansion rather than at variable-storage time) and so
+            # restores the literal-backslash behavior below. See
+            # https://github.com/pkgconf/pkgconf/issues/579.
+            self.assertEqual(libhello_nolib.get_variable(pkgconfig='escaped_var'), 'hello world')
+        elif not isinstance(impl, PkgConfigCLI) or (
+                impl.implementation == PkgConfigCLIImplementation.FREEDESKTOP and version_compare(impl.pkgbin_version, ">=0.29.1")) or (
+                impl.implementation == PkgConfigCLIImplementation.PKGCONF and (
+                    version_compare(impl.pkgbin_version, "<3.0.4") or version_compare(impl.pkgbin_version, ">=3.0.5"))):
             self.assertEqual(libhello_nolib.get_variable(pkgconfig='escaped_var'), r'hello\ world')
         self.assertEqual(libhello_nolib.get_variable(pkgconfig='unescaped_var'), 'hello world')
 


### PR DESCRIPTION
By knowing the implementation of pkg-config, we can make better decisions when special-casing code. As you can see in the following test change, that version comparison was really only meant for the FreeDesktop implementation.