### PR TITLE
cmake: add TARGET_LINKER_FILE, TARGET_FILE_NAME, TARGET_FILE_DIR

### DIFF
--- a/mesonbuild/cmake/generator.py
+++ b/mesonbuild/cmake/generator.py
@@ -56,9 +56,9 @@ def parse_generator_expressions(
         props = trace.targets[args[0]].properties.get(args[1], []) if args[0] in trace.targets else []
         return ';'.join(props)
 
-    def target_file(arg: str) -> str:
+    def target_artifact(arg: str, genex: str, linker_file: bool) -> str:
         if arg not in trace.targets:
-            mlog.warning(f"Unable to evaluate the cmake variable '$<TARGET_FILE:{arg}>'.")
+            mlog.warning(f"Unable to evaluate the cmake expression '$<{genex}:{arg}>'.")
             return ''
         tgt = trace.targets[arg]
 
@@ -78,15 +78,24 @@ def parse_generator_expressions(
             if 'RELEASE' in cfgs:
                 cfg = 'RELEASE'
 
-        for base in ['IMPORTED_IMPLIB', 'IMPORTED_LOCATION']:
+        # TARGET_LINKER_FILE is the import library on DLL platforms, and falls
+        # back to the main artifact (TARGET_FILE) everywhere else.
+        bases = ['IMPORTED_IMPLIB', 'IMPORTED_LOCATION'] if linker_file else ['IMPORTED_LOCATION']
+        for base in bases:
             for prop in [f'{base}_{cfg}', base]:
                 if prop in tgt.properties:
                     vals = [x for x in tgt.properties[prop] if x]
                     if len(vals) > 1:
-                        mlog.warning(f"'$<TARGET_FILE:{arg}>' evaluated to more than one file; only the first one is used.")
+                        mlog.warning(f"'$<{genex}:{arg}>' evaluated to more than one file; only the first one is used.")
                     return vals[0] if vals else ''
         mlog.warning(f"Unable to evaluate the cmake expression '$<{genex}:{arg}>'.")
         return ''
+
+    def target_file(arg: str) -> str:
+        return target_artifact(arg, 'TARGET_FILE', False)
+
+    def target_linker_file(arg: str) -> str:
+        return target_artifact(arg, 'TARGET_LINKER_FILE', True)
 
     supported: T.Dict[str, T.Callable[[str], str]] = {
         # Boolean functions
@@ -130,6 +139,7 @@ def parse_generator_expressions(
         'TARGET_NAME_IF_EXISTS': lambda x: x if x in trace.targets else '',
         'TARGET_PROPERTY': target_property,
         'TARGET_FILE': target_file,
+        'TARGET_LINKER_FILE': target_linker_file,
     }
 
     # Recursively evaluate generator expressions

--- a/mesonbuild/cmake/generator.py
+++ b/mesonbuild/cmake/generator.py
@@ -2,11 +2,12 @@
 # Copyright 2019 The Meson development team
 
 from __future__ import annotations
+import os
+import typing as T
 
 from .. import mesonlib
 from .. import mlog
 from .common import cmake_is_debug
-import typing as T
 
 if T.TYPE_CHECKING:
     from .traceparser import CMakeTraceParser, CMakeTarget
@@ -97,6 +98,14 @@ def parse_generator_expressions(
     def target_linker_file(arg: str) -> str:
         return target_artifact(arg, 'TARGET_LINKER_FILE', True)
 
+    def target_file_name(arg: str) -> str:
+        tgt_file = target_artifact(arg, 'TARGET_FILE_NAME', False)
+        return os.path.basename(tgt_file) if tgt_file else ''
+
+    def target_file_dir(arg: str) -> str:
+        tgt_file = target_artifact(arg, 'TARGET_FILE_DIR', False)
+        return os.path.dirname(tgt_file) if tgt_file else ''
+
     supported: T.Dict[str, T.Callable[[str], str]] = {
         # Boolean functions
         'BOOL': lambda x: '0' if x.upper() in {'', '0', 'FALSE', 'OFF', 'N', 'NO', 'IGNORE', 'NOTFOUND'} or x.endswith('-NOTFOUND') else '1',
@@ -139,6 +148,8 @@ def parse_generator_expressions(
         'TARGET_NAME_IF_EXISTS': lambda x: x if x in trace.targets else '',
         'TARGET_PROPERTY': target_property,
         'TARGET_FILE': target_file,
+        'TARGET_FILE_NAME': target_file_name,
+        'TARGET_FILE_DIR': target_file_dir,
         'TARGET_LINKER_FILE': target_linker_file,
     }
 

--- a/mesonbuild/cmake/generator.py
+++ b/mesonbuild/cmake/generator.py
@@ -85,6 +85,7 @@ def parse_generator_expressions(
                     if len(vals) > 1:
                         mlog.warning(f"'$<TARGET_FILE:{arg}>' evaluated to more than one file; only the first one is used.")
                     return vals[0] if vals else ''
+        mlog.warning(f"Unable to evaluate the cmake expression '$<{genex}:{arg}>'.")
         return ''
 
     supported: T.Dict[str, T.Callable[[str], str]] = {

--- a/mesonbuild/cmake/generator.py
+++ b/mesonbuild/cmake/generator.py
@@ -78,14 +78,13 @@ def parse_generator_expressions(
             if 'RELEASE' in cfgs:
                 cfg = 'RELEASE'
 
-        if f'IMPORTED_IMPLIB_{cfg}' in tgt.properties:
-            return ';'.join([x for x in tgt.properties[f'IMPORTED_IMPLIB_{cfg}'] if x])
-        elif 'IMPORTED_IMPLIB' in tgt.properties:
-            return ';'.join([x for x in tgt.properties['IMPORTED_IMPLIB'] if x])
-        elif f'IMPORTED_LOCATION_{cfg}' in tgt.properties:
-            return ';'.join([x for x in tgt.properties[f'IMPORTED_LOCATION_{cfg}'] if x])
-        elif 'IMPORTED_LOCATION' in tgt.properties:
-            return ';'.join([x for x in tgt.properties['IMPORTED_LOCATION'] if x])
+        for base in ['IMPORTED_IMPLIB', 'IMPORTED_LOCATION']:
+            for prop in [f'{base}_{cfg}', base]:
+                if prop in tgt.properties:
+                    vals = [x for x in tgt.properties[prop] if x]
+                    if len(vals) > 1:
+                        mlog.warning(f"'$<TARGET_FILE:{arg}>' evaluated to more than one file; only the first one is used.")
+                    return vals[0] if vals else ''
         return ''
 
     supported: T.Dict[str, T.Callable[[str], str]] = {

--- a/mesonbuild/cmake/generator.py
+++ b/mesonbuild/cmake/generator.py
@@ -83,11 +83,11 @@ def parse_generator_expressions(
         bases = ['IMPORTED_IMPLIB', 'IMPORTED_LOCATION'] if linker_file else ['IMPORTED_LOCATION']
         for base in bases:
             for prop in [f'{base}_{cfg}', base]:
-                if prop in tgt.properties:
-                    vals = [x for x in tgt.properties[prop] if x]
+                vals = [x for x in tgt.properties.get(prop, []) if x]
+                if vals:
                     if len(vals) > 1:
                         mlog.warning(f"'$<{genex}:{arg}>' evaluated to more than one file; only the first one is used.")
-                    return vals[0] if vals else ''
+                    return vals[0]
         mlog.warning(f"Unable to evaluate the cmake expression '$<{genex}:{arg}>'.")
         return ''
 


### PR DESCRIPTION
Supersedes #16097, fixing a bunch of related issues:

* During discussion of that PR there was a question of whether/when cmake would return more than one element in the IMPORTED_IMPLIB and IMPORTED_LOCATION properties. This shouldn't happen, so change Meson to warn if this is encountered
* While reviewing the code, I noticed that IMPORTED_IMPLIB is actually tied to TARGET_LINKER_FILE, not TARGET_FILE. So move the existing code to TARGET_LINKER_FILE and reimplement TARGET_FILE in the same vein but leaving out IMPORTED_IMPLIB.
* Finally implement TARGET_FILE_DIR because it was requested in #16096, and TARGET_FILE_NAME because it's easy

Cc @dnicolodi, @stephanlachnit 
Fixes: #16096