### PR TITLE
dependencies: keep llvm-config paths with spaces intact

### DIFF
--- a/mesonbuild/dependencies/configtool.py
+++ b/mesonbuild/dependencies/configtool.py
@@ -139,11 +139,17 @@ class ConfigToolDependency(ExternalDependency):
 
         return self.config is not None
 
-    def get_config_value(self, args: T.List[str], stage: str, required: bool = False) -> T.List[str]:
+    def get_config_output(self, args: T.List[str], stage: str, required: bool = False) -> str:
         p, out, err = Popen_safe_logged(self.config + args)
         if p.returncode != 0:
             if self.required or required:
                 raise DependencyException(f'Could not generate {stage} for {self.name}.\n{err}')
+            return ''
+        return out.strip()
+
+    def get_config_value(self, args: T.List[str], stage: str, required: bool = False) -> T.List[str]:
+        out = self.get_config_output(args, stage, required)
+        if not out:
             return []
         return split_args(out)
 

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -209,6 +209,7 @@ class LLVMDependencyConfigTool(ConfigToolDependency):
         self.provided_modules: T.List[str] = []
         self.required_modules: mesonlib.OrderedSet[str] = mesonlib.OrderedSet()
         self.module_details:   T.List[str] = []
+        self._llvm_dir_paths: T.Optional[T.List[str]] = None
         if not self.is_found:
             return
 
@@ -250,10 +251,31 @@ class LLVMDependencyConfigTool(ConfigToolDependency):
                 new_args.append(arg.lstrip('-l'))
             elif arg.startswith('-LIBPATH:'):
                 cpp = self.env.coredata.compilers[self.for_machine]['cpp']
-                new_args.extend(cpp.get_linker_search_args(arg.lstrip('-LIBPATH:')))
+                # removeprefix, not lstrip: lstrip takes a *set* of characters,
+                # so -LIBPATH:PATH\foo becomes \foo.
+                new_args.extend(cpp.get_linker_search_args(arg.removeprefix('-LIBPATH:')))
             else:
                 new_args.append(arg)
         return new_args
