### PR TITLE
move -fpermissive out of get_compiler_check_args(), fix clang-cl sanity check

### DIFF
--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -91,11 +91,13 @@ class CPPCompiler(CLikeCompiler, Compiler):
     def _sanity_check_source_code(self) -> str:
         return '#include <stddef.h>\nclass breakCCompiler;int main(void) { return 0; }\n'
 
+    def get_cpp_permissive_args(self) -> T.List[str]:
+        return []
+
     def get_compiler_check_args(self, mode: CompileCheckMode) -> T.List[str]:
-        # -fpermissive allows non-conforming code to compile which is necessary
-        # for many C++ checks. Particularly, the has_header_symbol check is
-        # too strict without this and always fails.
-        return super().get_compiler_check_args(mode) + ['-fpermissive']
+        # Compiler checks must accept non-conforming code. Particularly, the
+        # has_header_symbol check is too strict without this and always fails.
+        return super().get_compiler_check_args(mode) + self.get_cpp_permissive_args()
 
     def has_header_symbol(self, hname: str, symbol: str, prefix: str, *,
                           extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,
@@ -859,10 +861,6 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
             args.append('/permissive-')
         return args
 
-    def get_compiler_check_args(self, mode: CompileCheckMode) -> T.List[str]:
-        # XXX: this is a hack because so much GnuLike stuff is in the base CPPCompiler class.
-        return Compiler.get_compiler_check_args(self, mode)
-
 class CPP11AsCPP14Mixin(CompilerMixinBase):
 
     """Mixin class for VisualStudio and ClangCl to replace C++11 std with C++14.
@@ -975,10 +973,6 @@ class ClangClCPPCompiler(VisualStudioLikeCPPCompilerMixin, ClangClCompiler, CPPC
         # clang-cl does not support /interface.
         return ['-fmodules', '-fmodules-ts']
 
-    def get_compiler_check_args(self, mode: CompileCheckMode) -> T.List[str]:
-        # XXX: this is a hack because so much GnuLike stuff is in the base CPPCompiler class.
-        return ClangClCompiler.get_compiler_check_args(self, mode)
-
 
 class IntelClCPPCompiler(VisualStudioLikeCPPCompilerMixin, IntelVisualStudioLikeCompiler, CPPCompiler):
 
@@ -999,10 +993,6 @@ class IntelClCPPCompiler(VisualStudioLikeCPPCompilerMixin, IntelVisualStudioLike
         if version_compare(self.version, '>=2024.1.0'):
             cpp_stds += ['c++20']
         return self._get_options_impl(super().get_options(), cpp_stds)
-
-    def get_compiler_check_args(self, mode: CompileCheckMode) -> T.List[str]:
-        # XXX: this is a hack because so much GnuLike stuff is in the base CPPCompiler class.
-        return IntelVisualStudioLikeCompiler.get_compiler_check_args(self, mode)
 
 
 class IntelLLVMClCPPCompiler(IntelClCPPCompiler):
@@ -1092,6 +1082,9 @@ class TICPPCompiler(TICompiler, CPPCompiler):
 
     def get_always_args(self) -> T.List[str]:
         return []
+
+    def get_cpp_permissive_args(self) -> T.List[str]:
+        return ['-fpermissive']
 
     def get_option_link_args(self, target: 'BuildTarget', subproject: T.Optional[str] = None) -> T.List[str]:
         return []

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -861,6 +861,9 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
             args.append('/permissive-')
         return args
 
+    def get_cpp_permissive_args(self) -> T.List[str]:
+        return ['/permissive']
+
 class CPP11AsCPP14Mixin(CompilerMixinBase):
 
     """Mixin class for VisualStudio and ClangCl to replace C++11 std with C++14.

--- a/mesonbuild/compilers/mixins/arm.py
+++ b/mesonbuild/compilers/mixins/arm.py
@@ -140,6 +140,9 @@ class ArmclangCompiler(Compiler):
     def get_colorout_args(self, colortype: str) -> T.List[str]:
         return clang_color_args[colortype][:]
 
+    def get_cpp_permissive_args(self) -> T.List[str]:
+        return ['-fpermissive']
+
     def get_pch_suffix(self) -> str:
         return 'gch'
 

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -381,6 +381,9 @@ class GnuLikeCompiler(Compiler, metaclass=mesonlib.SimpleABC):
     def get_pie_args(self) -> T.List[str]:
         return ['-fPIE']
 
+    def get_cpp_permissive_args(self) -> T.List[str]:
+        return ['-fpermissive']
+
     @abc.abstractmethod
     def get_optimization_args(self, optimization_level: str) -> T.List[str]:
         pass

--- a/mesonbuild/compilers/mixins/pgi.py
+++ b/mesonbuild/compilers/mixins/pgi.py
@@ -50,6 +50,9 @@ class PGICompiler(Compiler):
             return ['-fPIC']
         return []
 
+    def get_cpp_permissive_args(self) -> T.List[str]:
+        return ['-fpermissive']
+
     def openmp_flags(self) -> T.List[str]:
         return ['-mp']
 


### PR DESCRIPTION
The first patch is the regression fix proper, the second at least makes all compilers homogeneous.

Fixes: #16203 