### PR TITLE
mtest: set TSAN_OPTIONS to abort by default

### DIFF
--- a/docs/markdown/Unit-tests.md
+++ b/docs/markdown/Unit-tests.md
@@ -38,10 +38,10 @@ set to a random value between 1..255. This can help find memory leaks on
 configurations using glibc, including with non-GCC compilers. This feature
 can be disabled as discussed in [[test]].
 
-### ASAN_OPTIONS, UBSAN_OPTIONS, and MSAN_OPTIONS
+### ASAN_OPTIONS, MSAN_OPTIONS, TSAN_OPTIONS, and UBSAN_OPTIONS
 
-By default, the environment variables `ASAN_OPTIONS`, `UBSAN_OPTIONS`, and
-`MSAN_OPTIONS` are set to enable aborting on detected violations and to give a
+By default, the environment variables `ASAN_OPTIONS`, `MSAN_OPTIONS`, `TSAN_OPTIONS`,
+and `UBSAN_OPTIONS` are set to enable aborting on detected violations and to give a
 backtrace. This feature can be disabled as discussed in [[test]].
 
 ## Coverage

--- a/docs/yaml/functions/test.yaml
+++ b/docs/yaml/functions/test.yaml
@@ -33,10 +33,11 @@ description: |
   test(..., env: nomalloc, ...)
   ```
 
-  By default, the environment variables `ASAN_OPTIONS`, `UBSAN_OPTIONS`,
-  and `MSAN_OPTIONS` are set to enable aborting on detected violations and to
-  give a backtrace. To suppress this, `ASAN_OPTIONS`, `UBSAN_OPTIONS`, or
-  `MSAN_OPTIONS` can be set in the environment.
+  By default, the environment variables `ASAN_OPTIONS`, `MSAN_OPTIONS`,
+  `TSAN_OPTIONS`, and `UBSAN_OPTIONS` are set to enable aborting on
+  detected violations and to give a backtrace. To suppress this,
+  `ASAN_OPTIONS`, `MSAN_OPTIONS`, `TSAN_OPTIONS`, or `UBSAN_OPTIONS`
+  can be set in the environment.
 
   In addition to running individual executables as test cases, `test()`
   can also be used to invoke an external test harness.  In this case,

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1494,14 +1494,16 @@ class SingleTestRunner:
 
         # Sanitizers do not default to aborting on error. This is counter to
         # expectations when using -Db_sanitize and has led to confusion in the wild
-        # in CI. Set our own values of {ASAN,UBSAN}_OPTIONS to rectify this, but
-        # only if the user has not defined them.
+        # in CI. Set our own values of {ASAN,MSAN,TSAN,UBSAN}_OPTIONS to rectify this,
+        # but only if the user has not defined them.
         if ('ASAN_OPTIONS' not in env or not env['ASAN_OPTIONS']):
             env['ASAN_OPTIONS'] = 'halt_on_error=1:abort_on_error=1:print_summary=1'
-        if ('UBSAN_OPTIONS' not in env or not env['UBSAN_OPTIONS']):
-            env['UBSAN_OPTIONS'] = 'halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1'
         if ('MSAN_OPTIONS' not in env or not env['MSAN_OPTIONS']):
             env['MSAN_OPTIONS'] = 'halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1'
+        if ('TSAN_OPTIONS' not in env or not env['TSAN_OPTIONS']):
+            env['TSAN_OPTIONS'] = 'halt_on_error=1:abort_on_error=1:print_summary=1'
+        if ('UBSAN_OPTIONS' not in env or not env['UBSAN_OPTIONS']):
+            env['UBSAN_OPTIONS'] = 'halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1'
 
         # Valgrind also doesn't reflect errors in its exit code by default.
         if 'VALGRIND_OPTS' not in env or not env['VALGRIND_OPTS']:


### PR DESCRIPTION
Follow-up to 7b7d2e06 and 8ba0ea68 which handle ASAN, MSAN, and UBSAN.

See #12400, #12852