### PR TITLE
introspection: drop dependencies with unknown name from output

### DIFF
--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -218,7 +218,8 @@ class IntrospectionInterpreter(AstInterpreter):
             has_fallback=has_fallback,
             conditional=node.condition_level > 0,
             node=node)
-        self.dependencies += [newdep]
+        if not isinstance(name, UnknownValue):
+            self.dependencies += [newdep]
         return newdep
 
     def build_target(self, node: BaseNode, args: T.List[TYPE_var], kwargs_raw: T.Dict[str, TYPE_var], targetclass: T.Type[BuildTarget]) -> T.Union[IntrospectionBuildTarget, UnknownValue]:

--- a/test cases/unit/139 introspection unknown dep/meson.build
+++ b/test cases/unit/139 introspection unknown dep/meson.build
@@ -1,0 +1,6 @@
+project('t', 'c')
+logind = get_option('logind')
+enable_logind = (logind != 'none')
+if enable_logind
+  logind_dep = dependency(logind, version: '>= 209')
+endif

--- a/test cases/unit/139 introspection unknown dep/meson.options
+++ b/test cases/unit/139 introspection unknown dep/meson.options
@@ -1,0 +1,1 @@
+option('logind', type: 'string')

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -4139,20 +4139,6 @@ class AllPlatformTests(BasePlatformTests):
                 'has_fallback': True,
                 'conditional': True
             },
-            {
-                'conditional': False,
-                'has_fallback': False,
-                'name': 'unknown',
-                'required': False,
-                'version': 'unknown'
-            },
-            {
-                'conditional': False,
-                'has_fallback': False,
-                'name': 'unknown',
-                'required': False,
-                'version': 'unknown'
-            },
         ]
         self.maxDiff = None
         self.assertListEqual(res_nb, expected)

--- a/unittests/platformagnostictests.py
+++ b/unittests/platformagnostictests.py
@@ -589,6 +589,12 @@ class PlatformAgnosticTests(BasePlatformTests):
                 self.assertEqual(self.getconf('debug', opts), True)
                 self.assertEqual(self.getconf('optimization', opts), '3')
 
+    def test_introspect_dependency_unknown_name(self):
+        testdir = os.path.join(self.unit_test_dir, '139 introspection unknown dep')
+        testfile = os.path.join(testdir, 'meson.build')
+        res = self.introspect_directory(testfile, ['--dependencies'] + self.meson_args)
+        self.assertListEqual(res, [])
+
     def test_setup_mixed_long_short_options(self) -> None:
         """Mixing unity and unity_size as long and short options should work."""
         testdir = self.copy_srcdir(os.path.join(self.common_test_dir, '1 trivial'))


### PR DESCRIPTION
They came out as `'unknown'` in the introspection output.

Fixes: #16046