### PR TITLE
backends/vs: fix potential infinite loop

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -2125,7 +2125,8 @@ class Vs2010Backend(backends.Backend):
         i = 0
         file = prefix
         while os.path.exists(file):
-            file = '%s%d' % (prefix, i)
+            file = f'{prefix}{i}'
+            i += 1
         return file
 
     def generate_debug_information(self, link: ET.Element) -> None:


### PR DESCRIPTION
We would just run a loop of `x = y while x exists { x = f'{y}0' }` which... means if `f'{y}0` exists we'll loop forever.