### PR TITLE
windows.compile_resources: do not call ccache

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -494,6 +494,10 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
                  full_version: T.Optional[str] = None):
         self.exelist = ccache + exelist
         self.exelist_no_ccache = exelist
+        if exelist and not ccache:
+            *_, first_exe = exelist[0].rsplit('/', maxsplit=1)
+            if first_exe.lower().startswith('ccache'):
+                del self.exelist_no_ccache[0]
         self.file_suffixes = lang_suffixes[self.language]
         self.can_compile_suffixes = set(self.file_suffixes)
         self.default_suffix = self.file_suffixes[0]


### PR DESCRIPTION
When the compiler is defined in the machine file to use ccache, Compiler.get_exelist() returns the ccache command even if ccache argument is False.

A heuristic was added to remove it from the exelist_no_ccache variable. This prevent a
"ccache: error: execute_noreturn of /showIncludes failed: No such file or directory"
warning when trying to compile windows ressources, because ccache.exe was used instead of cl.exe to invoke the compiler.