### PR TITLE
Fix bug with passing shared libraries to ldc2 (D/dlang)

### DIFF
--- a/mesonbuild/arglist.py
+++ b/mesonbuild/arglist.py
@@ -8,8 +8,8 @@ from functools import lru_cache
 import collections
 import enum
 import os
-import re
 import typing as T
+from mesonbuild.utils.universal import is_lib_filename
 
 if T.TYPE_CHECKING:
     from .linkers import StaticLinker
@@ -84,10 +84,6 @@ class CompilerArgs(T.MutableSequence[str]):
     # NOTE: not thorough. A list of potential corner cases can be found in
     # https://github.com/mesonbuild/meson/pull/4593#pullrequestreview-182016038
     dedup1_prefixes: T.Tuple[str, ...] = ()
-    dedup1_suffixes = ('.lib', '.dll', '.so', '.dylib', '.a')
-    # Match a .so of the form path/to/libfoo.so.0.1.0
-    # Only UNIX shared libraries require this. Others have a fixed extension.
-    dedup1_regex = re.compile(r'([\/\\]|\A)lib.*\.so(\.[0-9]+)?(\.[0-9]+)?(\.[0-9]+)?$')
     dedup1_args: T.Tuple[str, ...] = ()
     # In generate_link() we add external libs without de-dup, but we must
     # *always* de-dup these because they're special arguments to the linker
@@ -226,8 +222,7 @@ class CompilerArgs(T.MutableSequence[str]):
             return Dedup.OVERRIDDEN
         if arg in cls.dedup1_args or \
            arg.startswith(cls.dedup1_prefixes) or \
-           arg.endswith(cls.dedup1_suffixes) or \
-           re.search(cls.dedup1_regex, arg):
+           is_lib_filename(arg):
             return Dedup.UNIQUE
         return Dedup.NO_DEDUP
 

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -11,7 +11,8 @@ from .. import mesonlib
 from ..arglist import CompilerArgs
 from ..linkers import RSPFileSyntax
 from ..mesonlib import (
-    EnvironmentException, MesonBugException, version_compare, is_windows
+    EnvironmentException, MesonBugException, version_compare, is_windows,
+    is_lib_filename
 )
 from ..options import OptionKey
 
@@ -285,16 +286,15 @@ class DmdLikeCompilerMixin(CompilerMixinBase):
                     dcargs.append(arg)
                     continue
 
-                # Make sure static library files are passed properly to the linker.
-                if arg.endswith('.a') or arg.endswith('.lib'):
-                    if len(suffix) > 0 and not suffix.startswith('-'):
-                        dcargs.append('-L=' + suffix)
-                        continue
+                # Make sure library files are passed properly to the linker.
+                if is_lib_filename(suffix):
+                    dcargs.append('-L=' + suffix)
+                    continue
 
                 dcargs.append('-L=' + arg)
                 continue
-            elif not arg.startswith('-') and arg.endswith(('.a', '.lib')):
-                # ensure static libraries are passed through to the linker
+            elif not arg.startswith('-') and is_lib_filename(arg):
+                # ensure libraries are passed through to the linker
                 dcargs.append('-L=' + arg)
                 continue
             else:

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -193,6 +193,7 @@ __all__ = [
     'windows_detect_native_arch',
     'windows_proof_rm',
     'windows_proof_rmtree',
+    'is_lib_filename',
 ]
 
 SubProject = T.NewType('SubProject', str)
@@ -2872,3 +2873,12 @@ def unwrap_err(value: _T | None, msg: str) -> _T:
     if value is not None:
         return value
     raise MesonException(msg)
+
+LIB_FILE_SUFFIXES = ('.lib', '.dll', '.so', '.dylib', '.a')
+# Match a .so of the form path/to/libfoo.so.0.1.0
+# Only UNIX shared libraries require this. Others have a fixed extension.
+LIB_FILE_REGEX = re.compile(r'([\/\\]|\A)lib.*\.so(\.[0-9]+)?(\.[0-9]+)?(\.[0-9]+)?$')
+
+def is_lib_filename(filename: str) -> bool:
+    return filename.endswith(LIB_FILE_SUFFIXES) or \
+        re.search(LIB_FILE_REGEX, filename) is not None

--- a/test cases/d/18 so dependency via clib/clib/clib.c
+++ b/test cases/d/18 so dependency via clib/clib/clib.c
@@ -1,0 +1,10 @@
+#include "clib.h"
+#include <libxml2/libxml/xmlversion.h>
+#include <exampleshlib.h>
+#include <stdio.h>
+
+void clib_call_cdeps(void) {
+    printf("clib_call_cdeps called.\n");
+    exampleshlib_hello();
+    LIBXML_TEST_VERSION
+}

