### PR TITLE
compilers: route sanity-check link args through linker_to_compiler_args

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -282,9 +282,17 @@ class CLikeCompiler(Compiler):
         # Cross-compiling is hard. For example, you might need -nostdlib, or to pass --target, etc.
         mode = CompileCheckMode.COMPILE if self.is_cross and not self.environment.has_exe_wrapper() else CompileCheckMode.LINK
         cargs, b_largs = self._get_basic_compiler_args(mode)
-        largs = self.linker_to_compiler_args(b_largs)
         s_args, s_largs = super()._sanity_check_compile_args(sourcename, binname)
-        return s_args + cargs, s_largs + largs
+        # Base Compiler._sanity_check_compile_args returns raw
+        # language_link_args. MSVC-style linker_to_compiler_args() already
+        # emits a leading /link (even for []). Concatenating the raw list
+        # in front of that existing /link is the 1.12 #16111 bug
+        # (/SUBSYSTEM:CONSOLE /link). Appending it after convert(b_largs)
+        # is also wrong when the cross file already contains /link
+        # (the documented workaround): convert([]) + ['/link', …] becomes
+        # /link /link … and clang-cl forwards the second /link to the linker.
+        # Merge the raw lists and convert once so there is a single /link.
+        return s_args + cargs, self.linker_to_compiler_args(s_largs + b_largs)
 
     def check_header(self, hname: str, prefix: str, *,
                      extra_args: T.Union[None, T.List[str], T.Callable[['CompileCheckMode'], T.List[str]]] = None,

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -11,6 +11,7 @@ import json
 import operator
 import os
 import pickle
+import shutil
 import stat
 import subprocess
 import tempfile
@@ -29,8 +30,8 @@ import mesonbuild.modules.gnome
 import mesonbuild.scripts.depfixer
 import mesonbuild.scripts.env2mfile
 from mesonbuild import coredata
-from mesonbuild.compilers.c import ClangCCompiler, GnuCCompiler
-from mesonbuild.compilers.compilers import ManyInOneLinkerOptionStyle
+from mesonbuild.compilers.c import ClangCCompiler, ClangClCCompiler, GnuCCompiler, VisualStudioCCompiler
+from mesonbuild.compilers.compilers import CompileCheckMode, ManyInOneLinkerOptionStyle
 from mesonbuild.compilers.cpp import VisualStudioCPPCompiler
 from mesonbuild.compilers.d import DmdDCompiler
 from mesonbuild.compilers.detect import detect_c_compiler
@@ -2511,3 +2512,119 @@ Thread model: posix'''), '21.9.0')
                 mesonbuild.scripts.depfixer.fix_rpath(
                     fname, set(), '', '', {}, system='linux', verbose=False)
                 mock_fix_darwin.assert_not_called()
+
+    def _msvc_c_compiler(self, cls, *, is_cross, link_args=None, exelist=None):
+        env = get_fake_env()
+        env.add_lang_args('c', cls, MachineChoice.HOST)
+        env.coredata.optstore.set_option(
+            OptionKey('c_link_args', machine=MachineChoice.HOST),
+            link_args if link_args is not None else ['/SUBSYSTEM:CONSOLE'])
+        if cls is ClangClCCompiler:
+            linker = linkers.ClangClDynamicLinker(env, MachineChoice.HOST, [])
+            cc = cls(exelist or ['clang-cl'], '21.1.4', MachineChoice.HOST, env,
+                     'x86_64', linker=linker)
+        else:
+            linker = linkers.MSVCDynamicLinker(env, MachineChoice.HOST, [])
+            cc = cls([], exelist or ['cl'], '19.40', MachineChoice.HOST, env,
+                     'x64', linker=linker)
+        cc.is_cross = is_cross
+        return cc
+
+    def test_msvc_sanity_check_link_args_meet_existing_slash_link(self) -> None:
+        """#16111: raw c_link_args must join the /link convert() already emits.
+
+        1.12 prepended language_link_args in front of convert(b_largs).
+        convert([]) is already ['/link'] for cl and clang-cl, so
+        /SUBSYSTEM:CONSOLE /link is a compiler input.
+
+        The documented workaround puts /link in the cross file. Appending
+        those raw args after convert([]) yields /link /link ...; clang-cl
+        forwards the second /link to the linker. Merge + convert once
+        collapses that to a single /link.
+
+        clang-cl only treats lowercase /link (and -link) as the separator;
+        /LINK is an input file. Meson emits /link. We do not have cl.exe
+        here; cl coverage is the constructed command line.
+        """
+        for cls in (VisualStudioCCompiler, ClangClCCompiler):
+            with self.subTest(compiler=cls.__name__):
+                self.assertEqual(
+                    self._msvc_c_compiler(cls, is_cross=False).linker_to_compiler_args([]),
+                    ['/link'])
+
+                for is_cross, link_args in (
+                        (True, ['/SUBSYSTEM:CONSOLE']),
+                        (False, ['/SUBSYSTEM:CONSOLE']),
+                        (True, ['/link', '/SUBSYSTEM:CONSOLE']),
+                ):
+                    with self.subTest(is_cross=is_cross, link_args=link_args):
+                        cc = self._msvc_c_compiler(cls, is_cross=is_cross, link_args=link_args)
+                        cmd, largs = cc._sanity_check_compile_args('s.c', 's.exe')
+                        self.assertEqual(largs.count('/link'), 1, largs)
+                        self.assertLess(largs.index('/link'), largs.index('/SUBSYSTEM:CONSOLE'), largs)
+                        self.assertNotIn('/SUBSYSTEM:CONSOLE', cmd)
+
+                wrapped = list(self._msvc_c_compiler(
+                    cls, is_cross=False).build_wrapper_args(None, None, CompileCheckMode.LINK))
+                self.assertEqual(wrapped.count('/link'), 1, wrapped)
+                self.assertLess(wrapped.index('/link'), wrapped.index('/SUBSYSTEM:CONSOLE'), wrapped)
+
+    def test_gnu_sanity_check_still_forwards_c_link_args(self) -> None:
+        env = get_fake_env()
+        env.add_lang_args('c', GnuCCompiler, MachineChoice.HOST)
+        env.coredata.optstore.set_option(
+            OptionKey('c_link_args', machine=MachineChoice.HOST),
+            ['-Wl,--as-needed'])
+        linker = linkers.GnuBFDDynamicLinker(
+            [], env, MachineChoice.HOST, ManyInOneLinkerOptionStyle('-Wl,', ','), [])
+        cc = GnuCCompiler([], [], 'fake', MachineChoice.HOST, env, linker=linker)
+        _, largs = cc._sanity_check_compile_args('sanity.c', 'sanity.exe')
+        self.assertIn('-Wl,--as-needed', largs)
+        self.assertNotIn('/link', largs)
+
+    def test_msvc_sanity_check_driver_rejects_subsystem_before_slash_link(self) -> None:
+        """End-to-end: a driver that rejects /SUBSYSTEM before /link.
+
+        Used for both cl and clang-cl. Real clang-cl is used when present
+        (compile-only; this Mac has no link.exe).
+        """
+        script = textwrap.dedent("""\
+            import sys
+            args = sys.argv[1:]
+            if '/?' in args or '--version' in args:
+                print('CL.EXE COMPATIBILITY OPTIONS:')
+                raise SystemExit(0)
+            link_at = args.index('/link') if '/link' in args else len(args)
+            for arg in args[:link_at]:
+                if arg.upper().startswith('/SUBSYSTEM:'):
+                    print(f"clang-cl: error: no such file or directory: '{arg}'",
+                          file=sys.stderr)
+                    raise SystemExit(1)
+            raise SystemExit(0)
+            """)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fake = os.path.join(tmpdir, 'driver.py')
+            with open(fake, 'w', encoding='utf-8') as f:
+                f.write(script)
+            for cls in (VisualStudioCCompiler, ClangClCCompiler):
+                with self.subTest(compiler=cls.__name__):
+                    cc = self._msvc_c_compiler(
+                        cls, is_cross=True, exelist=[*python_command, fake])
+                    cc.sanity_check(tmpdir)
+
+        clang_cl = shutil.which('clang-cl')
+        if clang_cl is None:
+            for candidate in ('/opt/homebrew/opt/llvm/bin/clang-cl',
+                              '/usr/local/opt/llvm/bin/clang-cl'):
+                if os.path.isfile(candidate):
+                    clang_cl = candidate
+                    break
+        if clang_cl is None:
+            return
+        out = subprocess.check_output(
+            [clang_cl, '/?'], text=True, encoding='utf-8', stderr=subprocess.STDOUT)
+        if 'CL.EXE COMPATIBILITY' not in out:
+            return
+        cc = self._msvc_c_compiler(ClangClCCompiler, is_cross=True, exelist=[clang_cl])
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cc.sanity_check(tmpdir)


### PR DESCRIPTION
Fixes #16111.

Single CLike change. `visualstudio.py` is untouched.

## Why merge + convert once

`linker_to_compiler_args([])` is already `['/link']` for cl and clang-cl. 1.12 prepended raw `c_link_args` in front of that existing `/link`.

The documented workaround puts `/link` in the cross file. The other obvious join — append those raw args after `convert(b_largs)` — produces `/link /link …`. On real clang-cl the second `/link` is forwarded to the linker (observed with a fake `lld-link`: argv contained `' /link /SUBSYSTEM:CONSOLE'`).

Merge the raw lists and convert once so there is a single `/link`.

## cl vs clang-cl (run, not read)

Homebrew clang-cl 22.1.2:

* Only lowercase `/link` and `-link` are separators. `/LINK` / `/Link` are input files (`no such file or directory`).
* `/c … /SUBSYSTEM:CONSOLE /link` fails; `/c … /link /SUBSYSTEM:CONSOLE` exits 0.
* Extra `/link` after the separator is passed through to the linker.

No `cl.exe` here. MSVC coverage is the constructed command line; `cl` is generally case-insensitive, but Meson already emits `/link`.

## Tests

* `cl` and `clang-cl`: compile-only and link-mode sanity lines; cross-file `/link` workaround still one `/link`; `build_wrapper_args` still inserts `/link` (`linker_to_compiler_args([]) == ['/link']`).
* GNU `c_link_args` still forwarded.
* Fake driver for both; real clang-cl compile-only sanity when present.

No `cl.exe` / `link.exe` / `lld-link` on this Mac.