### PR TITLE
Fix hotdoc_bootstrap_theme regression

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -122,6 +122,7 @@ if T.TYPE_CHECKING:
     from . import kwargs as kwtypes
     from ..backend.backends import Backend
     from ..compilers.compilers import CompilerDict, Language
+    from ..interpreterbase import FeatureCheckBase
     from ..interpreterbase.baseobjects import InterpreterObject, TYPE_var, TYPE_kwargs
     from ..options import OptionDict
     from ..mesonlib import InstallScript, SubProject
@@ -284,7 +285,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                 subproject_dir: str = 'subprojects',
                 invoker_method_default_options: T.Optional[OptionDict] = None,
                 ast: T.Optional[mparser.CodeBlockNode] = None,
-                relaxations: T.Optional[T.Set[InterpreterRuleRelaxation]] = None,
+                relaxations: T.Optional[T.Dict[InterpreterRuleRelaxation, T.Optional[FeatureCheckBase]]] = None,
                 user_defined_options: T.Optional[SharedCMDOptions] = None,
                 cargo: T.Optional[cargo.Interpreter] = None,
             ) -> None:
@@ -297,7 +298,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         self.cargo = cargo
         self.summary: T.Dict[str, 'Summary'] = {}
         self.modules: T.Dict[str, NewExtensionModule] = {}
-        self.relaxations = relaxations or set()
+        self.relaxations = relaxations or {}
         if ast is None:
             self.load_root_meson_file()
         else:
@@ -328,6 +329,16 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     def __getnewargs_ex__(self) -> T.Tuple[T.Tuple[object], T.Dict[str, object]]:
         raise MesonBugException('This class is unpicklable')
+
+    def relaxed(self, relaxation: InterpreterRuleRelaxation) -> bool:
+        '''Check if a relaxation is in place, and if so whether it should warn
+           as a broken or deprecated feature.'''
+        if relaxation not in self.relaxations:
+            return False
+        feature = self.relaxations[relaxation]
+        if feature is not None:
+            feature.use(self.subproject, location=self.current_node)
+        return True
 
     def load_root_cargo_lock_file(self) -> None:
         cargo_lock = os.path.join(self.source_root, self.subdir, 'Cargo.lock')
@@ -1055,7 +1066,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                              kwargs: kwtypes.DoSubproject,
                              ast: T.Optional[mparser.CodeBlockNode] = None,
                              build_def_files: T.Optional[T.List[str]] = None,
-                             relaxations: T.Optional[T.Set[InterpreterRuleRelaxation]] = None,
+                             relaxations: T.Optional[T.Dict[InterpreterRuleRelaxation, T.Optional[FeatureCheckBase]]] = None,
                              cargo: T.Optional[cargo.Interpreter] = None) -> SubprojectHolder:
         for_machine = kwargs['for_machine']
         if for_machine is MachineChoice.BUILD:
@@ -1126,7 +1137,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                     kwargs, ast,
                     [str(f) for f in cm_int.bs_files],
                     relaxations={
-                        InterpreterRuleRelaxation.ALLOW_BUILD_DIR_FILE_REFERENCES,
+                        InterpreterRuleRelaxation.ALLOW_BUILD_DIR_FILE_REFERENCES: None,
                     }
             )
             result.cm_interpreter = cm_int
@@ -1154,7 +1165,7 @@ class Interpreter(InterpreterBase, HoldableObject):
 
             return self._do_subproject_meson(
                 subp_name, subdir, default_options, kwargs, ast,
-                relaxations={InterpreterRuleRelaxation.CARGO_SUBDIR} if ast is not None else None,
+                relaxations={InterpreterRuleRelaxation.CARGO_SUBDIR: None} if ast is not None else None,
                 cargo=cargo_int)
 
     @typed_pos_args('get_option', str)
@@ -2611,7 +2622,7 @@ class Interpreter(InterpreterBase, HoldableObject):
 
         self.create_build_subdir(subdir)
 
-        if InterpreterRuleRelaxation.CARGO_SUBDIR in self.relaxations and \
+        if self.relaxed(InterpreterRuleRelaxation.CARGO_SUBDIR) and \
            os.path.exists(os.path.join(self.environment.get_source_dir(), subdir, 'Cargo.toml')):
             codeblock = self.cargo.interpret(subdir, self.root_subdir)
             self._save_ast(subdir, codeblock)
@@ -3401,7 +3412,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                     self.validate_within_subproject(self.subdir, s)
                 except BuiltFileByNameError as e:
                     # In Meson 2.0 this should just raise
-                    if InterpreterRuleRelaxation.ALLOW_BUILD_DIR_FILE_REFERENCES not in self.relaxations:
+                    if not self.relaxed(InterpreterRuleRelaxation.ALLOW_BUILD_DIR_FILE_REFERENCES):
                         #raise
                         mlog.warning(str(e), location=self.current_node)
                     if path_has_root(s):

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import io, sys, traceback
 import dataclasses
 import functools
@@ -267,6 +268,7 @@ class InterpreterRuleRelaxation(Enum):
 
     ALLOW_BUILD_DIR_FILE_REFERENCES = 1
     CARGO_SUBDIR = 2
