### PR TITLE
Limit logging during test to prevent accidental secret exposure.

### DIFF
--- a/test cases/unit/70 cross test passed/exewrapper.py
+++ b/test cases/unit/70 cross test passed/exewrapper.py
@@ -15,7 +15,11 @@ def main():
     defined = 'MESON_EXE_WRAPPER' in os.environ
 
     if args.expected != defined:
-        print(os.environ, file=sys.stderr)
+        print(
+            'MESON_EXE_WRAPPER presence mismatch: '
+            f'expected={args.expected}, actual={defined}',
+            file=sys.stderr,
+        )
         return 1
     return 0
 


### PR DESCRIPTION
A unit test that runs on the Meson CI logs the entire os.environ, potentially leaking secrets. Consumers may also run these test suits on their CI, exposing their own secrets.