### PR TITLE
compilers: make sanity checks homogeneous and other small cleanups

### DIFF
--- a/mesonbuild/compilers/asm.py
+++ b/mesonbuild/compilers/asm.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import os
 import typing as T
 
-from ..mesonlib import EnvironmentException, get_meson_command
+from ..mesonlib import EnvironmentException, MesonException, get_meson_command
 from ..options import OptionKey
-from .compilers import Compiler
+from .compilers import Compiler, CompileCheckMode
 from ..linkers import RSPFileSyntax
 from ..linkers.linkers import VisualStudioLikeLinkerMixin
 from .mixins.metrowerks import MetrowerksCompiler, mwasmarm_instruction_set_args, mwasmeppc_instruction_set_args
@@ -213,6 +213,11 @@ class MasmCompiler(ASMCompiler):
 
     def get_output_args(self, outputname: str) -> T.List[str]:
         return ['/Fo', outputname]
+
+    def get_output_args_for_mode(self, outputname: str, mode: CompileCheckMode) -> T.List[str]:
+        if mode != CompileCheckMode.COMPILE:
+            raise MesonException("Linker support for MASM is not implemented")
+        return self.get_output_args(outputname)
 
     def get_optimization_args(self, optimization_level: str) -> T.List[str]:
         return []

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1433,6 +1433,9 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
 
     def _sanity_check_mode(self) -> CompileCheckMode:
         """Whether the sanity check links a binary, or only compiles one."""
+        # Cross-compiling is hard. For example, you might need -nostdlib, or to pass --target, etc.
+        if self.is_cross and not self.environment.has_exe_wrapper():
+            return CompileCheckMode.COMPILE
         return CompileCheckMode.LINK
 
     def get_external_compile_args(self) -> T.List[str]:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1466,7 +1466,7 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
             + self.get_external_compile_args()
         if mode is CompileCheckMode.COMPILE:
             return cargs, []
-        largs = self.get_external_link_args()
+        largs = self.get_linker_always_args() + self.get_external_link_args()
         return cargs, largs
 
     @abc.abstractmethod

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -679,6 +679,15 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
     def get_output_args(self, outputname: str) -> T.List[str]:
         pass
 
+    def get_output_args_for_mode(self, outputname: str, mode: CompileCheckMode) -> T.List[str]:
+        """
+        Output arguments for preprocessor output, object file or executable.
+        get_output_args() can discriminate between preprocessor or compiler
+        object file; use this to name an executable by passing CompileCheckMode.LINK
+        as the mode.
+        """
+        return self.get_output_args(outputname)
+
     def get_linker_output_args(self, outputname: str) -> T.List[str]:
         return self.linker.get_output_args(outputname)
 
@@ -961,7 +970,7 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
             # Preprocess mode outputs to stdout, so no output args
             if mode != CompileCheckMode.PREPROCESS:
                 output = self._get_compile_output(tmpdirname, mode)
-                commands += self.get_output_args(output)
+                commands += self.get_output_args_for_mode(output, mode)
             commands.extend(self.get_compiler_args_for_mode(CompileCheckMode(mode)))
 
             # extra_args must be last because it could contain '/link' to
@@ -1464,7 +1473,7 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
         cargs = self.exelist_no_ccache \
             + self.get_compiler_args_for_mode(mode) \
             + self.get_compiler_check_args(CompileCheckMode.COMPILE) \
