### PR TITLE
msetup: fix misleading error message about directories

### DIFF
--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -119,7 +119,7 @@ class MesonApp:
         return os.path.exists(fname)
 
     def validate_core_dirs(self, dir1: T.Optional[str], dir2: T.Optional[str]) -> T.Tuple[str, str]:
-        invalid_msg_prefix = f'Neither source directory {dir1!r} nor build directory {dir2!r}'
+        invalid_msg_prefix = f'Neither directory {dir1!r} nor directory {dir2!r}'
         if dir1 is None:
             if dir2 is None:
                 if not self.has_build_file('.') and self.has_build_file('..'):


### PR DESCRIPTION
`validate_core_dirs`'s signature is using generic argument names `dir1` and `dir2`, but its caller `validate_dirs` explicitly set `builddir` as `dir1` and `sourcedir` as `dir2`.

The content of `validate_core_dirs` is indeed using `dir1` as the `builddir`.

Error message has inverted hints and this fixed now.