### PR TITLE
Enable mypy `warn_unreachable`

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -9,7 +9,7 @@ follow_imports                = silent
 warn_redundant_casts          = True
 warn_unused_ignores           = True
 warn_return_any               = True
-# warn_unreachable            = True
+warn_unreachable              = True
 disallow_untyped_calls        = True
 disallow_untyped_defs         = True
 disallow_incomplete_defs      = True
@@ -26,6 +26,9 @@ check_untyped_defs            = True
 # future default behaviors
 allow_redefinition_new        = True
 local_partial_types           = True
+
+[mypy-mesonbuild.build]
+warn_unreachable              = False
 
 [mypy-mesonbuild.cmdline]
 strict_optional               = True
@@ -62,6 +65,9 @@ strict_optional               = True
 
 [mypy-mesonbuild.mesonmain]
 strict_optional               = True
+
+[mypy-mesonbuild.mformat]
+warn_unreachable              = False
 
 [mypy-mesonbuild.minit]
 strict_optional               = True

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -177,7 +177,6 @@ class IntrospectionInterpreter(AstInterpreter):
             # Like flatten_args_hack(), the values are really TYPE_nvar.
             spdirname = T.cast('TYPE_nvar', kwargs['subproject_dir'])
             if isinstance(spdirname, StringNode):
-                assert isinstance(spdirname.value, str)
                 self.subproject_dir = spdirname.value
         if not self.is_subproject():
             self.project_data['subprojects'] = []

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -24,6 +24,7 @@ if T.TYPE_CHECKING:
     from ..compilers.compilers import Language
     from ..interpreterbase import TYPE_var
     from ..options import ElementaryOptionValues, OptionDict
+    from .interpreter import TYPE_nkwargs, TYPE_nvar
     from .visitor import AstVisitor
 
 
@@ -173,7 +174,8 @@ class IntrospectionInterpreter(AstInterpreter):
             )
 
         if not self.is_subproject() and 'subproject_dir' in kwargs:
-            spdirname = kwargs['subproject_dir']
+            # Like flatten_args_hack(), the values are really TYPE_nvar.
+            spdirname = T.cast('TYPE_nvar', kwargs['subproject_dir'])
             if isinstance(spdirname, StringNode):
                 assert isinstance(spdirname.value, str)
                 self.subproject_dir = spdirname.value
@@ -437,12 +439,13 @@ class IntrospectionInterpreter(AstInterpreter):
         return None
 
     def flatten_kwargs(self, kwargs: T.Dict[str, TYPE_var], include_unknown_args: bool = False) -> T.Dict[str, TYPE_var]:
-        flattened_kwargs = {}
-        for key, val in kwargs.items():
+        # Like flatten_args_hack(), the values are really TYPE_nvar.
+        flattened_kwargs: TYPE_nkwargs = {}
+        for key, val in T.cast('TYPE_nkwargs', kwargs).items():
             if isinstance(val, BaseNode):
                 resolved = self.node_to_runtime_value(val)
                 if resolved is not None:
                     flattened_kwargs[key] = resolved
             elif isinstance(val, (str, bool, int, float)) or include_unknown_args:
                 flattened_kwargs[key] = val
-        return flattened_kwargs
+        return T.cast('T.Dict[str, TYPE_var]', flattened_kwargs)

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -561,9 +561,6 @@ class Backend:
                     add_dependency(nested)
 
         for target in targets.values():
-            if isinstance(target, build.CustomTargetIndex):
-                # Just transfer it to the CustomTarget code.
-                target = target.target
             if isinstance(target, build.CustomTarget):
                 for dep in target.get_target_dependencies():
                     add_dependency(dep)

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1581,9 +1581,7 @@ class Backend:
         for i in target.get_sources():
             if isinstance(i, build.LocalProgram):
                 i = i.program
-            if isinstance(i, str):
-                fname = [os.path.join(self.build_to_src, target.subdir, i)]
-            elif isinstance(i, build.BuildTarget):
+            if isinstance(i, build.BuildTarget):
                 fname = [self.get_target_filename(i)]
             elif isinstance(i, (build.CustomTarget, build.CustomTargetIndex)):
                 fname = [os.path.join(self.get_custom_target_output_dir(i), p) for p in i.get_outputs()]

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -207,7 +207,7 @@ class TestSerialisation:
     needs_exe_wrapper: bool
     is_parallel: bool
     cmd_args: T.List[str]
-    env: mesonlib.EnvironmentVariables
+    env: T.Optional[mesonlib.EnvironmentVariables]
     expected_fail: bool
     expected_exitcode: T.Optional[int]
     timeout: T.Optional[int]

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1687,7 +1687,7 @@ class Backend:
             if isinstance(i, build.BuildTarget):
                 cmd += self.build_target_to_cmd_array(i)
                 continue
-            elif isinstance(i, build.CustomTarget):
+            elif isinstance(i, (build.CustomTarget, build.CustomTargetIndex)):
                 # GIR scanner will attempt to execute this binary but
                 # it assumes that it is in path, so always give it a full path.
                 tmp = i.get_outputs()[0]
@@ -2129,7 +2129,7 @@ class Backend:
                         compiler += [k.absolute_path(self.source_dir, self.build_dir)]
                     elif isinstance(k, str):
                         compiler += [k]
-                    elif isinstance(k, (build.BuildTarget, build.CustomTarget)):
+                    elif isinstance(k, (build.BuildTarget, build.CustomTarget, build.CustomTargetIndex)):
                         compiler += k.get_outputs()
                     elif isinstance(k, programs.Program):
                         compiler += k.get_command()

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1317,7 +1317,8 @@ class NinjaBackend(backends.Backend):
         elif target.depfile_type == 'msvc':
             rulename = 'CUSTOM_COMMAND_MSVC_DEP'
         else:
-            rulename = 'CUSTOM_COMMAND'
+            # mypy does not see the "| None" until build.py is changed to strict_optional = True
+            rulename = 'CUSTOM_COMMAND' # type: ignore[unreachable]
         elem = NinjaBuildElement(self.all_outputs, ofilenames, rulename, srcs)
         elem.add_dep(deps)
 

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1226,7 +1226,7 @@ class Vs2010Backend(backends.Backend):
                                                platform: str,
                                                target_ext: str,
                                                vslite_ctx: _VSLITE_CTX,
-                                               target: build.AnyTargetType,
+                                               target: build.Target,
                                                proj_to_build_root: str,
                                                primary_src_lang: T.Optional[Language]) -> None:
         ET.SubElement(root, 'ImportGroup', Label='ExtensionSettings')
@@ -1578,7 +1578,7 @@ class Vs2010Backend(backends.Backend):
     # once a build/compile has generated these sources.
     #
     # This modifies the paths in 'gen_files' in place, as opposed to returning a new list of modified paths.
