### PR TITLE
cmake: avoid re-parsing preload wrapper arguments

### DIFF
--- a/docs/markdown/snippets/cmake_custom_target_backslashes.md
+++ b/docs/markdown/snippets/cmake_custom_target_backslashes.md
@@ -1,6 +1,7 @@
-## CMake custom targets accept arguments with backslashes
+## CMake command wrappers accept arguments with backslashes
 
-CMake subprojects can now configure `add_custom_target()` calls whose
-arguments contain backslashes. Meson's preload wrapper previously expanded
-those arguments a second time, which could reject valid command arguments
-such as regular expression backreferences during configuration.
+CMake subprojects can now configure `add_custom_command()`,
+`add_custom_target()`, and `set_property()` calls whose arguments contain
+backslashes. Meson's preload wrappers previously expanded those arguments a
+second time, which could reject valid values such as regular expression
+backreferences during configuration.

--- a/docs/markdown/snippets/cmake_custom_target_backslashes.md
+++ b/docs/markdown/snippets/cmake_custom_target_backslashes.md
@@ -1,0 +1,6 @@
+## CMake custom targets accept arguments with backslashes
+
+CMake subprojects can now configure `add_custom_target()` calls whose
+arguments contain backslashes. Meson's preload wrapper previously expanded
+those arguments a second time, which could reject valid command arguments
+such as regular expression backreferences during configuration.

--- a/mesonbuild/cmake/data/preload.cmake
+++ b/mesonbuild/cmake/data/preload.cmake
@@ -34,10 +34,10 @@ macro(add_custom_command)
   _add_custom_command(${ARGV})
 endmacro()
 
-macro(add_custom_target)
+function(add_custom_target)
   meson_ps_inspect_vars()
   _add_custom_target(${ARGV})
-endmacro()
+endfunction()
 
 macro(set_property)
   meson_ps_inspect_vars()

--- a/mesonbuild/cmake/data/preload.cmake
+++ b/mesonbuild/cmake/data/preload.cmake
@@ -29,20 +29,20 @@ endmacro()
 
 # Override some system functions with custom code and forward the args
 # to the original function
-macro(add_custom_command)
+function(add_custom_command)
   meson_ps_inspect_vars()
   _add_custom_command(${ARGV})
-endmacro()
+endfunction()
 
 function(add_custom_target)
   meson_ps_inspect_vars()
   _add_custom_target(${ARGV})
 endfunction()
 
-macro(set_property)
+function(set_property)
   meson_ps_inspect_vars()
   _set_property(${ARGV})
-endmacro()
+endfunction()
 
 function(set_source_files_properties)
   set(FILES)

--- a/test cases/cmake/8 custom command/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/CMakeLists.txt
@@ -143,6 +143,7 @@ add_custom_target(args_test_cmd
   COMMAND args_test ${ARGS_TEST}
 )
 add_custom_target(macro_name_cmd COMMAND macro_name)
+add_custom_target(backslash_cmd COMMAND ${CMAKE_COMMAND} -E echo "\\1")
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   message(STATUS "Running the -include test case on macro_name")

--- a/test cases/cmake/8 custom command/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/CMakeLists.txt
@@ -139,6 +139,11 @@ set(ARGS_TEST ${ARGS_TEST} arg2)
 
 add_executable(macro_name macro_name.cpp)
 add_executable(args_test args_test.cpp)
+add_custom_command(
+  OUTPUT backslash.txt
+  COMMAND ${CMAKE_COMMAND} -E echo "\\1"
+)
+set_property(TARGET macro_name PROPERTY MESON_TEST_BACKSLASH "\\1")
 add_custom_target(args_test_cmd
   COMMAND args_test ${ARGS_TEST}
 )


### PR DESCRIPTION
## Summary

Meson's preload wrappers for `add_custom_command()`, `add_custom_target()`, and `set_property()` forwarded `${ARGV}` from CMake macros. Macro arguments are substituted into the body as text, so values containing backslashes or literal variable references could be parsed and expanded a second time.

All three wrappers now use functions. In a function, `ARGV` is a normal variable, which avoids the extra parse. The CMake fixture covers a backslash argument for each wrapper.

This does not change the existing semicolon and empty-argument limitation. `${ARGV}` is still a CMake list, so expanding it cannot preserve those argument boundaries. Fixing that would require a separate forwarding mechanism.

Fixes #15281.

## Validation

- `./run_project_tests.py --only 'cmake/8 custom command' --failfast` (1 passed)
- `./run_project_tests.py --only cmake` (28 passed, 2 skipped)
- `./run_unittests.py cmake -q` (7 passed, 1 skipped)
- `./run_project_tests.py --only format` (9 passed)
- Reproduced the reported failure with the public `librsync` wrap project, then confirmed that configuration succeeds with this change
