### PR TITLE
Disable Windows Defender in CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -56,6 +56,17 @@ jobs:
             ifort: false
 
     steps:
+      - name: Disable Windows Defender
+        shell: pwsh
+        run: |
+          Set-MpPreference -DisableRealtimeMonitoring $true
+          Set-MpPreference -DisableBehaviorMonitoring $true
+          Set-MpPreference -DisableIOAVProtection $true
+          Set-MpPreference -DisableScriptScanning $true
+          Set-MpPreference -DisableArchiveScanning $true
+          Set-MpPreference -MAPSReporting Disabled
+          Set-MpPreference -SubmitSamplesConsent NeverSend
+
       - uses: actions/checkout@v6
 
       - name: Setup Python


### PR DESCRIPTION
Windows Defender can interfere with CI quite a bit. It takes resources and does quite a bit of scanning that can slow down CI or cause it to fail entirely due to resource starvation. I am no Windows Defender expert, but these settings[0] seemed like a good start.

Link: https://learn.microsoft.com/en-us/powershell/module/defender/set-mppreference?view=windowsserver2025-ps [0]