+    ALLOW_SANDBOX_VIOLATION = 4
 
 implicit_check_false_warning = """You should add the boolean check kwarg to the run_command call.
          It currently defaults to false,
@@ -329,6 +331,19 @@ class Interpreter(InterpreterBase, HoldableObject):
 
     def __getnewargs_ex__(self) -> T.Tuple[T.Tuple[object], T.Dict[str, object]]:
         raise MesonBugException('This class is unpicklable')
+
+    @contextlib.contextmanager
+    def relaxing(self, relaxation: InterpreterRuleRelaxation, feature: FeatureCheckBase) -> T.Iterator[None]:
+        '''Temporarily add a rule relaxation to the interpreter, with a
+           warning if it is encountered.'''
+        if relaxation in self.relaxations:
+            yield
+        else:
+            try:
+                self.relaxations[relaxation] = feature
+                yield
+            finally:
+                del self.relaxations[relaxation]
 
     def relaxed(self, relaxation: InterpreterRuleRelaxation) -> bool:
         '''Check if a relaxation is in place, and if so whether it should warn
@@ -2272,6 +2287,10 @@ class Interpreter(InterpreterBase, HoldableObject):
 
         self._validate_custom_target_outputs(len(inputs) > 1, kwargs['output'], "custom_target")
 
+        with self.relaxing(InterpreterRuleRelaxation.ALLOW_SANDBOX_VIOLATION,
+                           FeatureBroken('grabbing custom target depend_files from outside the current project', '1.12.0')):
+            depend_files = self.source_strings_to_files(kwargs['depend_files'])
+
         tg = build.CustomTarget(
             name,
             self.subdir,
@@ -2284,7 +2303,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             build_by_default=build_by_default,
             capture=kwargs['capture'],
             console=kwargs['console'],
-            depend_files=self.source_strings_to_files(kwargs['depend_files']),
+            depend_files=depend_files,
             depfile=kwargs['depfile'],
             extra_depends=kwargs['depends'],
             env=kwargs['env'],
@@ -3426,8 +3445,11 @@ class Interpreter(InterpreterBase, HoldableObject):
                         results.append(mesonlib.File.from_built_relative(rel))
                     else:
                         results.append(mesonlib.File.from_built_file(self.subdir, s))
-                else:
-                    results.append(mesonlib.File.from_source_file(self.environment.source_dir, self.subdir, s))
+                    continue
+                except SandboxViolationError:
+                    if not self.relaxed(InterpreterRuleRelaxation.ALLOW_SANDBOX_VIOLATION):
+                        raise
+                results.append(mesonlib.File.from_source_file(self.environment.source_dir, self.subdir, s))
             elif isinstance(s, (mesonlib.File, build.GeneratedList, Program,
                                 build.BuildTarget, build.CustomTargetIndex, build.CustomTarget,
                                 build.ExtractedObjects, build.StructuredSources)):

--- a/test cases/warning/10 depend_files sandbox violation/meson.build
+++ b/test cases/warning/10 depend_files sandbox violation/meson.build
@@ -1,0 +1,3 @@
+project('subproject depend_files sandbox violation')
+
+subproject('sub')

--- a/test cases/warning/10 depend_files sandbox violation/shared.py
+++ b/test cases/warning/10 depend_files sandbox violation/shared.py
@@ -1,0 +1,2 @@
+#! /usr/bin/env python3
+print('what were you looking for?')

--- a/test cases/warning/10 depend_files sandbox violation/subprojects/sub/meson.build
+++ b/test cases/warning/10 depend_files sandbox violation/subprojects/sub/meson.build
@@ -1,0 +1,8 @@
+project('sub')
+
+custom_target('t',
+  output: 'out',
+  command: [find_program('touch.py'), '@OUTPUT@'],
+  depend_files: '../../shared.py',
+  build_by_default: true,
+)

--- a/test cases/warning/10 depend_files sandbox violation/subprojects/sub/touch.py
+++ b/test cases/warning/10 depend_files sandbox violation/subprojects/sub/touch.py
@@ -1,0 +1,3 @@
+#! /usr/bin/env python3
+import sys
+open(sys.argv[1], "w").close()

--- a/test cases/warning/10 depend_files sandbox violation/test.json
+++ b/test cases/warning/10 depend_files sandbox violation/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "sub| test cases/warning/10 depend_files sandbox violation/subprojects/sub/meson.build:3: DEPRECATION: Project uses feature that was always broken, and is now deprecated since '1.12.0': grabbing custom target depend_files from outside the current project."
+    }
+  ]
+}


### PR DESCRIPTION
Meson 1.12.0 broke (and thus effectively deprecated) usage of files from outside the subproject in a custom project's `depend_files`. Unfortunately this makes all releases of Hotdoc fail to build with current Meson (hotdoc/hotdoc#328).

Let `source_strings_to_files` pass that through in the special case of coming from `depend_files`, degrading the previous error to a warning. To do so introduce a new relaxation, but attach it to a `FeatureDeprecated` so that the violation report is not lost.