### PR TITLE
docs: add MSYS2/MinGW-w64 packaging guide

### DIFF
--- a/docs/markdown/FAQ.md
+++ b/docs/markdown/FAQ.md
@@ -734,3 +734,9 @@ It's not necessary to treat preprocessor defines specially in Meson ([GH-6269](h
 
 This simplifies debugging build problems, since you always know that files in
 build directory X must come from the corresponding source directory X.
+
+## How do I create MSYS2 / MinGW-w64 pacman packages with Meson?
+
+You can create package configurations for MSYS2's MinGW-w64
+environments using `PKGBUILD` scripts. Please see the detailed
+snippet and explanation in [Create MSYS2 / MinGW-w64 pacman packages](howtox.md#create-msys2--mingw-w64-pacman-packages).

--- a/docs/markdown/howtox.md
+++ b/docs/markdown/howtox.md
@@ -369,3 +369,52 @@ main_exe = executable('main', main_sources, link_with : unityproof_lib)
 
 To link the static library into another library target, you may need to use
 `link_whole` instead of `link_with`.
+
+## Create MSYS2 / MinGW-w64 pacman packages
+
+To create a pacman package of a Meson project for MSYS2's MinGW-w64
+environments (such as UCRT64, CLANG64, or MINGW64), you should use a
+standard `PKGBUILD` configuration.
+
+Here are the important Meson flags to include in your `PKGBUILD`:
+
+- `MSYS2_ARG_CONV_EXCL="--prefix="`: MSYS2 converts Unix paths in
+  arguments to Windows paths automatically. Since Meson requires
+  the literal Unix prefix for the target installation root, you
+  must exclude the `--prefix` argument from this conversion.
+- `--prefix="${MINGW_PREFIX}"`: Installs the files in the correct
+  environment prefix directory (e.g., `/ucrt64`).
+- `--libdir="${MINGW_PREFIX}/lib"`: Ensures libraries are placed
+  inside the environment's `lib` directory.
+- `--buildtype=plain`: Instructs Meson not to add optimization
+  flags (such as `-O2`), allowing the environment's package flags
+  (`CFLAGS`, `CXXFLAGS`, etc.) to be fully respected.
+- `--wrap-mode=nodownload`: Prevents downloading subprojects during
+  the build, enforcing offline packaging.
+
+Example `PKGBUILD` snippet:
+
+```bash
+pkgname=("${MINGW_PACKAGE_PREFIX}-somepackage")
+...
+makedepends=("${MINGW_PACKAGE_PREFIX}-meson" "${MINGW_PACKAGE_PREFIX}-ninja")
+
+build() {
+  mkdir -p "build-${MSYSTEM}"
+  
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+  meson setup \
+    --prefix="${MINGW_PREFIX}" \
+    --libdir="${MINGW_PREFIX}/lib" \
+    --buildtype=plain \
+    --wrap-mode=nodownload \
+    "build-${MSYSTEM}" \
+    "${_realname}-${pkgver}"
+    
+  meson compile -C "build-${MSYSTEM}"
+}
+
+package() {
+  meson install -C "build-${MSYSTEM}" --destdir "${pkgdir}"
+}
+```


### PR DESCRIPTION
## Summary

This PR adds documentation explaining how to package Meson projects
for MSYS2/MinGW-w64 using pacman and PKGBUILD.

It introduces:

- A new How-To section describing the required Meson configuration.
- Documentation for the recommended configuration flags:
  - `MSYS2_ARG_CONV_EXCL`
  - `--prefix`
  - `--libdir`
  - `--buildtype=plain`
  - `--wrap-mode=nodownload`
- A PKGBUILD build/package template.
- A new FAQ entry linking to the detailed guide.

## Verification

- Ran:

  ```text
  python docs/validatelinks.py docs/sitemap.txt
  ```

- Ran:

  ```text
  python run_unittests.py VersionTests
  ```

Both commands completed successfully.

Closes #2729