-    def relocate_generated_file_paths_to_concrete_build_dir(self, gen_files: T.List[str], target: build.AnyTargetType) -> None:
+    def relocate_generated_file_paths_to_concrete_build_dir(self, gen_files: T.List[str], target: build.BuildTarget) -> None:
         (_, build_dir_tail) = os.path.split(self.src_to_build)
         meson_build_dir_for_buildtype = build_dir_tail[:-2] + coredata.get_genvs_default_buildtype_list()[0] # Get the first buildtype suffixed dir (i.e. '[builddir]_debug') from '[builddir]_vs'
         # Relative path from this .vcxproj to the directory containing the set of '..._[debug/debugoptimized/release]' setup meson build dirs.

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -2173,13 +2173,7 @@ class Vs2010Backend(backends.Backend):
         if 'masm' not in target.compilers:
             return None
 
-        if target.for_machine == MachineChoice.BUILD:
-            platform = self.build_platform
-        elif target.for_machine == MachineChoice.HOST:
-            platform = self.platform
-        else:
-            return None
-
+        platform = self.build_platform if target.for_machine is MachineChoice.BUILD else self.platform
         if platform in {'ARM', 'arm64', 'arm64ec'}:
             return 'marmasm'
         else:

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -2170,9 +2170,6 @@ class Vs2010Backend(backends.Backend):
     #
     # For now, assume it's the native ones. (same behavior as ninja backend)
     def get_masm_type(self, target: build.BuildTarget) -> T.Literal['marmasm', 'masm'] | None:
-        if not isinstance(target, build.BuildTarget):
-            return None
-
         if 'masm' not in target.compilers:
             return None
 

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -241,13 +241,9 @@ class PbxDict:
                         ofile.write(indent_level*INDENT + f'{i.key} = ')
                     i.value.write(ofile, indent_level)
                 else:
-                    print(i)
-                    print(i.key)
-                    print(i.value)
-                    raise RuntimeError('missing code')
+                    raise MesonBugException('should be unreachable')
             else:
-                print(i)
-                raise RuntimeError('missing code2')
+                raise MesonBugException('should be unreachable')
 
         indent_level -= 1
         ofile.write(indent_level*INDENT + '}')

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -434,32 +434,23 @@ class XCodeBackend(backends.Backend):
         self.target_filemap: dict[str, str] = {}
         for name, t in self.build_targets.items():
             for s in t.sources:
-                if isinstance(s, mesonlib.File):
-                    if '/' in s.fname:
-                        # From the top level down, add the folders containing the source file.
-                        folder = os.path.split(os.path.dirname(s.fname))
-                        while folder:
-                            fpath = os.path.join(*folder)
-                            # Multiple targets might use the same folders, so store their targets with them.
-                            # Otherwise, folders and their source files will appear in the wrong places in Xcode.
-                            if (fpath, t) not in self.foldermap:
-                                self.foldermap[(fpath, t)] = self.gen_id()
-                            else:
-                                break
-                            folder = folder[:-1]
-                    s = os.path.join(s.subdir, s.fname)
-                    self.filemap[s] = self.gen_id()
-            for o in t.objects:
-                if isinstance(o, str):
-                    o = os.path.join(t.subdir, o)
-                    self.filemap[o] = self.gen_id()
+                if '/' in s.fname:
+                    # From the top level down, add the folders containing the source file.
+                    folder = os.path.split(os.path.dirname(s.fname))
+                    while folder:
+                        fpath = os.path.join(*folder)
+                        # Multiple targets might use the same folders, so store their targets with them.
+                        # Otherwise, folders and their source files will appear in the wrong places in Xcode.
+                        if (fpath, t) not in self.foldermap:
+                            self.foldermap[(fpath, t)] = self.gen_id()
+                        else:
+                            break
+                        folder = folder[:-1]
+                s = os.path.join(s.subdir, s.fname)
+                self.filemap[s] = self.gen_id()
             for e in t.extra_files:
-                if isinstance(e, mesonlib.File):
-                    e = os.path.join(e.subdir, e.fname)
-                    self.filemap[e] = self.gen_id()
-                else:
-                    e = os.path.join(t.subdir, e)
-                    self.filemap[e] = self.gen_id()
+                e = os.path.join(e.subdir, e.fname)
+                self.filemap[e] = self.gen_id()
             self.target_filemap[name] = self.gen_id()
 
     def generate_buildstylemap(self) -> None:
@@ -523,8 +514,6 @@ class XCodeBackend(backends.Backend):
         self.custom_target_output_fileref = {}
         for tname, t in self.custom_targets.items():
             self.shell_targets[tname] = self.gen_id()
-            if not isinstance(t, build.CustomTarget):
-                continue
             (srcs, ofilenames, cmd) = self.eval_custom_target_command(t)
             for o in ofilenames:
                 self.custom_target_output_buildfile[o] = self.gen_id()
@@ -751,8 +740,6 @@ class XCodeBackend(backends.Backend):
                         fw_dict.add_item('fileRef', self.native_frameworks_fileref[f], f)
 
             for s in t.sources:
-                if not isinstance(s, mesonlib.File):
-                    continue
                 in_build_dir = s.is_built
                 s = os.path.join(s.subdir, s.fname)
                 sdict = PbxDict()
@@ -775,8 +762,6 @@ class XCodeBackend(backends.Backend):
                     continue
                 if isinstance(o, mesonlib.File):
                     o = os.path.join(o.subdir, o.fname)
-                elif isinstance(o, str):
-                    o = os.path.join(t.subdir, o)
                 else:
                     # TODO: handle CustomTarget | CustomTargetIndex | GeneratedList
                     raise MesonBugException('Not implemented, patches highly welcome')
@@ -801,8 +786,6 @@ class XCodeBackend(backends.Backend):
 
         # Custom targets are shell build phases in Xcode terminology.
         for tname, t in self.custom_targets.items():
-            if not isinstance(t, build.CustomTarget):
-                continue
             (srcs, ofilenames, cmd) = self.eval_custom_target_command(t)
             for o in ofilenames:
                 custom_dict = PbxDict()
@@ -910,8 +893,6 @@ class XCodeBackend(backends.Backend):
                         fw_dict.add_item('path', f'System/Library/Frameworks/{f}.framework')
                         fw_dict.add_item('sourceTree', 'SDKROOT')
             for s in t.sources:
-                if not isinstance(s, mesonlib.File):
-                    continue
                 in_build_dir = s.is_built
                 s = os.path.join(s.subdir, s.fname)
                 idval = self.fileref_ids[(tname, s)]
@@ -964,9 +945,6 @@ class XCodeBackend(backends.Backend):
                 if isinstance(o, mesonlib.File):
                     fullpath = o.absolute_path(self.environment.get_source_dir(), self.environment.get_build_dir())
                     o = os.path.join(o.subdir, o.fname)
-                elif isinstance(o, str):
-                    o = os.path.join(t.subdir, o)
-                    fullpath = os.path.join(self.environment.get_source_dir(), o)
                 else:
                     # TODO: handle CustomTarget, CustomTargeIndex, and GeneratedList
                     raise MesonBugException('Not implemented, patches highly welcome')
@@ -983,16 +961,12 @@ class XCodeBackend(backends.Backend):
                 o_dict.add_item('sourceTree', 'SOURCE_ROOT')
 
             for e in t.extra_files:
