### PR TITLE
Cleanup and fix sanitycheck linker args

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1435,6 +1435,16 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
         """Whether the sanity check links a binary, or only compiles one."""
         return CompileCheckMode.LINK
 
+    def get_external_compile_args(self) -> T.List[str]:
+        optstore = self.environment.coredata.optstore
+        return list(T.cast('T.List[str]', optstore.get_value_for(
+            OptionKey(f'{self.language}_args', machine=self.for_machine))))
+
+    def get_external_link_args(self) -> T.List[str]:
+        optstore = self.environment.coredata.optstore
+        return list(T.cast('T.List[str]', optstore.get_value_for(
+            OptionKey(f'{self.language}_link_args', machine=self.for_machine))))
+
     def _sanity_check_compile_args(self, sourcename: str, binname: str
                                    ) -> T.Tuple[T.List[str], T.List[str]]:
         """Get arguments to run compiler for sanity check.
@@ -1448,20 +1458,15 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
             arguments, the second is linker arguments
         """
         mode = self._sanity_check_mode()
-
-        optstore = self.environment.coredata.optstore
-        cargs = list(T.cast('T.List[str]', optstore.get_value_for(
-            OptionKey(f'{self.language}_args', machine=self.for_machine))))
         cargs = self.exelist_no_ccache \
             + self.get_always_args() \
             + self.get_compiler_check_args(CompileCheckMode.COMPILE) \
             + self.get_output_args(binname) \
             + [sourcename] \
-            + cargs
+            + self.get_external_compile_args()
         if mode is CompileCheckMode.COMPILE:
             return cargs, []
-        largs = list(T.cast('T.List[str]', optstore.get_value_for(
-            OptionKey(f'{self.language}_link_args', machine=self.for_machine))))
+        largs = self.get_external_link_args()
         return cargs, largs
 
     @abc.abstractmethod
@@ -1607,13 +1612,11 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
 
         if mode is CompileCheckMode.COMPILE:
             # Add DFLAGS from the env
-            args += T.cast('T.List[str]', self.environment.coredata.optstore.get_value_for(
-                OptionKey(f'{self.language}_args', machine=self.for_machine)))
+            args += self.get_external_compile_args()
         elif mode is CompileCheckMode.LINK:
             args += self.get_linker_always_args()
             # Add LDFLAGS from the env
-            args += T.cast('T.List[str]', self.environment.coredata.optstore.get_value_for(
-                OptionKey(f'{self.language}_link_args', machine=self.for_machine)))
+            args += self.get_external_link_args()
         # extra_args must override all other arguments, so we add them last
         args += extra_args
         return args

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1432,6 +1432,10 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
         """
         return compiler._sanity_check_compile_args(sourcename, binname)
 
+    def _sanity_check_mode(self) -> CompileCheckMode:
+        """Whether the sanity check links a binary, or only compiles one."""
+        return CompileCheckMode.LINK
+
     def _sanity_check_compile_args(self, sourcename: str, binname: str
                                    ) -> T.Tuple[T.List[str], T.List[str]]:
         """Get arguments to run compiler for sanity check.
