### PR TITLE
compilers/pgi: generate header dependency args for NVHPC/PGI

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2771,9 +2771,10 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             # See also: https://github.com/ninja-build/ninja/pull/2275
             restat = True
         rule = self.compiler_to_rule_name(compiler)
-        if langname == 'cuda':
-            # for cuda, we manually escape target name ($out) as $CUDA_ESCAPED_TARGET because nvcc doesn't support `-MQ` flag
-            depargs = NinjaCommandArg.list(compiler.get_dependency_gen_args('$CUDA_ESCAPED_TARGET', '$DEPFILE'), Quoting.none)
+        if compiler.needs_escaped_depfile_target():
+            # -MT does not escape the target for Make, so we escape $out
+            # ourselves as $ESCAPED_DEPFILE_TARGET (see generate_single_compile)
+            depargs = NinjaCommandArg.list(compiler.get_dependency_gen_args('$ESCAPED_DEPFILE_TARGET', '$DEPFILE'), Quoting.none)
         else:
             depargs = NinjaCommandArg.list(compiler.get_dependency_gen_args('$out', '$DEPFILE'), Quoting.none)
         command = compiler.get_exelist()
@@ -3368,8 +3369,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 element.add_dep(i)
         if dep_file:
             element.add_item('DEPFILE', dep_file)
-        if compiler.get_language() == 'cuda':
-            # for cuda, we manually escape target name ($out) as $CUDA_ESCAPED_TARGET because nvcc doesn't support `-MQ` flag
+        if compiler.needs_escaped_depfile_target():
             def quote_make_target(targetName: str) -> str:
                 # this escape implementation is taken from llvm
                 result = ''
@@ -3389,7 +3389,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                         result += '\\'
                     result += c
                 return result
-            element.add_item('CUDA_ESCAPED_TARGET', quote_make_target(rel_obj))
+            element.add_item('ESCAPED_DEPFILE_TARGET', quote_make_target(rel_obj))
         if self.ninja.should_use_rspfile(element) and compiler.rsp_file_syntax() == RSPFileSyntax.NASM:
             exe = compiler.get_exelist()
             # Add to commands the args created by generate_compile_rule_for().

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -25,7 +25,7 @@ from .mixins.gnu import gnu_common_warning_args, gnu_c_warning_args
 from .mixins.intel import IntelGnuLikeCompiler, IntelLLVMLikeCompiler, IntelVisualStudioLikeCompiler
 from .mixins.clang import ClangCompiler, ClangCStds
 from .mixins.elbrus import ElbrusCompiler
-from .mixins.pgi import PGICompiler
+from .mixins.pgi import PGICompiler, PGIDependencyMixin
 from .mixins.emscripten import EmscriptenMixin
 from .mixins.metrowerks import MetrowerksCompiler
 from .mixins.metrowerks import mwccarm_instruction_set_args, mwcceppc_instruction_set_args
@@ -281,7 +281,7 @@ class GnuCCompiler(GnuCStds, GnuCompiler, CCompiler):
         return ['-fpch-preprocess', '-include', os.path.basename(header)]
 
 
-class PGICCompiler(PGICompiler, CCompiler):
+class PGICCompiler(PGIDependencyMixin, PGICompiler, CCompiler):
     def __init__(self, ccache: T.List[str], exelist: T.List[str], version: str, for_machine: MachineChoice,
                  env: Environment, linker: T.Optional['DynamicLinker'] = None,
                  full_version: T.Optional[str] = None):
@@ -290,7 +290,7 @@ class PGICCompiler(PGICompiler, CCompiler):
         PGICompiler.__init__(self)
 
 
-class NvidiaHPC_CCompiler(PGICompiler, CCompiler):
+class NvidiaHPC_CCompiler(PGIDependencyMixin, PGICompiler, CCompiler):
 
     id = 'nvidia_hpc'
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1503,6 +1503,11 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
     def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
         return []
 
+    def needs_escaped_depfile_target(self) -> bool:
+        # True for compilers that support -MT but not -MQ, since -MT does not
+        # escape the target for Make and the backend must do it instead.
+        return False
+
     def get_std_exe_link_args(self) -> T.List[str]:
         # TODO: is this a linker property?
         return []

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -28,7 +28,7 @@ from .mixins.gnu import GnuCompiler, GnuCPPStds, gnu_common_warning_args, gnu_cp
 from .mixins.intel import IntelGnuLikeCompiler, IntelLLVMLikeCompiler, IntelVisualStudioLikeCompiler
 from .mixins.clang import ClangCompiler, ClangCPPStds
 from .mixins.elbrus import ElbrusCompiler
-from .mixins.pgi import PGICompiler
+from .mixins.pgi import PGICompiler, PGIDependencyMixin
 from .mixins.emscripten import EmscriptenMixin
 from .mixins.metrowerks import MetrowerksCompiler
 from .mixins.metrowerks import mwccarm_instruction_set_args, mwcceppc_instruction_set_args
@@ -551,7 +551,7 @@ class GnuCPPCompiler(_StdCPPLibMixin, GnuCPPStds, GnuCompiler, CPPCompiler):
         return ['-fmodules', '-fmodules-ts']
 
 
-class PGICPPCompiler(PGICompiler, CPPCompiler):
+class PGICPPCompiler(PGIDependencyMixin, PGICompiler, CPPCompiler):
     def __init__(self, ccache: T.List[str], exelist: T.List[str], version: str, for_machine: MachineChoice,
                  env: Environment, linker: T.Optional['DynamicLinker'] = None,
                  full_version: T.Optional[str] = None):
@@ -560,7 +560,7 @@ class PGICPPCompiler(PGICompiler, CPPCompiler):
         PGICompiler.__init__(self)
 
 
