### PR TITLE
interpreterobjects: Fix typo in error message

### DIFF
--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -149,7 +149,7 @@ class FeatureOptionHolder(ObjectHolder[Feature]):
             return self.held_object
 
         if self.held_object.is_enabled():
-            err_msg = f'Feature {self.held_object.name} cannot be enabled'
+            err_msg = f'Feature {self.held_object.name} cannot be disabled'
             if message:
                 err_msg += f': {message}'
             raise InterpreterException(err_msg)
@@ -187,7 +187,7 @@ class FeatureOptionHolder(ObjectHolder[Feature]):
             return self.held_object
 
         if self.held_object.is_disabled():
-            err_msg = f'Feature {self.held_object.name} cannot be disabled'
+            err_msg = f'Feature {self.held_object.name} cannot be enabled'
             if kwargs['error_message']:
                 err_msg += f': {kwargs["error_message"]}'
             raise InterpreterException(err_msg)

--- a/test cases/failing/101 feature require/test.json
+++ b/test cases/failing/101 feature require/test.json
@@ -2,7 +2,7 @@
   "stdout": [
     {
       "match": "re",
-      "line": ".*/meson\\.build:2:31: ERROR: Feature reqfeature cannot be enabled: frobnicator not available"
+      "line": ".*/meson\\.build:2:31: ERROR: Feature reqfeature cannot be disabled: frobnicator not available"
     }
   ]
 }

--- a/test cases/failing/102 feature require.bis/test.json
+++ b/test cases/failing/102 feature require.bis/test.json
@@ -2,7 +2,7 @@
   "stdout": [
     {
       "match": "re",
-      "line": ".*/meson\\.build:2:31: ERROR: Feature reqfeature cannot be enabled"
+      "line": ".*/meson\\.build:2:31: ERROR: Feature reqfeature cannot be disabled"
     }
   ]
 }


### PR DESCRIPTION
When trying to enable a disabled feature, the error should say '<feature> cannot be enabled' and not '<feature> cannot be disabled'.

Similar, when trying to disable an enabled feature.