### PR TITLE
Add libclang-rt-dev to ubunut-rolling

### DIFF
--- a/ci/ciimage/ubuntu-rolling/install.sh
+++ b/ci/ciimage/ubuntu-rolling/install.sh
@@ -17,7 +17,7 @@ pkgs=(
   llvm lcov
   dub ldc
   mingw-w64 mingw-w64-tools libz-mingw-w64-dev
-  libclang-dev
+  libclang-dev libclang-rt-dev
   libgcrypt20-dev
   libgpgme-dev
   libhdf5-dev


### PR DESCRIPTION
Debian/Ubuntu have changed their packaging such that libclang-dev no longer includes libclang-rt-dev. We require the libraries in libclang-rt-dev to run some of our tests.