### PR TITLE
compilers(MSVC): use `/Fe` for `.dll` too

### DIFF
--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -171,7 +171,8 @@ class VisualStudioLikeCompiler(Compiler, metaclass=mesonlib.SimpleABC):
     def get_output_args(self, outputname: str) -> T.List[str]:
         if self.mode == 'PREPROCESSOR':
             return ['/Fi' + outputname]
-        if outputname.endswith('.exe'):
+        # hack: this list is not exhaustive
+        if outputname.endswith(('.exe', '.dll')):
             return ['/Fe' + outputname]
         return ['/Fo' + outputname]
 


### PR DESCRIPTION
This avoids erroneously generating e.g.

```
clang-cl.exe ... /Fosanity_check_for_cython.dll sanity_check_for_cython.c ... /link ... /DLL
```

as happens in Meson 1.12.0 — see https://github.com/scipy/scipy/issues/25904 for an issue that might have been avoided without this bug.

Ref. https://learn.microsoft.com/en-us/cpp/build/reference/fo-object-file-name?view=msvc-170 vs. https://learn.microsoft.com/en-us/cpp/build/reference/fe-name-exe-file?view=msvc-170.

---

Issue diagnosed and patch generated by Claude Opus 5; patch reviewed and edited by me.