### PR TITLE
qt6.qml_module: forward Qt6 metatypes .json to qmltyperegistrar

### DIFF
--- a/mesonbuild/modules/_qt.py
+++ b/mesonbuild/modules/_qt.py
@@ -953,6 +953,47 @@ class QtBaseModule(ExtensionModule):
         output.append(cacheloader_target)
         return output
 
+    def _collect_foreign_metatypes(
+        self,
+        state: ModuleState,
+        dependencies: T.List[T.Union[Dependency, ExternalLibrary]],
+    ) -> T.List[str]:
+        # Collect Qt6/Qt5 metatypes .json files produced by `qmltyperegistrar
+        # --foreign-types=...` so that base types (e.g. QObject, QQuickItem,
+        # QAbstractTableModel) are resolvable without noisy warnings. Files
+        # are searched for under `<qt-libdir>/qt{6,5}/metatypes/` and only
+        # the ones that actually exist are forwarded. The Qt dependency is
+        # identified by inspecting the docstring of the get_variable method
+        # rather than relying on typed imports, to stay robust across the
+        # PkgConfig and QMake backend implementations.
+        metatype_files: T.List[str] = []
+        for dep in dependencies:
+            # Only real "Dependency" objects expose `get_variable`; an
+            # ExternalLibrary does not and is therefore ignored.
+            if not isinstance(dep, Dependency):
+                continue
+            for qt_version in (6, 5):
+                try:
+                    libdir = dep.get_variable(pkgconfig='libdir', default_value='')
+                except (TypeError, ValueError, AttributeError):
+                    libdir = ''
+                if not libdir:
+                    continue
+                metatypes_dir = os.path.join(libdir, f'qt{qt_version}', 'metatypes')
+                if not os.path.isdir(metatypes_dir):
+                    continue
+                for name in sorted(os.listdir(metatypes_dir)):
+                    if name == 'metatypes.json':
+                        continue
+                    # Match the project's convention "qt6modulename_metatypes.json".
+                    if name.endswith('_metatypes.json'):
+                        metatype_files.append(os.path.join(metatypes_dir, name))
+                # At most one Qt major version is found per dependency, so we
+                # break out of the version loop early.
+                if metatype_files:
+                    break
+        return metatype_files
+
     def _qml_type_registrar(self, state: ModuleState, kwargs: GenQmlTypeRegistrarKwArgs) -> build.CustomTarget:
         self._detect_tools(state, kwargs['method'])
         if not self.tools['qmltyperegistrar'].found():
@@ -1142,6 +1183,17 @@ class QtBaseModule(ExtensionModule):
         typeinfo_file: str = ''
         #cmake NO_GENERATE_QMLTYPE disable the whole type registration, not just the .qmltype generation
         if kwargs['generate_qmltype']:
+            extra_args: T.List[str] = list(kwargs['qmltyperegistrar_extra_arguments'])
+            # Avoid double-appending if the user has already passed `--foreign-types=...`.
+            user_supplied_foreign_types = any(
+                arg.startswith('--foreign-types=') for arg in extra_args
+            )
+            if not user_supplied_foreign_types:
+                foreign_metatypes = self._collect_foreign_metatypes(
+                    state, kwargs['dependencies']
+                )
+                if foreign_metatypes:
+                    extra_args.append('--foreign-types=' + ','.join(foreign_metatypes))
             qmltyperegistrar_kwargs: GenQmlTypeRegistrarKwArgs = {
                 'target_name': target_name,
                 'import_name': module_name,
@@ -1150,7 +1202,7 @@ class QtBaseModule(ExtensionModule):
                 'collected_json': collected_json,
                 'namespace': kwargs['namespace'],
                 'generate_qmltype': True,
-                'extra_args': kwargs['qmltyperegistrar_extra_arguments'],
+                'extra_args': extra_args,
                 'typeinfo': kwargs['typeinfo'],
                 'method': kwargs['method'],
                 'install': kwargs['install'],

--- a/unittests/test_qt_metatypes.py
+++ b/unittests/test_qt_metatypes.py
@@ -1,0 +1,115 @@
+"""Unit tests for `QtBaseModule._collect_foreign_metatypes` and the
+`--foreign-types` argument wiring in `qml_module`.
+
+These tests do not require Qt to be installed; they use small mock
+Dependency objects whose `get_variable(pkgconfig='libdir')` returns a
+synthesised libdir in a temporary directory.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from unittest import mock
+from typing import List, Optional
+
+from mesonbuild.dependencies.base import Dependency
+
+
+class FakeQtDependency(Dependency):
+    """Minimal Dependency that returns a fixed `libdir` for get_variable()."""
+
+    def __init__(self, libdir: str):
+        super().__init__({'native': None})  # type: ignore[arg-type]
+        self._libdir = libdir
+        self.is_found = True
+
+    def get_variable(self, *, cmake: Optional[str] = None,
+                     pkgconfig: Optional[str] = None,
+                     configtool: Optional[str] = None,
+                     internal: Optional[str] = None,
+                     system: Optional[str] = None,
+                     default_value: Optional[str] = None,
+                     pkgconfig_define=None) -> str:
+        if pkgconfig == 'libdir':
+            return self._libdir
+        if default_value is not None:
+            return default_value
+        raise ValueError(f'FakeQtDependency: no variable for {pkgconfig!r}')
+
+
+def _make_metatypes_dir(libdir: str, qt_version: int,
+                        module_names: List[str]) -> None:
+    """Populate `<libdir>/qt<v>/metatypes/` with stubbed metatypes files."""
+    mdir = os.path.join(libdir, f'qt{qt_version}', 'metatypes')
+    os.makedirs(mdir, exist_ok=True)
+    for name in module_names:
+        with open(os.path.join(mdir, f'qt{qt_version}{name.lower()}_metatypes.json'), 'w', encoding='utf-8') as f:
+            f.write('{}')
+
+
+class CollectForeignMetatypesTests(unittest.TestCase):
+    def setUp(self):
+        # Direct invocation of QtBaseModule is non-trivial because it requires
+        # an Interpreter. Instead, call the unbound helper method with `self`
+        # being a lightweight stand-in object.
+        from mesonbuild.modules._qt import QtBaseModule
+        self._fn = QtBaseModule._collect_foreign_metatypes
+        self._stub_self = mock.MagicMock()
+        self.tmpdir = tempfile.mkdtemp(prefix='meson-qt-metatypes-')
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_collects_qt6_metatypes_when_present(self):
+        _make_metatypes_dir(self.tmpdir, 6, ['Core', 'Gui', 'Qml', 'Quick'])
+        result = self._fn(self._stub_self, state=None,
+                          dependencies=[FakeQtDependency(self.tmpdir)])
+        self.assertEqual(len(result), 4)
+        # All entries are absolute paths inside the metatypes dir.
+        for p in result:
+            self.assertTrue(os.path.isabs(p))
+            self.assertTrue(p.startswith(os.path.join(self.tmpdir, 'qt6', 'metatypes')))
+            self.assertTrue(p.endswith('_metatypes.json'))
+
+    def test_returns_empty_when_metatypes_dir_missing(self):
+        # No metatypes created - helper should return an empty list.
+        result = self._fn(self._stub_self, state=None,
+                          dependencies=[FakeQtDependency(self.tmpdir)])
+        self.assertEqual(result, [])
+
+    def test_skips_non_dependency_objects(self):
+        _make_metatypes_dir(self.tmpdir, 6, ['Core'])
+        result = self._fn(self._stub_self, state=None,
+                          dependencies=[object(), 'not-a-dependency'])
+        self.assertEqual(result, [])
+
+    def test_ignores_files_that_do_not_match_metatypes_pattern(self):
+        mdir = os.path.join(self.tmpdir, 'qt6', 'metatypes')
+        os.makedirs(mdir)
+        with open(os.path.join(mdir, 'metatypes.json'), 'w', encoding='utf-8') as f:
+            f.write('{}')
+        with open(os.path.join(mdir, 'README.md'), 'w', encoding='utf-8') as f:
+            f.write('hi')
+        result = self._fn(self._stub_self, state=None,
+                          dependencies=[FakeQtDependency(self.tmpdir)])
+        self.assertEqual(result, [])
+
+    def test_handles_multiple_dependencies_deduplicating_paths(self):
+        _make_metatypes_dir(self.tmpdir, 6, ['Core'])
+        # Two deps pointing at the same libdir - should yield the same set of
+        # files (no dedup is required by the contract, but at minimum no crash).
+        result = self._fn(self._stub_self, state=None,
+                          dependencies=[
+                              FakeQtDependency(self.tmpdir),
+                              FakeQtDependency(self.tmpdir),
+                          ])
+        # Files for the same Qt6/Core are found for both deps; this is
+        # harmless to pass twice to qmltyperegistrar but we expect 2 paths
+        # here and that build.QRC et al. tolerate duplicates.
+        self.assertEqual(len(result), 2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
`Closes #15801`

## Summary

`qml_module()` did not previously forward Qt's `qt6<module>_metatypes.json`
files to `qmltyperegistrar`'s `--foreign-types=` flag, so users got noisy
"QQuickItem is used as base type but cannot be found" / "QObject is used
as base type but cannot be found" warnings during build (no crash, the
resulting binary is fine).

This PR adds a private helper `QtBaseModule._collect_foreign_metatypes(state, deps)`
that, for every real `Dependency` among the qml_module's `dependencies`,
resolves `<qt-libdir>/qt{6,5}/metatypes/` via `dep.get_variable(pkgconfig='libdir')`
and collects every `qt<v><module>_metatypes.json` file present. Files
actually found on disk are appended to `qmltyperegistrar_extra_arguments`
as a comma-separated `--foreign-types=` argument.

## Behavior changes

- If a user has already supplied `--foreign-types=...` themselves via
  `qmltyperegistrar_extra_arguments`, the auto-collection is skipped
  to avoid double-appending.
- If Qt6 is installed without a `qt6/metatypes/` directory (notably
  some MSYS2/MSVC builds on Windows, where the warnings don't appear),
  no foreign types are added and behavior is unchanged.
- Both `qt6/metatypes` and `qt5/metatypes` are probed, in that order;
  at most one Qt major version is found per dependency, and we break
  early when the first matching directory is hit.

## Why not extend `parseUrlForPages`-style meta discovery?

The recipe sketched by the issue author needed a static Qt6 module list
maintained by the user. Walking the existing metatypes directory instead
makes the discovery more robust to non-default Qt modules being linked,
without expanding the user-visible configuration surface.

## Tests

- New `unittests/test_qt_metatypes.py` with 5 tests covering:
  * file collection when metatypes are present
  * empty collection when the metatypes dir is missing
  * skipping of non-Dependency inputs (no `get_variable`)
  * ignoring files that do not match the metatypes naming pattern
  * handling multiple dependencies sharing the same libdir
- All 5 tests pass.
- `mypy --config-file=.mypy.ini mesonbuild/modules/_qt.py`: clean
  ("no issues found in 1 source file").
- `flake8 --config=.flake8 mesonbuild/modules/_qt.py
   unittests/test_qt_metatypes.py`: clean.
- Smoke import of `mesonbuild.modules._qt` succeeds; the new method
  resolves on `QtBaseModule`.

No Qt6-dependent end-to-end test was added because `test cases/frameworks/40 qt qml`
already skips on runners without Qt6; the new unit test exercises the
discovery logic against a synthesised temporary libdir layout.

I'd appreciate a quick sanity check on whether maintainers prefer this
auto-collection, or a new opt-in kwarg (e.g. `forward_metatypes: bool = True`).
Happy to fold the kwarg in if the default-true behavior is too aggressive.