### PR TITLE
Replace mesonlib.is_xxx with checks on the machine

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -606,6 +606,23 @@ class Backend:
             result.append(self.get_target_private_dir_abs(l))
         return result
 
+    def get_exe_interpreter(self, exe_cmd: T.List[str], for_machine: MachineChoice) -> T.List[str]:
+        """Return the command needed to run exe_cmd, if it is not directly executable."""
+        if exe_cmd[0].endswith('.jar'):
+            return ['java', '-jar']
+        # Wrap the executable in mono in very limited cases:
+        # - the executable can run on the build machine (if not, let the user make
+        #   their own decision, and use e.g. wine to start .NET executables)
+        # - the target does not use the .exe suffix for all executables (if so,
+        #   assume it is able to start .NET executables as well), or at least for
+        #   some as is the case for WSL1.
+        machine = self.environment.machines[for_machine]
+        if exe_cmd[0].endswith('.exe') and \
+                (self.environment.machines.matches_build_machine(for_machine) or not self.environment.need_exe_wrapper()) and \
+                not (machine.get_exe_suffix() == 'exe' or mesonlib.is_wsl()):
+            return ['mono']
+        return []
+
     def get_executable_serialisation(
             self, cmd: T.Iterable[build.CommandTypes],
             workdir: T.Optional[str] = None,
@@ -664,20 +681,17 @@ class Backend:
             extra_paths = []
 
         is_cross_built = not self.environment.machines.matches_build_machine(exe_for_machine)
-        if is_cross_built and self.environment.need_exe_wrapper():
+        interpreter = self.get_exe_interpreter(exe_cmd, exe_for_machine)
+        if interpreter:
+            exe_cmd = interpreter + exe_cmd
+            exe_wrapper = None
+        elif is_cross_built and self.environment.need_exe_wrapper():
             if not self.environment.has_exe_wrapper():
                 msg = 'An exe_wrapper is needed for ' + exe_cmd[0] + ' but was not found. Please define one ' \
                       'in cross file and check the command and/or add it to PATH.'
                 raise MesonException(msg)
             exe_wrapper = self.environment.get_exe_wrapper()
         else:
-            if exe_cmd[0].endswith('.jar'):
-                exe_cmd = ['java', '-jar'] + exe_cmd
-            # We know the executable can run on the build machine; do not wrap
-            # it in mono if the target uses the .exe suffix for all executables,
-            # or if .exe files can be run as is the case for WSL1.
-            elif exe_cmd[0].endswith('.exe') and not (machine.get_exe_suffix() == 'exe' or mesonlib.is_wsl()):
-                exe_cmd = ['mono'] + exe_cmd
             exe_wrapper = None
 
         workdir = workdir or self.environment.get_build_dir()

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -673,7 +673,10 @@ class Backend:
         else:
             if exe_cmd[0].endswith('.jar'):
                 exe_cmd = ['java', '-jar'] + exe_cmd
-            elif exe_cmd[0].endswith('.exe') and not (mesonlib.is_windows() or mesonlib.is_cygwin() or mesonlib.is_wsl() or machine.is_os2()):
+            # We know the executable can run on the build machine; do not wrap
+            # it in mono if the target uses the .exe suffix for all executables,
+            # or if .exe files can be run as is the case for WSL1.
+            elif exe_cmd[0].endswith('.exe') and not (machine.get_exe_suffix() == 'exe' or mesonlib.is_wsl()):
                 exe_cmd = ['mono'] + exe_cmd
             exe_wrapper = None
 

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -219,10 +219,16 @@ class TestSerialisation:
     depends: T.List[str]
     version: str
     verbose: bool
+    # Path of the test program itself.
+    exe_fname: str
 
     def __post_init__(self) -> None:
         if self.exe_wrapper is not None:
             assert isinstance(self.exe_wrapper, programs.ExternalProgram)
+
+    @property
+    def cmd_has_interpreter(self) -> bool:
+        return self.fname[0] != self.exe_fname
 
 
 def get_backend_from_name(backend: str, build: T.Optional[build.Build] = None) -> Backend:
@@ -1296,6 +1302,8 @@ class Backend:
             is_cross = self.environment.is_cross_build(test_for_machine)
             exe_wrapper = self.environment.get_exe_wrapper()
             machine = self.environment.machines[exe.for_machine]
+            exe_fname = cmd[0]
+            cmd = self.get_exe_interpreter(cmd, test_for_machine) + cmd
             if machine.is_windows() or machine.is_cygwin():
                 extra_bdeps: T.List[build.BuildTargetTypes] = []
                 if isinstance(exe, build.CustomTarget):
@@ -1358,7 +1366,7 @@ class Backend:
                                    isinstance(exe, build.Executable),
                                    [x.get_id() for x in depends],
                                    self.environment.coredata.version,
-                                   t.verbose)
+                                   t.verbose, exe_fname)
             arr.append(ts)
         return arr
 

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -321,6 +321,17 @@ class Backend:
             filename = t.get_filename()
         return os.path.join(self.get_target_dir(t), filename)
 
