### PR TITLE
dependencies/python: support 32-bit ARM Windows Python platform 'win-arm32'

### DIFF
--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -348,7 +348,9 @@ class _PythonDependencyBase(_Base):
             return 'x86_64'
         elif self.platform in {'win-arm64'}:
             return 'aarch64'
-        raise DependencyException('Unknown Windows Python platform {self.platform!r}')
+        elif self.platform in {'win-arm32'}:
+            return 'arm'
+        raise DependencyException(f'Unknown Windows Python platform {self.platform!r}')
 
     def get_windows_link_args(self, limited_api: bool, environment: 'Environment') -> T.Optional[T.List[str]]:
         if self.build_config:

--- a/unittests/test_python_windows_arch.py
+++ b/unittests/test_python_windows_arch.py
@@ -1,0 +1,87 @@
+"""Unit tests for `PythonInstallation._PythonDependencyBase.get_windows_python_arch`.
+
+[#14475](https://github.com/mesonbuild/meson/issues/14475) reports a crash on
+Windows 11 ARM64 when the host Python interpreter is 32-bit ARM, namely
+``sysconfig.get_platform()`` returns ``'win-arm32'``. The default branch of
+``get_windows_python_arch`` only recognised 'win32', 'win64', 'win-amd64' and
+'win-arm64', so 32-bit ARM fell through to the (non-f-string) "Unknown Windows
+Python platform {self.platform!r}" message and downstream ``.endswith('64')``
+calls crashed.
+
+These tests use a lightweight subclass overriding ``self.platform`` to avoid
+spinning up a real Python interpreter introspection.
+"""
+from __future__ import annotations
+
+import unittest
+
+from mesonbuild.dependencies.python import _PythonDependencyBase
+
+
+class _PlatformStub(_PythonDependencyBase):
+    """Injects a fixed `self.platform`, bypassing interpreter introspection."""
+
+    def __init__(self, platform: str):  # noqa: D401
+        self.platform = platform
+        # Avoid touching any real environment / interp setup.
+        self.embed = False
+        self.build_config = None
+        self.version = '3.12.0'
+        self.is_freethreaded = False
+        self.link_libpython = False
+        self.is_pypy = False
+        self.variables = {}
+        self.paths = {}
+        self.major_version = 3
+        self.compile_args: list[str] = []
+        self.is_found = True
+
+
+class WindowsPythonArchTests(unittest.TestCase):
+    def test_win32_x86(self):
+        self.assertEqual(_PlatformStub('win32').get_windows_python_arch(), 'x86')
+
+    def test_win_amd64_x86_64(self):
+        self.assertEqual(_PlatformStub('win-amd64').get_windows_python_arch(),
+                         'x86_64')
+
+    def test_win64_x86_64(self):
+        self.assertEqual(_PlatformStub('win64').get_windows_python_arch(),
+                         'x86_64')
+
+    def test_win_arm64_aarch64(self):
+        self.assertEqual(_PlatformStub('win-arm64').get_windows_python_arch(),
+                         'aarch64')
+
+    def test_win_arm32_arm(self):
+        # Regression test for #14475:
+        # `win-arm32` was previously reported as "Unknown Windows Python
+        # platform 'win-arm32'" and caused a downstream crash.
+        self.assertEqual(_PlatformStub('win-arm32').get_windows_python_arch(),
+                         'arm')
+
+    def test_mingw_x86_64(self):
+        self.assertEqual(_PlatformStub('mingw_x86_64').get_windows_python_arch(),
+                         'x86_64')
+
+    def test_mingw_i686_x86(self):
+        self.assertEqual(_PlatformStub('mingw_i686').get_windows_python_arch(),
+                         'x86')
+
+    def test_mingw_aarch64(self):
+        self.assertEqual(_PlatformStub('mingw_aarch64').get_windows_python_arch(),
+                         'aarch64')
+
+    def test_unknown_platform_raises_with_fstring(self):
+        # The error message used to be a literal "{var!r}" (missing f-prefix)
+        # so users could not diagnose what platform meson actually saw.
+        from mesonbuild.dependencies.base import DependencyException
+        with self.assertRaises(DependencyException) as ctx:
+            _PlatformStub('win-riscv').get_windows_python_arch()
+        # The message must include the literal platform string -- the f-string
+        # bug being fixed ensures {self.platform!r} is expanded.
+        self.assertIn("'win-riscv'", str(ctx.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #14475

## Root cause

The user reports Windows 11 ARM64 + Python 3.12 (32-bit ARM interpreter)
crashes meson with:

    Unknown Windows Python platform 'win-arm32'
    Unknown Windows Python platform 'win-arm32'
    ...
    AttributeError: 'NoneType' object has no attribute 'endswith'

`sysconfig.get_platform()` returns `'win-arm32'` for 32-bit ARM Python
on Windows. `BasicPythonExternalProgram` populates `self.platform` from
that, then `_PythonDependencyBase.get_windows_python_arch()` only
recognises `win32`, `win64`, `win-amd64`, `win-arm64`, and the
`mingw_*` flavors. The fallback branch raises:

    raise DependencyException(
        'Unknown Windows Python platform {self.platform!r}'
    )

Note that the message is **not** an f-string -- so even users hitting
this branch see a literal `{self.platform!r}` instead of the platform
value. The `DependencyException` raised here is caught by
`find_libpy_windows()` (so they see that warning twice), but the
call site at `dependencies/python.py` later does:

    self.get_windows_python_arch().endswith('64')

**unconditionally** (not inside the try/except), so on `win-arm32` the
exception re-propagates up the interpreter stack and surfaces as the
`AttributeError` crash rather than as a clean "is_found = False".

## Fix

- Add `'win-arm32'` to the recognised Windows Python platforms. Per
  the existing meson convention (envconfig.py, qt.py, dev.py,
  vs2010backend.py), 32-bit ARM maps to cpu_family `'arm'`.
- Make the fallback error message an f-string, so future unknown
  platforms surface their value rather than `{self.platform!r}`.
- No behaviour change for any previously known platform.

After this fix, the host-vs-Python arch mismatch is reported cleanly:
on an ARM64 host running 32-bit Python, `find_libpy_windows()` will log
"Need python for aarch64, but found arm" and set `is_found = False`.
That is the honest outcome (the user's compiler builds ARM64 binaries
while the libpython is ARM32), but at least meson no longer crashes
while making that determination.

## Tests

- New `unittests/test_python_windows_arch.py` with 9 tests covering:
  `win32` -> `x86`
  `win64` -> `x86_64`
  `win-amd64` -> `x86_64`
  `win-arm64` -> `aarch64`
  `win-arm32` -> `arm`  (regression for #14475)
  `mingw_*` flavors
  The unknown-fallback is now an f-string and includes the literal
  platform value.

- All 9 tests pass.
- `mypy --config-file=.mypy.ini mesonbuild/dependencies/python.py`:
  `Success: no issues found in 1 source file`.
- `flake8 --config=.flake8
   mesonbuild/dependencies/python.py
   unittests/test_python_windows_arch.py`: clean.
- `import mesonbuild.dependencies.python` succeeds.

Notes
-----
- Could not reproduce against a real `win-arm32` interpreter locally
  because such an interpreter is not available outside the Windows
  ARM32 ecosystem; the regression test substitutes a stub platform to
  exercise the dispatch table deterministically. The user's reported
  log message strings (`'Unknown Windows Python platform "win-arm32"'`
  twice, followed by `AttributeError`) match the code paths this PR
  repairs.
- Behaviour on the other Windows Python platforms is unchanged --
  verified by the same dispatch tests.