### PR TITLE
baseplatformtests: Don't specify "/" in os.path.join

### DIFF
--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -83,18 +83,18 @@ class BasePlatformTests(TestCase):
         cls.build_command, cls.clean_command, cls.test_command, cls.install_command, \
             cls.uninstall_command = get_backend_commands(cls.backend)
         # Test directories
-        cls.common_test_dir = os.path.join(src_root, 'test cases/common')
-        cls.python_test_dir = os.path.join(src_root, 'test cases/python')
-        cls.rust_test_dir = os.path.join(src_root, 'test cases/rust')
-        cls.vala_test_dir = os.path.join(src_root, 'test cases/vala')
-        cls.framework_test_dir = os.path.join(src_root, 'test cases/frameworks')
-        cls.unit_test_dir = os.path.join(src_root, 'test cases/unit')
-        cls.rewrite_test_dir = os.path.join(src_root, 'test cases/rewrite')
-        cls.linuxlike_test_dir = os.path.join(src_root, 'test cases/linuxlike')
-        cls.objc_test_dir = os.path.join(src_root, 'test cases/objc')
-        cls.objcpp_test_dir = os.path.join(src_root, 'test cases/objcpp')
-        cls.darwin_test_dir = os.path.join(src_root, 'test cases/darwin')
-        cls.fortran_test_dir = os.path.join(src_root, 'test cases/fortran')
+        cls.common_test_dir = os.path.join(src_root, 'test cases', 'common')
+        cls.python_test_dir = os.path.join(src_root, 'test cases', 'python')
+        cls.rust_test_dir = os.path.join(src_root, 'test cases', 'rust')
+        cls.vala_test_dir = os.path.join(src_root, 'test cases', 'vala')
+        cls.framework_test_dir = os.path.join(src_root, 'test cases', 'frameworks')
+        cls.unit_test_dir = os.path.join(src_root, 'test cases', 'unit')
+        cls.rewrite_test_dir = os.path.join(src_root, 'test cases', 'rewrite')
+        cls.linuxlike_test_dir = os.path.join(src_root, 'test cases', 'linuxlike')
+        cls.objc_test_dir = os.path.join(src_root, 'test cases', 'objc')
+        cls.objcpp_test_dir = os.path.join(src_root, 'test cases', 'objcpp')
+        cls.darwin_test_dir = os.path.join(src_root, 'test cases', 'darwin')
+        cls.fortran_test_dir = os.path.join(src_root, 'test cases', 'fortran')
 
         # Misc stuff
         if cls.backend is Backend.ninja:


### PR DESCRIPTION
This is needed because otherwise, while running `MSYSTEM= python run_unittests.py PlatformAgnosticTests.test_error_configuring_subdir` in msys2, I was getting this error:
```py
$ MSYSTEM= python run_unittests.py PlatformAgnosticTests.test_error_configuring_subdir
Meson build system 1.12.0.rc2 Unit Tests
pytest not found, using unittest instead
F
Stdout:
$ C:\msys64\mingw64\bin\python.exe C:\Users\moi15moi\Documents\GitHub\meson\meson.py setup --backend=ninja --prefix /usr --libdir lib C:\Users\moi15moi\Documents\GitHub\meson\tmp2judbrrm "C:\Users\moi15moi\Documents\GitHub\meson\test cases/common\152 index customtarget\subdir"
stdout:
The Meson build system
Version: 1.12.0.rc2
Source dir: C:\Users\moi15moi\Documents\GitHub\meson\test cases\common\152 index customtarget\subdir
Build dir: C:\Users\moi15moi\Documents\GitHub\meson\tmp2judbrrm
Build type: native build

ERROR: Not the project root: first statement must be a call to project()

Did you mean to run meson from the directory: "C:\Users\moi15moi\Documents\GitHub\meson\test cases\common\152 index customtarget"?

A full log can be found at C:\Users\moi15moi\Documents\GitHub\meson\tmp2judbrrm\meson-logs\meson-log.txt

======================================================================
FAIL: test_error_configuring_subdir (unittests.platformagnostictests.PlatformAgnosticTests.test_error_configuring_subdir)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\moi15moi\Documents\GitHub\meson\unittests\platformagnostictests.py", line 422, in test_error_configuring_subdir
    self.assertIn(f'Did you mean to run meson from the directory: "{testdir}"?', out)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 'Did you mean to run meson from the directory: "C:\\Users\\moi15moi\\Documents\\GitHub\\meson\\test cases/common\\152 index customtarget"?' not found in 'Build started at 2026-08-04T19:25:58.484065\nMain binary: C:\\msys64\\mingw64\\bin\\python.exe\nBuild Options: -Dbackend=ninja -Dprefix=/usr -Dlibdir=lib\nPython system: Window
s\nThe Meson build system\nVersion: 1.12.0.rc2\nSource dir: C:\\Users\\moi15moi\\Documents\\GitHub\\meson\\test cases\\common\\152 index customtarget\\subdir\nBuild dir: C:\\Users\\moi15moi\\Documents\\GitHub\\meson\\tmp2judbrrm\nBuild type: native build\n\nERROR: Not the project root: first statement must be a call to project()\n\nDid you mean
 to run meson from the directory: "C:\\Users\\moi15moi\\Documents\\GitHub\\meson\\test cases\\common\\152 index customtarget"?\n'

Stdout:
$ C:\msys64\mingw64\bin\python.exe C:\Users\moi15moi\Documents\GitHub\meson\meson.py setup --backend=ninja --prefix /usr --libdir lib C:\Users\moi15moi\Documents\GitHub\meson\tmp2judbrrm "C:\Users\moi15moi\Documents\GitHub\meson\test cases/common\152 index customtarget\subdir"
stdout:
The Meson build system
Version: 1.12.0.rc2
Source dir: C:\Users\moi15moi\Documents\GitHub\meson\test cases\common\152 index customtarget\subdir
Build dir: C:\Users\moi15moi\Documents\GitHub\meson\tmp2judbrrm
Build type: native build

ERROR: Not the project root: first statement must be a call to project()

Did you mean to run meson from the directory: "C:\Users\moi15moi\Documents\GitHub\meson\test cases\common\152 index customtarget"?

A full log can be found at C:\Users\moi15moi\Documents\GitHub\meson\tmp2judbrrm\meson-logs\meson-log.txt

----------------------------------------------------------------------
Ran 1 test in 0.479s

FAILED (failures=1)
Total time: 0.787 seconds
```

The msys2 CI doesn't catch this issue currently because PlatformAgnosticTests are skipped: https://github.com/mesonbuild/meson/blob/f004d10e758073a5aa15b195e7047f5c662f5581/unittests/platformagnostictests.py#L25