+    def get_aix_so_archive_name(self, t: build.AnyTargetType, filename: str) -> T.Optional[str]:
+        '''On AIX shared libraries are stored inside an archive; it is the archive
+        that gets linked against and installed.  Shared modules are not archived.
+        Return the name of the archive, or None if TARGET is not archived.'''
+        if not isinstance(t, build.SharedLibrary) or not t.aix_so_archive:
+            return None
+        if not self.environment.machines[t.for_machine].is_aix():
+            return None
+        linker, _ = t.get_clink_dynamic_linker_and_stdlibs()
+        return linker.get_archive_name(filename)
+
     def get_target_filename_abs(self, target: build.AnyTargetType) -> str:
         return os.path.join(self.environment.get_build_dir(), self.get_target_filename(target))
 
@@ -362,8 +373,7 @@ class Backend:
         if isinstance(target, build.SharedLibrary):
             link_lib = target.get_import_filename() or target.get_filename()
             # In AIX, if we archive .so, the blibpath must link to archived shared library otherwise to the .so file.
-            if mesonlib.is_aix() and target.aix_so_archive:
-                link_lib = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*', '.a', link_lib.replace('.so', '.a'))
+            link_lib = self.get_aix_so_archive_name(target, link_lib) or link_lib
             return Path(self.get_target_dir(target), link_lib).as_posix()
         elif isinstance(target, build.StaticLibrary):
             return Path(self.get_target_dir(target), target.get_filename()).as_posix()
@@ -1818,7 +1828,11 @@ class Backend:
                 if first_outdir is not False:
                     tag = t.install_tag[0] or ('devel' if isinstance(t, build.StaticLibrary) else 'runtime')
                     mappings = t.get_link_deps_mapping(d.prefix)
