### PR TITLE
cmake: keep private include dirs out of dependencies

### DIFF
--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -238,6 +238,7 @@ class ConverterTarget:
         self.generated: T.List[Path] = []
         self.generated_ctgt: T.List[CustomTargetReference] = []
         self.includes: T.List[Path] = []
+        self.public_includes: T.List[Path] = []
         self.sys_includes: T.List[Path] = []
         self.link_with: T.List[T.Union[ConverterTarget, ConverterCustomTarget]] = []
         self.object_libs: T.List[ConverterTarget] = []
@@ -371,7 +372,8 @@ class ConverterTarget:
             self.soversion = trace.targets[self.cmake_name].properties.get('SOVERSION', [None])[0]
 
             rtgt = resolve_cmake_trace_targets(self.cmake_name, trace, self.env, clib_compiler=self.clib_compiler)
-            self.includes += [Path(x) for x in rtgt.include_directories]
+            self.public_includes += [Path(x) for x in rtgt.include_directories]
+            self.includes += [Path(x) for x in rtgt.private_include_directories]
             self.link_flags += rtgt.link_flags
             self.public_link_flags += rtgt.public_link_flags
             self.public_compile_opts += rtgt.public_compile_opts
@@ -1171,6 +1173,7 @@ class CMakeInterpreter:
 
             # Determine the variable names
             inc_var = f'{tgt.name}_inc'
+            public_inc_var = f'{tgt.name}_public_inc'
             dir_var = f'{tgt.name}_dir'
             sys_var = f'{tgt.name}_sys'
             src_var = f'{tgt.name}_src'
@@ -1229,10 +1232,12 @@ class CMakeInterpreter:
                 generated += dependencies
 
             # Generate the function nodes
-            dir_node = assign(dir_var, function('include_directories', tgt.includes))
+            dir_node = assign(dir_var, function('include_directories', tgt.includes + tgt.public_includes))
+            public_dir_node = assign(public_inc_var, function('include_directories', tgt.public_includes))
             sys_node = assign(sys_var, function('include_directories', tgt.sys_includes, {'is_system': True}))
             inc_node = assign(inc_var, array([id_node(dir_var), id_node(sys_var)]))
-            node_list = [dir_node, sys_node, inc_node]
+            node_list = [dir_node, public_dir_node, sys_node, inc_node]
+            dep_kwargs['include_directories'] = id_node(public_inc_var)
             if tgt_func == 'header_only':
                 del dep_kwargs['link_with']
                 dep_node = assign(dep_var, function('declare_dependency', kwargs=dep_kwargs))

--- a/mesonbuild/cmake/tracetargets.py
+++ b/mesonbuild/cmake/tracetargets.py
@@ -41,6 +41,7 @@ def _get_framework_include_path(path: Path) -> T.Optional[str]:
 class ResolvedTarget:
     def __init__(self) -> None:
         self.include_directories: T.List[str] = []
+        self.private_include_directories: T.List[str] = []
         self.link_flags:          T.List[str] = []
         self.public_link_flags:   T.List[str] = []
         self.public_compile_opts: T.List[str] = []
@@ -112,6 +113,9 @@ def resolve_cmake_trace_targets(target_name: str,
 
         if 'INTERFACE_INCLUDE_DIRECTORIES' in tgt.properties:
             res.include_directories += [x for x in tgt.properties['INTERFACE_INCLUDE_DIRECTORIES'] if x]
+
+        if curr == target_name and 'INCLUDE_DIRECTORIES' in tgt.properties:
+            res.private_include_directories += [x for x in tgt.properties['INCLUDE_DIRECTORIES'] if x]
 
         if 'INTERFACE_LINK_OPTIONS' in tgt.properties:
             res.public_link_flags += [x for x in tgt.properties['INTERFACE_LINK_OPTIONS'] if x]


### PR DESCRIPTION
## Summary

- keep CMake target-private include directories on the converted target only
- expose only INTERFACE include directories through the generated Meson dependency
- preserve public and private include paths for the target itself

Fixes #13818

## Validation

- `python -m compileall -q mesonbuild/cmake`
- `git diff --check`
- `python -m pytest -q unittests --disable-warnings --maxfail=1` *(blocked by the environment: pytest-recording and pytest-vcr are both installed)*
- `run_tests.py` was blocked because Ninja is not installed in this environment