### PR TITLE
ci: gentoo: drop Qt 5 packages

### DIFF
--- a/ci/ciimage/gentoo/install.sh
+++ b/ci/ciimage/gentoo/install.sh
@@ -44,8 +44,6 @@ pkgs_stable=(
   media-libs/libsdl2
   dev-cpp/gtest
   sci-libs/hdf5
-  dev-qt/linguist-tools
-  dev-qt/qtwidgets:5
   llvm-core/llvm
   dev-qt/qtdeclarative:6
   dev-qt/qttools


### PR DESCRIPTION
They've been removed. We already have the Qt 6 equivalents here.