### PR TITLE
linkers: keep rpath-link for ld.bfd >= 2.28

### DIFF
--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -802,15 +802,16 @@ class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
             return (args, rpath_dirs_to_remove)
 
         # Rpaths to use while linking must be absolute. These are not
-        # written to the binary. Needed only with GNU ld, and only for
-        # versions before 2.28:
+        # written to the binary. Needed with GNU ld.bfd. GNU gold only
+        # needs this for versions before 2.28:
         # https://sourceware.org/bugzilla/show_bug.cgi?id=20535
         # https://sourceware.org/bugzilla/show_bug.cgi?id=16936
         # Not needed on Windows or other platforms that don't use RPATH
         # https://github.com/mesonbuild/meson/issues/1897
         #
-        # In 2.28 and on, $ORIGIN tokens inside of -rpath are respected,
-        # so we do not need to duplicate it in -rpath-link.
+        # Modern ld.bfd respects $ORIGIN inside of -rpath, but expands it
+        # relative to the DSO carrying DT_NEEDED. That can differ from the
+        # output directory, so keep the absolute -rpath-link as well.
         #
         # In addition, this linker option tends to be quite long and some
         # compilers have trouble dealing with it. That's why we will include
@@ -821,7 +822,7 @@ class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
         # ...instead of just one single looooong option, like this:
         #
         #   -Wl,-rpath-link,/path/to/folder1:/path/to/folder2:...
-        if self.id in {'ld.bfd', 'ld.gold'} and mesonlib.version_compare(self.version, '<2.28'):
+        if self.id == 'ld.bfd' or (self.id == 'ld.gold' and mesonlib.version_compare(self.version, '<2.28')):
             for p in rpath_paths:
                 args.extend(self._apply_prefix(['-rpath-link', os.path.join(build_dir, p)]))
 

--- a/test cases/unit/140 rpath link bfd/meson.build
+++ b/test cases/unit/140 rpath link bfd/meson.build
@@ -1,0 +1,4 @@
+project('rpath-link-bfd', 'c')
+
+subdir('src')
+subdir('mid')

--- a/test cases/unit/140 rpath link bfd/mid/b.c
+++ b/test cases/unit/140 rpath link bfd/mid/b.c
@@ -1,0 +1,5 @@
+int a_good(void);
+
+int b_value(void) {
+    return a_good();
+}

--- a/test cases/unit/140 rpath link bfd/mid/meson.build
+++ b/test cases/unit/140 rpath link bfd/mid/meson.build
@@ -1,0 +1,2 @@
+libb = shared_library('b', 'b.c', link_with: liba, soversion: '1')
+subdir('tests')

--- a/test cases/unit/140 rpath link bfd/mid/tests/main.c
+++ b/test cases/unit/140 rpath link bfd/mid/tests/main.c
@@ -1,0 +1,5 @@
+int b_value(void);
+
+int main(void) {
+    return b_value() != 42;
+}

--- a/test cases/unit/140 rpath link bfd/mid/tests/meson.build
+++ b/test cases/unit/140 rpath link bfd/mid/tests/meson.build
@@ -1,0 +1,1 @@
+executable('rpath-link-test', 'main.c', link_with: libb)

--- a/test cases/unit/140 rpath link bfd/src/a.c
+++ b/test cases/unit/140 rpath link bfd/src/a.c
@@ -1,0 +1,3 @@
+int a_good(void) {
+    return 42;
+}

--- a/test cases/unit/140 rpath link bfd/src/meson.build
+++ b/test cases/unit/140 rpath link bfd/src/meson.build
@@ -1,0 +1,1 @@
+liba = shared_library('a', 'a.c', soversion: '1')

