### PR TITLE
Remove MESON_SKIP_TEST in cmake/19 advanced options

### DIFF
--- a/test cases/cmake/19 advanced options/meson.build
+++ b/test cases/cmake/19 advanced options/meson.build
@@ -1,10 +1,5 @@
 project('cmake_set_opt', ['c', 'cpp'])
 
-comp = meson.get_compiler('cpp')
-if comp.get_argument_syntax() == 'msvc'
-  error('MESON_SKIP_TEST: MSVC is not supported because it does not support C++11')
-endif
-
 cm   = import('cmake')
 opts = cm.subproject_options()
 


### PR DESCRIPTION
MSVC now supports C++11[0].

Link: https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance?view=msvc-170 [0]