### PR TITLE
Use slots=True with dataclasses as much as possible

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from collections import deque
-from dataclasses import dataclass, InitVar
+from dataclasses import dataclass, field, InitVar
 from functools import lru_cache
 from itertools import chain
 from pathlib import Path
@@ -129,15 +129,15 @@ class InstallData:
     mesonintrospect: T.List[str]
     version: str
 
-    def __post_init__(self) -> None:
-        self.targets: T.List[TargetInstallData] = []
-        self.headers: T.List[InstallDataBase] = []
-        self.man: T.List[InstallDataBase] = []
-        self.emptydir: T.List[InstallEmptyDir] = []
-        self.data: T.List[InstallDataBase] = []
-        self.symlinks: T.List[InstallSymlinkData] = []
-        self.install_scripts: T.List[InstallScript] = []
-        self.install_subdirs: T.List[SubdirInstallData] = []
+    # Additional fields that are not part of the public initializer
+    targets: list[TargetInstallData] = field(default_factory=list, init=False)
+    headers: list[InstallDataBase] = field(default_factory=list, init=False)
+    man: list[InstallDataBase] = field(default_factory=list, init=False)
+    emptydir: list[InstallEmptyDir] = field(default_factory=list, init=False)
+    data: list[InstallDataBase] = field(default_factory=list, init=False)
+    symlinks: list[InstallSymlinkData] = field(default_factory=list, init=False)
+    install_scripts: list[InstallScript] = field(default_factory=list, init=False)
+    install_subdirs: list[SubdirInstallData] = field(default_factory=list, init=False)
 
 @dataclass(eq=False)
 class TargetInstallData:
@@ -154,6 +154,7 @@ class TargetInstallData:
     optional: bool = False
     tag: T.Optional[str] = None
     can_strip: bool = False
+    out_name: str = field(init=False)
 
     def __post_init__(self, outdir_name: T.Optional[str]) -> None:
         if outdir_name is None:

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -71,7 +71,7 @@ if T.TYPE_CHECKING:
 # Assembly files cannot be unitified and neither can LLVM IR files
 LANGS_CANT_UNITY: T.FrozenSet[Language] = frozenset({'d', 'fortran', 'vala', 'rust'})
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class RegenInfo:
     source_dir: str
     build_dir: str
@@ -107,7 +107,7 @@ class TestProtocol(enum.Enum):
         return 'tap'
 
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class CleanTrees:
     '''
     Directories outputted by custom targets that have to be manually cleaned
@@ -116,7 +116,7 @@ class CleanTrees:
     build_dir: str
     trees: T.List[str]
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class InstallData:
     source_dir: str
     build_dir: str
@@ -139,7 +139,7 @@ class InstallData:
     install_scripts: list[InstallScript] = field(default_factory=list, init=False)
     install_subdirs: list[SubdirInstallData] = field(default_factory=list, init=False)
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class TargetInstallData:
     fname: str
     outdir: str
@@ -161,14 +161,14 @@ class TargetInstallData:
             outdir_name = os.path.join('{prefix}', self.outdir)
         self.out_name = os.path.join(outdir_name, os.path.basename(self.fname))
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class InstallEmptyDir:
     path: str
     install_mode: 'FileMode'
     subproject: str
     tag: T.Optional[str] = None
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class InstallDataBase:
     path: str
     install_path: str
@@ -179,7 +179,7 @@ class InstallDataBase:
     data_type: T.Optional[str] = None
     follow_symlinks: T.Optional[bool] = None
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class InstallSymlinkData:
     target: str
     name: str
@@ -197,7 +197,7 @@ class SubdirInstallData(InstallDataBase):
         self.exclude = exclude
 
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class TestSerialisation:
     name: str
     project_name: str

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -246,13 +246,13 @@ def all_dependencies_recurse(source: object,
 class InvalidArguments(MesonException):
     pass
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class DependencyOverride(HoldableObject):
     dep: dependencies.Dependency
     node: 'BaseNode'
     explicit: bool = True
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class Headers(HoldableObject):
     sources: T.List[File]
     install_subdir: T.Optional[str]
@@ -285,7 +285,7 @@ class Headers(HoldableObject):
         return self.custom_install_mode
 
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class Man(HoldableObject):
     sources: T.List[File]
     custom_install_dir: T.Optional[str]
@@ -304,7 +304,7 @@ class Man(HoldableObject):
         return self.sources
 
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class EmptyDir(HoldableObject):
     path: str
     install_mode: 'FileMode'
@@ -312,7 +312,7 @@ class EmptyDir(HoldableObject):
     install_tag: T.Optional[str] = None
 
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class InstallDir(HoldableObject):
     source_subdir: str
     installable_subdir: str
@@ -326,7 +326,7 @@ class InstallDir(HoldableObject):
     install_tag: T.Optional[str] = None
     follow_symlinks: T.Optional[bool] = None
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class DepManifest:
     version: str
     license: T.List[str]
@@ -572,7 +572,7 @@ class Build:
             raise MesonBugException(f'Required static_linker for {target.for_machine} not found')
         return archiver
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class IncludeDirs(HoldableObject):
 
     """Internal representation of an include_directories call.
@@ -629,7 +629,7 @@ class IncludeDirs(HoldableObject):
         return strlist
 
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class ExtractedObjects(HoldableObject):
     '''
     Holds a list of sources for which the objects must be extracted
