### PR TITLE
ast/printer: fix list of nonassociative operators

### DIFF
--- a/mesonbuild/ast/printer.py
+++ b/mesonbuild/ast/printer.py
@@ -156,7 +156,7 @@ class AstPrinter(AstVisitor):
         self.maybe_parentheses(node, node.left, prec > prec_left)
         self.append_padded(node.operator.value, node)
         node.lineno = self.curr_line or node.lineno
-        self.maybe_parentheses(node, node.right, prec > prec_right or (prec == prec_right and node.operation in {'sub', 'div', 'mod'}))
+        self.maybe_parentheses(node, node.right, prec > prec_right or (prec == prec_right and node.operation in {'-', '/', '%'}))
 
     def visit_NotNode(self, node: mparser.NotNode) -> None:
         node.lineno = self.curr_line or node.lineno


### PR DESCRIPTION
The nonassociative operators were still listed as their operation name rather than the symbol, which is used since 1.11.0.  As a result, the AstPrinter would incorrectly leave out some parentheses.  Note however that this is very unlikely to happen in practice.

There are no existing testcases for AstPrinter, but I reproduced the bug and tested the fix by hacking mformat to use AstPrinter and mparser to drop ParenthesizedNodes.