### PR TITLE
Fixes for cargo [target.xxx] parser

### DIFF
--- a/mesonbuild/cargo/cfg.py
+++ b/mesonbuild/cargo/cfg.py
@@ -26,7 +26,7 @@ import enum
 import typing as T
 
 
-from ..mesonlib import MesonBugException, lookahead
+from ..mesonlib import MesonBugException, MesonException, lookahead
 
 if T.TYPE_CHECKING:
     _T = T.TypeVar('_T')
@@ -175,7 +175,7 @@ def _parse(ast: _LEX_STREAM_AH) -> IR:
         assert token is TokenType.RPAREN
         return Not(arg) if is_not else arg
     else:
-        raise MesonBugException(f'Unhandled Cargo token:{token} {value}')
+        raise MesonException(f'Unhandled Cargo token:{token} {value}')
 
 
 def parse(ast: _LEX_STREAM) -> IR:

--- a/mesonbuild/cargo/cfg.py
+++ b/mesonbuild/cargo/cfg.py
@@ -158,6 +158,7 @@ def _parse(ast: _LEX_STREAM_AH) -> IR:
         (token, value), n_stream = next(ast)
         assert token is TokenType.LPAREN
         if n_stream and n_stream[0] == TokenType.RPAREN:
+            (token, value), _ = next(ast)
             return type_(args)
         while True:
             args.append(_parse(ast))

