### PR TITLE
Add icx (oneAPI DPC++) linking support on Windows

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1802,7 +1802,7 @@ class BuildTarget(Target):
         else:
             compiler, _ = self.get_clink_dynamic_linker_and_stdlibs()
         # Mixing many languages with MSVC is not supported yet so ignore stdlibs.
-        return bool(compiler) and compiler.get_linker_id() in {'link', 'lld-link', 'xilink', 'optlink'}
+        return bool(compiler) and compiler.get_linker_id() in {'link', 'lld-link', 'xilink', 'optlink', 'icx'}
 
     def check_module_linking(self) -> None:
         '''

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -22,7 +22,7 @@ from .mixins.arm import ArmCompiler, ArmclangCompiler
 from .mixins.visualstudio import MSVCCompiler, ClangClCompiler
 from .mixins.gnu import GnuCompiler, GnuCStds
 from .mixins.gnu import gnu_common_warning_args, gnu_c_warning_args
-from .mixins.intel import IntelGnuLikeCompiler, IntelLLVMLikeCompiler, IntelVisualStudioLikeCompiler
+from .mixins.intel import IntelGnuLikeCompiler, IntelLLVMLikeCompiler, IntelVisualStudioLikeCompiler, IntelLLVMVisualStudioLikeCompiler
 from .mixins.clang import ClangCompiler, ClangCStds
 from .mixins.elbrus import ElbrusCompiler
 from .mixins.pgi import PGICompiler
@@ -504,7 +504,7 @@ class IntelClCCompiler(IntelVisualStudioLikeCompiler, VisualStudioLikeCCompilerM
         return args
 
 
-class IntelLLVMClCCompiler(IntelClCCompiler):
+class IntelLLVMClCCompiler(IntelLLVMVisualStudioLikeCompiler, IntelClCCompiler):
 
     id = 'intel-llvm-cl'
 

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -25,7 +25,7 @@ from .mixins.ti import TICompiler
 from .mixins.arm import ArmCompiler, ArmclangCompiler
 from .mixins.visualstudio import MSVCCompiler, ClangClCompiler
 from .mixins.gnu import GnuCompiler, GnuCPPStds, gnu_common_warning_args, gnu_cpp_warning_args
-from .mixins.intel import IntelGnuLikeCompiler, IntelLLVMLikeCompiler, IntelVisualStudioLikeCompiler
+from .mixins.intel import IntelGnuLikeCompiler, IntelLLVMLikeCompiler, IntelVisualStudioLikeCompiler, IntelLLVMVisualStudioLikeCompiler
 from .mixins.clang import ClangCompiler, ClangCPPStds
 from .mixins.elbrus import ElbrusCompiler
 from .mixins.pgi import PGICompiler
@@ -1005,7 +1005,7 @@ class IntelClCPPCompiler(VisualStudioLikeCPPCompilerMixin, IntelVisualStudioLike
         return IntelVisualStudioLikeCompiler.get_compiler_check_args(self, mode)
 
 
-class IntelLLVMClCPPCompiler(IntelClCPPCompiler):
+class IntelLLVMClCPPCompiler(IntelLLVMVisualStudioLikeCompiler, IntelClCPPCompiler):
 
     id = 'intel-llvm-cl'
 

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -505,6 +505,9 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
             target = 'x86' if 'IA-32' in err else 'x86_64'
             cls = c.IntelLLVMClCCompiler if lang == 'c' else cpp.IntelLLVMClCPPCompiler
             env.add_lang_args(cls.language, cls, for_machine)
+            # icx must drive linking itself: unlike link.exe it performs SYCL offload
+            # codegen (-fsycl). Forward MSVC linker flags via -Xlinker so -fsycl and
+            # objects stay on the icx driver side. CudaCompiler forwards to nvcc similarly.
             from .compilers import PrefixArgumentLinkerOptionStyle
             linker = linkers.IntelLLVMClDynamicLinker(
                 env, for_machine, [], exelist=compiler,

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -505,9 +505,11 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
             target = 'x86' if 'IA-32' in err else 'x86_64'
             cls = c.IntelLLVMClCCompiler if lang == 'c' else cpp.IntelLLVMClCPPCompiler
             env.add_lang_args(cls.language, cls, for_machine)
-            linker = linker = guess_win_linker(
-                    env, ['link'], cls, version,
-                    for_machine)
+            from .compilers import PrefixArgumentLinkerOptionStyle
+            linker = linkers.IntelLLVMClDynamicLinker(
+                env, for_machine, [], exelist=compiler,
+                prefix=PrefixArgumentLinkerOptionStyle('-Xlinker'),
+                version=version, direct=False, machine=None)
             return cls(
                 compiler, version, for_machine, env, target,
                 linker=linker)

--- a/mesonbuild/compilers/mixins/intel.py
+++ b/mesonbuild/compilers/mixins/intel.py
@@ -173,5 +173,8 @@ class IntelLLVMVisualStudioLikeCompiler:
         native = super().unix_args_to_native(args)  # type: ignore[misc]
         result: T.List[str] = []
         for arg in native:
-            result.append(arg)
+            if arg.startswith('/LIBPATH:'):
+                result += ['-Xlinker', arg]
+            else:
+                result.append(arg)
         return result

--- a/mesonbuild/compilers/mixins/intel.py
+++ b/mesonbuild/compilers/mixins/intel.py
@@ -166,7 +166,13 @@ class IntelVisualStudioLikeCompiler(VisualStudioLikeCompiler):
 
 class IntelLLVMVisualStudioLikeCompiler:
 
-    """Mixin for icx (Intel oneAPI DPC++) on Windows."""
+    """Mixin for icx (Intel oneAPI DPC++) on Windows.
+
+    unix_args_to_native emits some MSVC linker flags directly, bypassing the
+    linker's -Xlinker prefix. icx's clang-cl frontend silently drops the ones
+    it does not recognise, so wrap linker-only flags (currently /LIBPATH: from
+    -L) in -Xlinker; .lib names and include dirs are left as-is.
+    """
 
     @classmethod
     def unix_args_to_native(cls, args: T.List[str]) -> T.List[str]:

--- a/mesonbuild/compilers/mixins/intel.py
+++ b/mesonbuild/compilers/mixins/intel.py
@@ -162,3 +162,16 @@ class IntelVisualStudioLikeCompiler(VisualStudioLikeCompiler):
 
     def get_pch_base_name(self, header: str) -> str:
         return os.path.basename(header)
+
+
+class IntelLLVMVisualStudioLikeCompiler:
+
+    """Mixin for icx (Intel oneAPI DPC++) on Windows."""
+
+    @classmethod
+    def unix_args_to_native(cls, args: T.List[str]) -> T.List[str]:
+        native = super().unix_args_to_native(args)  # type: ignore[misc]
+        result: T.List[str] = []
+        for arg in native:
+            result.append(arg)
+        return result

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -1577,6 +1577,13 @@ class ClangClDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
         return ['-WX']
 
 
+class IntelLLVMClDynamicLinker(ClangClDynamicLinker):
+
+    """Intel oneAPI DPC++ (icx) driving the link step on Windows."""
+
+    id = 'icx'
+
+
 class XilinkDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
 
     """Intel's Xilink.exe."""

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -1583,6 +1583,11 @@ class IntelLLVMClDynamicLinker(ClangClDynamicLinker):
 
     id = 'icx'
 
+    # Use the driver-style output flag: a bare /OUT: (even via -Xlinker) works,
+    # but -o is the natural spelling for the icx driver and needs no forwarding.
+    def get_output_args(self, outputname: str) -> T.List[str]:
+        return ['-o', outputname]
+
 
 class XilinkDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
 

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -81,6 +81,9 @@ class WindowsModule(ExtensionModule):
                 return None
 
             comp = self.detect_compiler(state.environment.coredata.compilers[for_machine])
+            # Pick the resource compiler by toolchain flavour rather than an enumerated
+            # linker-id set: MSVC-style compilers (cl, clang-cl, icl, icx) expect
+            # rc/llvm-rc (.res); GNU-style toolchains use windres.
             if comp.get_argument_syntax() == 'msvc':
                 rescomp = search_programs(['rc', 'llvm-rc'])
             else:

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -81,7 +81,7 @@ class WindowsModule(ExtensionModule):
                 return None
 
             comp = self.detect_compiler(state.environment.coredata.compilers[for_machine])
-            if comp.linker and comp.linker.id in {'link', 'lld-link'}:
+            if comp.get_argument_syntax() == 'msvc':
                 rescomp = search_programs(['rc', 'llvm-rc'])
             else:
                 rescomp = search_programs(['windres', 'llvm-windres'])
@@ -191,7 +191,7 @@ class WindowsModule(ExtensionModule):
                                 '--rc', *rescomp.get_command(),
                                 '--cl', *compiler.get_exelist(False)])
 
-                if compiler.id in {'msvc', 'clang-cl', 'intel-cl'}:
+                if compiler.get_argument_syntax() == 'msvc':
                     depfile_type = 'msvc'
                     command.extend(['--Xarg=/showIncludes',
                                     '--Xarg=/EP',

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -151,7 +151,7 @@ class InstalledFile:
     def get_path(self, compiler: compilers.Compiler, env: environment.Environment) -> T.Optional[Path]:
         p = Path(self.path)
         canonical_compiler = compiler.get_id()
-        if ((canonical_compiler in ['clang-cl', 'intel-cl']) or
+        if ((canonical_compiler in ['clang-cl', 'intel-cl', 'intel-llvm-cl']) or
                 (env.machines.host.is_windows() and canonical_compiler in {'pgi', 'dmd', 'ldc'})):
             canonical_compiler = 'msvc'
 

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -47,8 +47,8 @@ from mesonbuild.compilers.mixins.clang import ClangCompiler
 from mesonbuild.compilers.mixins.elbrus import ElbrusCompiler
 from mesonbuild.compilers.mixins.gnu import GnuCompiler
 from mesonbuild.compilers.mixins.intel import IntelGnuLikeCompiler
-from mesonbuild.compilers.c import VisualStudioCCompiler, ClangClCCompiler
-from mesonbuild.compilers.cpp import VisualStudioCPPCompiler, ClangClCPPCompiler
+from mesonbuild.compilers.c import VisualStudioCCompiler, ClangClCCompiler, IntelLLVMClCCompiler
+from mesonbuild.compilers.cpp import VisualStudioCPPCompiler, ClangClCPPCompiler, IntelLLVMClCPPCompiler
 from mesonbuild.compilers import (
     detect_static_linker, detect_c_compiler, compiler_from_language,
     detect_compiler_for
@@ -1175,6 +1175,7 @@ class AllPlatformTests(BasePlatformTests):
         intel = IntelGnuLikeCompiler
         msvc = (VisualStudioCCompiler, VisualStudioCPPCompiler)
         clangcl = (ClangClCCompiler, ClangClCPPCompiler)
+        intelllvmcl = (IntelLLVMClCCompiler, IntelLLVMClCPPCompiler)
         ar = linkers.ArLinker
         lib = linkers.VisualStudioLinker
         langs = [('c', 'CC'), ('cpp', 'CXX')]
@@ -1217,6 +1218,14 @@ class AllPlatformTests(BasePlatformTests):
                     elif 'clang' in ebase:
                         self.assertIsInstance(ecc, clang)
                         self.assertIsInstance(elinker, ar)
+                    elif ebase.startswith(('icx', 'icpx')):
+                        # oneAPI DPC++ (icx/icpx): clang-cl-like on Windows,
+                        # clang-like on other platforms.
+                        if is_windows():
+                            self.assertIsInstance(ecc, intelllvmcl)
+                            self.assertIsInstance(elinker, lib)
+                        else:
+                            self.assertIsInstance(elinker, ar)
                     elif ebase.startswith('ic'):
                         self.assertIsInstance(ecc, intel)
                         self.assertIsInstance(elinker, ar)
@@ -1267,7 +1276,12 @@ class AllPlatformTests(BasePlatformTests):
                         self.assertIsInstance(cc.linker, (linkers.SolarisDynamicLinker, linkers.GnuLikeDynamicLinkerMixin))
                     else:
                         self.assertIsInstance(cc.linker, linkers.GnuLikeDynamicLinkerMixin)
-                if isinstance(cc, intel):
+                if isinstance(cc, intelllvmcl):
+                    # oneAPI DPC++ on Windows: msvc-style compiler that drives
+                    # the link step itself (for SYCL offload generation).
+                    self.assertIsInstance(linker, lib)
+                    self.assertIsInstance(cc.linker, linkers.IntelLLVMClDynamicLinker)
+                elif isinstance(cc, intel):
                     self.assertIsInstance(linker, ar)
                     if is_osx():
                         self.assertIsInstance(cc.linker, linkers.AppleDynamicLinker)
@@ -1922,7 +1936,14 @@ class AllPlatformTests(BasePlatformTests):
     def build_shared_lib(self, compiler, source, objectfile, outfile, impfile, extra_args=None):
         if extra_args is None:
             extra_args = []
-        if compiler.get_argument_syntax() == 'msvc':
+        if compiler.get_linker_id() == 'icx':
+            # icx drives the link itself and its clang-cl frontend drops bare
+            # MSVC linker flags; forward them to the underlying linker with
+            # -Xlinker and use the driver-style -o for output.
+            link_cmd = compiler.get_linker_exelist() + [
+                '-Xlinker', '/NOLOGO', '-Xlinker', '/DLL', '-Xlinker', '/DEBUG',
+                '-Xlinker', '/IMPLIB:' + impfile, '-o', outfile, objectfile]
+        elif compiler.get_argument_syntax() == 'msvc':
             link_cmd = compiler.get_linker_exelist() + [
                 '/NOLOGO', '/DLL', '/DEBUG', '/IMPLIB:' + impfile,
                 '/OUT:' + outfile, objectfile]
@@ -2772,7 +2793,7 @@ class AllPlatformTests(BasePlatformTests):
         extra_args = None
         libdir_flags = ['-L']
         env = get_fake_env(testdirlib, self.builddir, self.prefix)
-        if detect_c_compiler(env, MachineChoice.HOST).get_id() in {'msvc', 'clang-cl', 'intel-cl'}:
+        if detect_c_compiler(env, MachineChoice.HOST).get_id() in {'msvc', 'clang-cl', 'intel-cl', 'intel-llvm-cl'}:
             # msvc-like compiler, also test it with msvc-specific flags
             libdir_flags += ['/LIBPATH:', '-LIBPATH:']
         else:


### PR DESCRIPTION
This PR closes #12470

On Windows with icx (Intel oneAPI DPC++) Meson uses `link.exe` for linking but `link.exe` cannot do the SYCL offload step that `-fsycl` needs.It just ignores the flag (`LNK4044` so the program links but the SYCL kernel is missing at runtime.

This PR lets `icx` drive the link step itself like `clang` and `nvcc` do so `-fsycl` works. Since `icx` uses a clang-cl-like frontend that silently drops unknown MSVC linker flags, those flags are forwarded to the real linker with `-Xlinker` (close to how `CudaCompiler` forwards flags to `nvcc`) while objects and `-fsycl` stay on the `icx` side. `icx` is also treated as MSVC-style for import-lib / `.pdb` naming, for `/LIBPATH:` handling, and for choosing the resource compiler (`rc` instead of `windres`).

I tested it with `icx 2026.1.1` on Windows:
 A SYCL executable and a SYCL shared library build and run correctly;
 `run_project_tests.py` shows no new failures compared to master.

This is my first PR to Meson. Please let me know if anything should be done differently and I will gladly fix it