@@ -680,7 +680,7 @@ class ExtractedObjects(HoldableObject):
                                      'the object files for each compiler at once.')
 
 
-@dataclass(eq=False, order=False)
+@dataclass(slots=True, eq=False, order=False)
 class StructuredSources(HoldableObject):
 
     """A container for sources in languages that use filesystem hierarchy.
@@ -722,7 +722,7 @@ class StructuredSources(HoldableObject):
         return False
 
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class Target(HoldableObject, metaclass=SimpleABC):
 
     typename: T.ClassVar[str]
@@ -2092,7 +2092,7 @@ class Generator(HoldableObject):
         return output
 
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class GeneratedList(HoldableObject):
 
     """The output of generator.process."""
@@ -3375,7 +3375,7 @@ class Jar(BuildTarget):
     def get_default_install_dir(self) -> T.Tuple[str, str]:
         return self.environment.get_jar_dir(), '{jardir}'
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class CustomTargetIndex(CustomTargetBase, HoldableObject):
 
     """A special opaque object returned by indexing a CustomTarget. This object
@@ -3565,7 +3565,7 @@ class LocalProgram(programs.Program):
 
 # A bit poorly named, but this represents plain data files to copy
 # during install.
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class Data(HoldableObject):
     sources: T.List[File]
     install_dir: str
@@ -3581,7 +3581,7 @@ class Data(HoldableObject):
         if self.rename is None:
             self.rename = [os.path.basename(f.fname) for f in self.sources]
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class SymlinkData(HoldableObject):
     target: str
     name: str
@@ -3594,7 +3594,7 @@ class SymlinkData(HoldableObject):
             raise InvalidArguments(f'Link name is "{self.name}", but link names cannot contain path separators. '
                                    'The dir part should be in install_dir.')
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class TestSetup:
     exe_wrapper: T.List[str]
     gdb: bool

--- a/mesonbuild/cargo/builder.py
+++ b/mesonbuild/cargo/builder.py
@@ -17,7 +17,7 @@ if T.TYPE_CHECKING:
     import builtins
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class Builder:
 
     filename: str

--- a/mesonbuild/cargo/cfg.py
+++ b/mesonbuild/cargo/cfg.py
@@ -89,44 +89,44 @@ def lexer(raw: str) -> _LEX_STREAM:
         yield (TokenType.IDENTIFIER, val)
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class IR:
 
     """Base IR node for Cargo CFG."""
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class String(IR):
 
     value: str
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class Identifier(IR):
 
     value: str
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class Equal(IR):
 
     lhs: Identifier
     rhs: String
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class Any(IR):
 
     args: T.List[IR]
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class All(IR):
 
     args: T.List[IR]
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class Not(IR):
 
     value: IR

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -59,7 +59,7 @@ def _extra_deps_varname() -> str:
     return 'extra_deps'
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class PackageConfiguration:
     """Configuration for a package during dependency resolution."""
     for_machine: MachineChoice
@@ -251,13 +251,13 @@ class PackageState:
             return _dependency_name(package_name, self.manifest.package.api)
         raise MesonException(f'Package {package_name} does not support rust or proc-macro ABI')
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(slots=True, frozen=True)
 class PackageKey:
     package_name: str
     api: str
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class WorkspaceState:
     workspace: Workspace
     subdir: str

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -695,7 +695,7 @@ class BuiltinDependency(ExternalDependency):
     type_name = DependencyTypeName('builtin')
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class DependencyCandidate(T.Generic[DepType]):
 
     callable: T.Union[T.Type[DepType], T.Callable[[str, Environment, DependencyObjectKWs], DepType]]

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -78,7 +78,7 @@ if T.TYPE_CHECKING:
 #     2.4 Ensure that all libraries have the same boost tag (and are thus compatible)
 #   3. Select the libraries matching the requested modules
 
