### PR TITLE
Add ninja check-syntax target for C/C++ syntax-only checking

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -4105,6 +4105,20 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         elem.add_item('pool', 'console')
         self.add_build(elem)
 
+    def generate_check_syntax(self) -> None:
+        if 'check-syntax' in self.all_outputs:
+            return
+        supported_langs = {'c', 'cpp', 'objc', 'objcpp'}
+        if not any(self.have_language(lang) for lang in supported_langs):
+            return
+
+        cmd = self.environment.get_build_command() + \
+            ['--internal', 'check_syntax', self.environment.build_dir]
+        elem = self.create_phony_target('check-syntax', 'CUSTOM_COMMAND', 'PHONY')
+        elem.add_item('COMMAND', cmd)
+        elem.add_item('pool', 'console')
+        self.add_build(elem)
+
     def generate_rustdoc(self) -> None:
         if 'rustdoc' in self.all_outputs or not self.have_language('rust'):
             return
@@ -4197,6 +4211,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         self.generate_clippy_json_prereq()
         self.generate_clippy_json()
         self.generate_rustdoc()
+        self.generate_check_syntax()
         self.generate_tags('etags', 'TAGS')
         self.generate_tags('ctags', 'ctags')
         self.generate_tags('cscope', 'cscope')

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1271,6 +1271,9 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
     def get_compile_only_args(self) -> T.List[str]:
         return []
 
+    def get_syntax_only_args(self) -> T.Optional[T.List[str]]:
+        return None
+
     def get_preprocess_only_args(self) -> T.List[str]:
         raise EnvironmentException('This compiler does not have a preprocessor')
 

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -505,6 +505,9 @@ class GnuLikeCompiler(Compiler, metaclass=mesonlib.SimpleABC):
     def get_compile_only_args(self) -> T.List[str]:
         return ['-c']
 
+    def get_syntax_only_args(self) -> T.Optional[T.List[str]]:
+        return ['-fsyntax-only']
+
     def get_include_args(self, path: str, is_system: bool) -> T.List[str]:
         if not path:
             path = '.'

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -160,6 +160,9 @@ class VisualStudioLikeCompiler(Compiler, metaclass=mesonlib.SimpleABC):
     def get_compile_only_args(self) -> T.List[str]:
         return ['/c']
 
+    def get_syntax_only_args(self) -> T.Optional[T.List[str]]:
+        return ['/Zs']
+
     def get_no_optimization_args(self) -> T.List[str]:
         return ['/Od', '/Oi-']
 

--- a/mesonbuild/scripts/check_syntax.py
+++ b/mesonbuild/scripts/check_syntax.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 The Meson development team
+
+from __future__ import annotations
+
+import os
+import typing as T
+
+from .run_tool import run_tool_on_targets, run_with_buffered_output
+from .. import build, mlog
+from ..mesonlib import MachineChoice
+
+# Languages for which syntax-only checking is supported.
+SYNTAX_CHECK_LANGS = frozenset({'c', 'cpp', 'objc', 'objcpp'})
+
+# Compile-only flags that should be stripped when doing syntax-only checks,
+# since -fsyntax-only / /Zs replace them.
+COMPILE_ONLY_FLAGS = {'-c', '/c'}
+
+
+class SyntaxChecker:
+    def __init__(self, build_data: build.Build) -> None:
+        self.syntax_args: T.Dict[T.Tuple[str, str], T.List[str]] = {}
+        self.warned: T.Set[T.Tuple[str, str]] = set()
+
+        for machine in MachineChoice:
+            compilers = build_data.environment.coredata.compilers[machine]
+            machine_name = machine.get_lower_case_name()
+            for lang, compiler in compilers.items():
+                if lang not in SYNTAX_CHECK_LANGS:
+                    continue
+                syntax_args = compiler.get_syntax_only_args()
+                if syntax_args is not None:
+                    self.syntax_args[(machine_name, lang)] = syntax_args
+
+    def __call__(self, target: T.Dict[str, T.Any]) -> T.Iterable[T.Coroutine[None, None, int]]:
+        for src_block in target['target_sources']:
+            if 'compiler' not in src_block:
+                continue
+            lang = src_block['language']
+            if lang not in SYNTAX_CHECK_LANGS:
+                continue
+
+            machine = src_block['machine']
+            key = (machine, lang)
+            syntax_args = self.syntax_args.get(key)
+            if syntax_args is None:
+                if key not in self.warned:
+                    self.warned.add(key)
+                    mlog.warning(f'No syntax-only support for {lang} on {machine} machine; skipping')
+                continue
+
+            compiler_exe = src_block['compiler']
+            parameters = [p for p in src_block['parameters'] if p not in COMPILE_ONLY_FLAGS]
+
+            sources = src_block['sources'] + src_block.get('generated_sources', [])
+            for source in sources:
+                cmdlist = list(compiler_exe) + parameters + list(syntax_args) + [source]
+                yield run_with_buffered_output(cmdlist)
+
+
+def run(args: T.List[str]) -> int:
+    os.chdir(args[0])
+    build_data = build.load(os.getcwd())
+    return run_tool_on_targets(SyntaxChecker(build_data))


### PR DESCRIPTION
## Summary

Add a `ninja check-syntax` target that runs `-fsyntax-only` (GCC/Clang) or `/Zs` (MSVC) on all C/C++ source files, analogous to `cargo check` for Rust or `ninja clippy` for Rust in Meson.

This enables fast syntax and type checking without code generation — significantly faster than a full build for iterating on large C/C++ projects.

Fixes #12228

## Implementation

Follows the same architecture as `ninja clippy` (introduced in the clippy introspection work):

- **`get_syntax_only_args()`** added to compiler base class and overridden in `GnuLikeCompiler` (`-fsyntax-only`) and `VisualStudioLikeCompiler` (`/Zs`). Returns `None` for unsupported compilers.
- **`mesonbuild/scripts/check_syntax.py`** — Worker script modeled after `clippy.py`. Uses `run_tool_on_targets` to read `meson-info/intro-targets.json`, iterates over C-family source blocks, strips the compile-only flag (`-c`/`/c`), substitutes the syntax-only flag, and runs one subprocess per source file for parallelism.
- **`generate_check_syntax()`** in `ninjabackend.py` — Creates the phony target. Only added when at least one supported language (c, cpp, objc, objcpp) is in the project.

### Compiler coverage

| Compiler family | Flag | Via |
|----------------|------|-----|
| GCC, Clang, Apple Clang, Intel ICX, Emscripten, ARM Clang | `-fsyntax-only` | `GnuLikeCompiler` |
| MSVC, clang-cl, Intel ICL | `/Zs` | `VisualStudioLikeCompiler` |

### Design decisions

- **Per-source invocation** for parallelism and clear per-file error attribution (same pattern as clippy)
- **No prereq build step** — unlike clippy, `-fsyntax-only` doesn't need linked libraries to exist
- **Scope limited to C-family languages** initially; other languages (D, Fortran, CUDA) can be added later by implementing `get_syntax_only_args()` on their compiler classes

## Test plan

- [ ] `ninja check-syntax` produces no errors on a valid C/C++ project
- [ ] `ninja check-syntax` reports errors when a source file has a syntax error
- [ ] Target is not generated for projects without C-family languages
- [ ] Works with cross-compilation (both host and build machine compilers)


🤖 Generated with [Claude Code](https://claude.com/claude-code)