### PR TITLE
Support Wild linker

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -65,6 +65,7 @@ These are return values of the `get_linker_id` method in a compiler object.
 | ld.mold    | The fast MOLD linker                        |
 | ld.solaris | Solaris and illumos                         |
 | ld.wasm    | emscripten's wasm-ld linker                 |
+| ld.wild    | The fast Wild Linker                        |
 | ld.zigcc   | The Zig linker (C/C++ frontend; GNU-like)   |
 | ld64       | Apple ld64                                  |
 | ld64.lld   | The LLVM linker, with the ld64 interface    |

--- a/docs/markdown/snippets/wild-linker.md
+++ b/docs/markdown/snippets/wild-linker.md
@@ -1,0 +1,5 @@
+## Wild linker is now supported on Linux
+
+When `CC_LD` environment variables is set to `wild`, Meson will configure GCC 16+ or Clang
+to use Wild as the linker on Linux. You should expect to see line like this in the output:
+`C linker for the host machine: cc ld.wild 0.10.0` confirming that Wild was picked up.

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -12,7 +12,7 @@ import typing as T
 from ... import mesonlib
 from ... import options
 from ...linkers.linkers import AppleDynamicLinker, ClangClDynamicLinker, LLVMDynamicLinker, \
-    GnuBFDDynamicLinker, GnuGoldDynamicLinker, MoldDynamicLinker, VisualStudioLikeLinkerMixin
+    GnuBFDDynamicLinker, GnuGoldDynamicLinker, MoldDynamicLinker, VisualStudioLikeLinkerMixin, WildDynamicLinker
 from ...options import OptionKey
 from ..compilers import CompileCheckMode
 from .gnu import GnuLikeCompiler
@@ -188,6 +188,8 @@ class ClangCompiler(GnuLikeCompiler):
             return ['-fuse-ld=qcld']
         if linker == 'mold':
             return ['-fuse-ld=mold']
+        if linker == 'wild':
+            return ['--ld-path=wild']
 
         if shutil.which(linker):
             if not shutil.which(linker):
@@ -216,13 +218,16 @@ class ClangCompiler(GnuLikeCompiler):
                              mode: str = 'default') -> T.List[str]:
         args: T.List[str] = []
         if mode == 'thin':
-            # ThinLTO requires the use of gold, lld, ld64, lld-link or mold 1.1+
+            # ThinLTO requires the use of gold, lld, ld64, lld-link, mold 1.1+ or Wild 0.9+
             if isinstance(self.linker, (MoldDynamicLinker)):
                 # https://github.com/rui314/mold/commit/46995bcfc3e3113133620bf16445c5f13cd76a18
                 if not mesonlib.version_compare(self.linker.version, '>=1.1'):
                     raise mesonlib.MesonException("LLVM's ThinLTO requires mold 1.1+")
+            elif isinstance(self.linker, (WildDynamicLinker)):
+                if not mesonlib.version_compare(self.linker.version, '>=0.9'):
+                    raise mesonlib.MesonException("LLVM's ThinLTO requires Wild 0.9+")
             elif not isinstance(self.linker, (AppleDynamicLinker, ClangClDynamicLinker, LLVMDynamicLinker, GnuBFDDynamicLinker, GnuGoldDynamicLinker)):
-                raise mesonlib.MesonException(f"LLVM's ThinLTO only works with bfd, gold, lld, lld-link, ld64, or mold, not {self.linker.id}")
+                raise mesonlib.MesonException(f"LLVM's ThinLTO only works with bfd, gold, lld, lld-link, ld64, mold or wild, not {self.linker.id}")
             args.append(f'-flto={mode}')
         else:
             assert mode == 'default', 'someone forgot to wire something up'

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -544,6 +544,7 @@ class GnuCompiler(GnuLikeCompiler):
     _LTO_AUTO_VERSION = '>=10.0'
     _LTO_CACHE_VERSION = '>=15.1'
     _USE_MOLD_VERSION = '>=12.0.1'
+    _USE_WILD_VERSION = '>=16.0.1'
 
     def __init__(self, defines: T.Optional[T.Dict[str, str]]):
         super().__init__()
@@ -646,6 +647,8 @@ class GnuCompiler(GnuLikeCompiler):
     def use_linker_args(cls, linker: str, version: str) -> T.List[str]:
         if linker == 'mold' and mesonlib.version_compare(version, cls._USE_MOLD_VERSION):
             return ['-fuse-ld=mold']
+        elif linker == 'wild' and mesonlib.version_compare(version, cls._USE_WILD_VERSION):
+            return ['-fuse-ld=wild']
         return super().use_linker_args(linker, version)
 
     def get_lto_link_args(self, *, target: T.Optional[BuildTarget] = None, threads: int = 0,

--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -190,6 +190,8 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
             gnu_cls = linkers.GnuGoldDynamicLinker
         elif o.startswith('mold') or e.startswith('mold'):
             gnu_cls = linkers.MoldDynamicLinker
+        elif o.startswith('Wild') or e.startswith('Wild'):
+            gnu_cls = linkers.WildDynamicLinker
         else:
             gnu_cls = linkers.GnuBFDDynamicLinker
         linker = gnu_cls(compiler, env, for_machine, comp_class.LINKER_OPTION_STYLE, override, version=v)

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -1013,6 +1013,12 @@ class MoldDynamicLinker(GnuDynamicLinker):
     def get_thinlto_cache_args(self, path: str) -> T.List[str]:
         return self._apply_prefix(['--thinlto-cache-dir=' + path])
 
+class WildDynamicLinker(GnuDynamicLinker):
+
+    id = 'ld.wild'
+
+    def get_thinlto_cache_args(self, path: str) -> T.List[str]:
+        return self._apply_prefix(['-plugin-opt', 'cache-dir=' + path])
 
 class LLVMDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, DynamicLinker):
 

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -5668,7 +5668,7 @@ class AllPlatformTests(BasePlatformTests):
         cc = detect_c_compiler(env, MachineChoice.HOST)
         has_rsp = cc.linker.id in {
             'ld.bfd', 'ld.eld', 'ld.gold', 'ld.lld', 'ld.mold', 'ld.qcld', 'ld.wasm',
-            'link', 'lld-link', 'mwldarm', 'mwldeppc', 'optlink', 'xilink',
+            'link', 'lld-link', 'mwldarm', 'mwldeppc', 'optlink', 'wild', 'xilink',
         }
         self.assertEqual(cc.linker.get_accepts_rsp(), has_rsp)
 

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -1676,6 +1676,9 @@ class LinuxlikeTests(BasePlatformTests):
     def test_ld_environment_variable_lld(self):
         self._check_ld('ld.lld', 'lld', 'c', 'ld.lld')
 
+    def test_ld_environment_variable_wild(self):
+        self._check_ld('ld.wild', 'wild', 'c', 'ld.wild')
+
     @skip_if_not_language('rust')
     @skipIfNoExecutable('ld.gold')  # need an additional check here because _check_ld checks for gcc
     def test_ld_environment_variable_rust(self):


### PR DESCRIPTION
Mostly based on existing Mold infrastructure.

One thing I wasn't sure was linker id. Wild is mostly shipped as `wild` by the Cargo, although we recommend adding `ld.wild` symlink.

Testsuite fails with unrelated errors for me, so tested building mpv with GCC and Clang (obviously with Wild).