### PR TITLE
cargo: use new endpoint for downloads

### DIFF
--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -872,7 +872,7 @@ def load_cargo_lock(filename: str, subproject_dir: str) -> T.Optional[CargoLock]
                 checksum = package.checksum
                 if checksum is None:
                     checksum = cargolock.metadata[f'checksum {package.name} {package.version} ({package.source})']
-                url = f'https://crates.io/api/v1/crates/{package.name}/{package.version}/download'
+                url = f'https://static.crates.io/crates/{package.name}/{package.version}/download'
                 directory = f'{package.name}-{package.version}'
                 name = SubProject(meson_depname)
                 wrap_type = 'file'

--- a/unittests/cargotests.py
+++ b/unittests/cargotests.py
@@ -283,7 +283,7 @@ class CargoLockTest(unittest.TestCase):
             self.assertEqual(wraps['foo-0.1-rs'].directory, 'foo-0.1')
             self.assertEqual(wraps['foo-0.1-rs'].type, 'file')
             self.assertEqual(wraps['foo-0.1-rs'].get('method'), 'cargo')
-            self.assertEqual(wraps['foo-0.1-rs'].get('source_url'), 'https://crates.io/api/v1/crates/foo/0.1/download')
+            self.assertEqual(wraps['foo-0.1-rs'].get('source_url'), 'https://static.crates.io/crates/foo/0.1/download')
             self.assertEqual(wraps['foo-0.1-rs'].get('source_hash'), '8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb')
             self.assertEqual(wraps['gtk-rs-core-0.19'].name, 'gtk-rs-core-0.19')
             self.assertEqual(wraps['gtk-rs-core-0.19'].directory, 'gtk-rs-core-0.19')


### PR DESCRIPTION
Use the CDN rather than the API endpoint: https://blog.rust-lang.org/2024/03/11/crates-io-download-changes/

We already set a User-Agent fortunately.