### PR TITLE
ElbrusCompiler: Remove the lchmod hack

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -346,13 +346,9 @@ class ElbrusCCompiler(ElbrusCompiler, CCompiler):
         std_opt.set_versions(stds)
         return opts
 
-    # Elbrus C compiler does not have lchmod, but there is only linker warning, not compiler error.
-    # So we should explicitly fail at this case.
     def has_function(self, funcname: str, prefix: str, *,
                      extra_args: T.Optional[T.List[str]] = None,
                      dependencies: T.Optional[T.List['Dependency']] = None) -> T.Tuple[bool, bool]:
-        if funcname == 'lchmod':
-            return False, False
         return super().has_function(funcname, prefix, extra_args=extra_args, dependencies=dependencies)
 
 

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -640,13 +640,9 @@ class ElbrusCPPCompiler(ElbrusCompiler, CPPCompiler):
         std_opt.set_versions(cpp_stds, gnu=True)
         return opts
 
-    # Elbrus C++ compiler does not have lchmod, but there is only linker warning, not compiler error.
-    # So we should explicitly fail at this case.
     def has_function(self, funcname: str, prefix: str, *,
                      extra_args: T.Optional[T.List[str]] = None,
                      dependencies: T.Optional[T.List['Dependency']] = None) -> T.Tuple[bool, bool]:
-        if funcname == 'lchmod':
-            return False, False
         return super().has_function(funcname, prefix, extra_args=extra_args, dependencies=dependencies)
 
     # Elbrus C++ compiler does not support RTTI, so don't check for it.


### PR DESCRIPTION
With recent e2k glibc this hack is actually wrong and makes the find_function test fail.