### PR TITLE
cargo: support exclude in workspace manifests

### DIFF
--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -280,6 +280,8 @@ class Interpreter:
         self.manifests: T.Dict[str, T.Union[Manifest, Workspace]] = {}
         # Map of cargo package (name + api) to its state
         self.packages: T.Dict[PackageKey, PackageState] = {}
+        # Package names excluded from all workspaces
+        self.excluded_packages: T.Set[str] = set()
         # Map subdir to workspace
         self.workspaces: T.Dict[str, WorkspaceState] = {}
         # Files that should trigger a reconfigure if modified
@@ -411,6 +413,8 @@ class Interpreter:
         def _process_member(member: str) -> None:
             if member in processed_members:
                 return
+            if member in ws.workspace.exclude:
+                return
             pkg = ws.packages[member]
             # Process dependencies for all configured machines
             found = False
@@ -471,15 +475,28 @@ class Interpreter:
         if workspace.root_package:
             self._add_workspace_member(workspace.root_package, ws, '.')
 
+        # Validate and build the set of excluded members
+        excluded: T.Set[str] = set()
+        for e in workspace.exclude:
+            if not is_parent_path(self.subprojects_dir, e) or \
+                    len(pathlib.PurePath(e).parts) != 2:
+                raise MesonException(
+                    f'workspace exclude path "{e}" must reside under "{self.subprojects_dir}/"')
+            excluded.add(e)
         if extra_members is not None:
             for m in extra_members:
                 m = PurePath(m).as_posix()
+                if m in excluded:
+                    raise MesonException(f'{m} is excluded from workspace {subdir}/Cargo.toml')
                 if m not in workspace.members:
                     l = ', '.join(sorted(list(workspace.members)))
                     raise MesonException(f'{m} is not a workspace member for {subdir}/Cargo.toml (valid members are {l})')
                 if m not in workspace.default_members:
                     workspace.default_members.append(m)
+        workspace.default_members = [m for m in workspace.default_members if m not in excluded]
         for m in workspace.members:
+            if m in excluded:
+                continue
             self._load_workspace_member(ws, m)
         self.workspaces[subdir] = ws
         return ws
@@ -517,6 +534,8 @@ class Interpreter:
         return None
 
     def resolve_package(self, package_name: str, api: str) -> T.Optional[PackageState]:
+        if package_name in self.excluded_packages:
+            return None
         cargo_pkg = self._resolve_package(package_name, version.cargo_parse(api))
         if not cargo_pkg:
             return None
@@ -596,8 +615,24 @@ class Interpreter:
             if is_parent_path(self.subprojects_dir, dep_member):
                 if len(pathlib.PurePath(dep_member).parts) != 2:
                     raise MesonException('found "{self.subprojects_dir}" in path but it is not a valid subproject path')
-            self._load_workspace_member(ws, dep_member)
-            dep_pkg = self._require_workspace_member(ws, dep_member)
+            if dep_member in ws.workspace.exclude:
+                # Excluded members are not workspace members; load the manifest
+                # so the dependency graph can still be resolved, but do not
+                # register it on the workspace object.
+                m_subdir = os.path.join(ws.subdir, dep_member)
+                manifest_, _ = self._load_manifest(m_subdir, ws.workspace, dep_member)
+                assert isinstance(manifest_, Manifest)
+                key = PackageKey(manifest_.package.name, manifest_.package.api)
+                if key in self.packages:
+                    dep_pkg = self.packages[key]
+                else:
+                    dep_pkg = PackageState(manifest_, ws_subdir=ws.subdir,
+                                           ws_member=dep_member, downloaded=ws.downloaded)
+                    self.packages[key] = dep_pkg
+                self.excluded_packages.add(manifest_.package.name)
+            else:
+                self._load_workspace_member(ws, dep_member)
+                dep_pkg = self._require_workspace_member(ws, dep_member)
         elif dep.git:
             _, _, directory = _parse_git_url(dep.git, dep.branch)
             dep_pkg = self._fetch_package_from_subproject(dep.package, directory)