--- a/mesonbuild/cargo/cfg.py
+++ b/mesonbuild/cargo/cfg.py
@@ -185,7 +185,14 @@ def parse(ast: _LEX_STREAM) -> IR:
     :return: An mparser Node to be used as a conditional
     """
     ast_i: _LEX_STREAM_AH = lookahead(ast)
-    return _parse(ast_i)
+    try:
+        ir = _parse(ast_i)
+    except StopIteration:
+        raise MesonException('malformed cfg expression')
+
+    if next(ast_i, None) is not None:
+        raise MesonException('trailing text after cfg expression')
+    return ir
 
 
 def _eval_cfg(ir: IR, cfgs: T.Dict[str, str]) -> bool:

--- a/mesonbuild/cargo/cfg.py
+++ b/mesonbuild/cargo/cfg.py
@@ -136,6 +136,10 @@ class Not(IR):
 
 
 def _parse(ast: _LEX_STREAM_AH) -> IR:
+    def assertToken(t: TokenType, expected: str) -> None:
+        if token is not t:
+            raise MesonException(f'expected {expected}')
+
     (token, value), n_stream = next(ast)
     if n_stream is not None:
         ntoken, _ = n_stream
@@ -148,7 +152,7 @@ def _parse(ast: _LEX_STREAM_AH) -> IR:
         if ntoken is TokenType.EQUAL:
             next(ast)
             (token, value), _ = next(ast)
-            assert token is TokenType.STRING
+            assertToken(TokenType.STRING, 'string')
             assert value is not None
             return Equal(id_, String(value))
         return id_
@@ -156,7 +160,7 @@ def _parse(ast: _LEX_STREAM_AH) -> IR:
         type_ = All if token is TokenType.ALL else Any
         args: T.List[IR] = []
         (token, value), n_stream = next(ast)
-        assert token is TokenType.LPAREN
+        assertToken(TokenType.LPAREN, '"("')
         if n_stream and n_stream[0] == TokenType.RPAREN:
             (token, value), _ = next(ast)
             return type_(args)
@@ -165,15 +169,15 @@ def _parse(ast: _LEX_STREAM_AH) -> IR:
             (token, value), _ = next(ast)
             if token is TokenType.RPAREN:
                 break
-            assert token is TokenType.COMMA
+            assertToken(TokenType.COMMA, '")" or ","')
         return type_(args)
     elif token in {TokenType.NOT, TokenType.CFG}:
         is_not = token is TokenType.NOT
         (token, value), _ = next(ast)
-        assert token is TokenType.LPAREN
+        assertToken(TokenType.LPAREN, '"("')
         arg = _parse(ast)
         (token, value), _ = next(ast)
-        assert token is TokenType.RPAREN
+        assertToken(TokenType.RPAREN, '")"')
         return Not(arg) if is_not else arg
     else:
         raise MesonException(f'Unhandled Cargo token:{token} {value}')

--- a/mesonbuild/cargo/cfg.py
+++ b/mesonbuild/cargo/cfg.py
@@ -46,7 +46,6 @@ class TokenType(enum.Enum):
     NOT = enum.auto()
     COMMA = enum.auto()
     EQUAL = enum.auto()
-    CFG = enum.auto()
 
 
 def lexer(raw: str) -> _LEX_STREAM:
@@ -71,8 +70,6 @@ def lexer(raw: str) -> _LEX_STREAM:
                 yield (TokenType.ALL, None)
             elif val == 'not':
                 yield (TokenType.NOT, None)
-            elif val == 'cfg':
-                yield (TokenType.CFG, None)
             elif val:
                 yield (TokenType.IDENTIFIER, val)
 
@@ -171,14 +168,13 @@ def _parse(ast: _LEX_STREAM_AH) -> IR:
                 break
             assertToken(TokenType.COMMA, '")" or ","')
         return type_(args)
-    elif token in {TokenType.NOT, TokenType.CFG}:
-        is_not = token is TokenType.NOT
+    elif token is TokenType.NOT:
         (token, value), _ = next(ast)
         assertToken(TokenType.LPAREN, '"("')
         arg = _parse(ast)
         (token, value), _ = next(ast)
         assertToken(TokenType.RPAREN, '")"')
-        return Not(arg) if is_not else arg
+        return Not(arg)
     else:
         raise MesonException(f'Unhandled Cargo token:{token} {value}')
 
@@ -216,4 +212,6 @@ def _eval_cfg(ir: IR, cfgs: T.Dict[str, str]) -> bool:
 
 
 def eval_cfg(raw: str, cfgs: T.Dict[str, str]) -> bool:
-    return _eval_cfg(parse(lexer(raw)), cfgs)
+    if raw.startswith('cfg(') and raw.endswith(')'):
+        return _eval_cfg(parse(lexer(raw[4:-1])), cfgs)
+    return False

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -699,12 +699,6 @@ class Interpreter:
             else:
                 self._enable_feature(pkg, f, machine)
 
-    def has_check_cfg(self, machine: MachineChoice) -> bool:
-        if not self.environment.is_cross_build():
-            machine = MachineChoice.HOST
-        rustc = T.cast('RustCompiler', self.environment.coredata.compilers[machine]['rust'])
-        return rustc.has_check_cfg
-
     @functools.lru_cache(maxsize=None)
     def _get_cfgs(self, machine: MachineChoice, subproject: SubProject) -> T.Dict[str, str]:
         if not self.environment.is_cross_build():

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -192,9 +192,6 @@ class PackageState:
 
     def get_rustc_args(self, environment: Environment, subdir: str, machine: MachineChoice) -> T.List[str]:
         """Get rustc arguments for this package."""
-        if not environment.is_cross_build():
-            machine = MachineChoice.HOST
-
         rustc = T.cast('RustCompiler', environment.coredata.compilers[machine]['rust'])
         cfg = self.cfg[machine]
 
@@ -701,8 +698,6 @@ class Interpreter:
 
     @functools.lru_cache(maxsize=None)
     def _get_cfgs(self, machine: MachineChoice, subproject: SubProject) -> T.Dict[str, str]:
-        if not self.environment.is_cross_build():
-            machine = MachineChoice.HOST
         rustc = T.cast('RustCompiler', self.environment.coredata.compilers[machine]['rust'])
         cfgs = rustc.get_cfgs().copy()
         rustflags = T.cast('T.List[str]', self.environment.coredata.optstore.get_value_for(

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -576,10 +576,12 @@ class Interpreter:
             return  # Already prepared for this machine
 
         pkg.cfg[machine] = PackageConfiguration(for_machine=machine)
+
         # Merge target-specific dependencies that are enabled for this machine
+        rustc = T.cast('RustCompiler', self.environment.coredata.compilers[machine]['rust'])
         target_cfgs = self._get_cfgs(machine, pkg.get_subproject_name())
         for condition, dependencies in pkg.manifest.target.items():
-            if eval_cfg(condition, target_cfgs):
+            if condition == rustc.get_target_triple() or eval_cfg(condition, target_cfgs):
                 pkg.manifest.dependencies.update(dependencies)
 
         # If you specify the optional dependency with the dep: prefix anywhere in the [features]

--- a/unittests/cargotests.py
+++ b/unittests/cargotests.py
@@ -196,6 +196,8 @@ class CargoCfgTest(unittest.TestCase):
             'all(unix,)',
             'any(',
             'not(',
+            'not(all(unix,))',
+            'not(any)',
             ''
         ]
         for data in cases:

--- a/unittests/cargotests.py
+++ b/unittests/cargotests.py
@@ -180,11 +180,8 @@ class CargoCfgTest(unittest.TestCase):
                 (TokenType.IDENTIFIER, 'unix'),
                 (TokenType.RPAREN, None),
             ]),
-            ('cfg(windows)', [
-                (TokenType.CFG, None),
-                (TokenType.LPAREN, None),
+            ('windows', [
                 (TokenType.IDENTIFIER, 'windows'),
-                (TokenType.RPAREN, None),
             ]),
         ]
         for data, expected in cases:
@@ -229,7 +226,7 @@ class CargoCfgTest(unittest.TestCase):
                             cfg.Equal(cfg.Identifier("target_arch"), cfg.String("x86")),
                             cfg.Equal(cfg.Identifier("target_os"), cfg.String("linux")),
                         ]))),
-            ('cfg(all(any(target_os = "android", target_os = "linux"), any(custom_cfg)))',
+            ('all(any(target_os = "android", target_os = "linux"), any(custom_cfg))',
                 cfg.All([
                     cfg.Any([
                         cfg.Equal(cfg.Identifier("target_os"), cfg.String("android")),
@@ -261,12 +258,12 @@ class CargoCfgTest(unittest.TestCase):
             ('any(unix, windows)', True),
             ('all()', True),
             ('any()', False),
-            ('cfg(unix)', True),
-            ('cfg(windows)', False),
+            ('unix', True),
+            ('windows', False),
         ]
         for data, expected in cases:
             with self.subTest():
-                value = cfg.eval_cfg(data, d)
+                value = cfg.eval_cfg(f'cfg({data})', d)
                 self.assertEqual(value, expected)
 
 class CargoLockTest(unittest.TestCase):

--- a/unittests/cargotests.py
+++ b/unittests/cargotests.py
@@ -191,6 +191,18 @@ class CargoCfgTest(unittest.TestCase):
             with self.subTest():
                 self.assertListEqual(list(cfg.lexer(data)), expected)
 
+    def test_parse_invalid(self) -> None:
+        cases = [
+            'all(unix,)',
+            'any(',
+            'not(',
+            ''
+        ]
+        for data in cases:
+            with self.subTest():
+                with self.assertRaises(MesonException):
+                    cfg.parse(iter(cfg.lexer(data)))
+
     def test_parse(self) -> None:
         cases = [
             ('target_os = "windows"', cfg.Equal(cfg.Identifier("target_os"), cfg.String("windows"))),


### PR DESCRIPTION
Apply various fixes to catch invalid cfg expressions or treat them more like Cargo does; and add support for matching the target triple directly as in #16072.