### PR TITLE
tell Resolver how to load wraps from Cargo.lock

### DIFF
--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -849,55 +849,53 @@ def _parse_git_url(url: str, branch: T.Optional[str] = None) -> T.Tuple[str, str
     return url, revision, directory
 
 
-def load_cargo_lock(filename: str, subproject_dir: str) -> T.Optional[CargoLock]:
+def load_cargo_lock(filename: str, subproject_dir: str) -> CargoLock:
     """ Convert Cargo.lock into a list of wraps """
 
     # Map directory -> PackageDefinition, to avoid duplicates. Multiple packages
     # can have the same source URL, in that case we have a single wrap that
     # provides multiple dependency names.
-    if os.path.exists(filename):
-        toml = load_toml(filename)
-        raw_cargolock = T.cast('raw.CargoLock', toml)
-        cargolock = CargoLock.from_raw(raw_cargolock)
-        packagefiles_dir = os.path.join(subproject_dir, 'packagefiles')
-        wraps: T.Dict[str, PackageDefinition] = {}
-        for package in cargolock.package:
-            meson_depname = _dependency_name(package.name, version.api(package.version))
-            if package.source is None:
-                # This is project's package, or one of its workspace members.
-                continue
-            elif package.source == 'registry+https://github.com/rust-lang/crates.io-index':
-                checksum = package.checksum
-                if checksum is None:
-                    checksum = cargolock.metadata[f'checksum {package.name} {package.version} ({package.source})']
-                url = f'https://static.crates.io/crates/{package.name}/{package.version}/download'
-                directory = f'{package.name}-{package.version}'
-                name = SubProject(meson_depname)
-                wrap_type = 'file'
-                cfg = {
-                    'directory': directory,
-                    'source_url': url,
-                    'source_filename': f'{directory}.tar.gz',
-                    'source_hash': checksum,
-                    'method': 'cargo',
-                }
-            elif package.source.startswith('git+'):
-                url, revision, directory = _parse_git_url(package.source)
-                name = SubProject(directory)
-                wrap_type = 'git'
-                cfg = {
-                    'url': url,
-                    'revision': revision,
-                    'method': 'cargo',
-                }
-            else:
-                mlog.warning(f'Unsupported source URL in {filename}: {package.source}')
-                continue
-            if os.path.isdir(os.path.join(packagefiles_dir, name)):
-                cfg['patch_directory'] = name
-            if directory not in wraps:
-                wraps[directory] = PackageDefinition.from_values(name, subproject_dir, wrap_type, cfg)
-            wraps[directory].add_provided_dep(meson_depname)
-        cargolock.wraps = {w.name: w for w in wraps.values()}
-        return cargolock
-    return None
+    toml = load_toml(filename)
+    raw_cargolock = T.cast('raw.CargoLock', toml)
+    cargolock = CargoLock.from_raw(raw_cargolock)
+    packagefiles_dir = os.path.join(subproject_dir, 'packagefiles')
+    wraps: T.Dict[str, PackageDefinition] = {}
+    for package in cargolock.package:
+        meson_depname = _dependency_name(package.name, version.api(package.version))
+        if package.source is None:
+            # This is project's package, or one of its workspace members.
+            continue
+        elif package.source == 'registry+https://github.com/rust-lang/crates.io-index':
+            checksum = package.checksum
+            if checksum is None:
+                checksum = cargolock.metadata[f'checksum {package.name} {package.version} ({package.source})']
+            url = f'https://static.crates.io/crates/{package.name}/{package.version}/download'
+            directory = f'{package.name}-{package.version}'
+            name = SubProject(meson_depname)
+            wrap_type = 'file'
+            cfg = {
+                'directory': directory,
+                'source_url': url,
+                'source_filename': f'{directory}.tar.gz',
+                'source_hash': checksum,
+                'method': 'cargo',
+            }
+        elif package.source.startswith('git+'):
+            url, revision, directory = _parse_git_url(package.source)
+            name = SubProject(directory)
+            wrap_type = 'git'
+            cfg = {
+                'url': url,
+                'revision': revision,
+                'method': 'cargo',
+            }
+        else:
+            mlog.warning(f'Unsupported source URL in {filename}: {package.source}')
+            continue
+        if os.path.isdir(os.path.join(packagefiles_dir, name)):
+            cfg['patch_directory'] = name
+        if directory not in wraps:
+            wraps[directory] = PackageDefinition.from_values(name, subproject_dir, wrap_type, cfg)
+        wraps[directory].add_provided_dep(meson_depname)
+    cargolock.wraps = {w.name: w for w in wraps.values()}
+    return cargolock

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -301,10 +301,8 @@ class Interpreter:
         self.build_def_files: T.List[str] = []
         # Cargo packages
         filename = os.path.join(self.environment.get_source_dir(), subdir, 'Cargo.lock')
-        subprojects_dir = os.path.join(self.environment.get_source_dir(), subdir, subprojects_dir)
-        self.cargolock = load_cargo_lock(filename, subprojects_dir)
+        self.cargolock = self.environment.wrap_resolver.get_cargo_lock(subdir)
         if self.cargolock:
-            self.environment.wrap_resolver.merge_wraps(self.cargolock.wraps)
             self.build_def_files.append(filename)
 
     @property

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -335,9 +335,10 @@ class Interpreter(InterpreterBase, HoldableObject):
         from .. import cargo
         try:
             self.cargo = cargo.Interpreter(self.environment, self.subdir, self.subproject_dir)
-        except cargo.TomlImplementationMissing as e:
-            # error delayed to actual usage of a Cargo subproject
-            mlog.warning(f'cannot load Cargo.lock: {e}', fatal=False)
+        except cargo.TomlImplementationMissing:
+            # Error delayed to actual usage of a Cargo subproject. The warning
+            # has already been printed by Resolver.load_wraps().
+            pass
 
     def _redetect_machines(self) -> None:
         # Re-initialize machine descriptions. We can do a better job now because we

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -397,10 +397,10 @@ def run(options: argparse.Namespace) -> int:
     subprojects: T.Dict[SubProject, str] = {}
     extra_meson_args = []
     if options.include_subprojects:
-        subproject_dir = os.path.join(src_root, b.subproject_dir)
+        resolver = wrap.Resolver(src_root, b.subproject_dir, silent=True)
         for sub in set(itertools.chain(b.projects.host, b.projects.build)):
             if sub:
-                directory = wrap.get_directory(subproject_dir, sub)
+                directory = resolver.get_directory(sub)
                 subprojects[sub] = os.path.join(b.subproject_dir, directory)
         extra_meson_args.append('-Dwrap_mode=nodownload')
 

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -41,6 +41,8 @@ if T.TYPE_CHECKING:
     import http.client
     from typing_extensions import Literal
 
+    from ..cargo.manifest import CargoLock
+
     Method = Literal['meson', 'cmake', 'cargo']
 
 try:
@@ -367,6 +369,7 @@ class Resolver:
 
     def __post_init__(self) -> None:
         self.subdir_root = os.path.join(self.source_dir, self.subdir)
+        self.project_subdir = os.path.relpath(os.path.dirname(self.subdir_root), self.source_dir)
         self.cachedir = os.environ.get('MESON_PACKAGE_CACHE_DIR') or os.path.join(self.subdir_root, 'packagecache')
         self.wraps: T.Dict[str, PackageDefinition] = {}
         self.netrc: T.Optional[netrc] = None
@@ -376,6 +379,7 @@ class Resolver:
         self.wrapdb_provided_deps: T.Dict[str, str] = {}
         self.wrapdb_provided_programs: T.Dict[str, SubProject] = {}
         self.loaded_dirs: T.Set[str] = set()
+        self.cargolocks: T.Dict[str, T.Optional[CargoLock]] = {}
         self.load_wraps()
         self.load_netrc()
         self.load_wrapdb()
@@ -411,7 +415,36 @@ class Resolver:
         # Add provided deps and programs into our lookup tables
         for wrap in self.wraps.values():
             self.add_wrap(wrap)
+        self.get_cargo_lock(self.project_subdir, warn_only=True)
         self.loaded_dirs.add(self.subdir)
+
+    def get_cargo_lock(self, project_subdir: str, warn_only: bool = False) -> T.Optional[CargoLock]:
+        project_subdir = os.path.normpath(os.path.join(self.source_dir, project_subdir))
+        filename = os.path.join(project_subdir, 'Cargo.lock')
+        if filename in self.cargolocks:
+            return self.cargolocks[filename]
+
+        if not os.path.exists(filename):
+            self.cargolocks[filename] = None
+            return None
+
+        from ..cargo.interpreter import load_cargo_lock
+        from ..cargo.toml import TomlImplementationMissing
+        subdir_root = os.path.join(project_subdir, os.path.basename(self.subdir))
+        try:
+            cargolock = load_cargo_lock(filename, subdir_root)
+        except TomlImplementationMissing as e:
+            if not warn_only:
+                raise
+            # Error delayed to the actual usage of a Cargo subproject; do not
+            # cache the failure, so that it can be reported properly then.
+            mlog.warning(f'cannot load Cargo.lock: {e}', fatal=False, once=True)
+            return None
+
+        self.cargolocks[filename] = cargolock
+        if cargolock:
+            self.merge_wraps(cargolock.wraps)
+        return cargolock
 
     def add_wrap(self, wrap: PackageDefinition, ignore_dups: bool = False) -> None:
         for k in wrap.provided_deps.keys():
@@ -478,6 +511,7 @@ class Resolver:
         if self.wrap_mode != WrapMode.nopromote and subdir not in self.loaded_dirs:
             other_resolver = Resolver(self.source_dir, subdir, subproject, self.wrap_mode, self.wrap_frontend, self.allow_insecure, self.silent)
             self.merge_wraps(other_resolver.wraps)
+            self.cargolocks.update(other_resolver.cargolocks)
             self.loaded_dirs.add(subdir)
 
     def get_directory(self, packagename: str) -> str:

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -346,13 +346,6 @@ class PackageDefinition:
     def add_provided_dep(self, name: str) -> None:
         self.provided_deps[name] = None
 
-def get_directory(subdir_root: str, packagename: str) -> str:
-    fname = os.path.join(subdir_root, packagename + '.wrap')
-    if os.path.isfile(fname):
-        wrap = PackageDefinition.from_wrap_file(fname)
-        return wrap.directory
-    return packagename
-
 def verbose_git(cmd: T.List[str], workingdir: str, check: bool = False) -> bool:
     '''
     Wrapper to convert GitException to WrapException caught in interpreter.
@@ -486,6 +479,10 @@ class Resolver:
             other_resolver = Resolver(self.source_dir, subdir, subproject, self.wrap_mode, self.wrap_frontend, self.allow_insecure, self.silent)
             self.merge_wraps(other_resolver.wraps)
             self.loaded_dirs.add(subdir)
+
+    def get_directory(self, packagename: str) -> str:
+        wrap = self.wraps.get(packagename)
+        return wrap.directory if wrap else packagename
 
     def find_dep_provider(self, packagename: str) -> T.Tuple[T.Optional[str], T.Optional[str]]:
         # Python's ini parser converts all key values to lowercase.

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -442,8 +442,7 @@ class Resolver:
             return None
 
         self.cargolocks[filename] = cargolock
-        if cargolock:
-            self.merge_wraps(cargolock.wraps)
+        self.merge_wraps(cargolock.wraps)
         return cargolock
 
     def add_wrap(self, wrap: PackageDefinition, ignore_dups: bool = False) -> None:

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1655,6 +1655,26 @@ class AllPlatformTests(BasePlatformTests):
             # fails sometimes.
             pass
 
+    @skipIfNoExecutable('git')
+    @skip_if_not_language('rust')
+    def test_dist_subprojects_cargo(self):
+        if self.backend is not Backend.ninja:
+            raise SkipTest('Dist is only supported with Ninja')
+
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                project_dir = os.path.join(tmpdir, 'a')
+                shutil.copytree(os.path.join(self.rust_test_dir, '25 cargo lock'),
+                                project_dir)
+                git_init(project_dir)
+                self.init(project_dir)
+                self._run(self.meson_command + ['dist', '--include-subprojects'], workdir=self.builddir)
+        except PermissionError:
+            # When run under Windows CI, something (virus scanner?)
+            # holds on to the git files so cleaning up the dir
+            # fails sometimes.
+            pass
+
     def create_dummy_subproject(self, project_dir, name):
         path = os.path.join(project_dir, 'subprojects', name)
         os.makedirs(path)


### PR DESCRIPTION
Enable the usage of commands like `meson subprojects purge` and, more importantly, fix `meson dist --include-subprojects` for projects that use Cargo.lock.

Fixes: #15324 