### PR TITLE
Cleanup and fix sanitycheck linker args - 1.12 version

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1431,6 +1431,12 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
         """Whether the sanity check links a binary, or only compiles one."""
         return CompileCheckMode.LINK
 
+    def get_external_compile_args(self) -> T.List[str]:
+        return list(self.environment.coredata.get_external_args(self.for_machine, self.language))
+
+    def get_external_link_args(self) -> T.List[str]:
+        return list(self.environment.coredata.get_external_link_args(self.for_machine, self.language))
+
     def _sanity_check_compile_args(self, sourcename: str, binname: str
                                    ) -> T.Tuple[T.List[str], T.List[str]]:
         """Get arguments to run compiler for sanity check.
@@ -1444,12 +1450,11 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
             arguments, the second is linker arguments
         """
         mode = self._sanity_check_mode()
-
-        cargs = list(self.environment.coredata.get_external_args(self.for_machine, self.language))
-        cargs = self.exelist_no_ccache + self.get_always_args() + self.get_output_args(binname) + [sourcename] + cargs
+        cargs = self.exelist_no_ccache + self.get_always_args() + self.get_output_args(binname) + [sourcename] + \
+            self.get_external_compile_args()
         if mode is CompileCheckMode.COMPILE:
             return cargs, []
-        largs = list(self.environment.coredata.get_external_link_args(self.for_machine, self.language))
+        largs = self.get_external_link_args()
         return cargs, largs
 
     @abc.abstractmethod
@@ -1595,11 +1600,11 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
 
         if mode is CompileCheckMode.COMPILE:
             # Add DFLAGS from the env
-            args += self.environment.coredata.get_external_args(self.for_machine, self.language)
+            args += self.get_external_compile_args()
         elif mode is CompileCheckMode.LINK:
             args += self.get_linker_always_args()
             # Add LDFLAGS from the env
-            args += self.environment.coredata.get_external_link_args(self.for_machine, self.language)
+            args += self.get_external_link_args()
         # extra_args must override all other arguments, so we add them last
         args += extra_args
         return args

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1428,6 +1428,10 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
         """
         return compiler._sanity_check_compile_args(sourcename, binname)
 
+    def _sanity_check_mode(self) -> CompileCheckMode:
+        """Whether the sanity check links a binary, or only compiles one."""
+        return CompileCheckMode.LINK
+
     def _sanity_check_compile_args(self, sourcename: str, binname: str
                                    ) -> T.Tuple[T.List[str], T.List[str]]:
         """Get arguments to run compiler for sanity check.
@@ -1440,9 +1444,14 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
         :return: a tuple of arguments, the first is the executable and compiler
             arguments, the second is linker arguments
         """
+        mode = self._sanity_check_mode()
+
         cargs = list(self.environment.coredata.get_external_args(self.for_machine, self.language))
+        cargs = self.exelist_no_ccache + self.get_always_args() + self.get_output_args(binname) + [sourcename] + cargs
+        if mode is CompileCheckMode.COMPILE:
+            return cargs, []
         largs = list(self.environment.coredata.get_external_link_args(self.for_machine, self.language))
-        return self.exelist_no_ccache + self.get_always_args() + self.get_output_args(binname) + [sourcename] + cargs, largs
+        return cargs, largs
 
     @abc.abstractmethod
     def _sanity_check_source_code(self) -> str:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -909,7 +909,6 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
             args += self.get_preprocess_only_args()
         else:
             assert mode is CompileCheckMode.LINK
-            args += self.get_linker_always_args()
         return args
 
     def compiler_args(self, args: T.Optional[T.Iterable[str]] = None) -> CompilerArgs:
@@ -1598,6 +1597,7 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
             # Add DFLAGS from the env
             args += self.environment.coredata.get_external_args(self.for_machine, self.language)
         elif mode is CompileCheckMode.LINK:
+            args += self.get_linker_always_args()
             # Add LDFLAGS from the env
             args += self.environment.coredata.get_external_link_args(self.for_machine, self.language)
         # extra_args must override all other arguments, so we add them last

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -91,11 +91,13 @@ class CPPCompiler(CLikeCompiler, Compiler):
     def _sanity_check_source_code(self) -> str:
         return '#include <stddef.h>\nclass breakCCompiler;int main(void) { return 0; }\n'
 
+    def get_cpp_permissive_args(self) -> T.List[str]:
+        return []
+
     def get_compiler_check_args(self, mode: CompileCheckMode) -> T.List[str]:
-        # -fpermissive allows non-conforming code to compile which is necessary
-        # for many C++ checks. Particularly, the has_header_symbol check is
-        # too strict without this and always fails.
-        return super().get_compiler_check_args(mode) + ['-fpermissive']
+        # Compiler checks must accept non-conforming code. Particularly, the
+        # has_header_symbol check is too strict without this and always fails.
+        return super().get_compiler_check_args(mode) + self.get_cpp_permissive_args()
 
     def has_header_symbol(self, hname: str, symbol: str, prefix: str, *,
                           extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,
@@ -863,10 +865,6 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
             args.append('/permissive-')
         return args
 
-    def get_compiler_check_args(self, mode: CompileCheckMode) -> T.List[str]:
-        # XXX: this is a hack because so much GnuLike stuff is in the base CPPCompiler class.
-        return Compiler.get_compiler_check_args(self, mode)
-
 class CPP11AsCPP14Mixin(CompilerMixinBase):
 
     """Mixin class for VisualStudio and ClangCl to replace C++11 std with C++14.