-                    i = TargetInstallData(self.get_target_filename(t), first_outdir,
+                    # In AIX we archive our shared libraries, and it is the archive
+                    # that has to be installed rather than the .so itself.
+                    fname = self.get_target_filename(t)
+                    fname = self.get_aix_so_archive_name(t, fname) or fname
+                    i = TargetInstallData(fname, first_outdir,
                                           first_outdir_name,
                                           should_strip, mappings, t.rpath_dirs_to_remove,
                                           t.install_rpath, install_mode, t.subproject,

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1199,10 +1199,10 @@ class NinjaBackend(backends.Backend):
         self.add_build(elem)
         #In AIX, we archive shared libraries. If the instance is a shared library, we add a command to archive the shared library
         #object and create the build element.
-        if isinstance(target, build.SharedLibrary) and self.environment.machines[target.for_machine].is_aix():
-            if target.aix_so_archive:
-                elem = NinjaBuildElement(self.all_outputs, linker.get_archive_name(outname), 'AIX_LINKER', [outname])
-                self.add_build(elem)
+        archive_name = self.get_aix_so_archive_name(target, outname)
+        if archive_name is not None:
+            elem = NinjaBuildElement(self.all_outputs, archive_name, 'AIX_LINKER', [outname])
+            self.add_build(elem)
 
     def should_use_dyndeps_for_target(self, target: build.BuildTargetTypes) -> bool:
         if not self.ninja_has_dyndeps:
@@ -3614,12 +3614,10 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             target_file = self.get_target_filename_for_linking(target)
         else:
             target_file = self.get_target_filename(target)
-        if isinstance(target, build.SharedLibrary) and target.aix_so_archive:
-            if self.environment.machines[target.for_machine].is_aix():
-                linker, stdlib_args = target.get_clink_dynamic_linker_and_stdlibs()
-                target.get_outputs()[0] = linker.get_archive_name(target.get_outputs()[0])
-                target_file = target.get_outputs()[0]
-                target_file = os.path.join(self.get_target_dir(target), target_file)
+        archive_name = self.get_aix_so_archive_name(target, target.get_outputs()[0])
+        if archive_name is not None:
+            target.get_outputs()[0] = archive_name
+            target_file = os.path.join(self.get_target_dir(target), archive_name)
         symname = self.get_target_shsym_filename(target)
         elem = NinjaBuildElement(self.all_outputs, symname, 'SHSYM', target_file)
         # The library we will actually link to, which is an import library on Windows (not the DLL)
@@ -4214,10 +4212,9 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 # Add the first output of each target to the 'all' target so that
                 # they are all built
                 #Add archive file if shared library in AIX for build all.
-                if isinstance(t, build.SharedLibrary) and t.aix_so_archive:
-                    if self.environment.machines[t.for_machine].is_aix():
-                        linker, stdlib_args = t.get_clink_dynamic_linker_and_stdlibs()
-                        t.get_outputs()[0] = linker.get_archive_name(t.get_outputs()[0])
+                archive_name = self.get_aix_so_archive_name(t, t.get_outputs()[0])
+                if archive_name is not None:
+                    t.get_outputs()[0] = archive_name
                 targetlist.append(os.path.join(self.get_target_dir(t), t.get_outputs()[0]))
 
                 # Add an import library if shared library in OS/2 for build all

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -9,7 +9,7 @@ import string
 import typing as T
 
 from .. import options
-from ..mesonlib import is_windows, LibType, version_compare
+from ..mesonlib import LibType, version_compare
 from .compilers import Compiler, CompileCheckMode, CrossNoRunException, SimplePrefixLinkerOptionStyle
 
 if T.TYPE_CHECKING:
@@ -622,7 +622,7 @@ class CudaCompiler(Compiler):
         # On Windows, the version of the C++ standard used by nvcc is dictated by
         # the combination of CUDA version and MSVC version; the --std= is thus ignored
         # and attempting to use it will result in a warning: https://stackoverflow.com/a/51272091/741027
-        if not is_windows():
+        if not self.info.is_windows():
             std = self.get_compileropt_value('std', target, subproject)
             assert isinstance(std, str)
             if std != 'none':

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -53,6 +53,7 @@ if is_windows():
     defaults['objc'] = ['clang', 'clang-cl', 'gcc']
     defaults['objcpp'] = ['clang++', 'clang-cl', 'g++']
     defaults['cs'] = ['csc', 'mcs']
+    defaults['vs_static_linker'] = ['lib']
 else:
     if platform.machine().lower() == 'e2k':
         defaults['c'] = ['cc', 'gcc', 'lcc', 'clang']
@@ -76,7 +77,6 @@ defaults['vala'] = ['valac']
 defaults['cython'] = ['cython', 'cython3'] # Official name is cython, but Debian renamed it to cython3.
 defaults['static_linker'] = ['ar', 'gar']
 defaults['strip'] = ['strip']
-defaults['vs_static_linker'] = ['lib']
 defaults['clang_cl_static_linker'] = ['llvm-lib']
 defaults['cuda_static_linker'] = ['nvlink']
 defaults['gcc_static_linker'] = ['gcc-ar']
@@ -178,29 +178,30 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
                          once=True, fatal=False)
 
         m = env.machines[compiler.for_machine]
-        default_linkers = [[l] for l in defaults['static_linker']]
+        trials = [[l] for l in defaults['static_linker']]
         if compiler.language == 'cuda':
-            trials = [defaults['cuda_static_linker']] + default_linkers
+            trials = [defaults['cuda_static_linker']] + trials
         elif compiler.get_argument_syntax() == 'msvc':
-            trials = [defaults['vs_static_linker'], defaults['clang_cl_static_linker']]
+            trials = [defaults['clang_cl_static_linker']]
+            if 'vs_static_linker' in defaults:
+                trials = [defaults['vs_static_linker']] + trials
         elif m.is_os2() and env.coredata.optstore.get_value_for(OptionKey('os2_emxomf')):
-            trials = [defaults['emxomf_static_linker']] + default_linkers
+            trials = [defaults['emxomf_static_linker']] + trials
         elif compiler.id == 'gcc':
             # Use gcc-ar if available; needed for LTO
-            trials = [defaults['gcc_static_linker']] + default_linkers
+            trials = [defaults['gcc_static_linker']] + trials
         elif compiler.id == 'clang':
             # Use llvm-ar if available; needed for LTO
             llvm_ar = defaults['clang_static_linker']
             # Extract the version major of the compiler to use as a suffix
             suffix = compiler.version.split('.')[0]
             # Prefer suffixed llvm-ar first, then unsuffixed then the defaults
-            trials = [[f'{llvm_ar[0]}-{suffix}'], llvm_ar] + default_linkers
-        elif compiler.language == 'd':
+            trials = [[f'{llvm_ar[0]}-{suffix}'], llvm_ar] + trials
+        elif compiler.language == 'd' and m.is_windows():
             # Prefer static linkers over linkers used by D compilers
-            if m.is_windows():
-                trials = [defaults['vs_static_linker'], defaults['clang_cl_static_linker'], compiler.get_linker_exelist()]
-            else:
-                trials = default_linkers
+            trials = [defaults['clang_cl_static_linker'], compiler.get_linker_exelist()]
+            if 'vs_static_linker' in defaults:
+                trials = [defaults['vs_static_linker']] + trials
         elif compiler.id == 'intel-cl' and compiler.language == 'c': # why not cpp? Is this a bug?
             # Intel has its own linker that acts like Microsoft's lib
             trials = [['xilib']]
@@ -208,9 +209,10 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
             trials = [['ar']]  # For PGI on Windows, "ar" is just a wrapper calling link/lib.
         elif m.is_windows() and compiler.id == 'nasm':
             # This may well be LINK.EXE if it's under a MSVC environment
-            trials = [defaults['vs_static_linker'], defaults['clang_cl_static_linker']] + default_linkers
-        else:
-            trials = default_linkers
+            trials = [defaults['clang_cl_static_linker']] + trials
+            if 'vs_static_linker' in defaults:
+                trials = [defaults['vs_static_linker']] + trials
+
     popen_exceptions = {}
     for linker in trials:
         linker_name = os.path.basename(linker[0])

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -176,12 +176,14 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
             mlog.warning("No 'ar' binary in the cross file [binaries] section, "
                          "falling back to the build machine's archiver",
                          once=True, fatal=False)
+
+        m = env.machines[compiler.for_machine]
         default_linkers = [[l] for l in defaults['static_linker']]
         if compiler.language == 'cuda':
             trials = [defaults['cuda_static_linker']] + default_linkers
         elif compiler.get_argument_syntax() == 'msvc':
             trials = [defaults['vs_static_linker'], defaults['clang_cl_static_linker']]
-        elif env.machines[compiler.for_machine].is_os2() and env.coredata.optstore.get_value_for(OptionKey('os2_emxomf')):
+        elif m.is_os2() and env.coredata.optstore.get_value_for(OptionKey('os2_emxomf')):
             trials = [defaults['emxomf_static_linker']] + default_linkers
         elif compiler.id == 'gcc':
             # Use gcc-ar if available; needed for LTO
@@ -195,16 +197,16 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
             trials = [[f'{llvm_ar[0]}-{suffix}'], llvm_ar] + default_linkers
         elif compiler.language == 'd':
             # Prefer static linkers over linkers used by D compilers
-            if is_windows():
+            if m.is_windows():
                 trials = [defaults['vs_static_linker'], defaults['clang_cl_static_linker'], compiler.get_linker_exelist()]
             else:
                 trials = default_linkers
         elif compiler.id == 'intel-cl' and compiler.language == 'c': # why not cpp? Is this a bug?
             # Intel has its own linker that acts like Microsoft's lib
             trials = [['xilib']]
-        elif is_windows() and compiler.id == 'pgi': # this handles cpp / nvidia HPC, in addition to just c/fortran
+        elif m.is_windows() and compiler.id == 'pgi': # this handles cpp / nvidia HPC, in addition to just c/fortran
             trials = [['ar']]  # For PGI on Windows, "ar" is just a wrapper calling link/lib.
-        elif is_windows() and compiler.id == 'nasm':
+        elif m.is_windows() and compiler.id == 'nasm':
             # This may well be LINK.EXE if it's under a MSVC environment
             trials = [defaults['vs_static_linker'], defaults['clang_cl_static_linker']] + default_linkers
         else:

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -168,6 +168,14 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
     if linker is not None:
         trials = [linker]
     else:
+        # The names below are unprefixed, so when cross compiling they pick up
+        # the build machine's archiver.  That often works because GNU ar is
+        # often built to support multiple ELF or PE objects and LLVM tools are
+        # multi-target, but it may also fail silently.  Warn just to be safe.
+        if not env.machines.matches_build_machine(compiler.for_machine):
+            mlog.warning("No 'ar' binary in the cross file [binaries] section, "
+                         "falling back to the build machine's archiver",
+                         once=True, fatal=False)
         default_linkers = [[l] for l in defaults['static_linker']]
         if compiler.language == 'cuda':
             trials = [defaults['cuda_static_linker']] + default_linkers

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -238,13 +238,13 @@ def detect_static_linker(env: 'Environment', compiler: Compiler) -> StaticLinker
             return linkers.ArmarLinker(linker, env)
         if 'DMD32 D Compiler' in out or 'DMD64 D Compiler' in out:
             assert isinstance(compiler, d.DCompiler)
-            return linkers.DLinker(linker, env, compiler.arch)
+            return linkers.DLinker(linker, env, compiler.for_machine, compiler.arch)
         if 'LDC - the LLVM D compiler' in out:
             assert isinstance(compiler, d.DCompiler)
-            return linkers.DLinker(linker, env, compiler.arch, rsp_syntax=compiler.rsp_file_syntax())
+            return linkers.DLinker(linker, env, compiler.for_machine, compiler.arch, rsp_syntax=compiler.rsp_file_syntax())
         if 'GDC' in out and ' based on D ' in out:
             assert isinstance(compiler, d.DCompiler)
-            return linkers.DLinker(linker, env, compiler.arch)
+            return linkers.DLinker(linker, env, compiler.for_machine, compiler.arch)
         if err.startswith('Renesas') and 'rlink' in linker_name:
             return linkers.CcrxLinker(linker, env)
         if out.startswith('GNU ar'):

--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -250,6 +250,10 @@ class BasicPythonExternalProgram(ExternalProgram):
 class _PythonDependencyBase(_Base):
 
     for_machine: MachineChoice
+    platform: str
+
+    def is_windows_python(self) -> bool:
+        return self.platform.startswith(('win', 'mingw'))
 
     def __init__(self, python_holder: 'BasicPythonExternalProgram', embed: bool):
         self.embed = embed
@@ -295,7 +299,7 @@ class _PythonDependencyBase(_Base):
         # pyconfig.h is shared between regular and free-threaded builds in the
         # Windows installer from python.org, and hence does not define
         # Py_GIL_DISABLED correctly. So do it here:
-        if mesonlib.is_windows() and self.is_freethreaded:
+        if self.is_windows_python() and self.is_freethreaded:
             self.compile_args += ['-DPy_GIL_DISABLED']
 
     def find_libpy(self, environment: 'Environment') -> None:
@@ -538,7 +542,7 @@ class PythonSystemDependency(SystemDependency, _PythonDependencyBase):
             self.is_found = True
         elif self.link_libpython:
             # link args
-            if mesonlib.is_windows():
+            if self.is_windows_python():
                 self.find_libpy_windows(environment, limited_api=False)
             else:
                 self.find_libpy(environment)
@@ -562,7 +566,7 @@ class PythonSystemDependency(SystemDependency, _PythonDependencyBase):
 
         # https://sourceforge.net/p/mingw-w64/mailman/message/30504611/
         # https://github.com/python/cpython/pull/100137
-        if mesonlib.is_windows() and self.get_windows_python_arch().endswith('64') and mesonlib.version_compare(self.version, '<3.12'):
+        if self.is_windows_python() and self.get_windows_python_arch().endswith('64') and mesonlib.version_compare(self.version, '<3.12'):
             self.compile_args += ['-DMS_WIN64=']
 
         if not self.clib_compiler.has_header('Python.h', '', extra_args=self.compile_args)[0]:

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -440,11 +440,19 @@ class ArmarLinker(ArLikeLinker, StaticLinker):
 
 
 class DLinker(StaticLinker):
-    def __init__(self, exelist: T.List[str], env: Environment, arch: str, *, rsp_syntax: RSPFileSyntax = RSPFileSyntax.GCC):
+    def __init__(self, exelist: T.List[str], env: Environment, for_machine: MachineChoice, arch: str, *, rsp_syntax: RSPFileSyntax = RSPFileSyntax.GCC):
         super().__init__(exelist, env)
         self.id = exelist[0]
         self.arch = arch
         self.__rsp_syntax = rsp_syntax
+        self.__bitness_arg: T.List[str] = []
+        if env.machines[for_machine].is_windows():
+            if self.arch == 'x86_64':
+                self.__bitness_arg = ['-m64']
+            elif self.arch == 'x86_mscoff' and self.id == 'dmd':
+                self.__bitness_arg = ['-m32mscoff']
+            else:
+                self.__bitness_arg = ['-m32']
 
     def get_std_link_args(self, env: 'Environment', is_thin: bool) -> T.List[str]:
         return ['-lib']
@@ -453,13 +461,7 @@ class DLinker(StaticLinker):
         return ['-of=' + target]
 
     def get_linker_always_args(self) -> T.List[str]:
-        if mesonlib.is_windows():
-            if self.arch == 'x86_64':
-                return ['-m64']
-            elif self.arch == 'x86_mscoff' and self.id == 'dmd':
-                return ['-m32mscoff']
-            return ['-m32']
-        return []
+        return self.__bitness_arg
 
     def rsp_file_syntax(self) -> RSPFileSyntax:
         return self.__rsp_syntax
@@ -773,8 +775,7 @@ class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
         if extra_paths:
             all_paths.update(extra_paths)
 
-        # TODO: should this actually be "for (dragonfly|open)bsd"?
-        if mesonlib.is_dragonflybsd() or mesonlib.is_openbsd():
+        if m.is_dragonflybsd() or m.is_openbsd():
             # This argument instructs the compiler to record the value of
             # ORIGIN in the .dynamic section of the elf. On Linux this is done
             # by default, but is not on dragonfly/openbsd for some reason. Without this
@@ -795,10 +796,9 @@ class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
                 paths = paths + ':' + padding
         args.extend(self._apply_prefix(['-rpath', paths]))
 
-        # TODO: should this actually be "for solaris/sunos"?
         # NOTE: Remove the zigcc check once zig support "-rpath-link"
         # See https://github.com/ziglang/zig/issues/18713
-        if mesonlib.is_sunos() or self.id == 'ld.zigcc':
+        if m.is_sunos() or self.id == 'ld.zigcc':
             return (args, rpath_dirs_to_remove)
 
         # Rpaths to use while linking must be absolute. These are not
@@ -1404,9 +1404,10 @@ class PGIDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
 
     def get_std_shared_lib_args(self) -> T.List[str]:
         # PGI -shared is Linux only.
-        if mesonlib.is_windows():
+        m = self.environment.machines[self.for_machine]
+        if m.is_windows():
             return ['-Bdynamic', '-Mmakedll']
-        elif mesonlib.is_linux():
+        elif m.is_linux():
             return ['-shared']
         return []
 

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -13,12 +13,11 @@ import shutil
 import subprocess
 import sys
 import typing as T
-import re
 
 from . import build, tooldetect
 from .backend.backends import InstallData
 from .mesonlib import (InstallScriptFailure, MesonException, Popen_safe, RealPathAction,
-                       is_windows, is_aix, setup_vsenv, path_has_root, pickle_load, is_osx,
+                       is_windows, setup_vsenv, path_has_root, pickle_load, is_osx,
                        unwrap)
 from .options import OptionKey
 from .scripts import depfixer, destdir_join
@@ -754,13 +753,6 @@ class Installer:
 
     def install_targets(self, d: InstallData, dm: DirMaker, destdir: str, fullprefix: str) -> None:
         for t in d.targets:
-            # In AIX, we archive our shared libraries.  When we install any package in AIX we need to
-            # install the archive in which the shared library exists. The below code does the same.
-            # We change the .so files having lt_version or so_version to archive file install.
-            # If .so does not exist then it means it is in the archive. Otherwise it is a .so that exists.
-            if is_aix():
-                if not os.path.exists(t.fname) and '.so' in t.fname:
-                    t.fname = re.sub('[.][a]([.]?([0-9]+))*([.]?([a-z]+))*', '.a', t.fname.replace('.so', '.a'))
             if not self.should_install(t):
                 continue
             if not os.path.exists(t.fname):

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -17,7 +17,7 @@ import typing as T
 from . import build, tooldetect
 from .backend.backends import InstallData
 from .mesonlib import (InstallScriptFailure, MesonException, Popen_safe, RealPathAction,
-                       is_windows, setup_vsenv, path_has_root, pickle_load, is_osx,
+                       is_windows, setup_vsenv, path_has_root, pickle_load,
                        unwrap)
 from .options import OptionKey
 from .scripts import depfixer, destdir_join
@@ -620,9 +620,9 @@ class Installer:
                               '-C', os.getcwd(), '--no-rebuild')
             raise
 