-class NvidiaHPC_CPPCompiler(PGICompiler, CPPCompiler):
+class NvidiaHPC_CPPCompiler(PGIDependencyMixin, PGICompiler, CPPCompiler):
 
     id = 'nvidia_hpc'
 

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -711,6 +711,9 @@ class CudaCompiler(Compiler):
     def get_output_args(self, target: str) -> T.List[str]:
         return ['-o', target]
 
+    def needs_escaped_depfile_target(self) -> bool:
+        return True
+
     def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
         if version_compare(self.version, '>= 10.2'):
             # According to nvcc Documentation, `-MD` option is added after 10.2

--- a/mesonbuild/compilers/mixins/pgi.py
+++ b/mesonbuild/compilers/mixins/pgi.py
@@ -22,6 +22,24 @@ else:
     Compiler = object
 
 
+class PGIDependencyMixin(Compiler):
+
+    """Dependency file generation for the NVHPC/PGI C and C++ compilers.
+
+    Deliberately not mixed into the Fortran compilers: nvfortran accepts
+    -MD/-MT/-MF and exits 0, but writes no depfile. NVHPC's own help describes
+    -M as "Print dependencies to stdout in C++".
+    """
+
+    def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
+        # -MT, not -MQ: nvc's -MQ ignores its argument and writes the literal
+        # string "mttarget" as the target, in both the -MQ x and -MQ=x forms.
+        return ['-MD', '-MT', outtarget, '-MF', outfile]
+
+    def needs_escaped_depfile_target(self) -> bool:
+        return True
+
+
 class PGICompiler(Compiler):
 
     id = 'pgi'


### PR DESCRIPTION
Fixes #16160.

`PGICompiler` did not implement `get_dependency_gen_args()`, so it inherited the base
class stub returning `[]`. Meson still emitted `deps = gcc` and a `depfile` into the ninja
rule, but the compile line never received `-MD`/`-MF`, so no depfile was ever written:
ninja recorded **zero dependencies for every object** and a changed header never triggered
a rebuild.

Same defect as #11969 (CUDA), fixed in #12665, in a different compiler class.

This is not just a stale-build annoyance. An incremental build can silently produce a
binary whose translation units disagree about struct layout — no compile error, no
warning. In the project where I hit this, a member in a shared header shifted, only some
objects were rebuilt, and two struct members aliased: the program printed a nonsense value
and hung.

### `-MQ` must not be used here

`nvc` accepts `-MQ` but **ignores its argument**, writing the literal string `mttarget` as
the depfile target, which ninja then silently discards. That failure looks identical to
having no fix at all, so it is worth stating explicitly. Verified on nvc 26.3:

```console
$ nvc -MD -MQ 'ZZZ_unique_target' -MF q.d -c a.c -o q.o && head -1 q.d
mttarget : a.c \

$ nvc -MD -MT 'ZZZ_unique_target' -MF t.d -c a.c -o q.o && head -1 t.d
ZZZ_unique_target : a.c \
```

So `-MT` is used, as for nvcc.

### Escaping

`-MT` does not Make-escape the target, so this needs the escaping #12665 added for CUDA.
That was gated on `langname == 'cuda'` / `compiler.get_language() == 'cuda'`. Rather than
add a second special case, this adds a compiler predicate:

```python
def needs_escaped_depfile_target(self) -> bool:
    """Whether the depfile target must be Make-escaped by the backend."""
    return False
```

returning `True` for CUDA and PGI, with both `ninjabackend.py` gates switched to it. The
ninja variable `CUDA_ESCAPED_TARGET` is renamed `ESCAPED_DEPFILE_TARGET` since it is no
longer CUDA-specific. **No behaviour change for CUDA.**

### Tests

Two tests in `unittests/internaltests.py`:

* `test_pgi_dependency_gen_args` — the flags themselves.
* `test_depfile_target_escaping_is_declared` — ties `get_dependency_gen_args` to
  `needs_escaped_depfile_target` as an invariant across GCC, Clang and NVHPC: emitting
  `-MT` requires `True`, emitting `-MQ` requires `False`. This is the failure a future
  compiler addition is most likely to hit, and it only shows up for object paths
  containing a space, `$` or `#`.

Both fail on unpatched master (`[] != ['-MD', '-MT', 'foo.o', '-MF', 'foo.o.d']`) and pass
with the change. Full `internaltests.py`: 78 passed, 129 subtests.

### Real-world verification

On an NVHPC project (~34 objects, C plus Cython-generated C, `-mp=gpu`):

```console
$ grep -A2 '^rule c_COMPILER' build/build.ninja
 command = .../nvc $ARGS -MD -MT $ESCAPED_DEPFILE_TARGET -MF $DEPFILE -o $out -c $in

$ ninja -C build -t deps | grep -cE '^\S+\.o: #deps [1-9]'
34                                  # was 0
$ touch src/sw_domain.h && ninja -C build -n | grep -c 'Compiling C object'
13                                  # was 0
```

The 13 are exactly the objects including that header, across both extension modules. That
project's own test suites pass unchanged.

### Open questions

1. **Version gating.** #12665 gated CUDA on `>= 10.2`. I only have nvc 26.3 and do not know
   the earliest NVHPC/PGI release supporting `-MD`/`-MT`. Happy to add a bound if someone
   with older toolchains can name one.
2. **Classic PGI vs NVHPC.** `PGICompiler` backs both `PGICCompiler` (`pgcc`) and the
   `NvidiaHPC_*` classes. I verified NVHPC only. If legacy `pgcc` differs, the override
   may belong on the NVHPC classes instead of the shared mixin.
3. **Fortran.** The mixin is shared with the Fortran compilers, which I have not tested.