-@dataclasses.dataclass(eq=False, order=False)
+@dataclasses.dataclass(slots=True, eq=False, order=False)
 class UnknownFileException(Exception):
     path: Path
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -81,7 +81,7 @@ def _get_env_var(for_machine: MachineChoice, is_cross: bool, var_name: str) -> T
     return value
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class MachineMap:
     # BUILD if cross compiling, HOST if not cross compiling
     build: MachineChoice

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -155,7 +155,7 @@ def _project_version_validator(value: T.Union[T.List, str, mesonlib.File, None])
     return None
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class SandboxViolationError(InterpreterException):
 
     """Exception raised when trying to use files outside of this project
@@ -177,7 +177,7 @@ class SandboxViolationError(InterpreterException):
         return f'Sandbox violation: Tried to grab {self.inputtype} {self.name} from {msg}.'
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class BuiltFileByNameError(InterpreterException):
 
     name: str

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -474,7 +474,7 @@ def load_info_file(infodir: str, kind: T.Optional[str] = None) -> T.Any:
     with open(get_info_file(infodir, kind), encoding='utf-8') as fp:
         return json.load(fp)
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class IntroCommand:
     desc: str
     func: T.Optional[T.Callable[[cdata.CoreData, build.Build, backends.Backend], T.Union[dict, list]]] = None

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -202,7 +202,7 @@ class MutableModuleObject(ModuleObject):
     pass
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class ModuleInfo:
 
     """Metadata about a Module."""

--- a/mesonbuild/modules/codegen.py
+++ b/mesonbuild/modules/codegen.py
@@ -82,7 +82,7 @@ def is_subset_validator(choices: T.Set[str]) -> T.Callable[[T.List[str]], T.Opti
     return inner
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class _CodeGenerator(HoldableObject):
 
     name: str
@@ -97,7 +97,7 @@ class _CodeGenerator(HoldableObject):
         return self.program.found()
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class LexGenerator(_CodeGenerator):
     pass
 
@@ -193,7 +193,7 @@ class LexHolder(ObjectHolder[LexGenerator]):
         return target
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class YaccGenerator(_CodeGenerator):
     pass
 

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -77,7 +77,7 @@ class BlockParseException(ParseException):
 
 TV_TokenTypes = T.TypeVar('TV_TokenTypes', int, str, bool)
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class Token(T.Generic[TV_TokenTypes]):
     tid: str
     filename: str
@@ -270,7 +270,7 @@ class BaseNode:
             self.whitespaces.append(token)
 
 
-@dataclass(unsafe_hash=True)
+@dataclass(slots=True, unsafe_hash=True)
 class WhitespaceNode(BaseNode):
 
     value: str
@@ -285,7 +285,7 @@ class WhitespaceNode(BaseNode):
     def append(self, token: Token[str]) -> None:
         self.value += token.value
 
-@dataclass(unsafe_hash=True)
+@dataclass(slots=True, unsafe_hash=True)
 class ElementaryNode(T.Generic[TV_TokenTypes], BaseNode):
 
     value: TV_TokenTypes
@@ -302,7 +302,7 @@ class BooleanNode(ElementaryNode[bool]):
 class IdNode(ElementaryNode[str]):
     pass
 
-@dataclass(unsafe_hash=True)
+@dataclass(slots=True, unsafe_hash=True)
 class NumberNode(ElementaryNode[int]):
 
     raw_value: str = field(hash=False)
@@ -313,7 +313,7 @@ class NumberNode(ElementaryNode[int]):
         self.value = int(token.value, base=0)
         self.bytespan = token.bytespan
 
-@dataclass(unsafe_hash=True)
+@dataclass(slots=True, unsafe_hash=True)
 class StringNode(ElementaryNode[str]):
 
     raw_value: str = field(hash=False)
@@ -342,7 +342,7 @@ class BreakNode(ElementaryNode):
 class SymbolNode(ElementaryNode[str]):
     pass
 
-@dataclass(unsafe_hash=True)
+@dataclass(slots=True, unsafe_hash=True)
 class ArgumentNode(BaseNode):
 
     arguments: T.List[BaseNode] = field(hash=False)
@@ -401,7 +401,7 @@ class ArgumentNode(BaseNode):
     def __len__(self) -> int:
         return self.num_args() + self.num_kwargs()
 
-@dataclass(unsafe_hash=True)
+@dataclass(slots=True, unsafe_hash=True)
 class ArrayNode(BaseNode):
 
     lbracket: SymbolNode
@@ -414,7 +414,7 @@ class ArrayNode(BaseNode):
         self.args = args
         self.rbracket = rbracket
 
-@dataclass(unsafe_hash=True)
+@dataclass(slots=True, unsafe_hash=True)
 class DictNode(BaseNode):
 
     lcurl: SymbolNode
@@ -430,7 +430,7 @@ class DictNode(BaseNode):
 class EmptyNode(BaseNode):
     pass
 
-@dataclass(unsafe_hash=True)
+@dataclass(slots=True, unsafe_hash=True)
 class BinaryOperatorNode(BaseNode):
 
     left: BaseNode
@@ -449,7 +449,7 @@ class OrNode(BinaryOperatorNode):
 class AndNode(BinaryOperatorNode):
     pass
 
-@dataclass(unsafe_hash=True)
+@dataclass(slots=True, unsafe_hash=True)
 class ComparisonNode(BinaryOperatorNode):
 
     ctype: COMPARISONS
@@ -458,7 +458,7 @@ class ComparisonNode(BinaryOperatorNode):
         super().__init__(left, operator, right)
         self.ctype = ctype
 
-@dataclass(unsafe_hash=True)
+@dataclass(slots=True, unsafe_hash=True)
 class ArithmeticNode(BinaryOperatorNode):
 
     operation: ARITH_OPERATORS
@@ -467,7 +467,7 @@ class ArithmeticNode(BinaryOperatorNode):
         super().__init__(left, operator, right)
         self.operation = operation
 
-@dataclass(unsafe_hash=True)
+@dataclass(slots=True, unsafe_hash=True)
 class UnaryOperatorNode(BaseNode):
 
     operator: SymbolNode
@@ -484,7 +484,7 @@ class NotNode(UnaryOperatorNode):
 class UMinusNode(UnaryOperatorNode):
     pass
 
-@dataclass(unsafe_hash=True)
+@dataclass(slots=True, unsafe_hash=True)
 class CodeBlockNode(BaseNode):
 
     pre_whitespaces: T.Optional[WhitespaceNode] = field(hash=False)
@@ -503,7 +503,7 @@ class CodeBlockNode(BaseNode):
         else:
             self.pre_whitespaces.append(token)
 
-@dataclass(unsafe_hash=True)
+@dataclass(slots=True, unsafe_hash=True)
 class IndexNode(BaseNode):
 
     iobject: BaseNode
@@ -518,7 +518,7 @@ class IndexNode(BaseNode):
         self.index = index
         self.rbracket = rbracket
 
-@dataclass(unsafe_hash=True)
+@dataclass(slots=True, unsafe_hash=True)
 class MethodNode(BaseNode):
 
     source_object: BaseNode
@@ -537,7 +537,7 @@ class MethodNode(BaseNode):
         self.args = args
         self.rpar = rpar
 
-@dataclass(unsafe_hash=True)
+@dataclass(slots=True, unsafe_hash=True)
 class FunctionNode(BaseNode):
 
     func_name: IdNode
@@ -552,7 +552,7 @@ class FunctionNode(BaseNode):
         self.args = args
         self.rpar = rpar
 
-@dataclass(unsafe_hash=True)
+@dataclass(slots=True, unsafe_hash=True)
 class AssignmentNode(BaseNode):
 
     var_name: IdNode
@@ -568,7 +568,7 @@ class AssignmentNode(BaseNode):
 class PlusAssignmentNode(AssignmentNode):
     pass
 
-@dataclass(unsafe_hash=True)
+@dataclass(slots=True, unsafe_hash=True)
 class ForeachClauseNode(BaseNode):
 
     foreach_: SymbolNode = field(hash=False)
@@ -590,7 +590,7 @@ class ForeachClauseNode(BaseNode):
         self.endforeach = endforeach
 
 
-@dataclass(unsafe_hash=True)
+@dataclass(slots=True, unsafe_hash=True)
 class IfNode(BaseNode):
 
     if_: SymbolNode
@@ -603,7 +603,7 @@ class IfNode(BaseNode):
         self.condition = condition
         self.block = block
 
-@dataclass(unsafe_hash=True)
+@dataclass(slots=True, unsafe_hash=True)
 class ElseNode(BaseNode):
 
     else_: SymbolNode
@@ -614,7 +614,7 @@ class ElseNode(BaseNode):
         self.else_ = else_
         self.block = block
 
-@dataclass(unsafe_hash=True)
+@dataclass(slots=True, unsafe_hash=True)
 class IfClauseNode(BaseNode):
 
     ifs: T.List[IfNode] = field(hash=False)
@@ -626,7 +626,7 @@ class IfClauseNode(BaseNode):
         self.ifs = []
         self.elseblock = EmptyNode(linenode.lineno, linenode.colno, linenode.filename)
 
-@dataclass(unsafe_hash=True)
+@dataclass(slots=True, unsafe_hash=True)
 class TestCaseClauseNode(BaseNode):
 
     testcase: SymbolNode
@@ -641,7 +641,7 @@ class TestCaseClauseNode(BaseNode):
         self.block = block
         self.endtestcase = endtestcase
 
-@dataclass(unsafe_hash=True)
+@dataclass(slots=True, unsafe_hash=True)
 class TernaryNode(BaseNode):
 
     condition: BaseNode
@@ -659,7 +659,7 @@ class TernaryNode(BaseNode):
         self.falseblock = falseblock
 
 
-@dataclass(unsafe_hash=True)
+@dataclass(slots=True, unsafe_hash=True)
 class ParenthesizedNode(BaseNode):
 
     lpar: SymbolNode = field(hash=False)

--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -111,7 +111,7 @@ class Logger:
             self.print_progress()
 
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class Runner:
     logger: Logger
     r: InitVar[Resolver]

--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, InitVar
+from dataclasses import dataclass, field, InitVar
 import sys, os, subprocess
 import argparse
 import asyncio
@@ -119,14 +119,17 @@ class Runner:
     repo_dir: str
     options: 'Arguments'
 
+    wrap_resolver: Resolver = field(init=False)
+    run_method: T.Callable[[], bool] = field(init=False)
+    log_queue: list[tuple[mlog.TV_LoggableList, T.Any]] = field(default_factory=list, init=False)
+
     def __post_init__(self, r: Resolver) -> None:
         # FIXME: Do a copy because Resolver.resolve() is stateful method that
         # cannot be called from multiple threads.
         self.wrap_resolver = copy.copy(r)
         self.wrap_resolver.dirname = os.path.join(r.subdir_root, self.wrap.directory)
         self.wrap_resolver.wrap = self.wrap
-        self.run_method: T.Callable[[], bool] = self.options.subprojects_func.__get__(self)
-        self.log_queue: T.List[T.Tuple[mlog.TV_LoggableList, T.Any]] = []
+        self.run_method = self.options.subprojects_func.__get__(self)
 
     def log(self, *args: mlog.TV_Loggable, **kwargs: T.Any) -> None:
         self.log_queue.append((list(args), kwargs))

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -318,7 +318,7 @@ class OptionKey:
 if T.TYPE_CHECKING:
     OptionDict: TypeAlias = T.Dict[OptionKey, ElementaryOptionValues]
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class UserOption(T.Generic[_T], HoldableObject):
 
     name: str
@@ -361,7 +361,7 @@ class UserOption(T.Generic[_T], HoldableObject):
         self.value = self.validate_value(newvalue)
         return self.value != oldvalue
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class EnumeratedUserOption(UserOption[_T]):
 
     """A generic UserOption that has enumerated values."""
@@ -379,7 +379,7 @@ class UserStringOption(UserOption[str]):
             raise MesonException(f'The value of option "{self.name}" is "{value}", which is not a string.')
         return value
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class UserBooleanOption(EnumeratedUserOption[bool]):
 
     choices: T.List[bool] = dataclasses.field(default_factory=lambda: [True, False])
@@ -431,7 +431,7 @@ class _UserIntegerBase(UserOption[_T]):
         return T.cast('_T', value)
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class UserIntegerOption(_UserIntegerBase[int]):
 
     min_value: T.Optional[int] = None
@@ -452,7 +452,7 @@ class OctalInt(int):
         return oct(int(self))
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class UserUmaskOption(_UserIntegerBase[T.Union["Literal['preserve']", OctalInt]]):
 
     min_value: T.Optional[int] = dataclasses.field(default=0, init=False)
@@ -475,7 +475,7 @@ class UserUmaskOption(_UserIntegerBase[T.Union["Literal['preserve']", OctalInt]]
             raise MesonException(f'Invalid mode for option "{self.name}" {e}')
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class UserComboOption(EnumeratedUserOption[str]):
 
     def validate_value(self, value: object) -> str:
@@ -494,7 +494,7 @@ class UserComboOption(EnumeratedUserOption[str]):
         assert isinstance(value, str), 'for mypy'
         return value
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class UserArrayOption(UserOption[T.List[_T]]):
 
     value_: dataclasses.InitVar[T.Union[_T, T.List[_T]]]
@@ -513,7 +513,7 @@ class UserArrayOption(UserOption[T.List[_T]]):
         return [str(c) for c in self.choices]
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class UserStringArrayOption(UserArrayOption[str]):
 
     def listify(self, value: object) -> T.List[str]:
@@ -545,7 +545,7 @@ class UserStringArrayOption(UserArrayOption[str]):
         return newvalue
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class UserFeatureOption(UserComboOption):
 
     choices: T.List[str] = dataclasses.field(

--- a/mesonbuild/utils/core.py
+++ b/mesonbuild/utils/core.py
@@ -154,7 +154,7 @@ class EnvironmentVariables(HoldableObject):
         return env
 
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class ExecutableSerialisation:
 
     cmd_args: T.List[str]

--- a/mesonbuild/utils/core.py
+++ b/mesonbuild/utils/core.py
@@ -10,7 +10,7 @@ as possible for performance reasons.
 """
 
 from __future__ import annotations
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import os
 import typing as T
 
