### PR TITLE
configure_file: add strict to error on unused configuration keys

### DIFF
--- a/docs/markdown/snippets/configure_file_strict.md
+++ b/docs/markdown/snippets/configure_file_strict.md
@@ -1,0 +1,18 @@
+## `configure_file()` can require all configuration keys to be used
+
+`configure_file()` now accepts a `strict` keyword argument. When
+`strict: true` is set, configuration fails if any key in the
+`configuration:` object is not used by the input template.
+
+This covers `@KEY@` and `#mesondefine` substitutions, as well as the
+cmake equivalents (`${KEY}`, `@KEY@` with `format: 'cmake@'`, and
+`#cmakedefine`). The default remains `false` for backwards compatibility.
+
+```meson
+conf = configuration_data()
+conf.set('FOO', 1)
+conf.set('BAR', 0)
+# Fails if BAR is not referenced in config.h.in
+configure_file(input: 'config.h.in', output: 'config.h',
+               configuration: conf, strict: true)
+```

--- a/docs/yaml/functions/configure_file.yaml
+++ b/docs/yaml/functions/configure_file.yaml
@@ -160,6 +160,17 @@ kwargs:
       When specified, macro guards will be used instead of '#pragma once'. The
       macro guard name will be the specified name.
 
+  strict:
+    type: bool
+    default: false
+    since: 1.13.0
+    description: |
+      If `true`, configuration fails when any key in the
+      `configuration:` object is unused by the input template
+      (`@KEY@`, `#mesondefine`, `#cmakedefine`, or `${KEY}`).
+      Has no effect when `input:` is omitted, because every key
+      is written to the output.
+
   build_subdir:
     type: str
     since: 1.10.0

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2789,6 +2789,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                   validator=in_set_validator({'c', 'json', 'nasm'})),
         KwargInfo('macro_name', (str, NoneType), default=None, since='1.3.0'),
         KwargInfo('build_subdir', str, default='', since='1.10.0'),