--- a/mesonbuild/cargo/manifest.py
+++ b/mesonbuild/cargo/manifest.py
@@ -668,6 +668,7 @@ class Workspace:
             ws.profile = raw.get('profile')
 
         ws.members = list(PurePath(m).as_posix() for m in ws.members)
+        ws.exclude = list(PurePath(e).as_posix() for e in ws.exclude)
         if ws.default_members:
             ws.default_members = list(PurePath(m).as_posix() for m in ws.default_members)
         else:

--- a/test cases/failing/151 cargo workspace exclude outside/Cargo.lock
+++ b/test cases/failing/151 cargo workspace exclude outside/Cargo.lock
@@ -1,0 +1,5 @@
+version = 3
+
+[[package]]
+name = "exclude-outside-test"
+version = "0.1.0"

--- a/test cases/failing/151 cargo workspace exclude outside/Cargo.toml
+++ b/test cases/failing/151 cargo workspace exclude outside/Cargo.toml
@@ -1,0 +1,8 @@
+[workspace]
+members = [".", "other"]
+exclude = ["other"]
+
+[package]
+name = "exclude-outside-test"
+version = "0.1.0"
+edition = "2021"

--- a/test cases/failing/151 cargo workspace exclude outside/meson.build
+++ b/test cases/failing/151 cargo workspace exclude outside/meson.build
@@ -1,0 +1,8 @@
+project('exclude-outside-test', 'c')
+
+if not add_languages('rust', required: false)
+  error('MESON_SKIP_TEST Rust not present, required for Cargo subprojets')
+endif
+
+rust = import('rust')
+cargo_ws = rust.workspace()

--- a/test cases/failing/151 cargo workspace exclude outside/other/Cargo.toml
+++ b/test cases/failing/151 cargo workspace exclude outside/other/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "other"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["rlib"]

--- a/test cases/failing/151 cargo workspace exclude outside/other/src/lib.rs
+++ b/test cases/failing/151 cargo workspace exclude outside/other/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn hello() -> &'static str {
+    "hello from other"
+}

--- a/test cases/failing/151 cargo workspace exclude outside/src/main.rs
+++ b/test cases/failing/151 cargo workspace exclude outside/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("This should fail!");
+}

--- a/test cases/failing/151 cargo workspace exclude outside/test.json
+++ b/test cases/failing/151 cargo workspace exclude outside/test.json
@@ -1,0 +1,8 @@
+{
+  "stdout": [
+    {
+      "match": "re",
+      "line": ".*workspace exclude path \"other\" must reside under \"subprojects/\".*"
+    }
+  ]
+}

--- a/test cases/rust/47 workspace exclude/Cargo.lock
+++ b/test cases/rust/47 workspace exclude/Cargo.lock
@@ -1,0 +1,5 @@
+version = 3
+
+[[package]]
+name = "exclude_test"
+version = "0.1.0"

--- a/test cases/rust/47 workspace exclude/Cargo.toml
+++ b/test cases/rust/47 workspace exclude/Cargo.toml
@@ -1,0 +1,8 @@
+[workspace]
+members = [".", "subprojects/extra"]
+exclude = ["subprojects/extra"]
+
+[package]
+name = "exclude_test"
+version = "0.1.0"
+edition = "2021"

--- a/test cases/rust/47 workspace exclude/meson.build
+++ b/test cases/rust/47 workspace exclude/meson.build
@@ -1,0 +1,26 @@
+project('workspace exclude test', 'rust', default_options: ['rust_std=2021'])
+
+rust = import('rust')
+cargo_ws = rust.workspace()
+
+# 'extra' is excluded from the workspace, so it should NOT appear in packages()
+pkgs = cargo_ws.packages()
+assert(pkgs == ['exclude_test'], 'excluded member must not be in packages()')
+
+# Trying to access the excluded member via workspace.package() should fail
+testcase expect_error('workspace member "extra" not found')
+  cargo_ws.package('extra')
+endtestcase
+
+# The excluded subproject is still reachable via the standard meson subproject()
+extrasp = subproject('extra-0.1-rs')
+assert(extrasp.found(), 'excluded subproject should be reachable via subproject()')
+
+# Build the root package
+main_pkg = cargo_ws.package()
+e = executable('exclude-test', 'src/main.rs',
+  dependencies: main_pkg.dependencies(),
+  rust_args: main_pkg.rust_args(),
+  rust_dependency_map: main_pkg.rust_dependency_map(),
+)
+test('exclude-test', e)

