### PR TITLE
Update example cross files for emscripten/wasm

### DIFF
--- a/cross/wasm32-emscripten.txt
+++ b/cross/wasm32-emscripten.txt
@@ -1,0 +1,12 @@
+[binaries]
+c = 'emcc'
+cpp = 'em++'
+ar = 'emar'
+ranlib = 'emranlib'
+exe_wrapper = 'node'
+
+[host_machine]
+system = 'emscripten'
+cpu_family = 'wasm32'
+cpu = 'wasm32'
+endian = 'little'

--- a/cross/wasm64-emscripten.txt
+++ b/cross/wasm64-emscripten.txt
@@ -2,17 +2,17 @@
 c = 'emcc'
 cpp = 'em++'
 ar = 'emar'
+ranlib = 'emranlib'
 exe_wrapper = 'node'
 
 [built-in options]
-c_args = []
-c_link_args = ['-sEXPORT_ALL=1']
-cpp_args = []
-cpp_link_args = ['-sEXPORT_ALL=1']
+c_args = ['-m64']
+c_link_args = ['-m64']
+cpp_args = ['-m64']
+cpp_link_args = ['-m64']
 
 [host_machine]
-
 system = 'emscripten'
-cpu_family = 'wasm32'
-cpu = 'wasm32'
+cpu_family = 'wasm64'
+cpu = 'wasm64'
 endian = 'little'


### PR DESCRIPTION
- Use more specific name (since not all wasm is emscripten-built)
- Add a 64-bit version
- Remove -sEXPORT_ALL (this is not flag that most user should need/want)

See https://github.com/emscripten-core/emscripten/pull/27478