--- a/test cases/d/18 so dependency via clib/clib/clib.h
+++ b/test cases/d/18 so dependency via clib/clib/clib.h
@@ -1,0 +1,6 @@
+#ifndef CLIB_H
+#define CLIB_H
+
+void clib_call_cdeps(void);
+
+#endif

--- a/test cases/d/18 so dependency via clib/clib/meson.build
+++ b/test cases/d/18 so dependency via clib/clib/meson.build
@@ -1,0 +1,23 @@
+# Shared library as a subproject is handled differently than a library found with pkg-config,
+# let's add it to see the difference.
+exampleshlib_proj = subproject('exampleshlib')
+exampleshlib_dep = exampleshlib_proj.get_variable('exampleshlib_dep')
+
+# D standard runtime library (Phobos) bundles a copy of zlib (etc.c.zlib) and exports zlib C symbols globally
+# thus any reference to zlib functions get resolved via D's standard library and that prevents reproducing the bug.
+# We try with libxml2 as another widely deployed library instead.
+libxml2_dep = dependency('libxml-2.0')
+if not libxml2_dep.found()
+  error('MESON_SKIP_TEST requires libxml2')
+endif
+
+clib_lib = static_library('clib',
+    'clib.c',
+    dependencies : [libxml2_dep, exampleshlib_dep]
+)
+
+clib_dep = declare_dependency(
+    link_with : clib_lib,
+    dependencies : [libxml2_dep, exampleshlib_dep],
+    include_directories : include_directories('.'),
+)

--- a/test cases/d/18 so dependency via clib/main.d
+++ b/test cases/d/18 so dependency via clib/main.d
@@ -1,0 +1,6 @@
+
+extern (C) void clib_call_cdeps();
+
+void main() {
+    clib_call_cdeps();
+}

--- a/test cases/d/18 so dependency via clib/meson.build
+++ b/test cases/d/18 so dependency via clib/meson.build
@@ -1,0 +1,19 @@
+# project tests proper shared object dependency passing
+# of C lib via linker flag
+
+project('ldc-linker-bug', ['c', 'd'],
+    version : '0.1.0',
+    default_options : [
+      'warning_level=everything',
+      'c_std=c99',
+    ],
+)
+
+subdir('clib')
+
+d_sources = files('main.d')
+
+executable('prog',
+    d_sources,
+    dependencies : clib_dep,
+)

--- a/test cases/d/18 so dependency via clib/subprojects/exampleshlib/exampleshlib.c
+++ b/test cases/d/18 so dependency via clib/subprojects/exampleshlib/exampleshlib.c
@@ -1,0 +1,6 @@
+#include "exampleshlib.h"
+#include <stdio.h>
+
+void exampleshlib_hello(void) {
+    printf("exampleshlib_hello called.\n");
+}

--- a/test cases/d/18 so dependency via clib/subprojects/exampleshlib/exampleshlib.h
+++ b/test cases/d/18 so dependency via clib/subprojects/exampleshlib/exampleshlib.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void exampleshlib_hello(void);

--- a/test cases/d/18 so dependency via clib/subprojects/exampleshlib/meson.build
+++ b/test cases/d/18 so dependency via clib/subprojects/exampleshlib/meson.build
@@ -1,0 +1,20 @@
+project(
+  'exampleshlib',
+  'c',
+  meson_version : '>= 1.3.0',
+  version : '0.1',
+  default_options : ['warning_level=3'],
+)
+
+sources = [
+  'exampleshlib.c',
+]
+
+exampleshlib = shared_library(
+  'exampleshlib',
+  sources,
+  install : true,
+)
+
+exampleshlib_dep = declare_dependency(include_directories : include_directories('.'),
+  link_with : exampleshlib)

--- a/test cases/d/18 so dependency via clib/test.json
+++ b/test cases/d/18 so dependency via clib/test.json
@@ -1,0 +1,5 @@
+{
+  "installed": [
+    {"type": "shared_lib", "file": "usr/lib/exampleshlib"}
+  ]
+}

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -33,7 +33,7 @@ from mesonbuild.compilers import Compiler
 from mesonbuild.compilers.c import ClangCCompiler, ClangClCCompiler, GnuCCompiler, VisualStudioCCompiler
 from mesonbuild.compilers.compilers import CompileCheckMode, ManyInOneLinkerOptionStyle
 from mesonbuild.compilers.cpp import VisualStudioCPPCompiler
-from mesonbuild.compilers.d import DmdDCompiler
+from mesonbuild.compilers.d import DmdDCompiler, LLVMDCompiler
 from mesonbuild.compilers.detect import detect_c_compiler
 from mesonbuild.compilers.mixins.visualstudio import MSVCCompiler, ClangClCompiler
 from mesonbuild.linkers import linkers
