### PR TITLE
Assorted fixes for building MPV on Win32

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -314,8 +314,7 @@ class NinjaRule:
                                      element.elems) >= rsp_threshold
 
 class NinjaBuildElement:
-
-    rule: NinjaRule
+    rule: mesonlib.late_property[NinjaRule] = mesonlib.late_property()
 
     def __init__(self, all_outputs: T.Set[str], outfilenames: ListifiedStr, rulename: str, infilenames: ListifiedStr, implicit_outs: T.Optional[T.List[str]] = None):
         self.implicit_outfilenames = implicit_outs or []

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -275,11 +275,11 @@ class NinjaRule:
             outfile.write('\n')
 
     def _length_estimate(self, infiles: str, outfiles: str,
-                         elems: T.List[T.Tuple[str, T.List[str]]]) -> int:
+                         elems: T.Dict[str, T.List[str]]) -> int:
         # determine variables
         # this order of actions only approximates ninja's scoping rules, as
         # documented at: https://ninja-build.org/manual.html#ref_scope
-        ninja_vars = dict(elems)
+        ninja_vars = elems.copy()
         if self.deps is not None:
             ninja_vars['deps'] = [self.deps]
         if self.depfile is not None:
@@ -330,7 +330,7 @@ class NinjaBuildElement:
             self.infilenames = infilenames
         self.deps: T.Set[str] = set()
         self.orderdeps: T.Set[str] = set()
-        self.elems: T.List[T.Tuple[str, T.List[str]]] = []
+        self.elems: T.Dict[str, T.List[str]] = {}
         self.all_outputs = all_outputs
         self.output_errors = ''
 
@@ -347,16 +347,18 @@ class NinjaBuildElement:
             self.orderdeps.add(dep)
 
     def add_item(self, name: str, elems: T.Union[ListifiedStr, CompilerArgs]) -> None:
+        if name in self.elems:
+            raise MesonBugException(f'Item {name!r} added to a NinjaBuildElement more than once')
         # Always convert from GCC-style argument naming to the naming used by the
         # current compiler. Also filter system include paths, deduplicate, etc.
         if isinstance(elems, CompilerArgs):
             elems = elems.to_native()
         if isinstance(elems, str):
             elems = [elems]
-        self.elems.append((name, elems))
+        self.elems[name] = elems
 
         if name == 'DEPFILE':
-            self.elems.append((name + '_UNQUOTED', elems))
+            self.elems[name + '_UNQUOTED'] = elems
 
     @mesonlib.lazy_property
     def _should_use_rspfile(self) -> bool:
@@ -420,8 +422,7 @@ class NinjaBuildElement:
         else:
             qf = quote_func
 
-        for e in self.elems:
-            (name, elems) = e
+        for name, elems in self.elems.items():
             should_quote = name not in raw_names
             line = f' {name} = '
             newelems = []

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -360,6 +360,9 @@ class NinjaBuildElement:
         if name == 'DEPFILE':
             self.elems[name + '_UNQUOTED'] = elems
 
+    def remove_item(self, name: str) -> None:
+        del self.elems[name]
+
     @mesonlib.lazy_property
     def _should_use_rspfile(self) -> bool:
         # 'phony' is a rule built-in to ninja
@@ -3390,7 +3393,12 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                     result += c
                 return result
             element.add_item('CUDA_ESCAPED_TARGET', quote_make_target(rel_obj))
+        element.add_item('ARGS', commands)
+
+        # NinjaRule.should_use_rspfile counts element.elems too, which will
+        # exceed the RSP threshold only after added
         if self.ninja.should_use_rspfile(element) and compiler.rsp_file_syntax() == RSPFileSyntax.NASM:
+            element.remove_item('ARGS')
             exe = compiler.get_exelist()
             # Add to commands the args created by generate_compile_rule_for().
             # commands remain separate from exelist because they must stay
@@ -3409,8 +3417,6 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             cmd_type = f' (wrapped by meson {reason})' if reason else ''
             element.add_item('COMMAND', meson_exe_cmd)
             element.add_item('description', f'Compiling {compiler.get_display_language()} object {rel_obj}{cmd_type}')
-        else:
-            element.add_item('ARGS', commands)
 
         self.add_dependency_scanner_entries_to_element(target, compiler, element, src)
         self.add_build(element)

--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -437,7 +437,7 @@ class CMakeTraceParser:
 
         for i in args:
             if i in magic_keys:
-                if i == 'OUTPUT':
+                if i in {'OUTPUT', 'BYPRODUCTS'}:
                     fn = handle_output
                 elif i == 'DEPENDS':
                     fn = handle_depends


### PR DESCRIPTION
Hi all,

I'm coming again here from https://gitlab.freedesktop.org/gstreamer/meson-ports/ffmpeg/-/work_items/75, where I've been tracing consistent failures of Meson's response file generation for Nasm when building MPV.

I'm submitting this as a single MR because I ran into three different bugs when tracking the original issue. These are:

1. `NinjaBuildElement.rule` is not a nullable property, yet it is only set towards the end of its creation:
https://github.com/mesonbuild/meson/blob/c9bb03c2d1236ead370772f101891c670c2e54cf/mesonbuild/backend/ninjabackend.py#L489
which means that any attempts to debug its value or use it through `NinjaBuildElement._should_use_rspfile` before setting will fail with an `AttributeError` instead of raising the proper exception.
My proposed fix is to make it `None` so it will at least yield a proper access error or allow the existing exception check to raise.

2. The actual bug in the Nasm response generation test: I found a sort of TOCTOU issue regarding when I check the threshold, the standard check for `use_rspfile` in `NinjaBuildElement.write` tests against the complete set of `elems` in the `NinjaBuildElement`, which at that time includes the complete `ARGS` for `nasm_COMPILER`. But my original test is done against the initial (200 chars-ish) set of arguments, not the complete (4k chars) list, which yields a false negative. The result is that Meson still attempts to codegen a broken `nasm_COMPILER_RSP` rule whose contents will always be rejected by Nasm. 
My fix is to insert the `ARGS` as expected, but then determined if a Nasm-specific response file needs to be generated, and once it's confirmed, remove the item and codegen the response file.

3. The mpv build, when using libjxl from Git, fails with a missing `LIBJXL_VERSION` macro which ought to come from `tool_version_git.h`. Unlike others, the corresponding `add_custom_target` uses `BYPRODUCTS` to specify the output, as it's been pregenerated by the configure step.
https://github.com/libjxl/libjxl/blob/aea3a06e281fdee13e04815bfbf4f4132e7f59ea/tools/CMakeLists.txt#L106
This key is not handled by Meson, which this MR adds.

All feedback is appreciated.