-            + self.get_output_args(binname) \
+            + self.get_output_args_for_mode(binname, mode) \
             + [sourcename] \
             + self.get_external_compile_args()
         if mode is CompileCheckMode.COMPILE:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1459,7 +1459,7 @@ class Compiler(HoldableObject, metaclass=SimpleABC):
         """
         mode = self._sanity_check_mode()
         cargs = self.exelist_no_ccache \
-            + self.get_always_args() \
+            + self.get_compiler_args_for_mode(mode) \
             + self.get_compiler_check_args(CompileCheckMode.COMPILE) \
             + self.get_output_args(binname) \
             + [sourcename] \

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -44,9 +44,6 @@ class CsCompiler(BasicLinkerIsCompilerMixin, Compiler):
     def get_always_args(self) -> T.List[str]:
         return ['/nologo']
 
-    def get_linker_always_args(self) -> T.List[str]:
-        return ['/nologo']
-
     def get_output_args(self, fname: str) -> T.List[str]:
         return ['-out:' + fname]
 

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -528,16 +528,6 @@ class CudaCompiler(Compiler):
             }
             '''
 
-    def _sanity_check_mode(self) -> CompileCheckMode:
-        # Linking cross built apps is painful. You can't really
-        # tell if you should use -nostdlib or not and for example
-        # on OSX the compiler binary is the same but you need
-        # a ton of compiler flags to differentiate between
-        # arm and x86_64. So just compile.
-        if self.is_cross and not self.environment.has_exe_wrapper():
-            return CompileCheckMode.COMPILE
-        return CompileCheckMode.LINK
-
     def _sanity_check_compile_args(self, sourcename: str, binname: str
                                    ) -> T.Tuple[T.List[str], T.List[str]]:
         args, largs = super()._sanity_check_compile_args(sourcename, binname)

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -540,22 +540,18 @@ class CudaCompiler(Compiler):
 
     def _sanity_check_compile_args(self, sourcename: str, binname: str
                                    ) -> T.Tuple[T.List[str], T.List[str]]:
+        args, largs = super()._sanity_check_compile_args(sourcename, binname)
+
         # Disable warnings, compile with statically-linked runtime for minimum
         # reliance on the system.
-        flags = ['-w', '-cudart', 'static', sourcename]
+        args += ['-w', '-cudart', 'static']
 
         # Use the -ccbin option, if available, even during sanity checking.
         # Otherwise, on systems where CUDA does not support the default compiler,
         # NVCC becomes unusable.
-        flags += self._get_ccbin_args(None, '')
+        args += self._get_ccbin_args(None, '')
 
-        # If cross-compiling, we can't run the sanity check, only compile it.
-        mode = self._sanity_check_mode()
-        if mode is CompileCheckMode.COMPILE:
-            flags += self.get_compile_only_args()
-        flags += self.get_output_args(binname)
-
-        return self.exelist + flags, []
+        return args, largs
 
     def has_header_symbol(self, hname: str, symbol: str, prefix: str, *,
                           extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -1115,6 +1115,9 @@ class CLikeCompiler(Compiler):
     def _find_library_real(self, libname: str, extra_dirs: T.List[str], code: str, libtype: LibType,
                            lib_prefix_warning: bool, ignore_system_dirs: bool,
                            skip_link_check: bool = False) -> T.Optional[T.List[str]]:
+        largs = self.get_allow_undefined_link_args()
+        lcargs = self.linker_to_compiler_args(largs)
+
         # First try if we can just add the library as -l.
         # Gcc + co seem to prefer builtin lib dirs to -L dirs.
         # Only try to find std libs if no extra dirs specified.
@@ -1123,10 +1126,7 @@ class CLikeCompiler(Compiler):
         if ((not extra_dirs and libtype is LibType.PREFER_SHARED) or
                 libname in self.internal_libs):
             cargs = ['-l' + libname]
-            largs = self.get_allow_undefined_link_args()
-            extra_args = cargs + self.linker_to_compiler_args(largs)
-
-            if self.links(code, extra_args=extra_args, disable_cache=True)[0]:
+            if self.links(code, extra_args=cargs + lcargs, disable_cache=True)[0]:
                 return cargs
             # Don't do a manual search for internal libs
             if libname in self.internal_libs:
@@ -1145,8 +1145,6 @@ class CLikeCompiler(Compiler):
         except (mesonlib.MesonException, KeyError): # TODO evaluate if catching KeyError is wanted here
             elf_class = 0
         # Search in the specified dirs, and then in the system libraries
-        largs = self.get_allow_undefined_link_args()
-        lcargs = self.linker_to_compiler_args(largs)
         for d in itertools.chain(extra_dirs, [] if ignore_system_dirs else self.get_library_dirs(elf_class)):
             for p in patterns:
                 trials = self._get_trials_from_pattern(p, d, libname)

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -285,7 +285,7 @@ class CLikeCompiler(Compiler):
         b_cargs, b_largs = self._get_basic_compiler_args(mode)
         cargs = self.exelist_no_ccache + \
             self.get_compiler_check_args(CompileCheckMode.COMPILE) + \
-            self.get_output_args(binname) + \
+            self.get_output_args_for_mode(binname, mode) + \
             [sourcename] + \
             b_cargs
         if mode is CompileCheckMode.COMPILE:

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -275,12 +275,6 @@ class CLikeCompiler(Compiler):
     def gen_import_library_args(self, implibname: str) -> T.List[str]:
         return self.linker.import_library_args(implibname)
 
-    def _sanity_check_mode(self) -> CompileCheckMode:
-        # Cross-compiling is hard. For example, you might need -nostdlib, or to pass --target, etc.
-        if self.is_cross and not self.environment.has_exe_wrapper():
-            return CompileCheckMode.COMPILE
-        return CompileCheckMode.LINK
-
     def _sanity_check_compile_args(self, sourcename: str, binname: str
                                    ) -> T.Tuple[T.List[str], T.List[str]]:
         # _get_basic_compiler_args() already adds c_args/c_link_args (or

--- a/mesonbuild/compilers/mixins/islinker.py
+++ b/mesonbuild/compilers/mixins/islinker.py
@@ -15,6 +15,7 @@ classes for those cases.
 import typing as T
 
 from ...mesonlib import EnvironmentException, MesonException, is_windows
+from ..compilers import CompileCheckMode
 
 if T.TYPE_CHECKING:
     from ...compilers.compilers import Compiler
@@ -55,6 +56,11 @@ class BasicLinkerIsCompilerMixin(Compiler):
 
     def get_linker_always_args(self) -> T.List[str]:
         return []
+
+    def _sanity_check_mode(self) -> CompileCheckMode:
+        # These compilers produce an executable in one step, there is no
+        # separate link phase that could be skipped.
+        return CompileCheckMode.LINK
 
     def get_linker_lib_prefix(self) -> str:
         return ''

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -171,10 +171,12 @@ class VisualStudioLikeCompiler(Compiler, metaclass=mesonlib.SimpleABC):
     def get_output_args(self, outputname: str) -> T.List[str]:
         if self.mode == 'PREPROCESSOR':
             return ['/Fi' + outputname]
-        # hack: this list is not exhaustive
-        if outputname.endswith(('.exe', '.dll')):
-            return ['/Fe' + outputname]
         return ['/Fo' + outputname]
+
+    def get_output_args_for_mode(self, outputname: str, mode: CompileCheckMode) -> T.List[str]:
+        if mode is CompileCheckMode.LINK:
+            return ['/Fe' + outputname]
+        return self.get_output_args(outputname)
 
     def get_debug_args(self, is_debug: bool) -> T.List[str]:
         if is_debug:

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -163,12 +163,10 @@ class RustCompiler(Compiler):
     def needs_static_linker(self) -> bool:
         return False
 
-    def _sanity_check_compile_args(self, sourcename: str, binname: str
-                                   ) -> T.Tuple[T.List[str], T.List[str]]:
-        cmdlist, largs = super()._sanity_check_compile_args(sourcename, binname)
-        if self.info.kernel == 'none' and 'ld.' in self.get_linker_id():
-            largs.extend(rustc_link_args(['-nostartfiles']))
-        return cmdlist, largs
+    def _sanity_check_mode(self) -> CompileCheckMode:
+        if self.is_cross and not self.environment.has_exe_wrapper():
+            return CompileCheckMode.COMPILE
+        return CompileCheckMode.LINK
 
     def _sanity_check_source_code(self) -> str:
         if self.info.kernel != 'none':

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -163,11 +163,6 @@ class RustCompiler(Compiler):
     def needs_static_linker(self) -> bool:
         return False
 
-    def _sanity_check_mode(self) -> CompileCheckMode:
-        if self.is_cross and not self.environment.has_exe_wrapper():
-            return CompileCheckMode.COMPILE
-        return CompileCheckMode.LINK
-
     def _sanity_check_source_code(self) -> str:
         if self.info.kernel != 'none':
             return textwrap.dedent(

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -175,11 +175,6 @@ class SwiftCompiler(Compiler):
 
         return parameter_list
 
-    def _sanity_check_mode(self) -> CompileCheckMode:
-        if self.is_cross and not self.environment.has_exe_wrapper():
-            return CompileCheckMode.COMPILE
-        return CompileCheckMode.LINK
-
     def _sanity_check_compile_args(self, sourcename: str, binname: str
                                    ) -> T.Tuple[T.List[str], T.List[str]]:
         args, largs = super()._sanity_check_compile_args(sourcename, binname)

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -9,7 +9,7 @@ import typing as T
 
 from .. import mlog, options
 from ..mesonlib import first, MesonException, version_compare
-from .compilers import Compiler, clike_debug_args, PrefixArgumentLinkerOptionStyle
+from .compilers import Compiler, CompileCheckMode, clike_debug_args, PrefixArgumentLinkerOptionStyle
 
 if T.TYPE_CHECKING:
     from .. import build
@@ -175,21 +175,16 @@ class SwiftCompiler(Compiler):
 
         return parameter_list
 
+    def _sanity_check_mode(self) -> CompileCheckMode:
+        if self.is_cross and not self.environment.has_exe_wrapper():
+            return CompileCheckMode.COMPILE
+        return CompileCheckMode.LINK
+
     def _sanity_check_compile_args(self, sourcename: str, binname: str
                                    ) -> T.Tuple[T.List[str], T.List[str]]:
-        args = self.exelist.copy()
-        largs: T.List[str] = []
-
-        # TODO: I can't test this, but it doesn't seem right
-        if self.is_cross:
-            args.extend(self.get_compile_only_args())
-        else:
-            largs.extend(self.get_external_link_args())
-        args.extend(self.get_output_args(binname))
-        args.append(sourcename)
-
-        largs.extend(self.get_std_exe_link_args())
-
+        args, largs = super()._sanity_check_compile_args(sourcename, binname)
+        if self._sanity_check_mode() is CompileCheckMode.LINK:
+            largs.extend(self.get_std_exe_link_args())
         return args, largs
 
     def _sanity_check_source_code(self) -> str:

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -545,6 +545,18 @@ Thread model: posix'''), '21.9.0')
         dll_args, _ = cc._sanity_check_compile_args('t.c', 't.dll')
         self.assertIn('/Fet.dll', dll_args)
 
+    def test_sanity_check_args_msvc_compile_only(self):
+        cc = self._fake_msvc_cc()
+        cc.is_cross = True
+        with mock.patch.object(cc.environment, 'has_exe_wrapper', lambda: False):
+            args, largs = cc._sanity_check_compile_args('t.c', 't.exe')
+        # not linking: no linker arguments at all, and the output is an object
+        self.assertEqual(largs, [])
+        self.assertNotIn('/link', args)
+        self.assertNotIn('/SUBSYSTEM:CONSOLE', args)
+        self.assertIn('/Fot.exe', args)
+        self.assertIn(cc.get_compile_only_args()[0], args)
+
     def test_sanity_check_args_gnu(self):
         cc = self._fake_gnu_cc()
         args, largs = cc._sanity_check_compile_args('t.c', 't.exe')


### PR DESCRIPTION
Adjust `Compiler._sanity_check_compile_args()` and `Compiler._sanity_check_mode()` to handle most of the reasons why `Compiler` subclasses override it, leaving only minimal touches:
* CUDA adds `-w -cudart static -ccbin ...`
* D passes linker arguments through `unix_args_to_native()` and adds `_get_target_arch_args()`
* Swift adds `-emit-executable` via `get_std_exe_link_args()`

Probably Swift is the easiest to change by moving `get_std_exe_link_args()` to the superclass, but I'm not doing it here because Cython needs that option *not* to be there (because it adds `get_std_shared_lib_link_args()`).

@lucascolley this cleans up the `.exe`/`.dll` special casing too.