@@ -168,8 +168,8 @@ class ExecutableSerialisation:
     verbose: bool = False
     installdir_map: T.Optional[T.Dict[str, str]] = None
 
-    def __post_init__(self) -> None:
-        self.pickled = False
-        self.skip_if_destdir = False
-        self.subproject = T.cast('SubProject', '')  # avoid circular import
-        self.dry_run = False
+    pickled: bool = field(default=False, init=False)
+    skip_if_destdir: bool = field(default=False, init=False)
+    # cast to avoid circular import
+    subproject: SubProject = field(default=T.cast('SubProject', ''), init=False)
+    dry_run: bool = field(default=False, init=False)

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -588,7 +588,7 @@ class ThreeMachineChoice(enum.IntEnum):
         return MACHINE_NAMES[self.value]
 
 
-@dataclasses.dataclass(eq=False, order=False)
+@dataclasses.dataclass(slots=True, eq=False, order=False)
 class PerMachine(T.Generic[_T]):
     build: _T
     host: _T
@@ -626,7 +626,7 @@ class PerMachine(T.Generic[_T]):
         return PerMachine(build, host)
 
 
-@dataclasses.dataclass(eq=False, order=False)
+@dataclasses.dataclass(slots=True, eq=False, order=False)
 class PerThreeMachine(PerMachine[_T]):
     """Like `PerMachine` but includes `target` too.
 
@@ -678,7 +678,7 @@ class PerThreeMachine(PerMachine[_T]):
         return PerThreeMachine(build, host, target)
 
 
-@dataclasses.dataclass(eq=False, order=False)
+@dataclasses.dataclass(slots=True, eq=False, order=False)
 class PerMachineDefaultable(PerMachine[T.Optional[_T]]):
     """Extends `PerMachine` with the ability to default from `None`s.
     """
@@ -710,7 +710,7 @@ class PerMachineDefaultable(PerMachine[T.Optional[_T]]):
         return m.default_missing()
 
 
-@dataclasses.dataclass(eq=False, order=False)
+@dataclasses.dataclass(slots=True, eq=False, order=False)
 class PerThreeMachineDefaultable(PerMachineDefaultable[T.Optional[_T]], PerThreeMachine[T.Optional[_T]]):
     """Extends `PerThreeMachine` with the ability to default from `None`s.
     """
@@ -729,7 +729,7 @@ class PerThreeMachineDefaultable(PerMachineDefaultable[T.Optional[_T]], PerThree
         target = self.target if self.target is not None else host
         return PerThreeMachine(build, host, target)
 
-@dataclasses.dataclass(eq=False)
+@dataclasses.dataclass(slots=True, eq=False)
 class InstallScriptFailure:
 
     name: str
@@ -882,7 +882,7 @@ def windows_detect_native_arch() -> str:
             raise EnvironmentException('Unable to detect native OS architecture')
     return arch
 
-@dataclasses.dataclass
+@dataclasses.dataclass(slots=True)
 class VcsData:
     name: str
     cmd: str
@@ -1085,7 +1085,7 @@ def version_compare_many(vstr1: str, conditions: T.Union[str, T.Iterable[str]]) 
 
 _V = T.TypeVar('_V', bound='Comparable')
 
-@dataclasses.dataclass(order=False)
+@dataclasses.dataclass(slots=True, order=False)
 class Range(T.Generic[_V]):
     min: T.Optional[_V] = None
     min_eq: bool = False

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -2719,6 +2719,8 @@ class lazy_property(T.Generic[_T]):
     This works by shadowing itself with the calculated value, in the instance.
     Due to Python's MRO that means that the calculated value will be found
     before this property, speeding up subsequent lookups.
+
+    NOTE: Does not work correctly with slotted classes
     """
     def __init__(self, func: T.Callable[[T.Any], _T]) -> None:
         self.__name: T.Optional[str] = None

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from .. import mlog
 import contextlib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import urllib.request
 import urllib.error
 import urllib.parse
