### PR TITLE
Pin hotdoc to a release instead of tracking git master

### DIFF
--- a/ci/ciimage/fedora/install.sh
+++ b/ci/ciimage/fedora/install.sh
@@ -26,9 +26,15 @@ dnf -y upgrade
 
 # Install deps
 dnf -y install "${pkgs[@]}"
-# HACK: build hotdoc from git repo since current sdist is broken on modern compilers
-# change back to 'hotdoc' once it's fixed
-install_python_packages git+https://github.com/hotdoc/hotdoc
+
+# HACK: hotdoc's bootstrap theme misuses depend_files for its less_include_path
+# option, which Meson >=1.12 treats as a sandbox violation:
+# https://github.com/hotdoc/hotdoc/issues/328
+#
+# Pin meson <1.12 for hotdoc's own build and install without build isolation so
+# pip doesn't pull a newer meson into an ephemeral build env.
+install_python_packages "meson>=1.0,<1.12" meson-python ninja
+python3 -m pip install --no-build-isolation hotdoc==0.18.3
 
 # HACK: uninstall npm after building hotdoc, remove when we remove npm
 dnf -y remove nodejs-npm

--- a/ci/ciimage/opensuse/install.sh
+++ b/ci/ciimage/opensuse/install.sh
@@ -29,9 +29,15 @@ zypper --non-interactive update
 
 # Install deps
 zypper install -y "${pkgs[@]}"
-# HACK: build hotdoc from git repo since current sdist is broken on modern compilers
-# change back to 'hotdoc' once it's fixed
-install_python_packages git+https://github.com/hotdoc/hotdoc
+
+# HACK: hotdoc's bootstrap theme misuses depend_files for its less_include_path
+# option, which Meson >=1.12 treats as a sandbox violation:
+# https://github.com/hotdoc/hotdoc/issues/328
+#
+# Pin meson <1.12 for hotdoc's own build and install without build isolation so
+# pip doesn't pull a newer meson into an ephemeral build env.
+install_python_packages "meson>=1.0,<1.12" meson-python ninja
+python3 -m pip install --no-build-isolation hotdoc==0.18.3
 
 # HACK: uninstall npm after building hotdoc, remove when we remove npm
 zypper remove -y -u npm

--- a/ci/ciimage/ubuntu-rolling/install.sh
+++ b/ci/ciimage/ubuntu-rolling/install.sh
@@ -49,9 +49,14 @@ eatmydata apt-get -y build-dep meson
 eatmydata apt-get -y install "${pkgs[@]}" "${transitivepkgs[@]}"
 eatmydata apt-get -y install --no-install-recommends wine  # Wine is special
 
-# HACK: build hotdoc from git repo since current sdist is broken on modern compilers
-# change back to 'hotdoc' once it's fixed
-install_python_packages git+https://github.com/hotdoc/hotdoc
+# HACK: hotdoc's bootstrap theme misuses depend_files for its less_include_path
+# option, which Meson >=1.12 treats as a sandbox violation:
+# https://github.com/hotdoc/hotdoc/issues/328
+#
+# Pin meson <1.12 for hotdoc's own build and install without build isolation so
+# pip doesn't pull a newer meson into an ephemeral build env.
+install_python_packages "meson>=1.0,<1.12" meson-python ninja
+python3 -m pip install --no-build-isolation hotdoc==0.18.3
 
 # Lower ulimit before running dub, otherwise there's a very high chance it will OOM.
 # See: https://github.com/dlang/phobos/pull/9048 and https://github.com/dlang/phobos/pull/8990


### PR DESCRIPTION
The git+https://github.com/hotdoc/hotdoc install was introduced in c3531971a as a stopgap for a hotdoc sdist bug (C99 incompatibilities) that had already been fixed in git but not yet released. That fix has long since shipped in hotdoc 0.18.0+, so tracking git master is no longer needed for that reason.

Meanwhile, tracking an unpinned, continuously-moving branch meant we inevitably got bitten by a second, unrelated bug: hotdoc_bootstrap_theme misuses depend_files for its less_include_path option, which Meson
>=1.12 (released 2026-08-10) now rejects as a sandbox violation:

  ERROR: Sandbox violation: Tried to grab directory less from outside
  current (sub)project.

This bug is present in every hotdoc release currently on PyPI (0.18.0-0.18.3) as well as git master, so pinning alone doesn't avoid it. Work around it by pinning meson <1.12 for hotdoc's own build and installing without build isolation, so pip uses the pinned meson instead of fetching a newer one into an ephemeral build env. This mirrors the workaround used by other projects hitting the same issue (e.g. https://github.com/NVIDIA/nvnmos/pull/102).

A fix for the underlying hotdoc_bootstrap_theme bug has been proposed upstream: https://github.com/hotdoc/hotdoc/issues/328. Once it lands in a release, the meson<1.12 workaround can be dropped.