@@ -1000,10 +998,6 @@ class IntelClCPPCompiler(VisualStudioLikeCPPCompilerMixin, IntelVisualStudioLike
             cpp_stds += ['c++20']
         return self._get_options_impl(super().get_options(), cpp_stds)
 
-    def get_compiler_check_args(self, mode: CompileCheckMode) -> T.List[str]:
-        # XXX: this is a hack because so much GnuLike stuff is in the base CPPCompiler class.
-        return IntelVisualStudioLikeCompiler.get_compiler_check_args(self, mode)
-
 
 class IntelLLVMClCPPCompiler(IntelClCPPCompiler):
 
@@ -1092,6 +1086,9 @@ class TICPPCompiler(TICompiler, CPPCompiler):
 
     def get_always_args(self) -> T.List[str]:
         return []
+
+    def get_cpp_permissive_args(self) -> T.List[str]:
+        return ['-fpermissive']
 
     def get_option_link_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
         return []

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -528,6 +528,16 @@ class CudaCompiler(Compiler):
             }
             '''
 
+    def _sanity_check_mode(self) -> CompileCheckMode:
+        # Linking cross built apps is painful. You can't really
+        # tell if you should use -nostdlib or not and for example
+        # on OSX the compiler binary is the same but you need
+        # a ton of compiler flags to differentiate between
+        # arm and x86_64. So just compile.
+        if self.is_cross and not self.environment.has_exe_wrapper():
+            return CompileCheckMode.COMPILE
+        return CompileCheckMode.LINK
+
     def _sanity_check_compile_args(self, sourcename: str, binname: str
                                    ) -> T.Tuple[T.List[str], T.List[str]]:
         # Disable warnings, compile with statically-linked runtime for minimum
@@ -540,12 +550,8 @@ class CudaCompiler(Compiler):
         flags += self._get_ccbin_args(None, '')
 
         # If cross-compiling, we can't run the sanity check, only compile it.
-        if self.is_cross and not self.environment.has_exe_wrapper():
-            # Linking cross built apps is painful. You can't really
-            # tell if you should use -nostdlib or not and for example
-            # on OSX the compiler binary is the same but you need
-            # a ton of compiler flags to differentiate between
-            # arm and x86_64. So just compile.
+        mode = self._sanity_check_mode()
+        if mode is CompileCheckMode.COMPILE:
             flags += self.get_compile_only_args()
         flags += self.get_output_args(binname)
 

--- a/mesonbuild/compilers/cython.py
+++ b/mesonbuild/compilers/cython.py
@@ -10,7 +10,7 @@ import typing as T
 from .. import options
 from .. import mlog
 from ..mesonlib import version_compare, EnvironmentException
-from .compilers import Compiler
+from .compilers import CompileCheckMode, Compiler
 
 if T.TYPE_CHECKING:
     from ..options import MutableKeyedOptionDictType
@@ -88,6 +88,11 @@ class CythonCompiler(Compiler):
         largs.extend(compiler.get_std_shared_lib_link_args())
         largs.extend(compiler.get_allow_undefined_link_args())
         return args, largs
+
+    def _sanity_check_mode(self) -> CompileCheckMode:
+        # the sanity check only transpiles, the generated source is compiled
+        # and linked by _transpiled_sanity_check_compile_args()
+        return CompileCheckMode.COMPILE
 
     def _sanity_check_compile_args(self, sourcename: str, binname: str
                                    ) -> T.Tuple[T.List[str], T.List[str]]:

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -402,6 +402,7 @@ class DCompiler(Compiler):
     def _sanity_check_compile_args(self, sourcename: str, binname: str
                                    ) -> T.Tuple[T.List[str], T.List[str]]:
         args, largs = super()._sanity_check_compile_args(sourcename, binname)
+        largs = self.unix_args_to_native(largs)
         largs.extend(self._get_target_arch_args())
         return args, largs
 

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -57,8 +57,8 @@ class FortranCompiler(CLikeCompiler, Compiler):
                              'that example is to see if the compiler has Fortran 2008 Block element.')
 
     def _get_basic_compiler_args(self, mode: CompileCheckMode) -> T.Tuple[T.List[str], T.List[str]]:
-        cargs = self.environment.coredata.get_external_args(self.for_machine, self.language)
-        largs = self.environment.coredata.get_external_link_args(self.for_machine, self.language)
+        cargs = self.get_external_compile_args()
+        largs = self.get_external_link_args()
         return cargs, largs
 
     def _sanity_check_source_code(self) -> str:

--- a/mesonbuild/compilers/mixins/arm.py
+++ b/mesonbuild/compilers/mixins/arm.py
@@ -140,6 +140,9 @@ class ArmclangCompiler(Compiler):
     def get_colorout_args(self, colortype: str) -> T.List[str]:
         return clang_color_args[colortype][:]
 
+    def get_cpp_permissive_args(self) -> T.List[str]:
+        return ['-fpermissive']
+
     def get_pch_suffix(self) -> str:
         return 'gch'
 

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -357,9 +357,7 @@ class CLikeCompiler(Compiler):
                 pass
 
         # Add CFLAGS/CXXFLAGS/OBJCFLAGS/OBJCXXFLAGS and CPPFLAGS from the env
-        sys_args = self.environment.coredata.get_external_args(self.for_machine, self.language)
-        if isinstance(sys_args, str):
-            sys_args = [sys_args]
+        sys_args = self.get_external_compile_args()
         # Apparently it is a thing to inject linker flags both
         # via CFLAGS _and_ LDFLAGS, even though the former are
         # also used during linking. These flags can break
@@ -375,7 +373,7 @@ class CLikeCompiler(Compiler):
                 cargs += self.use_linker_args(ld_value[0], self.version)
 
             # Add LDFLAGS from the env
-            sys_ld_args = self.environment.coredata.get_external_link_args(self.for_machine, self.language)
+            sys_ld_args = self.get_external_link_args()
             # CFLAGS and CXXFLAGS go to both linking and compiling, but we want them
             # to only appear on the command line once. Remove dupes.
             largs += [x for x in sys_ld_args if x not in cleaned_sys_args]
@@ -1222,7 +1220,7 @@ class CLikeCompiler(Compiler):
         commands = self.get_exelist(ccache=False) + ['-v', '-E', '-']
         commands += self.get_always_args()
         # Add CFLAGS/CXXFLAGS/OBJCFLAGS/OBJCXXFLAGS from the env
-        commands += self.environment.coredata.get_external_args(self.for_machine, self.language)
+        commands += self.get_external_compile_args()
         mlog.debug('Finding framework path by running: ', ' '.join(commands), '\n')
         os_env = os.environ.copy()
         os_env['LC_ALL'] = 'C'

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -281,8 +281,17 @@ class CLikeCompiler(Compiler):
         # Cross-compiling is hard. For example, you might need -nostdlib, or to pass --target, etc.
         mode = CompileCheckMode.COMPILE if self.is_cross and not self.environment.has_exe_wrapper() else CompileCheckMode.LINK
         cargs, b_largs = self._get_basic_compiler_args(mode)
-        largs = self.linker_to_compiler_args(b_largs)
         s_args, s_largs = super()._sanity_check_compile_args(sourcename, binname)
+        if mode is CompileCheckMode.COMPILE:
+            # We aren't linking in this invocation (and can't run the result
+            # without an exe wrapper anyway), so don't pass any link-only
+            # arguments to a compile-only command. Some compilers add fixed
+            # flags (e.g. MSVC-style compilers always prepend /link) even
+            # when there is nothing to link, which would otherwise end up
+            # unused/misplaced in a compile-only invocation.
+            return s_args + cargs, []
+
+        largs = self.linker_to_compiler_args(b_largs)
         return s_args + cargs, s_largs + largs
 
     def check_header(self, hname: str, prefix: str, *,

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -276,10 +276,15 @@ class CLikeCompiler(Compiler):
     def gen_import_library_args(self, implibname: str) -> T.List[str]:
         return self.linker.import_library_args(implibname)
 
+    def _sanity_check_mode(self) -> CompileCheckMode:
+        # Cross-compiling is hard. For example, you might need -nostdlib, or to pass --target, etc.
+        if self.is_cross and not self.environment.has_exe_wrapper():
+            return CompileCheckMode.COMPILE
+        return CompileCheckMode.LINK
+
     def _sanity_check_compile_args(self, sourcename: str, binname: str
                                    ) -> T.Tuple[T.List[str], T.List[str]]:
-        # Cross-compiling is hard. For example, you might need -nostdlib, or to pass --target, etc.
-        mode = CompileCheckMode.COMPILE if self.is_cross and not self.environment.has_exe_wrapper() else CompileCheckMode.LINK
+        mode = self._sanity_check_mode()
         cargs, b_largs = self._get_basic_compiler_args(mode)
         s_args, s_largs = super()._sanity_check_compile_args(sourcename, binname)
         if mode is CompileCheckMode.COMPILE:

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -284,9 +284,13 @@ class CLikeCompiler(Compiler):
 
     def _sanity_check_compile_args(self, sourcename: str, binname: str
                                    ) -> T.Tuple[T.List[str], T.List[str]]:
+        # _get_basic_compiler_args() already adds c_args/c_link_args (or
+        # similar).  Calling super()._sanity_check_compile_args() would
+        # duplicate them and, for MSVC-like compilers, place the link
+        # arguments before the /link that linker_to_compiler_args() inserts.
         mode = self._sanity_check_mode()
-        cargs, b_largs = self._get_basic_compiler_args(mode)
-        s_args, s_largs = super()._sanity_check_compile_args(sourcename, binname)
+        b_cargs, b_largs = self._get_basic_compiler_args(mode)
+        cargs = self.exelist_no_ccache + self.get_output_args(binname) + [sourcename] + b_cargs
         if mode is CompileCheckMode.COMPILE:
             # We aren't linking in this invocation (and can't run the result
             # without an exe wrapper anyway), so don't pass any link-only
@@ -294,10 +298,10 @@ class CLikeCompiler(Compiler):
             # flags (e.g. MSVC-style compilers always prepend /link) even
             # when there is nothing to link, which would otherwise end up
             # unused/misplaced in a compile-only invocation.
-            return s_args + cargs, []
+            return cargs, []
 
         largs = self.linker_to_compiler_args(b_largs)
-        return s_args + cargs, s_largs + largs
+        return cargs, largs
 
     def check_header(self, hname: str, prefix: str, *,
                      extra_args: T.Union[None, T.List[str], T.Callable[['CompileCheckMode'], T.List[str]]] = None,

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -368,6 +368,8 @@ class CLikeCompiler(Compiler):
         cargs += cleaned_sys_args
 
         if mode is CompileCheckMode.LINK:
+            largs += self.get_linker_always_args()
+
             ld_value = self.environment.lookup_binary_entry(self.for_machine, self.language + '_ld')
             if ld_value is not None:
                 cargs += self.use_linker_args(ld_value[0], self.version)
@@ -1133,7 +1135,7 @@ class CLikeCompiler(Compiler):
         if ((not extra_dirs and libtype is LibType.PREFER_SHARED) or
                 libname in self.internal_libs):
             cargs = ['-l' + libname]
-            largs = self.get_linker_always_args() + self.get_allow_undefined_link_args()
+            largs = self.get_allow_undefined_link_args()
             extra_args = cargs + self.linker_to_compiler_args(largs)
 
             if self.links(code, extra_args=extra_args, disable_cache=True)[0]:
@@ -1155,7 +1157,7 @@ class CLikeCompiler(Compiler):
         except (mesonlib.MesonException, KeyError): # TODO evaluate if catching KeyError is wanted here
             elf_class = 0
         # Search in the specified dirs, and then in the system libraries
-        largs = self.get_linker_always_args() + self.get_allow_undefined_link_args()
+        largs = self.get_allow_undefined_link_args()
         lcargs = self.linker_to_compiler_args(largs)
         for d in itertools.chain(extra_dirs, [] if ignore_system_dirs else self.get_library_dirs(elf_class)):
             for p in patterns:

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -381,6 +381,9 @@ class GnuLikeCompiler(Compiler, metaclass=mesonlib.SimpleABC):
     def get_pie_args(self) -> T.List[str]:
         return ['-fPIE']
 
+    def get_cpp_permissive_args(self) -> T.List[str]:
+        return ['-fpermissive']
+
     @abc.abstractmethod
     def get_optimization_args(self, optimization_level: str) -> T.List[str]:
         pass

--- a/mesonbuild/compilers/mixins/pgi.py
+++ b/mesonbuild/compilers/mixins/pgi.py
@@ -50,6 +50,9 @@ class PGICompiler(Compiler):
             return ['-fPIC']
         return []
 
+    def get_cpp_permissive_args(self) -> T.List[str]:
+        return ['-fpermissive']
+
     def openmp_flags(self) -> T.List[str]:
         return ['-mp']
 

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -410,6 +410,9 @@ class RustCompiler(Compiler):
             return [f'--color={colortype}']
         raise MesonException(f'Invalid color type for rust {colortype}')
 
+    def get_external_link_args(self) -> T.List[str]:
+        return rustc_link_args(super().get_external_link_args())
+
     @functools.lru_cache(maxsize=None)
     def get_linker_always_args(self) -> T.List[str]:
         return rustc_link_args(super().get_linker_always_args()) + ['-Cdefault-linker-libraries']

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -165,12 +165,9 @@ class RustCompiler(Compiler):
 
     def _sanity_check_compile_args(self, sourcename: str, binname: str
                                    ) -> T.Tuple[T.List[str], T.List[str]]:
-        cmdlist = self.exelist.copy()
-        largs: T.List[str] = []
+        cmdlist, largs = super()._sanity_check_compile_args(sourcename, binname)
         if self.info.kernel == 'none' and 'ld.' in self.get_linker_id():
             largs.extend(rustc_link_args(['-nostartfiles']))
-        cmdlist.extend(self.get_output_args(binname))
-        cmdlist.append(sourcename)
         return cmdlist, largs
 
     def _sanity_check_source_code(self) -> str:

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -184,7 +184,7 @@ class SwiftCompiler(Compiler):
         if self.is_cross:
             args.extend(self.get_compile_only_args())
         else:
-            largs.extend(self.environment.coredata.get_external_link_args(self.for_machine, self.language))
+            largs.extend(self.get_external_link_args())
         args.extend(self.get_output_args(binname))
         args.append(sourcename)
 

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -110,6 +110,11 @@ class ValaCompiler(Compiler):
     def _sanity_check_source_code(self) -> str:
         return 'public static int main() { return 0; }'
 
+    def _sanity_check_mode(self) -> CompileCheckMode:
+        # the sanity check only transpiles, the generated source is compiled
+        # and linked by _transpiled_sanity_check_compile_args()
+        return CompileCheckMode.COMPILE
+
     def _sanity_check_compile_args(self, sourcename: str, binname: str
                                    ) -> T.Tuple[T.List[str], T.List[str]]:
         args, largs = super()._sanity_check_compile_args(sourcename, binname)

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -157,8 +157,7 @@ class ValaCompiler(Compiler):
         # no extra dirs are specified.
         if not extra_dirs:
             code = 'class MesonFindLibrary : Object { }'
-            args: T.List[str] = []
-            args += self.environment.coredata.get_external_args(self.for_machine, self.language)
+            args: T.List[str] = self.get_external_compile_args()
             vapi_args = ['--pkg', libname]
             args += vapi_args
             with self.cached_compile(code, extra_args=args, mode=CompileCheckMode.COMPILE) as p:
@@ -217,10 +216,10 @@ class ValaCompiler(Compiler):
 
         if mode is CompileCheckMode.COMPILE:
             # Add DFLAGS from the env
-            args += self.environment.coredata.get_external_args(self.for_machine, self.language)
+            args += self.get_external_compile_args()
         elif mode is CompileCheckMode.LINK:
             # Add LDFLAGS from the env
-            args += self.environment.coredata.get_external_link_args(self.for_machine, self.language)
+            args += self.get_external_link_args()
         # extra_args must override all other arguments, so we add them last
         args += extra_args
         return args

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -28,7 +28,7 @@ import mesonbuild.modules.gnome
 import mesonbuild.scripts.env2mfile
 from mesonbuild import coredata
 from mesonbuild.compilers.c import ClangCCompiler, GnuCCompiler
-from mesonbuild.compilers.compilers import ManyInOneLinkerOptionStyle
+from mesonbuild.compilers.compilers import Compiler, ManyInOneLinkerOptionStyle
 from mesonbuild.compilers.cpp import VisualStudioCPPCompiler
 from mesonbuild.compilers.d import DmdDCompiler
 from mesonbuild.compilers.detect import detect_c_compiler
@@ -309,6 +309,25 @@ class InternalTests(unittest.TestCase):
         # See: https://ninja-build.org/manual.html#_deps
         a = cc.compiler_args(cc.get_show_dep_args())
         self.assertEqual(a.to_native(copy=True), ['/showIncludes'])
+
+
+    def test_clike_sanity_check_drops_link_only_args_when_compile_only(self):
+        # When cross-compiling without an exe wrapper, CLikeCompiler's sanity
+        # check only compiles and never links because we can't run the
+        # executable. Therefore, it doesn't make sense for link-only arguments
+        # to be added on the command line. Some compilers warn about unused
+        # command line arguments.
+        env = get_fake_env()
+        linker = linkers.MoldDynamicLinker([], env, MachineChoice.HOST, '-Wl,', [])
+        cc = ClangCCompiler([], [], '14.0.0', MachineChoice.HOST, env, linker=linker)
+        cc.is_cross = True
+
+        with mock.patch.object(env, 'has_exe_wrapper', return_value=False), \
+             mock.patch.object(cc, '_get_basic_compiler_args', return_value=([], ['-fake-cross-link-arg'])), \
+             mock.patch.object(Compiler, '_sanity_check_compile_args', return_value=([], ['-Lfake-ldflags-arg'])):
+            _, largs = cc._sanity_check_compile_args('foo.c', 'foo.exe')
+
+        self.assertEqual(largs, [])
 
 
     def test_msvc_unix_args_to_native(self):

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -371,6 +371,14 @@ class InternalTests(unittest.TestCase):
                             ManyInOneLinkerOptionStyle('-Wl,', ','), [])
         return GnuCCompiler([], [], 'fake', MachineChoice.HOST, env, linker=linker)
 
+    def test_sanity_check_args_gnu(self):
+        cc = self._fake_gnu_cc()
+        args, largs = cc._sanity_check_compile_args('t.c', 't.exe')
+        # external args must reach the probe, but only once
+        self.assertEqual(args.count('-DCFLAG'), 1, args)
+        self.assertEqual((args + largs).count('-Wl,-O1'), 1, (args, largs))
+        self.assertIn('-Wl,-O1', largs)
+
     def test_compiler_check_args_os2(self):
         # the linker's always args (-Zomf on OS/2) must reach link mode checks
         cc = self._fake_gnu_cc(linker_cls=linkers.OS2OmfDynamicLinker)

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -378,6 +378,26 @@ class InternalTests(unittest.TestCase):
                             ManyInOneLinkerOptionStyle('-Wl,', ','), [])
         return GnuCCompiler([], [], 'fake', MachineChoice.HOST, env, linker=linker)
 
+    def assertAfterLink(self, args: T.List[str], flag: str) -> None:
+        '''Assert that a linker-only flag is passed exactly once, after /link.'''
+        self.assertEqual(args.count(flag), 1, f'{flag} not passed exactly once in {args}')
+        self.assertIn('/link', args)
+        self.assertLess(args.index('/link'), args.index(flag), f'{flag} passed before /link in {args}')
+
+    def test_sanity_check_args_msvc(self):
+        cc = self._fake_msvc_cc()
+        args, largs = cc._sanity_check_compile_args('t.c', 't.exe')
+        # external link args are passed once, and after /link
+        self.assertAfterLink(largs, '/SUBSYSTEM:CONSOLE')
+        self.assertNotIn('/SUBSYSTEM:CONSOLE', args)
+        # so are the linker's own always args
+        self.assertAfterLink(largs, '/release')
+        self.assertNotIn('/release', args)
+        # external compile args are passed to the compiler, not to the linker
+        self.assertNotIn('-DCFLAG', largs)
+        self.assertEqual(args.count('-DCFLAG'), 1, args)
+        self.assertIn('/Fet.exe', args)
+
     def test_sanity_check_args_gnu(self):
         cc = self._fake_gnu_cc()
         args, largs = cc._sanity_check_compile_args('t.c', 't.exe')
@@ -385,6 +405,16 @@ class InternalTests(unittest.TestCase):
         self.assertEqual(args.count('-DCFLAG'), 1, args)
         self.assertEqual((args + largs).count('-Wl,-O1'), 1, (args, largs))
         self.assertIn('-Wl,-O1', largs)
+
+    def test_compiler_check_args_msvc(self):
+        cc = self._fake_msvc_cc()
+        args = cc.build_wrapper_args(None, None, CompileCheckMode.LINK).to_native()
+        # linker-only flags belong after /link, not on the compiler command line
+        self.assertAfterLink(args, '/release')
+        self.assertAfterLink(args, '/SUBSYSTEM:CONSOLE')
+        args = cc.build_wrapper_args(None, None, CompileCheckMode.COMPILE).to_native()
+        self.assertNotIn('/release', args)
+        self.assertNotIn('/link', args)
 
     def test_compiler_check_args_os2(self):
         # the linker's always args (-Zomf on OS/2) must reach link mode checks
@@ -398,7 +428,7 @@ class InternalTests(unittest.TestCase):
 
         def fake_links(code, *, extra_args=None, **kwargs):
             args = cc.build_wrapper_args(extra_args, None, CompileCheckMode.LINK).to_native()
-            self.assertIn('/release', args)
+            self.assertAfterLink(args, '/release')
             return (True, False)
 
         with mock.patch.object(cc, 'links', fake_links):

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -27,7 +27,7 @@ import mesonbuild.environment
 import mesonbuild.modules.gnome
 import mesonbuild.scripts.env2mfile
 from mesonbuild import coredata
-from mesonbuild.compilers.c import ClangCCompiler, GnuCCompiler
+from mesonbuild.compilers.c import ClangCCompiler, GnuCCompiler, VisualStudioCCompiler
 from mesonbuild.compilers.compilers import Compiler, CompileCheckMode, ManyInOneLinkerOptionStyle
 from mesonbuild.compilers.cpp import VisualStudioCPPCompiler
 from mesonbuild.compilers.d import DmdDCompiler
@@ -362,6 +362,13 @@ class InternalTests(unittest.TestCase):
         self.assertEqual(ClangClCompiler.unix_args_to_native(['-idirafter', 'foo']), ['/clang:-idirafterfoo'])
         self.assertEqual(ClangClCompiler.unix_args_to_native(['-iquote', 'foo']), ['/clang:-iquotefoo'])
 
+    def _fake_msvc_cc(self, cflags='-DCFLAG', ldflags='/SUBSYSTEM:CONSOLE'):
+        with mock.patch.dict(os.environ, {'CFLAGS': cflags, 'LDFLAGS': ldflags}):
+            env = get_fake_env()
+        env.add_lang_args('c', VisualStudioCCompiler, MachineChoice.HOST)
+        linker = linkers.MSVCDynamicLinker(env, MachineChoice.HOST, [])
+        return VisualStudioCCompiler([], [], '20.00', MachineChoice.HOST, env, 'x64', linker=linker)
+
     def _fake_gnu_cc(self, cflags='-DCFLAG', ldflags='-Wl,-O1',
                      linker_cls=linkers.GnuBFDDynamicLinker):
         with mock.patch.dict(os.environ, {'CFLAGS': cflags, 'LDFLAGS': ldflags}):
@@ -385,6 +392,17 @@ class InternalTests(unittest.TestCase):
         args = cc.build_wrapper_args(None, None, CompileCheckMode.LINK)
         self.assertEqual(list(args).count('-Zomf'), 1, args)
         self.assertNotIn('-Zomf', cc.build_wrapper_args(None, None, CompileCheckMode.COMPILE))
+
+    def test_find_library_args_msvc(self):
+        cc = self._fake_msvc_cc()
+
+        def fake_links(code, *, extra_args=None, **kwargs):
+            args = cc.build_wrapper_args(extra_args, None, CompileCheckMode.LINK).to_native()
+            self.assertIn('/release', args)
+            return (True, False)
+
+        with mock.patch.object(cc, 'links', fake_links):
+            cc.find_library('foo', [])
 
     def test_compiler_args_class_gnuld(self):
         ## Test --start/end-group

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -28,7 +28,7 @@ import mesonbuild.modules.gnome
 import mesonbuild.scripts.env2mfile
 from mesonbuild import coredata
 from mesonbuild.compilers.c import ClangCCompiler, GnuCCompiler
-from mesonbuild.compilers.compilers import Compiler, ManyInOneLinkerOptionStyle
+from mesonbuild.compilers.compilers import Compiler, CompileCheckMode, ManyInOneLinkerOptionStyle
 from mesonbuild.compilers.cpp import VisualStudioCPPCompiler
 from mesonbuild.compilers.d import DmdDCompiler
 from mesonbuild.compilers.detect import detect_c_compiler
@@ -361,6 +361,22 @@ class InternalTests(unittest.TestCase):
         self.assertEqual(ClangClCompiler.unix_args_to_native(['-isystem', 'foo']), ['/clang:-isystemfoo'])
         self.assertEqual(ClangClCompiler.unix_args_to_native(['-idirafter', 'foo']), ['/clang:-idirafterfoo'])
         self.assertEqual(ClangClCompiler.unix_args_to_native(['-iquote', 'foo']), ['/clang:-iquotefoo'])
+
+    def _fake_gnu_cc(self, cflags='-DCFLAG', ldflags='-Wl,-O1',
+                     linker_cls=linkers.GnuBFDDynamicLinker):
+        with mock.patch.dict(os.environ, {'CFLAGS': cflags, 'LDFLAGS': ldflags}):
+            env = get_fake_env()
+        env.add_lang_args('c', GnuCCompiler, MachineChoice.HOST)
+        linker = linker_cls([], env, MachineChoice.HOST,
+                            ManyInOneLinkerOptionStyle('-Wl,', ','), [])
+        return GnuCCompiler([], [], 'fake', MachineChoice.HOST, env, linker=linker)
+
+    def test_compiler_check_args_os2(self):
+        # the linker's always args (-Zomf on OS/2) must reach link mode checks
+        cc = self._fake_gnu_cc(linker_cls=linkers.OS2OmfDynamicLinker)
+        args = cc.build_wrapper_args(None, None, CompileCheckMode.LINK)
+        self.assertEqual(list(args).count('-Zomf'), 1, args)
+        self.assertNotIn('-Zomf', cc.build_wrapper_args(None, None, CompileCheckMode.COMPILE))
 
     def test_compiler_args_class_gnuld(self):
         ## Test --start/end-group


### PR DESCRIPTION
Manual backport of #16166 to avoid conflicts with commits 19bcaef61b538c10defc543cc6b9e7be18ff1295 and e6bb7f2d1dfd458ef98ce92ac3dd942fdfdb4593.