### PR TITLE
compilers: keep MSVC linker flags out of checks

### DIFF
--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -127,6 +127,14 @@ class VisualStudioLikeCompiler(Compiler, metaclass=mesonlib.SimpleABC):
         # TODO: use ImmutableListProtocol[str] here instead
         return self.always_args.copy()
 
+    def get_compiler_args_for_mode(self, mode: CompileCheckMode) -> T.List[str]:
+        # Linker always-args are intended for link.exe, which Meson invokes as
+        # a separate build step.  Compiler checks link through cl.exe instead,
+        # where unwrapped linker options such as /release are compiler errors.
+        if mode is CompileCheckMode.LINK:
+            return self.get_always_args()
+        return super().get_compiler_args_for_mode(mode)
+
     def get_no_stdinc_args(self) -> T.List[str]:
         return ['/X']
 

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -28,7 +28,7 @@ import mesonbuild.modules.gnome
 import mesonbuild.scripts.env2mfile
 from mesonbuild import coredata
 from mesonbuild.compilers.c import ClangCCompiler, GnuCCompiler
-from mesonbuild.compilers.compilers import ManyInOneLinkerOptionStyle
+from mesonbuild.compilers.compilers import CompileCheckMode, ManyInOneLinkerOptionStyle
 from mesonbuild.compilers.cpp import VisualStudioCPPCompiler
 from mesonbuild.compilers.d import DmdDCompiler
 from mesonbuild.compilers.detect import detect_c_compiler
@@ -292,6 +292,13 @@ class InternalTests(unittest.TestCase):
 
         a = cc.compiler_args(cc.get_always_args())
         self.assertEqual(a.to_native(copy=True), ['/nologo', '/utf-8', '/Zc:__cplusplus'])
+
+        # Linker always-args must not leak into cl.exe compiler checks. In
+        # particular, link.exe accepts /release while cl.exe rejects it.
+        self.assertEqual(
+            cc.get_compiler_args_for_mode(CompileCheckMode.LINK),
+            ['/nologo', '/utf-8', '/Zc:__cplusplus'],
+        )
 
         # Ensure /source-charset: removes /utf-8
         a.append('/source-charset:utf-8')


### PR DESCRIPTION
`Compiler.get_compiler_args_for_mode()` started including the dynamic linker's always-arguments in 1.11. For MSVC builds, normal targets invoke `link.exe` separately, but compiler checks link through `cl.exe`. This placed linker-only options such as `/release` before `/link`, where `cl.exe` rejects them with D8043.

Keep link-mode compiler-check arguments limited to the MSVC compiler's own always-arguments. The regular link step still receives the dynamic linker's always-arguments through the backend.

The regression test uses the real `MSVCDynamicLinker` and verifies that link-mode compiler arguments do not contain its `/release` option.

Fixes #16086

Tests:

- `python run_unittests.py InternalTests.test_compiler_args_class_visualstudio`
- `python run_mypy.py mesonbuild/compilers/mixins/visualstudio.py`
- `git diff --check`