@@ -488,6 +488,23 @@ Thread model: posix'''), '21.9.0')
         self.assertEqual(ClangClCompiler.unix_args_to_native(['-isystem', 'foo']), ['/clang:-isystemfoo'])
         self.assertEqual(ClangClCompiler.unix_args_to_native(['-idirafter', 'foo']), ['/clang:-idirafterfoo'])
         self.assertEqual(ClangClCompiler.unix_args_to_native(['-iquote', 'foo']), ['/clang:-iquotefoo'])
+
+    def test_d_unix_args_to_native(self):
+        env = get_fake_env()
+        linker = linkers.GnuBFDDynamicLinker([], env, MachineChoice.HOST, ManyInOneLinkerOptionStyle('-Wl,', ','), [])
+        dmd = DmdDCompiler([], 'fake', MachineChoice.HOST, env, 'arch', linker=linker)
+        ldc = LLVMDCompiler([], 'fake', MachineChoice.HOST, env, 'arch', linker=linker)
+
+        for comp in (dmd, ldc):
+            with self.subTest(compiler=comp.id):
+                self.assertEqual(
+                    comp.unix_args_to_native(['/usr/lib/libfoo.so', 'libbar.so', 'libbaz.a', 'libqux.lib']),
+                    ['-L=/usr/lib/libfoo.so', '-L=libbar.so', '-L=libbaz.a', '-L=libqux.lib']
+                )
+                self.assertEqual(
+                    comp.unix_args_to_native(['-lfoo', '-L/usr/local/lib', '-pthread', '-Wl,-rpath=/foo']),
+                    ['-L=-lfoo', '-L=-L/usr/local/lib', '-L=-rpath=/foo']
+                )
 
     def _fake_msvc_cc(self, cflags='-DCFLAG', ldflags='/SUBSYSTEM:CONSOLE'):
         with mock.patch.dict(os.environ, {'CFLAGS': cflags, 'LDFLAGS': ldflags}):

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -2645,3 +2645,17 @@ Thread model: posix'''), '21.9.0')
                 mesonbuild.scripts.depfixer.fix_rpath(
                     fname, set(), '', '', {}, system='linux', verbose=False)
                 mock_fix_darwin.assert_not_called()
+
+    def test_is_lib_filename(self) -> None:
+        from mesonbuild.utils.universal import is_lib_filename
+
+        self.assertTrue(is_lib_filename('libfoo.so'))
+        self.assertTrue(is_lib_filename('libfoo.so.1.2.3'))
+        self.assertTrue(is_lib_filename('libfoo.dylib'))
+        self.assertTrue(is_lib_filename('libfoo.a'))
+        self.assertTrue(is_lib_filename('foo.dll'))
+        self.assertTrue(is_lib_filename('foo.lib'))
+
+        self.assertFalse(is_lib_filename('libfoo.so.txt'))
+        self.assertFalse(is_lib_filename('foo.c'))
+        self.assertFalse(is_lib_filename('foo.exe'))


### PR DESCRIPTION
LLM usage disclosure: i've consulted google's gemini to find out the place where and how to write a unit test here since I don't write python these days.

Current meson produces invalid command to build Dlang app that depends on an internal static C library built with meson that depends on a system shared library.

I've added a minimal test case to demonstrate, but it depends on blkid library and pkg-config (i've tried other libraries like zlib but it's unreliable, looks like ldc2 sorts the inputs, and there's no such problem with shared libraries built as a subproject). Overall I'm not sure if it's acceptable to put a test into this directory because it depends on a library to be installed.

This is the error before fix:
```
meson setup _build .

18 so dependency via clib (fix-ldc2-so-link)> ninja -C _build
ninja: Entering directory `_build'
[4/4] Linking target prog
FAILED: prog 
ldc2  -of=prog prog.p/main.d.o -L=--allow-shlib-undefined -link-defaultlib-shared -L=clib/libclib.a /usr/lib/x86_64-linux-gnu/libblkid.so
/usr/bin/ld: clib/libclib.a.p/clib.c.o: in function `clib_call_blkid':
/home/yur/projects/meson/test cases/d/18 so dependency via clib/_build/../clib/clib.c:5:(.text+0xe): undefined reference to `blkid_init_debug'
collect2: error: ld returned 1 exit status
Error: /usr/bin/cc failed with status: 1
ninja: build stopped: subcommand failed.
```

The fix is that "/usr/lib/x86_64-linux-gnu/libblkid.so" must be prefixed with "-L=" so that ldc2 passes it to the linker after the static library that references libblkid, otherwise it's passed before and thus unresolved reference.