### PR TITLE
boost: respect prefer_static when selecting libraries

### DIFF
--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -629,12 +629,29 @@ class BoostDependency(SystemDependency):
         if not self.debug:
             libs = [x for x in libs if not x.debug]
 
-        # Take the abitag from the first library and filter by it. This
-        # ensures that we have a set of libraries that are always compatible.
         if not libs:
             return []
-        abitag = libs[0].abitag
-        libs = [x for x in libs if x.abitag == abitag]
+
+        # Prefer the requested library type, but only when its ABI contains all
+        # requested modules that have a library component. This allows a
+        # complete set of the other type to be used as a fallback.
+        libs.sort(key=lambda x: x.static != self.static)
+        modules = ['boost_' + x for x in self.modules]
+        required_modules = [
+            mod for mod in modules if any(x.mod_name_matches(mod) for x in libs)
+        ]
+        libraries_by_abi: T.Dict[str, T.List[BoostLibraryFile]] = {}
+        for lib in libs:
+            libraries_by_abi.setdefault(lib.abitag, []).append(lib)
+        for abi_libs in libraries_by_abi.values():
+            if all(any(x.mod_name_matches(mod) for x in abi_libs) for mod in required_modules):
+                libs = abi_libs
+                break
+        else:
+            # Preserve the existing best-effort selection when no ABI has all
+            # requested library components. run_check() will report any
+            # genuinely missing modules after checking for header-only ones.
+            libs = next(iter(libraries_by_abi.values()))
 
         # Assume that we are building against the latest Python version
         # and that the other ones are only there for backwards compatibility.

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -33,6 +33,7 @@ from mesonbuild.compilers.cpp import VisualStudioCPPCompiler
 from mesonbuild.compilers.d import DmdDCompiler
 from mesonbuild.compilers.detect import detect_c_compiler
 from mesonbuild.compilers.mixins.visualstudio import MSVCCompiler, ClangClCompiler
+from mesonbuild.dependencies.boost import BoostDependency, BoostLibraryFile
 from mesonbuild.linkers import linkers
 from mesonbuild.interpreterbase import typed_pos_args, InvalidArguments, ObjectHolder
 from mesonbuild.interpreterbase import typed_pos_args, InvalidArguments, typed_kwargs, ContainerTypeInfo, KwargInfo
@@ -720,6 +721,62 @@ class InternalTests(unittest.TestCase):
             self._test_all_naming(cc, patterns, 'cygwin')
             env.machines.host.system = 'windows'
             self._test_all_naming(cc, patterns, 'windows-mingw')
+
+    def test_boost_library_preference(self):
+        boost = BoostDependency.__new__(BoostDependency)
+        boost.multithreading = True
+        boost.arch = ''
+        boost.debug = False
+        boost.for_machine = MachineChoice.HOST
+        boost.env = mock.Mock()
+        boost.env.coredata.optstore.get_value_for.side_effect = KeyError
+        boost.env.machines = {MachineChoice.HOST: mock.Mock()}
+        boost.env.machines[MachineChoice.HOST].is_openbsd.return_value = False
+
+        def filter_libs(static: bool, explicit_static: bool, names: T.List[str],
+                        modules: T.Sequence[str] = ('thread',)) -> T.List[str]:
+            boost.static = static
+            boost.explicit_static = explicit_static
+            boost.modules = list(modules)
+            libs = sorted(BoostLibraryFile(Path(name)) for name in names)
+            return [lib.name for lib in boost.filter_libraries(libs, '')]
+
+        both = ['libboost_thread.a', 'libboost_thread.so']
+        for static, explicit_static, expected in [
+            (False, False, 'libboost_thread.so'),
+            (True, False, 'libboost_thread.a'),
+            (False, True, 'libboost_thread.so'),
+            (True, True, 'libboost_thread.a'),
+        ]:
+            with self.subTest(static=static, explicit_static=explicit_static):
+                self.assertEqual(filter_libs(static, explicit_static, both), [expected])
+
+        self.assertEqual(filter_libs(True, False, ['libboost_thread.so']), ['libboost_thread.so'])
+        self.assertEqual(filter_libs(False, False, ['libboost_thread.a']), ['libboost_thread.a'])
+        self.assertEqual(filter_libs(True, False, both, ('asio', 'thread')), ['libboost_thread.a'])
+
+        modules = ('filesystem', 'thread')
+        for static, names, expected in [
+            (True,
+             ['libboost_filesystem.so', 'libboost_thread.a', 'libboost_thread.so'],
+             ['libboost_filesystem.so', 'libboost_thread.so']),
+            (False,
+             ['libboost_filesystem.a', 'libboost_thread.a', 'libboost_thread.so'],
+             ['libboost_filesystem.a', 'libboost_thread.a']),
+        ]:
+            with self.subTest(static=static, fallback=True):
+                self.assertEqual(filter_libs(static, False, names, modules), expected)
+
+        for static, names, expected in [
+            (True,
+             ['libboost_filesystem.so', 'libboost_thread.a', 'libboost_thread.so'],
+             ['libboost_thread.a']),
+            (False,
+             ['libboost_filesystem.a', 'libboost_thread.a', 'libboost_thread.so'],
+             ['libboost_thread.so']),
+        ]:
+            with self.subTest(static=static, explicit_static=True):
+                self.assertEqual(filter_libs(static, True, names, modules), expected)
 
     @skipIfNoPkgconfig
     def test_pkgconfig_parse_libs(self):


### PR DESCRIPTION
 Fixes #15458.

  When `static` is omitted, Boost keeps both static and shared candidates, but ABI selection did not account for the effective library preference.

  Select the first ABI set that fully covers the requested binary modules, trying the preferred library type before the fallback type. Explicit `static` selection remains strict, and header-only modules do
  not affect completeness.

  The regression test covers both preferences, explicit selection, single-variant fallback, header-only modules, and incomplete-preferred/complete-fallback sets.