### PR TITLE
Revert "cargo: Use --env-set when we have nightly rustc"

### DIFF
--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -178,18 +178,6 @@ class PackageState:
 
         return args
 
-    def get_env_args(self, rustc: RustCompiler, environment: Environment, subdir: str) -> T.List[str]:
-        """Get environment variable arguments for rustc."""
-        enable_env_set_args = rustc.enable_env_set_args()
-        if enable_env_set_args is None:
-            return []
-
-        env_dict = self.get_env_dict(environment, subdir)
-        env_args = list(enable_env_set_args)
-        for k, v in env_dict.items():
-            env_args.extend(['--env-set', f'{k}={v}'])
-        return env_args
-
     def get_rustc_args(self, environment: Environment, subdir: str, machine: MachineChoice) -> T.List[str]:
         """Get rustc arguments for this package."""
         rustc = T.cast('RustCompiler', environment.coredata.compilers[machine]['rust'])
@@ -198,7 +186,6 @@ class PackageState:
         args: T.List[str] = []
         args.extend(self.get_lint_args(rustc))
         args.extend(cfg.get_features_args())
-        args.extend(self.get_env_args(rustc, environment, subdir))
         return args
 
     def supported_abis(self) -> T.Set[RUST_ABI]:

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -567,15 +567,6 @@ class RustCompiler(Compiler):
                                    full_version=self.full_version,
                                    linker=self.linker, rustc=self)
 
-    def enable_env_set_args(self) -> T.Optional[T.List[str]]:
-        '''Extra arguments to enable --env-set support in rustc.
-        Returns None if not supported.
-        '''
-        if version_compare(self.version, '>= 1.76') and self.allow_nightly:
-            return ['-Z', 'unstable-options']
-        return None
-
-
 class ClippyRustCompiler(RustCompiler):
 
     """Clippy is a linter that wraps Rustc.


### PR DESCRIPTION
This reverts commit c63cfd95b3b93a25f1c8ac490603c37124ba20f0; [--env-set is being dropped from rustc](https://github.com/rust-lang/rust/pull/161831).  It can be reapplied once Meson starts supporting environment arguments natively.