### PR TITLE
mlog: Respect preexisting $LESS for pager

### DIFF
--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -148,6 +148,8 @@ class _Logger:
             env = os.environ.copy()
             if 'LESS' not in env:
                 env['LESS'] = 'RXF'
+            else:
+                env['LESS'] = 'RXF ' + env['LESS']
             # Set "-c" for lv to support color
             if 'LV' not in env:
                 env['LV'] = '-c'


### PR DESCRIPTION
I grew tired of seeing the following every time I wanted to check options with `meson configure`:

<img width="1364" height="536" alt="image" src="https://github.com/user-attachments/assets/91097c6f-9f4c-42fa-8c7f-fc49ebd06f52" />

I have `LESS` set to `--ignore-case`, which also coicidentally disabled Meson's `-R`.