-    def do_strip(self, strip_bin: T.List[str], fname: str, outname: str) -> None:
+    def do_strip(self, strip_bin: T.List[str], fname: str, outname: str, system: str) -> None:
         self.log(f'Stripping target {fname!r}.')
-        if is_osx():
+        if system == 'darwin':
             # macOS expects dynamic objects to be stripped with -x maximum.
             # To also strip the debug info, -S must be added.
             # See: https://www.unix.com/man-page/osx/1/strip/
@@ -779,7 +779,7 @@ class Installer:
                     if fname.endswith('.jar'):
                         self.log('Not stripping jar target: {}'.format(os.path.basename(fname)))
                         continue
-                    self.do_strip(d.strip_bin, fname, outname)
+                    self.do_strip(d.strip_bin, fname, outname, t.system)
                 if fname.endswith('.js'):
                     # Emscripten outputs js files and optionally a wasm file.
                     # If one was generated, install it as well.

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1555,7 +1555,7 @@ class SingleTestRunner:
                 return self.test.exe_wrapper.get_command() + self.test.fname
         elif self.test.cmd_is_built and not self.test.cmd_is_exe and is_windows():
             test_cmd = ExternalProgram._shebang_to_cmd(self.test.fname[0])
-            if test_cmd is not None:
+            if test_cmd:
                 test_cmd += self.test.fname[1:]
             return test_cmd
         return self.test.fname

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1290,9 +1290,6 @@ async def read_decode(reader: asyncio.StreamReader,
         if queue:
             await queue.put(None)
 
-def run_with_mono(fname: str) -> bool:
-    return fname.endswith('.exe') and not (is_windows() or is_cygwin() or is_os2())
-
 def check_testdata(objs: T.List[TestSerialisation]) -> T.List[TestSerialisation]:
     if not isinstance(objs, list):
         raise MesonVersionMismatchException('<unknown>', coredata_version)
@@ -1533,14 +1530,9 @@ class SingleTestRunner:
         return self.runobj.console_mode
 
     def _get_test_cmd(self) -> T.Optional[T.List[str]]:
-        testentry = self.test.fname[0]
-        if self.options.no_rebuild and self.test.cmd_is_built and not os.path.isfile(testentry):
-            raise TestException(f'The test program {testentry!r} does not exist. Cannot run tests before building them.')
-        if testentry.endswith('.jar'):
-            return ['java', '-jar'] + self.test.fname
-        elif not self.test.is_cross_built and run_with_mono(testentry):
-            return ['mono'] + self.test.fname
-        elif self.test.cmd_is_exe and self.test.is_cross_built and self.test.needs_exe_wrapper:
+        if self.options.no_rebuild and self.test.cmd_is_built and not os.path.isfile(self.test.exe_fname):
+            raise TestException(f'The test program {self.test.exe_fname!r} does not exist. Cannot run tests before building them.')
+        if self.test.cmd_is_exe and self.test.is_cross_built and self.test.needs_exe_wrapper:
             if self.test.exe_wrapper is None:
                 # Can not run test on cross compiled executable
                 # because there is no execute wrapper.
@@ -1553,7 +1545,9 @@ class SingleTestRunner:
                            'found. Please check the command and/or add it to PATH.')
                     raise TestException(msg.format(self.test.exe_wrapper.name))
                 return self.test.exe_wrapper.get_command() + self.test.fname
-        elif self.test.cmd_is_built and not self.test.cmd_is_exe and is_windows():
+        elif self.test.cmd_is_built and \
+                not (self.test.cmd_is_exe or self.test.cmd_has_interpreter) and \
+                is_windows():
             test_cmd = ExternalProgram._shebang_to_cmd(self.test.fname[0])
             if test_cmd:
                 test_cmd += self.test.fname[1:]


### PR DESCRIPTION
Using `mesonlib.is_xxx()` is prone to checking the incorrect machine when cross compiling, since it always checks the build machine.

There are certainly good uses, especially in envconfig, when looking for installed programs, and when checking certain build-machine-dependent aspects of tools command line, but in general it is best avoided.