-                if isinstance(e, mesonlib.File):
-                    e = os.path.join(e.subdir, e.fname)
-                else:
-                    e = os.path.join(t.subdir, e)
-                idval = self.fileref_ids[(tname, e)]
-                fullpath = os.path.join(self.environment.get_source_dir(), e)
+                path = os.path.join(e.subdir, e.fname)
+                idval = self.fileref_ids[(tname, path)]
+                fullpath = os.path.join(self.environment.get_source_dir(), path)
                 e_dict = PbxDict()
-                xcodetype = self.get_xcodetype(e)
-                name = os.path.basename(e)
-                path = e
+                xcodetype = self.get_xcodetype(path)
+                name = os.path.basename(path)
                 objects_dict.add_item(idval, e_dict, fullpath)
                 e_dict.add_item('isa', 'PBXFileReference')
                 e_dict.add_item('explicitFileType', xcodetype)
@@ -1021,8 +995,6 @@ class XCodeBackend(backends.Backend):
             target_dict.add_item('sourceTree', 'BUILT_PRODUCTS_DIR')
 
         for tname, t in self.custom_targets.items():
-            if not isinstance(t, build.CustomTarget):
-                continue
             (srcs, ofilenames, cmd) = self.eval_custom_target_command(t)
             for s in t.sources:
                 if not isinstance(s, mesonlib.File):
@@ -1191,8 +1163,6 @@ class XCodeBackend(backends.Backend):
         target_dict.add_item('sourceTree', '<group>')
         source_files_dict = PbxDict()
         for s in t.sources:
-            if not isinstance(s, mesonlib.File):
-                continue
             # If the file is in a folder, add it to the group representing that folder.
             if '/' in s.fname:
                 folder = '/'.join(s.fname.split('/')[:-1])
@@ -1214,20 +1184,13 @@ class XCodeBackend(backends.Backend):
                 continue
             if isinstance(o, mesonlib.File):
                 o = os.path.join(o.subdir, o.fname)
-            elif isinstance(o, str):
-                o = os.path.join(t.subdir, o)
             else:
                 # TODO: handle CustomTarget, CustomTargeIndex, and GeneratedList
                 raise MesonBugException('Not implemented, patches highly welcome')
             target_children.add_item(self.fileref_ids[(tid, o)], o)
         for e in t.extra_files:
-            if isinstance(e, mesonlib.File):
-                e = os.path.join(e.subdir, e.fname)
-            elif isinstance(e, str):
-                e = os.path.join(t.subdir, e)
-            else:
-                continue
-            target_children.add_item(self.fileref_ids[(tid, e)], e)
+            f = os.path.join(e.subdir, e.fname)
+            target_children.add_item(self.fileref_ids[(tid, f)], f)
         source_files_dict.add_item('name', 'Source files')
         source_files_dict.add_item('sourceTree', '<group>')
         return group_id
@@ -1417,8 +1380,6 @@ class XCodeBackend(backends.Backend):
     def generate_custom_target_shell_build_phases(self, objects_dict: PbxDict) -> None:
         # Custom targets are shell build phases in Xcode terminology.
         for tname, t in self.custom_targets.items():