--- a/unittests/linkertests.py
+++ b/unittests/linkertests.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 The Meson development team
+
+from pathlib import Path
+from unittest import mock, SkipTest
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+from mesonbuild.compilers.compilers import ManyInOneLinkerOptionStyle
+from mesonbuild.compilers.detect import detect_c_compiler
+from mesonbuild.linkers import linkers
+from mesonbuild.mesonlib import MachineChoice, is_linux
+
+from run_tests import get_fake_env
+
+from .baseplatformtests import BasePlatformTests
+
+
+class LinkerTests(unittest.TestCase):
+
+    def test_gnuld_rpath_link_version_gate(self):
+        env = get_fake_env()
+        env.machines.host.system = 'linux'
+        target = mock.Mock()
+        target.determine_rpath_dirs.return_value = ('lib',)
+        target.install_rpath = ''
+        target.build_rpath = ''
+        build_dir = os.path.join(os.sep, 'build')
+        rpath_link = f'-Wl,-rpath-link,{os.path.join(build_dir, "lib")}'
+
+        cases = (
+            ('bfd', linkers.GnuBFDDynamicLinker, '2.27', True),
+            ('bfd', linkers.GnuBFDDynamicLinker, '2.28', True),
+            ('gold', linkers.GnuGoldDynamicLinker, '2.27', True),
+            ('gold', linkers.GnuGoldDynamicLinker, '2.28', False),
+        )
+        for name, linker_cls, version, expected in cases:
+            with self.subTest(linker=name, version=version):
+                linker = linker_cls(
+                    [], env, MachineChoice.HOST,
+                    ManyInOneLinkerOptionStyle('-Wl,', ','), [], version=version)
+                args, _ = linker.build_rpath_args(build_dir, 'app', target)
+                if expected:
+                    self.assertIn(rpath_link, args)
+                else:
+                    self.assertNotIn(rpath_link, args)
+
+
+class BfdLinkerTests(BasePlatformTests):
+
+    def test_rpath_link_transitive_dependency(self):
+        if not is_linux():
+            raise SkipTest('GNU ld.bfd transitive rpath test requires Linux')
+        if shutil.which('ld.bfd') is None:
+            raise SkipTest('ld.bfd not found')
+
+        cc = detect_c_compiler(get_fake_env(), MachineChoice.HOST)
+        if cc.id not in {'gcc', 'clang'} or not cc.use_linker_args('bfd', ''):
+            raise SkipTest(f'{cc.id} cannot select ld.bfd for this test')
+
+        testdir = os.path.join(self.unit_test_dir, '140 rpath link bfd')
+        with tempfile.TemporaryDirectory() as hostile_dir:
+            hostile_src = Path(hostile_dir, 'a.c')
+            hostile_src.write_text('int incompatible_a(void) { return 0; }\n', encoding='utf-8')
+            hostile_lib = Path(hostile_dir, 'liba.so.1')
+            subprocess.check_call(
+                cc.get_exelist(ccache=False) + [
+                    '-shared', '-fPIC', '-Wl,-soname,liba.so.1',
+                    str(hostile_src), '-o', str(hostile_lib),
+                ])
+
+            env = {
+                'CC_LD': 'bfd',
+                'LD_LIBRARY_PATH': hostile_dir,
+            }
+            self.init(testdir, override_envvars=env)
+            compiler_info = self.introspect('--compilers')['host']['c']
+            if compiler_info['linker_id'] != 'ld.bfd':
+                raise SkipTest(f"configured linker is {compiler_info['linker_id']}, not ld.bfd")
+            self.build(override_envvars=env)


### PR DESCRIPTION
GNU ld.bfd expands `$ORIGIN` in `-rpath` relative to the DSO carrying the `DT_NEEDED` entry. When the output and a transitive dependency are in different build directories, those link-time search paths can therefore resolve from the wrong directory and allow another library earlier in the search order to win.

This change restores absolute `-rpath-link` arguments for ld.bfd regardless of version, while leaving the existing version handling for ld.gold unchanged.

The regression coverage checks the ld.bfd/ld.gold behavior at the 2.28 boundary and reproduces the transitive-dependency failure with a real ld.bfd link.

Fixes #16087