### PR TITLE
Ensure coverage info is not empty.

### DIFF
--- a/test cases/common/1 trivial/trivial.c
+++ b/test cases/common/1 trivial/trivial.c
@@ -1,6 +1,11 @@
 #include<stdio.h>
 
-int main(void) {
+int main(int argc, char **argv) {
+    /* Have a non-elidable branch to make sure coverage info is not empty. */
+    if(argc > 1) {
+        printf("A command line argument was passed to the program.\n");
+        (void)argv;
+    }
     printf("Trivial test is working.\n");
     return 0;
 }

--- a/test cases/common/243 escape++/test.c
+++ b/test cases/common/243 escape++/test.c
@@ -1,3 +1,9 @@
-int main(void) {
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+    if(argc > 1) {
+        printf("A command line argument was passed to this program.\n");
+        (void)argv;
+    }
     return 0;
 }


### PR DESCRIPTION
This seems to be caused by a change in lcov. Originally detected in Debian:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1144176