### PR TITLE
Migrate envcheck.py test to C

### DIFF
--- a/test cases/unit/2 testsetups/envcheck.c
+++ b/test cases/unit/2 testsetups/envcheck.c
@@ -1,0 +1,10 @@
+#include <stdlib.h>
+
+int
+main(void)
+{
+    if (getenv("PATH") == NULL)
+        return 1;
+
+    return 0;
+}

--- a/test cases/unit/2 testsetups/envcheck.py
+++ b/test cases/unit/2 testsetups/envcheck.py
@@ -1,5 +1,0 @@
-#!/usr/bin/env python3
-
-import os
-
-assert 'PATH' in os.environ

--- a/test cases/unit/2 testsetups/meson.build
+++ b/test cases/unit/2 testsetups/meson.build
@@ -21,7 +21,7 @@ add_test_setup('valgrind',
 buggy = executable('buggy', 'buggy.c', 'impl.c')
 test('Test buggy', buggy, suite: ['buggy'])
 
-envcheck = find_program('envcheck.py')
+envcheck = executable('envcheck', 'envcheck.c')
 test('test-env', envcheck)
 
 add_test_setup('empty')


### PR DESCRIPTION
In Valgrind test setups, we were running the Python interpreter under Valgrind. The Python interpreter is not code that we control, meaning that if something changes upstream that causes a Valgrind failure, we are victims of it.

By migrating to C, we can easily control the outcome.