### PR TITLE
Fix meson dist --include-subprojects with redirected wraps

### DIFF
--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -32,7 +32,7 @@ from ..mesonlib import (
     PerMachine, unique_list, SubProject,
 )
 from .. import coredata, mlog
-from ..wrap.wrap import PackageDefinition
+from ..wrap.wrap import PackageDefinition, WrapType
 
 if T.TYPE_CHECKING:
     from . import raw
@@ -872,7 +872,7 @@ def load_cargo_lock(filename: str, subproject_dir: str) -> CargoLock:
             url = f'https://static.crates.io/crates/{package.name}/{package.version}/download'
             directory = f'{package.name}-{package.version}'
             name = SubProject(meson_depname)
-            wrap_type = 'file'
+            wrap_type = WrapType.FILE
             cfg = {
                 'directory': directory,
                 'source_url': url,
@@ -883,7 +883,7 @@ def load_cargo_lock(filename: str, subproject_dir: str) -> CargoLock:
         elif package.source.startswith('git+'):
             url, revision, directory = _parse_git_url(package.source)
             name = SubProject(directory)
-            wrap_type = 'git'
+            wrap_type = WrapType.GIT
             cfg = {
                 'url': url,
                 'revision': revision,

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -32,7 +32,7 @@ from ..mesonlib import (
     PerMachine, unique_list, SubProject,
 )
 from .. import coredata, mlog
-from ..wrap.wrap import PackageDefinition
+from ..wrap.wrap import PackageDefinition, WrapType
 
 if T.TYPE_CHECKING:
     from . import raw
@@ -875,7 +875,7 @@ def load_cargo_lock(filename: str, subproject_dir: str) -> T.Optional[CargoLock]
                 url = f'https://crates.io/api/v1/crates/{package.name}/{package.version}/download'
                 directory = f'{package.name}-{package.version}'
                 name = SubProject(meson_depname)
-                wrap_type = 'file'
+                wrap_type = WrapType.FILE
                 cfg = {
                     'directory': directory,
                     'source_url': url,
@@ -886,7 +886,7 @@ def load_cargo_lock(filename: str, subproject_dir: str) -> T.Optional[CargoLock]
             elif package.source.startswith('git+'):
                 url, revision, directory = _parse_git_url(package.source)
                 name = SubProject(directory)
-                wrap_type = 'git'
+                wrap_type = WrapType.GIT
                 cfg = {
                     'url': url,
                     'revision': revision,

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -399,8 +399,11 @@ def run(options: argparse.Namespace) -> int:
     if options.include_subprojects:
         resolver = wrap.Resolver(src_root, b.subproject_dir, silent=True)
         for sub in set(itertools.chain(b.projects.host, b.projects.build)):
-            if sub:
-                directory = resolver.get_directory(sub)
+            if not sub:
+                continue
+
+            directory = resolver.get_directory(sub)
+            if directory is not None:
                 subprojects[sub] = os.path.join(b.subproject_dir, directory)
         extra_meson_args.append('-Dwrap_mode=nodownload')
 

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -27,8 +27,8 @@ from mesonbuild.mesonlib import (GIT, MesonException, RealPathAction, SimpleABC,
                                  windows_proof_rmtree, setup_vsenv, determine_worker_count, unwrap_err)
 from .options import OptionKey
 from mesonbuild.msetup import add_arguments as msetup_argparse
-from mesonbuild.wrap import wrap
 from mesonbuild import mlog, build, cmdline
+from mesonbuild.wrap.wrap import PackageDefinition
 from .scripts.meson_exe import run_exe
 
 if T.TYPE_CHECKING:
@@ -399,9 +399,23 @@ def run(options: argparse.Namespace) -> int:
     if options.include_subprojects:
         subproject_dir = os.path.join(src_root, b.subproject_dir)
         for sub in set(itertools.chain(b.projects.host, b.projects.build)):
-            if sub:
-                directory = wrap.get_directory(subproject_dir, sub)
-                subprojects[sub] = os.path.join(b.subproject_dir, directory)
+            if not sub:
+                continue
+
+            wrap_fname = os.path.join(subproject_dir, f'{sub}.wrap')
+            if os.path.isfile(wrap_fname):
+                package = PackageDefinition.from_wrap_file(wrap_fname)
+
+                # We do not need to include redirected wraps. The authoritative
+                # subproject will get added as we continue.
+                if package.redirected:
+                    continue
+
+                subdir = package.directory
+            else:
+                subdir = sub
+
+            subprojects[sub] = os.path.join(b.subproject_dir, subdir)
         extra_meson_args.append('-Dwrap_mode=nodownload')
 
     cls: T.Type[Dist]

--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -17,7 +17,7 @@ import zipfile
 from . import mlog
 from .ast import IntrospectionInterpreter
 from .mesonlib import quiet_git, GitException, Popen_safe, MesonException, windows_proof_rmtree
-from .wrap.wrap import (Resolver, WrapException, ALL_TYPES,
+from .wrap.wrap import (Resolver, WrapException, WrapType,
                         parse_patch_url, update_wrap_file, get_releases)
 
 if T.TYPE_CHECKING:
@@ -59,7 +59,7 @@ if T.TYPE_CHECKING:
         apply: bool
         save: bool
 
-ALL_TYPES_STRING = ', '.join(ALL_TYPES)
+ALL_TYPES_STRING = ', '.join(WrapType)
 
 if sys.version_info >= (3, 14):
     tarfile.TarFile.extraction_filter = staticmethod(tarfile.fully_trusted_filter)
@@ -739,7 +739,7 @@ def run(options: 'Arguments') -> int:
         wraps = list(r.wraps.values())
     types = [t.strip() for t in options.types.split(',')] if options.types else []
     for t in types:
-        if t not in ALL_TYPES:
+        if t not in tuple(WrapType):
             raise MesonException(f'Unknown subproject type {t!r}, supported types are: {ALL_TYPES_STRING}')
     tasks: T.List[T.Awaitable[bool]] = []
     task_names: T.List[str] = []

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -24,6 +24,7 @@ import json
 import gzip
 
 from base64 import b64encode
+from enum import Enum
 from netrc import netrc
 from pathlib import Path, PurePath
 from functools import lru_cache
@@ -53,8 +54,6 @@ except ImportError:
 
 REQ_TIMEOUT = 30.0
 WHITELIST_SUBDOMAIN = 'wrapdb.mesonbuild.com'
-
-ALL_TYPES = ['file', 'git', 'hg', 'svn', 'redirect']
 
 if sys.version_info >= (3, 14):
     import tarfile
@@ -189,6 +188,14 @@ def parse_patch_url(patch_url: str) -> T.Tuple[str, str]:
         raise WrapException(f'Invalid wrapdb URL {patch_url}')
 
 
+class WrapType(str, Enum):
+    FILE = 'file'
+    GIT = 'git'
+    HG = 'hg'
+    SVN = 'svn'
+    REDIRECT = 'redirect'
+
+
 class WrapException(MesonException):
     pass
 
@@ -196,7 +203,7 @@ class WrapNotFoundException(WrapException):
     pass
 
 class PackageDefinition:
-    def __init__(self, name: SubProject, subprojects_dir: str, type_: T.Optional[str] = None, values: T.Optional[T.Dict[str, str]] = None):
+    def __init__(self, name: SubProject, subprojects_dir: str, type_: T.Optional[WrapType] = None, values: T.Optional[T.Dict[str, str]] = None):
         self.name = name
         self.subprojects_dir = subprojects_dir
         self.type = type_
@@ -223,7 +230,7 @@ class PackageDefinition:
         self.provided_deps[self.name.lower()] = None
 
     @staticmethod
-    def from_values(name: SubProject, subprojects_dir: str, type_: str, values: T.Dict[str, str]) -> PackageDefinition:
+    def from_values(name: SubProject, subprojects_dir: str, type_: WrapType, values: T.Dict[str, str]) -> PackageDefinition:
         return PackageDefinition(name, subprojects_dir, type_, values)
 
     @staticmethod
@@ -245,7 +252,7 @@ class PackageDefinition:
 
         subprojects_dir = os.path.dirname(filename)
 
-        if type_ == 'redirect':
+        if type_ is WrapType.REDIRECT:
             # [wrap-redirect] have a `filename` value pointing to the real wrap
             # file we should parse instead. It must be relative to the current
             # wrap file location and must be in the form foo/subprojects/bar.wrap.
@@ -287,7 +294,7 @@ class PackageDefinition:
         return wrap
 
     @staticmethod
-    def _parse_wrap(filename: str) -> T.Tuple[configparser.ConfigParser, str, T.Dict[str, str]]:
+    def _parse_wrap(filename: str) -> T.Tuple[configparser.ConfigParser, WrapType, T.Dict[str, str]]:
         try:
             config = configparser.ConfigParser(interpolation=None)
             config.read(filename, encoding='utf-8')
@@ -299,10 +306,10 @@ class PackageDefinition:
         if not wrap_section.startswith('wrap-'):
             raise WrapException(f'{wrap_section!r} is not a valid first section in {filename}')
         type_ = wrap_section[5:]
-        if type_ not in ALL_TYPES:
+        if type_ not in tuple(WrapType):
             raise WrapException(f'Unknown wrap type {type_!r}')
         values = dict(config[wrap_section])
-        return config, type_, values
+        return config, WrapType(type_), values
 
     def parse_provide_section(self, config: configparser.ConfigParser) -> None:
         if config.has_section('provides'):
@@ -590,15 +597,15 @@ class Resolver:
             cached_directory = os.path.join(self.cachedir, self.directory)
             if os.path.isdir(cached_directory):
                 self.copy_tree(cached_directory, self.dirname)
-            elif self.wrap.type == 'file':
+            elif self.wrap.type is WrapType.FILE:
                 self._get_file(packagename)
             else:
                 self.check_can_download()
-                if self.wrap.type == 'git':
+                if self.wrap.type is WrapType.GIT:
                     self._get_git(packagename)
-                elif self.wrap.type == "hg":
+                elif self.wrap.type is WrapType.HG:
                     self._get_hg()
-                elif self.wrap.type == "svn":
+                elif self.wrap.type is WrapType.SVN:
                     self._get_svn()
                 else:
                     raise WrapException(f'Unknown wrap type {self.wrap.type!r}')

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -24,6 +24,7 @@ import json
 import gzip
 
 from base64 import b64encode
+from enum import Enum
 from netrc import netrc
 from pathlib import Path, PurePath
 from functools import lru_cache
@@ -55,8 +56,6 @@ except ImportError:
 
 REQ_TIMEOUT = 30.0
 WHITELIST_SUBDOMAIN = 'wrapdb.mesonbuild.com'
-
-ALL_TYPES = ['file', 'git', 'hg', 'svn', 'redirect']
 
 if sys.version_info >= (3, 14):
     import tarfile
@@ -191,6 +190,14 @@ def parse_patch_url(patch_url: str) -> T.Tuple[str, str]:
         raise WrapException(f'Invalid wrapdb URL {patch_url}')
 
 
+class WrapType(str, Enum):
+    FILE = 'file'
+    GIT = 'git'
+    HG = 'hg'
+    SVN = 'svn'
+    REDIRECT = 'redirect'
+
+
 class WrapException(MesonException):
     pass
 
@@ -198,7 +205,7 @@ class WrapNotFoundException(WrapException):
     pass
 
 class PackageDefinition:
-    def __init__(self, name: SubProject, subprojects_dir: str, type_: T.Optional[str] = None, values: T.Optional[T.Dict[str, str]] = None):
+    def __init__(self, name: SubProject, subprojects_dir: str, type_: T.Optional[WrapType] = None, values: T.Optional[T.Dict[str, str]] = None):
         self.name = name
         self.subprojects_dir = subprojects_dir
         self.type = type_
@@ -225,7 +232,7 @@ class PackageDefinition:
         self.provided_deps[self.name.lower()] = None
 
     @staticmethod
-    def from_values(name: SubProject, subprojects_dir: str, type_: str, values: T.Dict[str, str]) -> PackageDefinition:
+    def from_values(name: SubProject, subprojects_dir: str, type_: WrapType, values: T.Dict[str, str]) -> PackageDefinition:
         return PackageDefinition(name, subprojects_dir, type_, values)
 
     @staticmethod
@@ -247,7 +254,7 @@ class PackageDefinition:
 
         subprojects_dir = os.path.dirname(filename)
 
-        if type_ == 'redirect':
+        if type_ is WrapType.REDIRECT:
             # [wrap-redirect] have a `filename` value pointing to the real wrap
             # file we should parse instead. It must be relative to the current
             # wrap file location and must be in the form foo/subprojects/bar.wrap.
@@ -289,7 +296,7 @@ class PackageDefinition:
         return wrap
 
     @staticmethod
-    def _parse_wrap(filename: str) -> T.Tuple[configparser.ConfigParser, str, T.Dict[str, str]]:
+    def _parse_wrap(filename: str) -> T.Tuple[configparser.ConfigParser, WrapType, T.Dict[str, str]]:
         try:
             config = configparser.ConfigParser(interpolation=None)
             config.read(filename, encoding='utf-8')
@@ -301,10 +308,10 @@ class PackageDefinition:
         if not wrap_section.startswith('wrap-'):
             raise WrapException(f'{wrap_section!r} is not a valid first section in {filename}')
         type_ = wrap_section[5:]
-        if type_ not in ALL_TYPES:
+        if type_ not in tuple(WrapType):
             raise WrapException(f'Unknown wrap type {type_!r}')
         values = dict(config[wrap_section])
-        return config, type_, values
+        return config, WrapType(type_), values
 
     def parse_provide_section(self, config: configparser.ConfigParser) -> None:
         if config.has_section('provides'):
@@ -620,15 +627,15 @@ class Resolver:
             cached_directory = os.path.join(self.cachedir, self.directory)
             if os.path.isdir(cached_directory):
                 self.copy_tree(cached_directory, self.dirname)
-            elif self.wrap.type == 'file':
+            elif self.wrap.type is WrapType.FILE:
                 self._get_file(packagename)
             else:
                 self.check_can_download()
-                if self.wrap.type == 'git':
+                if self.wrap.type is WrapType.GIT:
                     self._get_git(packagename)
-                elif self.wrap.type == "hg":
+                elif self.wrap.type is WrapType.HG:
                     self._get_hg()
-                elif self.wrap.type == "svn":
+                elif self.wrap.type is WrapType.SVN:
                     self._get_svn()
                 else:
                     raise WrapException(f'Unknown wrap type {self.wrap.type!r}')

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -353,13 +353,6 @@ class PackageDefinition:
     def add_provided_dep(self, name: str) -> None:
         self.provided_deps[name] = None
 
-def get_directory(subdir_root: str, packagename: str) -> str:
-    fname = os.path.join(subdir_root, packagename + '.wrap')
-    if os.path.isfile(fname):
-        wrap = PackageDefinition.from_wrap_file(fname)
-        return wrap.directory
-    return packagename
-
 def verbose_git(cmd: T.List[str], workingdir: str, check: bool = False) -> bool:
     '''
     Wrapper to convert GitException to WrapException caught in interpreter.

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -520,9 +520,11 @@ class Resolver:
             self.cargolocks.update(other_resolver.cargolocks)
             self.loaded_dirs.add(subdir)
 
-    def get_directory(self, packagename: str) -> str:
+    def get_directory(self, packagename: str) -> T.Optional[str]:
         wrap = self.wraps.get(packagename)
-        return wrap.directory if wrap else packagename
+        if wrap:
+            return None if wrap.redirected else wrap.directory
+        return packagename
 
     def find_dep_provider(self, packagename: str) -> T.Tuple[T.Optional[str], T.Optional[str]]:
         # Python's ini parser converts all key values to lowercase.

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1675,6 +1675,88 @@ class AllPlatformTests(BasePlatformTests):
             # fails sometimes.
             pass
 
+    @skipIfNoExecutable('git')
+    def test_dist_nested_promoted_subproject(self):
+        '''
+        https://github.com/mesonbuild/meson/issues/12489
+
+        A subproject (e.g. glib) can itself depend on a nested subproject
+        (e.g. gvdb) whose sources are bundled inside the outer subproject's
+        own "subprojects" directory rather than the main project's. Meson
+        promotes the wrap file for such a nested subproject to the main
+        project's subprojects directory (writing a [wrap-redirect] wrap
+        there), but the actual source directory stays nested. `meson dist
+        --include-subprojects` used to look for the nested subproject
+        directly under the main project's subprojects directory (following
+        the promoted wrap file naively) and crashed with a FileNotFoundError
+        because that directory did not exist there.
+        '''
+        if self.backend is not Backend.ninja:
+            raise SkipTest('Dist is only supported with Ninja')
+
+        with tempfile.TemporaryDirectory() as project_dir:
+            with open(os.path.join(project_dir, 'meson.build'), 'w', encoding='utf-8') as f:
+                f.write(textwrap.dedent('''\
+                    project('gtk', version : '1.0')
+                    subproject('glib')
+                    '''))
+
+            glib_dir = os.path.join(project_dir, 'subprojects', 'glib')
+            gvdb_dir = os.path.join(glib_dir, 'subprojects', 'gvdb')
+            os.makedirs(gvdb_dir)
+
+            # glib is a normal subproject with its own wrap file
+            with open(os.path.join(project_dir, 'subprojects', 'glib.wrap'), 'w', encoding='utf-8') as f:
+                f.write(textwrap.dedent('''\
+                    [wrap-file]
+                    directory = glib
+                    '''))
+
+            # Only the main project and glib's wrap file are tracked by git;
+            # glib itself is *not* a git repository, mimicking a subproject
+            # fetched/extracted from a tarball
+            git_init(project_dir)
+
+            with open(os.path.join(glib_dir, 'meson.build'), 'w', encoding='utf-8') as f:
+                f.write(textwrap.dedent('''\
+                    project('glib', version : '1.0')
+                    subproject('gvdb')
+                    '''))
+
+            # gvdb is bundled inside glib's own subprojects directory, with
+            # its sources already extracted there
+            with open(os.path.join(glib_dir, 'subprojects', 'gvdb.wrap'), 'w', encoding='utf-8') as f:
+                f.write(textwrap.dedent('''\
+                    [wrap-file]
+                    directory = gvdb
+                    '''))
+            with open(os.path.join(gvdb_dir, 'meson.build'), 'w', encoding='utf-8') as f:
+                f.write(textwrap.dedent('''\
+                    project('gvdb', version : '1.0')
+                    '''))
+
+            self.init(project_dir)
+            # Configuring writes the promoted [wrap-redirect] wrap file
+            redirect_wrap = os.path.join(project_dir, 'subprojects', 'gvdb.wrap')
+            self.assertPathExists(redirect_wrap)
+            with open(redirect_wrap, encoding='utf-8') as f:
+                self.assertIn('[wrap-redirect]', f.read())
+
+            self._run(self.meson_command + ['dist', '--include-subprojects', '--no-tests',
+                                             '--formats', 'zip'],
+                      workdir=self.builddir)
+
+            zip_distfile = os.path.join(self.distdir, 'gtk-1.0.zip')
+            self.assertPathExists(zip_distfile)
+            z = zipfile.ZipFile(zip_distfile)
+            names = set(z.namelist())
+            # gvdb must end up nested inside glib, where it really lives...
+            self.assertIn('gtk-1.0/subprojects/glib/subprojects/gvdb/meson.build', names)
+            # ... and must not be duplicated (or looked up) directly under the
+            # main project's subprojects directory.
+            self.assertNotIn('gtk-1.0/subprojects/gvdb/meson.build', names)
+            self.assertNotIn('gtk-1.0/subprojects/gvdb.wrap', names)
+
     def create_dummy_subproject(self, project_dir, name):
         path = os.path.join(project_dir, 'subprojects', name)
         os.makedirs(path)

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1655,6 +1655,87 @@ class AllPlatformTests(BasePlatformTests):
             # fails sometimes.
             pass
 
+    @skipIfNoExecutable('git')
+    def test_dist_nested_promoted_subproject(self):
+        '''
+        https://github.com/mesonbuild/meson/issues/12489
+
+        A subproject (e.g. glib) can itself depend on a nested subproject
+        (e.g. gvdb) whose sources are bundled inside the outer subproject's
+        own "subprojects" directory rather than the main project's. Meson
+        promotes the wrap file for such a nested subproject to the main
+        project's subprojects directory (writing a [wrap-redirect] wrap
+        there), but the actual source directory stays nested. `meson dist
+        --include-subprojects` used to look for the nested subproject
+        directly under the main project's subprojects directory (following
+        the promoted wrap file naively) and crashed with a FileNotFoundError
+        because that directory did not exist there.
+        '''
+        if self.backend is not Backend.ninja:
+            raise SkipTest('Dist is only supported with Ninja')
+
+        with tempfile.TemporaryDirectory() as project_dir:
+            with open(os.path.join(project_dir, 'meson.build'), 'w', encoding='utf-8') as f:
+                f.write(textwrap.dedent('''\
+                    project('gtk', version : '1.0')
+                    subproject('glib')
+                    '''))
+
+            glib_dir = os.path.join(project_dir, 'subprojects', 'glib')
+            gvdb_dir = os.path.join(glib_dir, 'subprojects', 'gvdb')
+            os.makedirs(gvdb_dir)
+
+            # glib is a normal subproject with its own wrap file
+            with open(os.path.join(project_dir, 'subprojects', 'glib.wrap'), 'w', encoding='utf-8') as f:
+                f.write(textwrap.dedent('''\
+                    [wrap-file]
+                    directory = glib
+                    '''))
+            with open(os.path.join(glib_dir, 'meson.build'), 'w', encoding='utf-8') as f:
+                f.write(textwrap.dedent('''\
+                    project('glib', version : '1.0')
+                    subproject('gvdb')
+                    '''))
+
+            # gvdb is bundled inside glib's own subprojects directory, with
+            # its sources already extracted there
+            with open(os.path.join(glib_dir, 'subprojects', 'gvdb.wrap'), 'w', encoding='utf-8') as f:
+                f.write(textwrap.dedent('''\
+                    [wrap-file]
+                    directory = gvdb
+                    '''))
+            with open(os.path.join(gvdb_dir, 'meson.build'), 'w', encoding='utf-8') as f:
+                f.write(textwrap.dedent('''\
+                    project('gvdb', version : '1.0')
+                    '''))
+
+            # Only the main project and glib's wrap file are tracked by git;
+            # glib itself is *not* a git repository, mimicking a subproject
+            # fetched/extracted from a tarball
+            git_init(project_dir)
+
+            self.init(project_dir)
+            # Configuring writes the promoted [wrap-redirect] wrap file
+            redirect_wrap = os.path.join(project_dir, 'subprojects', 'gvdb.wrap')
+            self.assertPathExists(redirect_wrap)
+            with open(redirect_wrap, encoding='utf-8') as f:
+                self.assertIn('[wrap-redirect]', f.read())
+
+            self._run(self.meson_command + ['dist', '--include-subprojects', '--no-tests',
+                                             '--formats', 'zip'],
+                      workdir=self.builddir)
+
+            zip_distfile = os.path.join(self.distdir, 'gtk-1.0.zip')
+            self.assertPathExists(zip_distfile)
+            z = zipfile.ZipFile(zip_distfile)
+            names = set(z.namelist())
+            # gvdb must end up nested inside glib, where it really lives...
+            self.assertIn('gtk-1.0/subprojects/glib/subprojects/gvdb/meson.build', names)
+            # ... and must not be duplicated (or looked up) directly under the
+            # main project's subprojects directory.
+            self.assertNotIn('gtk-1.0/subprojects/gvdb/meson.build', names)
+            self.assertNotIn('gtk-1.0/subprojects/gvdb.wrap', names)
+
     def create_dummy_subproject(self, project_dir, name):
         path = os.path.join(project_dir, 'subprojects', name)
         os.makedirs(path)


### PR DESCRIPTION
When redirected wraps were used, mdist was searching for the source directory in the subprojects directory of the root project. However, the source for redirected wraps is actually located in some child subprojects directory. Subsequently, this resulted in a FileNotFoundError. By skipping redirected wraps as we collect subprojects, we can effectively prevent the issue from occuring because the authoritative subproject will be picked up and included in the dist.

Fixes: https://github.com/mesonbuild/meson/issues/12489