### PR TITLE
Stop depending on libwmf-config to run test

### DIFF
--- a/test cases/frameworks/21 libwmf/meson.build
+++ b/test cases/frameworks/21 libwmf/meson.build
@@ -1,11 +1,10 @@
 project('libwmf test', 'c')
 
-wm = find_program('libwmf-config', required : false)
-if not wm.found() or meson.is_cross_build()
-  error('MESON_SKIP_TEST: libwmf-config not installed')
+libwmf_dep = dependency('libwmf', version : '>= 0.2.8', required : false)
+if not libwmf_dep.found()
+  error('MESON_SKIP_TEST: libwmf not installed')
 endif
 
-libwmf_dep = dependency('libwmf', version : '>= 0.2.8')
 libwmf_ver = libwmf_dep.version()
 assert(libwmf_ver.split('.').length() > 1, 'libwmf version is "@0@"'.format(libwmf_ver))
 message('libwmf version is "@0@"'.format(libwmf_ver))
@@ -17,11 +16,14 @@ e = executable('libwmf_prog', 'libwmf_prog.c', dependencies : [libwmf_dep, ft_de
 
 test('libwmftest', e)
 
-# Test using the method keyword:
-
-dependency('libwmf', method : 'config-tool')
-dependency('libwmf', method : 'libwmf-config')
-
 # Check we can apply a version constraint
-dependency('libwmf', version: '>=@0@'.format(libwmf_dep.version()), method: 'pkg-config', required: false)
-dependency('libwmf', version: '>=@0@'.format(libwmf_dep.version()), method: 'config-tool')
+dependency('libwmf', version: '>=@0@'.format(libwmf_ver), method: 'pkg-config', required: false)
+
+# Test using the method keyword. Only exercise the config-tool method when
+# libwmf-config is actually available on PATH.
+libwmf_config = find_program('libwmf-config', required : false)
+if libwmf_config.found() and not meson.is_cross_build()
+  dependency('libwmf', method : 'config-tool')
+  dependency('libwmf', method : 'libwmf-config')
+  dependency('libwmf', version: '>=@0@'.format(libwmf_ver), method: 'config-tool')
+endif


### PR DESCRIPTION
Debian has stopped shipping libwmf-config in the default PATH. Therefore, we were skipping the test. Debian is shipping a pkg-config file that we can use instead to make sure that the test is still run.