+        KwargInfo('strict', bool, default=False, since='1.13.0'),
     )
     @apply_machine_map
     def func_configure_file(self, node: mparser.BaseNode, args: T.List[TYPE_var],
@@ -2811,6 +2812,9 @@ class Interpreter(InterpreterBase, HoldableObject):
 
         if kwargs['capture'] and not kwargs['command']:
             raise InvalidArguments('configure_file: "capture" keyword requires "command" keyword.')
+
+        if kwargs['strict'] and kwargs['configuration'] is None:
+            raise InvalidArguments('configure_file: "strict" keyword requires "configuration" keyword.')
 
         install_mode = self._warn_kwarg_install_mode_sticky(kwargs['install_mode'])
 
@@ -2870,9 +2874,14 @@ class Interpreter(InterpreterBase, HoldableObject):
                 raise InterpreterException('At most one input file can given in configuration mode')
             if inputs:
                 file_encoding = kwargs['encoding']
-                missing_variables, confdata_useless = \
+                missing_variables, confdata_useless, unused_variables = \
                     mesonlib.do_conf_file(inputs_abs[0], ofile_abs, conf,
                                           fmt, file_encoding, self.subproject)
+                if kwargs['strict'] and unused_variables:
+                    unused_list = ", ".join(repr(u) for u in sorted(unused_variables))
+                    raise InterpreterException(
+                        f"configure_file: strict mode: configuration data key(s) {unused_list} "
+                        f"were not used in the input file '{inputs[0]}'.")
                 if missing_variables:
                     var_list = ", ".join(repr(m) for m in sorted(missing_variables))
                     mlog.warning(

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -341,6 +341,7 @@ class ConfigureFile(TypedDict):
     macro_name: T.Optional[str]
     build_subdir: str
     copy: bool
+    strict: bool
 
 
 class Subproject(ExtractRequired):

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -1463,7 +1463,8 @@ def do_replacement(regex: T.Pattern[str], line: str,
         raise MesonException('Invalid variable format')
 
 def do_replacement_meson(regex: T.Pattern[str], line: str,
-                         confdata: T.Union[T.Dict[str, T.Tuple[str, T.Optional[str]]], 'ConfigurationData']) -> T.Tuple[str, T.Set[str]]:
+                         confdata: T.Union[T.Dict[str, T.Tuple[str, T.Optional[str]]], 'ConfigurationData'],
+                         used: T.Optional[T.Set[str]] = None) -> T.Tuple[str, T.Set[str]]:
     missing_variables: T.Set[str] = set()
 
     def variable_replace(match: T.Match[str]) -> str:
@@ -1479,6 +1480,8 @@ def do_replacement_meson(regex: T.Pattern[str], line: str,
             varname = match.group('variable')
             var_str = ''
             if varname in confdata:
+                if used is not None:
+                    used.add(varname)
                 var, _ = confdata.get(varname)
                 if isinstance(var, str):
                     var_str = var
@@ -1497,7 +1500,8 @@ def do_replacement_meson(regex: T.Pattern[str], line: str,
     return re.sub(regex, variable_replace, line), missing_variables
 
 def do_replacement_cmake(line: str, at_only: bool,
-                         confdata: T.Union[T.Dict[str, T.Tuple[str, T.Optional[str]]], 'ConfigurationData']) -> T.Tuple[str, T.Set[str]]:
+                         confdata: T.Union[T.Dict[str, T.Tuple[str, T.Optional[str]]], 'ConfigurationData'],
+                         used: T.Optional[T.Set[str]] = None) -> T.Tuple[str, T.Set[str]]:
     missing_variables: T.Set[str] = set()
 
     character_regex = re.compile(r'''
@@ -1507,6 +1511,8 @@ def do_replacement_cmake(line: str, at_only: bool,
     def variable_get(varname: str) -> str:
         var_str = ''
         if varname in confdata:
+            if used is not None:
+                used.add(varname)
             var, _ = confdata.get(varname)
             if isinstance(var, str):
                 var_str = var
@@ -1584,7 +1590,8 @@ def do_replacement_cmake(line: str, at_only: bool,
     return parse_line(line), missing_variables
 
 def do_define_meson(regex: T.Pattern[str], line: str, confdata: 'ConfigurationData',
-                    subproject: T.Optional[SubProject] = None) -> str:
+                    subproject: T.Optional[SubProject] = None,
+                    used: T.Optional[T.Set[str]] = None) -> str:
 
     arr = line.split()
     if len(arr) != 2:
@@ -1596,9 +1603,12 @@ def do_define_meson(regex: T.Pattern[str], line: str, confdata: 'ConfigurationDa
     except KeyError:
         return '/* #undef %s */\n' % varname
 
+    if used is not None:
+        used.add(varname)
+
     if isinstance(v, str):
         result = f'#define {varname} {v}'.strip() + '\n'
-        result, _ = do_replacement_meson(regex, result, confdata)
+        result, _ = do_replacement_meson(regex, result, confdata, used)
         return result
     elif isinstance(v, bool):
         if v:
@@ -1611,7 +1621,8 @@ def do_define_meson(regex: T.Pattern[str], line: str, confdata: 'ConfigurationDa
         raise MesonException('#mesondefine argument "%s" is of unknown type.' % varname)
 
 def do_define_cmake(line: str, confdata: 'ConfigurationData', at_only: bool,
-                    subproject: T.Optional[SubProject] = None) -> str:
+                    subproject: T.Optional[SubProject] = None,
+                    used: T.Optional[T.Set[str]] = None) -> str:
     cmake_bool_define = 'cmakedefine01' in line
 
     def get_cmake_define(line: str, confdata: 'ConfigurationData') -> str:
@@ -1625,6 +1636,8 @@ def do_define_cmake(line: str, confdata: 'ConfigurationData', at_only: bool,
         for token in arr[2:]:
             try:
                 v, _ = confdata.get(token)
+                if used is not None:
+                    used.add(token)
                 define_value += [str(v)]
             except KeyError:
                 define_value += [token]
@@ -1645,12 +1658,15 @@ def do_define_cmake(line: str, confdata: 'ConfigurationData', at_only: bool,
         else:
             return '/* #undef %s */\n' % varname
 
+    if used is not None:
+        used.add(varname)
+
     if not cmake_bool_define and not v:
         return '/* #undef %s */\n' % varname
 
     result = get_cmake_define(line, confdata)
     result = f'#define {varname} {result}'.strip() + '\n'
-    result, _ = do_replacement_cmake(result, at_only, confdata)
+    result, _ = do_replacement_cmake(result, at_only, confdata, used)
     return result
 
 def get_variable_regex(variable_format: Literal['meson', 'cmake', 'cmake@'] = 'meson') -> T.Pattern[str]:
@@ -1676,7 +1692,7 @@ def get_variable_regex(variable_format: Literal['meson', 'cmake', 'cmake@'] = 'm
 
 def do_conf_str(src: str, data: T.List[str], confdata: 'ConfigurationData',
                 variable_format: Literal['meson', 'cmake', 'cmake@'],
-                subproject: T.Optional[SubProject] = None) -> T.Tuple[T.List[str], T.Set[str], bool]:
+                subproject: T.Optional[SubProject] = None) -> T.Tuple[T.List[str], T.Set[str], bool, T.Set[str]]:
     if variable_format == 'meson':
         return do_conf_str_meson(src, data, confdata, subproject)
     elif variable_format in {'cmake', 'cmake@'}:
@@ -1685,7 +1701,7 @@ def do_conf_str(src: str, data: T.List[str], confdata: 'ConfigurationData',
         raise MesonException('Invalid variable format')
 
 def do_conf_str_meson(src: str, data: T.List[str], confdata: 'ConfigurationData',
-                      subproject: T.Optional[SubProject] = None) -> T.Tuple[T.List[str], T.Set[str], bool]:
+                      subproject: T.Optional[SubProject] = None) -> T.Tuple[T.List[str], T.Set[str], bool, T.Set[str]]:
 
     regex = get_variable_regex('meson')
 
@@ -1693,26 +1709,28 @@ def do_conf_str_meson(src: str, data: T.List[str], confdata: 'ConfigurationData'
 
     result: T.List[str] = []
     missing_variables: T.Set[str] = set()
+    used_variables: T.Set[str] = set()
     # Detect when the configuration data is empty and no tokens were found
     # during substitution so we can warn the user to use the `copy:` kwarg.
     confdata_useless = not confdata.keys()
     for line in data:
         if line.lstrip().startswith(search_token):
             confdata_useless = False
-            line = do_define_meson(regex, line, confdata, subproject)
+            line = do_define_meson(regex, line, confdata, subproject, used_variables)
         else:
             if re.search(r'#\s*cmakedefine', line):
                 raise MesonException(f'Format error in {src}: saw "{line.strip()}" when format set to "meson"')
-            line, missing = do_replacement_meson(regex, line, confdata)
+            line, missing = do_replacement_meson(regex, line, confdata, used_variables)
             missing_variables.update(missing)
             if missing:
                 confdata_useless = False
         result.append(line)
 
-    return result, missing_variables, confdata_useless
+    unused_variables = set(confdata.keys()) - used_variables
+    return result, missing_variables, confdata_useless, unused_variables
 
 def do_conf_str_cmake(src: str, data: T.List[str], confdata: 'ConfigurationData', at_only: bool,
-                      subproject: T.Optional[SubProject] = None) -> T.Tuple[T.List[str], T.Set[str], bool]:
+                      subproject: T.Optional[SubProject] = None) -> T.Tuple[T.List[str], T.Set[str], bool, T.Set[str]]:
 
     variable_format: Literal['cmake', 'cmake@'] = 'cmake'
     if at_only:
@@ -1722,6 +1740,7 @@ def do_conf_str_cmake(src: str, data: T.List[str], confdata: 'ConfigurationData'
 
     result: T.List[str] = []
     missing_variables: T.Set[str] = set()
+    used_variables: T.Set[str] = set()
     # Detect when the configuration data is empty and no tokens were found
     # during substitution so we can warn the user to use the `copy:` kwarg.
     confdata_useless = not confdata.keys()
@@ -1732,28 +1751,29 @@ def do_conf_str_cmake(src: str, data: T.List[str], confdata: 'ConfigurationData'
                 from ..interpreterbase.decorators import FeatureNew
                 FeatureNew.single_use('whitespace between `#` and `cmakedefine`', '1.9.0', subproject)
             confdata_useless = False
-            line = do_define_cmake(line, confdata, at_only, subproject)
+            line = do_define_cmake(line, confdata, at_only, subproject, used_variables)
         else:
             if '#mesondefine' in line:
                 raise MesonException(f'Format error in {src}: saw "{line.strip()}" when format set to "{variable_format}"')
-            line, missing = do_replacement_cmake(line, at_only, confdata)
+            line, missing = do_replacement_cmake(line, at_only, confdata, used_variables)
             missing_variables.update(missing)
             if missing:
                 confdata_useless = False
         result.append(line)
 
-    return result, missing_variables, confdata_useless
+    unused_variables = set(confdata.keys()) - used_variables
+    return result, missing_variables, confdata_useless, unused_variables
 
 def do_conf_file(src: str, dst: str, confdata: 'ConfigurationData',
                  variable_format: Literal['meson', 'cmake', 'cmake@'],
-                 encoding: str = 'utf-8', subproject: T.Optional[SubProject] = None) -> T.Tuple[T.Set[str], bool]:
+                 encoding: str = 'utf-8', subproject: T.Optional[SubProject] = None) -> T.Tuple[T.Set[str], bool, T.Set[str]]:
     try:
         with open(src, encoding=encoding, newline='') as f:
             data = f.readlines()
     except Exception as e:
         raise MesonException(f'Could not read input file {src}: {e!s}')
 
-    (result, missing_variables, confdata_useless) = do_conf_str(src, data, confdata, variable_format, subproject)
+    (result, missing_variables, confdata_useless, unused_variables) = do_conf_str(src, data, confdata, variable_format, subproject)
     dst_tmp = dst + '~'
     try:
         with open(dst_tmp, 'w', encoding=encoding, newline='') as f:
@@ -1762,7 +1782,7 @@ def do_conf_file(src: str, dst: str, confdata: 'ConfigurationData',
         raise MesonException(f'Could not write output file {dst}: {e!s}')
     shutil.copymode(src, dst_tmp)
     replace_if_different(dst, dst_tmp)
-    return missing_variables, confdata_useless
+    return missing_variables, confdata_useless, unused_variables
 
 CONF_C_PRELUDE = '''/*
  * Autogenerated by the Meson build system.

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -154,7 +154,7 @@ class AllPlatformTests(BasePlatformTests):
 
     def test_do_conf_file_by_format(self):
         def conf_str(in_data, confdata, vformat):
-            (result, missing_variables, confdata_useless) = do_conf_str('configuration_file', in_data, confdata, variable_format = vformat)
+            (result, missing_variables, confdata_useless, unused_variables) = do_conf_str('configuration_file', in_data, confdata, variable_format = vformat)
             return '\n'.join(result)
 
         def check_meson_format(confdata, result):
@@ -231,6 +231,54 @@ class AllPlatformTests(BasePlatformTests):
         #   Dict value in confdata
         confdata.values = {'VAR': (['value'], 'description')}
         self.assertRaises(MesonException, conf_str, ['#mesondefine VAR'], confdata, 'meson')
+
+    def test_do_conf_unused_keys(self):
+        confdata = ConfigurationData()
+        confdata.values = {'USED': ('yes', None), 'UNUSED': ('no', None)}
+
+        result, missing, useless, unused = do_conf_str(
+            'configuration_file', ['@USED@\n'], confdata, variable_format='meson')
+        self.assertEqual(unused, {'UNUSED'})
+
+        result, missing, useless, unused = do_conf_str(
+            'configuration_file', ['@USED@ @UNUSED@\n'], confdata, variable_format='meson')
+        self.assertEqual(unused, set())
+
+        result, missing, useless, unused = do_conf_str(
+            'configuration_file', ['#mesondefine USED\n'], confdata, variable_format='meson')
+        self.assertEqual(unused, {'UNUSED'})
+
+        result, missing, useless, unused = do_conf_str(
+            'configuration_file', ['#cmakedefine USED\n'], confdata, variable_format='cmake')
+        self.assertEqual(unused, {'UNUSED'})
+
+    def test_configure_file_strict_kwarg(self):
+        with tempfile.TemporaryDirectory() as srcdir:
+            with open(os.path.join(srcdir, 'meson.build'), 'w', encoding='utf-8') as f:
+                f.write(textwrap.dedent("""\
+                    project('strictconf')
+                    c = configuration_data()
+                    c.set('USED', '1')
+                    c.set('UNUSED', '2')
+                    configure_file(input: 'cfg.h.in', output: 'cfg.h',
+                                   configuration: c, strict: true)
+                    """))
+            with open(os.path.join(srcdir, 'cfg.h.in'), 'w', encoding='utf-8') as f:
+                f.write('#mesondefine USED\n')
+            out = self.init(srcdir, allow_fail=True)
+            self.assertTrue(
+                'UNUSED' in out and 'strict' in out,
+                'expected strict unused-key error, got:\n' + out)
+            self.wipe()
+            with open(os.path.join(srcdir, 'meson.build'), 'w', encoding='utf-8') as f:
+                f.write(textwrap.dedent("""\
+                    project('strictconf')
+                    c = configuration_data()
+                    c.set('USED', '1')
+                    configure_file(input: 'cfg.h.in', output: 'cfg.h',
+                                   configuration: c, strict: true)
+                    """))
+            self.init(srcdir)
 
     def test_cmake_configuration(self):
         if self.backend is not Backend.ninja:


### PR DESCRIPTION
Fixes #2978

Add an optional `strict` kwarg to `configure_file()` (default `false`).
When `true`, Meson fails configuration if any key in the
`configuration:` object is not consumed by the input template.

Tracked during substitution for meson and cmake formats
(`@KEY@`, `#mesondefine`, `#cmakedefine`, `${KEY}`).

When `input:` is omitted, every key is written to the output, so
`strict` has no effect.