@@ -374,19 +374,27 @@ class Resolver:
     allow_insecure: bool = False
     silent: bool = False
 
+    subdir_root: str = field(init=False)
+    project_subdir: str = field(init=False)
+    cachedir: str = field(init=False)
+    wrap: PackageDefinition = field(init=False)
+    directory: str = field(init=False)
+    dirname: str = field(init=False)
+
+    wraps: dict[str, PackageDefinition] = field(default_factory=dict, init=False)
+    netrc: netrc | None = field(default=None, init=False)
+    provided_deps: dict[str, PackageDefinition] = field(default_factory=dict, init=False)
+    provided_programs: dict[str, PackageDefinition] = field(default_factory=dict, init=False)
+    wrapdb: dict[str, T.Any] = field(default_factory=dict, init=False)
+    wrapdb_provided_deps: dict[str, str] = field(default_factory=dict, init=False)
+    wrapdb_provided_programs: dict[str, SubProject] = field(default_factory=dict, init=False)
+    loaded_dirs: set[str] = field(default_factory=set, init=False)
+    cargolocks: dict[str, CargoLock | None] = field(default_factory=dict, init=False)
+
     def __post_init__(self) -> None:
         self.subdir_root = os.path.join(self.source_dir, self.subdir)
         self.project_subdir = os.path.relpath(os.path.dirname(self.subdir_root), self.source_dir)
         self.cachedir = os.environ.get('MESON_PACKAGE_CACHE_DIR') or os.path.join(self.subdir_root, 'packagecache')
