### PR TITLE
Update debug arguments for CompCert compiler

### DIFF
--- a/mesonbuild/compilers/mixins/compcert.py
+++ b/mesonbuild/compilers/mixins/compcert.py
@@ -31,7 +31,7 @@ ccomp_optimization_args: T.Dict[str, T.List[str]] = {
 
 ccomp_debug_args: T.Dict[bool, T.List[str]] = {
     False: [],
-    True: ['-O0', '-g']
+    True: ['-g']
 }
 
 # As of CompCert 20.04, these arguments should be passed to the underlying gcc linker (via -WUl,<arg>)


### PR DESCRIPTION
Remove optimization flag '-O0' from debug arguments.

I think optimizations were accidentally disabled.