--- a/test cases/rust/47 workspace exclude/src/main.rs
+++ b/test cases/rust/47 workspace exclude/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello from exclude test!");
+}

--- a/test cases/rust/47 workspace exclude/subprojects/extra-0.1-rs.wrap
+++ b/test cases/rust/47 workspace exclude/subprojects/extra-0.1-rs.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory=extra
+method=cargo
+
+[provide]
+dependency_names=extra-0.1-rs

--- a/test cases/rust/47 workspace exclude/subprojects/extra/Cargo.toml
+++ b/test cases/rust/47 workspace exclude/subprojects/extra/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "extra"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["rlib"]

--- a/test cases/rust/47 workspace exclude/subprojects/extra/src/lib.rs
+++ b/test cases/rust/47 workspace exclude/subprojects/extra/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn hello() -> &'static str {
+    "hello from extra"
+}

--- a/unittests/cargotests.py
+++ b/unittests/cargotests.py
@@ -495,6 +495,50 @@ class CargoTomlTest(unittest.TestCase):
         self.assertEqual(dep.api, '1')
         self.assertEqual(sorted(set(dep.features)), ['full', 'parse'])
 
+    def test_cargo_toml_ws_exclude(self) -> None:
+        ws_toml = textwrap.dedent('''\
+            [workspace]
+            resolver = "2"
+            members = [".", "subprojects/extra"]
+            exclude = ["subprojects/extra"]
+
+            [package]
+            name = "myproject"
+            version = "0.1.0"
+            edition = "2021"
+        ''')
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fname = os.path.join(tmpdir, 'Cargo.toml')
+            with open(fname, 'w', encoding='utf-8') as f:
+                f.write(ws_toml)
+            workspace_toml = load_toml(fname)
+            workspace = Workspace.from_raw(workspace_toml, tmpdir)
+
+        self.assertEqual(workspace.exclude, ['subprojects/extra'])
+        self.assertIn('.', workspace.members)
+        self.assertIn('subprojects/extra', workspace.members)
+
+    def test_cargo_toml_ws_exclude_normalized(self) -> None:
+        ws_toml = textwrap.dedent('''\
+            [workspace]
+            resolver = "2"
+            members = ["subprojects\\\\foo", "subprojects/bar"]
+            exclude = ["subprojects\\\\foo"]
+
+            [package]
+            name = "myproject"
+            version = "0.1.0"
+            edition = "2021"
+        ''')
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fname = os.path.join(tmpdir, 'Cargo.toml')
+            with open(fname, 'w', encoding='utf-8') as f:
+                f.write(ws_toml)
+            workspace_toml = load_toml(fname)
+            workspace = Workspace.from_raw(workspace_toml, tmpdir)
+
+        self.assertEqual(workspace.exclude, ['subprojects/foo'])
+
     def test_cargo_toml_package(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             fname = os.path.join(tmpdir, 'Cargo.toml')


### PR DESCRIPTION
Resolves #16186.

### Summary of Changes
- **Manifest parsing:** Normalized `exclude` paths to POSIX form in `Workspace.from_raw()` to ensure consistency with workspace member path normalization.
- **Invariant enforcement:** Enforced that any entry in `workspace.exclude` must be located directly under `subprojects/<name>`. Attempting to exclude paths outside `subprojects/` raises a `MesonException`.
- **Workspace isolation:** Filtered excluded members from default workspace packages so they are not registered on the workspace object or queryable through workspace methods.
- **Path dependency handling:** Excluded path dependencies are tracked in the interpreter cache as standalone `PackageState` instances, ensuring dependency resolution succeeds while keeping them accessible strictly via `subproject()`.
- **Tests:** Added unit tests in `unittests/cargotests.py` for path normalization, a rust integration test verifying `subproject()` reachability without workspace exposure, and a failing test for invalid exclusion paths.