### PR TITLE
pkgconfig: don't expose build machine targets

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -597,6 +597,12 @@ class PkgConfigModule(NewExtensionModule):
                     if isinstance(l, str):
                         yield l
                     else:
+                        is_build_machine = l.for_machine is mesonlib.MachineChoice.BUILD
+                        is_proc_macro = l.rust_crate_type == 'proc-macro'
+
+                        if isinstance(l, build.BuildTarget) and (is_build_machine or is_proc_macro):
+                            continue
+
                         install_dir: T.Union[str, bool]
                         if uninstalled:
                             install_dir = os.path.dirname(state.backend.get_target_filename_abs(l))

--- a/test cases/rust/45 pkgconfig proc-macro/check_pc.py
+++ b/test cases/rust/45 pkgconfig proc-macro/check_pc.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+import sys
+
+with open(sys.argv[1], encoding='utf-8') as f:
+    libs_line = next(line for line in f if line.startswith('Libs:')).strip()
+
+assert '-lstaticlib' in libs_line, f'staticlib missing from Libs: {libs_line!r}'
+assert 'proc_macro_examples' not in libs_line, \
+    f'proc-macro wrongly listed in Libs: {libs_line!r}'
+print(f'OK: {libs_line}')

--- a/test cases/rust/45 pkgconfig proc-macro/lib.rs
+++ b/test cases/rust/45 pkgconfig proc-macro/lib.rs
@@ -1,0 +1,8 @@
+extern crate proc_macro_examples;
+use proc_macro_examples::make_answer;
+
+make_answer!();
+
+pub fn func() -> u32 {
+    answer()
+}

--- a/test cases/rust/45 pkgconfig proc-macro/meson.build
+++ b/test cases/rust/45 pkgconfig proc-macro/meson.build
@@ -1,0 +1,28 @@
+project('rust pkgconfig proc-macro', 'rust')
+
+rust = import('rust')
+pkgconfig = import('pkgconfig')
+
+pm = rust.proc_macro('proc_macro_examples', 'pm.rs')
+
+staticlib = static_library(
+    'staticlib',
+    'lib.rs',
+    link_with: pm,
+    rust_dependency_map: {'proc_macro_examples': 'proc_macro_examples'},
+)
+
+pkgconfig.generate(
+    staticlib,
+    name: 'staticlib',
+    filebase: 'staticlib',
+    description: 'static library using a proc-macro',
+)
+
+test(
+    'pkgconfig-proc-macro-check',
+    find_program('check_pc.py'),
+    args: [
+        join_paths(meson.current_build_dir(), 'meson-private', 'staticlib.pc'),
+    ],
+)

--- a/test cases/rust/45 pkgconfig proc-macro/pm.rs
+++ b/test cases/rust/45 pkgconfig proc-macro/pm.rs
@@ -1,0 +1,7 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+#[proc_macro]
+pub fn make_answer(_item: TokenStream) -> TokenStream {
+    "fn answer() -> u32 { 42 }".parse().unwrap()
+}

--- a/test cases/rust/45 pkgconfig proc-macro/test.json
+++ b/test cases/rust/45 pkgconfig proc-macro/test.json
@@ -1,0 +1,5 @@
+{
+  "installed": [
+    { "type": "file", "file": "usr/lib/pkgconfig/staticlib.pc"}
+  ]
+}


### PR DESCRIPTION
The following meson.build file was causing link time failures when used with the pkg-config module in another project. It turns out that the logos derive proc macro crate was being exposed in the .pc file when it shouldn't.

```meson
project(
    'dx9-rs',
    ['rust'],
    meson_version: '>=1.12',
    version: '0.1.0',
    license: 'MIT',
)

rust = import('rust')
pkgconfig = import('pkgconfig')

cargo_ws = rust.workspace()
pkg = cargo_ws.package('dx9-rs')

dx9_compiler = pkg.library('dx9_compiler', rust_abi: 'c', install: true)

dx9_compiler_dep = declare_dependency(link_with: dx9_compiler)
meson.override_dependency('dx9-rs', dx9_compiler_dep)

pkgconfig.generate(
    dx9_compiler,
    name: 'dx9_compiler',
    description: 'A dx9 shader compiler written in Rust',
    version: meson.project_version(),
)
```
