### PR TITLE
qt: use source_strings_to_files for the Qt module's generators

### DIFF
--- a/mesonbuild/modules/_qt.py
+++ b/mesonbuild/modules/_qt.py
@@ -525,7 +525,7 @@ class QtBaseModule(ExtensionModule):
             kwargs['extra_args'] + ['-o', '@OUTPUT@', '@INPUT@'],
             ['ui_@BASENAME@.h'],
             name=f'Qt{self.qt_version} ui')
-        sources = self._source_to_files(state, kwargs['sources'])
+        sources = self.interpreter.source_strings_to_files(kwargs['sources'])
         return gen.process_files(sources, state.subdir, preserve_path_from)
 
     @FeatureNew('qt.compile_moc', '0.59.0')
@@ -606,7 +606,7 @@ class QtBaseModule(ExtensionModule):
                 depends=depends,
                 depfile='moc_@BASENAME@.cpp.d',
                 name=f'Qt{self.qt_version} moc header')
-            headers = self._source_to_files(state, kwargs['headers'])
+            headers = self.interpreter.source_strings_to_files(kwargs['headers'])
             output.append(moc_gen.process_files(headers, state.subdir, preserve_path_from))
         if kwargs['sources']:
             source_gen_output: T.List[str] = ['@BASENAME@.moc']
@@ -617,7 +617,7 @@ class QtBaseModule(ExtensionModule):
                 self.tools['moc'], arguments, source_gen_output,
                 depfile='@BASENAME@.moc.d',
                 name=f'Qt{self.qt_version} moc source')
-            sources = self._source_to_files(state, kwargs['sources'])
+            sources = self.interpreter.source_strings_to_files(kwargs['sources'])
             output.append(moc_gen.process_files(sources, state.subdir, preserve_path_from))
 
         return output
@@ -926,7 +926,7 @@ class QtBaseModule(ExtensionModule):
             name=f'Qml cache generation for {target_name}')
 
         output: T.List[T.Union[build.CustomTarget, build.GeneratedList]] = []
-        qml_sources = self._source_to_files(state, kwargs['qml_sources'])
+        qml_sources = self.interpreter.source_strings_to_files(kwargs['qml_sources'])
         output.append(cache_gen.process_files(qml_sources, state.subdir))
 
         cachegen_inputs: T.List[str] = []

--- a/test cases/frameworks/4 qt/copyfile.py
+++ b/test cases/frameworks/4 qt/copyfile.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import sys
+import shutil
+
+shutil.copy(sys.argv[1], sys.argv[2])

--- a/test cases/frameworks/4 qt/manualinclude.cpp
+++ b/test cases/frameworks/4 qt/manualinclude.cpp
@@ -24,4 +24,4 @@ int main(int argc, char **argv) {
     return 0;
 }
 
-#include"manualinclude.moc"
+#include"manualincludeGen.moc"

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -9,8 +9,16 @@ fs = import('fs')
 qt5_modules = ['Widgets']
 qt6_modules = ['Widgets']
 
+copyfile = find_program('copyfile.py')
+copyfile_gen = generator(copyfile,
+  output: '@BASENAME@Gen.cpp',
+  arguments : ['@INPUT@', '@OUTPUT@'])
+
+manualinclude_cpp_gen = copyfile_gen.process('manualinclude.cpp')
+
 manualinclude_cpp = fs.copyfile('manualinclude.cpp')
 manualinclude_h = fs.copyfile('manualinclude.h')
+
 foreach qt : ['qt4', 'qt5', 'qt6']
   qt_modules = ['Core', 'Gui']
   if qt == 'qt5'
@@ -143,7 +151,7 @@ foreach qt : ['qt4', 'qt5', 'qt6']
 
     manpreprocessed = qtmodule.compile_moc(
       extra_args : ['-DMOC_EXTRA_FLAG'], # This is just a random macro to test `extra_arguments`
-      sources : 'manualinclude.cpp',
+      sources : manualinclude_cpp_gen,
       headers : 'manualinclude.h',
       method : get_option('method'),
       dependencies: mocdep,


### PR DESCRIPTION
Commit 1217faedc ("build: never pass str to Generator.process_files", 2026-06-15) replaced Generator.process_files's own input normalization with _qt.py's _source_to_files().  The two functions do different things for GeneratedList inputs, with _source_to_files() *not* adding a dependency from the input generator to the new one and also not wrapping the output into FileInTargetPrivateDir.

So, after the commit a GeneratedList passed to moc never depends on the input GeneratedList, and also has the wrong path.  The remaining _source_to_files uses are for .qrc and qmldir generation, and they existed even before commit 1217faedc.

Fixes: #16060