### PR TITLE
Fix racy wine prefix initialization in ubuntu-rolling cross CI

### DIFF
--- a/ci/ciimage/ubuntu-rolling/install.sh
+++ b/ci/ciimage/ubuntu-rolling/install.sh
@@ -49,6 +49,18 @@ eatmydata apt-get -y build-dep meson
 eatmydata apt-get -y install "${pkgs[@]}" "${transitivepkgs[@]}"
 eatmydata apt-get -y install --no-install-recommends wine  # Wine is special
 
+# Initialize the wine prefix now, at image-build time, while nothing else is
+# using wine concurrently. If left uninitialized, `wine` lazily creates
+# ~/.wine on first use. We run tests concurrently , and several of them can race
+# to bootstrap ~/.wine for the first time simultaneously, causing wine to
+# intermittently fail with:
+#
+#   wine client error:0: recvmsg: Connection reset by peer
+#
+# causing spurious "Executables created by <compiler> are not runnable"
+# sanity check failures.
+WINEDEBUG=-all wine wineboot --init
+
 # HACK: build hotdoc from git repo since current sdist is broken on modern compilers
 # change back to 'hotdoc' once it's fixed
 install_python_packages git+https://github.com/hotdoc/hotdoc


### PR DESCRIPTION
Wine wants to initialize the prefix on first use. In our CI, we were
initializing the prefix lazily when the tests actually ran. Since we run
tests in parallel, this became contentious and resulted in the following
failure:

    wine client error:0: recvmsg: Connection reset by peer

Sometimes the CI job would pass and other times it would fail.