### PR TITLE
CI/windows: Replace original pkg-config with pkgconf

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -90,13 +90,10 @@ jobs:
           Invoke-WebRequest -Uri $python27Url -OutFile $python27Msi
           Start-Process msiexec.exe -Wait -ArgumentList "/I $python27Msi /quiet"
 
-      - name: Install pkg-config
-        shell: pwsh
-        run: |
-          $pkgconfigDir = "${{ runner.temp }}\pkgconfig"
-          New-Item -ItemType Directory -Path $pkgconfigDir -Force
-          Invoke-WebRequest -Uri "https://raw.githubusercontent.com/mesonbuild/cidata/refs/heads/master/win32/pkg-config.exe" -OutFile "$pkgconfigDir\pkg-config.exe"
-          echo "$pkgconfigDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Install pkgconf
+        uses: MinoruSekine/setup-scoop@v5
+        with:
+          apps: pkgconf
 
       - name: Install Chocolatey Dependencies
         shell: pwsh


### PR DESCRIPTION
I am not sure why meson run it's test with a old pkg-config version (0.28).
I believe it might be a good idea to run test with pkgconf.