### PR TITLE
compilers/c: add c_std=clatest for MSVC's experimental C23 support

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -308,12 +308,12 @@ or compiler being used:
 | ------           | ------------- | ---------------                          | ----------- |
 | c_args           |               | free-form comma-separated list           | C compile arguments to use |
 | c_link_args      |               | free-form comma-separated list           | C link arguments to use |
-| c_std            | none          | none, c89, c99, c11, c17, c18, c2x, c23, c2y, gnu89, gnu99, gnu11, gnu17, gnu18, gnu2x, gnu23, gnu2y | C language standard to use |
+| c_std            | none          | none, c89, c99, c11, c17, c18, c2x, c23, c2y, clatest, gnu89, gnu99, gnu11, gnu17, gnu18, gnu2x, gnu23, gnu2y | C language standard to use |
 | c_winlibs        | see below     | free-form comma-separated list           | Standard Windows libs to link against |
 | c_thread_count   | 4             | integer value ≥ 0                        | Number of threads to use with emcc when using threads |
 | cpp_args         |               | free-form comma-separated list           | C++ compile arguments to use |
 | cpp_link_args    |               | free-form comma-separated list           | C++ link arguments to use |
-| cpp_std          | none          | none, c++98, c++03, c++11, c++14, c++17, c++20 <br/>c++2a, c++1z, gnu++03, gnu++11, gnu++14, gnu++17, gnu++1z, <br/> gnu++2a, gnu++20, vc++14, vc++17, vc++20, vc++latest | C++ language standard to use |
+| cpp_std          | none          | none, c++98, c++03, c++11, c++14, c++17, c++20, c++23, c++26, c++latest <br/>c++2a, c++1z, gnu++03, gnu++11, gnu++14, gnu++17, gnu++1z, <br/> gnu++2a, gnu++20, vc++14, vc++17, vc++20, vc++latest | C++ language standard to use |
 | cpp_debugstl     | false         | true, false                              | C++ STL debug mode |
 | cpp_eh           | default       | none, default, a, s, sc                  | C++ exception handling type |
 | cpp_rtti         | true          | true, false                              | Whether to enable RTTI (runtime type identification) |

--- a/docs/markdown/snippets/std-clatest-for-msvc.md
+++ b/docs/markdown/snippets/std-clatest-for-msvc.md
@@ -1,0 +1,5 @@
+## `c_std=clatest` support for MSVC
+
+The option enables all currently implemented compiler and standard library
+features proposed in the next draft C standard, as well as some in-progress and
+experimental features.

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -52,6 +52,7 @@ else:
 ALL_STDS = ['c89', 'c9x', 'c90', 'c99', 'c1x', 'c11', 'c17', 'c18', 'c2x', 'c23', 'c2y']
 ALL_STDS += [f'gnu{std[1:]}' for std in ALL_STDS]
 ALL_STDS += ['iso9899:1990', 'iso9899:199409', 'iso9899:1999', 'iso9899:2011', 'iso9899:2017', 'iso9899:2018', 'iso9899:2024']
+ALL_STDS += ['clatest']
 
 
 class CCompiler(CLikeCompiler, Compiler):
@@ -422,6 +423,7 @@ class VisualStudioCCompiler(MSVCCompiler, VisualStudioLikeCCompilerMixin, CCompi
 
     _C11_VERSION = '>=19.28'
     _C17_VERSION = '>=19.28'
+    _CLATEST_VERSION = '>=19.37'
 
     def __init__(self, ccache: T.List[str], exelist: T.List[str], version: str, for_machine: MachineChoice,
                  env: Environment, target: str,
@@ -438,6 +440,8 @@ class VisualStudioCCompiler(MSVCCompiler, VisualStudioLikeCCompilerMixin, CCompi
             stds += ['c11']
         if version_compare(self.version, self._C17_VERSION):
             stds += ['c17', 'c18']
+        if version_compare(self.version, self._CLATEST_VERSION):
+            stds += ['clatest']
         key = self.form_compileropt_key('std')
         std_opt = opts[key]
         assert isinstance(std_opt, options.UserStdOption), 'for mypy'
@@ -448,11 +452,13 @@ class VisualStudioCCompiler(MSVCCompiler, VisualStudioLikeCCompilerMixin, CCompi
         args = []
         std = self.get_compileropt_value('std', target, subproject)
 
-        # As of MVSC 16.8, /std:c11 and /std:c17 are the only valid C standard options.
+        # MSVC is not strictily conformant to c89 and c99 because the use of microsoft extensions.
         if std in {'c11'}:
             args.append('/std:c11')
         elif std in {'c17', 'c18'}:
             args.append('/std:c17')
+        elif std == 'clatest':
+            args.append('/std:clatest')
         return args
 
 


### PR DESCRIPTION
The option enables all currently implemented compiler and standard library features proposed in the next draft C standard, as well as some in-progress and experimental features.

https://learn.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version#stdclatest-1