@@ -1444,17 +1448,22 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
         :return: a tuple of arguments, the first is the executable and compiler
             arguments, the second is linker arguments
         """
+        mode = self._sanity_check_mode()
+
         optstore = self.environment.coredata.optstore
         cargs = list(T.cast('T.List[str]', optstore.get_value_for(
             OptionKey(f'{self.language}_args', machine=self.for_machine))))
-        largs = list(T.cast('T.List[str]', optstore.get_value_for(
-            OptionKey(f'{self.language}_link_args', machine=self.for_machine))))
-        return self.exelist_no_ccache \
+        cargs = self.exelist_no_ccache \
             + self.get_always_args() \
             + self.get_compiler_check_args(CompileCheckMode.COMPILE) \
             + self.get_output_args(binname) \
             + [sourcename] \
-            + cargs, largs
+            + cargs
+        if mode is CompileCheckMode.COMPILE:
+            return cargs, []
+        largs = list(T.cast('T.List[str]', optstore.get_value_for(
+            OptionKey(f'{self.language}_link_args', machine=self.for_machine))))
+        return cargs, largs
 
     @abc.abstractmethod
     def _sanity_check_source_code(self) -> str:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -909,7 +909,6 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
             args += self.get_preprocess_only_args()
         else:
             assert mode is CompileCheckMode.LINK
-            args += self.get_linker_always_args()
         return args
 
     def compiler_args(self, args: T.Optional[T.Iterable[str]] = None) -> CompilerArgs:
@@ -1611,6 +1610,7 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
             args += T.cast('T.List[str]', self.environment.coredata.optstore.get_value_for(
                 OptionKey(f'{self.language}_args', machine=self.for_machine)))
         elif mode is CompileCheckMode.LINK:
+            args += self.get_linker_always_args()
             # Add LDFLAGS from the env
             args += T.cast('T.List[str]', self.environment.coredata.optstore.get_value_for(
                 OptionKey(f'{self.language}_link_args', machine=self.for_machine)))

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -528,6 +528,16 @@ class CudaCompiler(Compiler):
             }
             '''
 
+    def _sanity_check_mode(self) -> CompileCheckMode:
+        # Linking cross built apps is painful. You can't really
+        # tell if you should use -nostdlib or not and for example
+        # on OSX the compiler binary is the same but you need
+        # a ton of compiler flags to differentiate between
+        # arm and x86_64. So just compile.
+        if self.is_cross and not self.environment.has_exe_wrapper():
+            return CompileCheckMode.COMPILE
+        return CompileCheckMode.LINK
+
     def _sanity_check_compile_args(self, sourcename: str, binname: str
                                    ) -> T.Tuple[T.List[str], T.List[str]]:
         # Disable warnings, compile with statically-linked runtime for minimum
@@ -540,12 +550,8 @@ class CudaCompiler(Compiler):
         flags += self._get_ccbin_args(None, '')
 
         # If cross-compiling, we can't run the sanity check, only compile it.
-        if self.is_cross and not self.environment.has_exe_wrapper():
-            # Linking cross built apps is painful. You can't really
-            # tell if you should use -nostdlib or not and for example
-            # on OSX the compiler binary is the same but you need
-            # a ton of compiler flags to differentiate between
-            # arm and x86_64. So just compile.
+        mode = self._sanity_check_mode()
+        if mode is CompileCheckMode.COMPILE:
             flags += self.get_compile_only_args()
         flags += self.get_output_args(binname)
 

--- a/mesonbuild/compilers/cython.py
+++ b/mesonbuild/compilers/cython.py
@@ -10,7 +10,7 @@ import typing as T
 from .. import options
 from .. import mlog
 from ..mesonlib import version_compare, EnvironmentException
-from .compilers import Compiler
+from .compilers import CompileCheckMode, Compiler
 
 if T.TYPE_CHECKING:
     from ..options import MutableKeyedOptionDictType
@@ -88,6 +88,11 @@ class CythonCompiler(Compiler):
         largs.extend(compiler.get_std_shared_lib_link_args())
         largs.extend(compiler.get_allow_undefined_link_args())
         return args, largs
+
+    def _sanity_check_mode(self) -> CompileCheckMode:
+        # the sanity check only transpiles, the generated source is compiled
+        # and linked by _transpiled_sanity_check_compile_args()
+        return CompileCheckMode.COMPILE
 
     def _sanity_check_compile_args(self, sourcename: str, binname: str
                                    ) -> T.Tuple[T.List[str], T.List[str]]:

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -402,6 +402,7 @@ class DCompiler(Compiler):
     def _sanity_check_compile_args(self, sourcename: str, binname: str
                                    ) -> T.Tuple[T.List[str], T.List[str]]:
         args, largs = super()._sanity_check_compile_args(sourcename, binname)
+        largs = self.unix_args_to_native(largs)
         largs.extend(self._get_target_arch_args())
         return args, largs
 

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -57,11 +57,8 @@ class FortranCompiler(CLikeCompiler, Compiler):
                              'that example is to see if the compiler has Fortran 2008 Block element.')
 
     def _get_basic_compiler_args(self, mode: CompileCheckMode) -> T.Tuple[T.List[str], T.List[str]]:
-        optstore = self.environment.coredata.optstore
-        cargs = list(T.cast('T.List[str]', optstore.get_value_for(
-            options.OptionKey(f'{self.language}_args', machine=self.for_machine))))
-        largs = list(T.cast('T.List[str]', optstore.get_value_for(
-            options.OptionKey(f'{self.language}_link_args', machine=self.for_machine))))
+        cargs = self.get_external_compile_args()
+        largs = self.get_external_link_args()
         return cargs, largs
 
     def _sanity_check_source_code(self) -> str:

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -285,14 +285,22 @@ class CLikeCompiler(Compiler):
 
     def _sanity_check_compile_args(self, sourcename: str, binname: str
                                    ) -> T.Tuple[T.List[str], T.List[str]]:
+        # _get_basic_compiler_args() already adds c_args/c_link_args (or
+        # similar).  Calling super()._sanity_check_compile_args() would
+        # duplicate them and, for MSVC-like compilers, place the link
+        # arguments before the /link that linker_to_compiler_args() inserts.
         mode = self._sanity_check_mode()
-        cargs, b_largs = self._get_basic_compiler_args(mode)
-        s_args, s_largs = super()._sanity_check_compile_args(sourcename, binname)
+        b_cargs, b_largs = self._get_basic_compiler_args(mode)
+        cargs = self.exelist_no_ccache + \
+            self.get_compiler_check_args(CompileCheckMode.COMPILE) + \
+            self.get_output_args(binname) + \
+            [sourcename] + \
+            b_cargs
         if mode is CompileCheckMode.COMPILE:
-            return s_args + cargs, []
+            return cargs, []
 
         largs = self.linker_to_compiler_args(b_largs)
-        return s_args + cargs, s_largs + largs
+        return cargs, largs
 
     def check_header(self, hname: str, prefix: str, *,
                      extra_args: T.Union[None, T.List[str], T.Callable[['CompileCheckMode'], T.List[str]]] = None,

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -368,6 +368,8 @@ class CLikeCompiler(Compiler):
         cargs += cleaned_sys_args
 
         if mode is CompileCheckMode.LINK:
+            largs += self.get_linker_always_args()
+
             ld_value = self.environment.lookup_binary_entry(self.for_machine, self.language + '_ld')
             if ld_value is not None:
                 cargs += self.use_linker_args(ld_value[0], self.version)
@@ -1133,7 +1135,7 @@ class CLikeCompiler(Compiler):
         if ((not extra_dirs and libtype is LibType.PREFER_SHARED) or
                 libname in self.internal_libs):
             cargs = ['-l' + libname]
-            largs = self.get_linker_always_args() + self.get_allow_undefined_link_args()
+            largs = self.get_allow_undefined_link_args()
             extra_args = cargs + self.linker_to_compiler_args(largs)
 
             if self.links(code, extra_args=extra_args, disable_cache=True)[0]:
@@ -1155,7 +1157,7 @@ class CLikeCompiler(Compiler):
         except (mesonlib.MesonException, KeyError): # TODO evaluate if catching KeyError is wanted here
             elf_class = 0
         # Search in the specified dirs, and then in the system libraries
-        largs = self.get_linker_always_args() + self.get_allow_undefined_link_args()
+        largs = self.get_allow_undefined_link_args()
         lcargs = self.linker_to_compiler_args(largs)
         for d in itertools.chain(extra_dirs, [] if ignore_system_dirs else self.get_library_dirs(elf_class)):
             for p in patterns:

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -277,19 +277,18 @@ class CLikeCompiler(Compiler):
     def gen_import_library_args(self, implibname: str) -> T.List[str]:
         return self.linker.import_library_args(implibname)
 
+    def _sanity_check_mode(self) -> CompileCheckMode:
+        # Cross-compiling is hard. For example, you might need -nostdlib, or to pass --target, etc.
+        if self.is_cross and not self.environment.has_exe_wrapper():
+            return CompileCheckMode.COMPILE
+        return CompileCheckMode.LINK
+
     def _sanity_check_compile_args(self, sourcename: str, binname: str
                                    ) -> T.Tuple[T.List[str], T.List[str]]:
-        # Cross-compiling is hard. For example, you might need -nostdlib, or to pass --target, etc.
-        mode = CompileCheckMode.COMPILE if self.is_cross and not self.environment.has_exe_wrapper() else CompileCheckMode.LINK
+        mode = self._sanity_check_mode()
         cargs, b_largs = self._get_basic_compiler_args(mode)
         s_args, s_largs = super()._sanity_check_compile_args(sourcename, binname)
         if mode is CompileCheckMode.COMPILE:
-            # We aren't linking in this invocation (and can't run the result
-            # without an exe wrapper anyway), so don't pass any link-only
-            # arguments to a compile-only command. Some compilers add fixed
-            # flags (e.g. MSVC-style compilers always prepend /link) even
-            # when there is nothing to link, which would otherwise end up
-            # unused/misplaced in a compile-only invocation.
             return s_args + cargs, []
 
         largs = self.linker_to_compiler_args(b_largs)

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -25,7 +25,6 @@ from pathlib import Path
 from ... import arglist
 from ... import mesonlib
 from ... import mlog
-from ...options import OptionKey
 from ...linkers.linkers import GnuLikeDynamicLinkerMixin, SolarisDynamicLinker, CompCertDynamicLinker
 from ...mesonlib import LibType
 from .. import compilers
@@ -356,10 +355,7 @@ class CLikeCompiler(Compiler):
                 pass
 
         # Add CFLAGS/CXXFLAGS/OBJCFLAGS/OBJCXXFLAGS and CPPFLAGS from the env
-        sys_args = T.cast('T.List[str]', self.environment.coredata.optstore.get_value_for(
-            OptionKey(f'{self.language}_args', machine=self.for_machine)))
-        if isinstance(sys_args, str):
-            sys_args = [sys_args]
+        sys_args = self.get_external_compile_args()
         # Apparently it is a thing to inject linker flags both
         # via CFLAGS _and_ LDFLAGS, even though the former are
         # also used during linking. These flags can break
@@ -375,8 +371,7 @@ class CLikeCompiler(Compiler):
                 cargs += self.use_linker_args(ld_value[0], self.version)
 
             # Add LDFLAGS from the env
-            sys_ld_args = T.cast('T.List[str]', self.environment.coredata.optstore.get_value_for(
-                OptionKey(f'{self.language}_link_args', machine=self.for_machine)))
+            sys_ld_args = self.get_external_link_args()
             # CFLAGS and CXXFLAGS go to both linking and compiling, but we want them
             # to only appear on the command line once. Remove dupes.
             largs += [x for x in sys_ld_args if x not in cleaned_sys_args]
@@ -1255,8 +1250,7 @@ class CLikeCompiler(Compiler):
         commands = self.get_exelist(ccache=False) + ['-v', '-E', '-']
         commands += self.get_always_args()
         # Add CFLAGS/CXXFLAGS/OBJCFLAGS/OBJCXXFLAGS from the env
-        commands += T.cast('T.List[str]', self.environment.coredata.optstore.get_value_for(
-            OptionKey(f'{self.language}_args', machine=self.for_machine)))
+        commands += self.get_external_compile_args()
         mlog.debug('Finding framework path by running: ', ' '.join(commands), '\n')
         os_env = os.environ.copy()
         os_env['LC_ALL'] = 'C'

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -410,6 +410,9 @@ class RustCompiler(Compiler):
             return [f'--color={colortype}']
         raise MesonException(f'Invalid color type for rust {colortype}')
 
+    def get_external_link_args(self) -> T.List[str]:
+        return rustc_link_args(super().get_external_link_args())
+
     @functools.lru_cache(maxsize=None)
     def get_linker_always_args(self) -> T.List[str]:
         return rustc_link_args(super().get_linker_always_args()) + ['-Cdefault-linker-libraries']

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -165,12 +165,9 @@ class RustCompiler(Compiler):
 
     def _sanity_check_compile_args(self, sourcename: str, binname: str
                                    ) -> T.Tuple[T.List[str], T.List[str]]:
-        cmdlist = self.exelist.copy()
-        largs: T.List[str] = []
+        cmdlist, largs = super()._sanity_check_compile_args(sourcename, binname)
         if self.info.kernel == 'none' and 'ld.' in self.get_linker_id():
             largs.extend(rustc_link_args(['-nostartfiles']))
-        cmdlist.extend(self.get_output_args(binname))
-        cmdlist.append(sourcename)
         return cmdlist, largs
 
     def _sanity_check_source_code(self) -> str:

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -184,8 +184,7 @@ class SwiftCompiler(Compiler):
         if self.is_cross:
             args.extend(self.get_compile_only_args())
         else:
-            largs.extend(T.cast('T.List[str]', self.environment.coredata.optstore.get_value_for(
-                options.OptionKey(f'{self.language}_link_args', machine=self.for_machine))))
+            largs.extend(self.get_external_link_args())
         args.extend(self.get_output_args(binname))
         args.append(sourcename)
 

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -110,6 +110,11 @@ class ValaCompiler(Compiler):
     def _sanity_check_source_code(self) -> str:
         return 'public static int main() { return 0; }'
 
+    def _sanity_check_mode(self) -> CompileCheckMode:
+        # the sanity check only transpiles, the generated source is compiled
+        # and linked by _transpiled_sanity_check_compile_args()
+        return CompileCheckMode.COMPILE
+
     def _sanity_check_compile_args(self, sourcename: str, binname: str
                                    ) -> T.Tuple[T.List[str], T.List[str]]:
         args, largs = super()._sanity_check_compile_args(sourcename, binname)

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -157,9 +157,7 @@ class ValaCompiler(Compiler):
         # no extra dirs are specified.
         if not extra_dirs:
             code = 'class MesonFindLibrary : Object { }'
-            args: T.List[str] = []
-            args += T.cast('T.List[str]', self.environment.coredata.optstore.get_value_for(
-                OptionKey(f'{self.language}_args', machine=self.for_machine)))
+            args: T.List[str] = self.get_external_compile_args()
             vapi_args = ['--pkg', libname]
             args += vapi_args
             with self.cached_compile(code, extra_args=args, mode=CompileCheckMode.COMPILE) as p:
@@ -218,12 +216,10 @@ class ValaCompiler(Compiler):
 
         if mode is CompileCheckMode.COMPILE:
             # Add DFLAGS from the env
-            args += T.cast('T.List[str]', self.environment.coredata.optstore.get_value_for(
-                OptionKey(f'{self.language}_args', machine=self.for_machine)))
+            args += self.get_external_compile_args()
         elif mode is CompileCheckMode.LINK:
             # Add LDFLAGS from the env
-            args += T.cast('T.List[str]', self.environment.coredata.optstore.get_value_for(
-                OptionKey(f'{self.language}_link_args', machine=self.for_machine)))
+            args += self.get_external_link_args()
         # extra_args must override all other arguments, so we add them last
         args += extra_args
         return args

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -489,6 +489,22 @@ Thread model: posix'''), '21.9.0')
         self.assertEqual(ClangClCompiler.unix_args_to_native(['-idirafter', 'foo']), ['/clang:-idirafterfoo'])
         self.assertEqual(ClangClCompiler.unix_args_to_native(['-iquote', 'foo']), ['/clang:-iquotefoo'])
 
+    def _fake_gnu_cc(self, cflags='-DCFLAG', ldflags='-Wl,-O1',
+                     linker_cls=linkers.GnuBFDDynamicLinker):
+        with mock.patch.dict(os.environ, {'CFLAGS': cflags, 'LDFLAGS': ldflags}):
+            env = get_fake_env()
+        env.add_lang_args('c', GnuCCompiler, MachineChoice.HOST)
+        linker = linker_cls([], env, MachineChoice.HOST,
+                            ManyInOneLinkerOptionStyle('-Wl,', ','), [])
+        return GnuCCompiler([], [], 'fake', MachineChoice.HOST, env, linker=linker)
+
+    def test_compiler_check_args_os2(self):
+        # the linker's always args (-Zomf on OS/2) must reach link mode checks
+        cc = self._fake_gnu_cc(linker_cls=linkers.OS2OmfDynamicLinker)
+        args = cc.build_wrapper_args(None, None, CompileCheckMode.LINK)
+        self.assertEqual(list(args).count('-Zomf'), 1, args)
+        self.assertNotIn('-Zomf', cc.build_wrapper_args(None, None, CompileCheckMode.COMPILE))
+
     def test_compiler_args_class_gnuld(self):
         ## Test --start/end-group
         env = get_fake_env()

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -498,6 +498,14 @@ Thread model: posix'''), '21.9.0')
                             ManyInOneLinkerOptionStyle('-Wl,', ','), [])
         return GnuCCompiler([], [], 'fake', MachineChoice.HOST, env, linker=linker)
 
+    def test_sanity_check_args_gnu(self):
+        cc = self._fake_gnu_cc()
+        args, largs = cc._sanity_check_compile_args('t.c', 't.exe')
+        # external args must reach the probe, but only once
+        self.assertEqual(args.count('-DCFLAG'), 1, args)
+        self.assertEqual((args + largs).count('-Wl,-O1'), 1, (args, largs))
+        self.assertIn('-Wl,-O1', largs)
+
     def test_compiler_check_args_os2(self):
         # the linker's always args (-Zomf on OS/2) must reach link mode checks
         cc = self._fake_gnu_cc(linker_cls=linkers.OS2OmfDynamicLinker)

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -505,6 +505,29 @@ Thread model: posix'''), '21.9.0')
                             ManyInOneLinkerOptionStyle('-Wl,', ','), [])
         return GnuCCompiler([], [], 'fake', MachineChoice.HOST, env, linker=linker)
 
+    def assertAfterLink(self, args: T.List[str], flag: str) -> None:
+        '''Assert that a linker-only flag is passed exactly once, after /link.'''
+        self.assertEqual(args.count(flag), 1, f'{flag} not passed exactly once in {args}')
+        self.assertIn('/link', args)
+        self.assertLess(args.index('/link'), args.index(flag), f'{flag} passed before /link in {args}')
+
+    def test_sanity_check_args_msvc(self):
+        cc = self._fake_msvc_cc()
+        args, largs = cc._sanity_check_compile_args('t.c', 't.exe')
+        # external link args are passed once, and after /link
+        self.assertAfterLink(largs, '/SUBSYSTEM:CONSOLE')
+        self.assertNotIn('/SUBSYSTEM:CONSOLE', args)
+        # so are the linker's own always args
+        self.assertAfterLink(largs, '/release')
+        self.assertNotIn('/release', args)
+        # external compile args are passed to the compiler, not to the linker
+        self.assertNotIn('-DCFLAG', largs)
+        self.assertEqual(args.count('-DCFLAG'), 1, args)
+        # linking, so name the executable with /Fe even if it is not a .exe
+        self.assertIn('/Fet.exe', args)
+        dll_args, _ = cc._sanity_check_compile_args('t.c', 't.dll')
+        self.assertIn('/Fet.dll', dll_args)
+
     def test_sanity_check_args_gnu(self):
         cc = self._fake_gnu_cc()
         args, largs = cc._sanity_check_compile_args('t.c', 't.exe')
@@ -512,6 +535,16 @@ Thread model: posix'''), '21.9.0')
         self.assertEqual(args.count('-DCFLAG'), 1, args)
         self.assertEqual((args + largs).count('-Wl,-O1'), 1, (args, largs))
         self.assertIn('-Wl,-O1', largs)
+
+    def test_compiler_check_args_msvc(self):
+        cc = self._fake_msvc_cc()
+        args = cc.build_wrapper_args(None, None, CompileCheckMode.LINK).to_native()
+        # linker-only flags belong after /link, not on the compiler command line
+        self.assertAfterLink(args, '/release')
+        self.assertAfterLink(args, '/SUBSYSTEM:CONSOLE')
+        args = cc.build_wrapper_args(None, None, CompileCheckMode.COMPILE).to_native()
+        self.assertNotIn('/release', args)
+        self.assertNotIn('/link', args)
 
     def test_compiler_check_args_os2(self):
         # the linker's always args (-Zomf on OS/2) must reach link mode checks
@@ -525,7 +558,7 @@ Thread model: posix'''), '21.9.0')
 
         def fake_links(code, *, extra_args=None, **kwargs):
             args = cc.build_wrapper_args(extra_args, None, CompileCheckMode.LINK).to_native()
-            self.assertIn('/release', args)
+            self.assertAfterLink(args, '/release')
             return (True, False)
 
         with mock.patch.object(cc, 'links', fake_links):

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -30,7 +30,7 @@ import mesonbuild.scripts.depfixer
 import mesonbuild.scripts.env2mfile
 from mesonbuild import coredata
 from mesonbuild.compilers import Compiler
-from mesonbuild.compilers.c import ClangCCompiler, ClangClCCompiler, GnuCCompiler
+from mesonbuild.compilers.c import ClangCCompiler, ClangClCCompiler, GnuCCompiler, VisualStudioCCompiler
 from mesonbuild.compilers.compilers import CompileCheckMode, ManyInOneLinkerOptionStyle
 from mesonbuild.compilers.cpp import VisualStudioCPPCompiler
 from mesonbuild.compilers.d import DmdDCompiler
@@ -489,6 +489,13 @@ Thread model: posix'''), '21.9.0')
         self.assertEqual(ClangClCompiler.unix_args_to_native(['-idirafter', 'foo']), ['/clang:-idirafterfoo'])
         self.assertEqual(ClangClCompiler.unix_args_to_native(['-iquote', 'foo']), ['/clang:-iquotefoo'])
 
+    def _fake_msvc_cc(self, cflags='-DCFLAG', ldflags='/SUBSYSTEM:CONSOLE'):
+        with mock.patch.dict(os.environ, {'CFLAGS': cflags, 'LDFLAGS': ldflags}):
+            env = get_fake_env()
+        env.add_lang_args('c', VisualStudioCCompiler, MachineChoice.HOST)
+        linker = linkers.MSVCDynamicLinker(env, MachineChoice.HOST, [])
+        return VisualStudioCCompiler([], [], '20.00', MachineChoice.HOST, env, 'x64', linker=linker)
+
     def _fake_gnu_cc(self, cflags='-DCFLAG', ldflags='-Wl,-O1',
                      linker_cls=linkers.GnuBFDDynamicLinker):
         with mock.patch.dict(os.environ, {'CFLAGS': cflags, 'LDFLAGS': ldflags}):
@@ -512,6 +519,17 @@ Thread model: posix'''), '21.9.0')
         args = cc.build_wrapper_args(None, None, CompileCheckMode.LINK)
         self.assertEqual(list(args).count('-Zomf'), 1, args)
         self.assertNotIn('-Zomf', cc.build_wrapper_args(None, None, CompileCheckMode.COMPILE))
+
+    def test_find_library_args_msvc(self):
+        cc = self._fake_msvc_cc()
+
+        def fake_links(code, *, extra_args=None, **kwargs):
+            args = cc.build_wrapper_args(extra_args, None, CompileCheckMode.LINK).to_native()
+            self.assertIn('/release', args)
+            return (True, False)
+
+        with mock.patch.object(cc, 'links', fake_links):
+            cc.find_library('foo', [])
 
     def test_compiler_args_class_gnuld(self):
         ## Test --start/end-group


### PR DESCRIPTION
Sanity check arguments were duplicated between `Compiler._sanity_check_compile_args()` and `CLikeCompiler._get_basic_compiler_args()`, and when the latter called the former via `super()` they ended up before the `/link` flag that MSVC wants.

Furthermore, the arguments from `get_linker_always_args()` were retrieved via `get_compiler_args_for_mode()` but that placed them before `/link`.

Fix the mess by building upon the infrastructure introduced by commit c9bb03c2d.

Cc: @tristan957
Fixes: #16086
Fixes: #16111 
Fixes: #16115