### PR TITLE
depfixer: rewrite fix_jar using zipfile

### DIFF
--- a/docs/markdown/snippets/reproducible-jar-install.md
+++ b/docs/markdown/snippets/reproducible-jar-install.md
@@ -1,0 +1,13 @@
+## Jar files are now installed reproducibly
+
+Installing a jar target used to invoke the `jar` tool to strip the
+`Class-Path` attribute from its manifest, even when there was none.
+This replaced the manifest's timestamp inside the jar with the time of
+installation, so two builds of the same sources produced different
+installed jars.
+
+Manifests are now edited with Python's `zipfile` module instead. Jars
+without a `Class-Path` attribute are installed unmodified, and when the
+attribute has to be stripped, all entry metadata such as timestamps is
+preserved. As a side effect, the `jar` binary is no longer needed at
+install time.

--- a/mesonbuild/scripts/depfixer.py
+++ b/mesonbuild/scripts/depfixer.py
@@ -11,6 +11,7 @@ import struct
 import shutil
 import subprocess
 import typing as T
+import zipfile
 
 from ..mesonlib import OrderedSet, generate_list, Popen_safe
 
@@ -790,20 +791,48 @@ def fix_darwin(fname: str, rpath_dirs_to_remove: T.Set[bytes], new_rpath: str, f
         raise SystemExit(err)
 
 def fix_jar(fname: str) -> None:
-    subprocess.check_call(['jar', 'xf', fname, 'META-INF/MANIFEST.MF'])
-    with open('META-INF/MANIFEST.MF', 'r+', encoding='utf-8') as f:
-        lines = f.readlines()
-        f.seek(0)
+    with zipfile.ZipFile(fname) as jar:
+        try:
+            manifest = jar.read('META-INF/MANIFEST.MF').decode('utf-8')
+        except KeyError:
+            return
+        lines = manifest.splitlines(keepends=True)
+        stripped = []
+        in_classpath = False
         for line in lines:
-            if not line.startswith('Class-Path:'):
-                f.write(line)
-        f.truncate()
-    # jar -um doesn't allow removing existing attributes.  Use -uM instead,
-    # which a) removes the existing manifest from the jar and b) disables
-    # special-casing for the manifest file, so we can re-add it as a normal
-    # archive member.  This puts the manifest at the end of the jar rather
-    # than the beginning, but the spec doesn't forbid that.
-    subprocess.check_call(['jar', 'ufM', fname, 'META-INF/MANIFEST.MF'])
+            if line.startswith('Class-Path:'):
+                in_classpath = True
+            elif in_classpath and line.startswith(' '):
+                # continuation of the Class-Path attribute value
+                pass
+            else:
+                in_classpath = False
+                stripped.append(line)
+        if stripped == lines:
+            # No Class-Path attribute to remove. Leave the jar alone:
+            # rewriting it would only replace the manifest's timestamp
+            # with the current time, hurting build reproducibility.
+            return
+        entries = [(info, jar.read(info)) for info in jar.infolist()]
+        comment = jar.comment
+    # Use a temp file so that an interrupted or failed rewrite does not leave a corrupt jar
+    tmpname = fname + '.tmp'
+    try:
+        with zipfile.ZipFile(tmpname, 'w') as jar:
+            jar.comment = comment
+            for info, data in entries:
+                if info.filename == 'META-INF/MANIFEST.MF':
+                    data = ''.join(stripped).encode('utf-8')
+                # Passing the original ZipInfo keeps all metadata
+                # (mtime, permissions, compression),
+                # for deterministic build results
+                jar.writestr(info, data)
+        shutil.copystat(fname, tmpname)
+    except BaseException:
+        if os.path.exists(tmpname):
+            os.unlink(tmpname)
+        raise
+    os.replace(tmpname, fname)
 
 def fix_rpath(fname: str, rpath_dirs_to_remove: T.Set[bytes], new_rpath: T.Union[str, bytes], final_path: str, install_name_mappings: T.Dict[str, str], system: str, verbose: bool = True) -> None:
     global INSTALL_NAME_TOOL  # pylint: disable=global-statement

--- a/test cases/java/7 linking/meson.build
+++ b/test cases/java/7 linking/meson.build
@@ -4,5 +4,7 @@ subdir('sub')
 
 javaprog = jar('myprog', 'com/mesonbuild/Linking.java',
   main_class : 'com.mesonbuild.Linking',
-  link_with : simplelib)
+  link_with : simplelib,
+  install : true,
+  install_dir : get_option('bindir'))
 test('mytest', javaprog)

