### PR TITLE
cmake: propagate generated-file dependencies to the compile order

### DIFF
--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -382,6 +382,18 @@ class ConverterTarget:
         elif self.type.upper() not in ['EXECUTABLE', 'OBJECT_LIBRARY']:
             mlog.warning('CMake: Target', mlog.bold(self.cmake_name), 'not found in CMake trace. This can lead to build errors')
 
+        # Handle set_source_files_properties(... OBJECT_DEPENDS ...): compiling a
+        # source may depend on (usually generated) files. Attach these at the target
+        # level so the generating custom targets are built first.
+        if trace.object_depends:
+            src_keys = set()
+            for x in self.sources + self.generated:
+                p = x if x.is_absolute() else self.src_dir / x
+                src_keys.add(p.resolve().as_posix())
+            for src, deps in trace.object_depends.items():
+                if src.resolve().as_posix() in src_keys:
+                    self.depends_raw += deps
+
         temp = []
         for cmd in self.link_libraries:
             # Let meson handle this arcane magic
@@ -502,7 +514,14 @@ class ConverterTarget:
         for arg in self.depends_raw:
             dep_tgt = output_target_map.target(arg)
             if dep_tgt:
-                self.depends.append(dep_tgt)
+                if dep_tgt not in self.depends:
+                    self.depends.append(dep_tgt)
+                continue
+            # File-level dependencies (e.g. from OBJECT_DEPENDS) resolve to the
+            # custom target generating the file
+            gen = output_target_map.generated(Path(arg))
+            if gen and gen not in self.depends:
+                self.depends.append(gen)
 
     def process_object_libs(self, obj_target_list: T.List['ConverterTarget'], linker_workaround: bool) -> None:
         # Try to detect the object library(s) from the generated input sources
@@ -1130,12 +1149,24 @@ class CMakeInterpreter:
                 if i.name not in processed:
                     process_target(i)
                 objec_libs += [extract_tgt(i)]
-            for i in tgt.depends:
-                if not isinstance(i, ConverterCustomTarget):
+            # CMake guarantees that all dependencies of a target -- including those
+            # of linked and add_dependencies targets, transitively -- are built
+            # before any of the target's sources compile (the ninja backend emits
+            # cmake_object_order_depends_target_* edges for this). Collect all
+            # reachable custom targets so their generated files exist in time.
+            dep_stack = list(tgt.depends)
+            visited_deps: T.Set[str] = set()
+            while dep_stack:
+                i = dep_stack.pop(0)
+                if i.name in visited_deps:
                     continue
-                if i.name not in processed:
-                    process_custom_target(i)
-                dependencies += [extract_tgt(i)]
+                visited_deps.add(i.name)
+                if isinstance(i, ConverterCustomTarget):
+                    if i.name not in processed:
+                        process_custom_target(i)
+                    dependencies += [extract_tgt(i)]
+                elif isinstance(i, ConverterTarget):
+                    dep_stack += i.depends
 
             # Generate the source list and handle generated sources
             sources += tgt.sources

--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -92,6 +92,10 @@ class CMakeTraceParser:
 
         self.explicit_headers: T.Set[Path] = set()
 
+        # Object dependencies set via set_source_files_properties(... OBJECT_DEPENDS ...),
+        # mapping the source file to the files its compilation depends on
+        self.object_depends: T.Dict[Path, T.List[str]] = {}
+
         # T.List of targes that were added with add_custom_command to generate files
         self.custom_targets: T.List[CMakeGeneratorTarget] = []
 
@@ -525,9 +529,10 @@ class CMakeTraceParser:
             else:
                 tgt.properties[identifier] = value
 
-        def do_source(src: str) -> None:
-            if identifier != 'HEADER_FILE_ONLY' or not self._str_to_bool(value):
-                return
+        def resolve_source(src: str) -> Path:
+            src_p = Path(src)
+            if src_p.is_absolute():
+                return src_p
 
             current_src_dir = self.var_to_str('MESON_PS_CMAKE_CURRENT_SOURCE_DIR')
             if not current_src_dir:
@@ -537,12 +542,14 @@ class CMakeTraceParser:
                 '''))
                 current_src_dir = '.'
 
-            cur_p = Path(current_src_dir)
-            src_p = Path(src)
+            return Path(current_src_dir) / src_p
 
-            if not src_p.is_absolute():
-                src_p = cur_p / src_p
-            self.explicit_headers.add(src_p)
+        def do_source(src: str) -> None:
+            if identifier == 'HEADER_FILE_ONLY':
+                if self._str_to_bool(value):
+                    self.explicit_headers.add(resolve_source(src))
+            elif identifier == 'OBJECT_DEPENDS':
+                self.object_depends.setdefault(resolve_source(src), []).extend(value)
 
         if scope == 'TARGET':
             for i in targets:

--- a/test cases/cmake/29 object depends/main.c
+++ b/test cases/cmake/29 object depends/main.c
@@ -1,0 +1,21 @@
+int object_depends_absolute(void);
+int object_depends_relative(void);
+int object_depends_subdir(void);
+int object_depends_transitive(void);
+
+int main(void)
+{
+    if (object_depends_absolute() != 1) {
+        return 1;
+    }
+    if (object_depends_relative() != 2) {
+        return 2;
+    }
+    if (object_depends_subdir() != 3) {
+        return 3;
+    }
+    if (object_depends_transitive() != 4) {
+        return 4;
+    }
+    return 0;
+}

--- a/test cases/cmake/29 object depends/meson.build
+++ b/test cases/cmake/29 object depends/meson.build
@@ -1,0 +1,14 @@
+project('cmake_object_depends', 'c')
+
+cm = import('cmake')
+
+sub_pro = cm.subproject('cmObjDep')
+
+exe1 = executable('main1', ['main.c'], dependencies: [
+  sub_pro.dependency('cmObjDepAbsolute'),
+  sub_pro.dependency('cmObjDepRelative'),
+  sub_pro.dependency('cmObjDepTransitive'),
+  sub_pro.dependency('cmObjDepSub'),
+])
+
+test('test1', exe1)

--- a/test cases/cmake/29 object depends/subprojects/cmObjDep/CMakeLists.txt
+++ b/test cases/cmake/29 object depends/subprojects/cmObjDep/CMakeLists.txt
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
+
+project(cmObjDep C)
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+# Generate <name>.h in several steps, so a lost compile-order dependency cannot
+# win the race against the compile of the source including the header.
+function(gen_header name)
+  add_custom_command(
+    OUTPUT  "${CMAKE_CURRENT_BINARY_DIR}/${name}.step1"
+    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/${name}.h.in" "${CMAKE_CURRENT_BINARY_DIR}/${name}.step1"
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${name}.h.in"
+  )
+  add_custom_command(
+    OUTPUT  "${CMAKE_CURRENT_BINARY_DIR}/${name}.step2"
+    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/${name}.step1" "${CMAKE_CURRENT_BINARY_DIR}/${name}.step2"
+    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${name}.step1"
+  )
+  add_custom_command(
+    OUTPUT  "${CMAKE_CURRENT_BINARY_DIR}/${name}.step3"
+    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/${name}.step2" "${CMAKE_CURRENT_BINARY_DIR}/${name}.step3"
+    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${name}.step2"
+  )
+  add_custom_command(
+    OUTPUT  "${CMAKE_CURRENT_BINARY_DIR}/${name}.h"
+    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/${name}.step3" "${CMAKE_CURRENT_BINARY_DIR}/${name}.h"
+    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${name}.step3"
+  )
+  add_custom_target(gen_${name} DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${name}.h")
+endfunction()
+
+gen_header(absolute)
+gen_header(relative)
+gen_header(transitive)
+
+# OBJECT_DEPENDS with an absolute source path
+set_source_files_properties(
+  "${CMAKE_CURRENT_SOURCE_DIR}/absolute.c"
+  PROPERTIES OBJECT_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/absolute.h")
+add_library(cmObjDepAbsolute STATIC absolute.c)
+
+# OBJECT_DEPENDS with a path relative to the current source directory
+set_source_files_properties(
+  relative.c
+  PROPERTIES OBJECT_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/relative.h")
+add_library(cmObjDepRelative STATIC relative.c)
+
+# transitive.c reaches gen_transitive only through the library it links against
+add_library(cmObjDepProvider STATIC provider.c)
+add_dependencies(cmObjDepProvider gen_transitive)
+
+add_library(cmObjDepTransitive STATIC transitive.c)
+target_link_libraries(cmObjDepTransitive PUBLIC cmObjDepProvider)
+
+add_subdirectory(sub)

--- a/test cases/cmake/29 object depends/subprojects/cmObjDep/absolute.c
+++ b/test cases/cmake/29 object depends/subprojects/cmObjDep/absolute.c
@@ -1,0 +1,6 @@
+#include "absolute.h"
+
+int object_depends_absolute(void)
+{
+    return ABSOLUTE_VALUE;
+}

--- a/test cases/cmake/29 object depends/subprojects/cmObjDep/absolute.h.in
+++ b/test cases/cmake/29 object depends/subprojects/cmObjDep/absolute.h.in
@@ -1,0 +1,1 @@
+#define ABSOLUTE_VALUE 1

--- a/test cases/cmake/29 object depends/subprojects/cmObjDep/provider.c
+++ b/test cases/cmake/29 object depends/subprojects/cmObjDep/provider.c
@@ -1,0 +1,4 @@
+int object_depends_provider(void)
+{
+    return 0;
+}

--- a/test cases/cmake/29 object depends/subprojects/cmObjDep/relative.c
+++ b/test cases/cmake/29 object depends/subprojects/cmObjDep/relative.c
@@ -1,0 +1,6 @@
+#include "relative.h"
+
+int object_depends_relative(void)
+{
+    return RELATIVE_VALUE;
+}

--- a/test cases/cmake/29 object depends/subprojects/cmObjDep/relative.h.in
+++ b/test cases/cmake/29 object depends/subprojects/cmObjDep/relative.h.in
@@ -1,0 +1,1 @@
+#define RELATIVE_VALUE 2

--- a/test cases/cmake/29 object depends/subprojects/cmObjDep/sub/CMakeLists.txt
+++ b/test cases/cmake/29 object depends/subprojects/cmObjDep/sub/CMakeLists.txt
@@ -1,0 +1,9 @@
+gen_header(subdir)
+
+# OBJECT_DEPENDS relative to this directory, not to the top level one
+set_source_files_properties(
+  subdir.c
+  PROPERTIES OBJECT_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/subdir.h")
+
+add_library(cmObjDepSub STATIC subdir.c)
+target_include_directories(cmObjDepSub PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/test cases/cmake/29 object depends/subprojects/cmObjDep/sub/subdir.c
+++ b/test cases/cmake/29 object depends/subprojects/cmObjDep/sub/subdir.c
@@ -1,0 +1,6 @@
+#include "subdir.h"
+
+int object_depends_subdir(void)
+{
+    return SUBDIR_VALUE;
+}

--- a/test cases/cmake/29 object depends/subprojects/cmObjDep/sub/subdir.h.in
+++ b/test cases/cmake/29 object depends/subprojects/cmObjDep/sub/subdir.h.in
@@ -1,0 +1,1 @@
+#define SUBDIR_VALUE 3

--- a/test cases/cmake/29 object depends/subprojects/cmObjDep/transitive.c
+++ b/test cases/cmake/29 object depends/subprojects/cmObjDep/transitive.c
@@ -1,0 +1,6 @@
+#include "transitive.h"
+
+int object_depends_transitive(void)
+{
+    return TRANSITIVE_VALUE;
+}

--- a/test cases/cmake/29 object depends/subprojects/cmObjDep/transitive.h.in
+++ b/test cases/cmake/29 object depends/subprojects/cmObjDep/transitive.h.in
@@ -1,0 +1,1 @@
+#define TRANSITIVE_VALUE 4


### PR DESCRIPTION
I ran into #9062 when trying to build glslang as subproject. 

I'm not familiar with meson internals, so this is an AI generated patch. However, it fixed the issue in my case, so I wanted to submit it here for proper review:


The CMake subproject translation dropped two kinds of compile-order dependency on generated files:

  * OBJECT_DEPENDS, set via set_source_files_properties(), was not parsed at all, so a source including a generated header had no edge to the custom target producing it.
  * Only the direct custom-target dependencies of a target were collected. CMake's ninja backend emits cmake_object_order_depends_target_* edges for the transitive closure, so a custom target reachable only through another regular target was lost.

Both make clean builds fail non-deterministically with a missing generated header. Parse OBJECT_DEPENDS in the trace parser, resolve file-level dependencies to the custom target generating the file, and walk the dependency graph transitively when collecting the custom targets a target must wait for.

Fixes #9062