### PR TITLE
envconfig: detect Rosetta 2 for can_run_host_binaries on Apple Silicon

### DIFF
--- a/docs/markdown/snippets/rosetta-can-run-host-binaries.md
+++ b/docs/markdown/snippets/rosetta-can-run-host-binaries.md
@@ -1,0 +1,8 @@
+## `meson.can_run_host_binaries()` now accounts for Rosetta 2 on Apple Silicon
+
+Previously, when cross-compiling for `x86_64` on an `aarch64` Mac,
+[[meson.can_run_host_binaries]] (and the underlying `needs_exe_wrapper`
+logic) always returned `false`, even though Rosetta 2 lets these Macs
+execute `x86_64` binaries directly. Meson now detects whether Rosetta 2
+is installed and, if so, reports that `x86_64` host binaries can run
+natively without requiring an `exe_wrapper`.

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -756,6 +756,19 @@ def detect_machine_info(compilers: T.Optional[CompilerDict] = None) -> MachineIn
         detect_kernel(system),
         detect_subsystem(system))
 
+def has_rosetta() -> bool:
+    """Whether Rosetta 2 is installed and able to translate x86_64 binaries.
+
+    oahd is the daemon that services Rosetta 2 translation requests; if it
+    can be reached, the kernel will transparently run x86_64 binaries on
+    this arm64 Mac.
+    """
+    try:
+        p, _, _ = Popen_safe(['/usr/bin/pgrep', '-q', 'oahd'])
+    except OSError:
+        return False
+    return p.returncode == 0
+
 # TODO make this compare two `MachineInfo`s purely. How important is the
 # `detect_cpu_family({})` distinction? It is the one impediment to that.
 def machine_info_can_run(machine_info: MachineInfo) -> bool:
@@ -773,7 +786,11 @@ def machine_info_can_run(machine_info: MachineInfo) -> bool:
         return False
     true_build_cpu_family = detect_cpu_family({})
     assert machine_info.cpu_family is not None, 'called on incomplete machine_info'
-    return \
-        (machine_info.cpu_family == true_build_cpu_family) or \
-        ((true_build_cpu_family == 'x86_64') and (machine_info.cpu_family == 'x86')) or \
-        ((true_build_cpu_family == 'mips64') and (machine_info.cpu_family == 'mips'))
+    if machine_info.cpu_family == true_build_cpu_family or \
+            (true_build_cpu_family == 'x86_64' and machine_info.cpu_family == 'x86') or \
+            (true_build_cpu_family == 'mips64' and machine_info.cpu_family == 'mips'):
+        return True
+    # Apple Silicon Macs can run x86_64 binaries via the Rosetta 2 translator.
+    if system == 'darwin' and true_build_cpu_family == 'aarch64' and machine_info.cpu_family == 'x86_64':
+        return has_rosetta()
+    return False


### PR DESCRIPTION
meson.can_run_host_binaries() always returned false when cross-compiling for x86_64 on an arm64 Mac, even though Rosetta 2 lets these machines execute x86_64 binaries transparently. machine_info_can_run() only compared CPU families for equality (plus narrow x86-on-x86_64 and mips-on-mips64 exceptions), with no awareness of Rosetta.

Add has_rosetta(), which checks whether the oahd translation daemon is running, and consult it in machine_info_can_run() when the host is Darwin/aarch64 and the target is x86_64.