--- a/test cases/java/7 linking/sub/meson.build
+++ b/test cases/java/7 linking/sub/meson.build
@@ -1,2 +1,4 @@
 simplelib = jar('simplelib',
- 'com/mesonbuild/SimpleLib.java')
+ 'com/mesonbuild/SimpleLib.java',
+ install : true,
+ install_dir : get_option('bindir'))

--- a/test cases/java/7 linking/test.json
+++ b/test cases/java/7 linking/test.json
@@ -1,0 +1,6 @@
+{
+  "installed": [
+    {"type": "file", "file": "usr/bin/myprog.jar"},
+    {"type": "file", "file": "usr/bin/simplelib.jar"}
+  ]
+}

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -91,6 +91,7 @@ class BasePlatformTests(TestCase):
         cls.unit_test_dir = os.path.join(src_root, 'test cases', 'unit')
         cls.rewrite_test_dir = os.path.join(src_root, 'test cases', 'rewrite')
         cls.linuxlike_test_dir = os.path.join(src_root, 'test cases', 'linuxlike')
+        cls.java_test_dir = os.path.join(src_root, 'test cases', 'java')
         cls.objc_test_dir = os.path.join(src_root, 'test cases', 'objc')
         cls.objcpp_test_dir = os.path.join(src_root, 'test cases', 'objcpp')
         cls.darwin_test_dir = os.path.join(src_root, 'test cases', 'darwin')

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -9,6 +9,7 @@ import textwrap
 import os
 import shutil
 import hashlib
+import zipfile
 from unittest import mock, skipUnless, SkipTest
 from glob import glob
 from pathlib import Path
@@ -2068,6 +2069,49 @@ class LinuxlikeTests(BasePlatformTests):
                     if 'linker' in src or src['language'] == 'rust':
                         for param in src['parameters']:
                             self.assertNotIn('liblib.rlib', param)
+
+    @skip_if_not_language('java')
+    def test_jar_install_reproducible(self):
+        '''
+        Test that a jar without a Class-Path manifest attribute is installed
+        unmodified, so that its manifest keeps the timestamp from build time
+        instead of getting stamped with the time of installation.
+        See https://reproducible-builds.org/ for why this is good.
+        '''
+        testdir = os.path.join(self.java_test_dir, '1 basic')
+        self.init(testdir)
+        self.build()
+        self.install()
+        built = Path(self.builddir, 'myprog.jar').read_bytes()
+        installed = Path(self.installdir, 'usr/bin/myprog.jar').read_bytes()
+        self.assertEqual(built, installed)
+
+    @skip_if_not_language('java')
+    def test_jar_install_strips_classpath(self):
+        '''
+        Test that installing a jar that links with other jars strips the
+        Class-Path attribute from its manifest while preserving the other
+        attributes, the entry order and the entry timestamps.
+        '''
+        testdir = os.path.join(self.java_test_dir, '7 linking')
+        self.init(testdir)
+        self.build()
+        self.install()
+        with zipfile.ZipFile(os.path.join(self.builddir, 'myprog.jar')) as jar:
+            manifest = jar.read('META-INF/MANIFEST.MF').decode('utf-8')
+            self.assertIn('Class-Path:', manifest)
+            built_infos = [(i.filename, i.date_time) for i in jar.infolist()]
+            built_contents = {i.filename: jar.read(i) for i in jar.infolist()}
+        with zipfile.ZipFile(os.path.join(self.installdir, 'usr', 'bin', 'myprog.jar')) as jar:
+            manifest = jar.read('META-INF/MANIFEST.MF').decode('utf-8')
+            self.assertNotIn('Class-Path:', manifest)
+            self.assertIn('Main-Class:', manifest)
+            # Entry order and mtimes must be preserved from the built jar
+            installed_infos = [(i.filename, i.date_time) for i in jar.infolist()]
+            self.assertEqual(installed_infos, built_infos)
+            for info in jar.infolist():
+                if info.filename != 'META-INF/MANIFEST.MF':
+                    self.assertEqual(jar.read(info), built_contents[info.filename])
 
     def test_sanitizers(self):
         testdir = os.path.join(self.unit_test_dir, '129 sanitizers')


### PR DESCRIPTION
As an alternative to #15529, this implements the `zipfile`-based rewrite of `fix_jar()` that @bonzini and @sp1ritCS suggested there, which helps making openSUSE's `libbluray` package build reproducible.

Without this change, `fix_jar()` unconditionally updated `META-INF/MANIFEST.MF` in every installed jar, even when there was no `Class-Path` attribute to remove and `jar ufM` used the current time as mtime.

This also helps with #4844 because with this change, no JDK needs to be installed.
And meson no longer extracts `META-INF/` into the current working directory.

Closes #15529

Q: Should the new test be squashed into the same commit as the related fix?