### PR TITLE
intro: report complete target dependencies

### DIFF
--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -64,6 +64,8 @@ specified. The JSON format for one target is defined as follows:
     "build_by_default": true / false,
     "target_sources": [],
     "extra_files": ["/path/to/file1.hpp", "/path/to/file2.hpp"],
+    "dependencies": ["external-dependency-name"],
+    "depends": ["target1-id", "target2-id"],
     "installed": true / false,
 }
 ```
@@ -76,6 +78,11 @@ corresponding install location is set to `null`.
 The `subproject` key specifies the name of the subproject this target
 was defined in, or `null` if the target was defined in the top level
 project.
+
+The `dependencies` key lists external dependencies used by the target.
+The `depends` key lists the IDs of other targets that must be built before
+this target. Those IDs can be looked up in the same targets introspection
+data.
 
 *(New in 0.56.0)* The `extra_files` key lists all files specified via
 the `extra_files` kwarg of a build target. See

--- a/docs/markdown/snippets/fix_intro_target_dependencies.md
+++ b/docs/markdown/snippets/fix_intro_target_dependencies.md
@@ -1,0 +1,7 @@
+## Target introspection reports all direct target dependencies
+
+The `depends` entry in `intro-targets.json` now reports direct target
+dependencies from target inputs, generated sources, extracted objects,
+internal linking, and explicit `depends` arguments. Previously it only
+reported the `dependencies` attribute used by alias and run targets, so most
+build target and custom target dependencies were omitted.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -37,10 +37,11 @@ from ..options import OptionKey
 if T.TYPE_CHECKING:
     from .._typing import ImmutableListProtocol
     from ..arglist import CompilerArgs
-    from ..build import TargetSources
+    from ..build import ExtractedObjects, TargetSources
     from ..compilers.compilers import Compiler, Language
     from ..environment import Environment
     from ..interpreter import Test
+    from ..interpreter.kwargs import TargetDepends
     from ..linkers import StaticLinker
     from ..mesonlib import InstallScript
     from ..options import ElementaryOptionValues
@@ -495,6 +496,59 @@ class Backend:
     def determine_ext_objs(self, objects: build.ExtractedObjects) -> T.List[str]:
         obj_list, _ = self._flatten_object_list(objects.target, [objects], '')
         return unique_list(obj_list)
+
+    def get_target_deps(self, targets: T.Mapping[str, build.Target], recursive: bool = False) -> T.Dict[str, build.Target]:
+        """Return target dependencies keyed by their introspection IDs."""
+        all_deps: T.Dict[str, build.Target] = {}
+
+        def add_dependency(dep: build.AnyTargetType | TargetDepends | File | ExtractedObjects) -> None:
+            if isinstance(dep, build.LocalProgram):
+                dep = dep.get_target()
+            if isinstance(dep, build.CustomTargetIndex):
+                dep = dep.get_target()
+            if isinstance(dep, build.Target):
+                all_deps[dep.get_id()] = dep
+            elif isinstance(dep, build.ExtractedObjects):
+                all_deps[dep.target.get_id()] = dep.target
+            elif isinstance(dep, build.GeneratedList):
+                generator = dep.get_generator()
+                for nested in chain(generator.depends, dep.depends, dep.extra_depends):
+                    add_dependency(nested)
+
+        for target in targets.values():
+            if isinstance(target, build.CustomTargetIndex):
+                # Just transfer it to the CustomTarget code.
+                target = target.target
+            if isinstance(target, build.CustomTarget):
+                for dep in target.get_target_dependencies():
+                    add_dependency(dep)
+            elif isinstance(target, build.RunTarget):
+                for dep in target.get_dependencies():
+                    add_dependency(dep)
+            elif isinstance(target, build.BuildTarget):
+                for dep in chain(target.link_targets, target.link_whole_targets):
+                    add_dependency(dep)
+
+                if isinstance(target, build.CompileTarget):
+                    for dep in target.depends:
+                        add_dependency(dep)
+
+                for dep in target.link_depends:
+                    add_dependency(dep)
+
+                for obj in target.objects:
+                    add_dependency(obj)
+            else:
+                raise MesonException(f'Unknown target type for target {target}')
+
+            for generated in target.get_generated_sources():
+                add_dependency(generated)
+
+        if not targets or not recursive:
+            return all_deps
+        result = self.get_target_deps(all_deps, recursive)
+        result.update(all_deps)
+        return result
 
     def _flatten_object_list(self, target: build.BuildTarget,
                              objects: T.Sequence[build.ObjectTypes],

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 import copy
-import itertools
 import os
 import xml.dom.minidom
 import xml.etree.ElementTree as ET
@@ -19,7 +18,6 @@ from .. import build
 from .. import mlog
 from .. import compilers
 from .. import mesonlib
-from .. import programs
 from ..mesonlib import (
     File, MesonBugException, MesonException, replace_if_different, version_compare, MachineChoice
 )
@@ -353,69 +351,6 @@ class Vs2010Backend(backends.Backend):
                 return '"%s" -arch=%s -host_arch=%s' % \
                     (script_path, os.environ['VSCMD_ARG_TGT_ARCH'], os.environ['VSCMD_ARG_HOST_ARCH'])
         return ''
-
-    def get_obj_target_deps(self, obj_list: list[build.ObjectTypes]) -> T.Iterable[tuple[str, build.BuildTarget]]:
-        result = {}
-        for o in obj_list:
-            if isinstance(o, build.ExtractedObjects):
-                result[o.target.get_id()] = o.target
-        return result.items()
-
-    def get_target_deps(self, t: T.Mapping[str, build.Target], recursive: bool = False) -> T.Dict[str, build.Target]:
-        all_deps: T.Dict[str, build.Target] = {}
-        for target in t.values():
-            if isinstance(target, build.CustomTargetIndex):
-                # just transfer it to the CustomTarget code
-                target = target.target
-            if isinstance(target, build.CustomTarget):
-                for d in target.get_target_dependencies():
-                    # FIXME: this isn't strictly correct, as the target doesn't
-                    # Get dependencies on non-targets, such as Files
-                    if isinstance(d, build.Target):
-                        all_deps[d.get_id()] = d
-            elif isinstance(target, build.RunTarget):
-                for d in target.get_dependencies():
-                    if isinstance(d, build.LocalProgram):
-                        d = d.program
-                    if isinstance(d, (programs.Program, build.GeneratedList)):
-                        continue
-                    all_deps[d.get_id()] = d.get_target()
-            elif isinstance(target, build.BuildTarget):
-                for ldep in target.link_targets:
-                    all_deps[ldep.get_id()] = ldep.get_target()
-                for ldep in target.link_whole_targets:
-                    all_deps[ldep.get_id()] = ldep.get_target()
-
-                for ldep in target.link_depends:
-                    if isinstance(ldep, File):
-                        # Already built, no target references needed
-                        pass
-                    else:
-                        all_deps[ldep.get_id()] = ldep.get_target()
-
-                for obj_id, objdep in self.get_obj_target_deps(target.objects):
-                    all_deps[obj_id] = objdep
-            else:
-                raise MesonException(f'Unknown target type for target {target}')
-
-            for gendep in target.get_generated_sources():
-                if isinstance(gendep, (build.CustomTarget, build.CustomTargetIndex)):
-                    all_deps[gendep.get_id()] = gendep.get_target()
-                else:
-                    generator = gendep.get_generator()
-                    for d in itertools.chain(generator.depends, gendep.depends, gendep.extra_depends):
-                        if isinstance(d, build.CustomTargetIndex):
-                            all_deps[d.get_id()] = d.target
-                        elif isinstance(d, build.Target):
-                            all_deps[d.get_id()] = d
-                        # FIXME: we don't handle other kinds of deps correctly here, such
-                        # as GeneratedLists, StructuredSources, and generated File.
-
-        if not t or not recursive:
-            return all_deps
-        ret = self.get_target_deps(all_deps, recursive)
-        ret.update(all_deps)
-        return ret
 
     def generate_solution_dirs(self, ofile: T.TextIO, parents: T.Sequence[PurePath]) -> None:
         prj_templ = 'Project("{%s}") = "%s", "%s", "{%s}"\n'

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -188,7 +188,7 @@ def list_targets(coredata: cdata.CoreData, builddata: build.Build, backend: back
             'extra_files': [os.path.normpath(os.path.join(src_dir, x.subdir, x.fname)) for x in target.extra_files],
             'subproject': target.subproject or None,
             'dependencies': [d.name for d in getattr(target, 'external_deps', [])],
-            'depends': [lib.get_id() for lib in getattr(target, 'dependencies', [])]
+            'depends': list(backend.get_target_deps({idname: target})),
         }
 
         vs_module_defs = getattr(target, 'vs_module_defs', None)

--- a/test cases/unit/56 introspection/meson.build
+++ b/test cases/unit/56 introspection/meson.build
@@ -39,7 +39,8 @@ t2 = executable('test@0@'.format('@0@'.format(var2)), sources: ['t2.cpp'], link_
 t3 = executable(var3, 't3.cpp', link_with: [sharedlib, staticlib], dependencies: [dep1])
 
 cus3 = custom_target('custom target test 3', output: 'file4', input: t3,
-                     command: [find_program('cp.py'), '@INPUT@', '@OUTPUT@'])
+                     command: [find_program('cp.py'), '@INPUT@', '@OUTPUT@'],
+                     depends: t1)
 
 ### BEGIN: Test inspired by taisei: https://github.com/taisei-project/taisei/blob/master/meson.build#L293
 systype = '@0@'.format(host_machine.system())

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -3851,6 +3851,17 @@ class AllPlatformTests(BasePlatformTests):
             })
 
         with self.subTest('Check targets'):
+            target_ids = {target['name']: target['id'] for target in res['targets']}
+            target_depends = {
+                'sharedTestLib': [],
+                'staticTestLib': [],
+                'custom target test 1': [],
+                'custom target test 2': [target_ids['custom target test 1']],
+                'test1': [target_ids['sharedTestLib']],
+                'test2': [target_ids['staticTestLib']],
+                'test3': [target_ids['sharedTestLib'], target_ids['staticTestLib']],
+                'custom target test 3': [target_ids['test1'], target_ids['test3']],
+            }
             targets_to_find = {
                 'sharedTestLib': ('shared library', True, False, 'sharedlib/meson.build',
                                 [os.path.join(testdir, 'sharedlib', 'shared.cpp')]),
@@ -3877,6 +3888,7 @@ class AllPlatformTests(BasePlatformTests):
                     self.assertEqual(i['build_by_default'], tgt[1])
                     self.assertEqual(i['installed'], tgt[2])
                     self.assertPathEqual(i['defined_in'], os.path.join(testdir, tgt[3]))
+                    self.assertEqual(sorted(i['depends']), sorted(target_depends[i['name']]))
                     targets_to_find.pop(i['name'], None)
                 for j in i['target_sources']:
                     if 'compiler' in j:
@@ -3974,12 +3986,16 @@ class AllPlatformTests(BasePlatformTests):
         res_nb = self.introspect_directory(testfile, ['--targets'] + self.meson_args)
 
         # Account for differences in output
+        # Source introspection cannot resolve target dependencies without
+        # configuring the project.
+        for i in res_nb:
+            del i['depends']
         res_wb = [i for i in res_wb if i['type'] != 'custom']
         for i in res_wb:
             if i['id'] == 'test1@exe':
                 i['build_by_default'] = 'unknown'
             i['filename'] = [os.path.relpath(x, self.builddir) for x in i['filename']]
-            for k in ('install_filename', 'dependencies', 'win_subsystem'):
+            for k in ('install_filename', 'dependencies', 'depends', 'win_subsystem'):
                 if k in i:
                     del i[k]
 
@@ -3997,6 +4013,21 @@ class AllPlatformTests(BasePlatformTests):
 
         self.maxDiff = None
         self.assertListEqual(res_nb, res_wb)
+
+    def test_introspect_compile_target_dependencies(self):
+        testdir = os.path.join(self.common_test_dir, '259 preprocess')
+        self.init(testdir)
+
+        targets = {target['id']: target for target in self.introspect('--targets')}
+        compile_target_ids = {
+            target['id'] for target in targets.values() if target['type'] == 'compile'
+        }
+
+        self.assertSetEqual(
+            set(targets['preprocessor_0@compile']['depends']),
+            {'bar.x@cus', 'foo.h@cus'},
+        )
+        self.assertSetEqual(set(targets['app@exe']['depends']), compile_target_ids)
 
     @skipIfNoExecutable('gettext')
     @skipIfNoExecutable('xgettext')

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -333,6 +333,17 @@ class LinuxlikeTests(BasePlatformTests):
         self.init(testdir, extra_args=['-Db_sanitize=address', '-Db_lundef=false'])
         self.build()
 
+    @skipIfNoExecutable('g-ir-scanner')
+    @skipIfNoPkgconfigDep('gobject-2.0')
+    def test_generate_gir_target_dependencies(self):
+        testdir = os.path.join(self.framework_test_dir, '12 multiple gir')
+        self.init(testdir)
+
+        targets = {target['name']: target for target in self.introspect('--targets')}
+        for gir, library in [('Meson-1.0.gir', 'girlib'),
+                             ('MesonSub-1.0.gir', 'girsubproject')]:
+            self.assertIn(targets[library]['id'], targets[gir]['depends'])
+
     def test_qt5dependency_no_lrelease(self):
         '''
         Test that qt5 detection with qmake works. This can't be an ordinary


### PR DESCRIPTION
## Problem

`intro-targets.json` fills `depends` from a target's `dependencies`
attribute. That attribute is only used by alias and run targets, so build
targets and custom targets usually report an empty dependency list.

This hides generated-source, linking, and GIR ordering from introspection.
For example, this build chain cannot be fully introspected:

```
generated-header -> foo -> Foo-1.0.gir -> foo-1.0.vapi -> app
```

## Fix

Move the Visual Studio backend's target dependency traversal to the common
backend and use it for `intro-targets.json`. Extend it to cover custom target
inputs, generated sources, extracted objects, internal linking, and explicit
`depends` arguments. The introspection output contains direct target IDs, not
the recursive closure.

This fixes configured-build introspection. Source-only introspection
(`meson introspect meson.build --targets`) does not construct the complete
build graph and still leaves `depends` empty. Recovering those target edges
from the AST is separate follow-up work.

Document the field and add generic introspection coverage plus a
`gnome.generate_gir()` regression test.

## Validation

```
python3 run_unittests.py -v \
  AllPlatformTests.test_introspect_json_dump \
  AllPlatformTests.test_introspect_targets_from_source \
  AllPlatformTests.test_introspect_compile_target_dependencies \
  LinuxlikeTests.test_generate_gir_target_dependencies
```

All four tests pass. The minimal VLS reproducer reports the complete target
chain after this change. VLS still needs to consume
`intro-targets.json[].depends`; this PR does not fix the VLS issue by itself.

## Related

- #7469
- vala-lang/vala-language-server#347
