### PR TITLE
Fixed oneAPI check and get version

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -667,8 +667,8 @@ searches for Microsoft MPI. *Since 1.11.0* Intel MPI is also supported.
 *New in 0.54.0* The `config-tool` and `system` method values. Previous
 versions would always try `pkg-config`, then `config-tool`, then `system`.
 
-**Note:** Intel oneAPI MPI wrappers `>= 2021.17` may not be detected correctly due to 
-instabilities in its versioning flag. 
+**Note:** Intel oneAPI Fortran compilers may have some 'display version'instabilities that 
+may prevent it from being detected correctly. 
 
 ## NetCDF
 

--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -667,8 +667,8 @@ searches for Microsoft MPI. *Since 1.11.0* Intel MPI is also supported.
 *New in 0.54.0* The `config-tool` and `system` method values. Previous
 versions would always try `pkg-config`, then `config-tool`, then `system`.
 
-**Note:** Intel oneAPI Fortran compilers may have some 'display version'instabilities that 
-may prevent it from being detected correctly. 
+**Note:** `ifx <=2021.18` is known to interact with some package 
+managers, preventing Meson from detecting Intel MPI versions correctly. 
 
 ## NetCDF
 

--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -667,6 +667,9 @@ searches for Microsoft MPI. *Since 1.11.0* Intel MPI is also supported.
 *New in 0.54.0* The `config-tool` and `system` method values. Previous
 versions would always try `pkg-config`, then `config-tool`, then `system`.
 
+**Note:** Intel oneAPI MPI wrappers `>= 2021.17` may not be detected correctly due to 
+instabilities in its versioning flag. 
+
 ## NetCDF
 
 *(added 0.50.0)*

--- a/mesonbuild/dependencies/mpi.py
+++ b/mesonbuild/dependencies/mpi.py
@@ -73,8 +73,6 @@ def mpi_factory(env: 'Environment',
             elif language == 'fortran':
                 if is_llvm_based:
                     tool_names.append('mpiifx')
-                    # As of oneAPI MPI 2021.17, version query results in an error
-                    nwargs['returncode_value'] = 1
                 else:
                     tool_names.append('mpiifort')
 
@@ -237,6 +235,10 @@ class MPIConfigToolDependency(ConfigToolDependency):
         v = re.search(r'(\d{4}) Update (\d)', first_line)
         if v:
             return valid, f'{v.group(1)}.{v.group(2)}'
+
+        # catch Intel OneAPI >2021.16, others
+        p, out = Popen_safe(tool + ['--help'])[:2]
+        valid = p.returncode == 0
 
         return valid, None
 

--- a/mesonbuild/dependencies/mpi.py
+++ b/mesonbuild/dependencies/mpi.py
@@ -237,8 +237,8 @@ class MPIConfigToolDependency(ConfigToolDependency):
             return valid, f'{v.group(1)}.{v.group(2)}'
 
         # catch Intel OneAPI >2021.16, others
-        p, out = Popen_safe(tool + ['--help'])[:2]
-        valid = p.returncode == 0
+        p, _ = Popen_safe(tool + ['--help'])[:2]
+        valid = valid or p.returncode == 0
 
         return valid, None
 

--- a/mesonbuild/dependencies/mpi.py
+++ b/mesonbuild/dependencies/mpi.py
@@ -73,6 +73,8 @@ def mpi_factory(env: 'Environment',
             elif language == 'fortran':
                 if is_llvm_based:
                     tool_names.append('mpiifx')
+                    # As of oneAPI MPI 2021.17, version query results in an error 
+                    nwargs['returncode_value'] = 1
                 else:
                     tool_names.append('mpiifort')
 
@@ -204,11 +206,23 @@ class MPIConfigToolDependency(ConfigToolDependency):
                 version = None
             return valid, version
 
-        # --version is not the same as -v
+        # --version (compiler) is not the same as -v/V (MPI wrapper)
+        
+        p, out = Popen_safe(tool + ['-V'])[:2]
+        valid = p.returncode == returncode
+        if valid:
+            # Intel OneAPI
+            v = re.search(r'\d+.\d+', first_line)
+            if v:
+                version = v.group(0)
+            else:
+                version = None
+            return valid, version
+        
         p, out = Popen_safe(tool + ['-v'])[:2]
         valid = p.returncode == returncode
         first_line = out.split('\n', maxsplit=1)[0]
-
+        
         # cases like "mpicc for MPICH version 4.2.2"
         v = re.search(r'\d+.\d+.\d+', first_line)
         if v:

--- a/mesonbuild/dependencies/mpi.py
+++ b/mesonbuild/dependencies/mpi.py
@@ -73,7 +73,7 @@ def mpi_factory(env: 'Environment',
             elif language == 'fortran':
                 if is_llvm_based:
                     tool_names.append('mpiifx')
-                    # As of oneAPI MPI 2021.17, version query results in an error 
+                    # As of oneAPI MPI 2021.17, version query results in an error
                     nwargs['returncode_value'] = 1
                 else:
                     tool_names.append('mpiifort')
@@ -207,7 +207,6 @@ class MPIConfigToolDependency(ConfigToolDependency):
             return valid, version
 
         # --version (compiler) is not the same as -v/V (MPI wrapper)
-        
         p, out = Popen_safe(tool + ['-V'])[:2]
         first_line = out.split('\n', maxsplit=1)[0]
         valid = p.returncode == returncode
@@ -219,11 +218,11 @@ class MPIConfigToolDependency(ConfigToolDependency):
             else:
                 version = None
             return valid, version
-        
+
         p, out = Popen_safe(tool + ['-v'])[:2]
         valid = p.returncode == returncode
         first_line = out.split('\n', maxsplit=1)[0]
-        
+
         # cases like "mpicc for MPICH version 4.2.2"
         v = re.search(r'\d+.\d+.\d+', first_line)
         if v:

--- a/mesonbuild/dependencies/mpi.py
+++ b/mesonbuild/dependencies/mpi.py
@@ -209,6 +209,7 @@ class MPIConfigToolDependency(ConfigToolDependency):
         # --version (compiler) is not the same as -v/V (MPI wrapper)
         
         p, out = Popen_safe(tool + ['-V'])[:2]
+        first_line = out.split('\n', maxsplit=1)[0]
         valid = p.returncode == returncode
         if valid:
             # Intel OneAPI


### PR DESCRIPTION
At early as 2021.16, oneAPI-MPI's versioning command may use a capital '-V' instead of lowercase '-v'. This is patched by adding an additional '-V' check. In addition, in only the Fortran wrappers, it gives an error code, ~~which is patched by adapting returncode_value to 1~~. This resolves #16052. 