### PR TITLE
cargo: add target triple to cfg when interpreting a manifest

### DIFF
--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -712,6 +712,7 @@ class Interpreter:
             machine = MachineChoice.HOST
         rustc = T.cast('RustCompiler', self.environment.coredata.compilers[machine]['rust'])
         cfgs = rustc.get_cfgs().copy()
+        cfgs.append(rustc.get_target_triple())
         rustflags = self.environment.coredata.get_external_args(machine, 'rust')
         rustflags_i = iter(rustflags)
         for i in rustflags_i:


### PR DESCRIPTION
It turns out a few crates uses the syntax
```
[target.aarch64-linux-android.dependencies.xxx]
...
```

to define dependencies (cpufeatures, heapless), and meson does not support it. Adding the triple works fine.