-        self.wraps: T.Dict[str, PackageDefinition] = {}
-        self.netrc: T.Optional[netrc] = None
-        self.provided_deps: T.Dict[str, PackageDefinition] = {}
-        self.provided_programs: T.Dict[str, PackageDefinition] = {}
-        self.wrapdb: T.Dict[str, T.Any] = {}
-        self.wrapdb_provided_deps: T.Dict[str, str] = {}
-        self.wrapdb_provided_programs: T.Dict[str, SubProject] = {}
-        self.loaded_dirs: T.Set[str] = set()
-        self.cargolocks: T.Dict[str, T.Optional[CargoLock]] = {}
         self.load_wraps()
         self.load_netrc()
         self.load_wrapdb()

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -364,7 +364,7 @@ def verbose_git(cmd: T.List[str], workingdir: str, check: bool = False) -> bool:
     except mesonlib.GitException as e:
         raise WrapException(str(e))
 
-@dataclass(eq=False)
+@dataclass(slots=True, eq=False)
 class Resolver:
     source_dir: str
     subdir: str


### PR DESCRIPTION
Slots are advantageous because they make runtime addition of class attributes a runtime and check time error (good), they also reduce memory usage, and can speed up attribute lookup. With dataclasses the traditional downsides of slots (complicated to inherit) are removed, so we should enable them as much as possible.

This does require that we declare all of the fields of a class to the dataclass context manager, so I've moved some attribute setup from `__post_init__` into the class body for some classes. I like the effect of this anyway, as now all of the fields are declared clearly in one place.

This is made possible by the move to python 3.10 as a minimum version.