+
+    def _config_dir_paths(self) -> T.List[str]:
+        if self._llvm_dir_paths is None:
+            cached: T.List[str] = []
+            for flag, stage in (('--libdir', 'link_args'), ('--includedir', 'compile_args')):
+                d = self.get_config_output([flag], stage)
+                if d:
+                    cached.append(d)
+            self._llvm_dir_paths = cached
+        return self._llvm_dir_paths
+
+    def get_config_value(self, args: T.List[str], stage: str, required: bool = False) -> T.List[str]:
+        raw = self.get_config_output(args, stage, required=required)
+        if not raw:
+            return []
+        # These are a single directory; split_args would break "C:\Program Files\...".
+        if args in (['--libdir'], ['--includedir']):
+            return [raw]
+        return mesonlib.split_args_protecting(raw, self._config_dir_paths())
 
     def __check_libfiles(self, shared: bool) -> None:
         """Use llvm-config's --libfiles to check if libraries exist."""

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -176,6 +176,7 @@ __all__ = [
     'get_meson_command',
     'set_meson_command',
     'split_args',
+    'split_args_protecting',
     'stringlistify',
     'underscorify',
     'substitute_values',
@@ -1455,6 +1456,55 @@ else:
 
 def join_args(args: T.Iterable[str]) -> str:
     return ' '.join([quote_arg(x) for x in args])
+
+
+def split_args_protecting(cmd: str, protect: T.Iterable[str]) -> T.List[str]:
+    """Split *cmd* like :func:`split_args`, keeping *protect* substrings intact.
+
+    Tools such as llvm-config on Windows print unquoted paths that contain
+    spaces (``C:\\Program Files\\LLVM\\lib``). :func:`split_args` then treats
+    those spaces as argument separators. Each protected path is replaced with
+    a space-free token, the string is split, and the original paths are
+    restored so each remains a single argument.
+    """
+    paths = sorted({p for p in protect if p}, key=len, reverse=True)
+    if not paths or not cmd:
+        return split_args(cmd) if cmd else []
+
+    variants: T.List[str] = []
+    seen: T.Set[str] = set()
+    for path in paths:
+        for variant in (path, path.replace('\\', '/'), path.replace('/', '\\')):
+            if variant and variant not in seen:
+                seen.add(variant)
+                variants.append(variant)
+    variants.sort(key=len, reverse=True)
+
+    token_map: T.List[T.Tuple[str, str]] = []
+    rewritten = cmd
+    for i, variant in enumerate(variants):
+        if variant not in rewritten:
+            continue
+        placeholder = f'__MESON_PROTECT_{i}__'
+        rewritten = rewritten.replace(variant, placeholder)
+        token_map.append((placeholder, variant))
+    if not token_map:
+        return split_args(cmd)
+
+    # POSIX shlex.split treats backslash as escape. A protected directory
+    # followed by \file (Windows llvm-config) would lose that separator.
+    bs_token = '__MESON_BS__'
+    rewritten = rewritten.replace('\\', bs_token)
+    return [
+        _restore_protected_args(part, token_map).replace(bs_token, '\\')
+        for part in split_args(rewritten)
+    ]
+
+
+def _restore_protected_args(part: str, token_map: T.List[T.Tuple[str, str]]) -> str:
+    for placeholder, variant in token_map:
+        part = part.replace(placeholder, variant)
+    return part
 
 
 def do_replacement(regex: T.Pattern[str], line: str,

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1347,6 +1347,41 @@ Thread model: posix'''), '21.9.0')
             self.assertEqual(quote_arg(arg), expected)
             self.assertEqual(split_args(expected)[0], arg)
 
+    def test_split_args_protecting(self):
+        split_args = mesonbuild.mesonlib.split_args
+        split_args_protecting = mesonbuild.mesonlib.split_args_protecting
+
+        libdir = r'C:\Program Files\LLVM\lib'
+        incdir = r'C:\Program Files\LLVM\include'
+        raw = f'-LIBPATH:{libdir} {libdir}\\LLVMCore.lib -I{incdir}'
+        self.assertNotEqual(split_args(raw), [
+            f'-LIBPATH:{libdir}',
+            f'{libdir}\\LLVMCore.lib',
+            f'-I{incdir}',
+        ])
+        self.assertEqual(split_args_protecting(raw, [libdir, incdir]), [
+            f'-LIBPATH:{libdir}',
+            f'{libdir}\\LLVMCore.lib',
+            f'-I{incdir}',
+        ])
+
+        raw_slash = '-LIBPATH:C:/Program Files/LLVM/lib C:/Program Files/LLVM/lib/LLVMCore.lib'
+        self.assertEqual(split_args_protecting(raw_slash, [libdir]), [
+            '-LIBPATH:C:/Program Files/LLVM/lib',
+            'C:/Program Files/LLVM/lib/LLVMCore.lib',
+        ])
+
+        posix_lib = '/usr/Program Files/LLVM/lib'
+        posix_raw = f'-L{posix_lib} {posix_lib}/libLLVMCore.a'
+        self.assertEqual(split_args_protecting(posix_raw, [posix_lib]), [
+            f'-L{posix_lib}',
+            f'{posix_lib}/libLLVMCore.a',
+        ])
+
+        self.assertEqual(split_args_protecting('-lLLVMCore -L/usr/lib', []),
+                         split_args('-lLLVMCore -L/usr/lib'))
+        self.assertEqual(split_args_protecting('', ['/tmp']), [])
+
     def test_depfile(self):
         for (f, target, expdeps) in [
                 # empty, unknown target


### PR DESCRIPTION
Fixes #13706.

## Summary
`llvm-config` on Windows prints unquoted paths such as
`-LIBPATH:C:\Program Files\LLVM\lib` and
`C:\Program Files\LLVM\lib\LLVMCore.lib`. `split_args` treats those
spaces as argument separators, so `dependency('llvm')` emits broken
ninja link lines.

- `--libdir` / `--includedir` are taken as a single path
- other llvm-config output is split while keeping those directory strings intact
- `-LIBPATH:` is stripped with `removeprefix` (`str.lstrip` is a character set
  and turns `-LIBPATH:PATH\foo` into `\foo`)

## Tests
- `python run_unittests.py InternalTests.test_split_args_protecting InternalTests.test_split_args InternalTests.test_quote_arg -v` — passed