-            if not isinstance(t, build.CustomTarget):
-                continue
             (srcs, ofilenames, cmd) = self.eval_custom_target_command(t, absolute_outputs=True)
             fixed_cmd, _ = self.as_meson_exe_cmdline(cmd[0],
                                                      cmd[1:],

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1822,6 +1822,9 @@ class BuildTarget(Target):
         for lib in itertools.chain(kwargs.get('link_with', []), self.link_targets):
             if isinstance(lib, (CustomTarget, CustomTargetIndex)):
                 lib_list.append(lib)
+            elif isinstance(lib, Jar):
+                raise MesonBugException(f'Build target of type "{self.typename}" cannot link with jar target "{lib.name}". '
+                                        f'Jar targets can only be linked into other jar targets.')
             else:
                 lib_list.append(lib.get(bl_type))
         return lib_list

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2930,12 +2930,6 @@ def flatten_command(cmd: T.Iterable[CommandTypes],
             final_cmd.extend(c)
             depend_files.extend(df)
             dependencies.extend(d)
-        elif isinstance(c, list):
-            # TODO: is this case even reachable?
-            c, df, d = flatten_command(c, subproject)
-            final_cmd.extend(c)
-            depend_files.extend(df)
-            dependencies.extend(d)
         else:
             raise InvalidArguments(f'Argument {c!r} in "command" is invalid')
     return final_cmd, depend_files, dependencies

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -3258,7 +3258,7 @@ class RunTarget(Target):
     def __init__(self, name: str,
                  command: T.Sequence[CommandTypes],
                  # the RunTarget case is used by gnome.yelp()
-                 dependencies: T.Sequence[Target | CustomTargetIndex | GeneratedList | programs.Program],
+                 dependencies: T.Sequence[AnyTargetType | programs.Program],
                  subdir: str,
                  environment: Environment,
                  build_project: BuildProject,
@@ -3277,7 +3277,7 @@ class RunTarget(Target):
         repr_str = "<{0} {1}: {2}>"
         return repr_str.format(self.__class__.__name__, self.get_id(), self.command[0])
 
-    def get_dependencies(self) -> T.List[Target | CustomTargetIndex | GeneratedList | programs.Program]:
+    def get_dependencies(self) -> T.List[AnyTargetType | programs.Program]:
         return self.dependencies
 
     def get_generated_sources(self) -> T.List[GeneratedTypes]:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2896,9 +2896,9 @@ class BothLibraries(SecondLevelHolder, LinkableTarget):
 
 
 def flatten_command(cmd: T.Iterable[CommandTypes],
-                    subproject: SubProject) -> tuple[list[str | File | BuildTarget | CustomTarget | programs.Program],
+                    subproject: SubProject) -> tuple[list[CommandTypes],
                                                      list[File], list[BuildTarget | CustomTarget]]:
-    final_cmd: list[str | File | programs.Program | BuildTarget | CustomTarget] = []
+    final_cmd: list[CommandTypes] = []
     depend_files: list[File] = []
     dependencies: list[BuildTarget | CustomTarget] = []
     for c in cmd:
@@ -2926,10 +2926,7 @@ def flatten_command(cmd: T.Iterable[CommandTypes],
         elif isinstance(c, CustomTargetIndex):
             FeatureNew.single_use('CustomTargetIndex for command argument', '0.60', subproject)
             dependencies.append(c.target)
-            c, df, d = flatten_command([File.from_built_file(c.get_subdir(), c.get_filename())], subproject)
-            final_cmd.extend(c)
-            depend_files.extend(df)
-            dependencies.extend(d)
+            final_cmd.append(c)
         else:
             raise InvalidArguments(f'Argument {c!r} in "command" is invalid')
     return final_cmd, depend_files, dependencies

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2905,10 +2905,9 @@ def flatten_command(cmd: T.Iterable[CommandTypes],
         if isinstance(c, LocalProgram):
             c = c.program
         if isinstance(c, str):
-            final_cmd.append(c)
+            pass
         elif isinstance(c, File):
             depend_files.append(c)
-            final_cmd.append(c)
         elif isinstance(c, programs.Program):
             if not c.found():
                 raise InvalidArguments('Tried to use not-found external program in "command"')
@@ -2918,17 +2917,15 @@ def flatten_command(cmd: T.Iterable[CommandTypes],
                 # Can only add a dependency on an external program which we
                 # know the absolute path of
                 depend_files.append(File.from_absolute_file(path))
-            # Do NOT flatten -- it is needed for later parsing
-            final_cmd.append(c)
+            # Add c, not path -- it is needed for later parsing
         elif isinstance(c, (BuildTarget, CustomTarget)):
             dependencies.append(c)
-            final_cmd.append(c)
         elif isinstance(c, CustomTargetIndex):
             FeatureNew.single_use('CustomTargetIndex for command argument', '0.60', subproject)
             dependencies.append(c.target)
-            final_cmd.append(c)
         else:
-            raise InvalidArguments(f'Argument {c!r} in "command" is invalid')
+            raise MesonBugException(f'Argument {c!r} in "command" is invalid')
+        final_cmd.append(c)
     return final_cmd, depend_files, dependencies
 
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -991,8 +991,8 @@ class BuildTarget(Target):
         # we have to call process_compilers() first and we need to process libraries
         # from link_with and link_whole first.
         # See https://github.com/mesonbuild/meson/pull/11957#issuecomment-1629243208.
-        link_targets = self._extract_link_with(kwargs)
-        link_whole_targets = self._extract_link_whole(kwargs)
+        link_targets = self._extract_link_with(kwargs.get('link_with', []))
+        link_whole_targets = self._extract_link_whole(kwargs.get('link_whole', []))
         self.link_targets.clear()
         self.link_whole_targets.clear()
         self.link(link_targets)
@@ -1815,11 +1815,11 @@ class BuildTarget(Target):
         assert isinstance(bl_type, str), 'for mypy'
         return T.cast('_LibraryType', bl_type)
 
-    def _extract_link_with(self, kwargs: BuildTargetKeywordArguments) -> list[LinkableTargetTypes]:
+    def _extract_link_with(self, link_with: list[LinkableTargetTypes]) -> list[LinkableTargetTypes]:
         bl_type = self._default_library_type()
 
         lib_list: list[LinkableTargetTypes] = []
-        for lib in itertools.chain(kwargs.get('link_with', []), self.link_targets):
+        for lib in itertools.chain(link_with, self.link_targets):
             if isinstance(lib, (CustomTarget, CustomTargetIndex)):
                 lib_list.append(lib)
             elif isinstance(lib, Jar):
@@ -1829,9 +1829,9 @@ class BuildTarget(Target):
                 lib_list.append(lib.get(bl_type))
         return lib_list
 
-    def _extract_link_whole(self, kwargs: BuildTargetKeywordArguments) -> list[StaticTargetTypes]:
+    def _extract_link_whole(self, link_whole: list[StaticTargetTypes]) -> list[StaticTargetTypes]:
         lib_list: list[StaticTargetTypes] = []
-        for lib in itertools.chain(kwargs.get('link_whole', []), self.link_whole_targets):
+        for lib in itertools.chain(link_whole, self.link_whole_targets):
             if isinstance(lib, BothLibraries):
                 lib = lib.get('static')
                 if not isinstance(lib, StaticLibrary):
@@ -3338,8 +3338,8 @@ class Jar(BuildTarget):
         self.main_class = kwargs.get('main_class', '')
         self.java_resources: T.Optional[StructuredSources] = kwargs.get('java_resources', None)
 
-    def _extract_link_with(self, kwargs: BuildTargetKeywordArguments) -> list[LinkableTargetTypes]:
-        return kwargs['link_with']
+    def _extract_link_with(self, link_with: list[LinkableTargetTypes]) -> list[LinkableTargetTypes]:
+        return link_with
 
     def get_main_class(self) -> str:
         return self.main_class

--- a/mesonbuild/cmake/common.py
+++ b/mesonbuild/cmake/common.py
@@ -137,10 +137,8 @@ def cmake_defines_to_args(raw: T.List[T.Dict[str, TYPE_var]], permissive: bool =
                 mlog.warning('  --> Ignoring this option')
                 continue
             if isinstance(val, (str, int, float)):
+                # FIXME: should bool use ON/OFF instead?
                 res += [f'-D{key}={val}']
-            elif isinstance(val, bool):
-                val_str = 'ON' if val else 'OFF'
-                res += [f'-D{key}={val_str}']
             else:
                 raise MesonException('Type "{}" of "{}" is not supported as for a CMake define value'.format(type(val).__name__, key))
 

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -346,7 +346,7 @@ class ConverterTarget:
                     self.override_options += [f'{i}_std={std}']
                 elif j in {'-fPIC', '-fpic', '-fPIE', '-fpie'}:
                     self.pie = True
-                elif isinstance(ctgt, ConverterCustomTarget):
+                elif ctgt is not None:
                     # Sometimes projects pass generated source files as compiler
                     # flags. Add these as generated sources to ensure that the
                     # corresponding custom target is run.2

--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -423,7 +423,7 @@ class CMakeTraceParser:
         def handle_depends(key: str, target: CMakeGeneratorTarget) -> None:
             target.depends += [key]
 
-        working_dir = None
+        working_dir: str | None = None
 
         def handle_working_dir(key: str, target: CMakeGeneratorTarget) -> None:
             nonlocal working_dir

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -502,8 +502,6 @@ class DCompiler(Compiler):
                 extra_args = extra_args(CompileCheckMode.COMPILE)
             if isinstance(extra_args, list):
                 args.extend(extra_args)
-            elif isinstance(extra_args, str):
-                args.append(extra_args)
         return args
 
     def run(self, code: 'mesonlib.FileOrString',

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -155,7 +155,7 @@ class FortranCompiler(CLikeCompiler, Compiler):
         # If no bounds are given, compute them in the limit of int32
         maxint = 0x7fffffff
         minint = -0x80000000
-        if not isinstance(low, int) or not isinstance(high, int):
+        if low is None or high is None:
             if self._compile_int(f'{expression} >= 0', prefix, extra_args, dependencies):
                 low = cur = 0
                 while self._compile_int(f'{expression} > {cur}', prefix, extra_args, dependencies):

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -11,7 +11,6 @@ of this is to have mixin's, which are classes that are designed *not* to be
 standalone, they only work through inheritance.
 """
 
-import collections
 import functools
 import glob
 import itertools
@@ -386,9 +385,6 @@ class CLikeCompiler(Compiler):
 
         if dependencies is None:
             dependencies = []
-        elif not isinstance(dependencies, collections.abc.Iterable):
-            # TODO: we want to ensure the front end does the listifing here
-            dependencies = [dependencies]
         # Collect compiler arguments
         cargs: arglist.CompilerArgs = self.compiler_args()
         largs: T.List[str] = []
@@ -1210,8 +1206,6 @@ class CLikeCompiler(Compiler):
         # These libraries are either built-in or invalid
         if libname in self.ignore_libs:
             return []
-        if isinstance(extra_dirs, str):
-            extra_dirs = [extra_dirs]
         key = (tuple(self.exelist), libname, tuple(extra_dirs), code, libtype, ignore_system_dirs, skip_link_check)
         if key not in self.find_library_cache:
             value = self._find_library_real(libname, extra_dirs, code, libtype, lib_prefix_warning, ignore_system_dirs, skip_link_check)
@@ -1270,8 +1264,6 @@ class CLikeCompiler(Compiler):
 
     def _find_framework_impl(self, name: str, extra_dirs: T.List[str],
                              allow_system: bool) -> T.Optional[T.List[str]]:
-        if isinstance(extra_dirs, str):
-            extra_dirs = [extra_dirs]
         key = (tuple(self.exelist), name, tuple(extra_dirs), allow_system)
         if key in self.find_framework_cache:
             value = self.find_framework_cache[key]

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -453,7 +453,7 @@ class CLikeCompiler(Compiler):
         # If no bounds are given, compute them in the limit of int32
         maxint = 0x7fffffff
         minint = -0x80000000
-        if not isinstance(low, int) or not isinstance(high, int):
+        if low is None or high is None:
             if self._compile_int(f'{expression} >= 0', prefix, extra_args, dependencies):
                 low = cur = 0
                 while self._compile_int(f'{expression} > {cur}', prefix, extra_args, dependencies):

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -151,8 +151,6 @@ class ValaCompiler(Compiler):
     def find_library(self, libname: str, extra_dirs: T.List[str], libtype: LibType = LibType.PREFER_SHARED,
                      lib_prefix_warning: bool = True, ignore_system_dirs: bool = False,
                      skip_link_check: bool = False) -> T.Optional[T.List[str]]:
-        if extra_dirs and isinstance(extra_dirs, str):
-            extra_dirs = [extra_dirs]
         # Valac always looks in the default vapi dir, so only search there if
         # no extra dirs are specified.
         if not extra_dirs:

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -703,7 +703,9 @@ class CompilerHolder(ObjectHolder['Compiler']):
             libtype = mesonlib.LibType.STATIC
         elif kwargs['static'] is False:
             libtype = mesonlib.LibType.SHARED
-        elif prefer_static:
+        # kwargs['static']'s "| None" is invisible until this module is compiled
+        # with strict_optional.
+        elif prefer_static: # type: ignore[unreachable]
             libtype = mesonlib.LibType.PREFER_STATIC
         else:
             libtype = mesonlib.LibType.PREFER_SHARED

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -153,12 +153,16 @@ _DEPENDS_KW: KwargInfo[T.List[build.BuildTargetTypes]] = KwargInfo(
     listify=True,
     default=[],
 )
+
+def _prefix_convertor(x: T.List[str] | str) -> str:
+    return '\n'.join(x) if isinstance(x, list) else x
+
 _PREFIX_KW: KwargInfo[str] = KwargInfo(
     'prefix',
     (str, ContainerTypeInfo(list, str)),
     default='',
     since_values={list: '1.0.0'},
-    convertor=lambda x: '\n'.join(x) if isinstance(x, list) else x)
+    convertor=_prefix_convertor)
 
 _NO_BUILTIN_ARGS_KW = KwargInfo('no_builtin_args', bool, default=False)
 _NAME_KW = KwargInfo('name', str, default='')

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -79,7 +79,7 @@ if T.TYPE_CHECKING:
 
         disabler: bool
         has_headers: T.List[str]
-        static: bool
+        static: bool | None
 
         # This list must be all of the `HeaderKW` values with `header_`
         # prepended to the key

--- a/mesonbuild/interpreter/dependencyfallbacks.py
+++ b/mesonbuild/interpreter/dependencyfallbacks.py
@@ -344,7 +344,8 @@ class DependencyFallbacksHolder(MesonInterpreterObject):
                 subp_name, varname = self.wrap_resolver.find_dep_provider(name)
                 if subp_name:
                     self.forcefallback |= subp_name in force_fallback_for
-                    if self.forcefallback or self.allow_fallback is True or required or self._get_subproject(subp_name):
+                    # allow_fallback's "| None" is invisible until this module is compiled with strict_optoinal
+                    if self.forcefallback or self.allow_fallback is True or required or self._get_subproject(subp_name): # type: ignore[unreachable]
                         self._subproject_impl(subp_name, varname)
                     break
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -4045,6 +4045,7 @@ class Interpreter(InterpreterBase, HoldableObject):
 
         if targetclass is not build.Jar:
             self.check_for_jar_sources(sources, targetclass)
+            self.check_for_jar_link_with(kwargs.get('link_with', []), targetclass)
 
         target: build.BuildTarget
         if targetclass is build.Executable:
@@ -4097,6 +4098,12 @@ class Interpreter(InterpreterBase, HoldableObject):
                 self.check_for_jar_sources(s.as_list(), targetclass)
             elif isinstance(s, (build.GeneratedList, build.CustomTarget, build.CustomTargetIndex)):
                 self.check_for_jar_sources(s.get_outputs(), targetclass)
+
+    def check_for_jar_link_with(self, link_with: T.Sequence[object], targetclass: T.Type[build.BuildTarget]) -> None:
+        for t in link_with:
+            if isinstance(t, build.Jar):
+                raise InvalidArguments(f'Build target of type "{targetclass.typename}" cannot link with jar target "{t.name}". '
+                                       f'Jar targets can only be linked into other jar targets.')
 
     def is_subproject(self) -> bool:
         return self.subproject != ''

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -4030,9 +4030,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                 outputs: T.Set[str] = set()
                 for f in v:
                     o: T.List[str]
-                    if isinstance(f, str):
-                        o = [os.path.basename(f)]
-                    elif isinstance(f, mesonlib.File):
+                    if isinstance(f, mesonlib.File):
                         o = [f.fname]
                     else:
                         o = f.get_outputs()

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -201,7 +201,7 @@ class FuncAddLanguages(ExtractRequired):
 class RunTarget(TypedDict):
 
     command: T.List[build.CommandTypes]
-    depends: T.List[TargetDepends]
+    depends: T.List[build.AnyTargetType | Program]
     env: EnvironmentVariables
 
 

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -99,11 +99,6 @@ def _install_mode_validator(mode: T.List[T.Union[str, bool, int]]) -> T.Optional
         if perms[8] not in {'-', 'x', 't', 'T'}:
             return f'permission character 9 must be "-", "t", "T", or "x", not {perms[8]}'
 
-        if len(mode) >= 2 and not isinstance(mode[1], (int, str, bool)):
-            return 'second component can only be a string, number, or False'
-        if len(mode) >= 3 and not isinstance(mode[2], (int, str, bool)):
-            return 'third component can only be a string, number, or False'
-
     return None
 
 

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -613,7 +613,7 @@ BUILD_SUBDIR_KW: KwargInfo[str] = KwargInfo(
     since='1.10.0'
 )
 
-def _objects_validator(vals: T.List[ObjectTypes]) -> T.Optional[str]:
+def _objects_validator(vals: T.List[ObjectTypes | GeneratedTypes]) -> T.Optional[str]:
     non_objects: T.List[str] = []
 
     for val in vals:

--- a/mesonbuild/interpreterbase/helpers.py
+++ b/mesonbuild/interpreterbase/helpers.py
@@ -19,9 +19,6 @@ if T.TYPE_CHECKING:
 
 
 def flatten(args: T.Union['TYPE_var', T.List['TYPE_var']]) -> T.List['TYPE_var']:
-    if isinstance(args, mparser.StringNode):
-        assert isinstance(args.value, str)
-        return [args.value]
     if not isinstance(args, collections.abc.Sequence):
         return [args]
     result: T.List['TYPE_var'] = []

--- a/mesonbuild/interpreterbase/interpreterbase.py
+++ b/mesonbuild/interpreterbase/interpreterbase.py
@@ -306,8 +306,10 @@ class InterpreterBase:
             if not isinstance(res, bool):
                 raise InvalidCode(f'If clause {result!r} does not evaluate to true or false.')
             prev_meson_version = mesonlib.project_meson_versions[self.subproject]
-            if self.tmp_meson_version and isinstance(prev_meson_version, mesonlib.Range):
-                always = prev_meson_version.always(self.tmp_meson_version)
+            # mypy does not know that evaluating the condition can set
+            # self.tmp_meson_version.
+            if self.tmp_meson_version and isinstance(prev_meson_version, mesonlib.Range): # type: ignore[unreachable]
+                always = prev_meson_version.always(self.tmp_meson_version) # type: ignore[unreachable]
                 if always is not None:
                     mlog.warning(f"Conditional on version '{self.tmp_meson_version}' always evaluates to {str(always).lower()}",
                                  location=self.current_node)

--- a/mesonbuild/interpreterbase/interpreterbase.py
+++ b/mesonbuild/interpreterbase/interpreterbase.py
@@ -184,11 +184,6 @@ class InterpreterBase:
     def evaluate_codeblock(self, node: mparser.CodeBlockNode, start: int = 0, end: T.Optional[int] = None) -> None:
         if node is None:
             return
-        if not isinstance(node, mparser.CodeBlockNode):
-            e = InvalidCode('Tried to execute a non-codeblock. Possibly a bug in the parser.')
-            e.lineno = node.lineno
-            e.colno = node.colno
-            raise e
         statements = node.lines[start:end]
         i = 0
         while i < len(statements):

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -422,8 +422,6 @@ def run(options: argparse.Namespace) -> int:
     project = cls(dist_name, src_root, bld_root, b.dist_scripts, subprojects, options)
     names = project.create_dist(archives)
 
-    if names is None:
-        return 1
     rc = 0
     if not options.no_tests:
         # Check only one.

--- a/mesonbuild/mformat.py
+++ b/mesonbuild/mformat.py
@@ -88,6 +88,8 @@ def match_path(filename: str, pattern: str) -> bool:
 @dataclass
 class EditorConfig:
 
+    # FIXME: these literals are not type-checked
+
     indent_style: T.Optional[Literal['space', 'tab']] = field(default=None, metadata={'getter': DefaultConfigParser.get})
     indent_size: T.Optional[int] = field(default=None, metadata={'getter': DefaultConfigParser.getint})
     tab_width: T.Optional[int] = field(default=None, metadata={'getter': DefaultConfigParser.getint})

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -34,7 +34,7 @@ if T.TYPE_CHECKING:
         name: str
         executable: str
         deps: str
-        language: Literal['c', 'cpp', 'cs', 'cuda', 'd', 'fortran', 'java', 'rust', 'objc', 'objcpp', 'vala']
+        language: Literal['c', 'cpp', 'cs', 'cuda', 'd', 'fortran', 'java', 'rust', 'objc', 'objcpp', 'vala'] | None
         build: bool
         builddir: str
         force: bool

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -49,7 +49,7 @@ if T.TYPE_CHECKING:
         profile: bool
         quiet: bool
         wd: str
-        destdir: str
+        destdir: str | None
         dry_run: bool
         skip_subprojects: str
         tags: str

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -369,11 +369,7 @@ def get_test_list(testdata: T.List[backends.TestSerialisation]) -> T.List[T.Dict
     result: T.List[T.Dict[str, T.Union[str, int, T.List[str], T.Dict[str, str]]]] = []
     for t in testdata:
         to: T.Dict[str, T.Union[str, int, T.List[str], T.Dict[str, str]]] = {}
-        if isinstance(t.fname, str):
-            fname = [t.fname]
-        else:
-            fname = t.fname
-        to['cmd'] = fname + t.cmd_args
+        to['cmd'] = t.fname + t.cmd_args
         if isinstance(t.env, mesonlib.EnvironmentVariables):
             to['env'] = t.env.get_env({})
         else:

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -370,10 +370,7 @@ def get_test_list(testdata: T.List[backends.TestSerialisation]) -> T.List[T.Dict
     for t in testdata:
         to: T.Dict[str, T.Union[str, int, T.List[str], T.Dict[str, str]]] = {}
         to['cmd'] = t.fname + t.cmd_args
-        if isinstance(t.env, mesonlib.EnvironmentVariables):
-            to['env'] = t.env.get_env({})
-        else:
-            to['env'] = t.env
+        to['env'] = t.env.get_env({}) if t.env else {}
         to['name'] = t.name
         to['workdir'] = t.workdir
         to['timeout'] = t.timeout

--- a/mesonbuild/modules/dlang.py
+++ b/mesonbuild/modules/dlang.py
@@ -93,10 +93,7 @@ class DlangModule(ExtensionModule):
                         ret, res = self._call_dubbin(['describe', name])
                         if ret == 0:
                             version = dep.get_version()
-                            if version is None:
-                                data[name] = ''
-                            else:
-                                data[name] = version
+                            data[name] = version
                 config[key] = data
             else:
                 def _do_validate(v: object) -> _JSONTypes:

--- a/mesonbuild/modules/hotdoc.py
+++ b/mesonbuild/modules/hotdoc.py
@@ -99,15 +99,13 @@ class HotdocTargetBuilder:
             argname = option.strip("-").replace("-", "_")
 
         value = self.kwargs.pop(argname)  # type: ignore[misc]
-        if value is not None and value_processor:
+        if value is None:
+            return
+        if value_processor:
             value = value_processor(value)
-
         self.set_arg_value(option, value)
 
     def set_arg_value(self, option: str, value: TYPE_var) -> None:
-        if value is None:
-            return
-
         if isinstance(value, bool):
             if value:
                 self.cmd.append(option)

--- a/mesonbuild/modules/snippets.py
+++ b/mesonbuild/modules/snippets.py
@@ -32,7 +32,7 @@ if T.TYPE_CHECKING:
         api: T.Optional[str]
         compilation: T.Optional[str]
         static_compilation: T.Optional[str]
-        static_only: bool
+        static_only: T.Optional[bool]
 
 
 class SnippetsModule(NewExtensionModule):

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -8,7 +8,7 @@ import codecs
 import os
 import typing as T
 
-from .mesonlib import MesonException
+from .mesonlib import MesonException, unwrap
 from . import mlog
 
 if T.TYPE_CHECKING:
@@ -855,7 +855,8 @@ class Parser:
                     temp_node.append_whitespaces(w)
 
                 not_token.bytespan = (not_token.bytespan[0], in_token.bytespan[1])
-                not_token.value += temp_node.whitespaces.value + in_token.value
+                # whitespace between not and in must have been added above
+                not_token.value += unwrap(temp_node.whitespaces).value + in_token.value
                 operator = self.create_node(SymbolNode, not_token)
                 return self.create_node(ComparisonNode, 'not in', left, operator, self.e5())
         return left

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1396,6 +1396,13 @@ class TestSubprocess:
 
         return self.stdo_task, self.stde_task
 
+    @staticmethod
+    async def _wait_for_exit(p: asyncio.subprocess.Process, timeout: float) -> bool:
+        """Wait for the process to exit, return True if it did."""
+        with suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(p.wait(), timeout=timeout)
+        return p.returncode is not None
+
     async def _kill(self) -> T.Optional[str]:
         # Python does not provide multiplatform support for
         # killing a process and all its children so we need
@@ -1411,25 +1418,19 @@ class TestSubprocess:
 
                 # Make sure the termination signal actually kills the process
                 # group, otherwise retry with a SIGKILL.
-                with suppress(asyncio.TimeoutError):
-                    await asyncio.wait_for(p.wait(), timeout=0.5)
-                if p.returncode is not None:
+                if await self._wait_for_exit(p, 0.5):
                     return None
 
                 os.killpg(p.pid, signal.SIGKILL)
 
-            with suppress(asyncio.TimeoutError):
-                await asyncio.wait_for(p.wait(), timeout=1)
-            if p.returncode is not None:
+            if await self._wait_for_exit(p, 1):
                 return None
 
             # An earlier kill attempt has not worked for whatever reason.
             # Try to kill it one last time with a direct call.
             # If the process has spawned children, they will remain around.
             p.kill()
-            with suppress(asyncio.TimeoutError):
-                await asyncio.wait_for(p.wait(), timeout=1)
-            if p.returncode is not None:
+            if await self._wait_for_exit(p, 1):
                 return None
             return 'Test process could not be killed.'
         except ProcessLookupError:

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -91,11 +91,6 @@ class OptionInterpreter:
         except mesonlib.MesonException as me:
             me.file = option_file
             raise me
-        if not isinstance(ast, mparser.CodeBlockNode):
-            e = OptionException('Option file is malformed.')
-            e.lineno = ast.lineno()
-            e.file = option_file
-            raise e
         for cur in ast.lines:
             try:
                 self.current_node = cur

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -884,8 +884,6 @@ class OptionStore:
 
     def add_system_option_internal(self, key: OptionKey, valobj: AnyOptionType) -> None:
         assert isinstance(valobj, UserOption)
-        if not isinstance(valobj.name, str):
-            assert isinstance(valobj.name, str)
         if key in self.options:
             return
 
@@ -1212,11 +1210,7 @@ class OptionStore:
 
     def is_backend_option(self, key: OptionKey) -> bool:
         """Convenience method to check if this is a backend option."""
-        if isinstance(key, str):
-            name: str = key
-        else:
-            name = key.name
-        return name.startswith('backend_')
+        return key.name.startswith('backend_')
 
     def is_compiler_option(self, key: OptionKey) -> bool:
         """Convenience method to check if this is a compiler option."""

--- a/mesonbuild/options.py
+++ b/mesonbuild/options.py
@@ -826,7 +826,7 @@ class OptionStore:
             key = key.as_host()
         return key
 
-    def get_pending_value(self, key: OptionKey, default: T.Optional[ElementaryOptionValues] = None) -> ElementaryOptionValues:
+    def get_pending_value(self, key: OptionKey, default: T.Optional[ElementaryOptionValues] = None) -> ElementaryOptionValues | None:
         key = self.ensure_and_validate_key(key)
         if key in self.options:
             return self.options[key].value

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -180,6 +180,7 @@ class MTypeID(MTypeBase):
         return [IdNode]
 
 class MTypeList(MTypeBase, T.Generic[_T]):
+    # FIXME: incorrect, any node can be passed to __init__
     node: ArrayNode
 
     def __init__(self, node: T.Optional[BaseNode] = None):
@@ -205,7 +206,7 @@ class MTypeList(MTypeBase, T.Generic[_T]):
         raise RewriterException('Internal error: _new_element_node of MTypeList was called')
 
     def _ensure_array_node(self) -> None:
-        if not isinstance(self.node, ArrayNode):
+        if not isinstance(T.cast('BaseNode', self.node), ArrayNode):
             tmp = self.node
             self.node = self._new_array_node([])
             self.node.args.arguments = [tmp]

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -35,6 +35,8 @@ if T.TYPE_CHECKING:
 class RewriterException(MesonException):
     pass
 
+_T = T.TypeVar('_T')
+
 # Note: when adding arguments, please also add them to the completion
 # scripts in $MESONSRC/data/shell-completions/
 def add_arguments(parser: ArgumentParser, formatter: _FormatterClass) -> None:
@@ -177,31 +179,35 @@ class MTypeID(MTypeBase):
     def supported_nodes(cls) -> T.List[type]:
         return [IdNode]
 
-class MTypeList(MTypeBase):
+class MTypeList(MTypeBase, T.Generic[_T]):
     node: ArrayNode
 
     def __init__(self, node: T.Optional[BaseNode] = None):
         super().__init__(node)
 
     @classmethod
-    def new_node(cls, value: T.Optional[T.List[T.Any]] = None) -> ArrayNode:
+    def new_node(cls, value: T.Union[_T, T.List[_T], None] = None) -> BaseNode:
         if value is None:
-            value = []
-        elif not isinstance(value, list):
-            return cls._new_element_node(value)
+            return cls._new_array_node([])
+        elif isinstance(value, list):
+            return cls._new_array_node(value)
+        return cls._new_element_node(value)
+
+    @classmethod
+    def _new_array_node(cls, value: T.List[_T]) -> ArrayNode:
         args = ArgumentNode(Token('', '', 0, 0, 0, None, ''))
         args.arguments = [cls._new_element_node(i) for i in value]
         return ArrayNode(_symbol('['), args, _symbol(']'))
 
     @classmethod
-    def _new_element_node(cls, value: T.Any) -> BaseNode:
+    def _new_element_node(cls, value: _T) -> BaseNode:
         # Overwrite in derived class
         raise RewriterException('Internal error: _new_element_node of MTypeList was called')
 
     def _ensure_array_node(self) -> None:
         if not isinstance(self.node, ArrayNode):
             tmp = self.node
-            self.node = self.new_node()
+            self.node = self._new_array_node([])
             self.node.args.arguments = [tmp]
 
     @staticmethod
@@ -262,7 +268,7 @@ class MTypeList(MTypeBase):
     def remove_regex(self, regex: str) -> None:
         self._remove_helper(regex, self._check_regex_matches)
 
-class MTypeStrList(MTypeList):
+class MTypeStrList(MTypeList[str]):
     def __init__(self, node: T.Optional[BaseNode] = None):
         super().__init__(node)
 
@@ -286,7 +292,7 @@ class MTypeStrList(MTypeList):
     def supported_element_nodes(cls) -> T.List[T.Type]:
         return [StringNode]
 
-class MTypeIDList(MTypeList):
+class MTypeIDList(MTypeList[str]):
     def __init__(self, node: T.Optional[BaseNode] = None):
         super().__init__(node)
 

--- a/mesonbuild/templates/samplefactory.py
+++ b/mesonbuild/templates/samplefactory.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import typing as T
 
+from mesonbuild.mesonlib import unwrap
 from mesonbuild.templates.valatemplates import ValaProject
 from mesonbuild.templates.fortrantemplates import FortranProject
 from mesonbuild.templates.objcpptemplates import ObjCppProject
@@ -39,4 +40,4 @@ _IMPL: T.Mapping[str, T.Union[T.Type[ClassImpl], T.Type[FileHeaderImpl], T.Type[
 
 
 def sample_generator(options: Arguments) -> SampleImpl:
-    return _IMPL[options.language](options)
+    return _IMPL[unwrap(options.language)](options)

--- a/mesonbuild/templates/sampleimpl.py
+++ b/mesonbuild/templates/sampleimpl.py
@@ -77,9 +77,10 @@ class SampleImpl(metaclass=SimpleABC):
     def _detect_sources(self, srcfiles: T.List[Path], transform: T.Callable[[str], str]) -> T.Tuple[str, T.List[Path]]:
         # Try a source based on the executable name, fallback to one based
         # on the project name if none is found.
-        expected_name = f'{transform(self.executable_name)}.{self.source_ext}'
-        if any(str(x) == expected_name for x in srcfiles):
-            return expected_name, srcfiles
+        if self.executable_name:
+            expected_name = f'{transform(self.executable_name)}.{self.source_ext}'
+            if any(str(x) == expected_name for x in srcfiles):
+                return expected_name, srcfiles
         expected_name = f'{transform(self.lowercase_token)}.{self.source_ext}'
         if any(str(x) == expected_name for x in srcfiles):
             return expected_name, srcfiles

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -1494,9 +1494,8 @@ def do_replacement_meson(regex: T.Pattern[str], line: str,
                         mlog.deprecation(msg)
                     var_str = str(var)
                 else:
-                    msg = f'Tried to replace variable {varname!r} value with ' \
-                          f'something other than a string or int: {var!r}'
-                    raise MesonException(msg)
+                    raise MesonBugException(f'Tried to replace variable {varname!r} value with '
+                                            f'something other than a string or int: {var!r}')
             else:
                 missing_variables.add(varname)
             return var_str
@@ -1521,9 +1520,8 @@ def do_replacement_cmake(line: str, at_only: bool,
             elif isinstance(var, int):
                 var_str = str(var)
             else:
-                msg = f'Tried to replace variable {varname!r} value with ' \
-                      f'something other than a string or int: {var!r}'
-                raise MesonException(msg)
+                raise MesonBugException(f'Tried to replace variable {varname!r} value with '
+                                        f'something other than a string or int: {var!r}')
         else:
             missing_variables.add(varname)
         return var_str

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -846,42 +846,47 @@ def darwin_get_object_archs(objpath: str) -> 'ImmutableListProtocol[str]':
 
     return meson_archs
 
-def windows_detect_native_arch() -> str:
-    """
-    The architecture of Windows itself: x86, amd64 or arm64
-    """
-    if sys.platform != 'win32':
+if sys.platform != 'win32':
+    def windows_detect_native_arch() -> str:
+        """
+        The architecture of Windows itself: x86, amd64 or arm64
+        """
         return ''
-    try:
-        import ctypes
-        process_arch = ctypes.c_ushort()
-        native_arch = ctypes.c_ushort()
-        kernel32 = ctypes.windll.kernel32
-        process = ctypes.c_void_p(kernel32.GetCurrentProcess())
-        # This is the only reliable way to detect an arm system if we are an x86/x64 process being emulated
-        if kernel32.IsWow64Process2(process, ctypes.byref(process_arch), ctypes.byref(native_arch)):
-            # https://docs.microsoft.com/en-us/windows/win32/sysinfo/image-file-machine-constants
-            if native_arch.value == 0x8664:
-                return 'amd64'
-            elif native_arch.value == 0x014C:
-                return 'x86'
-            elif native_arch.value == 0xAA64:
-                return 'arm64'
-            elif native_arch.value == 0x01C4:
-                return 'arm'
-    except (OSError, AttributeError):
-        pass
-    # These env variables are always available. See:
-    # https://msdn.microsoft.com/en-us/library/aa384274(VS.85).aspx
-    # https://blogs.msdn.microsoft.com/david.wang/2006/03/27/howto-detect-process-bitness/
-    arch = os.environ.get('PROCESSOR_ARCHITEW6432', '').lower()
-    if not arch:
+else:
+    def windows_detect_native_arch() -> str:
+        """
+        The architecture of Windows itself: x86, amd64 or arm64
+        """
         try:
-            # If this doesn't exist, something is messing with the environment
-            arch = os.environ['PROCESSOR_ARCHITECTURE'].lower()
-        except KeyError:
-            raise EnvironmentException('Unable to detect native OS architecture')
-    return arch
+            import ctypes
+            process_arch = ctypes.c_ushort()
+            native_arch = ctypes.c_ushort()
+            kernel32 = ctypes.windll.kernel32
+            process = ctypes.c_void_p(kernel32.GetCurrentProcess())
+            # This is the only reliable way to detect an arm system if we are an x86/x64 process being emulated
+            if kernel32.IsWow64Process2(process, ctypes.byref(process_arch), ctypes.byref(native_arch)):
+                # https://docs.microsoft.com/en-us/windows/win32/sysinfo/image-file-machine-constants
+                if native_arch.value == 0x8664:
+                    return 'amd64'
+                elif native_arch.value == 0x014C:
+                    return 'x86'
+                elif native_arch.value == 0xAA64:
+                    return 'arm64'
+                elif native_arch.value == 0x01C4:
+                    return 'arm'
+        except (OSError, AttributeError):
+            pass
+        # These env variables are always available. See:
+        # https://msdn.microsoft.com/en-us/library/aa384274(VS.85).aspx
+        # https://blogs.msdn.microsoft.com/david.wang/2006/03/27/howto-detect-process-bitness/
+        arch = os.environ.get('PROCESSOR_ARCHITEW6432', '').lower()
+        if not arch:
+            try:
+                # If this doesn't exist, something is messing with the environment
+                arch = os.environ['PROCESSOR_ARCHITECTURE'].lower()
+            except KeyError:
+                raise EnvironmentException('Unable to detect native OS architecture')
+        return arch
 
 @dataclasses.dataclass
 class VcsData:


### PR DESCRIPTION
While looking at strict_optional, I noticed that unreachable code warnings can help finding missing annotations, because they show the `None` branches as dead. So start by fixing those. There are only a couple places that are messy enough to warrant a file-based disable:

* mformat is using Literals that aren't checked
* build is problematic due to BothLibraries
